### PR TITLE
storage: fatal on corruption encountered in background

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1193,6 +1193,11 @@ func (p *Pebble) async(fn func()) {
 
 func (p *Pebble) makeMetricEtcEventListener(ctx context.Context) pebble.EventListener {
 	return pebble.EventListener{
+		BackgroundError: func(err error) {
+			if errors.Is(err, pebble.ErrCorruption) {
+				log.Fatalf(ctx, "local corruption detected: %v", err)
+			}
+		},
 		WriteStallBegin: func(info pebble.WriteStallBeginInfo) {
 			atomic.AddInt64(&p.writeStallCount, 1)
 			startNanos := timeutil.Now().UnixNano()


### PR DESCRIPTION
Previously, on-disk corruption would only fatal the node if an interator observed it. Corruption encountered by a background job like a compaction would not fatal the node. This can result in busy churning through compactions that repeatedly fail, impacting cluster stability and user query latencies.

Now, on-disk corruption results in immediately exiting the node.

Epic: none
Fixes: #101101
Release note (ops change): When local corruption of data is encountered by a background job, a node will now exit immediately.