### PR TITLE
release-23.1: clusterversion: mint 23.1

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -293,4 +293,4 @@ trace.opentelemetry.collector	string		address of an OpenTelemetry trace collecto
 trace.snapshot.rate	duration	0s	if non-zero, interval at which background trace snapshots are captured
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	22.2-102	set the active cluster version in the format '<major>.<minor>'
+version	version	23.1	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -245,6 +245,6 @@
 <tr><td><div id="setting-trace-snapshot-rate" class="anchored"><code>trace.snapshot.rate</code></div></td><td>duration</td><td><code>0s</code></td><td>if non-zero, interval at which background trace snapshots are captured</td></tr>
 <tr><td><div id="setting-trace-span-registry-enabled" class="anchored"><code>trace.span_registry.enabled</code></div></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://&lt;ui&gt;/#/debug/tracez</td></tr>
 <tr><td><div id="setting-trace-zipkin-collector" class="anchored"><code>trace.zipkin.collector</code></div></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>22.2-102</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td></tr>
+<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>23.1</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -391,7 +391,7 @@ select crdb_internal.get_vmodule()
 query T
 select regexp_replace(regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', ''), '10000', '');
 ----
-22.2
+23.1
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -484,7 +484,7 @@ select * from crdb_internal.gossip_alerts
 query T
 select regexp_replace(regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', ''), '10000', '');
 ----
-22.2
+23.1
 
 user root
 

--- a/pkg/cli/testdata/declarative-rules/deprules
+++ b/pkg/cli/testdata/declarative-rules/deprules
@@ -1,6 +1,6 @@
 dep
 ----
-debug declarative-print-rules 22.2-102 dep
+debug declarative-print-rules 23.1 dep
 deprules
 ----
 - name: 'CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'

--- a/pkg/cli/testdata/declarative-rules/invalid_version
+++ b/pkg/cli/testdata/declarative-rules/invalid_version
@@ -5,3 +5,4 @@ debug declarative-print-rules 1.1 op
 unsupported version number, the supported versions are: 
  latest
  22.2
+

--- a/pkg/cli/testdata/declarative-rules/oprules
+++ b/pkg/cli/testdata/declarative-rules/oprules
@@ -1,6 +1,6 @@
 op
 ----
-debug declarative-print-rules 22.2-102 op
+debug declarative-print-rules 23.1 op
 rules
 ----
 []

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -529,6 +529,9 @@ const (
 	// tables.
 	V23_1CreateSystemActivityUpdateJob
 
+	// V23_1 is CockroachDB v23.1. It's used for all v23.1.x patch releases.
+	V23_1
+
 	// *************************************************
 	// Step (1): Add new versions here.
 	// Do not add new versions to a patch release.
@@ -918,6 +921,10 @@ var rawVersionsSingleton = keyedVersions{
 		Key:     V23_1CreateSystemActivityUpdateJob,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 102},
 	},
+	{
+		Key:     V23_1,
+		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 0},
+	},
 
 	// *************************************************
 	// Step (2): Add new versions here.
@@ -939,7 +946,7 @@ const (
 	// finalVersion should be set on a release branch to the minted final cluster
 	// version key, e.g. to V22_2 on the release-22.2 branch once it is minted.
 	// Setting it has the effect of ensuring no versions are subsequently added.
-	finalVersion = invalidVersionKey
+	finalVersion = V23_1
 )
 
 var allowUpgradeToDev = envutil.EnvOrDefaultBool("COCKROACH_UPGRADE_TO_DEV_VERSION", false)
@@ -985,14 +992,6 @@ var versionsSingleton = func() keyedVersions {
 	}
 	return rawVersionsSingleton
 }()
-
-// V23_1 is a placeholder that will eventually be replaced by the actual 23.1
-// version Key, but in the meantime it points to the latest Key. The placeholder
-// is defined so that it can be referenced in code that simply wants to check if
-// a cluster is running 23.1 and has completed all associated migrations; most
-// version gates can use this instead of defining their own version key if all
-// simply need to check is that the cluster has upgraded to 23.1.
-var V23_1 = versionsSingleton[len(versionsSingleton)-1].Key
 
 const (
 	BinaryMinSupportedVersionKey = V22_2

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -568,7 +568,7 @@ select crdb_internal.get_vmodule()
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
 ----
-22.2
+23.1
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -722,7 +722,7 @@ SELECT * FROM crdb_internal.check_consistency(true, b'\x02', b'\x04')
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
 ----
-22.2
+23.1
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_can_login
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_can_login
@@ -21,7 +21,7 @@ SELECT crdb_internal.create_tenant(1001)
 upgrade 1
 
 query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
+SELECT crdb_internal.node_executable_version() = '23.1'
 ----
 true
 
@@ -34,7 +34,7 @@ SELECT crdb_internal.node_executable_version()
 user testuser nodeidx=0
 
 query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
+SELECT crdb_internal.node_executable_version() = '23.1'
 ----
 true
 
@@ -42,7 +42,7 @@ true
 user root nodeidx=1
 
 query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
+SELECT crdb_internal.node_executable_version() = '23.1'
 ----
 true
 
@@ -65,7 +65,7 @@ SELECT crdb_internal.node_executable_version()
 upgrade 2
 
 query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
+SELECT crdb_internal.node_executable_version() = '23.1'
 ----
 true
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_range_tombstones
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_range_tombstones
@@ -22,7 +22,7 @@ false
 upgrade 0
 
 query B nodeidx=0
-SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
+SELECT crdb_internal.node_executable_version() = '23.1'
 ----
 true
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
@@ -47,7 +47,7 @@ upgrade 1
 # Test that there are no problems creating role memberships on a mixed 22.2/23.1 cluster.
 
 query B nodeidx=1
-SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
+SELECT crdb_internal.node_executable_version() = '23.1'
 ----
 true
 
@@ -83,16 +83,16 @@ upgrade 2
 # Verify that all nodes are now running 23.1 binaries.
 
 query B nodeidx=0
-SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
+SELECT crdb_internal.node_executable_version() = '23.1'
 ----
 true
 
 query B nodeidx=1
-SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
+SELECT crdb_internal.node_executable_version() = '23.1'
 ----
 true
 
 query B nodeidx=2
-SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
+SELECT crdb_internal.node_executable_version() = '23.1'
 ----
 true


### PR DESCRIPTION
This mints the release branch as 23.1.

We should only merge this backport once we are sure won't need additional version gates for 23.1.

Backport 1/4 commits from #99128.

/cc @cockroachdb/release

---

As part of the 23.1 stability period tasks, this PR preps the 23.1 release branch and initializes 23.2 development, as per this release runbook: [Prep Release and Define Start of Development for Next Release](https://cockroachlabs.atlassian.net/wiki/spaces/RE/pages/2924740768/Prep+Release+and+Define+Start+of+Development+for+Next+Release).

This PR will contain 4 commits:

|commit|backported when|
|-|-|
|1. Set developmentBranch to false|soon after branch cut / before selecting beta.1 candidate|
|2. Update version.txt to alpha.8 (next release)|soon after branch cut / before selecting ~beta.1~ this week's alpha.8 candidate|
|3. Mint the previous release|should be final backport before the final RC / before selecting final RC candidate|
|4. Define the start of 23.2 development and placeholder key|_(not backported)_|


Release justification: non-production code change; mints this branch as 23.1.
Epic: REL-311
Fixes: Fixes: https://github.com/cockroachdb/cockroach/issues/102256
Release note: none.
