### PR TITLE
release-22.1: backupccl: pretend manifest files spans actually end at EndKey.Next on restore

### DIFF
--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -54,8 +54,14 @@ var targetRestoreSpanSize = settings.RegisterByteSizeSetting(
 // makeSimpleImportSpans partitions the spans of requiredSpans into a covering
 // of RestoreSpanEntry's which each have all overlapping files from the passed
 // backups assigned to them. The spans of requiredSpans are trimmed/removed
-// based on the lowWaterMark before the covering for them is generated. Consider
-// a chain of backups with files f1, f2… which cover spans as follows:
+// based on the lowWaterMark before the covering for them is generated.
+//
+// Note that because of https://github.com/cockroachdb/cockroach/issues/101963,
+// the spans of files are end key _inclusive_. Because the current definition
+// of spans are all end key _exclusive_, we work around this by assuming that
+// the end key of each file span is actually the next key of the end key.
+//
+// Consider a chain of backups with files f1, f2… which cover spans as follows:
 //
 //	backup
 //	0|     a___1___c c__2__e          h__3__i
@@ -68,9 +74,9 @@ var targetRestoreSpanSize = settings.RegisterByteSizeSetting(
 //
 // The cover for those spans would look like:
 //
-//	[a, c): 1, 4, 6
-//	[c, e): 2, 4, 6
-//	[e, f): 6
+//	[a, c\x00): 1, 2, 4, 6
+//	[c\x00, e\x00): 2, 4, 6
+//	[e\x00, f): 6
 //	[f, i): 3, 5, 6, 8
 //	[l, m): 9
 //
@@ -140,7 +146,8 @@ func makeSimpleImportSpans(
 
 			// TODO(dt): binary search to the first file in required span?
 			for _, f := range backups[layer].Files {
-				if sp := span.Intersect(f.Span); sp.Valid() {
+				fspan := endKeyInclusiveSpan(f.Span)
+				if sp := span.Intersect(fspan); sp.Valid() {
 					fileSpec := execinfrapb.RestoreFileSpec{Path: f.Path, Dir: backups[layer].Dir}
 					if dir, ok := backupLocalityMap[layer][f.LocalityKV]; ok {
 						fileSpec = execinfrapb.RestoreFileSpec{Path: f.Path, Dir: dir}
@@ -198,7 +205,7 @@ func makeSimpleImportSpans(
 							}
 						}
 					}
-				} else if span.EndKey.Compare(f.Span.Key) <= 0 {
+				} else if span.EndKey.Compare(fspan.Key) <= 0 {
 					// If this file starts after the needed span ends, then all the files
 					// remaining do too so we're done checking files for this span.
 					break
@@ -240,4 +247,21 @@ func makeEntry(start, end roachpb.Key, f execinfrapb.RestoreFileSpec) execinfrap
 		Span:  roachpb.Span{Key: start, EndKey: end},
 		Files: []execinfrapb.RestoreFileSpec{f},
 	}
+}
+
+// endKeyInclusiveSpan returns a span with the same start key as the input span
+// but with its end key as the next key of the input's end key.
+//
+// NB: a backup file can currently have keys equal to its span's EndKey due to
+// the bug: https://github.com/cockroachdb/cockroach/issues/101963, effectively
+// meaning that we have to treat the span as end key inclusive. Because
+// roachpb.Span and its associated operations are end key exclusive, we work
+// around this by replacing the end key with its next value in order to include
+// the end key.
+func endKeyInclusiveSpan(sp roachpb.Span) roachpb.Span {
+	isp := roachpb.Span{
+		Key:    sp.Key,
+		EndKey: sp.EndKey.Next(),
+	}
+	return isp
 }

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -118,6 +118,7 @@ func checkRestoreCovering(
 ) error {
 	var expectedPartitions int
 	required := make(map[string]*roachpb.SpanGroup)
+	requiredKey := make(map[string]roachpb.Key)
 
 	introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
 	if err != nil {
@@ -154,13 +155,27 @@ func checkRestoreCovering(
 						expectedPartitions++
 					}
 				}
+
+				if span.ContainsKey(f.Span.EndKey) {
+					// Since file spans are end key inclusive, we have to check
+					// if the end key is in the covering.
+					requiredKey[f.Path] = f.Span.EndKey
+				}
 			}
 		}
 	}
 	var spanIdx int
 	for _, c := range cov {
 		for _, f := range c.Files {
-			required[f.Path].Sub(c.Span)
+			if requireSpan, ok := required[f.Path]; ok {
+				requireSpan.Sub(c.Span)
+			}
+
+			if requireKey, ok := requiredKey[f.Path]; ok {
+				if c.Span.ContainsKey(requireKey) {
+					delete(requiredKey, f.Path)
+				}
+			}
 		}
 		for spans[spanIdx].EndKey.Compare(c.Span.Key) < 0 {
 			spanIdx++
@@ -181,6 +196,11 @@ func checkRestoreCovering(
 	if got := len(cov); got != expectedPartitions && !merged {
 		return errors.Errorf("expected %d partitions, got %d", expectedPartitions, got)
 	}
+
+	for name, uncoveredKey := range requiredKey {
+		return errors.Errorf("file %s was supposed to cover key %s", name, uncoveredKey)
+	}
+
 	return nil
 }
 
@@ -229,9 +249,9 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 
 	cover := makeSimpleImportSpans(spans, backups, nil, emptySpanFrontier, nil, noSpanTargetSize)
 	require.Equal(t, []execinfrapb.RestoreSpanEntry{
-		{Span: sp("a", "c"), Files: paths("1", "4", "6")},
-		{Span: sp("c", "e"), Files: paths("2", "4", "6")},
-		{Span: sp("e", "f"), Files: paths("6")},
+		{Span: sp("a", "c\x00"), Files: paths("1", "2", "4", "6")},
+		{Span: sp("c\x00", "e\x00"), Files: paths("2", "4", "6")},
+		{Span: sp("e\x00", "f"), Files: paths("6")},
 		{Span: sp("f", "i"), Files: paths("3", "5", "6", "8")},
 		{Span: sp("l", "m"), Files: paths("9")},
 	}, cover)


### PR DESCRIPTION
Backport 1/1 commits from #102179.

/cc @cockroachdb/release

---

Currently, a key's revision history can be split in such a way that the first part of the history is at the end of one SST, while the rest of its history is at the beginning of another SST. In this case, the backup manifest entry describing the first file will claim that the span ended at (and excludes) the split key, whereas in reality the file still contains some revisions of that key.

This patch introduces a workaround to these incorrect manifest file spans by conservatively assuming that all manifest file spans actually end at the next key of its end key during restore import span generation. This allows restore to actually consider all files that may end with a key that's split mid revision.

Addresses #101963

Release note (bug fix): fixes a bug where a backup with a key's revision history split across multiple SSTs may not correctly restore the proper revision of the key.

Epic: none.

Release Justification: low risk, high impact change to prevent corrupt restores.