### PR TITLE
c2c: clean up stream ingestion completion on resume

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -170,7 +170,7 @@ func (c *TenantStreamingClusters) WaitUntilHighWatermark(
 // Cutover sets the cutover timestamp on the replication job causing the job to
 // stop eventually.
 func (c *TenantStreamingClusters) Cutover(
-	producerJobID, ingestionJobID int, cutoverTime time.Time,
+	producerJobID, ingestionJobID int, cutoverTime time.Time, async bool,
 ) {
 	// Cut over the ingestion job and the job will stop eventually.
 	var cutoverStr string
@@ -178,8 +178,10 @@ func (c *TenantStreamingClusters) Cutover(
 		c.Args.DestTenantName, cutoverTime).Scan(&cutoverStr)
 	cutoverOutput := DecimalTimeToHLC(c.T, cutoverStr)
 	require.Equal(c.T, cutoverTime, cutoverOutput.GoTime())
-	jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
-	jobutils.WaitForJobToSucceed(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
+	if !async {
+		jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
+		jobutils.WaitForJobToSucceed(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
+	}
 }
 
 // StartStreamReplication producer job ID and ingestion job ID.

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -196,7 +196,7 @@ func TestTenantStreamingPauseOnPermanentJobError(t *testing.T) {
 
 	// Check dest has caught up the previous updates.
 	srcTime := c.SrcCluster.Server(0).Clock().Now()
-	c.Cutover(producerJobID, ingestionJobID, srcTime.GoTime())
+	c.Cutover(producerJobID, ingestionJobID, srcTime.GoTime(), false)
 	c.RequireFingerprintMatchAtTimestamp(srcTime.AsOfSystemTime())
 
 	// Ingestion happened one more time after resuming the ingestion job.
@@ -285,7 +285,7 @@ func TestTenantStreamingCheckpoint(t *testing.T) {
 
 	cutoverTime := c.DestSysServer.Clock().Now()
 	c.WaitUntilHighWatermark(cutoverTime, jobspb.JobID(ingestionJobID))
-	c.Cutover(producerJobID, ingestionJobID, cutoverTime.GoTime())
+	c.Cutover(producerJobID, ingestionJobID, cutoverTime.GoTime(), false)
 	cutoverFingerprint := c.RequireFingerprintMatchAtTimestamp(cutoverTime.AsOfSystemTime())
 
 	// Clients should never be started prior to a checkpointed timestamp
@@ -673,7 +673,7 @@ func TestTenantStreamingMultipleNodes(t *testing.T) {
 	c.WaitUntilStartTimeReached(jobspb.JobID(ingestionJobID))
 
 	cutoverTime := c.DestSysServer.Clock().Now()
-	c.Cutover(producerJobID, ingestionJobID, cutoverTime.GoTime())
+	c.Cutover(producerJobID, ingestionJobID, cutoverTime.GoTime(), false)
 	c.RequireFingerprintMatchAtTimestamp(cutoverTime.AsOfSystemTime())
 
 	// Since the data was distributed across multiple nodes, multiple nodes should've been connected to
@@ -797,7 +797,7 @@ func TestTenantReplicationProtectedTimestampManagement(t *testing.T) {
 			jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(replicationJobID))
 			var cutoverTime time.Time
 			c.DestSysSQL.QueryRow(t, "SELECT clock_timestamp()").Scan(&cutoverTime)
-			c.Cutover(producerJobID, replicationJobID, cutoverTime)
+			c.Cutover(producerJobID, replicationJobID, cutoverTime, false)
 		}
 
 		// Set GC TTL low, so that the GC job completes quickly in the test.

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -387,7 +387,7 @@ func TestReplicationJobResumptionStartTime(t *testing.T) {
 	canContinue <- struct{}{}
 	srcTime = c.SrcCluster.Server(0).Clock().Now()
 	c.WaitUntilHighWatermark(srcTime, jobspb.JobID(replicationJobID))
-	c.Cutover(producerJobID, replicationJobID, srcTime.GoTime())
+	c.Cutover(producerJobID, replicationJobID, srcTime.GoTime(), false)
 	jobutils.WaitForJobToSucceed(t, c.DestSysSQL, jobspb.JobID(replicationJobID))
 }
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -641,6 +641,7 @@ func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, err
 			// cutover ts in the future, this will need to change.
 			//
 			// On receiving a cutover signal, the processor must shutdown gracefully.
+			log.Infof(sip.Ctx(), "received cutover signal")
 			sip.internalDrained = true
 			return nil, nil
 

--- a/pkg/ccl/streamingccl/streamingest/testdata/cutover_after_pause
+++ b/pkg/ccl/streamingccl/streamingest/testdata/cutover_after_pause
@@ -1,0 +1,71 @@
+# Tests that the user can issue a cutover command while the stream ingestion job is paused, and that
+# the stream ingestion job eagerly completes on resumption.
+
+create-replication-clusters
+----
+
+start-replication-stream
+----
+
+let $start as=source-system
+SELECT clock_timestamp()::timestamp::string
+----
+
+exec-sql as=source-tenant
+CREATE TABLE d.x (id INT PRIMARY KEY, n INT);
+----
+
+exec-sql as=source-tenant
+EXPORT INTO CSV 'userfile:///dx' FROM SELECT 42, 42 UNION ALL SELECT 43, 43;
+----
+
+exec-sql as=source-tenant
+IMPORT INTO d.x CSV DATA ('userfile:///dx/export*-n*.0.csv');
+----
+
+let $afterImport as=source-system
+SELECT clock_timestamp()::timestamp::string
+----
+
+wait-until-high-watermark ts=$afterImport
+----
+
+job as=destination-system pause
+----
+
+job as=destination-system wait-for-state=paused
+----
+
+# Ensure the consumer job can complete even if the producer job is paused. This works because on
+# consumer job resumption, we take the cutover fast path: no stream ingestion dist sql processors
+# get set up, which would require an unpaused producer job.
+job as=source-system pause
+----
+
+job as=source-system wait-for-state=paused
+----
+
+# the cutover command automatically resumes the ingestion job.
+cutover ts=$afterImport async
+----
+
+job as=destination-system wait-for-state=succeeded
+----
+
+start-replicated-tenant
+----
+
+compare-tenant-fingerprints from=$start to=$afterImport with_revisions
+----
+
+compare-replication-results
+SELECT * FROM d.t1;
+----
+
+compare-replication-results
+SELECT * FROM d.t2;
+----
+
+compare-replication-results
+SELECT * FROM d.x;
+----


### PR DESCRIPTION
This patch ensures that the stream ingestion job completes properly on
resumption after the user established a cutover timestamp while the job was
paused.

Fixes https://github.com/cockroachdb/cockroach/issues/102158

Release note: none