### PR TITLE
sql: use system database regions as the default

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -153,7 +153,7 @@ CREATE DATABASE eu_central_db;
 CREATE TABLE eu_central_db.t (x INT);
 INSERT INTO eu_central_db.t VALUES (1), (2), (3);
 ----
-NOTICE: setting eu-central-1 as the PRIMARY REGION as no PRIMARY REGION was specified
+NOTICE: defaulting to 'WITH PRIMARY REGION "eu-central-1"' as no primary region was specified
 
 exec-sql
 BACKUP DATABASE eu_central_db INTO 'nodelocal://1/eu_central_database_backup/';

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-multiregion
@@ -136,7 +136,7 @@ CREATE DATABASE eu_central_db;
 CREATE TABLE eu_central_db.t (x INT);
 INSERT INTO eu_central_db.t VALUES (1), (2), (3);
 ----
-NOTICE: setting eu-central-1 as the PRIMARY REGION as no PRIMARY REGION was specified
+NOTICE: defaulting to 'WITH PRIMARY REGION "eu-central-1"' as no primary region was specified
 
 exec-sql
 BACKUP DATABASE eu_central_db INTO 'nodelocal://1/eu_central_database_backup/';

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
@@ -23,7 +23,7 @@ CREATE DATABASE db REGIONS "us-east1"
 query T noticetrace
 CREATE DATABASE db
 ----
-NOTICE: setting ap-southeast-2 as the PRIMARY REGION as no PRIMARY REGION was specified
+NOTICE: defaulting to 'WITH PRIMARY REGION "ap-southeast-2"' as no primary region was specified
 
 query TTBBT colnames
 SHOW REGIONS FROM DATABASE db

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_system_database
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_system_database
@@ -1,0 +1,66 @@
+# LogicTest: 3node-tenant-multiregion
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
+
+# Only the root user can modify the system database's regions.
+user root
+
+# Create a database before transforming the system database into a multi-region
+# database.
+statement ok
+CREATE DATABASE "non-mr-system-database"
+
+query TTBBT colnames
+SHOW REGIONS FROM DATABASE "non-mr-system-database"
+----
+database  region  primary  secondary  zones
+
+# Configure the regions on the system database
+statement ok
+ALTER DATABASE system PRIMARY REGION "test"
+
+statement ok
+ALTER DATABASE system ADD REGION "test1"
+
+query TTBBT colnames
+SHOW REGIONS FROM DATABASE system
+----
+database  region  primary  secondary  zones
+system    test    true     false      {}
+system    test1   false    false      {}
+
+# A database with no primary region should have the same regions as the system
+# database.
+statement ok
+CREATE DATABASE "defaults-to-system";
+
+query TTBBT colnames
+SHOW REGIONS FROM DATABASE "defaults-to-system"
+----
+database            region  primary  secondary  zones
+defaults-to-system  test    true     false      {}
+defaults-to-system  test1   false    false      {}
+
+# If any regions are provided when creating the region, then those regions are
+# used instead of the system database's regions.
+statement ok
+CREATE DATABASE "with-custom-primary" WITH PRIMARY REGION 'test1'
+
+query TTBBT colnames
+SHOW REGIONS FROM DATABASE "with-custom-primary"
+----
+database             region  primary  secondary  zones
+with-custom-primary  test1   true     false      {}
+
+# If sql.defaults.primary_region is set, then the database is created with the
+# setting's region as the only region.
+statement ok
+SET CLUSTER SETTING sql.defaults.primary_region TO 'test1';
+
+statement ok
+CREATE DATABASE "with-primary-setting"
+
+query TTBBT colnames
+SHOW REGIONS FROM DATABASE "with-primary-setting"
+----
+database              region  primary  secondary  zones
+with-primary-setting  test1   true     false      {}

