### PR TITLE
kv: add "dirty read" and "dirty write" anomalies to txn correctness test suite

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -171,6 +171,7 @@ go_test(
         "//pkg/kv/kvpb/kvpbmock",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/closedts",
+        "//pkg/kv/kvserver/concurrency",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/kvserverbase",

--- a/pkg/kv/kvclient/kvcoord/txn_correctness_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_correctness_test.go
@@ -1059,6 +1059,34 @@ func testTxnDBDirtyWriteAnomalyBothCommit(t *testing.T) {
 	checkConcurrency("dirty write", allLevels, []string{txn1, txn2}, verify, t)
 }
 
+// TestTxnDBDirtyReadAnomaly verifies that none of RC, SI, or SSI
+// isolation are subject to the dirty read anomaly.
+//
+// With dirty reads, a transaction writes to a key while a concurrent
+// transaction reads from that key. The writing transaction then rolls
+// back. If the reading transaction observes the write, either before or
+// after the rollback, it has experienced a dirty read.
+//
+// Dirty reads would typically fail with a history such as:
+//
+//	W1(A) R2(A) A1 C2
+func TestTxnDBDirtyReadAnomaly(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	txn1 := "W(A,1) A"
+	txn2 := "R(A) W(B,A) C"
+	verify := &verifier{
+		history: "R(B)",
+		checkFn: func(env map[string]int64) error {
+			if env["B"] != 0 {
+				return errors.Errorf("expected B=0, got %d", env["B"])
+			}
+			return nil
+		},
+	}
+	checkConcurrency("dirty read", allLevels, []string{txn1, txn2}, verify, t)
+}
+
 // TestTxnDBReadSkewAnomaly verifies that neither SI nor SSI isolation
 // are subject to the read skew anomaly, an example of a database
 // constraint violation known as inconsistent analysis[^1]. This


### PR DESCRIPTION
Closes #102097.

This PR adds testing of the "dirty read" anomaly and a trio of variants of the "dirty write" anomaly to the txn correctness test suite. The anomalies are proscribed at all isolation levels.

With dirty reads, a transaction writes to a key while a concurrent transaction reads from that key. The writing transaction then rolls back. If the reading transaction observes the write, either before or after the rollback, it has experienced a dirty read.

With dirty writes, two transactions concurrently write to the same key(s). If one transaction then rolls back, the final state must reflect the write performed by the committing transaction. Crucially, the rollback must not interfere with the write from the committing transaction.

Two closely related cases are when both transactions roll back and when both transactions commit. In the first case, the final state must reflect neither write. In the second case, the final state must reflect a consistent commit order across keys, such that all written keys reflect writes from the second transaction to commit.

Release note: None
