### PR TITLE
server: fix proper call for StartHotRangesLoggingScheduler

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -103,7 +103,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/goschedstats"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
@@ -2055,8 +2054,14 @@ func (s *Server) AcceptClients(ctx context.Context) error {
 		return err
 	}
 
-	if logcrash.DiagnosticsReportingEnabled.Get(&s.ClusterSettings().SV) {
-		structlogging.StartHotRangesLoggingScheduler(ctx, s.stopper, s.status, *s.sqlServer.internalExecutor, s.ClusterSettings())
+	if err := structlogging.StartHotRangesLoggingScheduler(
+		ctx,
+		s.stopper,
+		s.status,
+		*s.sqlServer.internalExecutor,
+		s.ClusterSettings(),
+	); err != nil {
+		return err
 	}
 
 	s.sqlServer.isReady.Set(true)

--- a/pkg/server/structlogging/BUILD.bazel
+++ b/pkg/server/structlogging/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/sql",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
+        "//pkg/util/log/logcrash",
         "//pkg/util/log/logpb",
         "//pkg/util/log/logutil",
         "//pkg/util/stop",

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -65,7 +65,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/schedulerlatency"
@@ -849,8 +848,14 @@ func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
 		}
 	}
 
-	if logcrash.DiagnosticsReportingEnabled.Get(&s.ClusterSettings().SV) {
-		structlogging.StartHotRangesLoggingScheduler(ctx, s.stopper, s.sqlServer.tenantConnect, *s.sqlServer.internalExecutor, s.ClusterSettings())
+	if err := structlogging.StartHotRangesLoggingScheduler(
+		ctx,
+		s.stopper,
+		s.sqlServer.tenantConnect,
+		*s.sqlServer.internalExecutor,
+		s.ClusterSettings(),
+	); err != nil {
+		return err
 	}
 
 	s.sqlServer.isReady.Set(true)


### PR DESCRIPTION
This patch fixes an issue when `structlogging.StartHotRangesLoggingScheduler` is guarded by `DiagnosticsReportingEnabled` cluster setting and doesn't properly handles changes of this setting.
Now, when diagnostics reporting is enabled via cluster setting, Hot range logging scheduler starts (if not started yet), and cancels previously started scheduler if setting is disabled.

Release note: None

Resolves: #101933

TODO: Manually backport to `23.1.x` with https://github.com/cockroachdb/cockroach/pull/101927