### PR TITLE
release-22.2: githubpost: add team label to issues

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -40,6 +40,7 @@ cockroachdb/kv:
     cockroachdb/kv-triage: roachtest
     cockroachdb/kv-prs: other
   triage_column_id: 14242655
+  label: T-kv
 cockroachdb/replication:
   aliases:
     cockroachdb/repl-prs: other

--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -53,10 +53,14 @@ func defaultFormatter(ctx context.Context, f failure) (issues.IssueFormatter, is
 
 	var projColID int
 	var mentions []string
+	var extraLabels []string
 	if len(teams) > 0 {
 		projColID = teams[0].TriageColumnID
 		for _, team := range teams {
 			mentions = append(mentions, "@"+string(team.Name()))
+			if team.Label != "" {
+				extraLabels = append(extraLabels, team.Label)
+			}
 		}
 	}
 	return issues.UnitTestFormatter, issues.PostRequest{
@@ -67,6 +71,7 @@ func defaultFormatter(ctx context.Context, f failure) (issues.IssueFormatter, is
 		HelpCommand:     issues.UnitTestHelpCommand(repro),
 		MentionOnCreate: mentions,
 		ProjectColumnID: projColID,
+		ExtraLabels:     extraLabels,
 	}
 }
 


### PR DESCRIPTION
Backport 2/2 commits from #102416.

/cc @cockroachdb/release

---

**TEAMS: add `T-kv` label for KV**

Epic: none
Release note: None

**githubpost: add team label to issues**

This patch automatically adds team labels to created issues. Previously, this was done by Blathers based on the project board, but not all teams use project boards -- and we may as well just set the correct label to begin with.

Epic: none
Release note: None
