### PR TITLE
multitenant: fix tenant_upgrade_test to allow new 23.2 versions to be added

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -349,7 +349,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 		// Ensure that the tenant still works and the target
 		// version wasn't reached.
 		initialTenantRunner.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1"}, {"2"}})
-		initialTenantRunner.CheckQueryResults(t, "SHOW CLUSTER SETTING version",
+		initialTenantRunner.CheckQueryResults(t, "SELECT split_part(version, '-', 1) FROM [SHOW CLUSTER SETTING version]",
 			[][]string{{v1.String()}})
 
 		// Restart the tenant and ensure that the version is correct.


### PR DESCRIPTION
Fixes #102028

Previously adding a new version would break this test
```
Failed
=== RUN   TestTenantUpgradeFailure/upgrade_tenant_have_it_crash_then_resume
    tenant_upgrade_test.go:352: query 'SHOW CLUSTER SETTING version': expected:
        1000023.1

        got:
        1000023.1-2

    --- FAIL: TestTenantUpgradeFailure/upgrade_tenant_have_it_crash_then_resume (60.42s)
```

Now the `-*` part of the version is ignored.

Release note: None