### PR TITLE
tree: fix decimal formatting for 0 with exponents <= -7

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -58,6 +58,15 @@ SELECT 'NaN'::FLOAT::DECIMAL, 'NaN'::DECIMAL
 ----
 NaN NaN
 
+# Test decimal returns correctly for exponents > -6.
+# We must *also* convert it to string, as the display driver (lib/pq) will
+# display the incorrect E-7, E-16 values.
+# Regression test for https://github.com/cockroachdb/cockroach/issues/102217.
+query TTTT
+SELECT 0::DECIMAL(19,0)::text, 0::DECIMAL(19,6)::text, 0::DECIMAL(19,7)::text, 0::DECIMAL(19,16)::text
+----
+0  0.000000  0.0000000  0.0000000000000000
+
 # Ensure trailing zeros are kept for decimal types with no listed scale,
 # and enforced when the scale is listed.
 


### PR DESCRIPTION
We previously did not match PG in outputting 0 with exponents <= -7 over the wire. This is because we try to match the "GDA" spec, but PG doesn't follow that for 0 (it should display a solitary 0 if it did).

This 0E-7 formatting still shows up when using the Cockroach CLI tool. I verified it works correctly when connecting via the PG tool.

Release note (bug fix): Fixed a bug where 0s with exponents <= 7 in NUMERIC types would display in a different format compared with PostgreSQL (before: 0E-7 vs after/PG: 0.0000000) when sent over the wire.

Resolves https://github.com/cockroachdb/cockroach/issues/102217