### PR TITLE
kv: add metric for server-side transaction refreshes

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -2060,9 +2060,10 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 		priorReads                 bool
 		tsLeaked                   bool
 		// Testing expectations.
-		expClientRefresh               bool   // pre-emptive or reactive client refresh
-		expClientAutoRetryAfterRefresh bool   // auto-retries of batches after client refresh
-		expClientRestart               bool   // client side restarts
+		expClientRefresh               bool   // pre-emptive or reactive client-side refresh
+		expClientAutoRetryAfterRefresh bool   // auto-retries of batches after client-side refresh
+		expClientRestart               bool   // client-side txn restart
+		expServerRefresh               bool   // server-side refresh
 		expOnePhaseCommit              bool   // 1PC commits
 		expFailure                     string // regexp pattern to match on error, if not empty
 	}{
@@ -2173,6 +2174,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return txn.CommitInBatch(ctx, b)
 			},
 			// No retries, server-side refresh, 1pc commit.
+			expServerRefresh:  true,
 			expOnePhaseCommit: true,
 		},
 		{
@@ -2190,6 +2192,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return txn.CommitInBatch(ctx, b)
 			},
 			// No retries, server-side refresh, 1pc commit.
+			expServerRefresh:  true,
 			expOnePhaseCommit: true,
 		},
 		{
@@ -2326,6 +2329,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			filter: newUncertaintyFilter(roachpb.Key("a")),
 			// We expect the request to succeed after a server-side retry.
 			expClientAutoRetryAfterRefresh: false,
+			expServerRefresh:               true,
 		},
 		{
 			// Even if accounting for the refresh spans would have exhausted the
@@ -2410,6 +2414,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *kv.Txn) error {
 				return txn.Put(ctx, "a", "put")
 			},
+			expServerRefresh: true,
 		},
 		{
 			name: "write too old with put after prior read",
@@ -2500,8 +2505,8 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *kv.Txn) error {
 				return txn.CPut(ctx, "a", "cput", kvclientutils.StrToCPutExistingValue("value"))
 			},
-			expClientAutoRetryAfterRefresh: false,              // non-matching value means we fail txn coord retry
-			expFailure:                     "unexpected value", // the failure we get is a condition failed error
+			expServerRefresh: true,               // non-matching value means we perform server-side refresh but then fail
+			expFailure:       "unexpected value", // the failure we get is a condition failed error
 		},
 		{
 			name: "write too old with cput matching older and newer values",
@@ -2514,6 +2519,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *kv.Txn) error {
 				return txn.CPut(ctx, "a", "cput", kvclientutils.StrToCPutExistingValue("value"))
 			},
+			expServerRefresh: true,
 		},
 		{
 			name: "write too old with cput matching older and newer values after prior read",
@@ -2550,6 +2556,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				}
 				return nil
 			},
+			expServerRefresh: true,
 		},
 		{
 			name: "write too old with increment after prior read",
@@ -2583,6 +2590,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *kv.Txn) error {
 				return txn.InitPut(ctx, "iput", "put", false)
 			},
+			expServerRefresh: true,
 		},
 		{
 			name: "write too old with initput after prior read",
@@ -2608,6 +2616,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *kv.Txn) error {
 				return txn.InitPut(ctx, "iput", "put", false)
 			},
+			expServerRefresh: true,
 		},
 		{
 			name: "write too old with initput matching older and newer values after prior read",
@@ -2636,8 +2645,8 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *kv.Txn) error {
 				return txn.InitPut(ctx, "iput", "put1", false)
 			},
-			expClientAutoRetryAfterRefresh: false,              // non-matching value means we fail txn coord retry
-			expFailure:                     "unexpected value", // the failure we get is a condition failed error
+			expServerRefresh: true,               // non-matching value means we perform server-side refresh but then fail
+			expFailure:       "unexpected value", // the failure we get is a condition failed error
 		},
 		{
 			name: "write too old with initput matching newer value",
@@ -2679,8 +2688,8 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *kv.Txn) error {
 				return txn.InitPut(ctx, "iput", "put", true)
 			},
-			expClientAutoRetryAfterRefresh: false,              // non-matching value means we fail txn coord retry
-			expFailure:                     "unexpected value", // condition failed error when failing on tombstones
+			expServerRefresh: true,               // non-matching value means we perform server-side refresh but then fail
+			expFailure:       "unexpected value", // condition failed error when failing on tombstones
 		},
 		{
 			name: "write too old with locking read",
@@ -2691,6 +2700,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				_, err := txn.ScanForUpdate(ctx, "a", "a\x00", 0)
 				return err
 			},
+			expServerRefresh:  true,
 			expOnePhaseCommit: true,
 		},
 		{
@@ -2799,6 +2809,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return txn.CommitInBatch(ctx, b) // will be a 1PC, won't get auto retry
 			},
 			// No retries, server-side refresh, 1pc commit.
