### PR TITLE
tree: fix type checking of IN subquery expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -447,7 +447,7 @@ SELECT (1, NULL) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 ----
 NULL
 
-query error unsupported comparison operator: <unknown> IN <tuple{tuple{int AS a, int AS b}}>
+query error subquery has too many columns
 SELECT NULL IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b));
 
 query error unsupported comparison operator: <tuple> IN <tuple{int}>
@@ -459,7 +459,7 @@ SELECT () IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 query error unsupported comparison operator: <tuple{string, unknown}> IN <tuple{tuple{int AS a, int AS b}}>
 SELECT ('string', NULL) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 
-query error unsupported comparison operator: <tuple{int, string, unknown}> IN <tuple{tuple{int AS a, int AS b}}>
+query error subquery has too few columns
 SELECT (2, 'string', NULL) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 
 query B
@@ -487,7 +487,7 @@ SELECT NULL NOT IN (SELECT * FROM (VALUES (1)) AS t(a))
 ----
 NULL
 
-query error unsupported comparison operator: <unknown> IN <tuple{tuple{int AS a, int AS b}}>
+query error subquery has too many columns
 SELECT NULL NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 
 query error unsupported comparison operator: <tuple> IN <tuple{int}>
@@ -499,7 +499,7 @@ SELECT () NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 query error unsupported comparison operator: <tuple{string, unknown}> IN <tuple{tuple{int AS a, int AS b}}>
 SELECT ('string', NULL) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 
-query error unsupported comparison operator: <tuple{int, string, unknown}> IN <tuple{tuple{int AS a, int AS b}}>
+query error subquery has too few columns
 SELECT (2, 'string', NULL) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 
 query B

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -143,10 +143,12 @@ true
 query error pgcode 42601 subquery must return only one column, found 2
 SELECT (SELECT 1, 2)
 
-query error unsupported comparison operator: <int> IN <tuple{tuple{int AS a, int AS b}}>
+# Outer query has 1 column, subquery has 2.
+query error pgcode 42601 subquery has too many columns
 SELECT 1 IN (SELECT 1 AS a, 2 AS b)
 
-query error unsupported comparison operator: <tuple{int, int}> IN <tuple{int}>
+# Outer query has 2 columns, subquery has 1.
+query error pgcode 42601 subquery has too few columns
 SELECT (1, 2) IN (SELECT 1 AS a)
 
 statement ok
@@ -162,7 +164,8 @@ INSERT INTO abc VALUES (1, 2, 3), (4, 5, 6)
 # statement ok
 # ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
 
-query error unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int AS a, int AS b, int AS c}}>
+# Outer query has 2 columns, subquery has 3.
+query error pgcode 42601 subquery has too many columns
 SELECT (1, 2) IN (SELECT * FROM abc)
 
 query B
@@ -897,3 +900,72 @@ query B
 select lower((select session_id from [show session_id])) = lower('$session_id')
 ----
 true
