### PR TITLE
sql: fix role membership cache to work with GC

### DIFF
--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -31,6 +31,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestUserLoginAfterGC sets an artificially low gc.ttl on system.role_members,
+// then verifies that the role membership cache still works. This is valuable to
+// test since we change the read timestamp of the transaction that populates the
+// role membership cache.
+func TestUserLoginAfterGC(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	// Create a user.
+	_, err := db.Exec(`CREATE USER newuser WITH password '123'`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`GRANT admin TO newuser`)
+	require.NoError(t, err)
+
+	// Sleep so that the system.role_members modification time is 2s in the past.
+	time.Sleep(2 * time.Second)
+
+	// Force a table GC with a threshold of 500ms in the past.
+	err = s.ForceTableGC(ctx, "system", "role_members", s.Clock().Now().Add(-int64(500*time.Millisecond), 0))
+	require.NoError(t, err)
+
+	// Verify that newuser can still log in.
+	newUserURL, cleanup := sqlutils.PGUrlWithOptionalClientCerts(
+		t, s.ServingSQLAddr(), t.Name(), url.UserPassword("newuser", "123"), false, /* withClientCerts */
+	)
+	defer cleanup()
+
+	newUserConn, err := sqltestutils.PGXConn(t, newUserURL)
+	require.NoError(t, err)
+	defer func() { _ = newUserConn.Close(ctx) }()
+
+	_, err = newUserConn.Exec(ctx, `SHOW GRANTS FOR newuser`)
+	require.NoError(t, err)
+}
+
 // TestGetUserTimeout verifies that user login attempts
 // fail with a suitable timeout when some system range(s) are
 // unavailable.


### PR DESCRIPTION
If the system.role_members table experienced an MVCC GC, and the cluster had a long enough period of inactivity before that GC, then the caching logic for reading from role_members would break. The cache uses the descriptor modification time as the transaction's read timestamp, but that timestamp could be beyond the GC threshold, thereby preventing the transaction from performing reads.

It should be safe to instead use the outer txn's read timestamp in order to fix the timestamp of the txn that populates the cache. Fixing the timestamp like this will still mean that that the inner txn sees the same data that the outer txn would have.

fixes https://github.com/cockroachdb/cockroach/issues/102385

Release note (bug fix): Fixed a bug only present in v23.1 alpha and beta versions, which could prevent a user from logging in or viewing/changing GRANTs if the cluster had a long enough period of inactivity.