### PR TITLE
kv: revive TestLostIncrement and TestLostUpdate

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -2848,7 +2848,7 @@ func TestTxnSetIsoLevel(t *testing.T) {
 	txn := kv.NewTxn(ctx, s.DB, 0 /* gatewayNodeID */)
 
 	defaultLevel := isolation.Serializable
-	levels := []isolation.Level{isolation.ReadCommitted, isolation.Snapshot, isolation.Serializable}
+	levels := isolation.Levels()
 
 	// The default isolation level is Serializable.
 	require.Equal(t, defaultLevel, txn.IsoLevel())

--- a/pkg/kv/kvserver/concurrency/isolation/levels.go
+++ b/pkg/kv/kvserver/concurrency/isolation/levels.go
@@ -46,3 +46,7 @@ func (l Level) PerStatementReadSnapshot() bool {
 
 // SafeValue implements the redact.SafeValue interface.
 func (Level) SafeValue() {}
+
+// Levels returns a list of all isolation levels, ordered from strongest to
+// weakest.
+func Levels() []Level { return []Level{Serializable, Snapshot, ReadCommitted} }


### PR DESCRIPTION
Informs #100131.

This commit revives and modernizes two tests that were removed/stripped down when snapshot isolation was previously deleted. It then expands the tests to exercise all isolation levels.

Release note: None