--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
@@ -8,10 +8,11 @@ go_test(
     args = ["-test.timeout=3595s"],
     data = [
         "//c-deps:libgeos",  # keep
+        "//pkg/ccl/logictestccl:testdata",  # keep
         "//pkg/sql/logictest:testdata",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    shard_count = 4,
+    shard_count = 5,
     tags = [
         "ccl_test",
         "cpu:2",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -615,6 +615,7 @@ go_test(
         "database_test.go",
         "delete_preserving_index_test.go",
         "descriptor_mutation_test.go",
+        "descriptor_test.go",
         "distsql_physical_planner_test.go",
         "distsql_plan_backfill_test.go",
         "distsql_plan_bulk_test.go",

--- a/pkg/sql/descriptor_test.go
+++ b/pkg/sql/descriptor_test.go
@@ -1,0 +1,51 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatDefaultRegionNotice(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	type testCase struct {
+		primary string
+		regions []string
+		expect  string
+	}
+	tests := []testCase{
+		{
+			primary: "us-east1",
+			expect:  `defaulting to 'WITH PRIMARY REGION "us-east1"' as no primary region was specified`,
+		},
+		{
+			primary: "us-east1",
+			regions: []string{"us-west2"},
+			expect:  `defaulting to 'WITH PRIMARY REGION "us-east1" REGIONS "us-west2"' as no primary region was specified`,
+		},
+		{
+			primary: "us-east1",
+			regions: []string{"us-west2", "us-central3"},
+			expect:  `defaulting to 'WITH PRIMARY REGION "us-east1" REGIONS "us-west2", "us-central3"' as no primary region was specified`,
+		},
+	}
+	for _, test := range tests {
+		var regions []tree.Name
+		for _, region := range test.regions {
+			regions = append(regions, tree.Name(region))
+		}
+		require.Equal(t, test.expect, formatDefaultRegionNotice(tree.Name(test.primary), regions).Error())
+	}
+}

--- a/pkg/sql/regions/BUILD.bazel
+++ b/pkg/sql/regions/BUILD.bazel
@@ -3,13 +3,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "regions",
-    srcs = ["region_provider.go"],
+    srcs = [
+        "db_regions.go",
+        "region_provider.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/regions",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/server/serverpb",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descs",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/regions/db_regions.go
+++ b/pkg/sql/regions/db_regions.go
@@ -1,0 +1,57 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package regions
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/errors"
+)
+
+// RegionSet is a map where each key is a region name.
+type RegionSet map[string]struct{}
+
+// GetDatabaseRegions returns the active regions from the database's region
+// enum. If the database is not multi-region, a nil RegionSet will be returned.
+func GetDatabaseRegions(
+	ctx context.Context, txn *kv.Txn, db catalog.DatabaseDescriptor, descs *descs.Collection,
+) (RegionSet, error) {
+	if !db.IsMultiRegion() {
+		return nil, nil
+	}
+	enumID, _ := db.MultiRegionEnumID()
+	typ, err := descs.ByIDWithLeased(txn).Get().Type(ctx, enumID)
+	if err != nil {
+		return nil, errors.NewAssertionErrorWithWrappedErrf(
+			err, "failed to resolve multi-region enum for the database (%d)", enumID,
+		)
+	}
+	t := typ.AsEnumTypeDescriptor()
+	if t == nil {
+		return nil, errors.WithDetailf(
+			errors.AssertionFailedf(
+				"multi-region type %s (%d) for the database is not an enum",
+				typ.GetName(), typ.GetID(),
+			), "descriptor: %v", typ)
+	}
+	set := make(map[string]struct{}, t.NumEnumMembers())
+	for i, n := 0, t.NumEnumMembers(); i < n; i++ {
+		// Skip regions which don't fully exist. This could mean that they
+		// are being dropped, or they are being added.
+		if !t.IsMemberReadOnly(i) {
+			set[t.GetMemberLogicalRepresentation(i)] = struct{}{}
+		}
+	}
+	return set, nil
+}

--- a/pkg/sql/regions/region_provider_test.go
+++ b/pkg/sql/regions/region_provider_test.go
@@ -133,7 +133,7 @@ func TestGetRegions(t *testing.T) {
 				lm.errs = map[descpb.ID]error{systemRegionsEnumID: errors.New("boom")}
 				return newTestCollection(lm)
 			}(),
-			expErrRE: `failed to resolve multi-region enum for the system database \(10\): boom`,
+			expErrRE: `failed to resolve multi-region enum for the database \(10\): boom`,
 		},
 		{
 			name:          "region enum type not an enum",
@@ -145,7 +145,7 @@ func TestGetRegions(t *testing.T) {
 				}
 				return newTestCollection(lm)
 			}(),
-			expErrRE: `multi-region type fake_crdb_region \(10\) for the system database is not an enum`,
+			expErrRE: `multi-region type fake_crdb_region \(10\) for the database is not an enum`,
 		},
 		{
 			name:          "read-only members ignored",


### PR DESCRIPTION
When creating a database, if the system database is configured as multi-region, use the system database's regions as the default for the new database. Currently, only tenants are permitted to have a multi-region system database, so the impact of this change is limited to CC serverless.

If the user specifies the primary region via the "CREATE DATABASE <db_name> WITH PRIMARY REGION <region>" SQL syntax or the 'sql.defaults_primary_region' setting, the region inheritance is skipped.

The default only applies at database creation time. If the user changes the primary region of the system database, or adds regions to the system database, it will not modify the multi-region configuration of existing database.

Fixes: #100788

Release Note: Multi region Serverless databases that are created without a primary region will inherit regions from the Serverless cluster's regions.