### PR TITLE
colexecjoin: improve hash joiner probing

### DIFF
--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -56,6 +56,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -94,12 +97,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -131,7 +137,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -139,6 +145,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -165,11 +174,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -191,7 +203,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -202,6 +214,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -240,12 +255,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -277,7 +295,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -285,6 +303,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -311,11 +332,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -337,7 +361,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -363,6 +387,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -393,12 +420,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -422,7 +452,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -430,6 +460,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -448,11 +481,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -466,7 +502,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -477,6 +513,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -507,12 +546,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -536,7 +578,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -544,6 +586,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -562,11 +607,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -580,7 +628,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -606,6 +654,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -636,12 +687,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -665,7 +719,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -673,6 +727,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -691,11 +748,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -709,7 +769,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -720,6 +780,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -750,12 +813,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -779,7 +845,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -787,6 +853,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -805,11 +874,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -823,7 +895,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -847,6 +919,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -888,12 +963,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -928,7 +1006,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -936,6 +1014,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -965,11 +1046,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -994,7 +1078,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1005,6 +1089,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1046,12 +1133,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1086,7 +1176,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1094,6 +1184,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1123,11 +1216,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1152,7 +1248,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1173,6 +1269,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1214,12 +1313,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1254,7 +1356,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1262,6 +1364,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1291,11 +1396,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1320,7 +1428,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1331,6 +1439,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1372,12 +1483,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1412,7 +1526,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1420,6 +1534,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1449,11 +1566,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1478,7 +1598,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1501,6 +1621,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1542,12 +1665,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1582,7 +1708,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1590,6 +1716,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1619,11 +1748,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1648,7 +1780,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1659,6 +1791,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1700,12 +1835,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1740,7 +1878,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1748,6 +1886,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1777,11 +1918,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1806,7 +1950,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1832,6 +1976,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1881,12 +2028,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1929,7 +2079,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1937,6 +2087,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -1974,11 +2127,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2011,7 +2167,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2022,6 +2178,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2071,12 +2230,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2119,7 +2281,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2127,6 +2289,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2164,11 +2329,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2201,7 +2369,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2227,6 +2395,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2264,12 +2435,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2300,7 +2474,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2308,6 +2482,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2333,11 +2510,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2358,7 +2538,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2369,6 +2549,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2406,12 +2589,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2442,7 +2628,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2450,6 +2636,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2475,11 +2664,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2500,7 +2692,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2526,6 +2718,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2556,12 +2751,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2585,7 +2783,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2593,6 +2791,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2611,11 +2812,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2629,7 +2833,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2640,6 +2844,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2670,12 +2877,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2699,7 +2909,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2707,6 +2917,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2725,11 +2938,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2743,7 +2959,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2769,6 +2985,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2805,12 +3024,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2840,7 +3062,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2848,6 +3070,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2872,11 +3097,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -2896,7 +3124,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2907,6 +3135,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2943,12 +3174,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2978,7 +3212,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2986,6 +3220,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3010,11 +3247,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3034,7 +3274,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3060,6 +3300,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -3092,12 +3335,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -3123,7 +3369,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3131,6 +3377,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -3151,11 +3400,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
@@ -3171,7 +3423,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3182,6 +3434,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3214,12 +3469,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3245,7 +3503,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3253,6 +3511,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3273,11 +3534,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3293,7 +3557,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3325,6 +3589,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3363,12 +3630,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3400,7 +3670,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -3408,6 +3678,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3434,11 +3707,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3460,7 +3736,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}
@@ -3484,6 +3760,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3514,12 +3793,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3543,7 +3825,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -3551,6 +3833,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3569,11 +3854,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3587,7 +3875,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}
@@ -3617,6 +3905,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3647,12 +3938,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3676,7 +3970,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -3684,6 +3978,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3702,11 +3999,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3720,7 +4020,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}
@@ -3742,6 +4042,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3783,12 +4086,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3823,7 +4129,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -3831,6 +4137,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3860,11 +4169,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3889,7 +4201,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}
@@ -3914,6 +4226,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3955,12 +4270,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -3995,7 +4313,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -4003,6 +4321,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4032,11 +4353,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4061,7 +4385,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}
@@ -4088,6 +4412,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4129,12 +4456,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4169,7 +4499,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -4177,6 +4507,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4206,11 +4539,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4235,7 +4571,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}
@@ -4268,6 +4604,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4317,12 +4656,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4365,7 +4707,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -4373,6 +4715,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4410,11 +4755,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4447,7 +4795,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}
@@ -4474,6 +4822,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4511,12 +4862,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4547,7 +4901,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -4555,6 +4909,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4580,11 +4937,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4605,7 +4965,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}
@@ -4629,6 +4989,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4659,12 +5022,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4688,7 +5054,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -4696,6 +5062,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4714,11 +5083,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4732,7 +5104,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}
@@ -4756,6 +5128,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4792,12 +5167,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4827,7 +5205,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -4835,6 +5213,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4859,11 +5240,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4883,7 +5267,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}
@@ -4907,6 +5291,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4939,12 +5326,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4970,7 +5360,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					} else {
@@ -4978,6 +5368,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -4998,11 +5391,14 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								if ht.ProbeScratch.differs[toCheck] {
+									continue
+								}
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								probeIdx = probeSel[toCheck]
 								buildIdx = int(keyID - 1)
@@ -5018,7 +5414,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									unique = cmpResult != 0
 								}
 
-								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								ht.ProbeScratch.differs[toCheck] = unique
 							}
 						}
 					}

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -67,6 +67,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -107,6 +108,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -211,6 +213,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -251,6 +254,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -370,6 +374,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -402,6 +407,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -482,6 +488,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -514,6 +521,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -609,6 +617,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -641,6 +650,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -721,6 +731,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -753,6 +764,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -846,6 +858,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -889,6 +902,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1002,6 +1016,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1045,6 +1060,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1168,6 +1184,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1211,6 +1228,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1324,6 +1342,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1367,6 +1386,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1492,6 +1512,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1535,6 +1556,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1648,6 +1670,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1691,6 +1714,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1819,6 +1843,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -1870,6 +1895,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2007,6 +2033,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2058,6 +2085,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2210,6 +2238,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2249,6 +2278,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2350,6 +2380,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2389,6 +2420,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2505,6 +2537,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2537,6 +2570,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2617,6 +2651,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2649,6 +2684,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2744,6 +2780,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2782,6 +2819,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2880,6 +2918,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -2918,6 +2957,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -3031,6 +3071,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -3065,6 +3106,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -3151,6 +3193,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -3185,6 +3228,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
+											ht.ProbeScratch.differs[toCheck] = true
 											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
