### PR TITLE
sql/schemachanger: block alter operations on system columns

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -611,6 +611,12 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 					"column %q in the middle of being dropped", t.GetColumn())
 			}
+			// Block modification on system columns.
+			if col.IsSystemColumn() {
+				return pgerror.Newf(
+					pgcode.FeatureNotSupported,
+					"cannot alter system column %q", col.GetName())
+			}
 			columnName := col.GetName()
 			if columnName == catpb.TTLDefaultExpirationColumnName &&
 				tableDesc.HasRowLevelTTL() &&
@@ -1599,6 +1605,13 @@ func dropColumnImpl(
 	}
 	if colToDrop.Dropped() {
 		return nil, nil
+	}
+
+	// Block modification on system columns.
+	if colToDrop.IsSystemColumn() {
+		return nil, pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"cannot alter system column %q", colToDrop.GetName())
 	}
 
 	if colToDrop.IsInaccessible() {

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -215,3 +215,14 @@ CREATE INDEX idx ON tab3(x) STORING (crdb_internal_mvcc_timestamp)
 
 statement error pgcode 42703 column "crdb_internal_mvcc_timestamp" does not exist
 CREATE INDEX idx ON tab3(x, (crdb_internal_mvcc_timestamp + 10))
+
+subtest alter_commands
+
+statement error pq: cannot rename system column "crdb_internal_mvcc_timestamp"
+ALTER TABLE tab3 RENAME crdb_internal_mvcc_timestamp TO blah;
+
+statement error pq: cannot alter system column "crdb_internal_mvcc_timestamp"
+ALTER TABLE tab3 DROP COLUMN crdb_internal_mvcc_timestamp;
+
+statement error pq: cannot alter system column "crdb_internal_mvcc_timestamp"
+ALTER TABLE tab3 ALTER COLUMN crdb_internal_mvcc_timestamp SET NOT NULL;

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -105,7 +105,13 @@ func (p *planner) findColumnToRename(
 	if err != nil {
 		return nil, err
 	}
-
+	// Block renaming of system columns.
+	if col.IsSystemColumn() {
+		return nil, pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"cannot rename system column %q", col.ColName(),
+		)
+	}
 	for _, tableRef := range tableDesc.DependedOnBy {
 		found := false
 		for _, colID := range tableRef.ColumnIDs {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_not_null.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_not_null.go
@@ -26,6 +26,14 @@ func alterTableSetNotNull(
 	if isColNotNull(b, tbl.TableID, columnID) {
 		return
 	}
+	// Block alters on system columns.
+	scpb.ForEachColumn(b, func(current scpb.Status, target scpb.TargetStatus, e *scpb.Column) {
+		if e.TableID == tbl.TableID &&
+			e.ColumnID == columnID {
+			// Block drops on system columns.
+			panicIfSystemColumn(e, t.Column.String())
+		}
+	})
 	b.Add(&scpb.ColumnNotNull{
 		TableID:  tbl.TableID,
 		ColumnID: columnID,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -160,6 +160,8 @@ func resolveColumnForDropColumn(
 		}
 		return nil, nil, true
 	}
+	// Block drops on system columns.
+	panicIfSystemColumn(col, n.Column.String())
 	return col, elts, false
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -918,3 +918,13 @@ func panicIfSchemaIsLocked(tableElements ElementResultSet) {
 		panic(sqlerrors.NewSchemaChangeOnLockedTableErr(ns.Name))
 	}
 }
+
+// panicIfSystemColumn blocks alter operations on system columns.
+func panicIfSystemColumn(column *scpb.Column, columnName string) {
+	if column.IsSystemColumn {
+		// Block alter operations on system columns.
+		panic(pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"cannot alter system column %q", columnName))
+	}
+}


### PR DESCRIPTION
Previously, it was possible to modify system columns with alter commands, which could lead to all sorts of bad behaviour, since these columns descriptors are shared node wide. This patch blocks alters on system columns in both the declarative schema and legacy schema changer.

fixes: #102314
fixes: #101599

Release note (bug fix): RENAME COLUMN was incorrctly allowed and would modify these columns node wide.