### PR TITLE
DNM: an attempt to break 22.2 restore

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
@@ -2398,8 +2399,7 @@ func (c *clusterImpl) MakeNodes(opts ...option.Option) string {
 }
 
 func (c *clusterImpl) IsLocal() bool {
-	// FIXME: I think radu made local more flexible and local is a prefix?
-	return c.name == "local"
+	return config.IsLocalClusterName(c.name)
 }
 
 func (c *clusterImpl) IsSecure() bool {

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -6084,6 +6084,7 @@ func MVCCExportToSST(
 				uint64(curSizeWithRangeKeys) >= opts.TargetSize
 			kvSize := int64(len(unsafeKey.Key) + len(unsafeValue))
 			if curSize == 0 && opts.MaxSize > 0 && kvSize > int64(opts.MaxSize) {
+				log.Infof(ctx, `single key max size error`)
 				// This single key exceeds the MaxSize. Even if we paginate below, this will still fail.
 				return roachpb.BulkOpSummary{}, MVCCKey{}, &ExceedMaxSizeError{reached: kvSize, maxSize: opts.MaxSize}
 			}
@@ -6099,6 +6100,10 @@ func MVCCExportToSST(
 				if isNewKey || !opts.StopMidKey {
 					resumeKey.Timestamp = hlc.Timestamp{}
 				}
+				log.Infof(ctx, `Returning early: stop mid key %t and reached max size %t; isNewKey %t`,
+					opts.StopMidKey,
+					reachedMaxSize,
+					isNewKey)
 				break
 			}
 			if reachedMaxSize {


### PR DESCRIPTION
This commit modifes the backupTCC test to:
1. Init 10 Bank workload rows, each with 2MB of payload
2.  Run under a cancellable context
3. Let the workloads run for between 5 and 10 minutes, post initialization
4. Run a full cluster backup with revision history with AOST randomly between
steps 3 and 4.
5. Cancel the workload.
6. Restore the bank database to the backup AOST and fingerprint.