### PR TITLE
kvserver: tighten and de-fatal replicaGC checks

### DIFF
--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/errors"
 	"go.etcd.io/raft/v3"
@@ -323,6 +324,9 @@ func (rgcq *replicaGCQueue) process(
 		if err := repl.store.RemoveReplica(ctx, repl, nextReplicaID, RemoveOptions{
 			DestroyData: true,
 		}); err != nil {
+			// Should never get an error from RemoveReplica.
+			const format = "error during replicaGC: %v"
+			logcrash.ReportOrPanic(ctx, &repl.store.ClusterSettings().SV, format, err)
 			return false, err
 		}
 	} else {


### PR DESCRIPTION
Now we return most failed checks as errors and report errors to sentry (but
without crashing).

Closes https://github.com/cockroachdb/cockroach/issues/94813.

Epic: None
Release note: None
