### PR TITLE
changefeedccl: metamorphically use a non-root user to create changefeeds in tests

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -957,7 +957,7 @@ func TestAlterChangefeedDatabaseScope(t *testing.T) {
 		})
 	}
 
-	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection)
+	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection, feedTestUseRootUserConnection)
 }
 
 func TestAlterChangefeedDatabaseScopeUnqualifiedName(t *testing.T) {
@@ -1006,7 +1006,7 @@ func TestAlterChangefeedDatabaseScopeUnqualifiedName(t *testing.T) {
 		})
 	}
 
-	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection)
+	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection, feedTestUseRootUserConnection)
 }
 
 func TestAlterChangefeedColumnFamilyDatabaseScope(t *testing.T) {
@@ -1051,7 +1051,7 @@ func TestAlterChangefeedColumnFamilyDatabaseScope(t *testing.T) {
 		})
 	}
 
-	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection)
+	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection, feedTestUseRootUserConnection)
 }
 
 func TestAlterChangefeedAlterTableName(t *testing.T) {
@@ -1108,7 +1108,7 @@ func TestAlterChangefeedAlterTableName(t *testing.T) {
 		})
 	}
 
-	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection)
+	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection, feedTestUseRootUserConnection)
 }
 
 func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
@@ -1662,9 +1662,10 @@ func TestAlterChangefeedAccessControl(t *testing.T) {
 		closeCf()
 
 		// No one can modify changefeeds created by admins, except for admins.
-		// In this case, the root user creates the changefeed.
-		currentFeed, closeCf = createFeed(`CREATE CHANGEFEED FOR table_a, table_b`)
-		asUser(t, f, `adminUser`, func(userDB *sqlutils.SQLRunner) {
+		asUser(t, f, `adminUser`, func(_ *sqlutils.SQLRunner) {
+			currentFeed, closeCf = createFeed(`CREATE CHANGEFEED FOR table_a, table_b`)
+		})
+		asUser(t, f, `otherAdminUser`, func(userDB *sqlutils.SQLRunner) {
 			userDB.Exec(t, "PAUSE job $1", currentFeed.JobID())
 			require.NoError(t, currentFeed.WaitForStatus(func(s jobs.Status) bool {
 				return s == jobs.StatusPaused

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -705,7 +705,7 @@ func TestAvroSchemaNaming(t *testing.T) {
 
 	}
 
-	cdcTest(t, testFn, feedTestForceSink("kafka"))
+	cdcTest(t, testFn, feedTestForceSink("kafka"), feedTestUseRootUserConnection)
 }
 
 func TestAvroSchemaNamespace(t *testing.T) {
@@ -747,7 +747,7 @@ func TestAvroSchemaNamespace(t *testing.T) {
 		require.Contains(t, foo.registry.SchemaForSubject(`superdrivers-value`), `"namespace":"super"`)
 	}
 
-	cdcTest(t, testFn, feedTestForceSink("kafka"))
+	cdcTest(t, testFn, feedTestForceSink("kafka"), feedTestUseRootUserConnection)
 }
 
 func TestTableNameCollision(t *testing.T) {
@@ -797,7 +797,7 @@ func TestTableNameCollision(t *testing.T) {
 		})
 	}
 
-	cdcTest(t, testFn, feedTestForceSink("kafka"))
+	cdcTest(t, testFn, feedTestForceSink("kafka"), feedTestUseRootUserConnection)
 }
 
 func TestAvroMigrateToUnsupportedColumn(t *testing.T) {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -529,6 +529,7 @@ type updateKnobsFn func(knobs *base.TestingKnobs)
 type feedTestOptions struct {
 	useTenant                    bool
 	forceNoExternalConnectionURI bool
+	forceRootUserConnection      bool
 	argsFn                       updateArgsFn
 	knobsFn                      updateKnobsFn
 	externalIODir                string
@@ -548,6 +549,12 @@ var feedTestNoTenants = func(opts *feedTestOptions) { opts.useTenant = false }
 // from randomly creating an external connection URI and providing that as the sink
 // rather than directly specifying it. (Feed tests never actually connect to anything external.)
 var feedTestNoExternalConnection = func(opts *feedTestOptions) { opts.forceNoExternalConnectionURI = true }
+
+// feedTestUseRootUserConnection is a feedTestOption that will force the cdctest.TestFeedFactory
+// to use the root user connection when creating changefeeds. This disables the typical behavior of cdc tests where
+// tests randomly choose between the root user connection or a test user connection where the test user
+// has privileges to create changefeeds on tables in the default database `d` only.
+var feedTestUseRootUserConnection = func(opts *feedTestOptions) { opts.forceRootUserConnection = true }
 
 // feedTestNoForcedSyntheticTimestamps is a feedTestOption that will prevent
 // the test from randomly forcing timestamps to be synthetic and offset five seconds into the future from
@@ -918,25 +925,39 @@ func makeFeedFactoryWithOptions(
 	switch sinkType {
 	case "kafka":
 		f := makeKafkaFeedFactory(srvOrCluster, db)
-		return f, func() {}
+		userDB, cleanup := getInitialDBForEnterpriseFactory(t, s, db, options)
+		f.(*kafkaFeedFactory).configureUserDB(userDB)
+		return f, func() { cleanup() }
 	case "cloudstorage":
 		if options.externalIODir == "" {
 			t.Fatalf("expected externalIODir option to be set")
 		}
 		f := makeCloudFeedFactory(srvOrCluster, db, options.externalIODir)
+		userDB, cleanup := getInitialDBForEnterpriseFactory(t, s, db, options)
+		f.(*cloudFeedFactory).configureUserDB(userDB)
 		return f, func() {
 			TestingSetIncludeParquetMetadata()()
+			cleanup()
 		}
 	case "enterprise":
 		sink, cleanup := pgURLForUser(username.RootUser)
 		f := makeTableFeedFactory(srvOrCluster, db, sink)
-		return f, cleanup
+		userDB, cleanupUserDB := getInitialDBForEnterpriseFactory(t, s, db, options)
+		f.(*tableFeedFactory).configureUserDB(userDB)
+		return f, func() {
+			cleanup()
+			cleanupUserDB()
+		}
 	case "webhook":
 		f := makeWebhookFeedFactory(srvOrCluster, db)
-		return f, func() {}
+		userDB, cleanup := getInitialDBForEnterpriseFactory(t, s, db, options)
+		f.(*webhookFeedFactory).enterpriseFeedFactory.configureUserDB(userDB)
+		return f, func() { cleanup() }
 	case "pubsub":
 		f := makePubsubFeedFactory(srvOrCluster, db)
-		return f, func() {}
+		userDB, cleanup := getInitialDBForEnterpriseFactory(t, s, db, options)
+		f.(*pubsubFeedFactory).enterpriseFeedFactory.configureUserDB(userDB)
+		return f, func() { cleanup() }
 	case "sinkless":
 		pgURLForUserSinkless := func(u string, pass ...string) (url.URL, func()) {
 			t.Logf("pgURL %s %s", sinkType, u)
@@ -962,6 +983,34 @@ func makeFeedFactoryWithOptions(
 	return nil, nil
 }
 
+func getInitialDBForEnterpriseFactory(
+	t *testing.T, s serverutils.TestTenantInterface, rootDB *gosql.DB, opts feedTestOptions,
+) (*gosql.DB, func()) {
+	// Instead of creating enterprise changefeeds on the root connection, we may
+	// choose to create them on a test user connection. This user should have the
+	// minimum privileges to create a changefeed in the default database `d`. This
+	// means they default to having the CHANGEFEED privilege on all tables in the db.
+	// For changefeed expressions to work, the SELECT privilege is also granted.
+	const percentNonRoot = 0.5
+	if !opts.forceRootUserConnection && rand.Float32() < percentNonRoot {
+		user := "EnterpriseFeedUser"
+		password := "hunter2"
+		createUserWithDefaultPrivilege(t, rootDB, user, password, "CHANGEFEED", "SELECT")
+		pgURL := url.URL{
+			Scheme: "postgres",
+			User:   url.UserPassword(user, password),
+			Host:   s.SQLAddr(),
+			Path:   `d`,
+		}
+		userDB, err := gosql.Open("postgres", pgURL.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return userDB, func() { _ = userDB.Close() }
+	}
+	return rootDB, func() {}
+}
+
 func getInitialSinkForSinklessFactory(
 	t *testing.T, db *gosql.DB, sinkForUser sinkForUser,
 ) (url.URL, func()) {
@@ -981,21 +1030,23 @@ func getInitialSinkForSinklessFactory(
 // createUserWithDefaultPrivilege creates a user using the provided db connection
 // such that they have the provided privilege on all existing tables and future tables.
 func createUserWithDefaultPrivilege(
-	t *testing.T, rootDB *gosql.DB, user string, password string, priv string,
+	t *testing.T, rootDB *gosql.DB, user string, password string, privs ...string,
 ) {
 	_, err := rootDB.Exec(fmt.Sprintf(`CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'`, user, password))
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Ensure the user has privileges on all existing tables.
-	_, err = rootDB.Exec(fmt.Sprintf(`GRANT %s ON * TO %s`, priv, user))
-	if err != nil && !testutils.IsError(err, "no object matched") {
-		t.Fatal(err)
-	}
-	// Ensure the user has privileges on all tables added in the future.
-	_, err = rootDB.Exec(fmt.Sprintf(`ALTER DEFAULT PRIVILEGES GRANT %s ON TABLES TO %s`, priv, user))
-	if err != nil {
-		t.Fatal(err)
+	for _, priv := range privs {
+		// Ensure the user has privileges on all existing tables.
+		_, err = rootDB.Exec(fmt.Sprintf(`GRANT %s ON * TO %s`, priv, user))
+		if err != nil && !testutils.IsError(err, "no object matched") {
+			t.Fatal(err)
+		}
+		// Ensure the user has privileges on all tables added in the future.
+		_, err = rootDB.Exec(fmt.Sprintf(`ALTER DEFAULT PRIVILEGES GRANT %s ON TABLES TO %s`, priv, user))
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
@@ -1262,6 +1313,9 @@ func ChangefeedJobPermissionsTestSetup(t *testing.T, s TestServer) {
 
 		`CREATE USER adminUser`,
 		`GRANT ADMIN TO adminUser`,
+
+		`CREATE USER otherAdminUser`,
+		`GRANT ADMIN TO otherAdminUser`,
 
 		`CREATE USER feedCreator`,
 		`GRANT CHANGEFEED ON table_a TO feedCreator`,

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -991,7 +991,7 @@ func getInitialDBForEnterpriseFactory(
 	// minimum privileges to create a changefeed in the default database `d`. This
 	// means they default to having the CHANGEFEED privilege on all tables in the db.
 	// For changefeed expressions to work, the SELECT privilege is also granted.
-	const percentNonRoot = 0.5
+	const percentNonRoot = 1
 	if !opts.forceRootUserConnection && rand.Float32() < percentNonRoot {
 		user := "EnterpriseFeedUser"
 		password := "hunter2"
@@ -1017,7 +1017,7 @@ func getInitialSinkForSinklessFactory(
 	// Instead of creating sinkless changefeeds on the root connection, we may choose to create
 	// them on a test user connection. This user should have the minimum privileges to create a changefeed,
 	// which means they default to having the SELECT privilege on all tables.
-	const percentNonRoot = 0.5
+	const percentNonRoot = 1
 	if rand.Float32() < percentNonRoot {
 		user := "SinklessFeedUser"
 		password := "hunter2"

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -938,16 +938,65 @@ func makeFeedFactoryWithOptions(
 		f := makePubsubFeedFactory(srvOrCluster, db)
 		return f, func() {}
 	case "sinkless":
-		sink, cleanup := pgURLForUser(username.RootUser)
-		f := makeSinklessFeedFactory(s, sink, pgURLForUser)
-		f.(*sinklessFeedFactory).currentDB = func(currentDB *string) error {
-			r := db.QueryRow("SELECT current_database()")
-			return r.Scan(currentDB)
+		pgURLForUserSinkless := func(u string, pass ...string) (url.URL, func()) {
+			t.Logf("pgURL %s %s", sinkType, u)
+			if len(pass) < 1 {
+				sink, cleanup := sqlutils.PGUrl(t, s.SQLAddr(), t.Name(), url.User(u))
+				sink.Path = "d"
+				return sink, cleanup
+			}
+			return url.URL{
+				Scheme: "postgres",
+				User:   url.UserPassword(u, pass[0]),
+				Host:   s.SQLAddr(), Path: "d"}, func() {}
 		}
-		return f, cleanup
+		sink, cleanup := getInitialSinkForSinklessFactory(t, db, pgURLForUserSinkless)
+		root, cleanupRoot := pgURLForUserSinkless(username.RootUser)
+		f := makeSinklessFeedFactory(s, sink, root, pgURLForUserSinkless)
+		return f, func() {
+			cleanup()
+			cleanupRoot()
+		}
 	}
 	t.Fatalf("unhandled sink type %s", sinkType)
 	return nil, nil
+}
+
+func getInitialSinkForSinklessFactory(
+	t *testing.T, db *gosql.DB, sinkForUser sinkForUser,
+) (url.URL, func()) {
+	// Instead of creating sinkless changefeeds on the root connection, we may choose to create
+	// them on a test user connection. This user should have the minimum privileges to create a changefeed,
+	// which means they default to having the SELECT privilege on all tables.
+	const percentNonRoot = 0.5
+	if rand.Float32() < percentNonRoot {
+		user := "SinklessFeedUser"
+		password := "hunter2"
+		createUserWithDefaultPrivilege(t, db, user, password, "SELECT")
+		return sinkForUser(user, password)
+	}
+	return sinkForUser(username.RootUser)
+}
+
+// createUserWithDefaultPrivilege creates a user using the provided db connection
+// such that they have the provided privilege on all existing tables and future tables.
+func createUserWithDefaultPrivilege(
+	t *testing.T, rootDB *gosql.DB, user string, password string, priv string,
+) {
+	_, err := rootDB.Exec(fmt.Sprintf(`CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'`, user, password))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Ensure the user has privileges on all existing tables.
+	_, err = rootDB.Exec(fmt.Sprintf(`GRANT %s ON * TO %s`, priv, user))
+	if err != nil && !testutils.IsError(err, "no object matched") {
+		t.Fatal(err)
+	}
+	// Ensure the user has privileges on all tables added in the future.
+	_, err = rootDB.Exec(fmt.Sprintf(`ALTER DEFAULT PRIVILEGES GRANT %s ON TABLES TO %s`, priv, user))
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func cdcTest(t *testing.T, testFn cdcTestFn, testOpts ...feedTestOption) {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -69,24 +69,28 @@ import (
 )
 
 type sinklessFeedFactory struct {
-	s           serverutils.TestTenantInterface
-	sink        url.URL
+	s serverutils.TestTenantInterface
+	// postgres url used for creating sinkless changefeeds. This may be the same as
+	// the rootURL.
+	sink url.URL
+	// postgres url for the root user, used for test internals.
+	rootURL     url.URL
 	sinkForUser sinkForUser
-	currentDB   func(db *string) error
 }
 
 // makeSinklessFeedFactory returns a TestFeedFactory implementation using the
 // `experimental-sql` uri.
 func makeSinklessFeedFactory(
-	s serverutils.TestTenantInterface, sink url.URL, sinkForUser sinkForUser,
+	s serverutils.TestTenantInterface, sink url.URL, rootConn url.URL, sinkForUser sinkForUser,
 ) cdctest.TestFeedFactory {
-	return &sinklessFeedFactory{s: s, sink: sink, sinkForUser: sinkForUser}
+	return &sinklessFeedFactory{s: s, sink: sink, rootURL: rootConn, sinkForUser: sinkForUser}
 }
 
+// AsUser executes fn as the specified user.
 func (f *sinklessFeedFactory) AsUser(user string, fn func(*sqlutils.SQLRunner)) error {
 	prevSink := f.sink
 	password := `hunter2`
-	if err := setPassword(user, password, f.sink); err != nil {
+	if err := f.setPassword(user, password); err != nil {
 		return err
 	}
 	defer func() { f.sink = prevSink }()
@@ -109,8 +113,8 @@ func (f *sinklessFeedFactory) AsUser(user string, fn func(*sqlutils.SQLRunner)) 
 	return nil
 }
 
-func setPassword(user, password string, uri url.URL) error {
-	rootDB, err := gosql.Open("postgres", uri.String())
+func (f *sinklessFeedFactory) setPassword(user, password string) error {
+	rootDB, err := gosql.Open("postgres", f.rootURL.String())
 	if err != nil {
 		return err
 	}
@@ -123,13 +127,6 @@ func setPassword(user, password string, uri url.URL) error {
 func (f *sinklessFeedFactory) Feed(create string, args ...interface{}) (cdctest.TestFeed, error) {
 	sink := f.sink
 	sink.RawQuery = sink.Query().Encode()
-	if f.currentDB == nil {
-		sink.Path = `d`
-	} else {
-		if err := f.currentDB(&sink.Path); err != nil {
-			return nil, err
-		}
-	}
 	// Use pgx directly instead of database/sql so we can close the conn
 	// (instead of returning it to the pool).
 	pgxConfig, err := pgx.ParseConfig(sink.String())
@@ -761,7 +758,7 @@ func (e *enterpriseFeedFactory) jobsTableConn() *gosql.DB {
 	return e.rootDB
 }
 
-// AsUser uses the previous (assumed to be root) connection to ensure
+// AsUser uses the previous connection to ensure
 // the user has the ability to authenticate, and saves it to poll
 // job status, then implements TestFeedFactory.AsUser().
 func (e *enterpriseFeedFactory) AsUser(user string, fn func(*sqlutils.SQLRunner)) error {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -745,16 +745,19 @@ func (di *depInjector) getJobFeed(jobID jobspb.JobID) *jobFeed {
 }
 
 type enterpriseFeedFactory struct {
-	s      serverutils.TestTenantInterface
-	di     *depInjector
-	db     *gosql.DB
+	s  serverutils.TestTenantInterface
+	di *depInjector
+	// db is used for creating changefeeds. This may be the same as rootDB.
+	db *gosql.DB
+	// rootDB is used for test internals.
 	rootDB *gosql.DB
 }
 
+func (e *enterpriseFeedFactory) configureUserDB(db *gosql.DB) {
+	e.db = db
+}
+
 func (e *enterpriseFeedFactory) jobsTableConn() *gosql.DB {
-	if e.rootDB == nil {
-		return e.db
-	}
 	return e.rootDB
 }
 
@@ -763,7 +766,6 @@ func (e *enterpriseFeedFactory) jobsTableConn() *gosql.DB {
 // job status, then implements TestFeedFactory.AsUser().
 func (e *enterpriseFeedFactory) AsUser(user string, fn func(*sqlutils.SQLRunner)) error {
 	prevDB := e.db
-	e.rootDB = e.db
 	defer func() { e.db = prevDB }()
 	password := `password`
 	_, err := e.rootDB.Exec(fmt.Sprintf(`ALTER USER %s WITH PASSWORD '%s'`, user, password))
@@ -825,14 +827,15 @@ func getInjectables(srvOrCluster interface{}) (serverutils.TestTenantInterface, 
 // makeTableFeedFactory returns a TestFeedFactory implementation using the
 // `experimental-sql` uri.
 func makeTableFeedFactory(
-	srvOrCluster interface{}, db *gosql.DB, sink url.URL,
+	srvOrCluster interface{}, rootDB *gosql.DB, sink url.URL,
 ) cdctest.TestFeedFactory {
 	s, injectables := getInjectables(srvOrCluster)
 	return &tableFeedFactory{
 		enterpriseFeedFactory: enterpriseFeedFactory{
-			s:  s,
-			di: newDepInjector(injectables...),
-			db: db,
+			s:      s,
+			di:     newDepInjector(injectables...),
+			db:     rootDB,
+			rootDB: rootDB,
 		},
 		uri: sink,
 	}
@@ -1024,14 +1027,15 @@ type cloudFeedFactory struct {
 // makeCloudFeedFactory returns a TestFeedFactory implementation using the cloud
 // storage uri.
 func makeCloudFeedFactory(
-	srvOrCluster interface{}, db *gosql.DB, dir string,
+	srvOrCluster interface{}, rootDB *gosql.DB, dir string,
 ) cdctest.TestFeedFactory {
 	s, injectables := getInjectables(srvOrCluster)
 	return &cloudFeedFactory{
 		enterpriseFeedFactory: enterpriseFeedFactory{
-			s:  s,
-			di: newDepInjector(injectables...),
-			db: db,
+			s:      s,
+			di:     newDepInjector(injectables...),
+			db:     rootDB,
+			rootDB: rootDB,
 		},
 		dir: dir,
 	}
@@ -1764,14 +1768,15 @@ func mustBeKafkaFeedFactory(f cdctest.TestFeedFactory) *kafkaFeedFactory {
 }
 
 // makeKafkaFeedFactory returns a TestFeedFactory implementation using the `kafka` uri.
-func makeKafkaFeedFactory(srvOrCluster interface{}, db *gosql.DB) cdctest.TestFeedFactory {
+func makeKafkaFeedFactory(srvOrCluster interface{}, rootDB *gosql.DB) cdctest.TestFeedFactory {
 	s, injectables := getInjectables(srvOrCluster)
 	return &kafkaFeedFactory{
 		knobs: &sinkKnobs{},
 		enterpriseFeedFactory: enterpriseFeedFactory{
-			s:  s,
-			db: db,
-			di: newDepInjector(injectables...),
+			s:      s,
+			db:     rootDB,
+			rootDB: rootDB,
+			di:     newDepInjector(injectables...),
 		},
 	}
 }
@@ -1964,14 +1969,15 @@ type webhookFeedFactory struct {
 var _ cdctest.TestFeedFactory = (*webhookFeedFactory)(nil)
 
 // makeWebhookFeedFactory returns a TestFeedFactory implementation using the `webhook-webhooks` uri.
-func makeWebhookFeedFactory(srvOrCluster interface{}, db *gosql.DB) cdctest.TestFeedFactory {
+func makeWebhookFeedFactory(srvOrCluster interface{}, rootDB *gosql.DB) cdctest.TestFeedFactory {
 	s, injectables := getInjectables(srvOrCluster)
 	useSecure := rand.Float32() < 0.5
 	return &webhookFeedFactory{
 		enterpriseFeedFactory: enterpriseFeedFactory{
-			s:  s,
-			db: db,
-			di: newDepInjector(injectables...),
+			s:      s,
+			db:     rootDB,
+			rootDB: rootDB,
+			di:     newDepInjector(injectables...),
 		},
 		useSecureServer: useSecure,
 	}
@@ -2363,7 +2369,7 @@ type pubsubFeedFactory struct {
 var _ cdctest.TestFeedFactory = (*pubsubFeedFactory)(nil)
 
 // makePubsubFeedFactory returns a TestFeedFactory implementation using the `pubsub` uri.
-func makePubsubFeedFactory(srvOrCluster interface{}, db *gosql.DB) cdctest.TestFeedFactory {
+func makePubsubFeedFactory(srvOrCluster interface{}, rootDB *gosql.DB) cdctest.TestFeedFactory {
 	s, injectables := getInjectables(srvOrCluster)
 
 	switch t := srvOrCluster.(type) {
@@ -2378,9 +2384,10 @@ func makePubsubFeedFactory(srvOrCluster interface{}, db *gosql.DB) cdctest.TestF
 
 	return &pubsubFeedFactory{
 		enterpriseFeedFactory: enterpriseFeedFactory{
-			s:  s,
-			db: db,
-			di: newDepInjector(injectables...),
+			s:      s,
+			db:     rootDB,
+			rootDB: rootDB,
+			di:     newDepInjector(injectables...),
 		},
 	}
 }


### PR DESCRIPTION
### changefeedccl: metamorphically create sinkless changefeeds as non-root user in tests

This change updates tests on sinkless changefeeds to sometimes create changefeeds as
a non-root user. This non-root user defaults to having the `SELECT` privilege on
all previous and future tables in the db. With this change, the "strictness" of tests
is increased in terms of permissions because tests will not assume that changefeeds are
being created by the root user.

Release note: None

Informs: https://github.com/cockroachdb/cockroach/issues/100831
Epic: None

### changefeedccl: metamorphically create enterprise changefeeds as non-root user in tests

This change updates tests on enterprise changefeeds to sometimes create changefeeds as
a non-root user. This non-root user defaults to having the `CHANGEFEED` privilege on
all previous and future tables in the db. With this change, the "strictness" of tests
is increased in terms of permissions because tests will not assume that changefeeds are
being created by the root user.

Release note: None

Closes: https://github.com/cockroachdb/cockroach/issues/100831
Epic: None

### do not merge: force tests to create changefeeds as non-root
The previous two commits made is so that we sometimes will use
a non-root user to create changefeeds in tests. This commit forces us to
always do so so we know that using a non-root user works in all tests.
This commit exists to help ensure that CI passes. It will be removed before
merging.

Release note: None
Epic: None

