### PR TITLE
startup: startup retry for ambiguous options fix

### DIFF
--- a/pkg/util/startup/BUILD.bazel
+++ b/pkg/util/startup/BUILD.bazel
@@ -19,11 +19,16 @@ go_library(
 
 go_test(
     name = "startup_test",
-    srcs = ["startup_test.go"],
+    srcs = [
+        "retry_test.go",
+        "startup_test.go",
+    ],
     args = ["-test.timeout=295s"],
+    embed = [":startup"],
     deps = [
         "//pkg/base",
         "//pkg/keys",
+        "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/roachpb",
         "//pkg/security/securityassets",

--- a/pkg/util/startup/retry.go
+++ b/pkg/util/startup/retry.go
@@ -136,7 +136,7 @@ func RunIdempotentWithRetryEx[T any](
 	var err error
 	retryOpts := startupRetryOpts
 	retryOpts.Closer = quiesce
-	for r := retry.StartWithCtx(ctx, startupRetryOpts); r.Next(); {
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		result, err = f(ctx)
 		if err == nil {
 			break

--- a/pkg/util/startup/retry_test.go
+++ b/pkg/util/startup/retry_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package startup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryIsInterruptedByStopper(t *testing.T) {
+	ctx := context.Background()
+	quiesce := make(chan struct{})
+	stop := make(chan struct{})
+	go func() {
+		_ = RunIdempotentWithRetry(ctx, quiesce, "trying hard",
+			func(ctx context.Context) error {
+				// Throttle tiny bit to avoid busy loop.
+				<-time.After(time.Millisecond)
+				return kvpb.NewError(kvpb.NewAmbiguousResultErrorf("test error")).GoError()
+			})
+		close(stop)
+	}()
+	close(quiesce)
+	select {
+	case <-stop:
+	case <-time.After(30 * time.Second):
+		t.Fatal("test retry didn't stop after 30 sec after quiesce")
+	}
+}
+
+func TestRetryOnlyAmbiguousErrors(t *testing.T) {
+	ctx := context.Background()
+	stop := make(chan struct{})
+	go func() {
+		_ = RunIdempotentWithRetry(ctx, make(chan struct{}), "trying hard",
+			func(ctx context.Context) error {
+				// Throttle tiny bit to avoid busy loop.
+				<-time.After(time.Millisecond)
+				return errors.New("non retryable")
+			})
+		close(stop)
+	}()
+	select {
+	case <-stop:
+	case <-time.After(30 * time.Second):
+		t.Fatal("retry didn't stop on non-retryable error")
+	}
+}
+
+func TestRetry(t *testing.T) {
+	ctx := context.Background()
+	const tries = 2
+	stop := make(chan int)
+	go func() {
+		count := 0
+		_ = RunIdempotentWithRetry(ctx, make(chan struct{}), "trying hard",
+			func(ctx context.Context) error {
+				count++
+				if count < tries {
+					return kvpb.NewError(kvpb.NewAmbiguousResultErrorf("test error")).GoError()
+				}
+				return nil
+			})
+		stop <- count
+	}()
+	select {
+	case count := <-stop:
+		require.Equal(t, tries, count, "expected number of retries before success")
+	case <-time.After(30 * time.Second):
+		t.Fatal("retry didn't stop on non-retryable error")
+	}
+}


### PR DESCRIPTION
Stopper quiesce channel was not correctly propagated to retry configs. This would make startup ignore attempts to abort.

Epic: none

Release note: None