### PR TITLE
cli: test loq recovery flakiness on span configs

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -257,7 +257,8 @@ func TestLossOfQuorumRecovery(t *testing.T) {
 	// attempt. That would increase number of replicas on system ranges to 5 and we
 	// would not be able to upreplicate properly. So we need to decommission old nodes
 	// first before proceeding.
-	grpcConn, err := tcAfter.Server(0).RPCContext().GRPCDialNode(tcAfter.Server(0).ServingRPCAddr(), tcAfter.Server(0).NodeID(), rpc.DefaultClass).Connect(ctx)
+	grpcConn, err := tcAfter.Server(0).RPCContext().GRPCDialNode(
+		tcAfter.Server(0).ServingRPCAddr(), tcAfter.Server(0).NodeID(), rpc.DefaultClass).Connect(ctx)
 	require.NoError(t, err, "Failed to create test cluster after recovery")
 	adminClient := serverpb.NewAdminClient(grpcConn)
 
@@ -272,6 +273,8 @@ func TestLossOfQuorumRecovery(t *testing.T) {
 			return nil
 		}), "Failed to activate replication queue")
 	}
+	require.NoError(t, tcAfter.WaitForZoneConfigPropagation(),
+		"Failed to ensure zone configs are propagated")
 	require.NoError(t, tcAfter.WaitForFullReplication(), "Failed to perform full replication")
 
 	for i := 0; i < len(tcAfter.Servers); i++ {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1446,19 +1446,30 @@ func (tc *TestCluster) WaitFor5NodeReplication() error {
 		// conformance since zone configs are propagated synchronously.
 		// Generous timeout is added to allow rangefeeds to catch up. On startup
 		// they could get delayed making test to fail.
-		now := tc.Server(0).Clock().Now()
-		for _, s := range tc.Servers {
-			scs := s.SpanConfigKVSubscriber().(spanconfig.KVSubscriber)
-			if err := testutils.SucceedsSoonError(func() error {
-				if scs.LastUpdated().Less(now) {
-					return errors.New("zone configs not propagated")
-				}
-				return nil
-			}); err != nil {
-				return err
-			}
+		err := tc.WaitForZoneConfigPropagation()
+		if err != nil {
+			return err
 		}
 		return tc.WaitForFullReplication()
+	}
+	return nil
+}
+
+// WaitForZoneConfigPropagation ensures that all span config subscribers caught
+// up till now. That would guarantee that zone configs set prior to this call
+// are applied.
+func (tc *TestCluster) WaitForZoneConfigPropagation() error {
+	now := tc.Server(0).Clock().Now()
+	for _, s := range tc.Servers {
+		scs := s.SpanConfigKVSubscriber().(spanconfig.KVSubscriber)
+		if err := testutils.SucceedsSoonError(func() error {
+			if scs.LastUpdated().Less(now) {
+				return errors.New("zone configs not propagated")
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Previously test could fail to enqueue range into consistency because span configs didn't propagate yet. This commit adds explicit wait for config propagation.

Fixes: #100352
Fixes: #102305

Release note: None