### PR TITLE
opt: cache restricted interesting orderings

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -178,7 +178,7 @@ SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE j = 2
 query T
 EXPLAIN (OPT, MEMO) SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE j = 2 AND i = 1
 ----
-memo (optimized, ~8KB, required=[presentation: info:6] [distribution: test])
+memo (optimized, ~9KB, required=[presentation: info:6] [distribution: test])
  ├── G1: (explain G2 [presentation: i:1,j:2,k:3] [distribution: test])
  │    └── [presentation: info:6] [distribution: test]
  │         ├── best: (explain G2="[presentation: i:1,j:2,k:3] [distribution: test]" [presentation: i:1,j:2,k:3] [distribution: test])

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1565,7 +1565,6 @@ PREPARE pscs13 AS SELECT $1::bigint, 13
 query T
 SELECT name FROM pg_catalog.pg_prepared_statements ORDER BY name
 ----
-pscs08
 pscs09
 pscs10
 pscs11
@@ -1582,7 +1581,6 @@ PREPARE pscs14 AS SELECT $1::int, 14
 query T
 SELECT name FROM pg_catalog.pg_prepared_statements ORDER BY name
 ----
-pscs08
 pscs09
 pscs11
 pscs12
@@ -1608,7 +1606,6 @@ query T
 SELECT name FROM pg_catalog.pg_prepared_statements ORDER BY name
 ----
 pscs11
-pscs13
 pscs14
 pscs15
 pscs16
@@ -1628,7 +1625,7 @@ statement ok
 BEGIN;
 INSERT INTO prep_stmts SELECT 1, name FROM pg_catalog.pg_prepared_statements;
 PREPARE pscs18 AS SELECT $1::inet, 18;
-EXECUTE pscs14(14);
+EXECUTE pscs11(11);
 PREPARE pscs19 AS SELECT $1::string, 19;
 INSERT INTO prep_stmts SELECT 2, name FROM pg_catalog.pg_prepared_statements;
 SELECT IF(nextval('s') <= 3, crdb_internal.force_retry('1 hour'), 0);
@@ -1646,13 +1643,11 @@ query IT
 SELECT which, name FROM prep_stmts ORDER BY which, name
 ----
 1  pscs11
-1  pscs13
 1  pscs14
 1  pscs15
 1  pscs16
 1  pscs17
-2  pscs14
-2  pscs15
+2  pscs11
 2  pscs16
 2  pscs17
 2  pscs18

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -701,7 +701,7 @@ upsert bc
 query T
 EXPLAIN (OPT, MEMO, REDACT) INSERT INTO bc SELECT a::float + 1 FROM a ON CONFLICT (b) DO UPDATE SET b = bc.b + 100
 ----
-memo (optimized, ~32KB, required=[presentation: info:19] [distribution: test])
+memo (optimized, ~33KB, required=[presentation: info:19] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:19] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -977,7 +977,7 @@ upsert d
 query T
 EXPLAIN (OPT, MEMO, REDACT) UPSERT INTO d VALUES (7.7)
 ----
-memo (optimized, ~5KB, required=[presentation: info:6] [distribution: test])
+memo (optimized, ~6KB, required=[presentation: info:6] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:6] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -1367,7 +1367,7 @@ update e
 query T
 EXPLAIN (OPT, MEMO, REDACT) UPDATE e SET e = 'eee' WHERE e > 'a'
 ----
-memo (optimized, ~15KB, required=[presentation: info:13] [distribution: test])
+memo (optimized, ~16KB, required=[presentation: info:13] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:13] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -1545,7 +1545,7 @@ delete f
 query T
 EXPLAIN (OPT, MEMO, REDACT) DELETE FROM f WHERE f = 8.5
 ----
-memo (optimized, ~15KB, required=[presentation: info:10] [distribution: test])
+memo (optimized, ~16KB, required=[presentation: info:10] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:10] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -1973,7 +1973,7 @@ select
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT a FROM a WHERE a % 8 > 2
 ----
-memo (optimized, ~6KB, required=[presentation: info:5] [distribution: test])
+memo (optimized, ~7KB, required=[presentation: info:5] [distribution: test])
  ├── G1: (explain G2 [presentation: a:1] [distribution: test])
  │    └── [presentation: info:5] [distribution: test]
  │         ├── best: (explain G2="[presentation: a:1] [distribution: test]" [presentation: a:1] [distribution: test])
