### PR TITLE
metric: avoid mutex deadlock and fix HdrHistogram.TotalSum

### DIFF
--- a/pkg/util/metric/hdrhistogram.go
+++ b/pkg/util/metric/hdrhistogram.go
@@ -240,9 +240,7 @@ func (h *HdrHistogram) Mean() float64 {
 	return h.mu.cumulative.Mean()
 }
 
+// TotalSum returns the (cumulative) sum of samples.
 func (h *HdrHistogram) TotalSum() float64 {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	return h.ToPrometheusMetric().GetSummary().GetSampleSum()
+	return h.ToPrometheusMetric().Histogram.GetSampleSum()
 }

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -400,7 +400,7 @@ func (h *Histogram) TotalCountWindowed() int64 {
 	return int64(h.ToPrometheusMetricWindowed().Histogram.GetSampleCount())
 }
 
-// TotalSum returns the (cumulative) number of samples.
+// TotalSum returns the (cumulative) sum of samples.
 func (h *Histogram) TotalSum() float64 {
 	return h.ToPrometheusMetric().Histogram.GetSampleSum()
 }


### PR DESCRIPTION
The method was calling `ToPrometheusMetric`, which expects the mutex to be unlocked. However, it was also locking the mutex. This commit fixes the deadlock.

The commit also fixes the implementation, which was broken. `ToPrometheusMetric` does not populate `prometheusgo.Metric.Summary`, so the use of `GetSummary` was broken.

The two bugs indicate a lack of testing coverage for this newly introduced functionality (in a28aa6cb). We should add some.

Epic: None
Release note: None