### PR TITLE
kv: support Rollback in Txn closure

### DIFF
--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -559,10 +559,11 @@ func TestDB_DelRange(t *testing.T) {
 func TestTxn_Commit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 	s, db := setup(t)
-	defer s.Stopper().Stop(context.Background())
+	defer s.Stopper().Stop(ctx)
 
-	err := db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
+	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		b := txn.NewBatch()
 		b.Put("aa", "1")
 		b.Put("ab", "2")
@@ -575,7 +576,7 @@ func TestTxn_Commit(t *testing.T) {
 	b := &kv.Batch{}
 	b.Get("aa")
 	b.Get("ab")
-	if err := db.Run(context.Background(), b); err != nil {
+	if err := db.Run(ctx, b); err != nil {
 		t.Fatal(err)
 	}
 	expected := map[string][]byte{
@@ -583,6 +584,27 @@ func TestTxn_Commit(t *testing.T) {
 		"ab": []byte("2"),
 	}
 	checkResults(t, expected, b.Results)
+}
+
+func TestTxn_Rollback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	s, db := setup(t)
+	defer s.Stopper().Stop(ctx)
+
+	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		if err := txn.Put(ctx, "a", "1"); err != nil {
+			return err
+		}
+		return txn.Rollback(ctx)
+	})
+	require.NoError(t, err)
+
+	// Check that the transaction was rolled back.
+	r, err := db.Get(ctx, "a")
+	require.NoError(t, err)
+	require.False(t, r.Exists())
 }
 
 func TestDB_Put_insecure(t *testing.T) {

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -760,6 +760,13 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 	return nil
 }
 
+// ClientFinalized is part of the kv.TxnSender interface.
+func (tc *TxnCoordSender) ClientFinalized() bool {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	return tc.mu.txnState == txnFinalized
+}
+
 // finalizeAndCleanupTxnLocked marks the transaction state as finalized and
 // closes all interceptors.
 func (tc *TxnCoordSender) finalizeAndCleanupTxnLocked(ctx context.Context) {

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -73,6 +73,11 @@ func (m *MockTransactionalSender) TxnStatus() roachpb.TransactionStatus {
 	return m.txn.Status
 }
 
+// ClientFinalized is part of the TxnSender interface.
+func (m *MockTransactionalSender) ClientFinalized() bool {
+	return m.txn.Status.IsFinalized()
+}
+
 // SetIsoLevel is part of the TxnSender interface.
 func (m *MockTransactionalSender) SetIsoLevel(isoLevel isolation.Level) error {
 	m.txn.IsoLevel = isoLevel

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -130,6 +130,11 @@ type TxnSender interface {
 	// TxnStatus exports the txn's status.
 	TxnStatus() roachpb.TransactionStatus
 
+	// ClientFinalized returns true is the client has issued an EndTxn
+	// request in an attempt to finalize the transaction. Once finalized,
+	// further batches except EndTxn(commit=false) will be rejected.
+	ClientFinalized() bool
+
 	// CreateSavepoint establishes a savepoint.
 	// This method is only valid when called on RootTxns.
 	//


### PR DESCRIPTION
This commit adds support for the following pattern in a transaction closure:

```go
db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
    return txn.Rollback(ctx)
})
```

Surprisingly, this would previously return an error:
```
TransactionStatusError: client already committed or rolled back the transaction. Trying to execute: 1 EndTxn (REASON_UNKNOWN)
```

This was because the txn retry loop in `txn.exec` would attempt to commit the rolled back transaction and encounter the `TransactionStatusError`. The loop is now made aware of the client finalization state, and uses this to decide whether to auto-commit.

Epic: None
Release note: None