### PR TITLE
server: tenant span stats handle different cluster version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_tenant_span_stats.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_tenant_span_stats.go
@@ -85,8 +85,7 @@ func registerTenantSpanStatsMixedVersion(r registry.Registry) {
 			})
 
 			mvt.InMixedVersion("fetch span stats - mixed", func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-				prevToCurrentError := "unable to service a mixed version request"
-				currentToPrevError := "An internal server error has occurred"
+				mixedVersionReqError := "unable to service a mixed version request"
 				unknownFieldError := "unknown field"
 
 				// If we have nodes in mixed versions.
@@ -107,9 +106,9 @@ func registerTenantSpanStatsMixedVersion(r registry.Registry) {
 						return err
 					}
 					// Ensure we get the expected error.
-					expected := assertExpectedError(errOutput.Error, prevToCurrentError)
+					expected := assertExpectedError(errOutput.Error, mixedVersionReqError)
 					if !expected {
-						return errors.Newf("expected '%s' in error message, got: '%v'", prevToCurrentError, errOutput.Error)
+						return errors.Newf("expected '%s' in error message, got: '%v'", mixedVersionReqError, errOutput.Error)
 					}
 
 					// Fetch span stats from current version node, dialing to a previous version node.
@@ -125,10 +124,10 @@ func registerTenantSpanStatsMixedVersion(r registry.Registry) {
 						return err
 					}
 					// Ensure we get the expected error.
-					expectedCurrToPrev := assertExpectedError(errOutput.Message, currentToPrevError)
+					expectedCurrToPrev := assertExpectedError(errOutput.Message, mixedVersionReqError)
 					expectedUnknown := assertExpectedError(errOutput.Message, unknownFieldError)
 					if !expectedCurrToPrev && !expectedUnknown {
-						return errors.Newf("expected '%s' or '%s' in error message, got: '%v'", currentToPrevError, unknownFieldError, errOutput.Error)
+						return errors.Newf("expected '%s' or '%s' in error message, got: '%v'", mixedVersionReqError, expectedUnknown, errOutput.Error)
 					}
 
 					// Fanout from current version node.
@@ -144,10 +143,10 @@ func registerTenantSpanStatsMixedVersion(r registry.Registry) {
 						return err
 					}
 					// Ensure we get the expected error.
-					expectedCurrToPrev = assertExpectedError(errOutput.Message, currentToPrevError)
+					expectedCurrToPrev = assertExpectedError(errOutput.Message, mixedVersionReqError)
 					expectedUnknown = assertExpectedError(errOutput.Message, unknownFieldError)
 					if !expectedCurrToPrev && !expectedUnknown {
-						return errors.Newf("expected '%s' or '%s' in error message, got: '%v'", currentToPrevError, unknownFieldError, errOutput.Error)
+						return errors.Newf("expected '%s' or '%s' in error message, got: '%v'", mixedVersionReqError, expectedUnknown, errOutput.Error)
 					}
 				} else {
 					// All nodes are on one version, but we're in mixed state (i.e. cluster version is on a different version)
@@ -175,10 +174,10 @@ func registerTenantSpanStatsMixedVersion(r registry.Registry) {
 						return err
 					}
 					// Ensure we get the expected error.
-					expectedCurrToPrev := assertExpectedError(errOutput.Message, currentToPrevError)
+					mixedClusterVersionErr := assertExpectedError(errOutput.Message, mixedVersionReqError)
 					expectedUnknown := assertExpectedError(errOutput.Message, unknownFieldError)
-					if !expectedCurrToPrev && !expectedUnknown {
-						return errors.Newf("expected '%s' or '%s' in error message, got: '%v'", currentToPrevError, unknownFieldError, errOutput.Error)
+					if !mixedClusterVersionErr && !expectedUnknown {
+						return errors.Newf("expected '%s' or '%s' in error message, got: '%v'", mixedVersionReqError, unknownFieldError, errOutput.Error)
 					}
 				}
 				return nil

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -3469,6 +3470,12 @@ func (s *systemStatusServer) SpanStats(
 		// already returns a proper gRPC error status.
 		return nil, err
 	}
+
+	// If the cluster's active version is less than 23.1 return a mixed version error.
+	if !s.st.Version.IsActive(ctx, clusterversion.V23_1) {
+		return nil, errors.New(MixedVersionErr)
+	}
+
 	// If we receive a request using the old format.
 	if isLegacyRequest(req) {
 		// We want to force 23.1 callers to use the new format (e.g. Spans field).
@@ -3482,6 +3489,7 @@ func (s *systemStatusServer) SpanStats(
 	if len(req.Spans) > int(roachpb.SpanStatsBatchLimit.Get(&s.st.SV)) {
 		return nil, errors.Newf(exceedSpanLimitPlaceholder, len(req.Spans), int(roachpb.SpanStatsBatchLimit.Get(&s.st.SV)))
 	}
+
 	return s.getSpanStatsInternal(ctx, req)
 }
 


### PR DESCRIPTION
Resolves: #102087

This change returns a mixed version error when the cluster version is different from node versions.

Release note: None