### PR TITLE
roachprod-microbench: improvements to reporting

### DIFF
--- a/pkg/cmd/roachprod-microbench/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/cmd/roachprod-microbench/cluster",
         "//pkg/cmd/roachprod-microbench/google",
         "//pkg/roachprod",
+        "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/ssh",
         "//pkg/roachprod/vm",

--- a/pkg/cmd/roachprod-microbench/benchmark_test.go
+++ b/pkg/cmd/roachprod-microbench/benchmark_test.go
@@ -25,8 +25,8 @@ func TestExtractBenchmarkResultsDataDriven(t *testing.T) {
 		if d.Cmd != "benchmark" {
 			d.Fatalf(t, "unknown command %s", d.Cmd)
 		}
-		result, fail := extractBenchmarkResults(d.Input)
-		output := fmt.Sprintf("%v %v", fail, result)
+		result := extractBenchmarkResults(d.Input)
+		output := fmt.Sprintf("%v", result)
 		return output
 	})
 }

--- a/pkg/cmd/roachprod-microbench/main.go
+++ b/pkg/cmd/roachprod-microbench/main.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/google"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -46,6 +47,7 @@ var (
 	flagCopy            = flags.Bool("copy", true, "copy and extract test binaries and libraries to the target cluster")
 	flagLenient         = flags.Bool("lenient", true, "tolerate errors in the benchmark results")
 	flagAffinity        = flags.Bool("affinity", true, "run benchmarks with iterations and binaries having affinity to the same node")
+	flagQuiet           = flags.Bool("quiet", false, "suppress progress output")
 	flagIterations      = flags.Int("iterations", 1, "number of iterations to run each benchmark")
 	workingDir          string
 	testArgs            []string
@@ -118,6 +120,7 @@ func setupVars() error {
 		}
 	}
 
+	config.Quiet = *flagQuiet
 	timestamp = timeutil.Now()
 	initLogger(filepath.Join(workingDir, fmt.Sprintf("roachprod-microbench-%s.log", timestamp.Format(timeFormat))))
 	l.Printf("roachprod-microbench %s", strings.Join(os.Args, " "))