@@ -2440,7 +2440,7 @@ project
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM bc JOIN f ON b = f + 1
 ----
-memo (optimized, ~25KB, required=[presentation: info:10] [distribution: test])
+memo (optimized, ~26KB, required=[presentation: info:10] [distribution: test])
  ├── G1: (explain G2 [presentation: b:1,c:2,f:5] [distribution: test])
  │    └── [presentation: info:10] [distribution: test]
  │         ├── best: (explain G2="[presentation: b:1,c:2,f:5] [distribution: test]" [presentation: b:1,c:2,f:5] [distribution: test])
@@ -2825,7 +2825,7 @@ project
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT f, g FROM f, LATERAL (SELECT count(DISTINCT c + f + 1) * 2 AS g FROM bc WHERE b * f < 10)
 ----
-memo (optimized, ~31KB, required=[presentation: info:12] [distribution: test])
+memo (optimized, ~32KB, required=[presentation: info:12] [distribution: test])
  ├── G1: (explain G2 [presentation: f:1,g:11] [distribution: test])
  │    └── [presentation: info:12] [distribution: test]
  │         ├── best: (explain G2="[presentation: f:1,g:11] [distribution: test]" [presentation: f:1,g:11] [distribution: test])
@@ -3260,7 +3260,7 @@ select
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM a WHERE a IN (2, 3, 4)
 ----
-memo (optimized, ~6KB, required=[presentation: info:5] [distribution: test])
+memo (optimized, ~7KB, required=[presentation: info:5] [distribution: test])
  ├── G1: (explain G2 [presentation: a:1] [distribution: test])
  │    └── [presentation: info:5] [distribution: test]
  │         ├── best: (explain G2="[presentation: a:1] [distribution: test]" [presentation: a:1] [distribution: test])

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -128,7 +128,7 @@ WHERE a.y>1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-memo (optimized, ~24KB, required=[presentation: y:2,x:6,c:11] [ordering: +2])
+memo (optimized, ~25KB, required=[presentation: y:2,x:6,c:11] [ordering: +2])
  ├── G1: (project G2 G3 y x)
  │    ├── [presentation: y:2,x:6,c:11] [ordering: +2]
  │    │    ├── best: (project G2="[ordering: +2]" G3 y x)
@@ -238,7 +238,7 @@ memo (optimized, ~7KB, required=[presentation: a:5,b:6,c:7,d:8])
 memo
 SELECT x FROM a WHERE x = 1 AND x+y = 1
 ----
-memo (optimized, ~8KB, required=[presentation: x:1])
+memo (optimized, ~9KB, required=[presentation: x:1])
  ├── G1: (project G2 G3 x)
  │    └── [presentation: x:1]
  │         ├── best: (project G2 G3 x)
@@ -441,7 +441,7 @@ memo (optimized, ~9KB, required=[presentation: info:3])
 memo
 SELECT DISTINCT tag FROM [SHOW TRACE FOR SESSION]
 ----
-memo (optimized, ~7KB, required=[presentation: tag:11])
+memo (optimized, ~8KB, required=[presentation: tag:11])
  ├── G1: (distinct-on G2 G3 cols=(11))
  │    └── [presentation: tag:11]
  │         ├── best: (distinct-on G2 G3 cols=(11))

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -91,7 +91,7 @@ project
 memo
 SELECT i FROM t WHERE st_intersects('LINESTRING(0.5 0.5, 0.7 0.7)', g) ORDER BY i LIMIT 1
 ----
-memo (optimized, ~13KB, required=[presentation: i:1])
+memo (optimized, ~14KB, required=[presentation: i:1])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:1]
  │         ├── best: (project G2 G3 i)
@@ -195,7 +195,7 @@ project
 memo
 SELECT i FROM t WHERE st_intersects('LINESTRING(100 100, 150 150)', g) ORDER BY i LIMIT 1
 ----
