### PR TITLE
rowexec: ensure lower bound for workmem of stats processors

### DIFF
--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -965,6 +965,21 @@ func NewLimitedMonitor(
 	return limitedMon
 }
 
+// NewLimitedMonitorWithLowerBound is similar to NewLimitedMonitor but
+// guarantees that the monitor's limit is at least minMemoryLimit bytes.
+// flowCtx.Mon is used as the parent for the new monitor.
+func NewLimitedMonitorWithLowerBound(
+	ctx context.Context, flowCtx *FlowCtx, name redact.RedactableString, minMemoryLimit int64,
+) *mon.BytesMonitor {
+	memoryLimit := GetWorkMemLimit(flowCtx)
+	if memoryLimit < minMemoryLimit {
+		memoryLimit = minMemoryLimit
+	}
+	limitedMon := mon.NewMonitorInheritWithLimit(name, memoryLimit, flowCtx.Mon)
+	limitedMon.StartNoReserved(ctx, flowCtx.Mon)
+	return limitedMon
+}
+
 // NewLimitedMonitorNoFlowCtx is the same as NewLimitedMonitor and should be
 // used when the caller doesn't have an access to *FlowCtx.
 func NewLimitedMonitorNoFlowCtx(

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -112,7 +112,16 @@ func newSampleAggregator(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "sample-aggregator-mem")
+	//
+	// sampleAggregator doesn't spill to disk, so ensure some reasonable lower
+	// bound on the workmem limit.
+	var minMemoryLimit int64 = 8 << 20 // 8MiB
+	if flowCtx.Cfg.TestingKnobs.MemoryLimitBytes != 0 {
+		minMemoryLimit = flowCtx.Cfg.TestingKnobs.MemoryLimitBytes
+	}
+	memMonitor := execinfra.NewLimitedMonitorWithLowerBound(
+		ctx, flowCtx, "sample-aggregator-mem", minMemoryLimit,
+	)
 	rankCol := len(input.OutputTypes()) - 8
 	s := &sampleAggregator{
 		spec:         spec,

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
@@ -305,6 +306,7 @@ func runSampleAggregator(
 
 func TestSampleAggregator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	server, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer server.Stopper().Stop(context.Background())

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -115,7 +115,16 @@ func newSamplerProcessor(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "sampler-mem")
+	//
+	// sampler doesn't spill to disk, so ensure some reasonable lower bound on
+	// the workmem limit.
+	var minMemoryLimit int64 = 8 << 20 // 8MiB
+	if flowCtx.Cfg.TestingKnobs.MemoryLimitBytes != 0 {
+		minMemoryLimit = flowCtx.Cfg.TestingKnobs.MemoryLimitBytes
+	}
+	memMonitor := execinfra.NewLimitedMonitorWithLowerBound(
+		ctx, flowCtx, "sampler-mem", minMemoryLimit,
+	)
 	s := &samplerProcessor{
 		input:           input,
 		memAcc:          memMonitor.MakeBoundAccount(),

--- a/pkg/sql/rowexec/sampler_test.go
+++ b/pkg/sql/rowexec/sampler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -195,6 +196,7 @@ type testCase struct {
 
 func TestSampler(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	for _, tc := range []testCase{
 		// Check distribution when capacity is held steady.
@@ -211,6 +213,7 @@ func TestSampler(t *testing.T) {
 
 func TestSamplerMemoryLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	for _, tc := range []testCase{
 		// While holding numSamples and minNumSamples fixed, increase the memory
@@ -242,6 +245,7 @@ func TestSamplerMemoryLimit(t *testing.T) {
 
 func TestSamplerSketch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	testCases := []struct {
 		typs          []*types.T

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -114,17 +114,9 @@ func newWindower(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// windower will overflow to disk if this limit is not enough.
-	limit := execinfra.GetWorkMemLimit(flowCtx)
-	if limit < memRequiredByWindower {
-		// The limit is set very low (likely by the tests in order to improve
-		// the test coverage), but the windower requires some amount of RAM, so
-		// we override the limit. This behavior is acceptable given that we
-		// don't expect anyone to lower the setting to less than 100KiB in
-		// production.
-		limit = memRequiredByWindower
-	}
-	limitedMon := mon.NewMonitorInheritWithLimit("windower-limited", limit, flowCtx.Mon)
-	limitedMon.StartNoReserved(ctx, flowCtx.Mon)
+	limitedMon := execinfra.NewLimitedMonitorWithLowerBound(
+		ctx, flowCtx, "windower-limited", memRequiredByWindower,
+	)
 	w.acc = limitedMon.MakeBoundAccount()
 	// If we have aggregate builtins that aggregate a single datum, we want
 	// them to reuse the same shared memory account with the windower. Notably,


### PR DESCRIPTION
Sampler and sampleAggregator don't know how to spill to disk, so we should ensure some reasonable lower bound (8MiB) on the workmem limit they get. This commit introduces a helper method for creating a monitor with the lower bound, that is now additionally used by the join reader and the windower.

Epic: None

Release note: None