@@ -130,7 +133,6 @@ func run() error {
 	if err != nil {
 		return err
 	}
-
 	var packages []string
 	if *flagCluster != "" {
 		binaries := []string{*flagBinaries}

--- a/pkg/cmd/roachprod-microbench/report.go
+++ b/pkg/cmd/roachprod-microbench/report.go
@@ -90,10 +90,10 @@ func (report *Report) closeReports() {
 	}
 }
 
-func (report *Report) writeBenchmarkErrorLogs(response cluster.RemoteResponse, index int) error {
+func (report *Report) writeBenchmarkErrorLogs(response cluster.RemoteResponse, tag string) error {
 	benchmarkResponse := response.Metadata.(benchmarkIndexed)
-	stdoutLogName := fmt.Sprintf("%s-%d-stdout.log", benchmarkResponse.name, index)
-	stderrLogName := fmt.Sprintf("%s-%d-stderr.log", benchmarkResponse.name, index)
+	stdoutLogName := fmt.Sprintf("%s-%s-stdout.log", benchmarkResponse.name, tag)
+	stderrLogName := fmt.Sprintf("%s-%s-stderr.log", benchmarkResponse.name, tag)
 	l.Printf("Writing error logs for benchmark at %s, %s\n", stdoutLogName, stderrLogName)
 
 	if err := os.WriteFile(filepath.Join(report.path, stdoutLogName), []byte(response.Stdout), 0644); err != nil {

--- a/pkg/cmd/roachprod-microbench/testdata/benchmark
+++ b/pkg/cmd/roachprod-microbench/testdata/benchmark
@@ -8,7 +8,7 @@ BenchmarkFastIntMap/4x4-4/map-sized-24  	       1	       977.0 ns/op	       0 B/
 BenchmarkFastIntMap/4x4-4/slice-24      	       1	      1406 ns/op	      64 B/op	       3 allocs/op
 PASS
 ----
-false [[BenchmarkFastIntMap/4x4-4/fastintmap-24 1 603.0 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/map-24 1 1039 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/map-sized-24 1 977.0 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/slice-24 1 1406 ns/op 64 B/op 3 allocs/op]]
+{[[BenchmarkFastIntMap/4x4-4/fastintmap-24 1 603.0 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/map-24 1 1039 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/map-sized-24 1 977.0 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/slice-24 1 1406 ns/op 64 B/op 3 allocs/op]] false false}
 
 # Scattered benchmark output
 benchmark
@@ -28,7 +28,7 @@ extra log noise
 1	      1406 ns/op	      64 B/op	       3 allocs/op
 PASS
 ----
-false [[BenchmarkFastIntMap/4x4-4/fastintmap-24 1 603.0 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/map-24 1 1039 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/map-sized-24 1 977.0 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/slice-24 1 1406 ns/op 64 B/op 3 allocs/op]]
+{[[BenchmarkFastIntMap/4x4-4/fastintmap-24 1 603.0 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/map-24 1 1039 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/map-sized-24 1 977.0 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/slice-24 1 1406 ns/op 64 B/op 3 allocs/op]] false false}
 
 # Missing benchmark name, and missing benchmark metrics (incorrect column count)
 benchmark
@@ -40,7 +40,7 @@ BenchmarkFastIntMap/4x4-4/map-sized-24  	       1	       977.0 ns/op
 BenchmarkFastIntMap/4x4-4/slice-24      	       1	      1406 ns/op	      64 B/op	       3 allocs/op
 PASS
 ----
-false [[BenchmarkFastIntMap/4x4-4/map-24 1 1039 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/map-sized-24 1 977.0 ns/op] [BenchmarkFastIntMap/4x4-4/slice-24 1 1406 ns/op 64 B/op 3 allocs/op]]
+{[[BenchmarkFastIntMap/4x4-4/map-24 1 1039 ns/op 0 B/op 0 allocs/op] [BenchmarkFastIntMap/4x4-4/map-sized-24 1 977.0 ns/op] [BenchmarkFastIntMap/4x4-4/slice-24 1 1406 ns/op 64 B/op 3 allocs/op]] false false}
 
 # Failed benchmark
 benchmark
@@ -49,7 +49,7 @@ cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
 BenchmarkFastIntMap/4x4-4/slice-24      	       1	      1406 ns/op	      64 B/op	       3 allocs/op
 FAIL
 ----
-true [[BenchmarkFastIntMap/4x4-4/slice-24 1 1406 ns/op 64 B/op 3 allocs/op]]
+{[[BenchmarkFastIntMap/4x4-4/slice-24 1 1406 ns/op 64 B/op 3 allocs/op]] true false}
 
 # Benchmark with panic
 benchmark
@@ -58,4 +58,16 @@ cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
 BenchmarkFastIntMap/4x4-4/slice-24      	       1	      1406 ns/op	      64 B/op	       3 allocs/op
 panic: something went wrong
 ----
-true [[BenchmarkFastIntMap/4x4-4/slice-24 1 1406 ns/op 64 B/op 3 allocs/op]]
+{[[BenchmarkFastIntMap/4x4-4/slice-24 1 1406 ns/op 64 B/op 3 allocs/op]] true false}
+
+# Benchmark with skipped benchmarks
+benchmark
+goos: linux
+goarch: amd64
+cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
+BenchmarkIntersectsLargePolygonsAndPoints
+    binary_predicates_bench_test.go:51: [disabled under -short]
+--- SKIP: BenchmarkIntersectsLargePolygonsAndPoints
+PASS
+----
+{[] false true}


### PR DESCRIPTION
This change introduces a few small improvements to the reporting capabilities in roachprod-microbench. Missing microbenchmarks are now classified by timeouts, errors, or skipped status. These will be outputted to the log for inspection afterward.

Also adds a quiet mode for reducing unnecessary output on CI builds.