-memo (optimized, ~13KB, required=[presentation: i:1])
+memo (optimized, ~14KB, required=[presentation: i:1])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:1]
  │         ├── best: (project G2 G3 i)

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -31,6 +31,10 @@ const (
 	// field is populated.
 	InterestingOrderings
 
+	// SimplifiedInterestingOrderings is set when the
+	// Relational.Rule.SimplifiedInterestingOrderings field is populated.
+	SimplifiedInterestingOrderings
+
 	// HasHoistableSubquery is set when the Scalar.Rule.HasHoistableSubquery
 	// is populated.
 	HasHoistableSubquery
@@ -262,6 +266,12 @@ type Relational struct {
 		// It is only valid once the Rule.Available.InterestingOrderings bit has
 		// been set.
 		InterestingOrderings OrderingSet
+
+		// SimplifiedInterestingOrderings is similar to InterestingOrderings. It
+		// contains the "interesting" orderings that have been simplified by the
+		// relational expression's functional dependencies. See
+		// OrderingChoice.Simplify.
+		SimplifiedInterestingOrderings OrderingSet
 
 		// UnfilteredCols is the set of all columns for which rows from their base
 		// table are guaranteed not to have been filtered. Rows may be duplicated,

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -31,9 +31,9 @@ const (
 	// field is populated.
 	InterestingOrderings
 
-	// SimplifiedInterestingOrderings is set when the
-	// Relational.Rule.SimplifiedInterestingOrderings field is populated.
-	SimplifiedInterestingOrderings
+	// RestrictedInterestingOrderings is set when the
+	// Relational.Rule.RestrictedInterestingOrderings field is populated.
+	RestrictedInterestingOrderings
 
 	// HasHoistableSubquery is set when the Scalar.Rule.HasHoistableSubquery
 	// is populated.
@@ -267,11 +267,10 @@ type Relational struct {
 		// been set.
 		InterestingOrderings OrderingSet
 
-		// SimplifiedInterestingOrderings is similar to InterestingOrderings. It
-		// contains the "interesting" orderings that have been simplified by the
-		// relational expression's functional dependencies. See
-		// OrderingChoice.Simplify.
-		SimplifiedInterestingOrderings OrderingSet
+		// RestrictedInterestingOrderings is similar to InterestingOrderings. It
+		// contains the "interesting" orderings that have been restricted to a
+		// given set of columns. See OrderingSet.RestrictToCols.
+		RestrictedInterestingOrderings []RestrictedInterestingOrdering
 
 		// UnfilteredCols is the set of all columns for which rows from their base
 		// table are guaranteed not to have been filtered. Rows may be duplicated,
@@ -285,6 +284,13 @@ type Relational struct {
 		// is only valid once the Rule.Available.UnfilteredCols bit has been set.
 		UnfilteredCols opt.ColSet
 	}
+}
+
+// RestrictedInterestingOrdering is an interesting ordering that has been
+// restricted to a set of columns. See OrderingSet.RestrictToCols.
+type RestrictedInterestingOrdering struct {
+	OrderingSet
+	Cols opt.ColSet
 }
 
 // Scalar properties are logical properties that are computed for scalar

--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -1085,6 +1085,22 @@ func (os *OrderingSet) RestrictToCols(cols opt.ColSet, fds *FuncDepSet) {
 	}
 }
 
+// RestrictToColsNoSimplify is similar to RestrictToCols but does not call
+// Simplify. It can be used when the ordering set has already been simplified.
+func (os *OrderingSet) RestrictToColsNoSimplify(cols opt.ColSet) {
+	old := *os
+	*os = old[:0]
+	for _, o := range old {
+		newOrd := o.Copy()
+		newOrd.RestrictToCols(cols)
+		if !newOrd.Any() {
+			// This function appends at most one element; it is ok to operate on
+			// the same slice.
+			os.Add(&newOrd)
+		}
+	}
+}
+
 func (os OrderingSet) String() string {
 	var buf bytes.Buffer
 	for i, o := range os {

--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -1085,22 +1085,6 @@ func (os *OrderingSet) RestrictToCols(cols opt.ColSet, fds *FuncDepSet) {
 	}
 }
 
-// RestrictToColsNoSimplify is similar to RestrictToCols but does not call
-// Simplify. It can be used when the ordering set has already been simplified.
-func (os *OrderingSet) RestrictToColsNoSimplify(cols opt.ColSet) {
-	old := *os
-	*os = old[:0]
-	for _, o := range old {
-		newOrd := o.Copy()
-		newOrd.RestrictToCols(cols)
-		if !newOrd.Any() {
-			// This function appends at most one element; it is ok to operate on
-			// the same slice.
-			os.Add(&newOrd)
-		}
-	}
-}
-
 func (os OrderingSet) String() string {
 	var buf bytes.Buffer
 	for i, o := range os {

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -58,8 +58,9 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	// left side. The CommuteJoin rule will ensure that we actually try both
 	// sides.
 	leftCols := leftEq.ToSet()
-	orders := ordering.DeriveSimplifiedInterestingOrderings(left).Copy()
-	orders.RestrictToColsNoSimplify(leftCols)
+	// NOTE: leftCols cannot be mutated after this point because it is used as a
+	// key to cache the restricted orderings in left's logical properties.
+	orders := ordering.DeriveRestrictedInterestingOrderings(left, leftCols).Copy()
 
 	var mustGenerateMergeJoin bool
 	leftFDs := &left.Relational().FuncDeps

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -57,11 +57,12 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	// We generate MergeJoin expressions based on interesting orderings from the
 	// left side. The CommuteJoin rule will ensure that we actually try both
 	// sides.
-	orders := ordering.DeriveInterestingOrderings(left).Copy()
-	leftCols, leftFDs := leftEq.ToSet(), &left.Relational().FuncDeps
-	orders.RestrictToCols(leftCols, leftFDs)
+	leftCols := leftEq.ToSet()
+	orders := ordering.DeriveSimplifiedInterestingOrderings(left).Copy()
+	orders.RestrictToColsNoSimplify(leftCols)
 
 	var mustGenerateMergeJoin bool
+	leftFDs := &left.Relational().FuncDeps
 	if len(orders) == 0 && leftCols.SubsetOf(leftFDs.ConstantCols()) {
 		// All left equality columns are constant, so we can trivially create
 		// an ordering.

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -302,7 +302,7 @@ project
 memo
 SELECT y, x-1 AS z FROM a WHERE x>y ORDER BY x, y DESC
 ----
-memo (optimized, ~6KB, required=[presentation: y:2,z:7] [ordering: +1,-2])
+memo (optimized, ~7KB, required=[presentation: y:2,z:7] [ordering: +1,-2])
  ├── G1: (project G2 G3 x y)
  │    ├── [presentation: y:2,z:7] [ordering: +1,-2]
  │    │    ├── best: (project G2="[ordering: +1,-2]" G3 x y)
@@ -702,7 +702,7 @@ memo (optimized, ~5KB, required=[presentation: y:2] [ordering: +7])
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY -ordinality
 ----
-memo (optimized, ~6KB, required=[presentation: y:2] [ordering: +8])
+memo (optimized, ~7KB, required=[presentation: y:2] [ordering: +8])
  ├── G1: (project G2 G3 y)
  │    ├── [presentation: y:2] [ordering: +8]
  │    │    ├── best: (sort G1)
@@ -725,7 +725,7 @@ memo (optimized, ~6KB, required=[presentation: y:2] [ordering: +8])
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY ordinality, x
 ----
-memo (optimized, ~7KB, required=[presentation: y:2] [ordering: +7])
+memo (optimized, ~8KB, required=[presentation: y:2] [ordering: +7])
  ├── G1: (ordinality G2)
  │    ├── [presentation: y:2] [ordering: +7]
  │    │    ├── best: (ordinality G2)

--- a/pkg/sql/opt/xform/testdata/rules/cycle
+++ b/pkg/sql/opt/xform/testdata/rules/cycle
@@ -62,7 +62,7 @@ expropt disable=MemoCycleTestRelRuleFilter skip-race
 ----
 error: memo group optimization passes surpassed limit of 100000; there may be a cycle in the memo
 details:
-memo (not optimized, ~15KB, required=[], cycle=[G1->G3->G5->G5])
+memo (not optimized, ~16KB, required=[], cycle=[G1->G3->G5->G5])
  ├── G1: (left-join G2 G3 G4)
  ├── G2: (scan ab,cols=()) (scan ab@ab_b_idx,cols=())
  │    └── []

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -449,7 +449,7 @@ project
 memo
 SELECT min(a) FROM abc
 ----
-memo (optimized, ~6KB, required=[presentation: min:7])
+memo (optimized, ~7KB, required=[presentation: min:7])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: min:7]
  │         ├── best: (scalar-group-by G4 G5 cols=())
@@ -511,7 +511,7 @@ memo (optimized, ~7KB, required=[presentation: min:7])
 memo
 SELECT max(a) FROM abc
 ----
-memo (optimized, ~6KB, required=[presentation: max:7])
+memo (optimized, ~7KB, required=[presentation: max:7])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: max:7]
  │         ├── best: (scalar-group-by G4 G5 cols=())
@@ -1693,7 +1693,7 @@ memo (optimized, ~9KB, required=[presentation: array_agg:7])
 memo
 SELECT array_agg(k) FROM (SELECT * FROM kuvw WHERE u=v ORDER BY u) GROUP BY w
 ----
-memo (optimized, ~14KB, required=[presentation: array_agg:7])
+memo (optimized, ~15KB, required=[presentation: array_agg:7])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:7]
  │         ├── best: (project G2 G3 array_agg)
@@ -2047,7 +2047,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
 memo
 SELECT DISTINCT ON (w, u) u, v, w FROM kuvw ORDER BY w, u, v DESC
 ----
-memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
+memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
  ├── G1: (distinct-on G2 G3 cols=(2,4),ordering=-3 opt(2,4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4,+2]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(2,4),ordering=-3 opt(2,4))
@@ -2078,7 +2078,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w, u DESC, v
 ----
-memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
+memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
@@ -2108,7 +2108,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w DESC, u DESC, v
 ----
-memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
+memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: -4]
  │    │    ├── best: (sort G1)
@@ -2138,7 +2138,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w, u, v DESC
 ----
-memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
+memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=+2,-3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(4),ordering=+2,-3 opt(4))
@@ -2172,7 +2172,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT (SELECT w FROM kuvw WHERE v=1 AND x=u) FROM xyz ORDER BY x+1, x
 ----
-memo (optimized, ~25KB, required=[presentation: w:12] [ordering: +13,+1])
+memo (optimized, ~26KB, required=[presentation: w:12] [ordering: +13,+1])
  ├── G1: (project G2 G3 x)
  │    ├── [presentation: w:12] [ordering: +13,+1]
  │    │    ├── best: (sort G1)
@@ -2295,7 +2295,7 @@ memo (optimized, ~26KB, required=[])
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
-memo (optimized, ~26KB, required=[])
+memo (optimized, ~27KB, required=[])
  ├── G1: (upsert G2 G3 G4 xyz)
  │    └── []
  │         ├── best: (upsert G2 G3 G4 xyz)
@@ -3305,7 +3305,7 @@ INDEX gg (g)
 memo
 SELECT d, e, count(*) FROM defg GROUP BY d, e LIMIT 10
 ----
-memo (optimized, ~19KB, required=[presentation: d:1,e:2,count:8])
+memo (optimized, ~20KB, required=[presentation: d:1,e:2,count:8])
  ├── G1: (limit G2 G3) (limit G4 G3) (limit G5 G3) (limit G6 G3)
  │    └── [presentation: d:1,e:2,count:8]
  │         ├── best: (limit G4="[limit hint: 10.00]" G3)
@@ -3516,7 +3516,7 @@ limit
 memo expect-not=GenerateLimitedGroupByScans
 SELECT d, e, count(*) FROM defg@{NO_INDEX_JOIN} GROUP BY d, e LIMIT 10
 ----
-memo (optimized, ~5KB, required=[presentation: d:1,e:2,count:8])
+memo (optimized, ~6KB, required=[presentation: d:1,e:2,count:8])
  ├── G1: (limit G2 G3)
  │    └── [presentation: d:1,e:2,count:8]
  │         ├── best: (limit G2="[limit hint: 10.00]" G3)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -227,7 +227,7 @@ inner-join (merge)
 memo expect=ReorderJoins
 SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
-memo (optimized, ~43KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
+memo (optimized, ~44KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (merge-join G2 G3 G10 inner-join,+1,+7) (merge-join G3 G2 G10 inner-join,+7,+1) (lookup-join G3 G10 abc@ab,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G5 G6 G10 inner-join,+7,+12) (merge-join G6 G5 G10 inner-join,+12,+7) (lookup-join G6 G10 stu,keyCols=[12],outCols=(1-3,7-9,12-14)) (merge-join G8 G9 G10 inner-join,+7,+12) (lookup-join G8 G10 xyz@xy,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G9 G8 G10 inner-join,+12,+7)
  │    └── [presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14]
  │         ├── best: (merge-join G5="[ordering: +7]" G6="[ordering: +(1|12)]" G10 inner-join,+7,+12)
@@ -335,7 +335,7 @@ SELECT *
 FROM stu, abc, xyz, pqr
 WHERE u = a AND a = x AND x = p
 ----
-memo (optimized, ~38KB, required=[presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
+memo (optimized, ~39KB, required=[presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+3,+6) (merge-join G3 G2 G5 inner-join,+6,+3) (lookup-join G3 G5 stu@uts,keyCols=[6],outCols=(1-3,6-8,12-14,18-22))
  │    └── [presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22]
  │         ├── best: (merge-join G2="[ordering: +3]" G3="[ordering: +(6|12|18)]" G5 inner-join,+3,+6)
@@ -429,7 +429,7 @@ INNER JOIN LATERAL (
 )
 ON a = v
 ----
-memo (optimized, ~15KB, required=[presentation: a:1,b:2,c:3,v:7,s:8,t:9,u:10])
+memo (optimized, ~16KB, required=[presentation: a:1,b:2,c:3,v:7,s:8,t:9,u:10])
  ├── G1: (inner-join-apply G2 G3 G4)
  │    └── [presentation: a:1,b:2,c:3,v:7,s:8,t:9,u:10]
  │         ├── best: (inner-join-apply G2 G3 G4)
@@ -1269,7 +1269,7 @@ memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
 memo expect=ReorderJoins
 SELECT * FROM abc FULL OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (full-join G2 G3 G4) (full-join G3 G2 G4) (merge-join G2 G3 G5 full-join,+1,+9)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (full-join G2 G3 G4)
@@ -1438,7 +1438,7 @@ New expression 1 of 1:
 memo
 SELECT * FROM abc LEFT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (merge-join G2 G3 G5 left-join,+1,+9)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (left-join G2 G3 G4)
@@ -2121,7 +2121,7 @@ left-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=b
 ----
-memo (optimized, ~16KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~17KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (inner-join G3 G2 G4)
@@ -2159,7 +2159,7 @@ CREATE TABLE kfloat (k FLOAT PRIMARY KEY)
 memo
 SELECT * FROM abc JOIN kfloat ON a=k
 ----
-memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,k:7])
+memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,k:7])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,k:7]
  │         ├── best: (inner-join G3 G2 G4)
@@ -2656,7 +2656,7 @@ No new expressions.
 memo expect-not=GenerateLookupJoins
 SELECT a,b,n,m FROM small INNER HASH JOIN abcd ON a=m
 ----
-memo (optimized, ~9KB, required=[presentation: a:6,b:7,n:2,m:1])
+memo (optimized, ~10KB, required=[presentation: a:6,b:7,n:2,m:1])
  ├── G1: (inner-join G2 G3 G4)
  │    └── [presentation: a:6,b:7,n:2,m:1]
  │         ├── best: (inner-join G2 G3 G4)
@@ -7181,7 +7181,7 @@ WHERE n.name = 'Upper West Side'
 OR n.name = 'Upper East Side'
 GROUP BY n.name, n.geom
 ----
-memo (optimized, ~34KB, required=[presentation: name:16,popn_per_sqkm:22])
+memo (optimized, ~35KB, required=[presentation: name:16,popn_per_sqkm:22])
  ├── G1: (project G2 G3 name)
  │    └── [presentation: name:16,popn_per_sqkm:22]
  │         ├── best: (project G2 G3 name)
@@ -10134,7 +10134,7 @@ SELECT 1 FROM (VALUES (1), (1)) JOIN (VALUES (1), (1), (1)) ON true
 UNION ALL
 SELECT 1 FROM (VALUES (1), (1), (1)) JOIN (VALUES (1), (1)) ON true
 ----
-memo (optimized, ~21KB, required=[presentation: ?column?:7])
+memo (optimized, ~22KB, required=[presentation: ?column?:7])
  ├── G1: (union-all G2 G3)
  │    └── [presentation: ?column?:7]
  │         ├── best: (union-all G2 G3)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -312,7 +312,7 @@ New expression 3 of 3:
 memo set=reorder_joins_limit=0 expect-not=ReorderJoins
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~22KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
+memo (optimized, ~23KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+1,+10)
  │    └── [presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12]
  │         ├── best: (merge-join G2="[ordering: +1]" G3 G5 inner-join,+1,+10)
@@ -360,7 +360,7 @@ memo (optimized, ~22KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:
 memo set=reorder_joins_limit=2
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~33KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
+memo (optimized, ~34KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (merge-join G2 G3 G8 inner-join,+1,+10) (merge-join G3 G2 G8 inner-join,+10,+1) (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12)) (merge-join G5 G6 G8 inner-join,+5,+11) (merge-join G6 G5 G8 inner-join,+11,+5) (lookup-join G6 G8 cy,keyCols=[11],outCols=(1,2,5,6,9-12))
  │    └── [presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12]
  │         ├── best: (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12))
@@ -521,7 +521,7 @@ inner-join (cross)
 memo set=reorder_joins_limit=0
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~29KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~30KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+2,+6)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G2 G3 G4)
@@ -587,7 +587,7 @@ memo (optimized, ~29KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:
 memo set=reorder_joins_limit=3
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~63KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~65KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (inner-join G10 G11 G12) (inner-join G11 G10 G12) (inner-join G13 G14 G12) (inner-join G14 G13 G12) (inner-join G15 G16 G12) (inner-join G16 G15 G12) (inner-join G17 G18 G12) (inner-join G18 G17 G12) (merge-join G3 G2 G19 inner-join,+6,+2) (merge-join G6 G5 G19 inner-join,+10,+6) (merge-join G9 G8 G19 inner-join,+10,+6) (merge-join G11 G10 G19 inner-join,+13,+10) (merge-join G14 G13 G19 inner-join,+13,+10) (merge-join G16 G15 G19 inner-join,+13,+10) (lookup-join G17 G19 abc,keyCols=[10],outCols=(1,2,5,6,9,10,13-16)) (merge-join G18 G17 G19 inner-join,+13,+10)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G3 G2 G4)
@@ -2739,7 +2739,7 @@ SELECT (
 )
   FROM table80901_1 AS tab_42921;
 ----