+
+subtest expressionInSubquery
+
+statement ok
+CREATE TABLE xy (x INT, y INT);
+
+statement ok
+CREATE TABLE ab (a INT, b INT);
+
+statement ok
+INSERT INTO xy VALUES (1,1), (2,2); INSERT INTO ab VALUES (2,2);
+
+# The outer (a, b) is already a tuple, so shouldn't be wrapped in another
+# tuple before comparison. This should succeed.
+query II
+SELECT * FROM ab WHERE (a, b) IN (SELECT x+1, y+1 FROM xy);
+----
+2  2
+
+# The outer ROW(ROW(a, b)) is already a tuple, so shouldn't be wrapped in
+# another tuple before comparison. But the comparison should fail due to
+# mismatched types.
+query error pgcode 22023 unsupported binary operator: <int> \+ <int> \(desired <tuple\{int, int\}>\)
+SELECT * FROM ab WHERE ROW(ROW(a, b)) IN (SELECT x+1 FROM xy);
+
+# The outer ROW(ROW(a, b)) is already a tuple, so shouldn't be wrapped in
+# another tuple before comparison. But the comparison should fail due to
+# mismatched types. Could this case possibly be supported?
+query error pgcode 22023 unsupported comparison operator: <tuple\{tuple\{int, int\}\}> IN <tuple\{tuple\{int, int\}\}>
+SELECT * FROM ab WHERE ROW(ROW(a, b)) IN (SELECT (x, y) FROM xy);
+
+# A similar case to the previous one, but this time matching on 2 tuple
+# expressions works.
+query II
+SELECT * FROM ab WHERE ((a,b), (1, 1)) IN (SELECT (x+1, y+1), (x, y) FROM xy)
+----
+2  2
+
+# Verify the above case with a single tuple comparison also works.
+query II
+SELECT * FROM ab WHERE ((a,b)) IN (SELECT (x+1, y+1) FROM xy)
+----
+2  2
+
+# The outer (2, 2) is already a tuple, so shouldn't be wrapped in another
+# tuple before comparison. This should succeed.
+query B
+SELECT (SELECT 2, 2) IN (SELECT x+1, y+1 FROM xy)
+----
+true
+
+query B
+SELECT (2, 2) IN (SELECT x+1, y+1 FROM xy)
+----
+true
+
+# The outer ((2, 2), (3, 3)) is already a tuple, so shouldn't be wrapped in
+# another tuple before comparison. But the comparison should fail due to
+# mismatched types.
+query error pgcode 22023 unsupported binary operator: <int> \+ <int> \(desired \<tuple\{int\, int\}>\)
+SELECT (SELECT (2, 2), (3, 3)) IN (SELECT x+1, y+1 FROM xy)
+
+# Outer scalar is a tuple with 2 elements. Subquery has only 1 column.
+query error pgcode 42601 subquery has too few columns
+SELECT (SELECT 2, 2) IN (SELECT x+1 FROM xy)
+
+# Outer scalar is a tuple with 2 elements. Subquery has 3 columns.
+query error pgcode 42601 subquery has too many columns
+SELECT (SELECT 2, 2) IN (SELECT x+1, y+1, x+y FROM xy)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -563,3 +563,108 @@ statement error could not decorrelate subquery
 SELECT
   CASE WHEN k < 5 THEN (SELECT array(SELECT 1) FROM corr tmp WHERE k*10 = corr.k) END
 FROM corr
+
+subtest expressionInSubquery
+
+statement ok
+CREATE TABLE xy (x INT, y INT);
+
+statement ok
+CREATE TABLE ab (a INT, b INT);
+
+# The outer (a, b) is already a tuple, so shouldn't be wrapped in another
+# tuple before comparison.
+query T
+SELECT * FROM [EXPLAIN (VERBOSE)
+SELECT * FROM ab WHERE (a, b) IN (SELECT x+1, y+1 FROM xy)] OFFSET 2;
+----
+·
+• hash join (semi)
+│ columns: (a, b)
+│ estimated row count: 1,000 (missing stats)
+│ equality: (a, b) = (column14, column15)
+│
+├── • scan
+│     columns: (a, b)
+│     estimated row count: 1,000 (missing stats)
+│     table: ab@ab_pkey
+│     spans: FULL SCAN
+│
+└── • render
+    │ columns: (column15, column14)
+    │ render column15: y + 1
+    │ render column14: x + 1
+    │
+    └── • scan
+          columns: (x, y)
+          estimated row count: 1,000 (missing stats)
+          table: xy@xy_pkey
+          spans: FULL SCAN
+
+# The outer (2, 2) is already a tuple, so shouldn't be wrapped in another
+# tuple before comparison.
+query T
+SELECT * FROM [EXPLAIN (VERBOSE)
+SELECT (SELECT 2, 2) IN (SELECT x+1, y+1 FROM xy)] OFFSET 2
+----
+·
+• root
+│ columns: ("?column?")
+│
+├── • values
+│     columns: ("?column?")
+│     size: 1 column, 1 row
+│     row 0, expr 0: @S2 = ANY @S1
+│
+├── • subquery
+│   │ id: @S1
+│   │ original sql: (SELECT x + 1, y + 1 FROM xy)
+│   │ exec mode: any rows
+│   │
+│   └── • render
+│       │ columns: (column9)
+│       │ render column9: (x + 1, y + 1)
+│       │
+│       └── • scan
+│             columns: (x, y)
+│             estimated row count: 1,000 (missing stats)
+│             table: xy@xy_pkey
+│             spans: FULL SCAN
+│
+└── • subquery
+    │ id: @S2
+    │ original sql: (SELECT 2, 2)
+    │ exec mode: one row
+    │
+    └── • values
+          columns: (column10)
+          size: 1 column, 1 row
+          row 0, expr 0: (2, 2)
+
+query T
+SELECT * FROM [EXPLAIN (VERBOSE)
+SELECT (2, 2) IN (SELECT x+1, y+1 FROM xy)] OFFSET 2
+----
+·
+• root
+│ columns: ("?column?")
+│
+├── • values
+│     columns: ("?column?")
+│     size: 1 column, 1 row
+│     row 0, expr 0: (2, 2) = ANY @S1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT x + 1, y + 1 FROM xy)
+    │ exec mode: any rows
+    │
+    └── • render
+        │ columns: (column8)
+        │ render column8: (x + 1, y + 1)
+        │
+        └── • scan
+              columns: (x, y)
+              estimated row count: 1,000 (missing stats)
+              table: xy@xy_pkey
+              spans: FULL SCAN

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -566,24 +566,27 @@ SELECT (SELECT 1 AS a, 2 AS b) AS r
 ----
 error (42601): subquery must return only one column, found 2
 
