### PR TITLE
allocator2: add generic clearableMemoMap

### DIFF
--- a/pkg/kv/kvserver/allocator/allocator2/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/allocator2/BUILD.bazel
@@ -3,7 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "allocator2",
-    srcs = ["constraint.go"],
+    srcs = [
+        "constraint.go",
+        "memo_helper.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocator2",
     visibility = ["//visibility:public"],
     deps = [
@@ -14,9 +17,13 @@ go_library(
 
 go_test(
     name = "allocator2_test",
-    srcs = ["constraint_test.go"],
+    srcs = [
+        "constraint_test.go",
+        "memo_helper_test.go",
+    ],
     args = ["-test.timeout=295s"],
     embed = [":allocator2"],
+    deps = ["@com_github_stretchr_testify//require"],
 )
 
 get_x_data(name = "get_x_data")

--- a/pkg/kv/kvserver/allocator/allocator2/memo_helper.go
+++ b/pkg/kv/kvserver/allocator/allocator2/memo_helper.go
@@ -1,0 +1,135 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package allocator2
+
+// clearableMemoMap is a generic map suited to the needs of various memos used
+// in the allocator. The key is any type that implements the mapKey interface
+// (e.g. storeIDPostingList). There is no removal from the map since the memo
+// is built up during an allocator round and then cleared for the next round.
+// The key-value pairs are stored in a mapEntry, which the caller is
+// responsible for initializing. The mapEntrySlice and its mapEntries are reused
+// (via the mapEntrySlicePool), since the contents of mapEntry may be allocation heavy.
+//
+// TODO(sumeer): remove the following example when we start using this map.
+//
+// For a concrete example, see the meansMemo.means in
+// https://github.com/cockroachdb/cockroach/pull/99977
+type clearableMemoMap[K mapKey, T mapEntry] struct {
+	entryAlloc mapEntryAllocator[T]
+	slicePool  mapEntrySlicePool[T]
+	entryMap   map[uint64]*mapEntrySlice[T]
+}
+
+// mapKey is the key of the map.
+type mapKey interface {
+	hash() uint64
+	// TODO(sumeer): we want the parameter to be the concrete type that
+	// implements mapKey instead of needing to do a type assertion in the method
+	// implementation. Is that possible with Go generics?
+	isEqual(b mapKey) bool
+}
+
+// mapEntry bundles together the key and value. The map implementation does
+// not care about the value since it is the caller's responsibility to
+// initialize.
+type mapEntry interface {
+	mapKey
+	// clear prepares the entry for reuse.
+	//
+	// TODO(sumeer): we want to call clear on the element of the mapEntrySlice,
+	// which means we need a pointer receiver. So callers need to implement
+	// mapEntry using a pointer type, which is a pain, since it requires them to
+	// pass a mapEntryAllocator to create a new struct whose pointer implements
+	// mapEntry.
+	clear()
+}
+
+// mapEntryAllocator returns a new non-nil mapEntry if the parameter is nil.
+// It should directly allocate from the Go memory allocator, i.e., it does not
+// need to do any pooling. The peculiar ensureNonNilMapEntry is needed since
+// the caller can't do x == nil, where x is an object of parameter T with type
+// constraint mapEntry ("mismatched types T and untyped nil"), or x == T(nil)
+// ("cannot convert nil to type T").
+type mapEntryAllocator[T mapEntry] interface {
+	ensureNonNilMapEntry(T) T
+}
+
+// mapEntrySlice is the value in the underlying Golang map to allow for hash
+// collisions. These will typically have a single entry. Since the memory of
+// these slices is reused, we use this simple approach to handle collisions,
+// instead of some form of open addressing scheme.
+type mapEntrySlice[T mapEntry] struct {
+	entries []T
+}
+
+// mapEntrySlicePool provides memory reuse. The methods can be directly backed
+// by a sync.Pool, since the caller already does the clearing needed for
+// reuse.
+type mapEntrySlicePool[T mapEntry] interface {
+	newEntry() *mapEntrySlice[T]
+	releaseEntry(slice *mapEntrySlice[T])
+}
+
+func newClearableMapMemo[K mapKey, T mapEntry](
+	entryAlloc mapEntryAllocator[T], slicePool mapEntrySlicePool[T],
+) *clearableMemoMap[K, T] {
+	return &clearableMemoMap[K, T]{
+		entryAlloc: entryAlloc,
+		slicePool:  slicePool,
+		entryMap:   map[uint64]*mapEntrySlice[T]{},
+	}
+}
+
+// get looks up k in the map and if found returns the entry and true, or
+// inserts an empty entry and returns that entry and false. The caller must
+// initialize that empty entry, including the key, so that subsequent calls to
+// isEqual can do meaningful computation. This assumes there is no error case
+// where the caller will not be able to populate the entry, which is true for
+// the current use cases. If needed we can add less efficient getIfFound and
+// put methods for use cases that need the capability to handle errors.
+func (cmm *clearableMemoMap[K, T]) get(k mapKey) (entry T, ok bool) {
+	h := k.hash()
+	var entrySlice *mapEntrySlice[T]
+	entrySlice, ok = cmm.entryMap[h]
+	if ok {
+		for i := range entrySlice.entries {
+			if entrySlice.entries[i].isEqual(k) {
+				return entrySlice.entries[i], true
+			}
+		}
+	} else {
+		entrySlice = cmm.slicePool.newEntry()
+		entrySlice.entries = entrySlice.entries[:0]
+		cmm.entryMap[h] = entrySlice
+	}
+	n := len(entrySlice.entries)
+	if cap(entrySlice.entries) > n {
+		entrySlice.entries = entrySlice.entries[:n+1]
+	} else {
+		size := (n + 1) * 2
+		entries := make([]T, n+1, size)
+		copy(entries, entrySlice.entries)
+		entrySlice.entries = entries
+	}
+	entrySlice.entries[n] = cmm.entryAlloc.ensureNonNilMapEntry(entrySlice.entries[n])
+	return entrySlice.entries[n], false
+}
+
+func (cmm *clearableMemoMap[K, T]) clear() {
+	for k, v := range cmm.entryMap {
+		for i := range v.entries {
+			v.entries[i].clear()
+		}
+		v.entries = v.entries[:0]
+		cmm.slicePool.releaseEntry(v)
+		delete(cmm.entryMap, k)
+	}
+}

--- a/pkg/kv/kvserver/allocator/allocator2/memo_helper_test.go
+++ b/pkg/kv/kvserver/allocator/allocator2/memo_helper_test.go
@@ -1,0 +1,133 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package allocator2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type intMapKey uint64
+
+func (k intMapKey) hash() uint64 {
+	// Cause hash collisions.
+	return uint64(k % 2)
+}
+
+func (k intMapKey) isEqual(b mapKey) bool {
+	bInt := b.(intMapKey)
+	return k == bInt
+}
+
+var _ mapKey = intMapKey(0)
+
+type intMapEntry struct {
+	intMapKey
+	// This is the kind of allocated state we want to reuse via clear.
+	state []struct{}
+}
+
+func (e *intMapEntry) clear() {
+	e.intMapKey = 0
+	e.state = e.state[:0]
+}
+
+var _ mapEntry = &intMapEntry{}
+
+type intEntryAlloc struct{}
+
+func (intEntryAlloc) ensureNonNilMapEntry(entry *intMapEntry) *intMapEntry {
+	if entry != nil {
+		return entry
+	}
+	return &intMapEntry{}
+}
+
+var _ mapEntryAllocator[*intMapEntry] = intEntryAlloc{}
+
+type intSlicePool struct {
+	t           *testing.T
+	freeEntries []*mapEntrySlice[*intMapEntry]
+}
+
+func (p *intSlicePool) newEntry() *mapEntrySlice[*intMapEntry] {
+	if len(p.freeEntries) == 0 {
+		return &mapEntrySlice[*intMapEntry]{}
+	}
+	rv := p.freeEntries[0]
+	p.freeEntries = p.freeEntries[1:]
+	return rv
+}
+
+func (p *intSlicePool) releaseEntry(slice *mapEntrySlice[*intMapEntry]) {
+	slice.entries = slice.entries[:cap(slice.entries)]
+	for i := range slice.entries {
+		if slice.entries[i] != nil {
+			require.EqualValues(p.t, 0, slice.entries[i].intMapKey)
+			require.Equal(p.t, 0, len(slice.entries[i].state))
+		}
+	}
+	p.freeEntries = append(p.freeEntries, slice)
+}
+
+var _ mapEntrySlicePool[*intMapEntry] = &intSlicePool{}
+
+// Avoid unused lint errors, due to linter being confused by generics.
+var _ = intEntryAlloc{}.ensureNonNilMapEntry
+var _ = (&intSlicePool{}).newEntry
+var _ = (&intSlicePool{}).releaseEntry
+var _ = (&intSlicePool{}).freeEntries
+
+func TestClearableMemoMap(t *testing.T) {
+	cm := newClearableMapMemo[intMapKey, *intMapEntry](intEntryAlloc{}, &intSlicePool{t: t})
+	entry, ok := cm.get(intMapKey(2))
+	require.False(t, ok)
+	entry.intMapKey = 2
+	entry.state = make([]struct{}, 5)
+
+	// Hash collision. So they will share the same *mapEntrySlice[*intMapEntry].
+	entry, ok = cm.get(intMapKey(4))
+	require.False(t, ok)
+	entry.intMapKey = 4
+	entry.state = make([]struct{}, 10)
+
+	entry, ok = cm.get(intMapKey(2))
+	require.True(t, ok)
+	require.EqualValues(t, 2, entry.intMapKey)
+
+	cm.clear()
+	// newEntry will get called and reuse the previously allocated *mapEntrySlice[*intMapEntry].
+	// The first element in that slice has an entry.state with capacity 5.
+	entry, ok = cm.get(intMapKey(4))
+	require.False(t, ok)
+	entry.intMapKey = 4
+	require.Equal(t, 0, len(entry.state))
+	require.Equal(t, 5, cap(entry.state))
+
+	// The second element in the slice has an entry.state with capacity 10.
+	entry, ok = cm.get(intMapKey(6))
+	require.False(t, ok)
+	entry.intMapKey = 6
+	require.Equal(t, 0, len(entry.state))
+	require.Equal(t, 10, cap(entry.state))
+
+	// Different slice.
+	entry, ok = cm.get(intMapKey(11))
+	require.False(t, ok)
+	entry.intMapKey = 11
+	require.Equal(t, 0, len(entry.state))
+	require.Equal(t, 0, cap(entry.state))
+
+	entry, ok = cm.get(intMapKey(11))
+	require.True(t, ok)
+	require.EqualValues(t, 11, entry.intMapKey)
+}


### PR DESCRIPTION
For use cases, see the prototype code in
https://github.com/cockroachdb/cockroach/pull/99977 that has specialized implementations (some of which are wastefully allocating memory).

Epic: none

Release note: None