### PR TITLE
backupccl: pretend manifest files spans actually end at EndKey.Next on restore

### DIFF
--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
@@ -208,9 +208,10 @@ func TestRunGenerativeSplitAndScatterRandomizedDestOnFailScatter(t *testing.T) {
 		numEntriesByNode[e.node]++
 	}
 
-	// There are at least 10 splits from the original backed up bank table. Plus
-	// the entries from the system table, etc. Sanity check this.
-	require.GreaterOrEqual(t, len(doneEntries), 10)
+	// There are at least 10 splits from the original backed up bank table.
+	// Because file spans are end key inclusive, this should result in at least
+	// 9 import spans. Sanity check this.
+	require.GreaterOrEqual(t, len(doneEntries), 9)
 
 	// The failed scatter chunks should be scattered to the nodes that have been
 	// scattered to before and cached.

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -102,8 +102,14 @@ var _ backupManifestFileIterator = &sstFileIterator{}
 // makeSimpleImportSpans partitions the spans of requiredSpans into a covering
 // of RestoreSpanEntry's which each have all overlapping files from the passed
 // backups assigned to them. The spans of requiredSpans are trimmed/removed
-// based on the lowWaterMark before the covering for them is generated. Consider
-// a chain of backups with files f1, f2… which cover spans as follows:
+// based on the lowWaterMark before the covering for them is generated.
+//
+// Note that because of https://github.com/cockroachdb/cockroach/issues/101963,
+// the spans of files are end key _inclusive_. Because the current definition
+// of spans are all end key _exclusive_, we work around this by assuming that
+// the end key of each file span is actually the next key of the end key.
+//
+// Consider a chain of backups with files f1, f2… which cover spans as follows:
 //
 //	backup
 //	0|     a___1___c c__2__e          h__3__i
@@ -116,9 +122,9 @@ var _ backupManifestFileIterator = &sstFileIterator{}
 //
 // The cover for those spans would look like:
 //
-//	[a, c): 1, 4, 6
-//	[c, e): 2, 4, 6
-//	[e, f): 6
+//	[a, c\x00): 1, 4, 6
+//	[c\x00, e\x00): 1, 2, 4, 6
+//	[e\x00, f): 2, 6
 //	[f, i): 3, 5, 6, 8
 //	[l, m): 9
 //
@@ -176,7 +182,8 @@ func makeSimpleImportSpans(
 						break
 					}
 					f := it.Value()
-					if sp := span.Intersect(f.Span); sp.Valid() {
+					fspan := endKeyInclusiveSpan(f.Span)
+					if sp := span.Intersect(fspan); sp.Valid() {
 						fileSpec := execinfrapb.RestoreFileSpec{Path: f.Path, Dir: backups[layer].Dir}
 						if dir, ok := backupLocalityMap[layer][f.LocalityKV]; ok {
 							fileSpec = execinfrapb.RestoreFileSpec{Path: f.Path, Dir: dir}
@@ -234,7 +241,7 @@ func makeSimpleImportSpans(
 								}
 							}
 						}
-					} else if span.EndKey.Compare(f.Span.Key) <= 0 {
+					} else if span.EndKey.Compare(fspan.Key) <= 0 {
 						// If this file starts after the needed span ends, then all the files
 						// remaining do too so we're done checking files for this span.
 						break
@@ -375,6 +382,11 @@ func (f spanCoveringFilter) getLayersCoveredLater(
 // trimmed/removed based on the lowWaterMark before the covering for them is
 // generated. These spans are generated one at a time and then sent to spanCh.
 //
+// Note that because of https://github.com/cockroachdb/cockroach/issues/101963,
+// the spans of files are end key _inclusive_. Because the current definition
+// of spans are all end key _exclusive_, we work around this by assuming that
+// the end key of each file span is actually the next key of the end key.
+//
 // Consider a chain of backups with files f1, f2… which cover spans as follows:
 //
 //	backup
@@ -389,11 +401,10 @@ func (f spanCoveringFilter) getLayersCoveredLater(
 // The cover for those spans would look like:
 //
 //	[a, b): 1, 6
-//	[b, c): 1, 4, 6
-//	[c, f): 2, 4, 6
+//	[b, f): 1, 2, 4, 6
 //	[f, g): 6
 //	[g, h): 5, 6
-//	[h, i): 3, 5, 8
+//	[h, i): 3, 5, 6, 8
 //	[l, m): 9
 //
 // This cover is created by iterating through the start and end keys of all the
@@ -538,7 +549,8 @@ func generateAndSendImportSpans(
 							sz = 16 << 20
 						}
 
-						if coverSpan.Overlaps(file.Span) {
+						fspan := endKeyInclusiveSpan(file.Span)
+						if coverSpan.Overlaps(fspan) {
 							covSize += sz
 							filesByLayer[layer] = append(filesByLayer[layer], file)
 						}
@@ -722,10 +734,11 @@ type fileHeapItem struct {
 }
 
 func (f fileHeapItem) key() roachpb.Key {
+	fspan := endKeyInclusiveSpan(f.file.Span)
 	if f.cmpEndKey {
-		return f.file.Span.EndKey
+		return fspan.EndKey
 	}
-	return f.file.Span.Key
+	return fspan.Key
 }
 
 type fileHeap struct {
@@ -779,11 +792,19 @@ func getNewIntersectingFilesByLayer(
 				}
 
 				f := iter.Value()
-				if span.Overlaps(f.Span) {
+				// NB: a backup file can currently have keys equal to its span's
+				// EndKey due to the bug:
+				// https://github.com/cockroachdb/cockroach/issues/101963,
+				// effectively meaning that we have to treat the span as end key
+				// inclusive. Because roachpb.Span and its associated operations
+				// are end key exclusive, we work around this by replacing the
+				// end key with its next value in order to include the end key.
+				fspan := endKeyInclusiveSpan(f.Span)
+				if span.Overlaps(fspan) {
 					layerFiles = append(layerFiles, f)
 				}
 
-				if span.EndKey.Compare(f.Span.Key) <= 0 {
+				if span.EndKey.Compare(fspan.Key) <= 0 {
 					break
 				}
 			}
@@ -792,4 +813,19 @@ func getNewIntersectingFilesByLayer(
 	}
 
 	return files, nil
+}
+
+// endKeyInclusiveSpan returns a span with the same start key as the input span
+// but with its end key as the next key of the input's end key.
+//
+// NB: a backup file can currently have keys equal to its span's EndKey due to
+// the bug: https://github.com/cockroachdb/cockroach/issues/101963, effectively
+// meaning that we have to treat the span as end key inclusive. Because
+// roachpb.Span and its associated operations are end key exclusive, we work
+// around this by replacing the end key with its next value in order to include
+// the end key.
+func endKeyInclusiveSpan(sp roachpb.Span) roachpb.Span {
+	isp := sp.Clone()
+	isp.EndKey = isp.EndKey.Next()
+	return isp
 }


### PR DESCRIPTION
Currently, a key's revision history can be split in such a way that the first part of the history is at the end of one SST, while the rest of its history is at the beginning of another SST. In this case, the backup manifest entry describing the first file will claim that the span ended at (and excludes) the split key, whereas in reality the file still contains some revisions of that key.

This patch introduces a workaround to these incorrect manifest file spans by conservatively assuming that all manifest file spans actually end at the next key of its end key during restore import span generation. This allows restore to actually consider all files that may end with a key that's split mid revision.

Addresses #101963

Release note (bug fix): fixes a bug where a backup with a key's revision history split across multiple SSTs may not correctly restore the proper revision of the key.

Epic: none.