### PR TITLE
server: use stats activity tables on sql stats endpoint

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -104,7 +104,13 @@ export function shortStatement(
 function formatStringArray(databases: string): string {
   try {
     // Case where the database is returned as an array in a string form.
-    return JSON.parse(databases).join(", ");
+    const d = JSON.parse(databases);
+    try {
+      // Case where the database is returned as an array of array in a string form.
+      return JSON.parse(d).join(", ");
+    } catch (e) {
+      return d.join(", ");
+    }
   } catch (e) {
     // Case where the database is a single value as a string.
     return databases;


### PR DESCRIPTION
With the new sql stats tables that contain the top 500 rows based on most used column, this PR updates the calls on the sql stats endpoint to use the new flow:

```mermaid
flowchart TD;
    A[Compare the TS on ACTIVITY Table with the Requested TS] --> B{Is the requested time \nperiod completely \non the table?}
    B -- Yes --> C[SELECT on ACTIVITY table]
    C --> D{Had results?}
    D -- Yes --> E[Return RESULTS]
    D -- No --> F[SELECT on PERSISTED table]
    B -- No ----> F
    F --> G{Had results?}
    G -- Yes --> E
    G -- No --> H[SELECT on COMBINED table]
    H --> E
```

Part Of: #101948

A following PR will deal when selecting a column that is not one of the ones selected to generate the activity tables.

Release note (performance improvement): SQL Activity endpoints now use first a table with the top data for the most used cases. If there is no data available, it used the previous flow with persisted data and if that is also empty, uses in-memory.