### PR TITLE
ugpradeccl: fix and unskip `TestTenantUpgradeFailure`

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/BUILD.bazel
@@ -24,7 +24,6 @@ go_test(
         "//pkg/sql/sqlinstance/instancestorage",
         "//pkg/sql/sqlliveness/slinstance",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/upgrade",

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance/instancestorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
@@ -195,7 +194,6 @@ func v0v1v2() (roachpb.Version, roachpb.Version, roachpb.Version) {
 // between version upgrades.
 func TestTenantUpgradeFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 98555, "flaky test")
 	defer log.Scope(t).Close(t)
 	// Contains information for starting a tenant
 	// and maintaining a stopper.
@@ -203,7 +201,19 @@ func TestTenantUpgradeFailure(t *testing.T) {
 		v2onMigrationStopper *stop.Stopper
 		tenantArgs           *base.TestTenantArgs
 	}
-	v0, v1, v2 := v0v1v2()
+	v0 := clusterversion.TestingBinaryMinSupportedVersion
+	v2 := clusterversion.TestingBinaryVersion
+	// v1 needs to be between v0 and v2. Set it to the minor release
+	// after v0 and before v2.
+	var v1 roachpb.Version
+	for _, version := range clusterversion.ListBetween(v0, v2) {
+		if version.Minor != v0.Minor {
+			v1 = version
+			break
+		}
+	}
+	require.NotEqual(t, v1, roachpb.Version{})
+
 	ctx := context.Background()
 	settings := cluster.MakeTestingClusterSettingsWithVersions(
 		v2,
@@ -249,7 +259,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 		// Shorten the reclaim loop so that terminated SQL servers don't block
 		// the upgrade from succeeding.
 		instancestorage.ReclaimLoopInterval.Override(ctx, &settings.SV, 250*time.Millisecond)
-		slinstance.DefaultTTL.Override(ctx, &settings.SV, 3*time.Second)
+		slinstance.DefaultTTL.Override(ctx, &settings.SV, 15*time.Second)
 		slinstance.DefaultHeartBeat.Override(ctx, &settings.SV, 500*time.Millisecond)
 		v2onMigrationStopper := stop.NewStopper()
 		// Initialize the version to the minimum it could be.
@@ -267,9 +277,6 @@ func TestTenantUpgradeFailure(t *testing.T) {
 				},
 				UpgradeManager: &upgradebase.TestingKnobs{
 					DontUseJobs: true,
-					ListBetweenOverride: func(from, to roachpb.Version) []roachpb.Version {
-						return []roachpb.Version{v1, v2}
-					},
 					RegistryOverride: func(v roachpb.Version) (upgradebase.Upgrade, bool) {
 						switch v {
 						case v1:
@@ -292,7 +299,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 									return nil
 								}), true
 						default:
-							panic("Unexpected version number observed.")
+							return nil, false
 						}
 					},
 				},


### PR DESCRIPTION
The code change unskips `TestTenantUpgradeFailure` after making the following changes to fix it:
1. Bump `slinstance.DefaultTTL.Override` from 3s to 15s
2. Ensure v2 isn't higher than `TestingBinaryVersion`

It also updates the registry override to let the test run all migrations.

Release note: None
Epic: none

Closes #98555