### PR TITLE
backupccl: support materialized view mutation in restore

### DIFF
--- a/pkg/ccl/backupccl/restore_schema_change_creation.go
+++ b/pkg/ccl/backupccl/restore_schema_change_creation.go
@@ -104,6 +104,9 @@ func jobDescriptionFromMutationID(
 					}
 				}
 				jobDescBuilder.WriteString(")")
+			case *descpb.DescriptorMutation_MaterializedViewRefresh:
+				jobDescBuilder.WriteString("refreshing materialized view with primary key ")
+				jobDescBuilder.WriteString(t.MaterializedViewRefresh.NewPrimaryIndex.Name)
 			default:
 				return "", 0, errors.Newf("unsupported mutation %+v, while restoring table %+v", m, tableDesc)
 			}

--- a/pkg/ccl/backupccl/testdata/backup-restore/materialized_view
+++ b/pkg/ccl/backupccl/testdata/backup-restore/materialized_view
@@ -1,0 +1,42 @@
+# We allow implicit access to non-admin users so that we can test
+# with nodelocal.
+new-cluster name=s1 allow-implicit-access
+----
+
+exec-sql
+CREATE DATABASE testdb;
+USE testdb;
+CREATE TABLE testdb.t (a int primary key, b int);
+CREATE MATERIALIZED VIEW testdb.mv AS SELECT a, b FROM testdb.t;
+INSERT INTO testdb.t (a, b) VALUES (1, 2);
+----
+
+exec-sql
+REFRESH MATERIALIZED VIEW mv;
+----
+
+exec-sql
+INSERT INTO testdb.t (a, b) VALUES (2, 3);
+----
+
+exec-sql
+REFRESH MATERIALIZED VIEW mv;
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://1/test/'
+----
+
+
+new-cluster name=s2 share-io-dir=s1 allow-implicit-access
+----
+
+exec-sql
+RESTORE DATABASE testdb FROM LATEST IN 'nodelocal://1/test/' WITH new_db_name = 'newdb';
+----
+
+query-sql
+SELECT * FROM newdb.mv;
+----
+1 2
+2 3


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/101075

Release note (bug fix): Fixed a bug that could prevent RESTORE from working if the backup had a refresh materialized view mutation in it.