### PR TITLE
sql: avoid error when flipping the range list behavior setting

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -780,6 +780,7 @@ go_test(
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/clusterunique",
         "//pkg/sql/contentionpb",
+        "//pkg/sql/deprecatedshowranges",
         "//pkg/sql/distsql",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",

--- a/pkg/sql/show_ranges_test.go
+++ b/pkg/sql/show_ranges_test.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/deprecatedshowranges"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -144,4 +146,32 @@ SELECT DISTINCT
 	FROM [%s]`, q), [][]string{{"true"}})
 		})
 	}
+}
+
+// Regression test for #102183 and #102218.
+func TestDeprecatedShowRangesWithClusterSettingChange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Initialize the plan cache with the default (modern) behavior.
+	deprecatedshowranges.ShowRangesDeprecatedBehaviorSetting.Override(ctx, &s.ClusterSettings().SV, false)
+	db.Exec(t, `TABLE crdb_internal.ranges_no_leases`)
+	db.Exec(t, `TABLE crdb_internal.ranges`)
+
+	// Now change the setting and verify that the plan cache is invalidated.
+	deprecatedshowranges.ShowRangesDeprecatedBehaviorSetting.Override(ctx, &s.ClusterSettings().SV, true)
+	db.Exec(t, `TABLE crdb_internal.ranges_no_leases`)
+	db.Exec(t, `TABLE crdb_internal.ranges`)
+
+	// Now change the setting back and verify that the plan cache is invalidated again.
+	deprecatedshowranges.ShowRangesDeprecatedBehaviorSetting.Override(ctx, &s.ClusterSettings().SV, false)
+	db.Exec(t, `TABLE crdb_internal.ranges_no_leases`)
+	db.Exec(t, `TABLE crdb_internal.ranges`)
 }


### PR DESCRIPTION
Fixes #102183.
Fixes #102218.

Prior to this patch, it wasn't possible to call
`crdb_internal.ranges{,_noleases}` or `SHOW RANGES`, then change the value of `sql.show_ranges_deprecated_behavior.enabled`, then use the range list again, in the same SQL session. The problem was caused by reuse of the now-invalid table descriptor in the plan cache.

This patch fixes it by ensuring the "deprecated" schema and the new schema use different descriptor versions.

Release note: None