### PR TITLE
release-23.1.0: metric: fix race in manual histogram

### DIFF
--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -495,6 +495,8 @@ func (mwh *ManualWindowHistogram) GetType() *prometheusgo.MetricType {
 
 // ToPrometheusMetric returns a filled-in prometheus metric of the right type.
 func (mwh *ManualWindowHistogram) ToPrometheusMetric() *prometheusgo.Metric {
+	mwh.RLock()
+	defer mwh.RUnlock()
 	m := &prometheusgo.Metric{}
 	if err := mwh.cum.Write(m); err != nil {
 		panic(err)


### PR DESCRIPTION
Backport 1/1 commits from #101949.

/cc @cockroachdb/release

Release justification: Fixes data race bug for ManualWindowHistogram added in 23.1.

---

It was possible for concurrent `Update` and `ToPrometheusMetric` calls to race due to a read lock not being held when calling `ToPrometheusMetric`.

This patch adds such a lock and updates the structure to conform to the regular convention of a `mu` struct field, which indicates fields requiring a lock.

```
dev test pkg/kv/kvserver -f TestTenantRateLimiter -v --stress --race
...
288 runs so far, 0 failures, over 14m15s
```

Fixes: #101901

Release note: None
