### PR TITLE
build: increase bincheck backoff to wait for server

### DIFF
--- a/.github/workflows/bincheck-test.yml
+++ b/.github/workflows/bincheck-test.yml
@@ -1,0 +1,24 @@
+name: bincheck-test
+
+on: [pull_request]
+
+jobs:
+
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt-get update && sudo apt-get install -y qemu-system-x86
+      - run: cd build/release/bincheck && ./test-linux ${{ github.ref_name }} ${{ github.sha }}
+
+  darwin:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cd build/release/bincheck && ./test-macos ${{ github.ref_name }} ${{ github.sha }}
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cd build/release/bincheck && bash test-windows ${{ github.ref_name }} ${{ github.sha }}

--- a/build/release/bincheck/bincheck
+++ b/build/release/bincheck/bincheck
@@ -35,7 +35,7 @@ echo ""
 "$cockroach" start-single-node --insecure --listening-url-file="$urlfile" --enterprise-encryption=path=cockroach-data,key=aes-128.key,old-key=plain --pid-file="$pidfile" &
 
 trap "kill -9 $! || true" EXIT
-for i in {0..3}
+for i in {0..5}
 do
   [[ -f "$urlfile" ]] && break
   backoff=$((2 ** i))


### PR DESCRIPTION
Darwin bincheck fails for 22.1.19, but 22.1.18 passes.

Try increasing the backoff increment to see if this fixes it.

Release: None