+			expServerRefresh:  true,
 			expOnePhaseCommit: true,
 		},
 		{
@@ -2825,6 +2836,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// The request will succeed after a server-side refresh.
 			expClientAutoRetryAfterRefresh: false,
+			expServerRefresh:               true,
 		},
 		{
 			name: "write too old with cput in batch commit",
@@ -2844,6 +2856,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// WriteTooOldError, and then once at the pushed timestamp. The
 			// server-side retry is enabled by the fact that there have not been any
 			// previous reads and so the transaction can commit at a pushed timestamp.
+			expServerRefresh:  true,
 			expOnePhaseCommit: true,
 		},
 		{
@@ -2861,10 +2874,31 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b.CPut("a", "cput", kvclientutils.StrToCPutExistingValue("orig"))
 				return txn.CommitInBatch(ctx, b) // will be a 1PC, won't get auto retry
 			},
-			expFailure: "unexpected value", // The CPut cannot succeed.
+			expServerRefresh: true,               // non-matching value means we perform server-side refresh but then fail
+			expFailure:       "unexpected value", // The CPut cannot succeed.
 		},
 		{
-			name: "multi-range batch with forwarded timestamp",
+			name: "multi-range batch commit with forwarded timestamp (err on first range)",
+			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
+				_, err := db.Get(ctx, "a") // set ts cache
+				return err
+			},
+			retryable: func(ctx context.Context, txn *kv.Txn) error {
+				b := txn.NewBatch()
+				b.Put("a", "put")
+				b.Put("c", "put")
+				return txn.CommitInBatch(ctx, b)
+			},
+			// The Put to "a" and the EndTxn will succeed after a server-side refresh.
+			// This will instruct the txn to stage at the post-refresh timestamp,
+			// qualifying for the implicit commit condition and avoiding a client-side
+			// refresh.
+			expServerRefresh:               true,
+			expClientRefresh:               false,
+			expClientAutoRetryAfterRefresh: false,
+		},
+		{
+			name: "multi-range batch commit with forwarded timestamp (err on second range)",
 			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
 				_, err := db.Get(ctx, "c") // set ts cache
 				return err
@@ -2875,11 +2909,15 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b.Put("c", "put")
 				return txn.CommitInBatch(ctx, b)
 			},
+			// The Put to "c" will succeed with a forwarded timestamp. However, the
+			// txn has already staged on the other range at an earlier timestamp. As a
+			// result, it does not qualify for the implicit commit condition and
+			// requires a client-side refresh.
 			expClientRefresh:               true,
 			expClientAutoRetryAfterRefresh: true,
 		},
 		{
-			name: "multi-range batch with forwarded timestamp and cput",
+			name: "multi-range batch commit with forwarded timestamp and cput",
 			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "a", "value")
 			},
@@ -2893,9 +2931,10 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b.Put("c", "put")
 				return txn.CommitInBatch(ctx, b) // both puts will succeed, no retry
 			},
+			expServerRefresh: true,
 		},
 		{
-			name: "multi-range batch with forwarded timestamp and cput and get",
+			name: "multi-range batch commit with forwarded timestamp and cput and get",
 			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "a", "value")
 			},
@@ -2916,7 +2955,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			expClientAutoRetryAfterRefresh: true,
 		},
 		{
-			name: "multi-range batch with forwarded timestamp and cput and delete range",
+			name: "multi-range batch commit with forwarded timestamp and cput and delete range",
 			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "c", "value")
 			},
@@ -2934,7 +2973,26 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			expClientAutoRetryAfterRefresh: true,
 		},
 		{
-			name: "multi-range batch with write too old",
+			name: "multi-range batch commit with write too old (err on first range)",
+			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
+				return db.Put(ctx, "a", "value")
+			},
+			retryable: func(ctx context.Context, txn *kv.Txn) error {
+				b := txn.NewBatch()
+				b.Put("a", "put")
+				b.Put("c", "put")
+				return txn.CommitInBatch(ctx, b)
+			},
+			// The Put to "a" and EndTxn will succeed after a server-side refresh.
+			// This will instruct the txn to stage at the post-refresh timestamp,
+			// qualifying for the implicit commit condition and avoiding a client-side
+			// refresh.
+			expServerRefresh:               true,
+			expClientRefresh:               false,
+			expClientAutoRetryAfterRefresh: false,
+		},
+		{
+			name: "multi-range batch commit with write too old (err on second range)",
 			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "c", "value")
 			},
@@ -2942,13 +3000,18 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b := txn.NewBatch()
 				b.Put("a", "put")
 				b.Put("c", "put")
-				return txn.CommitInBatch(ctx, b) // put to c will return WriteTooOldError
+				return txn.CommitInBatch(ctx, b)
 			},
+			// The Put to "c" will succeed after a server-side refresh. However, the
+			// txn has already staged on the other range at the pre-refresh timestamp.
+			// As a result, it does not qualify for the implicit commit condition and
+			// requires a client-side refresh.
+			expServerRefresh:               true,
 			expClientRefresh:               true,
 			expClientAutoRetryAfterRefresh: true,
 		},
 		{
-			name: "multi-range batch with write too old and failed cput",
+			name: "multi-range batch commit with write too old and failed cput",
 			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "a", "orig")
 			},
