### PR TITLE
backupccl: don't restore sql_instances, sqlliveness or lease rows

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -298,7 +298,7 @@ func ingestWithRetries(
 		if jobs.IsPermanentJobError(err) || errors.Is(err, context.Canceled) {
 			break
 		}
-		const msgFmt = "stream ingestion waits for retrying after error %s"
+		const msgFmt = "stream ingestion waits for retrying after error: %q"
 		log.Warningf(ctx, msgFmt, err)
 		updateRunningStatus(ctx, execCtx, ingestionJob, jobspb.ReplicationError,
 			fmt.Sprintf(msgFmt, err))

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -654,15 +654,8 @@ func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, err
 	return nil, nil
 }
 
-func (sip *streamIngestionProcessor) rekey(key roachpb.Key) ([]byte, error) {
-	rekey, ok, err := sip.rekeyer.RewriteKey(key, 0 /*wallTime*/)
-	if !ok {
-		return nil, errors.New("every key is expected to match tenant prefix")
-	}
-	if err != nil {
-		return nil, err
-	}
-	return rekey, nil
+func (sip *streamIngestionProcessor) rekey(key roachpb.Key) ([]byte, bool, error) {
+	return sip.rekeyer.RewriteKey(key, 0 /*wallTime*/)
 }
 
 func (sip *streamIngestionProcessor) bufferSST(sst *kvpb.RangeFeedSSTable) error {
@@ -714,13 +707,20 @@ func (sip *streamIngestionProcessor) bufferRangeKeyVal(
 	defer sp.Finish()
 
 	var err error
-	rangeKeyVal.RangeKey.StartKey, err = sip.rekey(rangeKeyVal.RangeKey.StartKey)
+	var ok bool
+	rangeKeyVal.RangeKey.StartKey, ok, err = sip.rekey(rangeKeyVal.RangeKey.StartKey)
 	if err != nil {
 		return err
 	}
-	rangeKeyVal.RangeKey.EndKey, err = sip.rekey(rangeKeyVal.RangeKey.EndKey)
+	if !ok {
+		return nil
+	}
+	rangeKeyVal.RangeKey.EndKey, ok, err = sip.rekey(rangeKeyVal.RangeKey.EndKey)
 	if err != nil {
 		return err
+	}
+	if !ok {
+		return nil
 	}
 	sip.rangeBatcher.buffer(rangeKeyVal)
 	return nil
@@ -749,9 +749,13 @@ func (sip *streamIngestionProcessor) bufferKV(kv *roachpb.KeyValue) error {
 	}
 
 	var err error
-	kv.Key, err = sip.rekey(kv.Key)
+	var ok bool
+	kv.Key, ok, err = sip.rekey(kv.Key)
 	if err != nil {
 		return err
+	}
+	if !ok {
+		return nil
 	}
 
 	if sip.rewriteToDiffKey {


### PR DESCRIPTION
Restoring these rows from the old cluster can cause the restored cluster to experience error when trying to plan and run queries that run on 'all' nodes due to the old rows in these tables that track the set of nodes still appearing to be valid until they expire.

Release note: none.
Epic: none.