### PR TITLE
release-22.2: sql: use bytes-based limiting in UPSERT

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2017,6 +2017,13 @@ func TestTenantLogic_upsert(
 	runLogicTest(t, "upsert")
 }
 
+func TestTenantLogic_upsert_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "upsert_non_metamorphic")
+}
+
 func TestTenantLogic_user(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
+++ b/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
@@ -1,0 +1,29 @@
+# LogicTest: !metamorphic
+
+# Regression test for UPSERT batching logic not respecting footprint-based
+# limiting (#102472).
+statement ok
+CREATE TABLE src (s STRING);
+CREATE TABLE dest (s STRING);
+INSERT INTO src SELECT repeat('a', 100000) FROM generate_series(1, 60)
+
+statement ok
+SET CLUSTER SETTING kv.raft.command.max_size='4MiB';
+
+statement ok
+SET CLUSTER SETTING sql.mutations.mutation_batch_byte_size='1MiB';
+
+# This statement produces a raft command of about 6 MB in size, so if the
+# batching logic is incorrect, we'll encounter "command is too large" error.
+statement ok
+UPSERT INTO dest (s) (SELECT s FROM src)
+
+statement ok
+RESET CLUSTER SETTING sql.mutations.mutation_batch_byte_size;
+
+statement ok
+RESET CLUSTER SETTING kv.raft.command.max_size;
+
+statement ok
+DROP TABLE src;
+DROP TABLE dest

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1990,6 +1990,13 @@ func TestLogic_upsert(
 	runLogicTest(t, "upsert")
 }
 
+func TestLogic_upsert_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "upsert_non_metamorphic")
+}
+
 func TestLogic_uuid(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1997,6 +1997,13 @@ func TestLogic_upsert(
 	runLogicTest(t, "upsert")
 }
 
+func TestLogic_upsert_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "upsert_non_metamorphic")
+}
+
 func TestLogic_uuid(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2011,6 +2011,13 @@ func TestLogic_upsert(
 	runLogicTest(t, "upsert")
 }
 
+func TestLogic_upsert_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "upsert_non_metamorphic")
+}
+
 func TestLogic_uuid(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1983,6 +1983,13 @@ func TestLogic_upsert(
 	runLogicTest(t, "upsert")
 }
 
+func TestLogic_upsert_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "upsert_non_metamorphic")
+}
+
 func TestLogic_uuid(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2011,6 +2011,13 @@ func TestLogic_upsert(
 	runLogicTest(t, "upsert")
 }
 
+func TestLogic_upsert_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "upsert_non_metamorphic")
+}
+
 func TestLogic_uuid(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2172,6 +2172,13 @@ func TestLogic_upsert(
 	runLogicTest(t, "upsert")
 }
 
+func TestLogic_upsert_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "upsert_non_metamorphic")
+}
+
 func TestLogic_user(
 	t *testing.T,
 ) {

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -104,7 +104,8 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 		}
 
 		// Are we done yet with the current batch?
-		if n.run.tw.currentBatchSize >= n.run.tw.maxBatchSize {
+		if n.run.tw.currentBatchSize >= n.run.tw.maxBatchSize ||
+			n.run.tw.b.ApproximateMutationBytes() >= n.run.tw.maxBatchByteSize {
 			break
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #102483.

/cc @cockroachdb/release

---

This commit fixes an oversight where we forgot to add footprint-based limiting logic (introduced in d844d8aa97cdee9f0a6fe0d43554c7495eedd306) to UPSERT operation (we added it to all other mutations). I've audited the code, and I think the only place where the footprint-based limiting behavior is still missing is the insert fast path node, but we cannot introduce it there because it relies on the assumption that only a single KV Batch is executed.

Fixes: #102472.

Release note (bug fix): Previously, CockroachDB could encounter "command is too large" error when evaluating UPSERT statements such that new values combined exceed `kv.raft.command.max_size` setting. This bug has
been present since before 21.1 version and initially all write operations (INSERT, UPDATE, DELETE) were affected; however, in 21.2 those three were fixed, but UPSERT was forgotten about.

Release justification: bug fix.