@@ -2961,11 +3024,11 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b.Put("c", "put")
 				return txn.CommitInBatch(ctx, b)
 			},
-			expClientAutoRetryAfterRefresh: false,              // non-matching value means we fail txn coord retry
-			expFailure:                     "unexpected value", // the failure we get is a condition failed error
+			expServerRefresh: true,               // non-matching value means we perform server-side refresh but then fail
+			expFailure:       "unexpected value", // the failure we get is a condition failed error
 		},
 		{
-			name: "multi-range batch with write too old and successful cput",
+			name: "multi-range batch commit with write too old and successful cput",
 			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "a", "orig")
 			},
@@ -2980,6 +3043,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// We expect the request to succeed after a server-side retry.
 			expClientAutoRetryAfterRefresh: false,
+			expServerRefresh:               true,
 		},
 		{
 			// This test checks the behavior of batches that were split by the
@@ -3031,6 +3095,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			filter: newUncertaintyFilter(roachpb.Key("a")),
 			// We expect the request to succeed after a server-side retry.
 			expClientAutoRetryAfterRefresh: false,
+			expServerRefresh:               true,
 		},
 		{
 			name: "cput within uncertainty interval after timestamp leaked",
@@ -3089,7 +3154,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			expClientRestart: true, // note this txn is read-only but still restarts
 		},
 		{
-			name: "multi-range batch with uncertainty interval error",
+			name: "multi-range batch commit with uncertainty interval error",
 			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "c", "value")
 			},
@@ -3101,12 +3166,17 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b.CPut("c", "cput", kvclientutils.StrToCPutExistingValue("value"))
 				return txn.CommitInBatch(ctx, b)
 			},
-			filter:                         newUncertaintyFilter(roachpb.Key("c")),
+			filter: newUncertaintyFilter(roachpb.Key("c")),
+			// The cput to "c" will succeed after a server-side refresh. However, the
+			// txn has already staged on the other range at the pre-refresh timestamp.
+			// As a result, it does not qualify for the implicit commit condition and
+			// requires a client-side refresh.
+			expServerRefresh:               true,
 			expClientRefresh:               true,
 			expClientAutoRetryAfterRefresh: true,
 		},
 		{
-			name: "multi-range batch with uncertainty interval error and get conflict",
+			name: "multi-range batch commit with uncertainty interval error and get conflict",
 			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "a", "init")
 			},
@@ -3128,7 +3198,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			expClientRestart: true, // will fail because of conflict on refresh span for the Get
 		},
 		{
-			name: "multi-range batch with uncertainty interval error and mixed success",
+			name: "multi-range batch commit with uncertainty interval error and mixed success",
 			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "c", "value")
 			},
@@ -3139,7 +3209,11 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return txn.CommitInBatch(ctx, b)
 			},
 			filter: newUncertaintyFilter(roachpb.Key("c")),
-			// Expect a transaction coord retry, which should succeed.
+			// The cput to "c" will succeed after a server-side refresh. However, the
+			// txn has already staged on the other range at the pre-refresh timestamp.
+			// As a result, it does not qualify for the implicit commit condition and
+			// requires a client-side refresh.
+			expServerRefresh:               true,
 			expClientRefresh:               true,
 			expClientAutoRetryAfterRefresh: true,
 		},
@@ -3289,8 +3363,9 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			}
 
 			// Verify metrics.
