### PR TITLE
cli: debug zip increase timeout to 60s

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -142,7 +142,7 @@ func runDebugZip(_ *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 
-	timeout := 10 * time.Second
+	timeout := 60 * time.Second
 	if cliCtx.cmdTimeout != 0 {
 		timeout = cliCtx.cmdTimeout
 	}


### PR DESCRIPTION
This is a change motivated by an ask by KV L2s as well as some flakiness in general with debug tests. There are some endpoints that produce a lot of data, which results in timeouts periodically even when everything is
working fine.

The CLI flag `--timeout` can also be used, but in general we would benefit from not relying on customers to provide a sufficient timeout

related internal slack conversation: https://cockroachlabs.slack.com/archives/C01CNRP6TSN/p1681975459756149

Informs #101623

Release note: None