### PR TITLE
kv: teach kvnemesis about isolation levels and snapshot isolation

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/kv/kvnemesis/kvnemesisutil",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/liveness",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
@@ -77,6 +78,7 @@ go_test(
         "//pkg/kv/kvnemesis/kvnemesisutil",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
@@ -111,6 +113,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvpb:kvpb_proto",
+        "//pkg/kv/kvserver/concurrency/isolation:isolation_proto",
         "//pkg/roachpb:roachpb_proto",
         "//pkg/util/hlc:hlc_proto",
         "@com_github_cockroachdb_errors//errorspb:errorspb_proto",
@@ -126,6 +129,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//errorspb",

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -145,6 +145,9 @@ func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 		})
 		var savedTxn *kv.Txn
 		txnErr := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			if err := txn.SetIsoLevel(o.IsoLevel); err != nil {
+				panic(err)
+			}
 			if savedTxn != nil && txn.TestingCloneTxn().Epoch == 0 {
 				// If the txn's current epoch is 0 and we've run at least one prior
 				// iteration, we were just aborted.

--- a/pkg/kv/kvnemesis/applier_test.go
+++ b/pkg/kv/kvnemesis/applier_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -104,7 +105,10 @@ func TestApplier(t *testing.T) {
 			"delrange", step(delRange(k1, k3, 6)),
 		},
 		{
-			"txn-delrange", step(closureTxn(ClosureTxnType_Commit, delRange(k2, k4, 1))),
+			"txn-ssi-delrange", step(closureTxn(ClosureTxnType_Commit, isolation.Serializable, delRange(k2, k4, 1))),
+		},
+		{
+			"txn-si-delrange", step(closureTxn(ClosureTxnType_Commit, isolation.Snapshot, delRange(k2, k4, 1))),
 		},
 		{
 			"get-err", step(get(k1)),
@@ -128,7 +132,10 @@ func TestApplier(t *testing.T) {
 			"delrange-err", step(delRange(k2, k3, 12)),
 		},
 		{
-			"txn-err", step(closureTxn(ClosureTxnType_Commit, delRange(k2, k4, 1))),
+			"txn-ssi-err", step(closureTxn(ClosureTxnType_Commit, isolation.Serializable, delRange(k2, k4, 1))),
+		},
+		{
+			"txn-si-err", step(closureTxn(ClosureTxnType_Commit, isolation.Snapshot, delRange(k2, k4, 1))),
 		},
 		{
 			"batch-mixed", step(batch(put(k2, 2), get(k1), del(k2, 1), del(k3, 1), scan(k1, k3), reverseScanForUpdate(k1, k5))),
@@ -137,13 +144,22 @@ func TestApplier(t *testing.T) {
 			"batch-mixed-err", step(batch(put(k2, 2), getForUpdate(k1), scanForUpdate(k1, k3), reverseScan(k1, k3))),
 		},
 		{
-			"txn-commit-mixed", step(closureTxn(ClosureTxnType_Commit, put(k5, 5), batch(put(k6, 6), delRange(k3, k5, 1)))),
+			"txn-ssi-commit-mixed", step(closureTxn(ClosureTxnType_Commit, isolation.Serializable, put(k5, 5), batch(put(k6, 6), delRange(k3, k5, 1)))),
 		},
 		{
-			"txn-commit-batch", step(closureTxnCommitInBatch(opSlice(get(k1), put(k6, 6)), put(k5, 5))),
+			"txn-si-commit-mixed", step(closureTxn(ClosureTxnType_Commit, isolation.Snapshot, put(k5, 5), batch(put(k6, 6), delRange(k3, k5, 1)))),
 		},
 		{
-			"txn-rollback", step(closureTxn(ClosureTxnType_Rollback, put(k5, 5))),
+			"txn-ssi-commit-batch", step(closureTxnCommitInBatch(isolation.Serializable, opSlice(get(k1), put(k6, 6)), put(k5, 5))),
+		},
+		{
+			"txn-si-commit-batch", step(closureTxnCommitInBatch(isolation.Snapshot, opSlice(get(k1), put(k6, 6)), put(k5, 5))),
+		},
+		{
+			"txn-ssi-rollback", step(closureTxn(ClosureTxnType_Rollback, isolation.Serializable, put(k5, 5))),
+		},
+		{
+			"txn-si-rollback", step(closureTxn(ClosureTxnType_Rollback, isolation.Snapshot, put(k5, 5))),
 		},
 		{
 			"split", step(split(k2)),

--- a/pkg/kv/kvnemesis/applier_test.go
+++ b/pkg/kv/kvnemesis/applier_test.go
@@ -146,9 +146,6 @@ func TestApplier(t *testing.T) {
 			"txn-rollback", step(closureTxn(ClosureTxnType_Rollback, put(k5, 5))),
 		},
 		{
-			"txn-error", step(closureTxn(ClosureTxnType_Rollback, put(k5, 5))),
-		},
-		{
 			"split", step(split(k2)),
 		},
 		{

--- a/pkg/kv/kvnemesis/operations.go
+++ b/pkg/kv/kvnemesis/operations.go
@@ -162,6 +162,10 @@ func (op Operation) format(w *strings.Builder, fctx formatCtx) {
 		newFctx.receiver = txnName
 		w.WriteString(fctx.receiver)
 		fmt.Fprintf(w, `.Txn(ctx, func(ctx context.Context, %s *kv.Txn) error {`, txnName)
+		w.WriteString("\n")
+		w.WriteString(newFctx.indent)
+		w.WriteString(newFctx.receiver)
+		fmt.Fprintf(w, `.SetIsoLevel(isolation.%s)`, o.IsoLevel)
 		formatOps(w, newFctx, o.Ops)
 		if o.CommitInBatch != nil {
 			newFctx.receiver = `b`

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -15,6 +15,7 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvnemesis";
 import "errorspb/errors.proto";
 import "gogoproto/gogo.proto";
 import "kv/kvpb/api.proto";
+import "kv/kvserver/concurrency/isolation/levels.proto";
 import "roachpb/data.proto";
 import "util/hlc/timestamp.proto";
 
@@ -34,6 +35,7 @@ message ClosureTxnOperation {
   repeated Operation ops = 2 [(gogoproto.nullable) = false];
   BatchOperation commit_in_batch = 3;
   ClosureTxnType type = 4;
+  cockroach.kv.kvserver.concurrency.isolation.Level iso_level = 7;
   Result result = 5 [(gogoproto.nullable) = false];
   roachpb.Transaction txn = 6;
 }

--- a/pkg/kv/kvnemesis/operations_test.go
+++ b/pkg/kv/kvnemesis/operations_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -77,6 +78,7 @@ func TestOperationsFormat(t *testing.T) {
 		{
 			step: step(
 				closureTxn(ClosureTxnType_Commit,
+					isolation.Serializable,
 					batch(get(k7), get(k8), del(k9, 1)),
 					delRange(k10, k11, 2),
 					put(k11, 3),

--- a/pkg/kv/kvnemesis/testdata/TestApplier/addsstable
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/addsstable
@@ -1,6 +1,6 @@
 echo
 ----
-db1.AddSSTable(ctx, tk(1), tk(4), ... /* @s1 */) // 1252 bytes (as writes)
+db0.AddSSTable(ctx, tk(1), tk(4), ... /* @s1 */) // 1252 bytes (as writes)
 // ^-- tk(1) -> sv(s1): /Table/100/"0000000000000001"/<ts> -> /BYTES/v1
 // ^-- tk(2) -> sv(s1): /Table/100/"0000000000000002"/<ts> -> /<empty>
 // ^-- [tk(3), tk(4)) -> sv(s1): /Table/100/"000000000000000{3"-4"} -> /<empty>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/addsstable
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/addsstable
@@ -1,6 +1,6 @@
 echo
 ----
-db0.AddSSTable(ctx, tk(1), tk(4), ... /* @s1 */) // 1252 bytes (as writes)
+db1.AddSSTable(ctx, tk(1), tk(4), ... /* @s1 */) // 1252 bytes (as writes)
 // ^-- tk(1) -> sv(s1): /Table/100/"0000000000000001"/<ts> -> /BYTES/v1
 // ^-- tk(2) -> sv(s1): /Table/100/"0000000000000002"/<ts> -> /<empty>
 // ^-- [tk(3), tk(4)) -> sv(s1): /Table/100/"000000000000000{3"-4"} -> /<empty>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/del-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/del-err
@@ -1,3 +1,3 @@
 echo
 ----
-db0.Del(ctx, tk(2) /* @s1 */) // context canceled
+db1.Del(ctx, tk(2) /* @s1 */) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/delrange-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/delrange-err
@@ -1,3 +1,3 @@
 echo
 ----
-db1.DelRange(ctx, tk(2), tk(3), true /* @s12 */) // context canceled
+db0.DelRange(ctx, tk(2), tk(3), true /* @s12 */) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/get-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/get-err
@@ -1,3 +1,3 @@
 echo
 ----
-db1.Get(ctx, tk(1)) // context canceled
+db0.Get(ctx, tk(1)) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/merge
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/merge
@@ -1,3 +1,3 @@
 echo
 ----
-db0.AdminMerge(ctx, tk(1)) // <nil>
+db1.AdminMerge(ctx, tk(1)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/merge
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/merge
@@ -1,3 +1,3 @@
 echo
 ----
-db1.AdminMerge(ctx, tk(1)) // <nil>
+db0.AdminMerge(ctx, tk(1)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/merge-again
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/merge-again
@@ -1,3 +1,3 @@
 echo
 ----
-db0.AdminMerge(ctx, tk(1)) // context canceled
+db1.AdminMerge(ctx, tk(1)) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/merge-again
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/merge-again
@@ -1,3 +1,3 @@
 echo
 ----
-db1.AdminMerge(ctx, tk(1)) // context canceled
+db0.AdminMerge(ctx, tk(1)) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/put-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/put-err
@@ -1,3 +1,3 @@
 echo
 ----
-db0.Put(ctx, tk(1), sv(1)) // context canceled
+db1.Put(ctx, tk(1), sv(1)) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/rscan-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/rscan-err
@@ -1,3 +1,3 @@
 echo
 ----
-db0.ReverseScan(ctx, tk(1), tk(3), 0) // context canceled
+db1.ReverseScan(ctx, tk(1), tk(3), 0) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/rscan-for-update-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/rscan-for-update-err
@@ -1,3 +1,3 @@
 echo
 ----
-db1.ReverseScanForUpdate(ctx, tk(1), tk(3), 0) // context canceled
+db0.ReverseScanForUpdate(ctx, tk(1), tk(3), 0) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/scan-for-update-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/scan-for-update-err
@@ -1,3 +1,3 @@
 echo
 ----
-db1.ScanForUpdate(ctx, tk(1), tk(3), 0) // context canceled
+db0.ScanForUpdate(ctx, tk(1), tk(3), 0) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/split
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/split
@@ -1,3 +1,3 @@
 echo
 ----
-db1.AdminSplit(ctx, tk(2)) // <nil>
+db0.AdminSplit(ctx, tk(2)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/split
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/split
@@ -1,3 +1,3 @@
 echo
 ----
-db0.AdminSplit(ctx, tk(2)) // <nil>
+db1.AdminSplit(ctx, tk(2)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/split-again
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/split-again
@@ -1,3 +1,3 @@
 echo
 ----
-db1.AdminSplit(ctx, tk(2)) // context canceled
+db0.AdminSplit(ctx, tk(2)) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/split-again
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/split-again
@@ -1,3 +1,3 @@
 echo
 ----
-db0.AdminSplit(ctx, tk(2)) // context canceled
+db1.AdminSplit(ctx, tk(2)) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/transfer
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/transfer
@@ -1,3 +1,3 @@
 echo
 ----
-db1.TransferLeaseOperation(ctx, tk(6), 1) // <nil>
+db0.TransferLeaseOperation(ctx, tk(6), 1) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/transfer
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/transfer
@@ -1,3 +1,3 @@
 echo
 ----
-db0.TransferLeaseOperation(ctx, tk(6), 1) // <nil>
+db1.TransferLeaseOperation(ctx, tk(6), 1) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/transfer-again
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/transfer-again
@@ -1,3 +1,3 @@
 echo
 ----
-db0.TransferLeaseOperation(ctx, tk(6), 1) // context canceled
+db1.TransferLeaseOperation(ctx, tk(6), 1) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/transfer-again
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/transfer-again
@@ -1,3 +1,3 @@
 echo
 ----
-db1.TransferLeaseOperation(ctx, tk(6), 1) // context canceled
+db0.TransferLeaseOperation(ctx, tk(6), 1) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-error
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-error
@@ -1,6 +1,0 @@
-echo
-----
-db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-  txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
-  return errors.New("rollback")
-}) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-commit-batch
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-commit-batch
@@ -1,0 +1,12 @@
+echo
+----
+db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Snapshot)
+  txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
+  b := &kv.Batch{}
+  b.Get(tk(1)) // (<nil>, <nil>)
+  b.Put(tk(6), sv(6)) // <nil>
+  txn.CommitInBatch(ctx, b) // @<ts> <nil>
+  return nil
+}) // @<ts> <nil>
+// ^-- txnpb:<txn>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-commit-mixed
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-commit-mixed
@@ -1,6 +1,7 @@
 echo
 ----
-db1.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Snapshot)
   txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
   {
     b := &kv.Batch{}

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-delrange
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-delrange
@@ -1,6 +1,7 @@
 echo
 ----
-db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+db1.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Snapshot)
   txn.DelRange(ctx, tk(2), tk(4), true /* @s1 */) // @<ts> <nil>
   return nil
 }) // @<ts> <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-err
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Snapshot)
   txn.DelRange(ctx, tk(2), tk(4), true /* @s1 */)
   return nil
 }) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-rollback
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-rollback
@@ -1,6 +1,7 @@
 echo
 ----
-db1.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Snapshot)
   txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-commit-batch
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-commit-batch
@@ -1,6 +1,7 @@
 echo
 ----
-db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+db1.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
   b := &kv.Batch{}
   b.Get(tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-commit-mixed
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-commit-mixed
@@ -1,0 +1,14 @@
+echo
+----
+db1.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
+  txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
+  {
+    b := &kv.Batch{}
+    b.Put(tk(6), sv(6)) // <nil>
+    b.DelRange(tk(3), tk(5), true /* @s1 */) // <nil>
+    txn.Run(ctx, b) // @<ts> <nil>
+  }
+  return nil
+}) // @<ts> <nil>
+// ^-- txnpb:<txn>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-delrange
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-delrange
@@ -2,7 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
-  txn.Put(ctx, tk(1), sv(1)) // <nil>
-  txn.Put(ctx, tk(2), sv(2)) // <nil>
+  txn.DelRange(ctx, tk(2), tk(4), true /* @s1 */) // @<ts> <nil>
   return nil
-}) // result is ambiguous: boom
+}) // @<ts> <nil>
+// ^-- txnpb:<txn>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-err
@@ -1,0 +1,7 @@
+echo
+----
+db1.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
+  txn.DelRange(ctx, tk(2), tk(4), true /* @s1 */)
+  return nil
+}) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-rollback
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-rollback
@@ -1,0 +1,7 @@
+echo
+----
+db1.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
+  txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
+  return errors.New("rollback")
+}) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestOperationsFormat/3
+++ b/pkg/kv/kvnemesis/testdata/TestOperationsFormat/3
@@ -1,6 +1,7 @@
 echo
 ----
 ···db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+···  txn.SetIsoLevel(isolation.Serializable)
 ···  {
 ···    b := &kv.Batch{}
 ···    b.Get(tk(7))

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_del-del_transaction_committed
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_del-del_transaction_committed
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_del-del_transaction_committed_but_wrong_seq
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_del-del_transaction_committed_but_wrong_seq
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_committed
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_committed
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_committed_but_has_validation_error
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_committed_but_has_validation_error
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_did_not_commit
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_did_not_commit
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-put_transaction_committed
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-put_transaction_committed
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-put_transaction_committed_but_has_validation_error
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-put_transaction_committed_but_has_validation_error
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_delete_with_expected_write_after_write_transaction_with_shadowed_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_delete_with_expected_write_after_write_transaction_with_shadowed_delete
@@ -3,6 +3,7 @@ echo
 db0.Del(ctx, tk(1) /* @s1 */) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(3)) // <nil>
   txn.Del(ctx, tk(1) /* @s4 */) // <nil>
   txn.Put(ctx, tk(1), sv(5)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // (/Table/100/"0000000000000001", <nil>)
   return nil
 }) // @0.000000002,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_extra_deletion
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_extra_deletion
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // @0.000000002,0 (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil
 }) // @0.000000002,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_missing_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_missing_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // @0.000000002,0 (/Table/100/"0000000000000001", <nil>)
   return nil
 }) // @0.000000001,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_returning_wrong_value
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_returning_wrong_value
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // @0.000000002,0 <nil>
   return nil
 }) // @0.000000002,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_with_spurious_deletion
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_with_spurious_deletion
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // @0.000000002,0 (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil
 }) // @0.000000002,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(3), sv(3)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s4 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil
 }) // @0.000000004,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_and_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_and_delete
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Del(ctx, tk(1) /* @s3 */) // @0.000000004,0 <nil>
 db0.Put(ctx, tk(1), sv(4)) // @0.000000005,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s5 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil
 }) // @0.000000003,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_incorrectly_deleting_keys_outside_span_boundary
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_incorrectly_deleting_keys_outside_span_boundary
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(4), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s3 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000004", <nil>)
   return nil
 }) // @0.000000003,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_returning_keys_outside_span_boundary
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_returning_keys_outside_span_boundary
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(4), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s3 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000004", <nil>)
   return nil
 }) // @0.000000003,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_with_missing_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_with_missing_write
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(3), sv(3)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s4 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil
 }) // @0.000000004,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_with_write_timestamp_disagreement
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_with_write_timestamp_disagreement
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(3), sv(3)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s4 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", /Table/100/"0000000000000003", <nil>)
   return nil
 }) // @0.000000004,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_scan_after_writes_and_delete_returning_missing_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_scan_after_writes_and_delete_returning_missing_key