-			require.Equal(t, tc.expClientRefresh, metrics.RefreshSuccess.Count() != 0, "TxnMetrics.RefreshSuccess")
-			require.Equal(t, tc.expClientAutoRetryAfterRefresh, metrics.RefreshAutoRetries.Count() != 0, "TxnMetrics.RefreshAutoRetries")
+			require.Equal(t, tc.expClientRefresh, metrics.ClientRefreshSuccess.Count() != 0, "TxnMetrics.ClientRefreshSuccess")
+			require.Equal(t, tc.expClientAutoRetryAfterRefresh, metrics.ClientRefreshAutoRetries.Count() != 0, "TxnMetrics.ClientRefreshAutoRetries")
+			require.Equal(t, tc.expServerRefresh, metrics.ServerRefreshSuccess.Count() != 0, "TxnMetrics.ServerRefreshSuccess")
 			require.Equal(t, tc.expClientRestart, metrics.Restarts.TotalSum() != 0, "TxnMetrics.Restarts")
 			require.Equal(t, tc.expOnePhaseCommit, metrics.Commits1PC.Count() != 0, "TxnMetrics.Commits1PC")
 		})

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -312,20 +312,15 @@ func (tc *TxnCoordSender) initCommonInterceptors(
 		condensedIntentsEveryN: &tc.TxnCoordSenderFactory.condensedIntentsEveryN,
 	}
 	tc.interceptorAlloc.txnSpanRefresher = txnSpanRefresher{
-		st:    tcf.st,
-		knobs: &tcf.testingKnobs,
-		riGen: riGen,
+		st:      tcf.st,
+		knobs:   &tcf.testingKnobs,
+		riGen:   riGen,
+		metrics: &tc.metrics,
 		// We can only allow refresh span retries on root transactions
 		// because those are the only places where we have all of the
 		// refresh spans. If this is a leaf, as in a distributed sql flow,
 		// we need to propagate the error to the root for an epoch restart.
-		canAutoRetry:                        typ == kv.RootTxn,
-		clientRefreshSuccess:                tc.metrics.ClientRefreshSuccess,
-		clientRefreshFail:                   tc.metrics.ClientRefreshFail,
-		clientRefreshFailWithCondensedSpans: tc.metrics.ClientRefreshFailWithCondensedSpans,
-		clientRefreshMemoryLimitExceeded:    tc.metrics.ClientRefreshMemoryLimitExceeded,
-		clientRefreshAutoRetries:            tc.metrics.ClientRefreshAutoRetries,
-		serverRefreshSuccess:                tc.metrics.ServerRefreshSuccess,
+		canAutoRetry: typ == kv.RootTxn,
 	}
 	tc.interceptorAlloc.txnLockGatekeeper = txnLockGatekeeper{
 		wrapped:                 tc.wrapped,

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -319,12 +319,13 @@ func (tc *TxnCoordSender) initCommonInterceptors(
 		// because those are the only places where we have all of the
 		// refresh spans. If this is a leaf, as in a distributed sql flow,
 		// we need to propagate the error to the root for an epoch restart.
-		canAutoRetry:                  typ == kv.RootTxn,
-		refreshSuccess:                tc.metrics.RefreshSuccess,
-		refreshFail:                   tc.metrics.RefreshFail,
-		refreshFailWithCondensedSpans: tc.metrics.RefreshFailWithCondensedSpans,
-		refreshMemoryLimitExceeded:    tc.metrics.RefreshMemoryLimitExceeded,
-		refreshAutoRetries:            tc.metrics.RefreshAutoRetries,
+		canAutoRetry:                        typ == kv.RootTxn,
+		clientRefreshSuccess:                tc.metrics.ClientRefreshSuccess,
+		clientRefreshFail:                   tc.metrics.ClientRefreshFail,
+		clientRefreshFailWithCondensedSpans: tc.metrics.ClientRefreshFailWithCondensedSpans,
+		clientRefreshMemoryLimitExceeded:    tc.metrics.ClientRefreshMemoryLimitExceeded,
+		clientRefreshAutoRetries:            tc.metrics.ClientRefreshAutoRetries,
+		serverRefreshSuccess:                tc.metrics.ServerRefreshSuccess,
 	}
 	tc.interceptorAlloc.txnLockGatekeeper = txnLockGatekeeper{
 		wrapped:                 tc.wrapped,

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -109,6 +108,7 @@ type txnSpanRefresher struct {
 	knobs   *ClientTestingKnobs
 	riGen   rangeIteratorFactory
 	wrapped lockedSender
+	metrics *TxnMetrics
 
 	// refreshFootprint contains key spans which were read during the
 	// transaction. In case the transaction's timestamp needs to be pushed, we can
@@ -129,13 +129,6 @@ type txnSpanRefresher struct {
 
 	// canAutoRetry is set if the txnSpanRefresher is allowed to auto-retry.
 	canAutoRetry bool
-
-	clientRefreshSuccess                *metric.Counter
-	clientRefreshFail                   *metric.Counter
-	clientRefreshFailWithCondensedSpans *metric.Counter
-	clientRefreshMemoryLimitExceeded    *metric.Counter
-	clientRefreshAutoRetries            *metric.Counter
-	serverRefreshSuccess                *metric.Counter
 }
 
 // SendLocked implements the lockedSender interface.
@@ -207,7 +200,7 @@ func (sr *txnSpanRefresher) maybeCondenseRefreshSpans(
 			sr.refreshFootprint.clear()
 		}
 		if sr.refreshFootprint.condensed && !condensedBefore {
-			sr.clientRefreshMemoryLimitExceeded.Inc(1)
+			sr.metrics.ClientRefreshMemoryLimitExceeded.Inc(1)
 		}
 	}
 }
@@ -314,7 +307,7 @@ func (sr *txnSpanRefresher) maybeRefreshAndRetrySend(
 	log.Eventf(ctx, "refresh succeeded; retrying original request")
 	ba = ba.ShallowCopy()
 	ba.UpdateTxn(refreshToTxn)
-	sr.clientRefreshAutoRetries.Inc(1)
+	sr.metrics.ClientRefreshAutoRetries.Inc(1)
 
 	// To prevent starvation of batches that are trying to commit, split off the
 	// EndTxn request into its own batch on auto-retries. This avoids starvation
@@ -511,11 +504,11 @@ func (sr *txnSpanRefresher) tryRefreshTxnSpans(
 	// Track the result of the refresh in metrics.
 	defer func() {
 		if err == nil {
-			sr.clientRefreshSuccess.Inc(1)
+			sr.metrics.ClientRefreshSuccess.Inc(1)
 		} else {
-			sr.clientRefreshFail.Inc(1)
+			sr.metrics.ClientRefreshFail.Inc(1)
 			if sr.refreshFootprint.condensed {
-				sr.clientRefreshFailWithCondensedSpans.Inc(1)
+				sr.metrics.ClientRefreshFailWithCondensedSpans.Inc(1)
 			}
 		}
 	}()
@@ -645,7 +638,7 @@ func (sr *txnSpanRefresher) forwardRefreshTimestampOnResponse(
 				"CanForwardReadTimestamp set. ba: %s, ba.Txn: %s, br.Txn: %s", ba.Summary(), baTxn, brTxn)
 		}
 		sr.refreshedTimestamp.Forward(brTxn.ReadTimestamp)
-		sr.serverRefreshSuccess.Inc(1)
+		sr.metrics.ServerRefreshSuccess.Inc(1)
 	} else if brTxn.ReadTimestamp.Less(baTxn.ReadTimestamp) {
 		return errors.AssertionFailedf("received transaction in response with "+
 			"earlier read timestamp than in the request. ba.Txn: %s, br.Txn: %s", baTxn, brTxn)

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
@@ -31,15 +31,16 @@ import (
 func makeMockTxnSpanRefresher() (txnSpanRefresher, *mockLockedSender) {
 	mockSender := &mockLockedSender{}
 	return txnSpanRefresher{
-		st:                            cluster.MakeTestingClusterSettings(),
-		knobs:                         new(ClientTestingKnobs),
-		wrapped:                       mockSender,
-		canAutoRetry:                  true,
-		refreshSuccess:                metric.NewCounter(metaRefreshSuccess),
-		refreshFail:                   metric.NewCounter(metaRefreshFail),
-		refreshFailWithCondensedSpans: metric.NewCounter(metaRefreshFailWithCondensedSpans),
-		refreshMemoryLimitExceeded:    metric.NewCounter(metaRefreshMemoryLimitExceeded),
-		refreshAutoRetries:            metric.NewCounter(metaRefreshAutoRetries),
+		st:                                  cluster.MakeTestingClusterSettings(),
+		knobs:                               new(ClientTestingKnobs),
+		wrapped:                             mockSender,
+		canAutoRetry:                        true,
+		clientRefreshSuccess:                metric.NewCounter(metaClientRefreshSuccess),
+		clientRefreshFail:                   metric.NewCounter(metaClientRefreshFail),
+		clientRefreshFailWithCondensedSpans: metric.NewCounter(metaClientRefreshFailWithCondensedSpans),
+		clientRefreshMemoryLimitExceeded:    metric.NewCounter(metaClientRefreshMemoryLimitExceeded),
+		clientRefreshAutoRetries:            metric.NewCounter(metaClientRefreshAutoRetries),
+		serverRefreshSuccess:                metric.NewCounter(metaServerRefreshSuccess),
 	}, mockSender
 }
 
@@ -285,17 +286,18 @@ func TestTxnSpanRefresherRefreshesTransactions(t *testing.T) {
 				require.Equal(t, tc.expRefreshTS, br.Txn.WriteTimestamp)
 				require.Equal(t, tc.expRefreshTS, br.Txn.ReadTimestamp)
 				require.Equal(t, tc.expRefreshTS, tsr.refreshedTimestamp)
-				require.Equal(t, int64(1), tsr.refreshSuccess.Count())
-				require.Equal(t, int64(0), tsr.refreshFail.Count())
-				require.Equal(t, int64(1), tsr.refreshAutoRetries.Count())
+				require.Equal(t, int64(1), tsr.clientRefreshSuccess.Count())
+				require.Equal(t, int64(0), tsr.clientRefreshFail.Count())
+				require.Equal(t, int64(1), tsr.clientRefreshAutoRetries.Count())
+				require.Equal(t, int64(0), tsr.serverRefreshSuccess.Count())
 			} else {
 				require.Nil(t, br)
 				require.NotNil(t, pErr)
 				require.Zero(t, tsr.refreshedTimestamp)
-				require.Equal(t, int64(0), tsr.refreshSuccess.Count())
-				require.Equal(t, int64(0), tsr.refreshAutoRetries.Count())
-				// Note that we don't check the tsr.refreshFail metric here as tests
-				// here expect the refresh to not be attempted, not to fail.
+				require.Equal(t, int64(0), tsr.clientRefreshSuccess.Count())
+				require.Equal(t, int64(0), tsr.clientRefreshFail.Count())
+				require.Equal(t, int64(0), tsr.clientRefreshAutoRetries.Count())
+				require.Equal(t, int64(0), tsr.serverRefreshSuccess.Count())
 			}
 		})
 	}