+# Return the same error as Postgres.
 build
 SELECT 1 IN (SELECT 1 AS a, 2 AS b) AS r
 ----
-error (22023): unsupported comparison operator: <int> IN <tuple{tuple{int AS a, int AS b}}>
+error (42601): subquery has too many columns
 
+# Return the same error as Postgres.
 build
 SELECT (1, 2) IN (SELECT 1 AS a) AS r
 ----
-error (22023): unsupported comparison operator: <tuple{int, int}> IN <tuple{int}>
+error (42601): subquery has too few columns
 
 exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 ----
 
+# Return the same error as Postgres.
 build
 SELECT (1, 2) IN (SELECT * FROM abc) AS r
 ----
-error (22023): unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int AS a, int AS b, int AS c}}>
+error (42601): subquery has too many columns
 
 build
 SELECT (1, 2) IN (SELECT a, b FROM abc) AS r
@@ -2317,3 +2320,93 @@ scalar-group-by
  └── aggregations
       └── count [as=count:7]
            └── column6:6
+
+exec-ddl
+CREATE TABLE xy (x INT, y INT)
+----
+
+exec-ddl
+CREATE TABLE ab (a INT, b INT)
+----
+
+build
+SELECT * FROM ab WHERE (a, b) IN (SELECT x+1, y+1 FROM xy)
+----
+project
+ ├── columns: a:1 b:2
+ └── select
+      ├── columns: a:1 b:2 ab.rowid:3!null ab.crdb_internal_mvcc_timestamp:4 ab.tableoid:5
+      ├── scan ab
+      │    └── columns: a:1 b:2 ab.rowid:3!null ab.crdb_internal_mvcc_timestamp:4 ab.tableoid:5
+      └── filters
+           └── any: eq
+                ├── project
+                │    ├── columns: column13:13
+                │    ├── project
+                │    │    ├── columns: "?column?":11 "?column?":12
+                │    │    ├── scan xy
+                │    │    │    └── columns: x:6 y:7 xy.rowid:8!null xy.crdb_internal_mvcc_timestamp:9 xy.tableoid:10
+                │    │    └── projections
+                │    │         ├── x:6 + 1 [as="?column?":11]
+                │    │         └── y:7 + 1 [as="?column?":12]
+                │    └── projections
+                │         └── ("?column?":11, "?column?":12) [as=column13:13]
+                └── (a:1, b:2)
+
+build
+SELECT * FROM ab WHERE ((a,b), (1, 1)) IN (SELECT (x+1, y+1), (x, y) FROM xy)
+----
+project
+ ├── columns: a:1 b:2
+ └── select
+      ├── columns: a:1 b:2 ab.rowid:3!null ab.crdb_internal_mvcc_timestamp:4 ab.tableoid:5
+      ├── scan ab
+      │    └── columns: a:1 b:2 ab.rowid:3!null ab.crdb_internal_mvcc_timestamp:4 ab.tableoid:5
+      └── filters
+           └── any: eq
+                ├── project
+                │    ├── columns: column13:13
+                │    ├── project
+                │    │    ├── columns: "?column?":11 "?column?":12
+                │    │    ├── scan xy
+                │    │    │    └── columns: x:6 y:7 xy.rowid:8!null xy.crdb_internal_mvcc_timestamp:9 xy.tableoid:10
+                │    │    └── projections
+                │    │         ├── (x:6 + 1, y:7 + 1) [as="?column?":11]
+                │    │         └── (x:6, y:7) [as="?column?":12]
+                │    └── projections
+                │         └── ("?column?":11, "?column?":12) [as=column13:13]
+                └── ((a:1, b:2), (1, 1))
+
+build
+SELECT (SELECT 2, 2) IN (SELECT x+1, y+1 FROM xy)
+----
+project
+ ├── columns: "?column?":11
+ ├── values
+ │    └── ()
+ └── projections
+      └── any: eq [as="?column?":11]
+           ├── project
+           │    ├── columns: column9:9
+           │    ├── project
+           │    │    ├── columns: "?column?":7 "?column?":8
+           │    │    ├── scan xy
+           │    │    │    └── columns: x:2 y:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           │    │    └── projections
+           │    │         ├── x:2 + 1 [as="?column?":7]
+           │    │         └── y:3 + 1 [as="?column?":8]
+           │    └── projections
+           │         └── ("?column?":7, "?column?":8) [as=column9:9]
+           └── subquery
+                └── max1-row
+                     ├── columns: column10:10!null
+                     └── project
+                          ├── columns: column10:10!null
+                          ├── project
+                          │    ├── columns: "?column?":1!null
+                          │    ├── values
+                          │    │    └── ()
+                          │    └── projections
+                          │         └── 2 [as="?column?":1]
+                          └── projections
+                               └── ("?column?":1, "?column?":1) [as=column10:10]

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2288,7 +2288,11 @@ func typeCheckComparisonOp(
 				pgerror.Newf(pgcode.InvalidParameterValue, unsupportedCompErrFmt, sig)
 		}
 
