### PR TITLE
opt: fix internal error when planning correlated ANY subqueries

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -570,6 +570,12 @@ func (b *Builder) buildAny(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		return nil, b.decorrelationError()
 	}
 
+	if b.planLazySubqueries {
+		// We cannot currently plan uncorrelated ANY subqueries as
+		// lazily-evaluated routines.
+		return nil, b.decorrelationError()
+	}
+
 	// Build the execution plan for the input subquery.
 	plan, err := b.buildRelational(any.Input)
 	if err != nil {
@@ -700,6 +706,14 @@ func (b *Builder) buildExistsSubquery(
 			),
 			tree.DBoolFalse,
 		}, types.Bool), nil
+	}
+
+	if b.planLazySubqueries {
+		// We cannot currently plan uncorrelated Exists subqueries as
+		// lazily-evaluated routines. However, this path should never be
+		// executed because the ConvertUncorrelatedExistsToCoalesceSubquery rule
+		// converts all uncorrelated Exists into Coalesce+Subquery expressions.
+		return nil, b.decorrelationError()
 	}
 
 	// Build the execution plan for the subquery. Note that the subquery could

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -564,6 +564,24 @@ SELECT
   CASE WHEN k < 5 THEN (SELECT array(SELECT 1) FROM corr tmp WHERE k*10 = corr.k) END
 FROM corr
 
+# Regression test for #101980.
+# Case where a correlated exists subquery contains an uncorrelated ANY subquery.
+# We do not currently plan uncorrelated ANY subqueries as lazily-evaluated
+# routines, so this should cause a decorrelation error, not an internal error.
+statement ok
+CREATE TABLE t101980a (a INT);
+CREATE TABLE t101980b (b INT);
+INSERT INTO t101980a VALUES (1);
+INSERT INTO t101980b VALUES (1);
+
+statement error could not decorrelate subquery
+SELECT b FROM t101980a
+FULL JOIN t101980b ON b IN (
+  SELECT b FROM t101980b, t101980a
+  WHERE a = 0
+    OR b IN (SELECT b FROM t101980b)
+);
+
 subtest expressionInSubquery
 
 statement ok


### PR DESCRIPTION
This commit fixes a bug where a decorrelation error was not returned
when trying to build uncorrelated ANY subqueries within a
lazily-evaluated routine, which is not yet supported. Instead of the
error, the ANY subquery would be planned as an eagerly-evaluate
subquery. This violated the requirement that no eagerly-evaluated
subqueries are planned within a lazily-evaluated routine, and caused an
internal error.

Fixes #101980

Release note (bug fix): A minor bug has been fixed that caused an
internal error for some queries with nested subqueries instead of the
more appropriate "could not decorrelate subquery" error. This bug was
only present in pre-release alpha and beta versions of 23.1.
