### PR TITLE
ccl/changefeedccl: skip TestChangefeedJobUpdateFailsIfNotClaimed

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4182,6 +4182,7 @@ func TestChangefeedRetryableError(t *testing.T) {
 
 func TestChangefeedJobUpdateFailsIfNotClaimed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 101506, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// Set TestingKnobs to return a known session for easier


### PR DESCRIPTION
Refs: #101506

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None
Epic: None