### PR TITLE
release-22.2: pgwire: fix decoding array placeholder arguments

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/BUILD.bazel
+++ b/pkg/sql/pgwire/pgwirebase/BUILD.bazel
@@ -39,7 +39,6 @@ go_library(
         "//pkg/util/uint128",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_dustin_go_humanize//:go-humanize",
-        "@com_github_jackc_pgtype//:pgtype",
         "@com_github_lib_pq//oid",
     ],
 )

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/errors"
 	"github.com/dustin/go-humanize"
-	"github.com/jackc/pgtype"
 	"github.com/lib/pq/oid"
 )
 
@@ -442,60 +441,6 @@ func DecodeDatum(
 				return nil, tree.MakeParseError(string(b), typ, err)
 			}
 			return d, nil
-		case oid.T__int2, oid.T__int4, oid.T__int8:
-			var arr pgtype.Int8Array
-			if err := arr.DecodeText(nil, b); err != nil {
-				return nil, tree.MakeParseError(string(b), typ, err)
-			}
-			if arr.Status != pgtype.Present {
-				return tree.DNull, nil
-			}
-			if err := validateArrayDimensions(len(arr.Dimensions), len(arr.Elements)); err != nil {
-				return nil, err
-			}
-			out := tree.NewDArray(types.Int)
-			var d tree.Datum
-			for _, v := range arr.Elements {
-				if v.Status != pgtype.Present {
-					d = tree.DNull
-				} else {
-					d = tree.NewDInt(tree.DInt(v.Int))
-				}
-				if err := out.Append(d); err != nil {
-					return nil, err
-				}
-			}
-			return out, nil
-		case oid.T__text, oid.T__name:
-			var arr pgtype.TextArray
-			if err := arr.DecodeText(nil, b); err != nil {
-				return nil, tree.MakeParseError(string(b), typ, err)
-			}
-			if arr.Status != pgtype.Present {
-				return tree.DNull, nil
-			}
-			if err := validateArrayDimensions(len(arr.Dimensions), len(arr.Elements)); err != nil {
-				return nil, err
-			}
-			out := tree.NewDArray(types.String)
-			if id == oid.T__name {
-				out.ParamTyp = types.Name
-			}
-			var d tree.Datum
-			for _, v := range arr.Elements {
-				if v.Status != pgtype.Present {
-					d = tree.DNull
-				} else {
-					d = tree.NewDString(v.String)
-					if id == oid.T__name {
-						d = tree.NewDNameFromDString(d.(*tree.DString))
-					}
-				}
-				if err := out.Append(d); err != nil {
-					return nil, err
-				}
-			}
-			return out, nil
 		case oid.T_jsonb, oid.T_json:
 			if err := validateStringBytes(b); err != nil {
 				return nil, err

--- a/pkg/sql/pgwire/testdata/pgtest/array
+++ b/pkg/sql/pgwire/testdata/pgtest/array
@@ -12,3 +12,21 @@ ReadyForQuery
 {"Type":"ParseComplete"}
 {"Type":"ErrorResponse","Code":"08P01"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT $1::TEXT[], $2::INT8[], $3::NAME[]"}
+Bind {"Parameters": [{"text": "{key1, subkey1}"}, {"text": "{11,  22}"}, {"text": "{UnQuoted,  \"Quoted\"}"}]}
+Describe {"ObjectType": "P"}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"RowDescription","Fields":[{"Name":"text","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":1009,"DataTypeSize":-1,"TypeModifier":-1,"Format":0},{"Name":"int8","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":1016,"DataTypeSize":-1,"TypeModifier":-1,"Format":0},{"Name":"name","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":1003,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"{key1,subkey1}"},{"text":"{11,22}"},{"text":"{UnQuoted,Quoted}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 // The assertions in this test should also be caught by the integration tests on
@@ -147,7 +148,12 @@ func TestIntArrayRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Compare(evalCtx, d) != 0 {
+	// Arrays are decoded into strings by DecodeDatum, then will be converted into
+	// DArrays later during execution.
+	gotString := tree.MustBeDString(got)
+	gotArray, _, err := tree.ParseDArrayFromString(evalCtx, string(gotString), types.Int)
+	require.NoError(t, err)
+	if gotArray.Compare(evalCtx, d) != 0 {
 		t.Fatalf("expected %s, got %s", d, got)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #101571.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/97984

There was code that's been there since 2018, and it was added before we had better logic for parsing arrays in pgwire format. We can remove it and instead fallback to the general case, which was added later:
```
		if typ.Family() == types.ArrayFamily {
			// Arrays come in in their string form, so we parse them as such and later
			// convert them to their actual datum form.
			if err := validateStringBytes(b); err != nil {
				return nil, err
			}
			return tree.NewDString(string(b)), nil
		}
```

Release note (bug fix): Fixed a bug where CockroachDB would incorrectly parse arrays if they were sent as placeholder arguments to a prepared statement, and the argument had spaces in between the array elements.