@@ -418,9 +420,10 @@ func TestTxnSpanRefresherPreemptiveRefresh(t *testing.T) {
 	br, pErr := tsr.SendLocked(ctx, ba)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
-	require.Equal(t, int64(1), tsr.refreshSuccess.Count())
-	require.Equal(t, int64(0), tsr.refreshFail.Count())
-	require.Equal(t, int64(0), tsr.refreshAutoRetries.Count())
+	require.Equal(t, int64(1), tsr.clientRefreshSuccess.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshFail.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshAutoRetries.Count())
+	require.Equal(t, int64(0), tsr.serverRefreshSuccess.Count())
 	require.True(t, tsr.refreshFootprint.empty())
 	require.False(t, tsr.refreshInvalid)
 
@@ -452,9 +455,9 @@ func TestTxnSpanRefresherPreemptiveRefresh(t *testing.T) {
 	br, pErr = tsr.SendLocked(ctx, ba)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
-	require.Equal(t, int64(2), tsr.refreshSuccess.Count())
-	require.Equal(t, int64(0), tsr.refreshFail.Count())
-	require.Equal(t, int64(0), tsr.refreshAutoRetries.Count())
+	require.Equal(t, int64(2), tsr.clientRefreshSuccess.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshFail.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshAutoRetries.Count())
 	require.Equal(t, []roachpb.Span{scanArgs.Span()}, tsr.refreshFootprint.asSlice())
 	require.False(t, tsr.refreshInvalid)
 
@@ -494,9 +497,10 @@ func TestTxnSpanRefresherPreemptiveRefresh(t *testing.T) {
 	require.Regexp(t,
 		"TransactionRetryError: retry txn \\(RETRY_SERIALIZABLE - failed preemptive refresh "+
 			"due to a conflict: committed value on key \"a\"\\)", pErr)
-	require.Equal(t, int64(2), tsr.refreshSuccess.Count())
-	require.Equal(t, int64(1), tsr.refreshFail.Count())
-	require.Equal(t, int64(0), tsr.refreshAutoRetries.Count())
+	require.Equal(t, int64(2), tsr.clientRefreshSuccess.Count())
+	require.Equal(t, int64(1), tsr.clientRefreshFail.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshAutoRetries.Count())
+	require.Equal(t, int64(0), tsr.serverRefreshSuccess.Count())
 	require.Equal(t, []roachpb.Span{scanArgs.Span()}, tsr.refreshFootprint.asSlice())
 	require.False(t, tsr.refreshInvalid)
 
@@ -533,9 +537,10 @@ func TestTxnSpanRefresherPreemptiveRefresh(t *testing.T) {
 	br, pErr = tsr.SendLocked(ctx, ba)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
-	require.Equal(t, int64(3), tsr.refreshSuccess.Count())
-	require.Equal(t, int64(1), tsr.refreshFail.Count())
-	require.Equal(t, int64(0), tsr.refreshAutoRetries.Count())
+	require.Equal(t, int64(3), tsr.clientRefreshSuccess.Count())
+	require.Equal(t, int64(1), tsr.clientRefreshFail.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshAutoRetries.Count())
+	require.Equal(t, int64(0), tsr.serverRefreshSuccess.Count())
 	require.Equal(t, []roachpb.Span{scanArgs.Span()}, tsr.refreshFootprint.asSlice())
 	require.False(t, tsr.refreshInvalid)
 }
@@ -603,9 +608,10 @@ func TestTxnSpanRefresherPreemptiveRefreshIsoLevel(t *testing.T) {
 			if tt.expRefresh {
 				expRefreshSuccess = 1
 			}
-			require.Equal(t, expRefreshSuccess, tsr.refreshSuccess.Count())
-			require.Equal(t, int64(0), tsr.refreshFail.Count())
-			require.Equal(t, int64(0), tsr.refreshAutoRetries.Count())
+			require.Equal(t, expRefreshSuccess, tsr.clientRefreshSuccess.Count())
+			require.Equal(t, int64(0), tsr.clientRefreshFail.Count())
+			require.Equal(t, int64(0), tsr.clientRefreshAutoRetries.Count())
+			require.Equal(t, int64(0), tsr.serverRefreshSuccess.Count())
 			require.True(t, tsr.refreshFootprint.empty())
 			require.False(t, tsr.refreshInvalid)
 		})
@@ -846,9 +852,9 @@ func TestTxnSpanRefresherSplitEndTxnOnAutoRetry(t *testing.T) {
 					default:
 						require.Fail(t, "unexpected")
 					}
-					require.Equal(t, expSuccess, tsr.refreshSuccess.Count())
-					require.Equal(t, expFail, tsr.refreshFail.Count())
-					require.Equal(t, expAutoRetries, tsr.refreshAutoRetries.Count())
+					require.Equal(t, expSuccess, tsr.clientRefreshSuccess.Count())
+					require.Equal(t, expFail, tsr.clientRefreshFail.Count())
+					require.Equal(t, expAutoRetries, tsr.clientRefreshAutoRetries.Count())
 
 					require.Equal(t, []roachpb.Span{scanArgs.Span()}, tsr.refreshFootprint.asSlice())
 					require.False(t, tsr.refreshInvalid)
@@ -881,9 +887,9 @@ func TestTxnSpanRefresherSplitEndTxnOnAutoRetry(t *testing.T) {
 					default:
 						require.Fail(t, "unexpected")
 					}
-					require.Equal(t, expSuccess, tsr.refreshSuccess.Count())
-					require.Equal(t, expFail, tsr.refreshFail.Count())
-					require.Equal(t, expAutoRetries, tsr.refreshAutoRetries.Count())
+					require.Equal(t, expSuccess, tsr.clientRefreshSuccess.Count())
+					require.Equal(t, expFail, tsr.clientRefreshFail.Count())
+					require.Equal(t, expAutoRetries, tsr.clientRefreshAutoRetries.Count())
 
 					if errIdx < 2 {
 						require.Equal(t, []roachpb.Span(nil), tsr.refreshFootprint.asSlice())
@@ -968,7 +974,7 @@ func TestTxnSpanRefresherMaxTxnRefreshSpansBytes(t *testing.T) {
 	require.False(t, tsr.refreshInvalid)
 	require.Equal(t, 2+roachpb.SpanOverhead, tsr.refreshFootprint.bytes)
 	require.False(t, tsr.refreshFootprint.condensed)
-	require.Equal(t, int64(0), tsr.refreshMemoryLimitExceeded.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshMemoryLimitExceeded.Count())
 	require.Zero(t, tsr.refreshedTimestamp)
 
 	// Exceed the limit again, this time with a non-adjacent span such that
@@ -985,8 +991,8 @@ func TestTxnSpanRefresherMaxTxnRefreshSpansBytes(t *testing.T) {
 	require.True(t, tsr.refreshFootprint.condensed)
 	require.False(t, tsr.refreshInvalid)
 	require.Zero(t, tsr.refreshedTimestamp)
-	require.Equal(t, int64(1), tsr.refreshMemoryLimitExceeded.Count())
-	require.Equal(t, int64(0), tsr.refreshFailWithCondensedSpans.Count())
+	require.Equal(t, int64(1), tsr.clientRefreshMemoryLimitExceeded.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshFailWithCondensedSpans.Count())
 
 	// Return a transaction retry error and make sure the metric indicating that
 	// we did not retry due to the refresh span bytes is incremented.
@@ -999,7 +1005,7 @@ func TestTxnSpanRefresherMaxTxnRefreshSpansBytes(t *testing.T) {
 	exp := kvpb.NewTransactionRetryError(kvpb.RETRY_SERIALIZABLE, "")
 	require.Equal(t, exp, pErr.GetDetail())
 	require.Nil(t, br)
-	require.Equal(t, int64(1), tsr.refreshFailWithCondensedSpans.Count())
+	require.Equal(t, int64(1), tsr.clientRefreshFailWithCondensedSpans.Count())
 }
 
 // TestTxnSpanRefresherAssignsCanForwardReadTimestamp tests that the
@@ -1014,6 +1020,9 @@ func TestTxnSpanRefresherAssignsCanForwardReadTimestamp(t *testing.T) {
 	txn := makeTxnProto()
 	keyA, keyB := roachpb.Key("a"), roachpb.Key("b")
 	keyC, keyD := roachpb.Key("c"), roachpb.Key("d")
+	refreshTS1 := txn.WriteTimestamp.Add(1, 0)
+	refreshTS2 := txn.WriteTimestamp.Add(2, 0)
+	refreshTS3 := txn.WriteTimestamp.Add(3, 0)
 
 	// Send a Put request. Should set CanForwardReadTimestamp flag. Should not
 	// collect refresh spans.
@@ -1027,15 +1036,26 @@ func TestTxnSpanRefresherAssignsCanForwardReadTimestamp(t *testing.T) {
 		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
 
 		br := ba.CreateReply()
-		br.Txn = ba.Txn
+		br.Txn = ba.Txn.Clone()
+		br.Txn.Refresh(refreshTS1) // server-side refresh
 		return br, nil
 	})
 
 	br, pErr := tsr.SendLocked(ctx, ba)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
+	require.NotNil(t, br.Txn)
+	require.Equal(t, refreshTS1, br.Txn.WriteTimestamp)
+	require.Equal(t, refreshTS1, br.Txn.ReadTimestamp)
+	txn.Update(br.Txn)
+
+	require.Equal(t, refreshTS1, tsr.refreshedTimestamp)
 	require.Nil(t, tsr.refreshFootprint.asSlice())
 	require.False(t, tsr.refreshInvalid)
+	require.Equal(t, int64(0), tsr.clientRefreshSuccess.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshFail.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshAutoRetries.Count())
+	require.Equal(t, int64(1), tsr.serverRefreshSuccess.Count())
 
 	// Send a Put request for a transaction with a fixed commit timestamp.
 	// Should NOT set CanForwardReadTimestamp flag.
@@ -1058,6 +1078,7 @@ func TestTxnSpanRefresherAssignsCanForwardReadTimestamp(t *testing.T) {
 	br, pErr = tsr.SendLocked(ctx, baFixed)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
+	require.Equal(t, refreshTS1, tsr.refreshedTimestamp)
 	require.Nil(t, tsr.refreshFootprint.asSlice())
 	require.False(t, tsr.refreshInvalid)
 
@@ -1073,15 +1094,26 @@ func TestTxnSpanRefresherAssignsCanForwardReadTimestamp(t *testing.T) {
 		require.IsType(t, &kvpb.ScanRequest{}, ba.Requests[0].GetInner())
 
 		br = ba.CreateReply()
-		br.Txn = ba.Txn
+		br.Txn = ba.Txn.Clone()
+		br.Txn.Refresh(refreshTS2) // server-side refresh
 		return br, nil
 	})
 
 	br, pErr = tsr.SendLocked(ctx, ba)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
+	require.NotNil(t, br.Txn)
+	require.Equal(t, refreshTS2, br.Txn.WriteTimestamp)
+	require.Equal(t, refreshTS2, br.Txn.ReadTimestamp)
+	txn.Update(br.Txn)
+
+	require.Equal(t, refreshTS2, tsr.refreshedTimestamp)
 	require.Equal(t, []roachpb.Span{scanArgs.Span()}, tsr.refreshFootprint.asSlice())
 	require.False(t, tsr.refreshInvalid)
+	require.Equal(t, int64(0), tsr.clientRefreshSuccess.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshFail.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshAutoRetries.Count())
+	require.Equal(t, int64(2), tsr.serverRefreshSuccess.Count())
 
 	// Send another Scan request. Should NOT set CanForwardReadTimestamp flag.
 	ba.Requests = nil
@@ -1101,6 +1133,7 @@ func TestTxnSpanRefresherAssignsCanForwardReadTimestamp(t *testing.T) {
 	br, pErr = tsr.SendLocked(ctx, ba)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
+	require.Equal(t, refreshTS2, tsr.refreshedTimestamp)
 	require.Equal(t, []roachpb.Span{{Key: keyA, EndKey: keyB}, {Key: keyC, EndKey: keyD}}, tsr.refreshFootprint.asSlice())
 	require.False(t, tsr.refreshInvalid)
 
@@ -1121,30 +1154,43 @@ func TestTxnSpanRefresherAssignsCanForwardReadTimestamp(t *testing.T) {
 	br, pErr = tsr.SendLocked(ctx, ba)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
+	require.Equal(t, refreshTS2, tsr.refreshedTimestamp)
 	require.Equal(t, []roachpb.Span{{Key: keyA, EndKey: keyB}, {Key: keyC, EndKey: keyD}}, tsr.refreshFootprint.asSlice())
 	require.False(t, tsr.refreshInvalid)
 
-	// Increment the transaction's epoch and send another Put request. Should
+	// Increment the transaction's epoch and send a ConditionalPut request. Should
 	// set CanForwardReadTimestamp flag.
 	ba.Requests = nil
-	ba.Add(&kvpb.PutRequest{RequestHeader: kvpb.RequestHeader{Key: keyB}})
+	ba.Add(&kvpb.ConditionalPutRequest{RequestHeader: kvpb.RequestHeader{Key: keyB}})
 
 	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		require.Len(t, ba.Requests, 1)
 		require.True(t, ba.CanForwardReadTimestamp)
-		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+		require.IsType(t, &kvpb.ConditionalPutRequest{}, ba.Requests[0].GetInner())
 
-		br = ba.CreateReply()
-		br.Txn = ba.Txn
-		return br, nil
+		// Return an error that contains a server-side refreshed transaction.
+		txn := ba.Txn.Clone()
+		txn.Refresh(refreshTS3) // server-side refresh
+		pErr := kvpb.NewErrorWithTxn(&kvpb.ConditionFailedError{}, txn)
+		return nil, pErr
 	})
 
 	tsr.epochBumpedLocked()
 	br, pErr = tsr.SendLocked(ctx, ba)
-	require.Nil(t, pErr)
-	require.NotNil(t, br)
+	require.Nil(t, br)
+	require.NotNil(t, pErr)
+	require.NotNil(t, pErr.GetTxn())
+	require.Equal(t, refreshTS3, pErr.GetTxn().WriteTimestamp)
+	require.Equal(t, refreshTS3, pErr.GetTxn().ReadTimestamp)
+	txn.Update(pErr.GetTxn())
+
+	require.Equal(t, refreshTS3, tsr.refreshedTimestamp)
 	require.Equal(t, []roachpb.Span(nil), tsr.refreshFootprint.asSlice())
 	require.False(t, tsr.refreshInvalid)
+	require.Equal(t, int64(0), tsr.clientRefreshSuccess.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshFail.Count())
+	require.Equal(t, int64(0), tsr.clientRefreshAutoRetries.Count())
+	require.Equal(t, int64(3), tsr.serverRefreshSuccess.Count())
 }
 
 // TestTxnSpanRefresherEpochIncrement tests that a txnSpanRefresher's refresh


### PR DESCRIPTION
Generalized server-side transaction refreshes were introduced in 972915d7. This PR adds a new metric to track the number of server-side refreshes, called `txn.refresh.success_server_side`. The metric is maintained by the `txnSpanRefresher`, making it easy to test and associate with the specific transaction that experienced the server-side refresh.

The primary motivation for this change is that it allows us to make `TestTxnCoordSenderRetries` more interesting. We will be using this test to exercise snapshot isolation (#100131), and it is useful to see when transactions avoid retry errors due to server-side refreshes.

Epic: None
Release note: None