### PR TITLE
ttl: decode error repro

### DIFF
--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -13,6 +13,7 @@ package rowenc_test
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"testing"
@@ -1257,4 +1258,36 @@ func TestDecodeKeyVals(t *testing.T) {
 			require.Equal(t, tc.expectedNumVals, actualNumVals)
 		})
 	}
+}
+
+func TestDecodeIndexKeyToDatums(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	keyBytes, err := hex.DecodeString("f389fd08c48e96c53997ff12434f4e")
+	require.NoError(t, err)
+	codec := keys.SystemSQLCodec
+	typs := []*types.T{
+		types.Int,
+		types.String,
+		types.String,
+		types.Int,
+		types.Int,
+	}
+	dirs := []catenumpb.IndexColumn_Direction{
+		catenumpb.IndexColumn_ASC,
+		catenumpb.IndexColumn_ASC,
+		catenumpb.IndexColumn_ASC,
+		catenumpb.IndexColumn_ASC,
+		catenumpb.IndexColumn_ASC,
+	}
+	var alloc tree.DatumAlloc
+	datums, err := DecodeIndexKeyToDatums(
+		codec,
+		typs,
+		dirs,
+		keyBytes,
+		&alloc,
+	)
+	require.NoError(t, err) // failing
+	_ = datums
 }


### PR DESCRIPTION
```
=== RUN   TestDecodeIndexKeyToDatums
    index_encoding_test.go:1291: 
        	Error Trace:	/Users/ewall/go/src/github.com/cockroachdb/cockroach/pkg/sql/rowenc/index_encoding_test.go:1291
        	Error:      	Received unexpected error:
        	            	did not find terminator 0x0 in buffer 0x12434f4e
        	            	(1) attached stack trace
        	            	  -- stack trace:
        	            	  | github.com/cockroachdb/cockroach/pkg/util/encoding.getBytesLength
        	            	  | 	/Users/ewall/go/src/github.com/cockroachdb/cockroach/pkg/util/encoding/encoding.go:815
        	            	  | github.com/cockroachdb/cockroach/pkg/util/encoding.PeekLength
        	            	  | 	/Users/ewall/go/src/github.com/cockroachdb/cockroach/pkg/util/encoding/encoding.go:1999
        	            	  | github.com/cockroachdb/cockroach/pkg/sql/rowenc.EncDatumFromBuffer
        	            	  | 	/Users/ewall/go/src/github.com/cockroachdb/cockroach/pkg/sql/rowenc/encoded_datum.go:153
        	            	  | github.com/cockroachdb/cockroach/pkg/sql/rowenc.DecodeKeyVals
        	            	  | 	/Users/ewall/go/src/github.com/cockroachdb/cockroach/pkg/sql/rowenc/index_encoding.go:483
        	            	  | github.com/cockroachdb/cockroach/pkg/sql/rowenc.DecodeIndexKey
        	            	  | 	/Users/ewall/go/src/github.com/cockroachdb/cockroach/pkg/sql/rowenc/index_encoding.go:436
        	            	  | github.com/cockroachdb/cockroach/pkg/sql/rowenc.DecodeIndexKeyToDatums
        	            	  | 	/Users/ewall/go/src/github.com/cockroachdb/cockroach/pkg/sql/rowenc/index_encoding.go:450
        	            	  | github.com/cockroachdb/cockroach/pkg/sql/rowenc_test.TestDecodeIndexKeyToDatums
        	            	  | 	/Users/ewall/go/src/github.com/cockroachdb/cockroach/pkg/sql/rowenc/index_encoding_test.go:1284
        	            	  | testing.tRunner
        	            	  | 	/Users/ewall/go/go1.19.7/src/testing/testing.go:1446
        	            	  | runtime.goexit
        	            	  | 	/Users/ewall/go/go1.19.7/src/runtime/asm_amd64.s:1594
        	            	Wraps: (2) did not find terminator 0x0 in buffer 0x12434f4e
        	            	Error types: (1) *withstack.withStack (2) *errutil.leafError
        	Test:       	TestDecodeIndexKeyToDatums
--- FAIL: TestDecodeIndexKeyToDatums (0.00s)
```