### PR TITLE
sql: fix nil pointer in EXECUTE command with UDF

### DIFF
--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -35,7 +35,6 @@ func (p *planner) fillInPlaceholders(
 	}
 
 	qArgs := make(tree.QueryArguments, len(params))
-	var semaCtx tree.SemaContext
 	for i, e := range params {
 		idx := tree.PlaceholderIdx(i)
 
@@ -54,7 +53,7 @@ func (p *planner) fillInPlaceholders(
 			}
 		}
 		typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
-			ctx, e, typ, "EXECUTE parameter" /* context */, &semaCtx, volatility.Volatile, true, /*allowAssignmentCast*/
+			ctx, e, typ, "EXECUTE parameter" /* context */, p.SemaCtx(), volatility.Volatile, true, /*allowAssignmentCast*/
 		)
 		if err != nil {
 			return nil, pgerror.WithCandidateCode(err, pgcode.WrongObjectType)

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1669,3 +1669,24 @@ DEALLOCATE ALL
 
 statement ok
 RESET prepared_statements_cache_size
+
+subtest execute_udf
+
+statement ok
+PREPARE q99008 AS select $1::int
+
+query I
+EXECUTE q99008 (length('cat'))
+----
+3
+
+statement error unknown function: f\(\): function undefined
+EXECUTE q99008 (f(10))
+
+statement ok
+CREATE FUNCTION f(i int) RETURNS INT LANGUAGE SQL AS $$ SELECT i $$
+
+query I
+EXECUTE q99008 (f(10))
+----
+10


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/99008

Release note (bug fix): Fixed a crash that could occur if EXECUTE was used and one of the arguments was an inline user-defined function.