### PR TITLE
release-22.2: cdc: use int64 for emitted bytes telemetry

### DIFF
--- a/pkg/ccl/changefeedccl/telemetry.go
+++ b/pkg/ccl/changefeedccl/telemetry.go
@@ -69,8 +69,8 @@ func (ptl *periodicTelemetryLogger) recordEmittedBytes(numBytes int) {
 	ptl.sinkTelemetryData.emittedBytes.Add(int64(numBytes))
 }
 
-func (ptl *periodicTelemetryLogger) resetEmittedBytes() int {
-	return int(ptl.sinkTelemetryData.emittedBytes.Swap(0))
+func (ptl *periodicTelemetryLogger) resetEmittedBytes() int64 {
+	return ptl.sinkTelemetryData.emittedBytes.Swap(0)
 }
 
 // recordEmittedBytes implements the telemetryLogger interface.
@@ -96,7 +96,7 @@ func (ptl *periodicTelemetryLogger) maybeFlushLogs() {
 	continuousTelemetryEvent := &eventpb.ChangefeedEmittedBytes{
 		CommonChangefeedEventDetails: ptl.changefeedDetails,
 		JobId:                        int64(ptl.job.ID()),
-		EmittedBytes:                 int32(ptl.resetEmittedBytes()),
+		EmittedBytes:                 ptl.resetEmittedBytes(),
 		LoggingInterval:              loggingInterval,
 	}
 	log.StructuredEvent(ptl.ctx, continuousTelemetryEvent)
@@ -111,7 +111,7 @@ func (ptl *periodicTelemetryLogger) close() {
 	continuousTelemetryEvent := &eventpb.ChangefeedEmittedBytes{
 		CommonChangefeedEventDetails: ptl.changefeedDetails,
 		JobId:                        int64(ptl.job.ID()),
-		EmittedBytes:                 int32(ptl.resetEmittedBytes()),
+		EmittedBytes:                 ptl.resetEmittedBytes(),
 		LoggingInterval:              loggingInterval,
 		Closing:                      true,
 	}

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -256,7 +256,7 @@ message ChangefeedEmittedBytes {
   int64 job_id = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) =  "redact:\"nonsensitive\""];
 
   // The number of bytes emitted.
-  int32 emitted_bytes = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  int64 emitted_bytes = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
   // The time period in nanoseconds between emitting telemetry events of this type (per-aggregator).
   int64 logging_interval = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];


### PR DESCRIPTION
Previously, the stored `emitted_bytes` field was an int32, which can hold a maximum value of 2.1GB. This value is too small because the logging period is 24h and changefeeds can emit much more than 2.1GB in 24h. This change updates the field to be an int64, which solves this problem.

Epic: None
Release note: None
Closes: https://github.com/cockroachdb/cockroach/issues/101676
Release justification: This change is very small and fixes a bug in telemetry logs.
Having accurate telemetry logs is important for product work.