### PR TITLE
sql: prevent declarative-rules test churn when new versions are added

### DIFF
--- a/pkg/cli/declarative_print_rules_test.go
+++ b/pkg/cli/declarative_print_rules_test.go
@@ -28,16 +28,17 @@ func TestDeclarativeRules(t *testing.T) {
 	defer c.Cleanup()
 
 	t.Run("declarative corpus validation standalone command", func(t *testing.T) {
-		version := clusterversion.TestingBinaryVersion
 		invalidOut, err := c.RunWithCapture(fmt.Sprintf("debug declarative-print-rules %s op", "1.1"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		opOut, err := c.RunWithCapture(fmt.Sprintf("debug declarative-print-rules %s op", version.String()))
+		version := clusterversion.TestingBinaryVersion
+		versionString := strings.Split(version.String(), "-")[0]
+		opOut, err := c.RunWithCapture(fmt.Sprintf("debug declarative-print-rules %s op", versionString))
 		if err != nil {
 			t.Fatal(err)
 		}
-		depOut, err := c.RunWithCapture(fmt.Sprintf("debug declarative-print-rules %s dep", version.String()))
+		depOut, err := c.RunWithCapture(fmt.Sprintf("debug declarative-print-rules %s dep", versionString))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cli/testdata/declarative-rules/deprules
+++ b/pkg/cli/testdata/declarative-rules/deprules
@@ -1,6 +1,6 @@
 dep
 ----
-debug declarative-print-rules 1000023.1-2 dep
+debug declarative-print-rules 1000023.1 dep
 deprules
 ----
 - name: 'CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'

--- a/pkg/cli/testdata/declarative-rules/oprules
+++ b/pkg/cli/testdata/declarative-rules/oprules
@@ -1,6 +1,6 @@
 op
 ----
-debug declarative-print-rules 1000023.1-2 op
+debug declarative-print-rules 1000023.1 op
 rules
 ----
 []


### PR DESCRIPTION
Fixes #102126

Previously, adding new 23.2 version results in this test failure:
```
Failed
=== RUN   TestDeclarativeRules/declarative_corpus_validation_standalone_command
[debug declarative-print-rules 1.1 op]
[debug declarative-print-rules 1000023.1-4 op]
[debug declarative-print-rules 1000023.1-4 dep]
    declarative_print_rules_test.go:46:
        /home/roach/.cache/bazel/_bazel_roach/c5a4e7d36696d9cd970af2045211a7df/sandbox/processwrapper-sandbox/6812/execroot/com_github_cockroachdb_cockroach/bazel-out/k8-fastbuild/bin/pkg/cli/cli_test_/cli_test.runfiles/com_github_cockroachdb_cockroach/pkg/cli/testdata/declarative-rules/invalid_version:1:
        invalid_version [0 args]
        -----
        ----
        debug declarative-print-rules 1.1 op
        unsupported version number, the supported versions are:
         latest
         1000022.2
    declarative_print_rules_test.go:55:
        /home/roach/.cache/bazel/_bazel_roach/c5a4e7d36696d9cd970af2045211a7df/sandbox/processwrapper-sandbox/6812/execroot/com_github_cockroachdb_cockroach/bazel-out/k8-fastbuild/bin/pkg/cli/cli_test_/cli_test.runfiles/com_github_cockroachdb_cockroach/pkg/cli/testdata/declarative-rules/oprules:1:

        expected:
        debug declarative-print-rules 1000023.1-2 op
        rules
        ----
        []

        found:
        debug declarative-print-rules 1000023.1-4 op
        rules
        ----
        []
    --- FAIL: TestDeclarativeRules/declarative_corpus_validation_standalone_command (0.06s)
```

This change ignores the version string after the `-`.

Release note: None