### PR TITLE
release-23.1: sql: set system db survival as max survival goal

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survial_goal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survial_goal
@@ -1,0 +1,103 @@
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
+# knob-opt: sync-event-log
+# LogicTest: multiregion-9node-3region-3azs-tenant
+
+# Only the root user can modify the system database's regions.
+user root
+
+statement ok
+CREATE FUNCTION get_db_survival_goal() RETURNS SETOF RECORD
+LANGUAGE SQL
+AS $$
+ SELECT
+ name,
+ survival_goal
+ FROM crdb_internal.databases
+ WHERE name IN ('system', 'alter_survive_db', 'survive_zone_db')
+ ORDER BY name;
+$$;
+
+query T
+SELECT get_db_survival_goal()
+----
+(system,)
+
+statement ok
+CREATE DATABASE alter_survive_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1";
+CREATE DATABASE survive_zone_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1";
+
+# Make sure that system db survival goal is not affected when it's not multi-regional.
+statement ok
+ALTER DATABASE alter_survive_db SURVIVE REGION FAILURE;
+
+query T
+SELECT get_db_survival_goal()
+----
+(alter_survive_db,region)
+(survive_zone_db,zone)
+(system,)
+
+statement ok
+ALTER DATABASE alter_survive_db SURVIVE ZONE FAILURE;
+
+query T
+SELECT get_db_survival_goal()
+----
+(alter_survive_db,zone)
+(survive_zone_db,zone)
+(system,)
+
+# Make system db multi-regional
+statement ok
+ALTER DATABASE system PRIMARY REGION "ca-central-1";
+ALTER DATABASE system ADD REGION "ap-southeast-2";
+ALTER DATABASE system ADD REGION "us-east-1";
+
+query T
+SELECT get_db_survival_goal()
+----
+(alter_survive_db,zone)
+(survive_zone_db,zone)
+(system,zone)
+
+# Make sure system db survival goal is upgraded.
+statement ok
+ALTER DATABASE alter_survive_db SURVIVE REGION FAILURE;
+
+query T
+SELECT get_db_survival_goal()
+----
+(alter_survive_db,region)
+(survive_zone_db,zone)
+(system,region)
+
+# Make sure system db survival goal is downgraded.
+statement ok
+ALTER DATABASE alter_survive_db SURVIVE ZONE FAILURE;
+
+query T
+SELECT get_db_survival_goal()
+----
+(alter_survive_db,zone)
+(survive_zone_db,zone)
+(system,zone)
+
+statement ok
+ALTER DATABASE system SURVIVE REGION FAILURE;
+
+query T
+SELECT get_db_survival_goal()
+----
+(alter_survive_db,zone)
+(survive_zone_db,zone)
+(system,region)
+
+statement ok
+ALTER DATABASE system SURVIVE ZONE FAILURE;
+
+query T
+SELECT get_db_survival_goal()
+----
+(alter_survive_db,zone)
+(survive_zone_db,zone)
+(system,zone)

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 14,
+    shard_count = 15,
     tags = ["cpu:4"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/generated_test.go
@@ -114,6 +114,13 @@ func TestCCLLogic_multi_region_show(
 	runCCLLogicTest(t, "multi_region_show")
 }
 
+func TestCCLLogic_multi_region_survial_goal(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "multi_region_survial_goal")
+}
+
 func TestCCLLogic_multi_region_zone_config_extensions(
 	t *testing.T,
 ) {

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -249,6 +249,19 @@ func TranslateSurvivalGoal(g tree.SurvivalGoal) (descpb.SurvivalGoal, error) {
 	}
 }
 
+// TranslateProtoSurvivalGoal translate a descpb.SurvivalGoal into a
+// tree.SurvivalGoal.
+func TranslateProtoSurvivalGoal(g descpb.SurvivalGoal) (tree.SurvivalGoal, error) {
+	switch g {
+	case descpb.SurvivalGoal_ZONE_FAILURE:
+		return tree.SurvivalGoalZoneFailure, nil
+	case descpb.SurvivalGoal_REGION_FAILURE:
+		return tree.SurvivalGoalRegionFailure, nil
+	default:
+		return 0, errors.Newf("unknown survival goal: %d", g)
+	}
+}
+
 // TranslateDataPlacement translates a tree.DataPlacement into a
 // descpb.DataPlacement.
 func TranslateDataPlacement(g tree.DataPlacement) (descpb.DataPlacement, error) {


### PR DESCRIPTION
Backport 1/1 commits from #102279.

/cc @cockroachdb/release

---

Fixes: #102134

Release note (enterprise change): This commit adds logic to set multi-region system database's survival goal to the max non-system databases' survival in the cluster whenever an ALTER DATABASE...SURVIVE...FAILURE is issued.

Release justification: necessary for multi-region serverless GA