### PR TITLE
kv: improve `TestTxnCoordSenderRetries`

### DIFF
--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -287,6 +287,11 @@ func (db *DB) Clock() *hlc.Clock {
 	return db.clock
 }
 
+// Context returns the DB's DBContext.
+func (db *DB) Context() DBContext {
+	return db.ctx
+}
+
 // NewDB returns a new DB.
 func NewDB(
 	actx log.AmbientContext, factory TxnSenderFactory, clock *hlc.Clock, stopper *stop.Stopper,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -2435,20 +2435,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			expClientRestart: true,
 		},
 		{
-			name: "write too old with get in the clear",
-			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
-				return db.Put(ctx, "a", "put")
-			},
-			retryable: func(ctx context.Context, txn *kv.Txn) error {
-				if _, err := txn.Get(ctx, "b"); err != nil {
-					return err
-				}
-				return txn.Put(ctx, "a", "put")
-			},
-			expClientRefresh:               true,
-			expClientAutoRetryAfterRefresh: true,
-		},
-		{
 			name: "write too old with get conflict",
 			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "a", "put")


### PR DESCRIPTION
This PR improves `TestTxnCoordSenderRetries` in two ways, in preparation for its use to be expanded to demonstrate the difference in behavior between isolation levels.

### use local TxnMetrics in TestTxnCoordSenderRetries

The first commit updates `TestTxnCoordSenderRetries` to use a local `kv.DB` with a local `TxnMetrics` for its test transaction. This allows the test to precisely assert on the metrics without having to worry about other transactions in the system affecting them.

### add preemptive refreshes and 1PCs to TestTxnCoordSenderRetries

The second commit adds more testing conditions to TestTxnCoordSenderRetries. Each test now asserts it expectations for preemptive refreshes and for 1-phase commits.