### PR TITLE
changefeedccl: Prevent tests from being blocked indefinitely

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4196,7 +4196,10 @@ func TestChangefeedJobUpdateFailsIfNotClaimed(t *testing.T) {
 		knobs := s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
 		errChan := make(chan error, 1)
 		knobs.HandleDistChangefeedError = func(err error) error {
-			errChan <- err
+			select {
+			case errChan <- err:
+			default:
+			}
 			return err
 		}
 


### PR DESCRIPTION
Conditionally emit error to the error channel.

Fixes: #101506

Release note: None