### PR TITLE
kvserver: check PROSCRIBED lease status over UNUSABLE

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -303,6 +303,7 @@ go_test(
         "replica_raft_overload_test.go",
         "replica_raft_test.go",
         "replica_raft_truncation_test.go",
+        "replica_range_lease_test.go",
         "replica_rangefeed_test.go",
         "replica_rankings_test.go",
         "replica_sideload_test.go",

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -1589,3 +1589,9 @@ func (nl *NodeLiveness) TestingSetDecommissioningInternal(
 ) (changeCommitted bool, err error) {
 	return nl.setMembershipStatusInternal(ctx, oldLivenessRec, targetStatus)
 }
+
+// TestingMaybeUpdate replaces the liveness (if it appears newer) and invokes
+// the registered callbacks if the node became live in the process. For testing.
+func (nl *NodeLiveness) TestingMaybeUpdate(ctx context.Context, newRec Record) {
+	nl.maybeUpdate(ctx, newRec)
+}

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -615,21 +615,21 @@ func (p *pendingLeaseRequest) newResolvedHandle(pErr *kvpb.Error) *leaseRequestH
 // EXPIRED status is that it reflects that a new lease with a start timestamp
 // greater than or equal to now can be acquired non-cooperatively.
 //
-// If the lease is not EXPIRED, the request timestamp is taken into account. The
-// expiration timestamp is adjusted for clock offset; if the request timestamp
-// falls into the so-called "stasis period" at the end of the lifetime of the
-// lease, or if the request timestamp is beyond the end of the lifetime of the
-// lease, the status is UNUSABLE. Callers typically want to react to an UNUSABLE
-// lease status by extending the lease, if they are in a position to do so.
+// If the lease is not EXPIRED, the lease's start timestamp is checked against
+// the minProposedTimestamp. This timestamp indicates the oldest timestamp that
+// a lease can have as its start time and still be used by the node. It is set
+// both in cooperative lease transfers and to prevent reuse of leases across
+// node restarts (which would result in latching violations). Leases with start
+// times preceding this timestamp are assigned a status of PROSCRIBED and can
+// not be used. Instead, a new lease should be acquired by callers.
 //
-// For request timestamps falling before the lease's stasis period, the lease's
-// start timestamp is checked against the minProposedTimestamp. This timestamp
-// indicates the oldest timestamp that a lease can have as its start time and
-// still be used by the node. It is set both in cooperative lease transfers and
-// to prevent reuse of leases across node restarts (which would result in
-// latching violations). Leases with start times preceding this timestamp are
-// assigned a status of PROSCRIBED and can not be not be used. Instead, a new
-// lease should be acquired by callers.
+// If the lease is not EXPIRED or PROSCRIBED, the request timestamp is taken
+// into account. The expiration timestamp is adjusted for clock offset; if the
+// request timestamp falls into the so-called "stasis period" at the end of the
+// lifetime of the lease, or if the request timestamp is beyond the end of the
+// lifetime of the lease, the status is UNUSABLE. Callers typically want to
+// react to an UNUSABLE lease status by extending the lease, if they are in a
+// position to do so.
 //
 // Finally, for requests timestamps falling before the stasis period of a lease
 // that is not EXPIRED and also not PROSCRIBED, the status is VALID.
@@ -713,14 +713,19 @@ func (r *Replica) leaseStatus(
 	maxOffset := r.store.Clock().MaxOffset()
 	stasis := expiration.Add(-int64(maxOffset), 0)
 	ownedLocally := lease.OwnedBy(r.store.StoreID())
+	// NB: the order of these checks is important, and goes from stronger to
+	// weaker reasons why the lease may be considered invalid. For example,
+	// EXPIRED or PROSCRIBED must take precedence over UNUSABLE, because some
+	// callers consider UNUSABLE as valid. For an example issue that this ordering
+	// may cause, see https://github.com/cockroachdb/cockroach/issues/100101.
 	if expiration.LessEq(now.ToTimestamp()) {
 		status.State = kvserverpb.LeaseState_EXPIRED
-	} else if stasis.LessEq(reqTS) {
-		status.State = kvserverpb.LeaseState_UNUSABLE
 	} else if ownedLocally && lease.ProposedTS != nil && lease.ProposedTS.Less(minProposedTS) {
 		// If the replica owns the lease, additional verify that the lease's
 		// proposed timestamp is not earlier than the min proposed timestamp.
 		status.State = kvserverpb.LeaseState_PROSCRIBED
+	} else if stasis.LessEq(reqTS) {
+		status.State = kvserverpb.LeaseState_UNUSABLE
 	} else {
 		status.State = kvserverpb.LeaseState_VALID
 	}

--- a/pkg/kv/kvserver/replica_range_lease_test.go
+++ b/pkg/kv/kvserver/replica_range_lease_test.go
@@ -1,0 +1,150 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReplicaLeaseStatus tests that Replica.leaseStatus returns a valid lease
+// status, both for expiration- and epoch-based leases.
+func TestReplicaLeaseStatus(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	const maxOffset = 100 * time.Nanosecond
+	clock := hlc.NewClock(hlc.NewHybridManualClock(), maxOffset, maxOffset)
+
+	r1 := roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 1, ReplicaID: 1}
+	ts := []hlc.ClockTimestamp{
+		{WallTime: 500, Logical: 0},  // before lease start
+		{WallTime: 1000, Logical: 0}, // lease start
+		{WallTime: 2000, Logical: 0}, // within lease
+		{WallTime: 2950, Logical: 0}, // within stasis
+		{WallTime: 3000, Logical: 0}, // lease expiration
+		{WallTime: 3500, Logical: 0}, // expired
+		{WallTime: 5000, Logical: 0}, // next expiration
+	}
+	inStasis := ts[3].ToTimestamp()
+	expLease := roachpb.Lease{
+		Replica:    r1,
+		Start:      ts[1],
+		Expiration: ts[4].ToTimestamp().Clone(),
+		ProposedTS: &hlc.ClockTimestamp{WallTime: ts[1].WallTime - 100},
+	}
+	epoLease := roachpb.Lease{
+		Replica:    expLease.Replica,
+		Start:      expLease.Start,
+		Epoch:      5,
+		ProposedTS: expLease.ProposedTS,
+	}
+
+	oldLiveness := livenesspb.Liveness{
+		NodeID: 1, Epoch: 4, Expiration: hlc.LegacyTimestamp{WallTime: ts[1].WallTime},
+	}
+	curLiveness := livenesspb.Liveness{
+		NodeID: 1, Epoch: 5, Expiration: hlc.LegacyTimestamp{WallTime: ts[4].WallTime},
+	}
+	expLiveness := livenesspb.Liveness{
+		NodeID: 1, Epoch: 6, Expiration: hlc.LegacyTimestamp{WallTime: ts[6].WallTime},
+	}
+
+	for _, tc := range []struct {
+		lease         roachpb.Lease
+		now           hlc.ClockTimestamp
+		minProposedTS hlc.ClockTimestamp
+		reqTS         hlc.Timestamp
+		liveness      livenesspb.Liveness
+		want          kvserverpb.LeaseState
+		wantErr       string
+	}{
+		// Expiration-based lease, EXPIRED.
+		{lease: expLease, now: ts[5], want: kvserverpb.LeaseState_EXPIRED},
+		{lease: expLease, now: ts[4], want: kvserverpb.LeaseState_EXPIRED},
+		// Expiration-based lease, PROSCRIBED.
+		{lease: expLease, now: ts[3], minProposedTS: ts[1], want: kvserverpb.LeaseState_PROSCRIBED},
+		{lease: expLease, now: ts[3], minProposedTS: ts[2], want: kvserverpb.LeaseState_PROSCRIBED},
+		{lease: expLease, now: ts[3], minProposedTS: ts[3], reqTS: inStasis,
+			want: kvserverpb.LeaseState_PROSCRIBED},
+		{lease: expLease, now: ts[3], minProposedTS: ts[4], reqTS: inStasis,
+			want: kvserverpb.LeaseState_PROSCRIBED},
+		// Expiration-based lease, UNUSABLE.
+		{lease: expLease, now: ts[3], reqTS: inStasis, want: kvserverpb.LeaseState_UNUSABLE},
+		// Expiration-based lease, VALID.
+		{lease: expLease, now: ts[2], reqTS: ts[2].ToTimestamp(), want: kvserverpb.LeaseState_VALID},
+
+		// Epoch-based lease, EXPIRED.
+		{lease: epoLease, now: ts[5], liveness: curLiveness, want: kvserverpb.LeaseState_EXPIRED},
+		{lease: epoLease, now: ts[4], liveness: curLiveness, want: kvserverpb.LeaseState_EXPIRED},
+		{lease: epoLease, now: ts[2], liveness: expLiveness, want: kvserverpb.LeaseState_EXPIRED},
+		// Epoch-based lease, PROSCRIBED.
+		{lease: epoLease, now: ts[3], liveness: curLiveness, minProposedTS: ts[1],
+			want: kvserverpb.LeaseState_PROSCRIBED},
+		{lease: epoLease, now: ts[2], liveness: curLiveness, minProposedTS: ts[2],
+			want: kvserverpb.LeaseState_PROSCRIBED},
+		// Epoch-based lease, UNUSABLE.
+		{lease: epoLease, now: ts[3], liveness: curLiveness, reqTS: ts[3].ToTimestamp(),
+			want: kvserverpb.LeaseState_UNUSABLE},
+		// Epoch-based lease, VALID.
+		{lease: epoLease, now: ts[2], liveness: curLiveness, want: kvserverpb.LeaseState_VALID},
+
+		// Epoch-based lease, ERROR.
+		{lease: epoLease, now: ts[2], want: kvserverpb.LeaseState_ERROR,
+			wantErr: "liveness record not found"},
+		{lease: epoLease, now: ts[2], liveness: oldLiveness, want: kvserverpb.LeaseState_ERROR,
+			wantErr: "node liveness info for n1 is stale"},
+	} {
+		t.Run("", func(t *testing.T) {
+			l := liveness.NewNodeLiveness(liveness.NodeLivenessOptions{
+				Clock: clock,
+				Gossip: gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry(),
+					zonepb.DefaultZoneConfigRef()),
+			})
+			r := Replica{store: &Store{
+				Ident: &roachpb.StoreIdent{StoreID: 1, NodeID: 1},
+				cfg:   StoreConfig{Clock: clock, NodeLiveness: l},
+			}}
+			var empty livenesspb.Liveness
+			if maybeLiveness := tc.liveness; maybeLiveness != empty {
+				l.TestingMaybeUpdate(ctx, liveness.Record{Liveness: maybeLiveness})
+			}
+
+			got := r.leaseStatus(ctx, tc.lease, tc.now, tc.minProposedTS, hlc.ClockTimestamp{}, tc.reqTS)
+			if tc.wantErr != "" {
+				require.Contains(t, got.ErrInfo, tc.wantErr)
+				got.ErrInfo = ""
+			}
+			assert.Equal(t, kvserverpb.LeaseStatus{
+				Lease: tc.lease, Now: tc.now, RequestTime: tc.reqTS, State: tc.want, Liveness: tc.liveness,
+			}, got)
+		})
+	}
+}


### PR DESCRIPTION
The PROSCRIBED lease status, just like EXPIRED, puts a lease to a definitely invalid state. The UNUSABLE state (when request timestamp is in stasis period) is less of a clear cut: we still own the lease but callers may use or not use it depending on context.

For example, the closed timestamp side-transport ignores the UNUSABLE state (because we still own the lease), and takes it as usable for its purposes. Because of the order in which the checks were made, this has lead to a bug: a PROSCRIBED lease is reported as UNUSABLE during stasis periods, the closed timestamp side-transport then considers it usable, and updates closed timestamps when it shouldn't.

This commit fixes the bug by swapping the order of checks in the leaseStatus method. The order now goes from "hard" checks like EXPIRED and PROSCRIBED, to "softer" UNUSABLE, and (when the softness is put to the limit) VALID.

Fixes #98698
Fixes #99931
Fixes #100101
Epic: none

Release note (bug fix): a bug is fixed in closed timestamp updates within its side-transport. Previously, during asymmetric partitions, a node that transfers a lease away, and misses a liveness heartbeat, could then erroneously update the closed timestamp during the stasis period of its liveness. This could lead to closed timestamp invariant violation, and node crashes; in extreme cases this could lead to inconsistencies in read-only queries.