### PR TITLE
jobs: Use thread safe map to override resumer constructor

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7545,15 +7545,14 @@ func TestRestoreTypeDescriptorsRollBack(t *testing.T) {
 
 	for _, server := range tc.Servers {
 		registry := server.JobRegistry().(*jobs.Registry)
-		registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+		registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*restoreResumer)
 				r.testingKnobs.beforePublishingDescriptors = func() error {
 					return errors.New("boom")
 				}
 				return r
-			},
-		}
+			})
 	}
 
 	sqlDB.Exec(t, `
@@ -7676,16 +7675,15 @@ func TestOfflineDescriptorsDuringRestore(t *testing.T) {
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(
+				jobspb.TypeRestore, func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.beforePublishingDescriptors = func() error {
 						notifyBackfill(ctx)
 						return nil
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -7772,16 +7770,15 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.beforePublishingDescriptors = func() error {
 						notifyBackfill(ctx)
 						return nil
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -7881,16 +7878,15 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.beforePublishingDescriptors = func() error {
 						notifyBackfill(ctx)
 						return nil
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -8015,16 +8011,15 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.afterPublishingDescriptors = func() error {
 						notifyContinue(ctx)
 						return errors.New("injected error")
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -8077,16 +8072,15 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.afterPublishingDescriptors = func() error {
 						notifyContinue(ctx)
 						return errors.New("injected error")
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -8141,16 +8135,15 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.afterPublishingDescriptors = func() error {
 						notifyContinue(ctx)
 						return errors.New("injected error")
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		// Use the same connection throughout (except for the concurrent RESTORE) to
@@ -8210,16 +8203,15 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.afterPublishingDescriptors = func() error {
 						notifyContinue(ctx)
 						return errors.New("injected error")
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -8517,9 +8509,9 @@ func TestRestoreJobEventLogging(t *testing.T) {
 
 	var forceFailure bool
 	for i := range tc.Servers {
-		tc.TenantOrServer(i).JobRegistry().(*jobs.Registry).TestingResumerCreationKnobs = map[jobspb.Type]func(
-			raw jobs.Resumer) jobs.Resumer{
-			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+		tc.TenantOrServer(i).JobRegistry().(*jobs.Registry).TestingWrapResumerConstructor(
+			jobspb.TypeRestore,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*restoreResumer)
 				r.testingKnobs.beforePublishingDescriptors = func() error {
 					if forceFailure {
@@ -8528,8 +8520,7 @@ func TestRestoreJobEventLogging(t *testing.T) {
 					return nil
 				}
 				return r
-			},
-		}
+			})
 	}
 
 	sqlDB.Exec(t, `CREATE DATABASE r1`)
@@ -8974,9 +8965,9 @@ func TestRestorePauseOnError(t *testing.T) {
 			jobRegistry = tc.Servers[i].TestTenants()[0].JobRegistry()
 		}
 
-		jobRegistry.(*jobs.Registry).TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.
-			Resumer{
-			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+		jobRegistry.(*jobs.Registry).TestingWrapResumerConstructor(
+			jobspb.TypeRestore,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*restoreResumer)
 				r.testingKnobs.beforePublishingDescriptors = func() error {
 					if forceFailure {
@@ -8985,8 +8976,7 @@ func TestRestorePauseOnError(t *testing.T) {
 					return nil
 				}
 				return r
-			},
-		}
+			})
 	}
 
 	sqlDB.Exec(t, `CREATE DATABASE r1`)
@@ -9230,15 +9220,14 @@ func TestRestoreSchemaDescriptorsRollBack(t *testing.T) {
 
 	for _, server := range tc.Servers {
 		registry := server.JobRegistry().(*jobs.Registry)
-		registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+		registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*restoreResumer)
 				r.testingKnobs.beforePublishingDescriptors = func() error {
 					return errors.New("boom")
 				}
 				return r
-			},
-		}
+			})
 	}
 
 	sqlDB.Exec(t, `
@@ -9426,13 +9415,12 @@ func TestExportRequestBelowGCThresholdOnDataExcludedFromBackup(t *testing.T) {
 
 	for _, server := range tc.Servers {
 		registry := server.JobRegistry().(*jobs.Registry)
-		registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-			jobspb.TypeBackup: func(raw jobs.Resumer) jobs.Resumer {
+		registry.TestingWrapResumerConstructor(jobspb.TypeBackup,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*backupResumer)
 				r.testingKnobs.ignoreProtectedTimestamps = true
 				return r
-			},
-		}
+			})
 	}
 	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
