### PR TITLE
streamingest,replicationtestutils: deflake a couple of c2c tests

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/contextutil",
+        "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_apd_v3//:apd",

--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -258,8 +259,26 @@ func CreateTenantStreamingClusters(
 		}
 	}
 
-	// Start the source cluster.
-	srcCluster, srcURL, srcCleanup := startTestCluster(ctx, t, serverArgs, args.SrcNumNodes)
+	g := ctxgroup.WithContext(ctx)
+
+	var srcCluster *testcluster.TestCluster
+	var srcURL url.URL
+	var srcCleanup func()
+	g.GoCtx(func(ctx context.Context) error {
+		// Start the source cluster.
+		srcCluster, srcURL, srcCleanup = startTestCluster(ctx, t, serverArgs, args.SrcNumNodes)
+		return nil
+	})
+
+	var destCluster *testcluster.TestCluster
+	var destCleanup func()
+	g.GoCtx(func(ctx context.Context) error {
+		// Start the destination cluster.
+		destCluster, _, destCleanup = startTestCluster(ctx, t, serverArgs, args.DestNumNodes)
+		return nil
+	})
+
+	require.NoError(t, g.Wait())
 
 	clusterSettings := cluster.MakeTestingClusterSettings()
 	for _, setting := range []*settings.BoolSetting{
@@ -275,9 +294,6 @@ func CreateTenantStreamingClusters(
 	}
 	srcTenantServer, srcTenantConn := serverutils.StartTenant(t, srcCluster.Server(0), tenantArgs)
 	waitForTenantPodsActive(t, srcTenantServer, 1)
-
-	// Start the destination cluster.
-	destCluster, _, destCleanup := startTestCluster(ctx, t, serverArgs, args.DestNumNodes)
 
 	tsc := &TenantStreamingClusters{
 		T:               t,
@@ -355,13 +371,12 @@ func CreateScatteredTable(t *testing.T, c *TenantStreamingClusters, numNodes int
 	// Create a source table with multiple ranges spread across multiple nodes
 	numRanges := 50
 	rowsPerRange := 20
-	c.SrcTenantSQL.Exec(t, fmt.Sprintf(`
-  CREATE TABLE d.scattered (key INT PRIMARY KEY);
-  INSERT INTO d.scattered (key) SELECT * FROM generate_series(1, %d);
-  ALTER TABLE d.scattered SPLIT AT (SELECT * FROM generate_series(%d, %d, %d));
-  ALTER TABLE d.scattered SCATTER;
-  `, numRanges*rowsPerRange, rowsPerRange, (numRanges-1)*rowsPerRange, rowsPerRange))
-	c.SrcSysSQL.CheckQueryResultsRetry(t, "SELECT count(distinct lease_holder) from crdb_internal.ranges", [][]string{{fmt.Sprint(numNodes)}})
+	c.SrcTenantSQL.Exec(t, "CREATE TABLE d.scattered (key INT PRIMARY KEY)")
+	c.SrcTenantSQL.Exec(t, "INSERT INTO d.scattered (key) SELECT * FROM generate_series(1, $1)",
+		numRanges*rowsPerRange)
+	c.SrcTenantSQL.Exec(t, "ALTER TABLE d.scattered SPLIT AT (SELECT * FROM generate_series($1::INT, $2::INT, $3::INT))",
+		rowsPerRange, (numRanges-1)*rowsPerRange, rowsPerRange)
+	c.SrcTenantSQL.Exec(t, "ALTER TABLE d.scattered SCATTER")
 }
 
 var defaultSrcClusterSetting = map[string]string{

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -433,13 +433,12 @@ func TestTenantStreamingUnavailableStreamAddress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 94738, "flaky test")
 	skip.UnderRace(t, "takes too long with multiple nodes")
 
 	ctx := context.Background()
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs
 
-	args.SrcNumNodes = 3
+	args.SrcNumNodes = 4
 	args.DestNumNodes = 3
 
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
@@ -625,13 +624,12 @@ func TestTenantStreamingDeleteRange(t *testing.T) {
 func TestTenantStreamingMultipleNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 86206)
 
 	skip.UnderRace(t, "takes too long with multiple nodes")
 
 	ctx := context.Background()
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs
-	args.SrcNumNodes = 3
+	args.SrcNumNodes = 4
 	args.DestNumNodes = 3
 
 	// Track the number of unique addresses that were connected to
@@ -648,6 +646,8 @@ func TestTenantStreamingMultipleNodes(t *testing.T) {
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
 	defer cleanup()
 
+	// Make sure we have data on all nodes, so that we will have multiple
+	// connections and client addresses (and actually test multi-node).
 	replicationtestutils.CreateScatteredTable(t, c, 3)
 
 	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)


### PR DESCRIPTION
TestTenantStreamingMultipleNodes and
TestTenantStreamingUnavailableStreamAddress were flaky, and fixed here.

I also tried enabling those in under --race, but failed, running with multiple nodes hits the 15 minutes deadline under race.

Changed a few small things:
- we create 2 test clusters for c2c (clearly..) which was done sequentially. Now it's parallelized (speeds up the test a bit).
- we have 50 ranges that we were hoping to scatter over 3 nodes, it should be enough but rarely all leases are on a single node. Increasing this number doesn't help, instead, this pr changed the number of nodes on the source cluster from 3 to 4. This doesn't guarantee success but looks like it should reduce flakiness significantly (I cannot repro this failure locally under stress).
- broke down the CREAT/INSERT/SPLIT/SCATTER command - only to make it easy to see where the issues are and where the time is spent.
- dropped the check in CreateScatteredTable() because we will always have leases on all 3 nodes, the verification that we need is to have the leases of the scattered table spread, not any lease. This check was misleading and therefore removed.

Epic: none
Fixes: #86227
Fixes: #94738
Fixes: #86206

Release note: None