@@ -3282,83 +3326,81 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										if !probeVal && buildVal {
-											cmpResult = -1
-										} else if probeVal && !buildVal {
-											cmpResult = 1
-										} else {
-											cmpResult = 0
-										}
-
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									if !probeVal && buildVal {
+										cmpResult = -1
+									} else if probeVal && !buildVal {
+										cmpResult = 1
+									} else {
+										cmpResult = 0
+									}
+
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										if !probeVal && buildVal {
-											cmpResult = -1
-										} else if probeVal && !buildVal {
-											cmpResult = 1
-										} else {
-											cmpResult = 0
-										}
-
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									if !probeVal && buildVal {
+										cmpResult = -1
+									} else if probeVal && !buildVal {
+										cmpResult = 1
+									} else {
+										cmpResult = 0
+									}
+
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -3367,62 +3409,58 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										if !probeVal && buildVal {
-											cmpResult = -1
-										} else if probeVal && !buildVal {
-											cmpResult = 1
-										} else {
-											cmpResult = 0
-										}
-
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									if !probeVal && buildVal {
+										cmpResult = -1
+									} else if probeVal && !buildVal {
+										cmpResult = 1
+									} else {
+										cmpResult = 0
+									}
+
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
 
-									{
-										var cmpResult int
+								{
+									var cmpResult int
 
-										if !probeVal && buildVal {
-											cmpResult = -1
-										} else if probeVal && !buildVal {
-											cmpResult = 1
-										} else {
-											cmpResult = 0
-										}
-
-										unique = cmpResult != 0
+									if !probeVal && buildVal {
+										cmpResult = -1
+									} else if probeVal && !buildVal {
+										cmpResult = 1
+									} else {
+										cmpResult = 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -3447,67 +3485,65 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-										cmpResult = bytes.Compare(probeVal, buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+									cmpResult = bytes.Compare(probeVal, buildVal)
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-										cmpResult = bytes.Compare(probeVal, buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+									cmpResult = bytes.Compare(probeVal, buildVal)
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -3516,46 +3552,42 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-										cmpResult = bytes.Compare(probeVal, buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+									cmpResult = bytes.Compare(probeVal, buildVal)
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
 
-									{
-										var cmpResult int
-										cmpResult = bytes.Compare(probeVal, buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								{
+									var cmpResult int
+									cmpResult = bytes.Compare(probeVal, buildVal)
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -3586,67 +3618,65 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+									cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+									cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -3655,46 +3685,42 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+									cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
 
-									{
-										var cmpResult int
-										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								{
+									var cmpResult int
+									cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -3717,89 +3743,87 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+									continue
+								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -3808,68 +3832,64 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -3895,89 +3915,87 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+									continue
+								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -3986,68 +4004,64 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -4075,89 +4089,87 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+									continue
+								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -4166,68 +4178,64 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := int64(probeVal), int64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
+										a, b := int64(probeVal), int64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -4261,105 +4269,103 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+									continue
+								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := float64(probeVal), float64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else if a == b {
+										a, b := float64(probeVal), float64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else if a == b {
+											cmpResult = 0
+										} else if math.IsNaN(a) {
+											if math.IsNaN(b) {
 												cmpResult = 0
-											} else if math.IsNaN(a) {
-												if math.IsNaN(b) {
-													cmpResult = 0
-												} else {
-													cmpResult = -1
-												}
 											} else {
-												cmpResult = 1
+												cmpResult = -1
 											}
+										} else {
+											cmpResult = 1
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := float64(probeVal), float64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else if a == b {
+										a, b := float64(probeVal), float64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else if a == b {
+											cmpResult = 0
+										} else if math.IsNaN(a) {
+											if math.IsNaN(b) {
 												cmpResult = 0
-											} else if math.IsNaN(a) {
-												if math.IsNaN(b) {
-													cmpResult = 0
-												} else {
-													cmpResult = -1
-												}
 											} else {
-												cmpResult = 1
+												cmpResult = -1
 											}
+										} else {
+											cmpResult = 1
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -4368,84 +4374,80 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := float64(probeVal), float64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else if a == b {
+										a, b := float64(probeVal), float64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else if a == b {
+											cmpResult = 0
+										} else if math.IsNaN(a) {
+											if math.IsNaN(b) {
 												cmpResult = 0
-											} else if math.IsNaN(a) {
-												if math.IsNaN(b) {
-													cmpResult = 0
-												} else {
-													cmpResult = -1
-												}
 											} else {
-												cmpResult = 1
+												cmpResult = -1
 											}
+										} else {
+											cmpResult = 1
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
 
 									{
-										var cmpResult int
-
-										{
-											a, b := float64(probeVal), float64(buildVal)
-											if a < b {
-												cmpResult = -1
-											} else if a > b {
-												cmpResult = 1
-											} else if a == b {
+										a, b := float64(probeVal), float64(buildVal)
+										if a < b {
+											cmpResult = -1
+										} else if a > b {
+											cmpResult = 1
+										} else if a == b {
+											cmpResult = 0
+										} else if math.IsNaN(a) {
+											if math.IsNaN(b) {
 												cmpResult = 0
-											} else if math.IsNaN(a) {
-												if math.IsNaN(b) {
-													cmpResult = 0
-												} else {
-													cmpResult = -1
-												}
 											} else {
-												cmpResult = 1
+												cmpResult = -1
 											}
+										} else {
+											cmpResult = 1
 										}
-
-										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -4473,81 +4475,79 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										if probeVal.Before(buildVal) {
-											cmpResult = -1
-										} else if buildVal.Before(probeVal) {
-											cmpResult = 1
-										} else {
-											cmpResult = 0
-										}
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									if probeVal.Before(buildVal) {
+										cmpResult = -1
+									} else if buildVal.Before(probeVal) {
+										cmpResult = 1
+									} else {
+										cmpResult = 0
+									}
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										if probeVal.Before(buildVal) {
-											cmpResult = -1
-										} else if buildVal.Before(probeVal) {
-											cmpResult = 1
-										} else {
-											cmpResult = 0
-										}
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									if probeVal.Before(buildVal) {
+										cmpResult = -1
+									} else if buildVal.Before(probeVal) {
+										cmpResult = 1
+									} else {
+										cmpResult = 0
+									}
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -4556,60 +4556,56 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										if probeVal.Before(buildVal) {
-											cmpResult = -1
-										} else if buildVal.Before(probeVal) {
-											cmpResult = 1
-										} else {
-											cmpResult = 0
-										}
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									if probeVal.Before(buildVal) {
+										cmpResult = -1
+									} else if buildVal.Before(probeVal) {
+										cmpResult = 1
+									} else {
+										cmpResult = 0
+									}
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
 
-									{
-										var cmpResult int
+								{
+									var cmpResult int
 
-										if probeVal.Before(buildVal) {
-											cmpResult = -1
-										} else if buildVal.Before(probeVal) {
-											cmpResult = 1
-										} else {
-											cmpResult = 0
-										}
-										unique = cmpResult != 0
+									if probeVal.Before(buildVal) {
+										cmpResult = -1
+									} else if buildVal.Before(probeVal) {
+										cmpResult = 1
+									} else {
+										cmpResult = 0
 									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -4634,67 +4630,65 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-										cmpResult = probeVal.Compare(buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+									cmpResult = probeVal.Compare(buildVal)
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-										cmpResult = probeVal.Compare(buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+									cmpResult = probeVal.Compare(buildVal)
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -4703,46 +4697,42 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-										cmpResult = probeVal.Compare(buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+									cmpResult = probeVal.Compare(buildVal)
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
 
-									{
-										var cmpResult int
-										cmpResult = probeVal.Compare(buildVal)
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								{
+									var cmpResult int
+									cmpResult = probeVal.Compare(buildVal)
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -4767,79 +4757,77 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										var err error
-										cmpResult, err = probeVal.Compare(buildVal)
-										if err != nil {
-											colexecerror.ExpectedError(err)
-										}
-
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									var err error
+									cmpResult, err = probeVal.Compare(buildVal)
+									if err != nil {
+										colexecerror.ExpectedError(err)
+									}
+
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										var err error
-										cmpResult, err = probeVal.Compare(buildVal)
-										if err != nil {
-											colexecerror.ExpectedError(err)
-										}
-
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									var err error
+									cmpResult, err = probeVal.Compare(buildVal)
+									if err != nil {
+										colexecerror.ExpectedError(err)
+									}
+
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -4848,58 +4836,54 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										var err error
-										cmpResult, err = probeVal.Compare(buildVal)
-										if err != nil {
-											colexecerror.ExpectedError(err)
-										}
-
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									var err error
+									cmpResult, err = probeVal.Compare(buildVal)
+									if err != nil {
+										colexecerror.ExpectedError(err)
+									}
+
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
 
-									{
-										var cmpResult int
+								{
+									var cmpResult int
 
-										var err error
-										cmpResult, err = probeVal.Compare(buildVal)
-										if err != nil {
-											colexecerror.ExpectedError(err)
-										}
-
-										unique = cmpResult != 0
+									var err error
+									cmpResult, err = probeVal.Compare(buildVal)
+									if err != nil {
+										colexecerror.ExpectedError(err)
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -4924,71 +4908,69 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											if !buildIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-											}
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										if !buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
 										}
-										continue
-									}
-									if buildIsNull {
+									} else {
 										ht.ProbeScratch.differs[toCheck] = true
-										continue
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
+								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeIsNull := probeVecNulls.NullAt(probeIdx)
-									if probeIsNull {
-										if ht.allowNullEquality {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											ht.ProbeScratch.foundNull[toCheck] = true
-										}
-										continue
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeIsNull := probeVecNulls.NullAt(probeIdx)
+								if probeIsNull {
+									if ht.allowNullEquality {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										ht.ProbeScratch.differs[toCheck] = true
+										ht.ProbeScratch.foundNull[toCheck] = true
 									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					} else {
@@ -4997,50 +4979,46 @@ func (ht *HashTable) checkColForDistinctTuples(
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									buildIsNull := buildVecNulls.NullAt(buildIdx)
-									if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-										continue
-									}
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
-
-									{
-										var cmpResult int
-
-										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								buildIsNull := buildVecNulls.NullAt(buildIdx)
+								if buildIsNull {
+									ht.ProbeScratch.differs[toCheck] = true
+									continue
 								}
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
+
+								{
+									var cmpResult int
+
+									cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+									unique = cmpResult != 0
+								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.ToCheckID[toCheck]
-								if keyID != 0 {
-									probeIdx = probeSel[toCheck]
-									buildIdx = int(keyID - 1)
-									probeVal := probeKeys.Get(probeIdx)
-									buildVal := buildKeys.Get(buildIdx)
-									var unique bool
+								probeIdx = probeSel[toCheck]
+								buildIdx = int(keyID - 1)
+								probeVal := probeKeys.Get(probeIdx)
+								buildVal := buildKeys.Get(buildIdx)
+								var unique bool
 
-									{
-										var cmpResult int
+								{
+									var cmpResult int
 
-										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+									cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
-										unique = cmpResult != 0
-									}
-
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									unique = cmpResult != 0
 								}
+
+								ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 							}
 						}
 					}
@@ -5188,7 +5166,7 @@ func (ht *HashTable) FindBuckets(
 	zeroHeadIDForDistinctTuple bool,
 	probingAgainstItself bool,
 ) {
-	ht.ProbeScratch.SetupLimitedSlices(batch.Length(), ht.BuildMode)
+	ht.ProbeScratch.SetupLimitedSlices(batch.Length())
 	if zeroHeadIDForDistinctTuple {
 		if probingAgainstItself {
 			{

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -58,6 +58,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -96,12 +99,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -133,7 +139,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -141,6 +147,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -167,11 +176,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -193,7 +205,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -204,6 +216,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -242,12 +257,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -279,7 +297,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -287,6 +305,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -313,11 +334,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -339,7 +363,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -365,6 +389,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -395,12 +422,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -424,7 +454,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -432,6 +462,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -450,11 +483,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -468,7 +504,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -479,6 +515,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -509,12 +548,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -538,7 +580,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -546,6 +588,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -564,11 +609,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -582,7 +630,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -608,6 +656,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -638,12 +689,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -667,7 +721,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -675,6 +729,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -693,11 +750,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -711,7 +771,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -722,6 +782,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -752,12 +815,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -781,7 +847,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -789,6 +855,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -807,11 +876,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -825,7 +897,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -849,6 +921,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -890,12 +965,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -930,7 +1008,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -938,6 +1016,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -967,11 +1048,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -996,7 +1080,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1007,6 +1091,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1048,12 +1135,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1088,7 +1178,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1096,6 +1186,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1125,11 +1218,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1154,7 +1250,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1169,6 +1265,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1210,12 +1309,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1250,7 +1352,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1258,6 +1360,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1287,11 +1392,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1316,7 +1424,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1327,6 +1435,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1368,12 +1479,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1408,7 +1522,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1416,6 +1530,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1445,11 +1562,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1474,7 +1594,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1490,6 +1610,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1531,12 +1654,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1571,7 +1697,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1579,6 +1705,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1608,11 +1737,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1637,7 +1769,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1648,6 +1780,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1689,12 +1824,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1729,7 +1867,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1737,6 +1875,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1766,11 +1907,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -1795,7 +1939,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1816,6 +1960,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1857,12 +2004,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1897,7 +2047,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1905,6 +2055,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1934,11 +2087,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -1963,7 +2119,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1974,6 +2130,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2015,12 +2174,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2055,7 +2217,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2063,6 +2225,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2092,11 +2257,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2121,7 +2289,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2136,6 +2304,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2177,12 +2348,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2217,7 +2391,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2225,6 +2399,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2254,11 +2431,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2283,7 +2463,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2294,6 +2474,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2335,12 +2518,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2375,7 +2561,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2383,6 +2569,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2412,11 +2601,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2441,7 +2633,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2457,6 +2649,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2498,12 +2693,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2538,7 +2736,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2546,6 +2744,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2575,11 +2776,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2604,7 +2808,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2615,6 +2819,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2656,12 +2863,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2696,7 +2906,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2704,6 +2914,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2733,11 +2946,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2762,7 +2978,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2784,6 +3000,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2825,12 +3044,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2865,7 +3087,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2873,6 +3095,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2902,11 +3127,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -2931,7 +3159,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2942,6 +3170,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -2983,12 +3214,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3023,7 +3257,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3031,6 +3265,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3060,11 +3297,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3089,7 +3329,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3104,6 +3344,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3145,12 +3388,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3185,7 +3431,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3193,6 +3439,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3222,11 +3471,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3251,7 +3503,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3262,6 +3514,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3303,12 +3558,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3343,7 +3601,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3351,6 +3609,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3380,11 +3641,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3409,7 +3673,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3425,6 +3689,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3466,12 +3733,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3506,7 +3776,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3514,6 +3784,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3543,11 +3816,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3572,7 +3848,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3583,6 +3859,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3624,12 +3903,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3664,7 +3946,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3672,6 +3954,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3701,11 +3986,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3730,7 +4018,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3756,6 +4044,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3805,12 +4096,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3853,7 +4147,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3861,6 +4155,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3898,11 +4195,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3935,7 +4235,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3946,6 +4246,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -3995,12 +4298,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4043,7 +4349,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4051,6 +4357,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4088,11 +4397,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4125,7 +4437,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4151,6 +4463,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4188,12 +4503,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4224,7 +4542,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4232,6 +4550,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4257,11 +4578,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4282,7 +4606,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4293,6 +4617,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4330,12 +4657,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4366,7 +4696,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4374,6 +4704,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4399,11 +4732,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4424,7 +4760,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4450,6 +4786,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4480,12 +4819,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4509,7 +4851,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4517,6 +4859,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4535,11 +4880,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4553,7 +4901,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4564,6 +4912,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4594,12 +4945,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4623,7 +4977,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4631,6 +4985,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4649,11 +5006,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4667,7 +5027,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4693,6 +5053,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4729,12 +5092,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4764,7 +5130,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4772,6 +5138,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4796,11 +5165,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4820,7 +5192,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4831,6 +5203,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4867,12 +5242,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4902,7 +5280,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4910,6 +5288,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4934,11 +5315,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -4958,7 +5342,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4984,6 +5368,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -5016,12 +5403,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -5047,7 +5437,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -5055,6 +5445,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -5075,11 +5468,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -5095,7 +5491,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -5106,6 +5502,9 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -5138,12 +5537,15 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -5169,7 +5571,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -5177,6 +5579,9 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -5197,11 +5602,14 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
@@ -5217,7 +5625,7 @@ func (ht *HashTable) checkCol(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -59,83 +59,81 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -144,62 +142,58 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -211,83 +205,81 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -296,62 +288,58 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -378,67 +366,65 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -447,46 +433,42 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -498,67 +480,65 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -567,46 +547,42 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -633,67 +609,65 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -702,46 +676,42 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -753,67 +723,65 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -822,46 +790,42 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -886,89 +850,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -977,68 +939,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1050,89 +1008,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1141,68 +1097,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1218,89 +1170,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1309,68 +1259,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1382,89 +1328,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1473,68 +1417,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1551,89 +1491,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1642,68 +1580,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1715,89 +1649,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1806,68 +1738,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1889,89 +1817,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1980,68 +1906,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2053,89 +1975,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2144,68 +2064,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2221,89 +2137,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2312,68 +2226,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2385,89 +2295,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2476,68 +2384,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2554,89 +2458,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2645,68 +2547,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2718,89 +2616,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2809,68 +2705,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2893,89 +2785,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2984,68 +2874,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3057,89 +2943,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -3148,68 +3032,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3225,89 +3105,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -3316,68 +3194,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3389,89 +3263,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -3480,68 +3352,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3558,89 +3426,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -3649,68 +3515,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3722,89 +3584,87 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -3813,68 +3673,64 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3901,105 +3757,103 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4008,84 +3862,80 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4097,105 +3947,103 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4204,84 +4052,80 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4308,81 +4152,79 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4391,60 +4233,56 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4456,81 +4294,79 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4539,60 +4375,56 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4619,67 +4451,65 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4688,46 +4518,42 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4739,67 +4565,65 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4808,46 +4632,42 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4874,79 +4694,77 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4955,58 +4773,54 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -5018,79 +4832,77 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -5099,58 +4911,54 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -5177,71 +4985,69 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -5250,50 +5056,46 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -5305,71 +5107,69 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -5378,50 +5178,46 @@ func (ht *HashTable) checkCol(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -5984,8 +5984,8 @@ func (ht *HashTable) checkColDeleting(
 // key is removed from ToCheck if it has already been visited in a previous
 // probe, or the bucket has reached the end (key not found in build table). The
 // new length of ToCheck is returned by this function.
-func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []int) uint64 {
-	ht.checkCols(probeVecs, nToCheck, probeSel)
+func (ht *HashTable) Check(nToCheck uint64, probeSel []int) uint64 {
+	ht.checkCols(ht.Keys, nToCheck, probeSel)
 	nDiffers := uint64(0)
 	switch ht.probeMode {
 	case HashTableDefaultProbeMode:

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -59,6 +59,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -101,12 +104,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -142,7 +148,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -150,6 +156,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -180,11 +189,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -210,7 +222,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -221,6 +233,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -263,12 +278,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -304,7 +322,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -312,6 +330,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -342,11 +363,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -372,7 +396,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -398,6 +422,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -432,12 +459,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -465,7 +495,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -473,6 +503,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -495,11 +528,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -517,7 +553,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -528,6 +564,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -562,12 +601,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -595,7 +637,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -603,6 +645,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -625,11 +670,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -647,7 +695,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -673,6 +721,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -707,12 +758,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -740,7 +794,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -748,6 +802,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -770,11 +827,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -792,7 +852,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -803,6 +863,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -837,12 +900,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -870,7 +936,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -878,6 +944,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -900,11 +969,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -922,7 +994,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -946,6 +1018,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -991,12 +1066,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1035,7 +1113,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1043,6 +1121,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1076,11 +1157,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1109,7 +1193,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1120,6 +1204,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1165,12 +1252,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1209,7 +1299,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1217,6 +1307,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1250,11 +1343,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1283,7 +1379,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1298,6 +1394,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1343,12 +1442,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1387,7 +1489,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1395,6 +1497,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1428,11 +1533,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1461,7 +1569,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1472,6 +1580,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1517,12 +1628,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1561,7 +1675,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1569,6 +1683,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1602,11 +1719,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1635,7 +1755,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1651,6 +1771,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1696,12 +1819,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1740,7 +1866,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1748,6 +1874,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1781,11 +1910,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1814,7 +1946,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -1825,6 +1957,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1870,12 +2005,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1914,7 +2052,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -1922,6 +2060,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1955,11 +2096,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -1988,7 +2132,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2009,6 +2153,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2054,12 +2201,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2098,7 +2248,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2106,6 +2256,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2139,11 +2292,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2172,7 +2328,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2183,6 +2339,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2228,12 +2387,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2272,7 +2434,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2280,6 +2442,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2313,11 +2478,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2346,7 +2514,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2361,6 +2529,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2406,12 +2577,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2450,7 +2624,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2458,6 +2632,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2491,11 +2668,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2524,7 +2704,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2535,6 +2715,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2580,12 +2763,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2624,7 +2810,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2632,6 +2818,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2665,11 +2854,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2698,7 +2890,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2714,6 +2906,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2759,12 +2954,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2803,7 +3001,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2811,6 +3009,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2844,11 +3045,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2877,7 +3081,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -2888,6 +3092,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2933,12 +3140,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -2977,7 +3187,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -2985,6 +3195,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3018,11 +3231,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3051,7 +3267,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3073,6 +3289,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3118,12 +3337,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3162,7 +3384,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3170,6 +3392,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3203,11 +3428,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3236,7 +3464,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3247,6 +3475,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3292,12 +3523,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3336,7 +3570,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3344,6 +3578,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3377,11 +3614,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3410,7 +3650,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3425,6 +3665,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3470,12 +3713,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3514,7 +3760,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3522,6 +3768,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3555,11 +3804,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3588,7 +3840,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3599,6 +3851,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3644,12 +3899,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3688,7 +3946,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3696,6 +3954,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3729,11 +3990,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3762,7 +4026,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3778,6 +4042,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3823,12 +4090,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3867,7 +4137,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -3875,6 +4145,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3908,11 +4181,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3941,7 +4217,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -3952,6 +4228,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -3997,12 +4276,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4041,7 +4323,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4049,6 +4331,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4082,11 +4367,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4115,7 +4403,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4141,6 +4429,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4194,12 +4485,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4246,7 +4540,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4254,6 +4548,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4295,11 +4592,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4336,7 +4636,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4347,6 +4647,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4400,12 +4703,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4452,7 +4758,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4460,6 +4766,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4501,11 +4810,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4542,7 +4854,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4568,6 +4880,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4609,12 +4924,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4649,7 +4967,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4657,6 +4975,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4686,11 +5007,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4715,7 +5039,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4726,6 +5050,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4767,12 +5094,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4807,7 +5137,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4815,6 +5145,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4844,11 +5177,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4873,7 +5209,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -4899,6 +5235,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4933,12 +5272,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4966,7 +5308,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -4974,6 +5316,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -4996,11 +5341,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5018,7 +5366,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -5029,6 +5377,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5063,12 +5414,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5096,7 +5450,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -5104,6 +5458,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5126,11 +5483,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5148,7 +5508,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -5174,6 +5534,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5214,12 +5577,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5253,7 +5619,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -5261,6 +5627,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5289,11 +5658,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5317,7 +5689,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -5328,6 +5700,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5368,12 +5743,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5407,7 +5785,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -5415,6 +5793,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5443,11 +5824,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5471,7 +5855,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -5497,6 +5881,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5533,12 +5920,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5568,7 +5958,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -5576,6 +5966,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5600,11 +5993,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5624,7 +6020,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}
@@ -5635,6 +6031,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5671,12 +6070,15 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5706,7 +6108,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						} else {
@@ -5714,6 +6116,9 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5738,11 +6143,14 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+									if ht.ProbeScratch.differs[toCheck] {
+										continue
+									}
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if ht.Visited[keyID] {
 										ht.ProbeScratch.differs[toCheck] = true
@@ -5762,7 +6170,7 @@ func (ht *HashTable) checkColDeleting(
 										unique = cmpResult != 0
 									}
 
-									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									ht.ProbeScratch.differs[toCheck] = unique
 								}
 							}
 						}

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -60,91 +60,89 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -153,70 +151,66 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -228,91 +222,89 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -321,70 +313,66 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -411,75 +399,73 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -488,54 +474,50 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -547,75 +529,73 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -624,54 +604,50 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -698,75 +674,73 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -775,54 +749,50 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -834,75 +804,73 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -911,54 +879,50 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -983,97 +947,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1082,76 +1044,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1163,97 +1121,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1262,76 +1218,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1347,97 +1299,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1446,76 +1396,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1527,97 +1473,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1626,76 +1570,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1712,97 +1652,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1811,76 +1749,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1892,97 +1826,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -1991,76 +1923,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2082,97 +2010,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2181,76 +2107,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2262,97 +2184,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2361,76 +2281,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2446,97 +2362,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2545,76 +2459,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2626,97 +2536,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2725,76 +2633,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2811,97 +2715,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -2910,76 +2812,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2991,97 +2889,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -3090,76 +2986,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3182,97 +3074,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -3281,76 +3171,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3362,97 +3248,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -3461,76 +3345,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3546,97 +3426,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -3645,76 +3523,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3726,97 +3600,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -3825,76 +3697,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3911,97 +3779,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4010,76 +3876,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4091,97 +3953,95 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4190,76 +4050,72 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4286,113 +4142,111 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4401,92 +4255,88 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4498,113 +4348,111 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											continue
-										}
-										if buildIsNull {
+										} else {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
-											continue
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4613,92 +4461,88 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4725,89 +4569,87 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4816,68 +4658,64 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4889,89 +4727,87 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -4980,68 +4816,64 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -5068,75 +4900,73 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -5145,54 +4975,50 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -5204,75 +5030,73 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -5281,54 +5105,50 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -5355,87 +5175,85 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -5444,66 +5262,62 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -5515,87 +5329,85 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -5604,66 +5416,62 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
+										}
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -5690,79 +5498,77 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -5771,58 +5577,54 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -5834,79 +5636,77 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												if !buildIsNull {
-													ht.ProbeScratch.differs[toCheck] = true
-												}
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeIsNull := probeVecNulls.NullAt(probeIdx)
-										if probeIsNull {
-											if ht.allowNullEquality {
-												ht.ProbeScratch.differs[toCheck] = true
-											} else {
-												ht.ProbeScratch.ToCheckID[toCheck] = 0
-											}
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									if probeIsNull {
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.differs[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
@@ -5915,58 +5715,54 @@ func (ht *HashTable) checkColDeleting(
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull := buildVecNulls.NullAt(buildIdx)
-										if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.ToCheckID[toCheck]
-									if keyID != 0 {
-										if ht.Visited[keyID] {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									if ht.Visited[keyID] {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
 									}
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -5995,6 +5791,10 @@ func (ht *HashTable) Check(nToCheck uint64, probeSel []int) uint64 {
 			for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
+				if ht.ProbeScratch.foundNull[toCheck] {
+					ht.ProbeScratch.ToCheckID[toCheck] = 0
+					continue
+				}
 				if !ht.ProbeScratch.differs[toCheck] {
 					keyID := ht.ProbeScratch.ToCheckID[toCheck]
 					if ht.ProbeScratch.HeadID[toCheck] == 0 {
@@ -6024,6 +5824,10 @@ func (ht *HashTable) Check(nToCheck uint64, probeSel []int) uint64 {
 			for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
+				if ht.ProbeScratch.foundNull[toCheck] {
+					ht.ProbeScratch.ToCheckID[toCheck] = 0
+					continue
+				}
 				if !ht.ProbeScratch.differs[toCheck] {
 					keyID := ht.ProbeScratch.ToCheckID[toCheck]
 					if ht.ProbeScratch.HeadID[toCheck] == 0 {

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -587,8 +587,8 @@ func _CHECK_BODY(
 // key is removed from ToCheck if it has already been visited in a previous
 // probe, or the bucket has reached the end (key not found in build table). The
 // new length of ToCheck is returned by this function.
-func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []int) uint64 {
-	ht.checkCols(probeVecs, nToCheck, probeSel)
+func (ht *HashTable) Check(nToCheck uint64, probeSel []int) uint64 {
+	ht.checkCols(ht.Keys, nToCheck, probeSel)
 	nDiffers := uint64(0)
 	switch ht.probeMode {
 	case HashTableDefaultProbeMode:

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -109,6 +109,13 @@ func _CHECK_COL_BODY(
 	// {{end}}
 	for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 		// {{/*
+		//     If the tuple is already marked as different, there is no point in
+		//     checking it further.
+		// */}}
+		if ht.ProbeScratch.differs[toCheck] {
+			continue
+		}
+		// {{/*
 		//     The build table tuple (identified by ToCheckID value) is being
 		//     compared to the corresponding probing tuple (with the ordinal
 		//     'toCheck') to determine if it is an equality match.
@@ -212,16 +219,12 @@ func _CHECK_COL_BODY(
 		// {{/*
 		//     Now both values are not NULL, so we have to perform actual
 		//     comparison.
-		//     TODO(yuzefovich): depending on the type, it might be faster
-		//     to check whether differs[toCheck] is already true. My guess
-		//     is that for simple types like int64 introducing a conditional
-		//     will be slower.
 		// */}}
 		probeVal := probeKeys.Get(probeIdx)
 		buildVal := buildKeys.Get(buildIdx)
 		var unique bool
 		_ASSIGN_NE(unique, probeVal, buildVal, _, probeKeys, buildKeys)
-		ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+		ht.ProbeScratch.differs[toCheck] = unique
 	}
 	// {{end}}
 	// {{/*

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -579,11 +579,160 @@ func _CHECK_BODY(
 
 // Check performs an equality check between the current key in the ToCheckID
 // bucket and the probe key at that index. If there is a match, the HashTable's
-// same array is updated to lazily populate the linked list of identical build
-// table keys. The visited flag for corresponding build table key is also set. A
+// Same array is updated to lazily populate the linked list of identical build
+// table keys. The Visited flag for corresponding build table key is also set. A
 // key is removed from ToCheck if it has already been visited in a previous
 // probe, or the bucket has reached the end (key not found in build table). The
 // new length of ToCheck is returned by this function.
+//
+// Let's walk through an example of how this function works for the INNER join
+// when the right source is not distinct (i.e. with the
+// HashTableDefaultProbeMode probe mode and Same being non-nil).
+//
+// In this example the right source contains the following tuples:
+//
+//	[-1, -2, -4, -1, -3, -2, -1, -3]
+//
+// and for simplicity we will assume that our hash function is
+//
+//	h(i) = i % 2
+//
+// while the hash table only uses two buckets.
+//
+// During the build phase, before we get to Check function, the hash table is
+// constructed in the following manner:
+//
+//	ht.BuildScratch.First = [2, 1]
+//	ht.BuildScratch.Next  = [x, 4, 3, 6, 5, 7, 0, 8, 0]    ('x' means reserved)
+//
+// Describing in words what this tells us is: say, if we have a value i with
+// h(i) = 1, then in order to iterate over all possible matches we do the
+// following traversal:
+//   - start at keyID = First[h(i)] = First[1] = 1 (i.e. zeroth tuple is the
+//     first "candidate")
+//   - then for each "candidate" keyID, do nextKeyID = Next[keyID] until it
+//     becomes zero, so we will try keyIDs Next[1] = 4, Next[4] = 5,
+//     Next[5] = 7, Next[7] = 8, and then stop.
+//
+// With this background in mind, let's imagine that the first probing batch from
+// the left is [-3, -1, -5].
+//
+// On the first iteration of probing (i.e. the first Check call), we populate
+// the following:
+// -    ToCheck = [0, 1, 2]
+// -  ToCheckID = [1, 1, 1].
+// which means that for each probing tuple we have a hash match, and it's the
+// zeroth build tuple. Check function finds that only the first probing tuple -1
+// matches with the zeroth build tuple, so we end up with the following:
+// -    differs = [true, false, true]
+// -  HeadID[1] = 1.
+// However, since we're selecting the "same" tuples (i.e. populating the Same
+// slice), we actually want to continue probing the first tuple from the batch
+// for more matches, so we still include it into the ToCheck Slice and do:
+//
+//	Visited[1] = true.
+//
+// Then we proceed to the second iteration of probing with all tuples still
+// included:
+// -    ToCheck = [0, 1, 2]
+// -  ToCheckID = [4, 4, 4].
+// Check function again finds that only the first probing tuple matches with the
+// "candidate", so we end up with the following:
+// -    differs = [true, false, true].
+// Again, since we want to find all "same" tuples, we find that build tuples
+// with firstID=1 and keyID=4 are the same, so we do
+// -    Same[1] = 4
+// - Visited[4] = true.
+//
+// On the third iteration, we're still checking all the probing tuples:
+// -    ToCheck = [0, 1, 2]
+// -  ToCheckID = [5, 5, 5].
+// This time the Check function finds that the zeroth probing tuple has a match:
+// -    differs = [false, true, true]
+// -  HeadID[0] = 5
+// - Visited[5] = true.
+//
+// On the fourth iteration, we're still checking all the probing tuples:
+// -    ToCheck = [0, 1, 2]
+// -  ToCheckID = [7, 7, 7].
+// The Check function finds that the first probing tuple has a match:
+// -    differs = [true, false, true].
+// We have firstID = 1 and keyID = 7 and do:
+// -    Same[7] = Same[1] = 4
+// -    Same[1] = 7
+// - Visited[7] = true.
+//
+// On the fifth iteration, we're still checking all the probing tuples:
+// -    ToCheck = [0, 1, 2]
+// -  ToCheckID = [8, 8, 8].
+// The Check function finds that the zeroth probing tuple has a match:
+// -    differs = [false, true, true].
+// We have firstID = 5 and keyID = 8 and do:
+// -    Same[5] = 8
+// - Visited[8] = true.
+//
+// At this point, after five Check calls, there are no more "candidates" for any
+// probing tuples (since we reached the end of the hash chain for each probing
+// tuple), and the hash joiner will proceed to collecting the matches. Let's
+// summarize the current state of things:
+// - BuildScratch.First = [2, 1]
+// - BuildScratch.Next  = [x, 4, 3, 6, 5, 7, 0, 8, 0]    ('x' means reserved)
+// -              Same  = [x, 7, 0, 0, 0, 8, 0, 4, 0]
+// -            Visited = [t, t, f, f, t, t, f, t, t]    ('f' means false, 't' means true)
+// -             HeadID = [5, 1, 0].
+// What this means is that the zeroth probing tuple -3 has an equality match
+// with (HeadID[0] = 5) the fourth build tuple -3 as well as (Same[5] = 8) the
+// seventh build tuple -3; the first probing tuple -1 has an equality match with
+// build tuples with keyIDs HeadID[1] = 1, Same[1] = 7, Same[7] = 4 (i.e. the
+// zeroth, the sixth, and the third build tuples with value -1); and the second
+// probing tuple -5 doesn't have any matches.
+//
+// Now let's quickly go through the second probing batch from the left source
+// that has values [-1, -2, -3].
+//
+// On the first Check call we have:
+// -    ToCheck = [0, 1, 2]
+// -  ToCheckID = [1, 2, 1].
+// We find that zeroth and first probing tuple have matches, but since the build
+// tuple with keyID=1 has already been visited, we don't include it to be
+// checked again, yet keyID=2 hasn't been visited, so we still continue probing
+// the first tuple:
+// -     HeadID = [1, 2, 0]
+// -    ToCheck = [1, 2]
+// -  ToCheckID = [x, 3, 4]
+// - Visited[2] = true.
+//
+// On the second Check call we find that both probing tuples didn't get matches
+// with the candidates (i.e. they had hash collisions), so we continue probing
+// both of them:
+// -     HeadID = [1, 2, 0]
+// -    ToCheck = [1, 2]
+// -  ToCheckID = [x, 6, 5]
+// - Visited[3] = true.
+//
+// On the third Check call both tuples got matches.
+// -     HeadID = [1, 2, 5]
+// -    Same[2] = 6
+// - Visited[6] = true.
+// Both tuples are removed from the ToCheck slice because for the -2 probing
+// tuple we reached the end of the hash chain and for the -3 probing tuple we
+// found a match that has been previously visited.
+//
+// At this point, after three Check calls, there are no more "candidates" for
+// any probing tuples, and the hash joiner will proceed to collecting the
+// matches. The current state of things:
+// - BuildScratch.First = [2, 1]
+// - BuildScratch.Next  = [x, 4, 3, 6, 5, 7, 0, 8, 0]    ('x' means reserved)
+// -              Same  = [x, 7, 6, 0, 0, 8, 0, 4, 0]
+// -            Visited = [t, t, t, t, t, t, t, t, t]    ('t' means true)
+// -             HeadID = [1, 2, 5].
+// This means that the zeroth probing tuple -1 has equality matches with keyIDs
+// 1, 7, 4; the first probing tuple -2 with keyIDs 2, 6; the second probing
+// tuple -3 with keyIDs 5, 8.
+//
+// We also have fully visited all tuples in the hash table, so all future
+// probing batches will be handled more efficiently (namely, once we find a
+// match, we stop probing for the corresponding tuple).
 func (ht *HashTable) Check(nToCheck uint64, probeSel []int) uint64 {
 	ht.checkCols(ht.Keys, nToCheck, probeSel)
 	nDiffers := uint64(0)

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -541,56 +541,47 @@ func (hj *hashJoiner) exec() coldata.Batch {
 		hj.ht.ComputeBuckets(hj.probeState.buckets, hj.ht.Keys, batchSize, sel)
 
 		// Then, we initialize ToCheckID with the initial hash buckets and
-		// ToCheck with all applicable indices.
-		hj.ht.ProbeScratch.SetupLimitedSlices(batchSize, hj.ht.BuildMode)
+		// ToCheck with all applicable indices. Notably, only probing tuples
+		// that have hash matches are included into ToCheck whereas ToCheckID is
+		// correctly set for all tuples.
+		hj.ht.ProbeScratch.SetupLimitedSlices(batchSize)
 		// Early bounds checks.
 		toCheckIDs := hj.ht.ProbeScratch.ToCheckID
 		_ = toCheckIDs[batchSize-1]
 		var nToCheck uint64
-		switch hj.spec.JoinType {
-		case descpb.LeftAntiJoin, descpb.RightAntiJoin, descpb.ExceptAllJoin:
-			// The setup of probing for LEFT/RIGHT ANTI and EXCEPT ALL joins
-			// needs a special treatment in order to reuse the same "check"
-			// functions below.
-			for i, bucket := range hj.probeState.buckets[:batchSize] {
-				f := hj.ht.BuildScratch.First[bucket]
-				//gcassert:bce
-				toCheckIDs[i] = f
-				if hj.ht.BuildScratch.First[bucket] != 0 {
-					// Non-zero "first" key indicates that there is a match of hashes
-					// and we need to include the current tuple to check whether it is
-					// an actual match.
-					hj.ht.ProbeScratch.ToCheck[nToCheck] = uint64(i)
-					nToCheck++
-				}
+		for i, bucket := range hj.probeState.buckets[:batchSize] {
+			f := hj.ht.BuildScratch.First[bucket]
+			//gcassert:bce
+			toCheckIDs[i] = f
+			if f != 0 {
+				// Non-zero "first" key indicates that there is a match of
+				// hashes, and we need to include the current tuple to check
+				// whether it is an actual match.
+				hj.ht.ProbeScratch.ToCheck[nToCheck] = uint64(i)
+				nToCheck++
 			}
-		default:
-			for i, bucket := range hj.probeState.buckets[:batchSize] {
-				f := hj.ht.BuildScratch.First[bucket]
-				//gcassert:bce
-				toCheckIDs[i] = f
-			}
-			copy(hj.ht.ProbeScratch.ToCheck, colexechash.HashTableInitialToCheck[:batchSize])
-			nToCheck = uint64(batchSize)
 		}
 
-		// Now we collect all matches that we can emit in the probing phase
-		// in a single batch.
 		hj.prepareForCollecting(batchSize)
-
 		checker, collector := hj.ht.Check, hj.collect
 		if hj.spec.rightDistinct {
 			checker, collector = hj.ht.DistinctCheck, hj.distinctCollect
 		}
 
+		// Now we find equality matches for all probing tuples.
 		for nToCheck > 0 {
 			// Continue searching for the build table matching keys while the
 			// ToCheck array is non-empty.
 			nToCheck = checker(nToCheck, sel)
-			// TODO(yuzefovich): check whether we can omit the 'toCheck'
-			// tuple if the new ToCheckID is 0.
-			for _, toCheck := range hj.ht.ProbeScratch.ToCheck[:nToCheck] {
-				hj.ht.ProbeScratch.ToCheckID[toCheck] = hj.ht.BuildScratch.Next[hj.ht.ProbeScratch.ToCheckID[toCheck]]
+			toCheckSlice := hj.ht.ProbeScratch.ToCheck[:nToCheck]
+			nToCheck = 0
+			for _, toCheck := range toCheckSlice {
+				nextID := hj.ht.BuildScratch.Next[hj.ht.ProbeScratch.ToCheckID[toCheck]]
+				toCheckIDs[toCheck] = nextID
+				if nextID != 0 {
+					hj.ht.ProbeScratch.ToCheck[nToCheck] = toCheck
+					nToCheck++
+				}
 			}
 		}
 
@@ -598,6 +589,8 @@ func (hj *hashJoiner) exec() coldata.Batch {
 		// collecting from.
 		hj.probeState.prevBatchResumeIdx = 0
 
+		// Finally, we collect all matches that we can emit in the probing phase
+		// in a single batch.
 		nResults := collector(batch, batchSize, sel)
 		if nResults > 0 {
 			hj.congregate(nResults, batch)


### PR DESCRIPTION
This PR contains several commits that improve the hash joiner probing. The last commit contains an extensive comment about how different pieces used throughout the probing phase fit together. Overall, this PR improves the speed of the hash join by up to 30% with minor slowdowns in some cases in the microbenchmarks; there appear to be some minor changes for the hash aggregator and the unordered distinct, full colexec benchmarks are [here](https://gist.github.com/yuzefovich/0834cf0477abbd9b9ba0189970d15338).

Impact of the PR on TPCH queries (averaged over 100 runs of `tpchvec/perf`):
```
Q1:	before: 4.08s	after: 4.03s	 -1.14%
Q2:	before: 3.08s	after: 3.04s	 -1.27%
Q3:	before: 2.52s	after: 2.45s	 -2.80%
Q4:	before: 1.90s	after: 1.83s	 -3.59%
Q5:	before: 2.58s	after: 2.41s	 -6.30%
Q6:	before: 6.63s	after: 6.60s	 -0.54%
Q7:	before: 6.34s	after: 6.24s	 -1.56%
Q8:	before: 1.20s	after: 1.17s	 -2.85%
Q9:	before: 5.60s	after: 5.70s	 1.88%
Q10:	before: 2.27s	after: 2.15s	 -5.61%
Q11:	before: 0.69s	after: 0.68s	 -0.71%
Q12:	before: 7.13s	after: 7.07s	 -0.74%
Q13:	before: 1.26s	after: 1.26s	 -0.10%
Q14:	before: 0.68s	after: 0.66s	 -1.89%
Q15:	before: 3.83s	after: 3.82s	 -0.47%
Q16:	before: 0.93s	after: 0.91s	 -2.12%
Q17:	before: 0.27s	after: 0.27s	 -0.18%
Q18:	before: 2.45s	after: 2.48s	 1.11%
Q19:	before: 0.55s	after: 0.54s	 -1.15%
Q20:	before: 11.65s	after: 11.73s	 0.67%
Q21:	before: 7.22s	after: 7.13s	 -1.21%
Q22:	before: 0.61s	after: 0.59s	 -2.56%
```

Epic: None