### PR TITLE
storage: fix setting shared creator ID

### DIFF
--- a/pkg/roachpb/version.go
+++ b/pkg/roachpb/version.go
@@ -49,9 +49,9 @@ func (v Version) LessEq(otherV Version) bool {
 	return v.Equal(otherV) || v.Less(otherV)
 }
 
-// AtLeast returns true if the receiver is greater than or requal to the parameter.
+// AtLeast returns true if the receiver is greater than or equal to the parameter.
 func (v Version) AtLeast(otherV Version) bool {
-	return !otherV.Less(v)
+	return !v.Less(otherV)
 }
 
 // String implements the fmt.Stringer interface.

--- a/pkg/roachpb/version_test.go
+++ b/pkg/roachpb/version_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kr/pretty"
 )
 
-func TestVersionLess(t *testing.T) {
+func TestVersionCmp(t *testing.T) {
 	v := func(major, minor, patch, internal int32) Version {
 		return Version{
 			Major:    major,
@@ -50,6 +50,12 @@ func TestVersionLess(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			if a, e := test.v1.Less(test.v2), test.less; a != e {
 				t.Errorf("expected %s < %s? %t; got %t", pretty.Sprint(test.v1), pretty.Sprint(test.v2), e, a)
+			}
+			if a, e := test.v1.Equal(test.v2), test.v1 == test.v2; a != e {
+				t.Errorf("expected %s = %s? %t; got %t", pretty.Sprint(test.v1), pretty.Sprint(test.v2), e, a)
+			}
+			if a, e := test.v1.AtLeast(test.v2), test.v1 == test.v2 || !test.less; a != e {
+				t.Errorf("expected %s >= %s? %t; got %t", pretty.Sprint(test.v1), pretty.Sprint(test.v2), e, a)
 			}
 		})
 	}


### PR DESCRIPTION
The `AtLeast` version check was incorrect and we weren't setting the Creator ID.

The code is improved to also set the Creator ID when the version is bumped.

We are missing unit tests for shared storage but there is currently no way to use a test / in-memory shared store; we will add tests when we address this.

Epic: none
Release note: None