### PR TITLE
server: log instead of returning error

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -983,7 +983,7 @@ func getStatementDetails(
 	if settings.Version.IsActive(ctx, clusterversion.V23_1AddSystemActivityTables) {
 		activityHasData, err = activityTablesHaveFullData(ctx, ie, testingKnobs, reqStartTime)
 		if err != nil {
-			return nil, serverError(ctx, err)
+			log.Errorf(ctx, "Error on getStatementDetails: %s", err)
 		}
 	}
 


### PR DESCRIPTION
This fix was made on the backport PRs from #102026, but was missing on the original PR to master.

Part Of: #101948

Logs the error message, instead of returning an error, so the endpoint can still work if there is an issue on the activity tables.

Release note: None