-memo (optimized, ~66KB, required=[presentation: ?column?:50])
+memo (optimized, ~68KB, required=[presentation: ?column?:50])
  ├── G1: (project G2 G3)
  │    └── [presentation: ?column?:50]
  │         ├── best: (project G2 G3)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -2002,7 +2002,7 @@ memo (optimized, ~4KB, required=[presentation: d:1,f:3,e:2] [ordering: +1,+3,+2]
 memo expect=GeneratePartialOrderTopK
 SELECT * FROM defg ORDER BY d, f, e LIMIT 10
 ----
-memo (optimized, ~14KB, required=[presentation: d:1,e:2,f:3,g:4] [ordering: +1,+3,+2])
+memo (optimized, ~15KB, required=[presentation: d:1,e:2,f:3,g:4] [ordering: +1,+3,+2])
  ├── G1: (limit G2 G3 ordering=+1,+3,+2) (top-k G2 &{10 +1,+3,+2 }) (top-k G4 &{10 +1,+3,+2 }) (top-k G5 &{10 +1,+3,+2 }) (top-k G6 &{10 +1,+3,+2 }) (top-k G2 &{10 +1,+3,+2 +1,+3}) (top-k G4 &{10 +1,+3,+2 +1}) (top-k G5 &{10 +1,+3,+2 +1,+3}) (top-k G6 &{10 +1,+3,+2 +1,+3}) (top-k G4 &{10 +1,+3,+2 +1,+3})
  │    ├── [presentation: d:1,e:2,f:3,g:4] [ordering: +1,+3,+2]
  │    │    ├── best: (top-k G6="[ordering: +1,+3] [limit hint: 100.00]" &{10 +1,+3,+2 +1,+3})

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -263,7 +263,7 @@ CREATE INDEX idx2 ON p (s) WHERE i > 0
 memo expect=GeneratePartialIndexScans
 SELECT * FROM p WHERE i > 0 AND s = 'foo'
 ----
-memo (optimized, ~17KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
+memo (optimized, ~18KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
  ├── G1: (select G2 G3) (index-join G4 p,cols=(1-5)) (index-join G5 p,cols=(1-5)) (index-join G6 p,cols=(1-5)) (index-join G7 p,cols=(1-5))
  │    └── [presentation: k:1,i:2,f:3,s:4,b:5]
  │         ├── best: (index-join G4 p,cols=(1-5))
@@ -583,7 +583,7 @@ project
 memo
 SELECT k FROM a WHERE v > 1
 ----
-memo (optimized, ~7KB, required=[presentation: k:1])
+memo (optimized, ~8KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -620,7 +620,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k = 5
 ----
-memo (optimized, ~9KB, required=[presentation: k:1])
+memo (optimized, ~10KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -718,7 +718,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND v = 5
 ----
-memo (optimized, ~10KB, required=[presentation: k:1])
+memo (optimized, ~11KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -970,7 +970,7 @@ select
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 ----
-memo (optimized, ~8KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G4 G5)
@@ -1034,7 +1034,7 @@ select
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
 ----
-memo (optimized, ~11KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~12KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G6 G7)
@@ -1102,7 +1102,7 @@ select
 memo
 SELECT * FROM b WHERE (u, k, v) > (1, 2, 3) AND (u, k, v) < (8, 9, 10)
 ----
-memo (optimized, ~8KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G3)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G4 G3)
@@ -6323,7 +6323,7 @@ CREATE INVERTED INDEX idx2 ON pi (j) WHERE s = 'bar'
 memo expect=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'bar'
 ----
-memo (optimized, ~13KB, required=[presentation: k:1,s:2,j:3])
+memo (optimized, ~14KB, required=[presentation: k:1,s:2,j:3])
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 pi,cols=(1-3))
  │    └── [presentation: k:1,s:2,j:3]
  │         ├── best: (index-join G6 pi,cols=(1-3))
@@ -7158,7 +7158,7 @@ inner-join (zigzag pqr@q pqr@r)
 memo expect=GenerateZigzagJoins
 SELECT q,r FROM pqr WHERE q = 1 AND r = 2
 ----
-memo (optimized, ~16KB, required=[presentation: q:2,r:3])
+memo (optimized, ~17KB, required=[presentation: q:2,r:3])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G7) (zigzag-join G3 pqr@q pqr@r)
  │    └── [presentation: q:2,r:3]
  │         ├── best: (zigzag-join G3 pqr@q pqr@r)
@@ -7304,7 +7304,7 @@ inner-join (zigzag pqr@q pqr@s)
 memo expect=GenerateZigzagJoins
 SELECT q,s FROM pqr WHERE q = 1 AND s = 'foo'
 ----
-memo (optimized, ~13KB, required=[presentation: q:2,s:4])
+memo (optimized, ~14KB, required=[presentation: q:2,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (zigzag-join G3 pqr@q pqr@s)
  │    └── [presentation: q:2,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
@@ -7836,7 +7836,7 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~38KB, required=[presentation: p:1,q:2,r:3,s:4])
+memo (optimized, ~39KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G9) (select G10 G9) (lookup-join G11 G12 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G13 G9 pqr,keyCols=[1],outCols=(1-4))
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
@@ -10029,7 +10029,7 @@ JOIN t61795 AS t2 ON t1.c = t1.b AND t1.b = t2.b
 WHERE t1.a = 10 OR t2.b != abs(t2.b)
 ORDER BY t1.b ASC
 ----
-memo (optimized, ~34KB, required=[presentation: a:1] [ordering: +2])
+memo (optimized, ~35KB, required=[presentation: a:1] [ordering: +2])
  ├── G1: (project G2 G3 a b)
  │    ├── [presentation: a:1] [ordering: +2]
  │    │    ├── best: (sort G1)


### PR DESCRIPTION
#### opt: cache simplified interesting orderings

The `GenerateMergeJoins` rule simplifies the interesting orderings of a
join's left child with respect to the child's functional dependencies.
Simplifying an ordering set is computationally expensive, and it can
dominate the CPU-time of optimizing queries with many joins and
interesting orderings. In a query with many joins, `GenerateMergeJoins`
fires repeatedly with the same left child. To avoid repeatedly computing
the same simplified interesting orderings, we cache them in
`props.Relational.Rule.SimplifiedInterestingOrderings`. This
significantly reduces the planning time of some queries.

Release note (performance improvement): Query planning time has been reduced
for some queries with multiple joins.

#### opt: cache restricted interesting orderings

This commit builds on the last commit by caching interesting orderings
that are restricted to a specific column set, not just simplified
interesting orderings. Restricting an ordering set is computationally
expensive (see `OrderingSet.RestrictToCols`), and queries with many
joins can repeatedly restrict the same interesting orderings of a
relation with the same set of columns. Caching restricted orderings
eliminates this duplicate work.

Epic: None

Release note: None
