### PR TITLE
roachtest: fix flake in acceptance/version-upgrade

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1051,17 +1051,7 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 	visibility := 1.0
 	if notvisible := og.randIntn(20) == 0; notvisible {
 		visibility = 0.0
-		partiallyVisibleIndexNotSupported, err := isClusterVersionLessThan(
-			ctx, tx, clusterversion.ByKey(clusterversion.V23_2_PartiallyVisibleIndexes),
-		)
-		if err != nil {
-			return nil, err
-		}
-		if !partiallyVisibleIndexNotSupported {
-			if og.randIntn(2) == 0 {
-				visibility = og.params.rng.Float64()
-			}
-		}
+		// TODO(rytaft): sometimes set visibility in range (0.0, 1.0).
 	}
 
 	def := &tree.CreateIndex{


### PR DESCRIPTION
Remove the code that generates partially visibile indexes in the `schemachange` workload until I can figure out how to make it not flaky.

Informs #102431

Release note: None