### PR TITLE
kvserver: only return range info when `ClientRangeInfo` set

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2675,6 +2675,9 @@ message Header {
   // by the client's DistSender, however it will preserve the value of the field
   // `ExplicitlyRequested` so that requests passed to DistSender can request
   // `RangeInfos` if desired.
+  //
+  // If empty, range info is never returned (from 23.2 onwards). Use
+  // ExplicitlyRequested to force an update for an otherwise-empty field.
   ClientRangeInfo client_range_info = 17 [(gogoproto.nullable) = false];
   // bounded_staleness is set when a read-only batch is performing a bounded
   // staleness read and wants its timestamp to be chosen dynamically, based

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -252,7 +252,7 @@ func (tc *testContext) SendWrapped(args kvpb.Request) (kvpb.Response, *kvpb.Erro
 	return tc.SendWrappedWith(kvpb.Header{}, args)
 }
 
-// addBogusReplicaToRangeDesc modifies the range descriptor to include a second
+// addBogusReplicaToRangeDesc modifies the range descriptor to include an additional
 // replica. This is useful for tests that want to pretend they're transferring
 // the range lease away, as the lease can only be obtained by Replicas which are
 // part of the range descriptor.
@@ -260,15 +260,17 @@ func (tc *testContext) SendWrapped(args kvpb.Request) (kvpb.Response, *kvpb.Erro
 func (tc *testContext) addBogusReplicaToRangeDesc(
 	ctx context.Context,
 ) (roachpb.ReplicaDescriptor, error) {
-	secondReplica := roachpb.ReplicaDescriptor{
-		NodeID:    2,
-		StoreID:   2,
-		ReplicaID: 2,
-	}
 	oldDesc := *tc.repl.Desc()
+	newID := oldDesc.NextReplicaID
+	newReplica := roachpb.ReplicaDescriptor{
+		NodeID:    roachpb.NodeID(newID),
+		StoreID:   roachpb.StoreID(newID),
+		ReplicaID: newID,
+	}
 	newDesc := oldDesc
-	newDesc.InternalReplicas = append(newDesc.InternalReplicas, secondReplica)
-	newDesc.NextReplicaID = 3
+	newDesc.InternalReplicas = append(newDesc.InternalReplicas, newReplica)
+	newDesc.NextReplicaID++
+	newDesc.IncrementGeneration()
 
 	dbDescKV, err := tc.store.DB().Get(ctx, keys.RangeDescriptorKey(oldDesc.StartKey))
 	if err != nil {
@@ -302,7 +304,7 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.engine)
 	tc.repl.mu.RUnlock()
 	tc.repl.raftMu.Unlock()
-	return secondReplica, nil
+	return newReplica, nil
 }
 
 func newTransaction(
@@ -13866,24 +13868,54 @@ func TestRangeInfoReturned(t *testing.T) {
 	var tc testContext
 	tc.Start(ctx, t, stopper)
 
+	// Add a couple of bogus configuration changes to bump the generation to 2,
+	// and request a new lease to bump the lease sequence to 2.
+	_, err := tc.addBogusReplicaToRangeDesc(ctx)
+	require.NoError(t, err)
+	_, err = tc.addBogusReplicaToRangeDesc(ctx)
+	require.NoError(t, err)
+
+	{
+		lease, _ := tc.repl.GetLease()
+		tc.repl.RevokeLease(ctx, lease.Sequence)
+
+		tc.repl.mu.Lock()
+		st := tc.repl.leaseStatusAtRLocked(ctx, tc.Clock().NowAsClockTimestamp())
+		ll := tc.repl.requestLeaseLocked(ctx, st)
+		tc.repl.mu.Unlock()
+		select {
+		case pErr := <-ll.C():
+			require.NoError(t, pErr.GoError())
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout")
+		}
+	}
+
 	ri := tc.repl.GetRangeInfo(ctx)
 	require.False(t, ri.Lease.Empty())
 	require.Equal(t, roachpb.LAG_BY_CLUSTER_SETTING, ri.ClosedTimestampPolicy)
+	require.EqualValues(t, 2, ri.Desc.Generation)
+	require.EqualValues(t, 2, ri.Lease.Sequence)
 	staleDescGen := ri.Desc.Generation - 1
 	staleLeaseSeq := ri.Lease.Sequence - 1
 	wrongCTPolicy := roachpb.LEAD_FOR_GLOBAL_READS
 
-	requestLease := ri.Lease
-	requestLease.Sequence = 0
-
 	for _, test := range []struct {
 		cri roachpb.ClientRangeInfo
-		req kvpb.Request
 		exp *roachpb.RangeInfo
 	}{
 		{
-			// Empty client info. This case shouldn't happen.
+			// Empty client info doesn't return any info. This case shouldn't happen
+			// for requests via DistSender, but can happen e.g. with lease requests
+			// that are submitted directly to the replica.
 			cri: roachpb.ClientRangeInfo{},
+			exp: nil,
+		},
+		{
+			// ExplicitlyRequested returns lease info.
+			cri: roachpb.ClientRangeInfo{
+				ExplicitlyRequested: true,
+			},
 			exp: &ri,
 		},
 		{
@@ -13948,26 +13980,12 @@ func TestRangeInfoReturned(t *testing.T) {
 			},
 			exp: &ri,
 		},
-		{
-			// RequestLeaseRequest without ClientRangeInfo. These bypass
-			// DistSender and don't need range info returned.
-			cri: roachpb.ClientRangeInfo{},
-			req: &kvpb.RequestLeaseRequest{
-				Lease:     requestLease,
-				PrevLease: ri.Lease,
-			},
-			exp: nil,
-		},
 	} {
 		t.Run("", func(t *testing.T) {
 			ba := &kvpb.BatchRequest{}
 			ba.Header.ClientRangeInfo = test.cri
-			req := test.req
-			if req == nil {
-				args := getArgs(roachpb.Key("a"))
-				req = &args
-			}
-			ba.Add(req)
+			req := getArgs(roachpb.Key("a"))
+			ba.Add(&req)
 			br, pErr := tc.Sender().Send(ctx, ba)
 			require.NoError(t, pErr.GoError())
 			if test.exp == nil {

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -772,7 +772,7 @@ message ClientRangeInfo {
   int64 lease_sequence = 2 [(gogoproto.casttype) = "LeaseSequence"];
   RangeClosedTimestampPolicy closed_timestamp_policy = 3;
   // ExplicitlyRequested causes range info to be returned even if other fields
-  // are up-to-date.
+  // are up-to-date or empty.
   bool explicitly_requested = 4;
 }
 


### PR DESCRIPTION
Previously, passing an empty `ClientRangeInfo` would always generate and return range info, because the zero values are always considered stale. An exception was made for lease requests, since these bypass DistSender and never use `ClientRangeInfo`.

This patch instead only returns range info when a non-empty `ClientRangeInfo` is passed, with a version gate for 23.1 compatibility.

Epic: none
Release note: None