### PR TITLE
sql: allow COPY ... TO in a prepared statement

### DIFF
--- a/pkg/acceptance/testdata/node/base-test.js
+++ b/pkg/acceptance/testdata/node/base-test.js
@@ -40,7 +40,7 @@ describe('error cases', () => {
   const cases = [{
     name: 'not enough params',
     query: { text: 'SELECT 3', values: ['foo'] },
-    msg: "expected 0 arguments, got 1",
+    msg: "bind message supplies 1 parameters, but prepared statement \"\" requires 0",
     code: '08P01',
   }, {
     name: 'invalid utf8',

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2216,6 +2216,22 @@ func (ex *connExecutor) execCmd() (retErr error) {
 				log.VEventf(ctx, 2, "portal resolved to: %s", portal.Stmt.AST.String())
 			}
 			ex.curStmtAST = portal.Stmt.AST
+			if copyTo, ok := ex.curStmtAST.(*tree.CopyTo); ok {
+				// The execution uses the same logic as if it were a simple query. This
+				// is because we no-op preparing of a COPY statement, in order to match
+				// Postgres behavior. Since there is no plan, we use the connExecutor
+				// to execute a prepared COPY.
+				copyCmd := CopyOut{
+					ParsedStmt:   portal.Stmt.Statement,
+					Stmt:         copyTo,
+					TimeReceived: tcmd.TimeReceived,
+				}
+				copyRes := ex.clientComm.CreateCopyOutResult(copyCmd, pos)
+				res = copyRes
+				stmtCtx := withStatement(ctx, copyTo)
+				ev, payload = ex.execCopyOut(stmtCtx, copyCmd, copyRes)
+				return nil
+			}
 
 			pinfo := &tree.PlaceholderInfo{
 				PlaceholderTypesInfo: tree.PlaceholderTypesInfo{

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -158,6 +158,11 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.CommentOnIndex(ctx, n)
 	case *tree.CommentOnTable:
 		return p.CommentOnTable(ctx, n)
+	case *tree.CopyTo:
+		// COPY TO does not actually get prepared in any meaningful way. This means
+		// it can't have placeholder arguments, and the execution can use the same
+		// logic as if it were a simple query. This matches the Postgres behavior.
+		return &zeroNode{}, nil
 	case *tree.CreateDatabase:
 		return p.CreateDatabase(ctx, n)
 	case *tree.CreateIndex:
@@ -331,6 +336,7 @@ func init() {
 		&tree.CommentOnIndex{},
 		&tree.CommentOnConstraint{},
 		&tree.CommentOnTable{},
+		&tree.CopyTo{},
 		&tree.CreateDatabase{},
 		&tree.CreateExtension{},
 		&tree.CreateExternalConnection{},

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -1040,3 +1040,71 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"0"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+### Tests for COPY ... TO with prepared statements.
+
+send
+Parse {"Query": "COPY (select 1) TO STDOUT"}
+Bind
+Describe {"ObjectType": "P"}
+Execute
+Sync
+----
+
+# Everything works fine with no placeholders.
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"NoData"}
+{"Type":"CopyOutResponse","ColumnFormatCodes":[0]}
+{"Type":"CopyData","Data":"310a"}
+{"Type":"CopyDone"}
+{"Type":"CommandComplete","CommandTag":"COPY 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# We match the PostgreSQL behavior when trying to bind a placeholder in COPY TO.
+send
+Parse {"Query": "COPY (select $1::int) TO STDOUT"}
+Bind {"Parameters": [{"text":"1"}]}
+Execute
+Sync
+----
+
+until keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"08P01","Message":"bind message supplies 1 parameters, but prepared statement \"\" requires 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# And it's also an error to _not_ bind a placeholder.
+send
+Parse {"Query": "COPY (select $1::int) TO STDOUT"}
+Bind
+Execute
+Sync
+----
+
+until keepErrMessage noncrdb_only
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ErrorResponse","Code":"42P02","Message":"there is no parameter $1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# CockroachDB has the same error as PostgreSQL, with a slightly different message.
+until keepErrMessage crdb_only
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CopyOutResponse","ColumnFormatCodes":null}
+{"Type":"ErrorResponse","Code":"42P02","Message":"COPY (SELECT $1::INT8) TO STDOUT: no value provided for placeholder: $1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -65,7 +65,7 @@ func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) 
 		*tree.BeginTransaction,
 		*tree.CommentOnColumn, *tree.CommentOnConstraint, *tree.CommentOnDatabase, *tree.CommentOnIndex, *tree.CommentOnTable, *tree.CommentOnSchema,
 		*tree.CommitTransaction,
-		*tree.CopyFrom, *tree.CreateDatabase, *tree.CreateIndex, *tree.CreateView,
+		*tree.CopyFrom, *tree.CopyTo, *tree.CreateDatabase, *tree.CreateIndex, *tree.CreateView,
 		*tree.CreateSequence,
 		*tree.CreateStats,
 		*tree.Deallocate, *tree.Discard, *tree.DropDatabase, *tree.DropIndex,

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1590,6 +1590,16 @@ func (stmt *Select) copyNode() *Select {
 	return &stmtCopy
 }
 
+func (n *CopyTo) walkStmt(v Visitor) Statement {
+	if newStmt, changed := walkStmt(v, n.Statement); changed {
+		// Make a copy of the CopyTo statement.
+		stmtCopy := *n
+		ret := &(stmtCopy)
+		ret.Statement = newStmt
+	}
+	return n
+}
+
 // walkStmt is part of the walkableStmt interface.
 func (stmt *Select) walkStmt(v Visitor) Statement {
 	ret := stmt


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/102180

Release note (bug fix): Fixed a bug where COPY ... TO statements would always fail when used in a prepared statement. This is fixed now, and CockroachDB matches the pgwire handling of prepared COPY ... TO statements.