@@ -10349,8 +10337,9 @@ func TestBackupRestoreTelemetryEvents(t *testing.T) {
 
 	var forceFailure bool
 	for i := range tc.Servers {
-		tc.TenantOrServer(i).JobRegistry().(*jobs.Registry).TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+		tc.TenantOrServer(i).JobRegistry().(*jobs.Registry).TestingWrapResumerConstructor(
+			jobspb.TypeRestore,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*restoreResumer)
 				r.testingKnobs.beforePublishingDescriptors = func() error {
 					if forceFailure {
@@ -10359,8 +10348,7 @@ func TestBackupRestoreTelemetryEvents(t *testing.T) {
 					return nil
 				}
 				return r
-			},
-		}
+			})
 	}
 
 	sqlDB.Exec(t, `SET application_name = 'backup_test'`)

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -682,14 +682,13 @@ func TestAlterChangefeedPersistSinkURI(t *testing.T) {
 
 	doneCh := make(chan struct{})
 	defer close(doneCh)
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-		jobspb.TypeChangefeed: func(raw jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeChangefeed,
+		func(raw jobs.Resumer) jobs.Resumer {
 			r := fakeResumer{
 				done: doneCh,
 			}
 			return &r
-		},
-	}
+		})
 
 	sqlDB.QueryRow(t, `CREATE CHANGEFEED FOR TABLE foo, bar INTO $1`, unredactedSinkURI).Scan(&changefeedID)
 

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -152,14 +152,13 @@ func TestShowChangefeedJobs(t *testing.T) {
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-		jobspb.TypeChangefeed: func(raw jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeChangefeed,
+		func(raw jobs.Resumer) jobs.Resumer {
 			r := fakeResumer{
 				done: doneCh,
 			}
 			return &r
-		},
-	}
+		})
 
 	query = `SET CLUSTER SETTING kv.rangefeed.enabled = true`
 	sqlDB.Exec(t, query)
@@ -253,14 +252,13 @@ func TestShowChangefeedJobsStatusChange(t *testing.T) {
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-		jobspb.TypeChangefeed: func(raw jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeChangefeed,
+		func(raw jobs.Resumer) jobs.Resumer {
 			r := fakeResumer{
 				done: doneCh,
 			}
 			return &r
-		},
-	}
+		})
 
 	query = `SET CLUSTER SETTING kv.rangefeed.enabled = true`
 	sqlDB.Exec(t, query)

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -684,18 +684,18 @@ func newDepInjector(srvs ...feedInjectable) *depInjector {
 			}
 
 		// Arrange for error reporting resumer to be used.
