### PR TITLE
kv: delete `(hlc.Timestamp).DeprecatedTryToClockTimestamp`

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -184,8 +184,6 @@ const (
 	// TODODelete_V22_2Start demarcates work towards CockroachDB v22.2.
 	TODODelete_V22_2Start
 
-	// TODODelete_V22_2LocalTimestamps enables the use of local timestamps in MVCC values.
-	TODODelete_V22_2LocalTimestamps
 	// TODODelete_V22_2PebbleFormatSplitUserKeysMarkedCompacted updates the Pebble format
 	// version that recombines all user keys that may be split across multiple
 	// files into a single table.
@@ -612,10 +610,6 @@ var rawVersionsSingleton = keyedVersions{
 	{
 		Key:     TODODelete_V22_2Start,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 2},
-	},
-	{
-		Key:     TODODelete_V22_2LocalTimestamps,
-		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 4},
 	},
 	{
 		Key:     TODODelete_V22_2PebbleFormatSplitUserKeysMarkedCompacted,

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -397,18 +397,6 @@ func (LegacyTimestamp) SafeValue() {}
 // Synthetic flag set to false.
 type ClockTimestamp Timestamp
 
-// DeprecatedTryToClockTimestamp attempts to downcast a Timestamp into a
-// ClockTimestamp. Returns the result and a boolean indicating whether the cast
-// succeeded.
-// TODO(nvanbenschoten): remove this in v23.1 when we remove the synthetic
-// timestamp bit.
-func (t Timestamp) DeprecatedTryToClockTimestamp() (ClockTimestamp, bool) {
-	if t.Synthetic {
-		return ClockTimestamp{}, false
-	}
-	return ClockTimestamp(t), true
-}
-
 // UnsafeToClockTimestamp converts a Timestamp to a ClockTimestamp, regardless
 // of whether such a cast would be legal according to the Synthetic flag. The
 // method should only be used in tests.


### PR DESCRIPTION
Informs #101938.

This function has been possible to delete since v23.1.

Release note: None