### PR TITLE
tenantcapabilitiesauthorizer: avoid log spam

### DIFF
--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -372,6 +372,7 @@ func (a *Authorizer) getMode(
 		if reader == nil {
 			// The server has started but the reader hasn't started/bound
 			// yet. Block requests that would need specific capabilities.
+			log.Warningf(ctx, "capability check for tenant %s before capability reader exists, assuming capability is unavailable", tid)
 			selectedMode = authorizerModeV222
 		} else {
 			// We have a reader. Did we get data from the rangefeed yet?
@@ -380,7 +381,9 @@ func (a *Authorizer) getMode(
 			if !found {
 				// No data from the rangefeed yet. Assume caps are still
 				// unavailable.
-				log.Warningf(ctx, "capability check for tenant %s before capability reader exists, assuming capability is unavailable", tid.String())
+				log.VInfof(ctx, 2,
+					"no capability information for tenant %s; requests that require capabilities may be denied",
+					tid)
 				selectedMode = authorizerModeV222
 			}
 		}


### PR DESCRIPTION
One of the previous commits was misusing log.Warning where log.VEventf was expected.

Release note: None
Epic: None