### PR TITLE
colexec: improve hash joiner benchmarks

### DIFF
--- a/pkg/sql/colexec/crossjoiner_test.go
+++ b/pkg/sql/colexec/crossjoiner_test.go
@@ -439,7 +439,7 @@ func BenchmarkCrossJoiner(b *testing.B) {
 		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
 		for _, joinType := range []descpb.JoinType{descpb.InnerJoin, descpb.LeftSemiJoin} {
 			for _, nRows := range []int{1, 1 << 4, 1 << 8, 1 << 11, 1 << 13} {
-				cols := newIntColumns(nCols, nRows)
+				cols := newIntColumns(nCols, nRows, 1 /* dupCount */)
 				tc := &joinTestCase{
 					joinType:   joinType,
 					leftTypes:  sourceTypes,

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -173,15 +173,32 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 	require.Equal(t, 0, sem.GetCount())
 }
 
-// newIntColumns returns nCols columns of types.Int with increasing values
-// starting at 0.
-func newIntColumns(nCols int, length int) []coldata.Vec {
+// newIntColumns returns nCols columns of types.Int with non-decreasing values
+// starting at 0. dupCount controls the number of duplicates for each row
+// (including the row itself), use dupCount=1 for distinct tuples.
+func newIntColumns(nCols int, length int, dupCount int) []coldata.Vec {
 	cols := make([]coldata.Vec, nCols)
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		cols[colIdx] = testAllocator.NewMemColumn(types.Int, length)
 		col := cols[colIdx].Int64()
 		for i := 0; i < length; i++ {
-			col[i] = int64(i)
+			col[i] = int64(i / dupCount)
+		}
+	}
+	return cols
+}
+
+// newBytesColumns returns nCols columns of types.Bytes with non-decreasing
+// values of 8 byte size, starting at '00000000'. dupCount controls the number
+// of duplicates for each row (including the row itself), use dupCount=1 for
+// distinct tuples.
+func newBytesColumns(nCols int, length int, dupCount int) []coldata.Vec {
+	cols := make([]coldata.Vec, nCols)
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		cols[colIdx] = testAllocator.NewMemColumn(types.Bytes, length)
+		col := cols[colIdx].Bytes()
+		for i := 0; i < length; i++ {
+			col.Set(i, []byte(fmt.Sprintf("%08d", i/dupCount)))
 		}
 	}
 	return cols
@@ -201,59 +218,66 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 		},
 		DiskMonitor: testDiskMonitor,
 	}
-	nCols := 4
-	sourceTypes := make([]*types.T, nCols)
-	for colIdx := 0; colIdx < nCols; colIdx++ {
-		sourceTypes[colIdx] = types.Int
-	}
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
 	defer cleanup()
 	var monitorRegistry colexecargs.MonitorRegistry
 	defer monitorRegistry.Close(ctx)
 
-	for _, spillForced := range []bool{false, true} {
-		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
-		for _, nRows := range []int{1, 1 << 4, 1 << 8, 1 << 12, 1 << 16, 1 << 20} {
-			if spillForced && nRows < coldata.BatchSize() {
-				// Forcing spilling to disk on very small input size doesn't
-				// provide a meaningful signal, so we skip such config.
-				continue
-			}
-			cols := newIntColumns(nCols, nRows)
-			for _, fullOuter := range []bool{false, true} {
-				joinType := descpb.InnerJoin
-				if fullOuter {
-					joinType = descpb.FullOuterJoin
+	nCols := 4
+	for _, typ := range []*types.T{types.Int, types.Bytes} {
+		sourceTypes := make([]*types.T, nCols)
+		for colIdx := 0; colIdx < nCols; colIdx++ {
+			sourceTypes[colIdx] = typ
+		}
+		for _, spillForced := range []bool{false, true} {
+			flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
+			for _, nRows := range []int{1, 1 << 4, 1 << 8, 1 << 12, 1 << 16, 1 << 20} {
+				if spillForced && nRows < coldata.BatchSize() {
+					// Forcing spilling to disk on very small input size doesn't
+					// provide a meaningful signal, so we skip such config.
+					continue
 				}
-				tc := &joinTestCase{
-					joinType:     joinType,
-					leftTypes:    sourceTypes,
-					leftOutCols:  []uint32{0, 1},
-					leftEqCols:   []uint32{0, 2},
-					rightTypes:   sourceTypes,
-					rightOutCols: []uint32{2, 3},
-					rightEqCols:  []uint32{0, 1},
+				var cols []coldata.Vec
+				if typ == types.Int {
+					cols = newIntColumns(nCols, nRows, 1 /* dupCount */)
+				} else {
+					cols = newBytesColumns(nCols, nRows, 1 /* dupCount */)
 				}
-				tc.init()
-				spec := createSpecForHashJoiner(tc)
-				b.Run(fmt.Sprintf("spillForced=%t/rows=%d/fullOuter=%t", spillForced, nRows, fullOuter), func(b *testing.B) {
-					b.SetBytes(int64(8 * nRows * nCols * 2))
-					b.ResetTimer()
-					for i := 0; i < b.N; i++ {
-						leftSource := colexectestutils.NewChunkingBatchSource(testAllocator, sourceTypes, cols, nRows)
-						rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, sourceTypes, cols, nRows)
-						hj, _, err := createDiskBackedHashJoiner(
-							ctx, flowCtx, spec, []colexecop.Operator{leftSource, rightSource},
-							func() {}, queueCfg, 0 /* numForcedRepartitions */, false, /* delegateFDAcquisitions */
-							colexecop.NewTestingSemaphore(VecMaxOpenFDsLimit), &monitorRegistry,
-						)
-						require.NoError(b, err)
-						hj.Init(ctx)
-						for b := hj.Next(); b.Length() > 0; b = hj.Next() {
-						}
+				for _, fullOuter := range []bool{false, true} {
+					joinType := descpb.InnerJoin
+					if fullOuter {
+						joinType = descpb.FullOuterJoin
 					}
-				})
+					tc := &joinTestCase{
+						joinType:     joinType,
+						leftTypes:    sourceTypes,
+						leftOutCols:  []uint32{0, 1},
+						leftEqCols:   []uint32{0, 2},
+						rightTypes:   sourceTypes,
+						rightOutCols: []uint32{2, 3},
+						rightEqCols:  []uint32{0, 1},
+					}
+					tc.init()
+					spec := createSpecForHashJoiner(tc)
+					b.Run(fmt.Sprintf("%s/spillForced=%t/rows=%d/fullOuter=%t", typ, spillForced, nRows, fullOuter), func(b *testing.B) {
+						b.SetBytes(int64(8 * nRows * nCols * 2))
+						b.ResetTimer()
+						for i := 0; i < b.N; i++ {
+							leftSource := colexectestutils.NewChunkingBatchSource(testAllocator, sourceTypes, cols, nRows)
+							rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, sourceTypes, cols, nRows)
+							hj, _, err := createDiskBackedHashJoiner(
+								ctx, flowCtx, spec, []colexecop.Operator{leftSource, rightSource},
+								func() {}, queueCfg, 0 /* numForcedRepartitions */, false, /* delegateFDAcquisitions */
+								colexecop.NewTestingSemaphore(VecMaxOpenFDsLimit), &monitorRegistry,
+							)
+							require.NoError(b, err)
+							hj.Init(ctx)
+							for b := hj.Next(); b.Length() > 0; b = hj.Next() {
+							}
+						}
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This commit improves the hash joiner benchmarks in the following manner:
- it adds BYTES type (previously, we only used INT)
- it fully exhausts the hash joiner (previously, we would stop at an
arbitrary point, as if the query had a LIMIT; this could actually hide
some aspects of the performance - when Same slice is fully built)
- it makes it so that the data in `rightDistinct=true` scenario is
actually distinct
- it removes `fullOuter` dimension while only keeping the inner join
(this dimension doesn't seem that useful, relatively speaking)
- it adds another dimension for the number of equality columns
(previously, we would only run with 2 eq cols, now we run with 1 and 3)
- it adjusts `nulls=true` case to use NULL values randomly with 10%
probability (rather than only setting the first tuple to be all NULLs)
- it introduces another `leftDistinct` dimension.

Probably the biggest change is how the input tuples are populated.
Previously, we created a single batch with 1024 different rows, and that
batch would be repeated certain number of times on both sides. This
doesn't matter that much for the right source (because there we simply
buffer all tuples anyway), but it's not really reasonable for the left
source - every probing batch is the duplicate of the first batch. This
commit changes that so that we generate a set of tuples of the target
length in the ordered fashion, then shuffle the set, and chunk it up
into separate batches. This is likely to be a better approximation of
the production data sets - each probing batch might now have some new
tuples never seen previously.

All of these changes make the benchmark not comparable to before this
commit, so this commit will be backported to 23.1.

Epic: None

Release note: None