### PR TITLE
release: increase bincheck timeout

### DIFF
--- a/build/release/bincheck/bincheck
+++ b/build/release/bincheck/bincheck
@@ -35,7 +35,7 @@ echo ""
 "$cockroach" start-single-node --insecure --listening-url-file="$urlfile" --enterprise-encryption=path=cockroach-data,key=aes-128.key,old-key=plain --pid-file="$pidfile" &
 
 trap "kill -9 $! || true" EXIT
-for i in {0..3}
+for i in {0..8}
 do
   [[ -f "$urlfile" ]] && break
   backoff=$((2 ** i))


### PR DESCRIPTION
Increase overall timeout for bincheck in order to be less flaky running the tests on GitHub runners.

Epic: none
Release note: None