### PR TITLE
bazel: update to 5.4.1

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,1 @@
-cockroachdb/5.4.0
+cockroachdb/5.4.1


### PR DESCRIPTION
Epic: none
Release note: None