@@ -1,11 +1,13 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil
 }) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000002":v2, <nil>)
   txn.Del(ctx, tk(1) /* @s3 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_tranactional_scan_after_write_and_delete_returning_extra_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_tranactional_scan_after_write_and_delete_returning_extra_key
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   txn.Del(ctx, tk(1) /* @s3 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_delete_with_write_on_another_key_after_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_delete_with_write_on_another_key_after_delete
@@ -2,6 +2,7 @@ echo
 ----
 db0.Del(ctx, tk(1) /* @s1 */) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   txn.Del(ctx, tk(1) /* @s3 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_deleterange_followed_by_put_after_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_deleterange_followed_by_put_after_writes
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // (/Table/100/"0000000000000001", <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_deleterange_followed_by_put_after_writes_with_write_timestamp_disagreement
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_deleterange_followed_by_put_after_writes_with_write_timestamp_disagreement
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // (/Table/100/"0000000000000001", <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_shadowed_by_deleterange_after_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_shadowed_by_deleterange_after_writes
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   txn.DelRange(ctx, tk(1), tk(3), true /* @s3 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_shadowed_by_deleterange_after_writes_with_write_timestamp_disagreement
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_shadowed_by_deleterange_after_writes_with_write_timestamp_disagreement
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   txn.DelRange(ctx, tk(1), tk(3), true /* @s3 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_with_correct_commit_time
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_with_correct_commit_time
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   return nil
 }) // @0.000000001,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_with_incorrect_commit_time
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_with_incorrect_commit_time
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   return nil
 }) // @0.000000001,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_scan_followed_by_delete_outside_time_range
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_scan_followed_by_delete_outside_time_range
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_scan_followed_by_delete_within_time_range
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_scan_followed_by_delete_within_time_range
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_first_write_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_first_write_missing
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_second_write_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_second_write_missing
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_the_correct_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_the_correct_writes
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   return nil
 }) // @0.000000001,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_write_timestamp_disagreement
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_write_timestamp_disagreement
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_first_write_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_first_write_missing
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_second_write_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_second_write_missing
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_the_correct_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_the_correct_writes
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   return nil
 }) // @0.000000001,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_write_timestamp_disagreement
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_write_timestamp_disagreement
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_batch_delete_with_write_correctly_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_batch_delete_with_write_correctly_missing
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   {
     b := &kv.Batch{}
     b.Del(tk(1) /* @s1 */) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_batch_put_with_write_correctly_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_batch_put_with_write_correctly_missing
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   {
     b := &kv.Batch{}
     b.Put(tk(1), sv(1)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_delete_with_write_correctly_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_delete_with_write_correctly_missing
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_delete_with_write_incorrectly_present
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_delete_with_write_incorrectly_present
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_put_with_write_correctly_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_put_with_write_correctly_missing
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_put_with_write_incorrectly_present
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_put_with_write_incorrectly_present
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_after_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_after_delete
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_after_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_after_write
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_before_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_before_delete
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_before_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_before_write
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_scan_after_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_scan_after_write
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // <nil>
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Scan(ctx, tk(1), tk(3), 0) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_scan_before_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_scan_before_write
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_read_before_and_after_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_read_before_and_after_delete
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_read_before_and_after_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_read_before_and_after_write
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_scan_before_and_after_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_scan_before_and_after_write
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // <nil>
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_read_and_write_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_read_and_write_with_empty_time_overlap
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_read_and_write_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_read_and_write_with_non-empty_time_overlap
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_after_writes_and_deletes_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_after_writes_and_deletes_with_empty_time_overlap
@@ -3,11 +3,13 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s3 */) // <nil>
   txn.Del(ctx, tk(2) /* @s4 */) // <nil>
   return nil
 }) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Get(ctx, tk(2)) // (v2, <nil>)
   txn.Get(ctx, tk(3)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_after_writes_and_deletes_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_after_writes_and_deletes_with_non-empty_time_overlap
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Del(ctx, tk(1) /* @s3 */) // @0.000000003,0 <nil>
 db0.Del(ctx, tk(2) /* @s4 */) // @0.000000004,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Get(ctx, tk(2)) // (v2, <nil>)
   txn.Get(ctx, tk(3)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_and_deletes_after_write_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_and_deletes_after_write_with_empty_time_overlap
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_and_deletes_after_write_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_and_deletes_after_write_with_non-empty_time_overlap
@@ -2,6 +2,7 @@ echo
 ----
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_one_missing_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_one_missing_with_empty_time_overlap
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Get(ctx, tk(2)) // (<nil>, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_one_missing_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_one_missing_with_non-empty_time_overlap
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Get(ctx, tk(2)) // (<nil>, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_with_empty_time_overlap
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(4)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Get(ctx, tk(2)) // (v3, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_with_non-empty_time_overlap
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000003,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(4)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Get(ctx, tk(2)) // (v3, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scan_and_write_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scan_and_write_with_empty_time_overlap
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scan_and_write_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scan_and_write_with_non-empty_time_overlap
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_after_delete_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_after_delete_with_empty_time_overlap
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Del(ctx, tk(2) /* @s4 */) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_after_delete_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_after_delete_with_non-empty_time_overlap
@@ -6,6 +6,7 @@ db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Del(ctx, tk(2) /* @s4 */) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(5)) // @0.000000004,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_one_missing_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_one_missing_with_empty_time_overlap
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_one_missing_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_one_missing_with_non-empty_time_overlap
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_with_empty_time_overlap
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(4)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, /Table/100/"0000000000000002":v3, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // (/Table/100/"0000000000000002":v3, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_with_non-empty_time_overlap
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000003,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(4)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, /Table/100/"0000000000000002":v3, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // (/Table/100/"0000000000000002":v3, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactional_deletes_with_out_of_order_commit_times
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactional_deletes_with_out_of_order_commit_times
@@ -3,6 +3,7 @@ echo
 db0.Del(ctx, tk(1) /* @s1 */) // @0.000000002,0 <nil>
 db0.Del(ctx, tk(2) /* @s2 */) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s3 */) // <nil>
   txn.Del(ctx, tk(2) /* @s4 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_deletes_of_the_same_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_deletes_of_the_same_key
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_deletes_of_the_same_key_with_extra_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_deletes_of_the_same_key_with_extra_write
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_put_delete_ops_of_the_same_key_with_incorrect_read
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_put_delete_ops_of_the_same_key_with_incorrect_read
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_put_delete_ops_of_the_same_key_with_reads
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_put_delete_ops_of_the_same_key_with_reads
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_extra_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_extra_write
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_reads
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_reads
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_scans
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_scans
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Scan(ctx, tk(1), tk(3), 0) // <nil>
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_delete_put_of_the_same_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_delete_put_of_the_same_key
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_put_delete_of_the_same_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_put_delete_of_the_same_key
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_put_delete_of_the_same_key_with_extra_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_put_delete_of_the_same_key_with_extra_write
@@ -1,6 +1,7 @@
 echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+  txn.SetIsoLevel(isolation.Serializable)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/validator_test.go
+++ b/pkg/kv/kvnemesis/validator_test.go
@@ -337,7 +337,7 @@ func TestValidate(t *testing.T) {
 			steps: []Step{
 				step(withResultTS(del(k1, s1), t1)),
 				step(withResultTS(put(k1, s2), t2)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResultOK(put(k1, s3)),
 					withResultOK(del(k1, s4)),
 					withResultOK(put(k1, s5)),
@@ -373,7 +373,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally committed put with the correct writes",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 				), t1)),
 			},
@@ -383,7 +383,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally committed delete with the correct writes",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(del(k1, s1)),
 				), t1)),
 			},
@@ -392,7 +392,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally committed put with first write missing",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(put(k2, s2)),
 				), t1)),
@@ -402,7 +402,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally committed delete with first write missing",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(del(k1, s1)),
 					withResult(del(k2, s2)),
 				), t1)),
@@ -412,7 +412,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally committed put with second write missing",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(put(k2, s2)),
 				), t1)),
@@ -422,7 +422,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally committed delete with second write missing",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(del(k1, s1)),
 					withResult(del(k2, s2)),
 				), t1)),
@@ -432,7 +432,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally committed put with write timestamp disagreement",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(put(k2, s2)),
 				), t1)),
@@ -442,7 +442,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally committed delete with write timestamp disagreement",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(del(k1, s1)),
 					withResult(del(k2, s2)),
 				), t1)),
@@ -454,7 +454,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally rolled back put with write (correctly) missing",
 			steps: []Step{
-				step(withResultErr(closureTxn(ClosureTxnType_Rollback,
+				step(withResultErr(closureTxnSSI(ClosureTxnType_Rollback,
 					withResult(put(k1, s1)),
 				), errors.New(`rollback`))),
 			},
@@ -463,7 +463,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally rolled back delete with write (correctly) missing",
 			steps: []Step{
-				step(withResultErr(closureTxn(ClosureTxnType_Rollback,
+				step(withResultErr(closureTxnSSI(ClosureTxnType_Rollback,
 					withResult(del(k1, s1)),
 				), errors.New(`rollback`))),
 			},
@@ -472,7 +472,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally rolled back put with write (incorrectly) present",
 			steps: []Step{
-				step(withResultErr(closureTxn(ClosureTxnType_Rollback,
+				step(withResultErr(closureTxnSSI(ClosureTxnType_Rollback,
 					withResult(put(k1, s1)),
 				), errors.New(`rollback`))),
 			},
@@ -481,7 +481,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally rolled back delete with write (incorrectly) present",
 			steps: []Step{
-				step(withResultErr(closureTxn(ClosureTxnType_Rollback,
+				step(withResultErr(closureTxnSSI(ClosureTxnType_Rollback,
 					withResult(del(k1, s1)),
 				), errors.New(`rollback`))),
 			},
@@ -490,7 +490,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally rolled back batch put with write (correctly) missing",
 			steps: []Step{
-				step(withResultErr(closureTxn(ClosureTxnType_Rollback,
+				step(withResultErr(closureTxnSSI(ClosureTxnType_Rollback,
 					withResult(batch(
 						withResult(put(k1, s1)),
 					)),
@@ -501,7 +501,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactionally rolled back batch delete with write (correctly) missing",
 			steps: []Step{
-				step(withResultErr(closureTxn(ClosureTxnType_Rollback,
+				step(withResultErr(closureTxnSSI(ClosureTxnType_Rollback,
 					withResult(batch(
 						withResult(del(k1, s1)),
 					)),
@@ -512,7 +512,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed puts of the same key",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(put(k1, s2)),
 				), t1)),
@@ -534,7 +534,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed deletes of the same key",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(del(k1, s1)),
 					withResult(del(k1, s2)),
 				), t1)),
@@ -544,7 +544,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed writes (put, delete) of the same key",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(del(k1, s2)),
 				), t1)),
@@ -554,7 +554,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed writes (delete, put) of the same key",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(del(k1, s1)),
 					withResult(put(k1, s2)),
 				), t1)),
@@ -564,7 +564,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed puts of the same key with extra write",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(put(k1, s2)),
 				), t2)),
@@ -574,7 +574,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed deletes of the same key with extra write",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(del(k1, s1)),
 					withResult(del(k1, s2)),
 				), t1)),
@@ -584,7 +584,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed writes (put, delete) of the same key with extra write",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResultOK(put(k1, s1)),
 					withResultOK(del(k1, s2)),
 				), t1)),
@@ -594,7 +594,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "ambiguous put-put transaction committed",
 			steps: []Step{
-				step(withAmbResult(closureTxn(ClosureTxnType_Commit,
+				step(withAmbResult(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(put(k2, s2)),
 				))),
@@ -604,7 +604,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "ambiguous put-del transaction committed",
 			steps: []Step{
-				step(withAmbResult(closureTxn(ClosureTxnType_Commit,
+				step(withAmbResult(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(del(k2, s2)),
 				))),
@@ -618,7 +618,7 @@ func TestValidate(t *testing.T) {
 			// them if any of the writes show up.
 			name: "ambiguous del-del transaction committed",
 			steps: []Step{
-				step(withAmbResult(closureTxn(ClosureTxnType_Commit,
+				step(withAmbResult(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(del(k1, s1)),
 					withResult(del(k1, s2)),
 				))),
@@ -628,7 +628,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "ambiguous del-del transaction committed but wrong seq",
 			steps: []Step{
-				step(withAmbResult(closureTxn(ClosureTxnType_Commit,
+				step(withAmbResult(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(del(k1, s1)),
 					withResult(del(k1, s2)),
 				))),
@@ -638,7 +638,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "ambiguous put-put transaction did not commit",
 			steps: []Step{
-				step(withAmbResult(closureTxn(ClosureTxnType_Commit,
+				step(withAmbResult(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(put(k2, s2)),
 				))),
@@ -648,7 +648,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "ambiguous put-del transaction did not commit",
 			steps: []Step{
-				step(withAmbResult(closureTxn(ClosureTxnType_Commit,
+				step(withAmbResult(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(del(k2, s2)),
 				))),
@@ -658,7 +658,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "ambiguous put-put transaction committed but has validation error",
 			steps: []Step{
-				step(withAmbResult(closureTxn(ClosureTxnType_Commit,
+				step(withAmbResult(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(put(k2, s2)),
 				))),
@@ -668,7 +668,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "ambiguous put-del transaction committed but has validation error",
 			steps: []Step{
-				step(withAmbResult(withTimestamp(closureTxn(ClosureTxnType_Commit,
+				step(withAmbResult(withTimestamp(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(del(k2, s2)),
 				), t2))),
@@ -866,7 +866,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s2), t3)),
 				step(withResultTS(put(k2, s3), t2)),
 				step(withResultTS(put(k2, s4), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), v1),
 					withReadResult(get(k2), v3),
 				), t3)),
@@ -881,7 +881,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k2, s2), t2)),
 				step(withResultTS(del(k1, s3), t3)),
 				step(withResultTS(del(k2, s4), t4)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), ``),
 					withReadResult(get(k2), v2),
 					withReadResult(get(k3), ``),
@@ -897,7 +897,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s2), t2)),
 				step(withResultTS(put(k2, s3), t2)),
 				step(withResultTS(put(k2, s4), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), v1),
 					withReadResult(get(k2), v3),
 				), t3)),
@@ -910,11 +910,11 @@ func TestValidate(t *testing.T) {
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k2, s2), t2)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResultOK(del(k1, s3)),
 					withResultOK(del(k2, s4)),
 				), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), ``),
 					withReadResult(get(k2), v2),
 					withReadResult(get(k3), ``),
@@ -927,7 +927,7 @@ func TestValidate(t *testing.T) {
 			name: "transactional reads and deletes after write with non-empty time overlap",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), v1),
 					withResult(del(k1, s2)),
 					withReadResult(get(k1), ``),
@@ -942,7 +942,7 @@ func TestValidate(t *testing.T) {
 			name: "transactional reads and deletes after write with empty time overlap",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), ``),
 					withResult(del(k1, s2)),
 					withReadResult(get(k1), ``),
@@ -959,7 +959,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k1, s2), t2)),
 				step(withResultTS(put(k2, s3), t2)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), v1),
 					withReadResult(get(k2), ``),
 				), t1)),
@@ -973,7 +973,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k1, s2), t2)),
 				step(withResultTS(put(k2, s3), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), v1),
 					withReadResult(get(k2), ``),
 				), t1)),
@@ -986,7 +986,7 @@ func TestValidate(t *testing.T) {
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k1, s2), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), v1),
 					withResult(put(k2, s3)),
 				), t2)),
@@ -999,7 +999,7 @@ func TestValidate(t *testing.T) {
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k1, s2), t2)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), v1),
 					withResultOK(put(k2, s3)),
 				), t2)),
@@ -1010,7 +1010,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "transaction with read before and after write",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), ``),
 					withResult(put(k1, s1)),
 					withReadResult(get(k1), v1),
@@ -1022,7 +1022,7 @@ func TestValidate(t *testing.T) {
 			name: "transaction with read before and after delete",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), v1),
 					withResult(del(k1, s2)),
 					withReadResult(get(k1), ``),
@@ -1033,7 +1033,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "transaction with incorrect read before write",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), v1),
 					withResult(put(k1, s1)),
 					withReadResult(get(k1), v1),
@@ -1045,7 +1045,7 @@ func TestValidate(t *testing.T) {
 			name: "transaction with incorrect read before delete",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), ``),
 					withResult(del(k1, s2)),
 					withReadResult(get(k1), ``),
@@ -1056,7 +1056,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "transaction with incorrect read after write",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), ``),
 					withResult(put(k1, s1)),
 					withReadResult(get(k1), ``),
@@ -1068,7 +1068,7 @@ func TestValidate(t *testing.T) {
 			name: "transaction with incorrect read after delete",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), v1),
 					withResultOK(del(k1, s2)),
 					withReadResult(get(k1), v1),
@@ -1079,7 +1079,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed puts of the same key with reads",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), ``),
 					withResult(put(k1, s1)),
 					withReadResult(get(k1), v1),
@@ -1092,7 +1092,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed put/delete ops of the same key with reads",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), ``),
 					withResult(put(k1, s1)),
 					withReadResult(get(k1), v1),
@@ -1105,7 +1105,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed put/delete ops of the same key with incorrect read",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withReadResult(get(k1), ``),
 					withResult(put(k1, s1)),
 					withReadResult(get(k1), v1),
@@ -1118,7 +1118,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactional put with correct commit time",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 				), t1)),
 			},
@@ -1127,7 +1127,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one transactional put with incorrect commit time",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 				), t1)),
 			},
@@ -1138,7 +1138,7 @@ func TestValidate(t *testing.T) {
 			steps: []Step{
 				// NB: this Delete comes first in operation order, but the write is delayed.
 				step(withResultTS(del(k1, s1), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k2, s2)),
 					withResult(del(k1, s3)),
 				), t2)),
@@ -1150,7 +1150,7 @@ func TestValidate(t *testing.T) {
 			steps: []Step{
 				step(withResultTS(del(k1, s1), t2)),
 				step(withResultTS(del(k2, s2), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(del(k1, s3)),
 					withResult(del(k2, s4)),
 				), t1)),
@@ -1161,7 +1161,7 @@ func TestValidate(t *testing.T) {
 			name: "one transactional scan followed by delete within time range",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
 					withResult(del(k1, s2)),
 				), t2)),
@@ -1173,7 +1173,7 @@ func TestValidate(t *testing.T) {
 			name: "one transactional scan followed by delete outside time range",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
 					withResult(del(k1, s2)),
 				), t4)),
@@ -1255,7 +1255,7 @@ func TestValidate(t *testing.T) {
 			name: "one tranactional scan after write and delete returning extra key",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k2, s2)),
 					withResult(del(k1, s3)),
 				), t2)),
@@ -1288,11 +1288,11 @@ func TestValidate(t *testing.T) {
 		{
 			name: "one scan after writes and delete returning missing key",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k1, s1)),
 					withResult(put(k2, s2)),
 				), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k2, v2)),
 					withResult(del(k1, s3)),
 				), t2)),
@@ -1403,7 +1403,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s2), t3)),
 				step(withResultTS(put(k2, s3), t2)),
 				step(withResultTS(put(k2, s4), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1), scanKV(k2, v3)),
 					withScanResultTS(scan(k2, k4), noTS, scanKV(k2, v3)),
 				), t2)),
@@ -1419,7 +1419,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k2, s3), t1)),
 				step(withResultTS(del(k2, s4), t2)),
 				step(withResultTS(put(k2, s5), t4)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
 					withScanResultTS(scan(k2, k4), noTS),
 				), t2)),
@@ -1434,7 +1434,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s2), t2)),
 				step(withResultTS(put(k2, s3), t2)),
 				step(withResultTS(put(k2, s4), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1), scanKV(k2, v3)),
 					withScanResultTS(scan(k2, k4), noTS, scanKV(k2, v3)),
 				), t2)),
@@ -1449,7 +1449,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s2), t2)),
 				step(withResultTS(put(k2, s3), t1)),
 				step(withResultTS(del(k2, s4), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
 					withScanResultTS(scan(k2, k4), noTS),
 				), t3)),
@@ -1463,7 +1463,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k1, s2), t2)),
 				step(withResultTS(put(k2, s3), t2)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
 					withScanResultTS(scan(k2, k4), noTS),
 				), t2)),
@@ -1477,7 +1477,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k1, s2), t2)),
 				step(withResultTS(put(k2, s3), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
 					withScanResultTS(scan(k2, k4), noTS),
 				), t1)),
@@ -1490,7 +1490,7 @@ func TestValidate(t *testing.T) {
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k1, s2), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
 					withResult(put(k2, s3)),
 				), t2)),
@@ -1503,7 +1503,7 @@ func TestValidate(t *testing.T) {
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k1, s2), t2)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
 					withResult(put(k2, s3)),
 				), t2)),
@@ -1514,7 +1514,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "transaction with scan before and after write",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS),
 					withResult(put(k1, s1)),
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
@@ -1525,7 +1525,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "transaction with incorrect scan before write",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
 					withResult(put(k1, s1)),
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
@@ -1536,7 +1536,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "transaction with incorrect scan after write",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS),
 					withResult(put(k1, s1)),
 					withScanResultTS(scan(k1, k3), noTS),
@@ -1547,7 +1547,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "two transactionally committed puts of the same key with scans",
 			steps: []Step{
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withScanResultTS(scan(k1, k3), noTS),
 					withResult(put(k1, s1)),
 					withScanResultTS(scan(k1, k3), noTS, scanKV(k1, v1)),
@@ -1579,7 +1579,7 @@ func TestValidate(t *testing.T) {
 			name: "one deleterange after write",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s2), noTS, roachpb.Key(k1)),
 				), t2)),
 			},
@@ -1589,7 +1589,7 @@ func TestValidate(t *testing.T) {
 			name: "one deleterange after write returning wrong value",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s2), t2),
 				), t2)),
 			},
@@ -1599,7 +1599,7 @@ func TestValidate(t *testing.T) {
 			name: "one deleterange after write missing write",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s2), t2, roachpb.Key(k1)),
 				), t1)),
 			},
@@ -1609,7 +1609,7 @@ func TestValidate(t *testing.T) {
 			name: "one deleterange after write extra deletion",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t2)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s2), t2, roachpb.Key(k1), roachpb.Key(k2)),
 				), t2)),
 			},
@@ -1619,7 +1619,7 @@ func TestValidate(t *testing.T) {
 			name: "one deleterange after write with spurious deletion",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s2), t2, roachpb.Key(k1), roachpb.Key(k2)),
 				), t2)),
 			},
@@ -1631,7 +1631,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k2, s2), t2)),
 				step(withResultTS(put(k3, s3), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s4), noTS, roachpb.Key(k1), roachpb.Key(k2)),
 				), t4)),
 				step(withScanResultTS(scan(k1, k4), t4, scanKV(k3, v3))),
@@ -1644,7 +1644,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k2, s2), t2)),
 				step(withResultTS(put(k3, s3), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s4), noTS, roachpb.Key(k1), roachpb.Key(k2), roachpb.Key(k3)),
 				), t4)),
 			},
@@ -1656,7 +1656,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k2, s2), t2)),
 				step(withResultTS(put(k3, s3), t3)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s4), noTS, roachpb.Key(k1), roachpb.Key(k2)),
 				), t4)),
 				step(withScanResultTS(scan(k1, k4), t5, scanKV(k3, v3))),
@@ -1670,7 +1670,7 @@ func TestValidate(t *testing.T) {
 				step(withResultTS(put(k2, s2), t2)),
 				step(withResultTS(del(k1, s3), t4)),
 				step(withResultTS(put(k1, s4), t5)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s5), noTS, roachpb.Key(k1), roachpb.Key(k2)),
 				), t3)),
 			},
@@ -1680,7 +1680,7 @@ func TestValidate(t *testing.T) {
 			name: "one transactional deleterange followed by put after writes",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s2), noTS, roachpb.Key(k1)),
 					withResult(put(k2, s3)),
 				), t2)),
@@ -1691,7 +1691,7 @@ func TestValidate(t *testing.T) {
 			name: "one transactional deleterange followed by put after writes with write timestamp disagreement",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s2), noTS, roachpb.Key(k1)),
 					withResult(put(k2, s3)),
 				), t2)),
@@ -1702,7 +1702,7 @@ func TestValidate(t *testing.T) {
 			name: "one transactional put shadowed by deleterange after writes",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k2, s2)),
 					withDeleteRangeResult(delRange(k1, k3, s3), noTS, roachpb.Key(k1), roachpb.Key(k2)),
 				), t2)),
@@ -1713,7 +1713,7 @@ func TestValidate(t *testing.T) {
 			name: "one transactional put shadowed by deleterange after writes with write timestamp disagreement",
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withResult(put(k2, s2)),
 					withDeleteRangeResult(delRange(k1, k3, s3), noTS, roachpb.Key(k1), roachpb.Key(k2)),
 				), t2)),
@@ -1725,7 +1725,7 @@ func TestValidate(t *testing.T) {
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k4, s2), t2)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s3), noTS, roachpb.Key(k1), roachpb.Key(k4)),
 				), t3)),
 			},
@@ -1736,7 +1736,7 @@ func TestValidate(t *testing.T) {
 			steps: []Step{
 				step(withResultTS(put(k1, s1), t1)),
 				step(withResultTS(put(k4, s2), t2)),
-				step(withResultTS(closureTxn(ClosureTxnType_Commit,
+				step(withResultTS(closureTxnSSI(ClosureTxnType_Commit,
 					withDeleteRangeResult(delRange(k1, k3, s3), noTS, roachpb.Key(k1), roachpb.Key(k4)),
 				), t3)),
 			},


### PR DESCRIPTION
Informs #100169.

This commit teaches kvnemesis about transaction isolation levels, and specifically to generate snapshot isolation transaction closures. The commit is strictly plumbing because isolation level is currently a no-op. Once snapshot isolation is implemented, the validator logic in kvnemesis will need to change.

Release note: None