### PR TITLE
sql: add bounds checking to resolved function definition functions

### DIFF
--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -316,6 +316,9 @@ func combineOverloads(a, b []QualifiedOverload) []QualifiedOverload {
 // method, function is resolved to one overload, so that we can get rid of this
 // function and similar methods below.
 func (fd *ResolvedFunctionDefinition) GetClass() (FunctionClass, error) {
+	if len(fd.Overloads) < 1 {
+		return 0, errors.AssertionFailedf("no overloads found for function %s", fd.Name)
+	}
 	ret := fd.Overloads[0].Class
 	for i := range fd.Overloads {
 		if fd.Overloads[i].Class != ret {
@@ -331,6 +334,9 @@ func (fd *ResolvedFunctionDefinition) GetClass() (FunctionClass, error) {
 // different length. This is good enough since we don't create UDF with
 // ReturnLabel.
 func (fd *ResolvedFunctionDefinition) GetReturnLabel() ([]string, error) {
+	if len(fd.Overloads) < 1 {
+		return nil, errors.AssertionFailedf("no overloads found for function %s", fd.Name)
+	}
 	ret := fd.Overloads[0].ReturnLabels
 	for i := range fd.Overloads {
 		if len(ret) != len(fd.Overloads[i].ReturnLabels) {
@@ -344,6 +350,9 @@ func (fd *ResolvedFunctionDefinition) GetReturnLabel() ([]string, error) {
 // checking each overload's HasSequenceArguments flag. Ambiguous error is
 // returned if there is any overload has a different flag.
 func (fd *ResolvedFunctionDefinition) GetHasSequenceArguments() (bool, error) {
+	if len(fd.Overloads) < 1 {
+		return false, errors.AssertionFailedf("no overloads found for function %s", fd.Name)
+	}
 	ret := fd.Overloads[0].HasSequenceArguments
 	for i := range fd.Overloads {
 		if ret != fd.Overloads[i].HasSequenceArguments {


### PR DESCRIPTION
`ResolvedFunctionDefinition` utility functions now return an error if there are no overloads in the resolved function. Previously, this could panic since it was assumed there was at least one overload. There probably should be at least one overload at this point, so the error will hopefully aid with future debugging.

Epic: none
Fixes: #102235

Release note: None