### PR TITLE
ui: enable initial data fetch in insecure mode

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -653,15 +653,19 @@ export function alertDataSync(store: Store<AdminUIState>) {
     // Always refresh health.
     dispatch(refreshHealth());
 
+    const { Insecure } = getDataFromServer();
     // We should not send out requests to the endpoints below if
     // the user has not successfully logged in since the requests
     // will always return with a 401 error.
-    if (
-      !state.login ||
-      !state.login.loggedInUser ||
-      state.login.loggedInUser == ``
-    ) {
-      return;
+    // Insecure mode is an exception, where login state is irrelevant.
+    if (!Insecure) {
+      if (
+        !state.login ||
+        !state.login.loggedInUser ||
+        state.login.loggedInUser == ``
+      ) {
+        return;
+      }
     }
 
     // Load persistent settings which have not yet been loaded.


### PR DESCRIPTION
Previously, `alertDataSync`, the function that populates missing cluster info, did not consider insecure mode when assessing a user's login state.

Because the 23.1 test cluster is running in insecure mode, the UI is noticeably missing it's cluster ID.

Resolves #102350
Epic: none
Release note: None