### PR TITLE
kvserver,storage: BatchCommitStats plumbing for raft appends and metrics

### DIFF
--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -87,6 +87,9 @@ type AppendStats struct {
 	PebbleBegin time.Time
 	PebbleEnd   time.Time
 	PebbleBytes int64
+	// Only set when !NonBlocking, which means almost never, since
+	// kv.raft_log.non_blocking_synchronization.enabled defaults to true.
+	PebbleCommitStats storage.BatchCommitStats
 
 	Sync bool
 	// If true, PebbleEnd-PebbleBegin does not include the sync time.
@@ -113,8 +116,9 @@ type LogStore struct {
 // SyncCallback is a callback that is notified when a raft log write has been
 // durably committed to disk. The function is handed the response messages that
 // are associated with the MsgStorageAppend that triggered the fsync.
+// commitStats is populated iff this was a non-blocking sync.
 type SyncCallback interface {
-	OnLogSync(context.Context, []raftpb.Message)
+	OnLogSync(context.Context, []raftpb.Message, storage.BatchCommitStats)
 }
 
 func newStoreEntriesBatch(eng storage.Engine) storage.Batch {
@@ -257,6 +261,7 @@ func (s *LogStore) storeEntriesAndCommitBatch(
 			ctx:            ctx,
 			cb:             cb,
 			msgs:           m.Responses,
+			batch:          batch,
 			metrics:        s.Metrics,
 			logCommitBegin: stats.PebbleBegin,
 		}
@@ -269,10 +274,11 @@ func (s *LogStore) storeEntriesAndCommitBatch(
 			return RaftState{}, errors.Wrap(err, expl)
 		}
 		stats.PebbleEnd = timeutil.Now()
+		stats.PebbleCommitStats = batch.CommitStats()
 		if wantsSync {
 			logCommitEnd := stats.PebbleEnd
 			s.Metrics.RaftLogCommitLatency.RecordValue(logCommitEnd.Sub(stats.PebbleBegin).Nanoseconds())
-			cb.OnLogSync(ctx, m.Responses)
+			cb.OnLogSync(ctx, m.Responses, storage.BatchCommitStats{})
 		}
 	}
 	stats.Sync = wantsSync
@@ -325,6 +331,8 @@ type nonBlockingSyncWaiterCallback struct {
 	ctx  context.Context
 	cb   SyncCallback
 	msgs []raftpb.Message
+	// Used to extract stats. This is the batch that has been synced.
+	batch storage.WriteBatch
 	// Used to record Metrics.
 	metrics        Metrics
 	logCommitBegin time.Time
@@ -334,7 +342,8 @@ type nonBlockingSyncWaiterCallback struct {
 func (cb *nonBlockingSyncWaiterCallback) run() {
 	dur := timeutil.Since(cb.logCommitBegin).Nanoseconds()
 	cb.metrics.RaftLogCommitLatency.RecordValue(dur)
-	cb.cb.OnLogSync(cb.ctx, cb.msgs)
+	commitStats := cb.batch.CommitStats()
+	cb.cb.OnLogSync(cb.ctx, cb.msgs, commitStats)
 	cb.release()
 }
 

--- a/pkg/kv/kvserver/logstore/logstore_bench_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_bench_test.go
@@ -38,7 +38,7 @@ func (b *discardBatch) Commit(bool) error {
 
 type noopSyncCallback struct{}
 
-func (noopSyncCallback) OnLogSync(context.Context, []raftpb.Message) {}
+func (noopSyncCallback) OnLogSync(context.Context, []raftpb.Message, storage.BatchCommitStats) {}
 
 func BenchmarkLogStore_StoreEntries(b *testing.B) {
 	defer log.Scope(b).Close(b)

--- a/pkg/kv/kvserver/logstore/sync_waiter.go
+++ b/pkg/kv/kvserver/logstore/sync_waiter.go
@@ -95,8 +95,8 @@ func (w *SyncWaiterLoop) waitLoop(ctx context.Context, stopper *stop.Stopper) {
 			if err := w.wg.SyncWait(); err != nil {
 				log.Fatalf(ctx, "SyncWait error: %+v", err)
 			}
-			w.wg.Close()
 			w.cb.run()
+			w.wg.Close()
 		case <-stopper.ShouldQuiesce():
 			return
 		}
@@ -108,7 +108,9 @@ func (w *SyncWaiterLoop) waitLoop(ctx context.Context, stopper *stop.Stopper) {
 // durably committed. It may never be called in case the stopper stops.
 //
 // The syncWaiter will be Closed after its SyncWait method completes. It must
-// not be Closed by the caller.
+// not be Closed by the caller. The cb is called before the syncWaiter is
+// closed, in case the cb implementation needs to extract something form the
+// syncWaiter.
 //
 // If the SyncWaiterLoop has already been stopped, the callback will never be
 // called.

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -759,6 +759,61 @@ bytes preserved during flushes and compactions over the lifetime of the process.
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
+	metaBatchCommitCount = metric.Metadata{
+		Name:        "storage.batch-commit.count",
+		Help:        "Count of batch commits. See storage.AggregatedBatchCommitStats for details.",
+		Measurement: "Commit Ops",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaBatchCommitDuration = metric.Metadata{
+		Name: "storage.batch-commit.duration",
+		Help: "Cumulative time spent in batch commit. " +
+			"See storage.AggregatedBatchCommitStats for details.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaBatchCommitSemWaitDuration = metric.Metadata{
+		Name: "storage.batch-commit.sem-wait.duration",
+		Help: "Cumulative time spent in semaphore wait, for batch commit. " +
+			"See storage.AggregatedBatchCommitStats for details.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaBatchCommitWALQWaitDuration = metric.Metadata{
+		Name: "storage.batch-commit.wal-queue-wait.duration",
+		Help: "Cumulative time spent waiting for memory blocks in the WAL queue, for batch commit. " +
+			"See storage.AggregatedBatchCommitStats for details.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaBatchCommitMemStallDuration = metric.Metadata{
+		Name: "storage.batch-commit.mem-stall.duration",
+		Help: "Cumulative time spent in a write stall due to too many memtables, for batch commit. " +
+			"See storage.AggregatedBatchCommitStats for details.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaBatchCommitL0StallDuration = metric.Metadata{
+		Name: "storage.batch-commit.l0-stall.duration",
+		Help: "Cumulative time spent in a write stall due to high read amplification in L0, for batch commit. " +
+			"See storage.AggregatedBatchCommitStats for details.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaBatchCommitWALRotDuration = metric.Metadata{
+		Name: "storage.batch-commit.wal-rotation.duration",
+		Help: "Cumulative time spent waiting for WAL rotation, for batch commit. " +
+			"See storage.AggregatedBatchCommitStats for details.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaBatchCommitCommitWaitDuration = metric.Metadata{
+		Name: "storage.batch-commit.commit-wait.duration",
+		Help: "Cumulative time spent waiting for WAL sync, for batch commit. " +
+			"See storage.AggregatedBatchCommitStats for details.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 )
 
 var (
@@ -2068,6 +2123,14 @@ type StoreMetrics struct {
 	FlushableIngestCount          *metric.Gauge
 	FlushableIngestTableCount     *metric.Gauge
 	FlushableIngestTableSize      *metric.Gauge
+	BatchCommitCount              *metric.Gauge
+	BatchCommitDuration           *metric.Gauge
+	BatchCommitSemWaitDuration    *metric.Gauge
+	BatchCommitWALQWaitDuration   *metric.Gauge
+	BatchCommitMemStallDuration   *metric.Gauge
+	BatchCommitL0StallDuration    *metric.Gauge
+	BatchCommitWALRotWaitDuration *metric.Gauge
+	BatchCommitCommitWaitDuration *metric.Gauge
 
 	RdbCheckpoints *metric.Gauge
 
@@ -2684,6 +2747,14 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		FlushableIngestCount:          metric.NewGauge(metaFlushableIngestCount),
 		FlushableIngestTableCount:     metric.NewGauge(metaFlushableIngestTableCount),
 		FlushableIngestTableSize:      metric.NewGauge(metaFlushableIngestTableBytes),
+		BatchCommitCount:              metric.NewGauge(metaBatchCommitCount),
+		BatchCommitDuration:           metric.NewGauge(metaBatchCommitDuration),
+		BatchCommitSemWaitDuration:    metric.NewGauge(metaBatchCommitSemWaitDuration),
+		BatchCommitWALQWaitDuration:   metric.NewGauge(metaBatchCommitWALQWaitDuration),
+		BatchCommitMemStallDuration:   metric.NewGauge(metaBatchCommitMemStallDuration),
+		BatchCommitL0StallDuration:    metric.NewGauge(metaBatchCommitL0StallDuration),
+		BatchCommitWALRotWaitDuration: metric.NewGauge(metaBatchCommitWALRotDuration),
+		BatchCommitCommitWaitDuration: metric.NewGauge(metaBatchCommitCommitWaitDuration),
 
 		RdbCheckpoints: metric.NewGauge(metaRdbCheckpoints),
 
@@ -3035,6 +3106,15 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.FlushableIngestCount.Update(int64(m.Flush.AsIngestCount))
 	sm.FlushableIngestTableCount.Update(int64(m.Flush.AsIngestTableCount))
 	sm.FlushableIngestTableSize.Update(int64(m.Flush.AsIngestBytes))
+	sm.BatchCommitCount.Update(int64(m.BatchCommitStats.Count))
+	sm.BatchCommitDuration.Update(int64(m.BatchCommitStats.TotalDuration))
+	sm.BatchCommitSemWaitDuration.Update(int64(m.BatchCommitStats.SemaphoreWaitDuration))
+	sm.BatchCommitWALQWaitDuration.Update(int64(m.BatchCommitStats.WALQueueWaitDuration))
+	sm.BatchCommitMemStallDuration.Update(int64(m.BatchCommitStats.MemTableWriteStallDuration))
+	sm.BatchCommitL0StallDuration.Update(int64(m.BatchCommitStats.L0ReadAmpWriteStallDuration))
+	sm.BatchCommitWALRotWaitDuration.Update(int64(m.BatchCommitStats.WALRotationDuration))
+	sm.BatchCommitCommitWaitDuration.Update(int64(m.BatchCommitStats.CommitWaitDuration))
+
 	// Update the maximum number of L0 sub-levels seen.
 	sm.l0SublevelsTracker.Lock()
 	sm.l0SublevelsTracker.swag.Record(timeutil.Now(), float64(m.Levels[0].Sublevels))

--- a/pkg/kv/kvserver/replica_raft_test.go
+++ b/pkg/kv/kvserver/replica_raft_test.go
@@ -17,11 +17,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/assert"
 	"go.etcd.io/raft/v3/tracker"
@@ -98,7 +100,18 @@ func Test_handleRaftReadyStats_SafeFormat(t *testing.T) {
 			PebbleBegin:       ts(3),
 			PebbleEnd:         ts(4),
 			PebbleBytes:       1024 * 5,
-			Sync:              true,
+			PebbleCommitStats: storage.BatchCommitStats{
+				BatchCommitStats: pebble.BatchCommitStats{
+					TotalDuration:               100 * time.Millisecond,
+					SemaphoreWaitDuration:       2 * time.Millisecond,
+					WALQueueWaitDuration:        5 * time.Millisecond,
+					MemTableWriteStallDuration:  8 * time.Millisecond,
+					L0ReadAmpWriteStallDuration: 11 * time.Millisecond,
+					WALRotationDuration:         14 * time.Millisecond,
+					CommitWaitDuration:          17 * time.Millisecond,
+				},
+			},
+			Sync: true,
 		},
 		tSnapBegin: ts(4),
 		tSnapEnd:   ts(5),

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -785,6 +785,10 @@ func (s spanSetBatch) Repr() []byte {
 	return s.b.Repr()
 }
 
+func (s spanSetBatch) CommitStats() storage.BatchCommitStats {
+	return s.b.CommitStats()
+}
+
 // NewBatch returns a storage.Batch that asserts access of the underlying
 // Batch against the given SpanSet. We only consider span boundaries, associated
 // timestamps are not considered.

--- a/pkg/kv/kvserver/testdata/handle_raft_ready_stats.txt
+++ b/pkg/kv/kvserver/testdata/handle_raft_ready_stats.txt
@@ -1,3 +1,3 @@
 echo
 ----
-raft ready handling: 5.00s [append=1.00s, apply=1.00s, sync=1.00s, snap=1.00s, other=1.00s], wrote [append-batch=5.0 KiB, append-ent=1.0 KiB (7), append-sst=5.0 MiB (3), apply=3 B (2 in 9 batches)], state_assertions=4, snapshot applied
+raft ready handling: 5.00s [append=1.00s, apply=1.00s, sync=1.00s, snap=1.00s, other=1.00s], wrote [append-batch=5.0 KiB, append-ent=1.0 KiB (7), append-sst=5.0 MiB (3), apply=3 B (2 in 9 batches)], state_assertions=4, snapshot applied pebble stats: [commit-wait 17ms wal-q 5ms mem-stall 8ms l0-stall 11ms wal-rot 14ms sem 2ms]

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -773,7 +773,10 @@ type Pebble struct {
 		syncutil.Mutex
 		AggregatedIteratorStats
 	}
-
+	batchCommitStats struct {
+		syncutil.Mutex
+		AggregatedBatchCommitStats
+	}
 	// Relevant options copied over from pebble.Options.
 	unencryptedFS vfs.FS
 	logCtx        context.Context
@@ -1350,6 +1353,19 @@ func (p *Pebble) aggregateIterStats(stats IteratorStats) {
 	p.iterStats.InternalSteps += stats.Stats.ForwardStepCount[pebble.InternalIterCall] + stats.Stats.ReverseStepCount[pebble.InternalIterCall]
 }
 
+func (p *Pebble) aggregateBatchCommitStats(stats BatchCommitStats) {
+	p.batchCommitStats.Lock()
+	p.batchCommitStats.Count++
+	p.batchCommitStats.TotalDuration += stats.TotalDuration
+	p.batchCommitStats.SemaphoreWaitDuration += stats.SemaphoreWaitDuration
+	p.batchCommitStats.WALQueueWaitDuration += stats.WALQueueWaitDuration
+	p.batchCommitStats.MemTableWriteStallDuration += stats.MemTableWriteStallDuration
+	p.batchCommitStats.L0ReadAmpWriteStallDuration += stats.L0ReadAmpWriteStallDuration
+	p.batchCommitStats.WALRotationDuration += stats.WALRotationDuration
+	p.batchCommitStats.CommitWaitDuration += stats.CommitWaitDuration
+	p.batchCommitStats.Unlock()
+}
+
 // Closed implements the Engine interface.
 func (p *Pebble) Closed() bool {
 	return p.closed
@@ -1785,6 +1801,9 @@ func (p *Pebble) GetMetrics() Metrics {
 	p.iterStats.Lock()
 	m.Iterator = p.iterStats.AggregatedIteratorStats
 	p.iterStats.Unlock()
+	p.batchCommitStats.Lock()
+	m.BatchCommitStats = p.batchCommitStats.AggregatedBatchCommitStats
+	p.batchCommitStats.Unlock()
 	return m
 }
 
@@ -1892,7 +1911,7 @@ func (p *Pebble) GetAuxiliaryDir() string {
 
 // NewBatch implements the Engine interface.
 func (p *Pebble) NewBatch() Batch {
-	return newPebbleBatch(p.db, p.db.NewIndexedBatch(), false /* writeOnly */, p.settings, p)
+	return newPebbleBatch(p.db, p.db.NewIndexedBatch(), false /* writeOnly */, p.settings, p, p)
 }
 
 // NewReadOnly implements the Engine interface.
@@ -1902,12 +1921,12 @@ func (p *Pebble) NewReadOnly(durability DurabilityRequirement) ReadWriter {
 
 // NewUnindexedBatch implements the Engine interface.
 func (p *Pebble) NewUnindexedBatch() Batch {
-	return newPebbleBatch(p.db, p.db.NewBatch(), false /* writeOnly */, p.settings, p)
+	return newPebbleBatch(p.db, p.db.NewBatch(), false /* writeOnly */, p.settings, p, p)
 }
 
 // NewWriteBatch implements the Engine interface.
 func (p *Pebble) NewWriteBatch() WriteBatch {
-	return newPebbleBatch(p.db, p.db.NewBatch(), true /* writeOnly */, p.settings, p)
+	return newPebbleBatch(p.db, p.db.NewBatch(), true /* writeOnly */, p.settings, p, p)
 }
 
 // NewSnapshot implements the Engine interface.

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -49,7 +49,7 @@ type pebbleIterator struct {
 	// statsReporter is used to sum iterator stats across all the iterators
 	// during the lifetime of the Engine when the iterator is closed or its
 	// stats reset. It's intended to be used with (*Pebble). It must not be nil.
-	statsReporter statsReporter
+	statsReporter iterStatsReporter
 
 	// Set to true to govern whether to call SeekPrefixGE or SeekGE. Skips
 	// SSTables based on MVCC/Engine key when true.
@@ -75,7 +75,7 @@ type pebbleIterator struct {
 	mvccDone bool
 }
 
-type statsReporter interface {
+type iterStatsReporter interface {
 	aggregateIterStats(IteratorStats)
 }
 
@@ -99,7 +99,7 @@ func newPebbleIterator(
 	handle pebble.Reader,
 	opts IterOptions,
 	durability DurabilityRequirement,
-	statsReporter statsReporter,
+	statsReporter iterStatsReporter,
 ) *pebbleIterator {
 	p := pebbleIterPool.Get().(*pebbleIterator)
 	p.reusable = false // defensive
@@ -158,7 +158,7 @@ func (p *pebbleIterator) init(
 	iter pebbleiter.Iterator,
 	opts IterOptions,
 	durability DurabilityRequirement,
-	statsReporter statsReporter,
+	statsReporter iterStatsReporter,
 ) {
 	*p = pebbleIterator{
 		iter:               iter,
@@ -185,7 +185,7 @@ func (p *pebbleIterator) initReuseOrCreate(
 	clone bool,
 	opts IterOptions,
 	durability DurabilityRequirement,
-	statsReporter statsReporter,
+	statsReporter iterStatsReporter,
 ) {
 	if iter != nil && !clone {
 		p.init(iter, opts, durability, statsReporter)


### PR DESCRIPTION
Pebble now produces detailed stats for a batch commit. These are partially
plumbed into kvserver, for (a) log statements related to raft appends,
(b) cumulative duration metrics applicable for all writes (raft and state
machine).

Informs https://github.com/cockroachdb/pebble/issues/1943

Epic: none

Release note: None