### PR TITLE
WIP: status, server: expose network connectivity endpoint

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -5077,6 +5077,106 @@ Support status: [reserved](#support-status)
 
 
 
+## NetworkConnectivity
+
+`POST /_status/connectivity`
+
+
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.NetworkConnectivityRequest-string) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| liveness_by_node_id | [NetworkConnectivityResponse.LivenessByNodeIdEntry](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.LivenessByNodeIdEntry) | repeated |  | [reserved](#support-status) |
+| latencies | [NetworkConnectivityResponse.LatenciesEntry](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.LatenciesEntry) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.LivenessByNodeIdEntry"></a>
+#### NetworkConnectivityResponse.LivenessByNodeIdEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NetworkConnectivityResponse-int32) |  |  |  |
+| value | [cockroach.kv.kvserver.liveness.livenesspb.Liveness](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.kv.kvserver.liveness.livenesspb.Liveness) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.LatenciesEntry"></a>
+#### NetworkConnectivityResponse.LatenciesEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NetworkConnectivityResponse-int32) |  |  |  |
+| value | [NetworkConnectivityResponse.NodeLatencies](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.NodeLatencies) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.NodeLatencies"></a>
+#### NetworkConnectivityResponse.NodeLatencies
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| latencies | [NetworkConnectivityResponse.NodeLatencies.LatenciesEntry](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.NodeLatencies.LatenciesEntry) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.NodeLatencies.LatenciesEntry"></a>
+#### NetworkConnectivityResponse.NodeLatencies.LatenciesEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NetworkConnectivityResponse-int32) |  |  |  |
+| value | [int64](#cockroach.server.serverpb.NetworkConnectivityResponse-int64) |  |  |  |
+
+
+
+
+
+
 ## RequestCA
 
 `GET /_join/v1/ca`

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1529,6 +1529,20 @@ func (g *Gossip) OnFirstRangeChanged(cb func(*roachpb.RangeDescriptor)) {
 	})
 }
 
+func (g *Gossip) GetKnownNodeIDs() ([]roachpb.NodeID, error) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	infos, err := g.mu.is.getMatchedInfos(MakePrefixPattern(KeyNodeDescPrefix))
+	if err != nil {
+		return nil, err
+	}
+	nodeIDs := make([]roachpb.NodeID, len(infos))
+	for idx, info := range infos {
+		nodeIDs[idx] = info.NodeID
+	}
+	return nodeIDs, nil
+}
+
 // MakeOptionalGossip initializes an OptionalGossip instance wrapping a
 // (possibly nil) *Gossip.
 //

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1979,6 +1979,46 @@ message CriticalNodesResponse {
   roachpb.SpanConfigConformanceReport report = 2 [(gogoproto.nullable) = false];
 }
 
+message NetworkConnectivityRequest {
+  string node_id = 1 [
+    (gogoproto.customname) = "NodeID"
+  ];
+}
+
+message NetworkConnectivityResponse {
+  enum IsLive {
+    LIVE = 0;
+    NOT_CONNECTED = 1;
+    PARTITIONED = 2;
+    REMOVED = 3;
+  }
+
+  message NodeLatencies {
+    map<int32, google.protobuf.Duration> latencies = 1 [
+      (gogoproto.nullable) = false,
+      (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID",
+      (gogoproto.stdduration) = true
+    ];
+  }
+
+  message PeerStatus {
+    map<int32, IsLive> connectivity = 1 [
+      (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID",
+      (gogoproto.nullable) = false
+    ];
+  }
+
+  map<int32, NodeLatencies> latencies = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+  ];
+
+  map<int32, PeerStatus> peer_connection_statuses = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+  ];
+}
+
 service Status {
   // Certificates retrieves a copy of the TLS certificates.
   rpc Certificates(CertificatesRequest) returns (CertificatesResponse) {
@@ -2441,4 +2481,10 @@ service Status {
   // ListExecutionInsights returns potentially problematic statements cluster-wide,
   // along with actions we suggest the application developer might take to remedy them.
   rpc ListExecutionInsights(ListExecutionInsightsRequest) returns (ListExecutionInsightsResponse) {}
+
+  rpc NetworkConnectivity(NetworkConnectivityRequest) returns (NetworkConnectivityResponse) {
+    option (google.api.http) = {
+      post: "/_status/connectivity"
+    };
+  }
 }


### PR DESCRIPTION
This patch introduces new endpoint which aimed to provide information about network connection status between nodes rather than nodes statuses (that is done with node liveness api).

`NetworkConnectivity` endpoint relies on gossip client to get all known nodes in the cluster and then checks `rpcCtx.ConnHealth` for every peer. It can tell us following:
- connection is live if no error returned;
- `ErrNoConnection` returned if nodes don't have connection;
- other errors indicate that network connection is unhealthy;

This functionality should not care about whether node is decommissioned, shutdown or whatever.

Later on, it'll be used in conjunction with node liveness statuses to distinguish more specific reasons why network connection is broken. For instance,
- if node liveness status is DEAD and connection is failed, then it should not be considered as network issue.
- if node liveness status is LIVE/DECOMMISSIONING and network connection is failed, then it is network partitioning;

Release note: None