### PR TITLE
colexecdisk: close ordered synchronizer in external sort in edge case

### DIFF
--- a/pkg/sql/colexec/colexecdisk/external_sort.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort.go
@@ -193,6 +193,7 @@ type externalSorter struct {
 		acquiredFDs int
 	}
 
+	merger  colexecop.ClosableOperator
 	emitter colexecop.Operator
 
 	testingKnobs struct {
@@ -429,13 +430,19 @@ func (s *externalSorter) Next() coldata.Batch {
 				}
 				n++
 			}
-			merger := s.createMergerForPartitions(n)
-			merger.Init(s.Ctx)
+			// Store the merger in the external sort to make sure it's always
+			// closed correctly. In the happy path, it'll be closed after being
+			// exhausted in the loop below, but in case a panic is thrown (e.g.
+			// due to context cancellation), the merger will be cleaned up in
+			// Close. (In the happy path Close will be called twice on the last
+			// created merger, and that's ok because the interface allows it.)
+			s.merger = s.createMergerForPartitions(n)
+			s.merger.Init(s.Ctx)
 			s.numPartitions -= n
-			for b := merger.Next(); ; b = merger.Next() {
+			for b := s.merger.Next(); ; b = s.merger.Next() {
 				partitionDone := s.enqueue(b)
 				if b.Length() == 0 || partitionDone {
-					if err := merger.Close(s.Ctx); err != nil {
+					if err := s.merger.Close(s.Ctx); err != nil {
 						colexecerror.InternalError(err)
 					}
 					break
@@ -638,6 +645,11 @@ func (s *externalSorter) Close(ctx context.Context) error {
 	if s.partitioner != nil {
 		lastErr = s.partitioner.Close(ctx)
 		s.partitioner = nil
+	}
+	if s.merger != nil {
+		if err := s.merger.Close(ctx); err != nil {
+			lastErr = err
+		}
 	}
 	if c, ok := s.emitter.(colexecop.Closer); ok {
 		if err := c.Close(ctx); err != nil {


### PR DESCRIPTION
This commit fixes an edge case where the external sort could forget to clean up after the ordered synchronizer (the "merger") it used to merge multiple partitions on disk into one. In particular, if a panic is thrown during the merge process (e.g. due to context cancellation), we would never close the merger. This would then lead to never finishing the tracing span of the synchronizer. This is now fixed by always tracking the last created merger and closing it in `externalSort.Close` (which is always called).

Epic: None

Release note: None