-		s.JobRegistry().(*jobs.Registry).TestingResumerCreationKnobs =
-			map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeChangefeed: func(raw jobs.Resumer) jobs.Resumer {
-					f := di.getJobFeed(raw.(*changefeedResumer).job.ID())
-					return &reportErrorResumer{
-						wrapped: raw,
-						jobFailed: func() {
-							f.jobFailed(f.FetchTerminalJobErr())
-						},
-					}
-				},
-			}
+		s.JobRegistry().(*jobs.Registry).TestingWrapResumerConstructor(
+			jobspb.TypeChangefeed,
+			func(raw jobs.Resumer) jobs.Resumer {
+				f := di.getJobFeed(raw.(*changefeedResumer).job.ID())
+				return &reportErrorResumer{
+					wrapped: raw,
+					jobFailed: func() {
+						f.jobFailed(f.FetchTerminalJobErr())
+					},
+				}
+			},
+		)
 	}
 
 	return di

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -303,8 +303,8 @@ func TestTenantStatusWithFutureCutoverTime(t *testing.T) {
 	waitBeforeCh := make(chan struct{})
 	waitAfterCh := make(chan struct{})
 	registry := c.DestSysServer.JobRegistry().(*jobs.Registry)
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-		jobspb.TypeStreamIngestion: func(raw jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeStreamIngestion,
+		func(raw jobs.Resumer) jobs.Resumer {
 			r := blockingResumer{
 				orig:       raw,
 				waitBefore: waitBeforeCh,
@@ -312,8 +312,7 @@ func TestTenantStatusWithFutureCutoverTime(t *testing.T) {
 				ctx:        ctx,
 			}
 			return &r
-		},
-	}
+		})
 	defer ctxCancel()
 	unblockResumerStart := func() {
 		waitBeforeCh <- struct{}{}
@@ -391,8 +390,8 @@ func TestTenantStatusWithLatestCutoverTime(t *testing.T) {
 	waitBeforeCh := make(chan struct{})
 	waitAfterCh := make(chan struct{})
 	registry := c.DestSysServer.JobRegistry().(*jobs.Registry)
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-		jobspb.TypeStreamIngestion: func(raw jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeStreamIngestion,
+		func(raw jobs.Resumer) jobs.Resumer {
 			r := blockingResumer{
 				orig:       raw,
 				waitBefore: waitBeforeCh,
@@ -400,8 +399,7 @@ func TestTenantStatusWithLatestCutoverTime(t *testing.T) {
 				ctx:        ctx,
 			}
 			return &r
-		},
-	}
+		})
 	defer ctxCancel()
 	unblockResumerStart := func() {
 		waitBeforeCh <- struct{}{}

--- a/pkg/jobs/helpers.go
+++ b/pkg/jobs/helpers.go
@@ -26,3 +26,9 @@ func ResetConstructors() func() {
 		globalMu.constructors = old
 	}
 }
+
+// TestingWrapResumerConstructor injects a wrapper around resumer creation for
+// the specified job type.
+func (r *Registry) TestingWrapResumerConstructor(typ jobspb.Type, wrap func(Resumer) Resumer) {
+	r.creationKnobs.Store(typ, wrap)
+}

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -1531,10 +1531,9 @@ func TestInternalSystemJobsAccess(t *testing.T) {
 	// users requires jobs to be created and run. Thus, this test only creates jobs of type
 	// jobspb.TypeImport and overrides the import resumer.
 	registry := s.JobRegistry().(*jobs.Registry)
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{}
-	registry.TestingResumerCreationKnobs[jobspb.TypeImport] = func(r jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeImport, func(r jobs.Resumer) jobs.Resumer {
 		return &fakeResumer{}
-	}
+	})
 
 	asUser := func(user string, f func(userDB *sqlutils.SQLRunner)) {
 		pgURL := url.URL{

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -715,10 +715,10 @@ func TestCSVImportCanBeResumed(t *testing.T) {
 	var jobID jobspb.JobID = -1
 	var importSummary roachpb.RowCount
 
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
+	registry.TestingWrapResumerConstructor(jobspb.TypeImport,
 		// Arrange for our special job resumer to be
 		// returned the very first time we start the import.
-		jobspb.TypeImport: func(raw jobs.Resumer) jobs.Resumer {
+		func(raw jobs.Resumer) jobs.Resumer {
 			resumer := raw.(*importResumer)
 			resumer.testingKnobs.alwaysFlushJobProgress = true
 			resumer.testingKnobs.afterImport = func(summary roachpb.RowCount) error {
@@ -733,8 +733,7 @@ func TestCSVImportCanBeResumed(t *testing.T) {
 				}
 			}
 			return resumer
-		},
-	}
+		})
 
 	testBarrier, csvBarrier := newSyncBarrier()
 	csv1 := newCsvGenerator(0, 10*batchSize+1, &intGenerator{}, &strGenerator{})
@@ -823,10 +822,10 @@ func TestCSVImportMarksFilesFullyProcessed(t *testing.T) {
 	var jobID jobspb.JobID = -1
 	var importSummary roachpb.RowCount
 
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
+	registry.TestingWrapResumerConstructor(jobspb.TypeImport,
 		// Arrange for our special job resumer to be
 		// returned the very first time we start the import.
-		jobspb.TypeImport: func(raw jobs.Resumer) jobs.Resumer {
+		func(raw jobs.Resumer) jobs.Resumer {
 			resumer := raw.(*importResumer)
 			resumer.testingKnobs.alwaysFlushJobProgress = true
 			resumer.testingKnobs.afterImport = func(summary roachpb.RowCount) error {
@@ -842,8 +841,7 @@ func TestCSVImportMarksFilesFullyProcessed(t *testing.T) {
 				}
 			}
 			return resumer
-		},
-	}
+		})
 
 	csv1 := newCsvGenerator(0, 10*batchSize+1, &intGenerator{}, &strGenerator{})
 	csv2 := newCsvGenerator(0, 20*batchSize-1, &intGenerator{}, &strGenerator{})

--- a/pkg/upgrade/upgrades/alter_jobs_add_job_type_test.go
+++ b/pkg/upgrade/upgrades/alter_jobs_add_job_type_test.go
@@ -137,15 +137,13 @@ func TestAlterSystemJobsTableAddJobTypeColumn(t *testing.T) {
 
 	// Start a job of each type.
 	registry := s.JobRegistry().(*jobs.Registry)
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{}
 	jobspb.ForEachType(func(typ jobspb.Type) {
 		// The upgrade creates migration and schemachange jobs, so we do not
 		// need to create more. We should not override resumers for these job types,
 		// otherwise the upgrade will hang.
 		if typ != jobspb.TypeMigration && typ != jobspb.TypeSchemaChange {
-			registry.TestingResumerCreationKnobs[typ] = func(r jobs.Resumer) jobs.Resumer {
-				return &fakeResumer{}
-			}
+			registry.TestingWrapResumerConstructor(
+				typ, func(r jobs.Resumer) jobs.Resumer { return &fakeResumer{} })
 
 			record := jobs.Record{
 				Details: jobspb.JobDetailsForEveryJobType[typ],

--- a/pkg/upgrade/upgrades/backfill_jobs_info_table_migration_test.go
+++ b/pkg/upgrade/upgrades/backfill_jobs_info_table_migration_test.go
@@ -53,15 +53,12 @@ func TestBackfillJobsInfoTable(t *testing.T) {
 	r := tc.Server(0).JobRegistry().(*jobs.Registry)
 	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	defer tc.Stopper().Stop(ctx)
-	r.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{}
 	jobspb.ForEachType(func(typ jobspb.Type) {
 		// The upgrade creates migration and schemachange jobs, so we do not
 		// need to create more. We should not override resumers for these job types,
 		// otherwise the upgrade will hang.
 		if typ != jobspb.TypeMigration && typ != jobspb.TypeSchemaChange {
-			r.TestingResumerCreationKnobs[typ] = func(r jobs.Resumer) jobs.Resumer {
-				return &fakeResumer{}
-			}
+			r.TestingWrapResumerConstructor(typ, func(r jobs.Resumer) jobs.Resumer { return &fakeResumer{} })
 		}
 	}, false)
 


### PR DESCRIPTION
Replace map with sync.Map to ensure the access to
testing knob overrides is thread safe.

Fixes #102221
Release note: None