### PR TITLE
workload: fix performance regresion from accessing query execution mode

### DIFF
--- a/pkg/workload/BUILD.bazel
+++ b/pkg/workload/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgconn",
         "@com_github_jackc_pgx_v5//pgxpool",
-        "@com_github_jackc_pgx_v5//tracelog",
         "@com_github_lib_pq//:pq",
         "@com_github_spf13_pflag//:pflag",
         "@org_golang_x_sync//errgroup",

--- a/pkg/workload/pgx_helpers.go
+++ b/pkg/workload/pgx_helpers.go
@@ -36,8 +36,11 @@ type MultiConnPool struct {
 		// preparedStatements is a map from name to SQL. The statements in the map
 		// are prepared whenever a new connection is acquired from the pool.
 		preparedStatements map[string]string
-		method             pgx.QueryExecMode
 	}
+
+	// NOTE(seanc@): method is on the hot-path, therefore make all reads to the
+	// query exec mode a dirty read.
+	method pgx.QueryExecMode
 }
 
 // MultiConnPoolCfg encapsulates the knobs passed to NewMultiConnPool.
@@ -203,7 +206,7 @@ func NewMultiConnPool(
 	if !ok {
 		return nil, errors.Errorf("unknown method %s", cfg.Method)
 	}
-	m.mu.method = queryMode
+	m.method = queryMode
 
 	for i := range urls {
 		connsPerPool := distributeMax(connsPerURL[i], maxConnsPerPool)
@@ -287,9 +290,7 @@ func (m *MultiConnPool) Close() {
 
 // Method returns the query execution mode of the connection pool.
 func (m *MultiConnPool) Method() pgx.QueryExecMode {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.mu.method
+	return m.method
 }
 
 // WarmupConns warms up numConns connections across all pools contained within


### PR DESCRIPTION
sync.RWMutex RLock() became a hot path for essentially a read-only value.  The
execution mode of a pool and query doesn't change after program initialization.

Release note: None
Fixes: #101494