### PR TITLE
sqlstats: only include local region in statement_statistics

### DIFF
--- a/pkg/ccl/multiregionccl/testdata/secondary_region
+++ b/pkg/ccl/multiregionccl/testdata/secondary_region
@@ -1,6 +1,3 @@
-skip issue-num=98020
-----
-
 new-cluster localities=us-east-1,us-east-1,us-west-1,us-west-1,us-central-1,us-central-1,us-central-1,eu-west-1,eu-west-1,eu-west-1
 ----
 


### PR DESCRIPTION
Part of #89949.

Addresses #98020.
Addresses #99563.

Related to cockroachdb/roachperf#129.
Related to #102170.

Previously, we attempted to record all the regions hit in a single statement execution in the sqlstats tables, leaning on the sqlAddressResolver to map traced nodeIDs to localities at execution time.

While the sqlAddressResolver is generally non-blocking, the introduction of this code did cause some of the multiregion "this query shouldn't span regions" tests to start [flaking][] and it's more recently been [implicated][] in a 2.5% performance regression.

Given that the probabilistic nature of the tracing meant that we generally weren't capturing all the relevant nodeIDs anyway, it seems like the most prudent thing to do here is take a step back and regroup.

In the short term, let's stop even trying to gather all these regions. In the medium/long term, let's see if we can find a better approach.

[flaking]: https://github.com/cockroachdb/cockroach/issues/98020
[implicated]: https://github.com/cockroachdb/roachperf/pull/129

Release note: None