### PR TITLE
release-23.1.0: kvserver: always bump epoch when acquiring expired epoch lease

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1581,4 +1583,76 @@ func TestLeaseUpgradeVersionGate(t *testing.T) {
 		return nil
 	})
 	tc.WaitForLeaseUpgrade(ctx, t, desc)
+}
+
+// TestLeaseRequestBumpsEpoch tests that a non-cooperative lease acquisition of
+// an expired epoch lease always bumps the epoch of the outgoing leaseholder,
+// regardless of the type of lease being acquired.
+func TestLeaseRequestBumpsEpoch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunTrueAndFalse(t, "expLease", func(t *testing.T, expLease bool) {
+		ctx := context.Background()
+		st := cluster.MakeTestingClusterSettings()
+		kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false)
+
+		manual := hlc.NewHybridManualClock()
+		args := base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				Settings: st,
+				Knobs: base.TestingKnobs{
+					Store: &kvserver.StoreTestingKnobs{
+						// Required by TestCluster.MoveRangeLeaseNonCooperatively.
+						AllowLeaseRequestProposalsWhenNotLeader: true,
+						DisableAutomaticLeaseRenewal:            true,
+					},
+					Server: &server.TestingKnobs{
+						WallClock: manual,
+					},
+				},
+			},
+		}
+		tc := testcluster.StartTestCluster(t, 2, args)
+		defer tc.Stopper().Stop(ctx)
+
+		// Create range and upreplicate.
+		key := tc.ScratchRange(t)
+		tc.AddVotersOrFatal(t, key, tc.Target(1))
+		desc := tc.LookupRangeOrFatal(t, key)
+
+		// Make sure n1 has an epoch lease.
+		t0 := tc.Target(0)
+		tc.TransferRangeLeaseOrFatal(t, desc, t0)
+		prevLease, _, err := tc.FindRangeLease(desc, &t0)
+		require.NoError(t, err)
+		require.Equal(t, roachpb.LeaseEpoch, prevLease.Type())
+
+		// Non-cooperatively move the lease to n2.
+		kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, expLease)
+		t1 := tc.Target(1)
+		newLease, err := tc.MoveRangeLeaseNonCooperatively(ctx, desc, t1, manual)
+		require.NoError(t, err)
+		require.NotNil(t, newLease)
+		if expLease {
+			require.Equal(t, roachpb.LeaseExpiration, newLease.Type())
+		} else {
+			require.Equal(t, roachpb.LeaseEpoch, newLease.Type())
+		}
+
+		// Check that n1's liveness epoch was bumped.
+		l0 := tc.Server(0).NodeLiveness().(*liveness.NodeLiveness)
+		livenesses, err := l0.GetLivenessesFromKV(ctx)
+		require.NoError(t, err)
+		var liveness livenesspb.Liveness
+		for _, l := range livenesses {
+			if l.NodeID == 1 {
+				liveness = l
+				break
+			}
+		}
+		require.NotZero(t, liveness)
+		require.Greater(t, liveness.Epoch, prevLease.Epoch)
+	})
 }

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -315,7 +315,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 		}
 	}
 
-	if err := p.requestLeaseAsync(ctx, nextLeaseHolder, reqLease, status, leaseReq); err != nil {
+	if err := p.requestLeaseAsync(ctx, nextLeaseHolder, status, leaseReq); err != nil {
 		// We failed to start the asynchronous task. Send a blank NotLeaseHolderError
 		// back to indicate that we have no idea who the range lease holder might
 		// be; we've withdrawn from active duty.
@@ -338,11 +338,10 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 // specified replica. The request is sent in an async task.
 //
 // The status argument is used as the expected value for liveness operations.
-// reqLease and leaseReq must be consistent with the LeaseStatus.
+// leaseReq must be consistent with the LeaseStatus.
 func (p *pendingLeaseRequest) requestLeaseAsync(
 	parentCtx context.Context,
 	nextLeaseHolder roachpb.ReplicaDescriptor,
-	reqLease roachpb.Lease,
 	status kvserverpb.LeaseStatus,
 	leaseReq kvpb.Request,
 ) error {
@@ -384,7 +383,7 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 		func(ctx context.Context) {
 			defer sp.Finish()
 
-			err := p.requestLease(ctx, nextLeaseHolder, reqLease, status, leaseReq)
+			err := p.requestLease(ctx, nextLeaseHolder, status, leaseReq)
 			// Error will be handled below.
 
 			// We reset our state below regardless of whether we've gotten an error or
@@ -425,16 +424,13 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 func (p *pendingLeaseRequest) requestLease(
 	ctx context.Context,
 	nextLeaseHolder roachpb.ReplicaDescriptor,
-	reqLease roachpb.Lease,
 	status kvserverpb.LeaseStatus,
 	leaseReq kvpb.Request,
 ) error {
-	// If requesting an epoch-based lease & current state is expired,
-	// potentially heartbeat our own liveness or increment epoch of
-	// prior owner. Note we only do this if the previous lease was
-	// epoch-based.
-	if reqLease.Type() == roachpb.LeaseEpoch && status.State == kvserverpb.LeaseState_EXPIRED &&
-		status.Lease.Type() == roachpb.LeaseEpoch {
+	// If we're replacing an expired epoch-based lease, we must increment the
+	// epoch of the prior owner to invalidate its leases. If we were the owner,
+	// then we instead heartbeat to become live.
+	if status.Lease.Type() == roachpb.LeaseEpoch && status.State == kvserverpb.LeaseState_EXPIRED {
 		var err error
 		// If this replica is previous & next lease holder, manually heartbeat to become live.
 		if status.OwnedBy(nextLeaseHolder.StoreID) &&


### PR DESCRIPTION
Backport 1/1 commits from #101942.

/cc @cockroachdb/release

---

Previously, a lease acquisition only bumped the epoch of an expired epoch leaseholder if the new lease was also an epoch lease. However, we have to bump the epoch regardless of the new lease type, to properly invalidate the old leaseholder's leases. This patch bumps the epoch regardless of the new lease type.

Resolves #101836.

Epic: none
Release note: None
