### PR TITLE
logictestccl: add retry to allow cluster setting to propagate

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
@@ -20,7 +20,7 @@ SET CLUSTER SETTING sql.defaults.primary_region = 'ap-southeast-2'
 statement error PRIMARY REGION must be specified if REGIONS are specified
 CREATE DATABASE db REGIONS "us-east1"
 
-query T noticetrace
+query T noticetrace retry
 CREATE DATABASE db
 ----
 NOTICE: defaulting to 'WITH PRIMARY REGION "ap-southeast-2"' as no primary region was specified


### PR DESCRIPTION
The `multi_region_default_primary_region` logic test has one test case that depends on a cluster setting to be set. This can cause flakes because the cluster setting may not always be propagated by the time the test case executes. This patch adds a retry to prevent the flakes.

Fixes #101897

Release note: None