### PR TITLE
workload: add prometheus NewGoCollector

### DIFF
--- a/pkg/workload/cli/BUILD.bazel
+++ b/pkg/workload/cli/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/workload/histogram",
         "//pkg/workload/workloadsql",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_prometheus_client_golang//prometheus/collectors",
         "@com_github_prometheus_client_golang//prometheus/promhttp",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_pflag//:pflag",

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/cockroachdb/cockroach/pkg/workload/workloadsql"
 	"github.com/cockroachdb/errors"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -415,6 +416,7 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 		*histogramsMaxLatency,
 		gen.Meta().Name,
 	)
+	reg.Registerer().MustRegister(collectors.NewGoCollector())
 	// Expose the prometheus gatherer.
 	go func() {
 		if err := http.ListenAndServe(


### PR DESCRIPTION
Previously, the workload would register only a Histogram for the corresponding workload. This change adds NewGoCollector which exports Go runtime metrics, i.e., gc and goroutines.

This change makes it easy to investigate performance regressions within the workload generator.

Epic: none

Release note: workload generators now export Go runtime metrics via Prometheus endpoint.