-		desired := types.MakeTuple([]*types.T{typ})
+		desired := typ
+		if desired.Family() != types.TupleFamily {
+			desired = types.MakeTuple([]*types.T{typ})
+		}
+
 		typedRight, err = foldedRight.TypeCheck(ctx, semaCtx, desired)
 		if err != nil {
 			sigWithErr := fmt.Sprintf(compExprsFmt, left, op, right, err)


### PR DESCRIPTION
A query of the form `SELECT * FROM ab WHERE (a, b) IN (SELECT x+1, y+1 FROM xy)`
may error out:
```
ERROR: unsupported binary operator: <int> + <int> (desired <tuple{int, int}>)
SQLSTATE: 22023
```
But similar query `SELECT * FROM ab WHERE (a, b) IN (SELECT x, y FROM xy)`
does not error out. 

In the former case, extra type checking is done, and we use the type of
the left expression as the desired type of the right expression.
However, there is a line of code to wrap the desired type in a tuple
since when type checking the right side subquery, we expect there to be
a tuple to peek into to get the desired type:
https://github.com/cockroachdb/cockroach/blob/410c3785d498dba622165f4cdc4d202a71a239f8/pkg/sql/opt/optbuilder/subquery.go#L94-L95

However, when the left is already a tuple, adding the extra tuple
layer may make it look like the desired type is tuple{tuple{int, int}},
for example, when it really should be tuple{int, int}.

The fix is to avoid wrapping the desired type in a tuple if it's already
a tuple.

Also, subquery building is updated to return error message 
`(42601): subquery has too many columns`
or
`(42601): subquery has too few columns` 
similar to Postgres, when appropriate.

Fixes: #63777

Release note (bug fix): This patch fixes handling of expressions in IN
clauses such as `(c1, c2) IN (SELECT c3+1, c4+1 FROM ...)`.
Previously such query expressions would error out during type checking.