### PR TITLE
release-23.1.0: sqlstats: only include local region in statement_statistics

### DIFF
--- a/pkg/ccl/multiregionccl/testdata/secondary_region
+++ b/pkg/ccl/multiregionccl/testdata/secondary_region
@@ -1,6 +1,3 @@
-skip issue-num=98020
-----
-
 new-cluster localities=us-east-1,us-east-1,us-west-1,us-west-1,us-central-1,us-central-1,us-central-1,eu-west-1,eu-west-1,eu-west-1
 ----
 

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -12,9 +12,7 @@ package sql
 
 import (
 	"context"
-	"sort"
 	"strconv"
-	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/contentionpb"
@@ -22,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/idxrecommendations"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -189,7 +186,11 @@ func (ex *connExecutor) recordStatementSummary(
 	}
 
 	nodes := util.CombineUniqueInt64(getNodesFromPlanner(planner), []int64{nodeID})
-	regions := getRegionsForNodes(ctx, nodes, planner.DistSQLPlanner().sqlAddressResolver)
+
+	regions := []string{}
+	if region, ok := ex.server.cfg.Locality.Find("region"); ok {
+		regions = append(regions, region)
+	}
 
 	recordedStmtStats := sqlstats.RecordedStmtStats{
 		SessionID:            ex.sessionID,
@@ -326,50 +327,4 @@ func getNodesFromPlanner(planner *planner) []int64 {
 		})
 	}
 	return nodes
-}
-
-var regionsPool = sync.Pool{
-	New: func() interface{} {
-		return make(map[string]struct{})
-	},
-}
-
-func getRegionsForNodes(
-	ctx context.Context, nodeIDs []int64, resolver sqlinstance.AddressResolver,
-) []string {
-	if resolver == nil {
-		return nil
-	}
-
-	instances, err := resolver.GetAllInstances(ctx)
-	if err != nil {
-		return nil
-	}
-
-	regions := regionsPool.Get().(map[string]struct{})
-	defer func() {
-		for region := range regions {
-			delete(regions, region)
-		}
-		regionsPool.Put(regions)
-	}()
-
-	for _, instance := range instances {
-		for _, node := range nodeIDs {
-			// TODO(todd): Using int64 for nodeIDs was inappropriate, see #95088.
-			if int32(instance.InstanceID) == int32(node) {
-				if region, ok := instance.Locality.Find("region"); ok {
-					regions[region] = struct{}{}
-				}
-				break
-			}
-		}
-	}
-
-	result := make([]string, 0, len(regions))
-	for region := range regions {
-		result = append(result, region)
-	}
-	sort.Strings(result)
-	return result
 }


### PR DESCRIPTION
Backport 1/1 commits from #102192.

/cc @cockroachdb/release

---

Part of #89949.

Addresses #98020.
Addresses #99563.

Related to cockroachdb/roachperf#129.
Related to #102170.

Previously, we attempted to record all the regions hit in a single statement execution in the sqlstats tables, leaning on the sqlAddressResolver to map traced nodeIDs to localities at execution time.

While the sqlAddressResolver is generally non-blocking, the introduction of this code did cause some of the multiregion "this query shouldn't span regions" tests to start [flaking][] and it's more recently been [implicated][] in a 2.5% performance regression.

Given that the probabilistic nature of the tracing meant that we generally weren't capturing all the relevant nodeIDs anyway, it seems like the most prudent thing to do here is take a step back and regroup.

In the short term, let's stop even trying to gather all these regions. In the medium/long term, let's see if we can find a better approach.

[flaking]: https://github.com/cockroachdb/cockroach/issues/98020
[implicated]: https://github.com/cockroachdb/roachperf/pull/129

Release note: None

Release justification: fixes for high-priority or high-severity bugs in existing functionality