### PR TITLE
leaktest: ignore pgconn async close worker

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -58,6 +58,8 @@ func interestingGoroutines() map[int64]string {
 			strings.Contains(stack, "sentry-go.(*HTTPTransport).worker") ||
 			// Ignore the opensensus worker, which is created by the event exporter.
 			strings.Contains(stack, "go.opencensus.io/stats/view.(*worker).start") ||
+			// Ignore pgconn which creates a goroutine to do an async cleanup.
+			strings.Contains(stack, "github.com/jackc/pgconn.(*PgConn).asyncClose.func1") ||
 			// Seems to be gccgo specific.
 			(runtime.Compiler == "gccgo" && strings.Contains(stack, "testing.T.Parallel")) ||
 			// Ignore intentionally long-running logging goroutines that live for the


### PR DESCRIPTION
Unfortunately I cannot repro this locally :(

Epic: none

Fixes: #97698
Fixes: #97346

Release note: None