### PR TITLE
kvserver: validate returned load split keys

### DIFF
--- a/pkg/kv/kvserver/replica_split_load.go
+++ b/pkg/kv/kvserver/replica_split_load.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/split"
@@ -249,4 +250,47 @@ func (r *Replica) recordBatchForLoadBasedSplitting(
 	if shouldInitSplit {
 		r.store.splitQueue.MaybeAddAsync(ctx, r, r.store.Clock().NowAsClockTimestamp())
 	}
+}
+
+// loadSplitKey returns a suggested load split key for the range if it exists,
+// otherwise it returns nil. If there were any errors encountered when
+// validating the split key, the error is returned as well.
+func (r *Replica) loadSplitKey(ctx context.Context, now time.Time) roachpb.Key {
+	splitKey := r.loadBasedSplitter.MaybeSplitKey(ctx, now)
+	if splitKey == nil {
+		return nil
+	}
+
+	// We swallow the error here and instead log an event. It is currently
+	// expected that the load based splitter may return the start key of the
+	// range.
+	if err := splitKeyPreCheck(r.Desc().RSpan(), splitKey); err != nil {
+		log.KvDistribution.VEventf(ctx, 1, "suggested load split key not usable: %s", err)
+		return nil
+	}
+
+	return splitKey
+}
+
+// splitKeyPreCheck checks that a split key is addressable and not the same as
+// the start key. An error is returned if these are not true. Additional checks
+// are made in adminSplitWithDescriptor when a split request is processed by
+// the replica.
+func splitKeyPreCheck(rspan roachpb.RSpan, splitKey roachpb.Key) error {
+	splitRKey, err := keys.Addr(splitKey)
+	if err != nil {
+		return err
+	}
+
+	// If the split key is equal to the start key of the range, it is treated as
+	// a no-op in adminSplitWithDescriptor, however it is treated as an error
+	// here because we shouldn't be suggesting split keys that are identical to
+	// the start key of the range.
+	if splitRKey.Equal(rspan.Key) {
+		return errors.Errorf(
+			"split key is equal to range start key (split_key=%s)",
+			splitRKey)
+	}
+
+	return nil
 }

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -196,7 +196,7 @@ func (sq *splitQueue) shouldQueue(
 		repl.GetMaxBytes(), repl.shouldBackpressureWrites(), confReader)
 
 	if !shouldQ && repl.SplitByLoadEnabled() {
-		if splitKey := repl.loadBasedSplitter.MaybeSplitKey(ctx, repl.Clock().PhysicalTime()); splitKey != nil {
+		if splitKey := repl.loadSplitKey(ctx, repl.Clock().PhysicalTime()); splitKey != nil {
 			shouldQ, priority = true, 1.0 // default priority
 		}
 	}
@@ -285,8 +285,7 @@ func (sq *splitQueue) processAttempt(
 	}
 
 	now := r.Clock().PhysicalTime()
-	splitByLoadKey := r.loadBasedSplitter.MaybeSplitKey(ctx, now)
-	if splitByLoadKey != nil {
+	if splitByLoadKey := r.loadSplitKey(ctx, now); splitByLoadKey != nil {
 		loadStats := r.loadStats.Stats()
 		batchHandledQPS := loadStats.QueriesPerSecond
 		raftAppliedQPS := loadStats.WriteKeysPerSecond


### PR DESCRIPTION
It is possible for the split key returned from the load based splitter
to be the start key of the range. This can occur when one row is
particularly hot and the row uses column families. In such cases,
although the load based finder would track 20 unique keys, with
different suffixes, the resulting split key returned would always be the
same prefix.

e.g. for YCSB with column families:

We wish to split at:

/Table/104/2/"user2933389304617401955"/7/1

However the returned, safe SQL key is:

/Table/104/2/‹"user2933389304617401955"›

Which is the only possible key returned for the range.

This commit doesn't address the same key being returned, instead it
validates that the key isn't equal to the start key before the split
queue begins processing the split.

Resolves: https://github.com/cockroachdb/cockroach/issues/102136

Release note: None