### PR TITLE
roachtest: some more logging for costfuzz and unoptimized query oracle

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -305,6 +306,17 @@ type queryComparisonHelper struct {
 // plan, and the output of running the query so they can be logged in case of
 // failure.
 func (h *queryComparisonHelper) runQuery(stmt string) ([][]string, error) {
+	// Log this statement with a timestamp but commented out. This will help in
+	// cases when the stmt will get stuck and the whole test will time out (in
+	// such a scenario, since the stmt didn't execute successfully, it won't get
+	// logged by the caller).
+	h.logStmt(fmt.Sprintf("-- %s: %s", timeutil.Now(),
+		// Remove all newline symbols to log this stmt as a single line. This
+		// way this auxiliary logging takes up less space (if the stmt executes
+		// successfully, it'll still get logged with the nice formatting).
+		strings.ReplaceAll(stmt, "\n", "")),
+	)
+
 	runQueryImpl := func(stmt string) ([][]string, error) {
 		rows, err := h.conn.Query(stmt)
 		if err != nil {


### PR DESCRIPTION
This commit modifies the costfuzz and unoptimized query oracle tests to always log each "main" statement. The stmt is commented out so that the log is still replayable. Additionally, a timestamp is included to help with debugging later.

Informs: #101823.

Epic: None

Release note: None