### PR TITLE
sql/tests: deflake TestErrorDuringExtendedProtocolCommit (again)

### DIFF
--- a/pkg/sql/tests/autocommit_extended_protocol_test.go
+++ b/pkg/sql/tests/autocommit_extended_protocol_test.go
@@ -170,12 +170,12 @@ func TestErrorDuringExtendedProtocolCommit(t *testing.T) {
 		},
 		BeforeAutoCommit: func(ctx context.Context, stmt string) error {
 			if shouldErrorOnAutoCommit.Get() {
-				shouldErrorOnAutoCommit.Set(false)
 				// Only inject the error if we're in the same trace as the one we
 				// saw when executing our test query. This is so we know that this
 				// autocommit corresponds to our test qyery rather than an internal
 				// query.
 				if traceID == tracing.SpanFromContext(ctx).TraceID() {
+					shouldErrorOnAutoCommit.Set(false)
 					return errors.New("injected error")
 				}
 			}


### PR DESCRIPTION
This fixes a race condition with how the error gets injected.

fixes https://github.com/cockroachdb/cockroach/issues/101217
Release note: None