### PR TITLE
clusterversion: remove stability period guidance for version gates

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -521,18 +521,6 @@ const (
 	// tables.
 	V23_1CreateSystemActivityUpdateJob
 
-	// **********************************************************
-	// ** If we haven't yet selected a final 23.1 RC candidate **
-	// Step 1a: Add new versions for release-23.1 branch above here.
-	// **********************************************************
-	// Where to add new versions?
-	// - If the version gate is being backported to release-23.1, add the new version above this comment.
-	//   This can be done during 23.1 Stability until we select a final RC.
-	// - If the version gate is for 23.2 development (not being backported to release-23.1), add the
-	//   new version above "Step 1b"
-	// - Do not add new versions to a patch release.
-	// *************************************************
-
 	// V23_1 is CockroachDB v23.1. It's used for all v23.1.x patch releases.
 	V23_1
 
@@ -541,7 +529,7 @@ const (
 	V23_2Start
 
 	// *************************************************
-	// Step 1b: Add new version for 23.2 development here.
+	// Step (1) Add new versions here.
 	// Do not add new versions to a patch release.
 	// *************************************************
 )
@@ -921,19 +909,6 @@ var rawVersionsSingleton = keyedVersions{
 		Key:     V23_1CreateSystemActivityUpdateJob,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 102},
 	},
-
-	// **********************************************************
-	// ** If we haven't yet selected a final 23.1 RC candidate **
-	// Step 2a: Add new versions for release-23.1 branch above here.
-	// **********************************************************
-	// Where to add new versions?
-	// - If the version gate is being backported to release-23.1, add the new version above this comment.
-	//   This can be done during 23.1 Stability until we select a final RC.
-	// - If the version gate is for 23.2 development (not being backported to release-23.1), add the
-	//   new version above "Step 2b"
-	// - Do not add new versions to a patch release.
-	// *************************************************
-
 	{
 		Key:     V23_1,
 		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 0},
@@ -944,7 +919,7 @@ var rawVersionsSingleton = keyedVersions{
 	},
 
 	// *************************************************
-	// Step 2b: Add new version gates for 23.2 development here.
+	// Step (2): Add new versions here.
 	// Do not add new versions to a patch release.
 	// *************************************************
 }


### PR DESCRIPTION
Now that we’re out of the stability period, this PR removes the stability period guidance that was temporarily added in https://github.com/cockroachdb/cockroach/pull/99982, putting back in place the guidance to always append version gates to the end of the list.

Additional Context:

During the stability period before we mint the release branch,
version gates can either be added before or after the “mint”
version gate, depending of whether the version gate is for the
release [that is being stabilized], or for the next development
cycle.

Once we’re out of the stability period, version gates should
just always be append to the end of the list of version gates.

Release note: None
Epic: REL-311