### PR TITLE
sqlstats: fix flaky test TestSQLStatsLatencyInfo

### DIFF
--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/mon",
+        "//pkg/util/timeutil",
         "@com_github_jackc_pgx_v4//:pgx",
         "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
Sometimes the statements were taking a longer time than expected to complete, making the check for the latency max to fail.
This commits adds a bigger margin for the statement execution time, to avoid flakes.
It also improves error messages to make it easier to identify which ones has failed.

Fixes #101926

Release note: None