### PR TITLE
kvserver: record metrics for work preempted or paced

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -80,6 +80,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util",
+        "//pkg/util/admission",
         "//pkg/util/hlc",
         "//pkg/util/iterutil",
         "//pkg/util/limit",

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -373,6 +374,10 @@ func evalExport(
 			}
 		}
 	}
-
+	if reply.ResumeReason == kvpb.RESUME_ELASTIC_CPU_LIMIT {
+		if h := admission.ElasticCPUWorkHandleFromContext(ctx); h != nil {
+			h.NoteWorkPreempted()
+		}
+	}
 	return result.Result{}, nil
 }

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -122,6 +122,8 @@ type Controller interface {
 	// AdmitRaftEntry informs admission control of a raft log entry being
 	// written to storage.
 	AdmitRaftEntry(context.Context, roachpb.TenantID, roachpb.StoreID, roachpb.RangeID, raftpb.Entry)
+	// KVMetrics returns WorkQueueMetrics related to KV work admissions.
+	KVMetrics() *admission.WorkQueueMetrics
 }
 
 // TenantWeightProvider can be periodically asked to provide the tenant
@@ -467,6 +469,14 @@ func (n *controllerImpl) AdmitRaftEntry(
 	if handle.UseAdmittedWorkDone() {
 		log.Fatalf(ctx, "unexpected handle.UseAdmittedWorkDone")
 	}
+}
+
+// KVMetrics returns the WorkQueueMetrics associated with the KV work queue.
+func (n *controllerImpl) KVMetrics() *admission.WorkQueueMetrics {
+	if n.kvAdmissionQ == nil {
+		return nil
+	}
+	return n.kvAdmissionQ.Metrics()
 }
 
 // FollowerStoreWriteBytes captures stats about writes done to a store by a

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1182,6 +1182,15 @@ func (n *Node) batchInternal(
 
 	var writeBytes *kvadmission.StoreWriteBytes
 	defer func() {
+		if handle.ElasticCPUWorkHandle != nil {
+			pri := admissionpb.WorkPriority(args.AdmissionHeader.Priority)
+			if m := n.storeCfg.KVAdmissionController.KVMetrics(); m != nil {
+				if handle.ElasticCPUWorkHandle.PreemptedWork() {
+					m.IncPreempted(pri)
+				}
+				m.RecordPacing(pri, handle.ElasticCPUWorkHandle.PacedWork())
+			}
+		}
 		n.storeCfg.KVAdmissionController.AdmittedKVWorkDone(handle, writeBytes)
 		writeBytes.Release()
 	}()

--- a/pkg/util/admission/elastic_cpu_work_handle.go
+++ b/pkg/util/admission/elastic_cpu_work_handle.go
@@ -42,6 +42,9 @@ type ElasticCPUWorkHandle struct {
 	// between that running time and what this handle was allotted.
 	runningTimeAtLastCheck, differenceWithAllottedAtLastCheck time.Duration
 
+	preemptedWork bool
+	pacedWork     time.Duration
+
 	testingOverrideRunningTime func() time.Duration
 
 	testingOverrideOverLimit func() (bool, time.Duration)
@@ -115,6 +118,32 @@ func (h *ElasticCPUWorkHandle) overLimitInner() (overLimit bool, difference time
 	h.runningTimeAtLastCheck, h.differenceWithAllottedAtLastCheck = runningTime, grunning.Difference(runningTime, h.allotted)
 	h.itersSinceLastCheck = 0
 	return false, h.differenceWithAllottedAtLastCheck
+}
+
+// NoteWorkPreempted records the fact that this handle going over limit
+// preempted work at least once.
+func (h *ElasticCPUWorkHandle) NoteWorkPreempted() {
+	h.preemptedWork = true
+}
+
+// NoteWorkPaced records the fact that this handle going over limit delayed work
+// by some duration.
+func (h *ElasticCPUWorkHandle) NoteWorkPaced(delay time.Duration) {
+	h.pacedWork += delay
+}
+
+// PreemptedWork returns whether work using this handle reported being preempted
+// due to Overlimit (NB: this may be false even if `Overlimit()` was called and
+// returned true, in the case that the caller elected to ignore it and continue
+// working rather than be preempted).
+func (h *ElasticCPUWorkHandle) PreemptedWork() bool {
+	return h.preemptedWork
+}
+
+// PacedWork returns the total amount of time spent being paced that any work
+// using this handle reported.
+func (h *ElasticCPUWorkHandle) PacedWork() time.Duration {
+	return h.pacedWork
 }
 
 // TestingOverrideOverLimit allows tests to override the behaviour of


### PR DESCRIPTION
When elastic CPU work limiting either preempts work or paces it on a given node, recording that fact in a metric makes it easier to determine that limited CPU on that node is indeed impacting work and by how much.

Release note: none.

Epic: none.