### PR TITLE
dev: delete aggressive check for bazel install

### DIFF
--- a/pkg/cmd/dev/main.go
+++ b/pkg/cmd/dev/main.go
@@ -13,7 +13,6 @@ package main
 import (
 	"log"
 	"os"
-	"os/exec"
 )
 
 const (
@@ -24,11 +23,6 @@ const (
 func main() {
 	log.SetFlags(0)
 	log.SetPrefix("")
-
-	if _, err := exec.LookPath("bazel"); err != nil {
-		log.Printf("ERROR: bazel not found in $PATH")
-		os.Exit(1)
-	}
 
 	dev := makeDevCmd()
 


### PR DESCRIPTION
This doesn't really seem necessary -- you'll get this error message at some point if we try to shell out to bazel. Not all the dev subcommands actually need bazel installed.

This can also cause failures in `dev test --stress`.

Epic: none
Release note: None