### PR TITLE
release-23.1.0: scripts: point bump-pebble.sh at correct release branch

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -20,7 +20,7 @@ popd() { builtin popd "$@" > /dev/null; }
 # NOTE: After a new release has been cut, update this to the appropriate
 # Cockroach branch name (i.e. release-22.2, etc.), and corresponding Pebble
 # branch name (e.g. crl-release-21.2, etc.).
-BRANCH=release-23.1
+BRANCH=release-23.1.0
 PEBBLE_BRANCH=crl-release-23.1
 
 # The script can only be run from a specific branch.


### PR DESCRIPTION
The `bump-pebble.sh` script currently points at `release-23.1`. This will fail the script when it is run, as it checks that the invoker is currently on the branch the script is intended to bump.

Update the cockroach branch to `release-23.1.0`

Release note: None.

Release justification: Tooling fix.

Epic: None.