### PR TITLE
githubpost: add team label to issues

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -43,6 +43,7 @@ cockroachdb/kv:
     cockroachdb/kv-triage: roachtest
     cockroachdb/kv-prs: other
   triage_column_id: 14242655
+  label: T-kv
 cockroachdb/replication:
   aliases:
     cockroachdb/repl-prs: other

--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -68,10 +68,14 @@ func defaultFormatter(ctx context.Context, f failure) (issues.IssueFormatter, is
 
 	var projColID int
 	var mentions []string
+	var extraLabels []string
 	if len(teams) > 0 {
 		projColID = teams[0].TriageColumnID
 		for _, team := range teams {
 			mentions = append(mentions, "@"+string(team.Name()))
+			if team.Label != "" {
+				extraLabels = append(extraLabels, team.Label)
+			}
 		}
 	}
 	return issues.UnitTestFormatter, issues.PostRequest{
@@ -82,6 +86,7 @@ func defaultFormatter(ctx context.Context, f failure) (issues.IssueFormatter, is
 		HelpCommand:     issues.UnitTestHelpCommand(repro),
 		MentionOnCreate: mentions,
 		ProjectColumnID: projColID,
+		ExtraLabels:     extraLabels,
 	}
 }
 

--- a/pkg/cmd/bazci/githubpost/githubpost_test.go
+++ b/pkg/cmd/bazci/githubpost/githubpost_test.go
@@ -23,12 +23,13 @@ import (
 )
 
 type issue struct {
-	testName   string
-	title      string
-	message    string
-	expRepro   string
-	mention    []string
-	hasProject bool
+	testName    string
+	title       string
+	message     string
+	expRepro    string
+	mention     []string
+	extraLabels []string
+	hasProject  bool
 }
 
 func init() {
@@ -99,11 +100,12 @@ func TestListFailuresFromJSON(t *testing.T) {
 			fileName: "implicit-pkg.json",
 			expPkg:   "github.com/cockroachdb/cockroach/pkg/util/stop",
 			expIssues: []issue{{
-				testName:   "TestStopperWithCancelConcurrent",
-				title:      "util/stop: TestStopperWithCancelConcurrent failed",
-				message:    "this is just a testing issue",
-				mention:    []string{"@cockroachdb/kv"},
-				hasProject: true,
+				testName:    "TestStopperWithCancelConcurrent",
+				title:       "util/stop: TestStopperWithCancelConcurrent failed",
+				message:     "this is just a testing issue",
+				mention:     []string{"@cockroachdb/kv"},
+				extraLabels: []string{"T-kv"},
+				hasProject:  true,
 			}},
 			formatter: defaultFormatter,
 		},
@@ -112,11 +114,12 @@ func TestListFailuresFromJSON(t *testing.T) {
 			fileName: "stress-failure.json",
 			expPkg:   "github.com/cockroachdb/cockroach/pkg/kv/kvserver",
 			expIssues: []issue{{
-				testName:   "TestReplicateQueueRebalance",
-				title:      "kv/kvserver: TestReplicateQueueRebalance failed",
-				message:    "replicate_queue_test.go:88: condition failed to evaluate within 45s: not balanced: [10 1 10 1 8]",
-				mention:    []string{"@cockroachdb/kv"},
-				hasProject: true,
+				testName:    "TestReplicateQueueRebalance",
+				title:       "kv/kvserver: TestReplicateQueueRebalance failed",
+				message:     "replicate_queue_test.go:88: condition failed to evaluate within 45s: not balanced: [10 1 10 1 8]",
+				mention:     []string{"@cockroachdb/kv"},
+				extraLabels: []string{"T-kv"},
+				hasProject:  true,
 			}},
 			formatter: defaultFormatter,
 		},
@@ -125,11 +128,12 @@ func TestListFailuresFromJSON(t *testing.T) {
 			fileName: "stress-fatal.json",
 			expPkg:   "github.com/cockroachdb/cockroach/pkg/kv/kvserver",
 			expIssues: []issue{{
-				testName:   "TestGossipHandlesReplacedNode",
-				title:      "kv/kvserver: TestGossipHandlesReplacedNode failed",
-				message:    "F180711 20:13:15.826193 83 storage/replica.go:1877  [n?,s1,r1/1:/M{in-ax}] on-disk and in-memory state diverged:",
-				mention:    []string{"@cockroachdb/kv"},
-				hasProject: true,
+				testName:    "TestGossipHandlesReplacedNode",
+				title:       "kv/kvserver: TestGossipHandlesReplacedNode failed",
+				message:     "F180711 20:13:15.826193 83 storage/replica.go:1877  [n?,s1,r1/1:/M{in-ax}] on-disk and in-memory state diverged:",
+				mention:     []string{"@cockroachdb/kv"},
+				extraLabels: []string{"T-kv"},
+				hasProject:  true,
 			}},
 			formatter: defaultFormatter,
 		},
@@ -169,11 +173,12 @@ func TestListFailuresFromJSON(t *testing.T) {
 			expPkg:   "github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord",
 			expIssues: []issue{
 				{
-					testName:   "TestTxnCoordSenderPipelining",
-					title:      "kv/kvclient/kvcoord: TestTxnCoordSenderPipelining failed",
-					message:    `injected failure`,
-					mention:    []string{"@cockroachdb/kv"},
-					hasProject: true,
+					testName:    "TestTxnCoordSenderPipelining",
+					title:       "kv/kvclient/kvcoord: TestTxnCoordSenderPipelining failed",
+					message:     `injected failure`,
+					mention:     []string{"@cockroachdb/kv"},
+					extraLabels: []string{"T-kv"},
+					hasProject:  true,
 				},
 				{
 					testName: "TestAbortReadOnlyTransaction",
@@ -185,8 +190,9 @@ TestTxnCoordSenderPipelining - 1.00s
 Slow passing tests:
 TestAnchorKey - 1.01s
 `,
-					mention:    []string{"@cockroachdb/kv"},
-					hasProject: true,
+					mention:     []string{"@cockroachdb/kv"},
+					extraLabels: []string{"T-kv"},
+					hasProject:  true,
 				},
 			},
 			formatter: defaultFormatter,
@@ -299,10 +305,11 @@ TestXXA - 1.00s
 			expPkg:   "internal/metamorphic",
 			expIssues: []issue{
 				{
-					testName: "TestMeta",
-					title:    "internal/metamorphic: TestMeta failed",
-					message:  "panic: induced panic",
-					expRepro: `go test -tags 'invariants' -exec 'stress -p 1' -timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed 1600209371838097000 -ops "uniform:5000-10000"`,
+					testName:    "TestMeta",
+					title:       "internal/metamorphic: TestMeta failed",
+					message:     "panic: induced panic",
+					expRepro:    `go test -tags 'invariants' -exec 'stress -p 1' -timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed 1600209371838097000 -ops "uniform:5000-10000"`,
+					extraLabels: []string{"metamorphic-failure"},
 				},
 			},
 			formatter: formatPebbleMetamorphicIssue,
@@ -360,6 +367,7 @@ TestXXA - 1.00s
 				}
 				assert.Equal(t, c.expIssues[curIssue].mention, req.MentionOnCreate)
 				assert.Equal(t, c.expIssues[curIssue].hasProject, req.ProjectColumnID != 0)
+				assert.Equal(t, c.expIssues[curIssue].extraLabels, req.ExtraLabels)
 				// On next invocation, we'll check the next expected issue.
 				curIssue++
 				return nil


### PR DESCRIPTION
**TEAMS: add `T-kv` label for KV**

Epic: none
Release note: None

**githubpost: add team label to issues**

This patch automatically adds team labels to created issues. Previously, this was done by Blathers based on the project board, but not all teams use project boards -- and we may as well just set the correct label to begin with.

Epic: none
Release note: None