### PR TITLE
status: bump goroutine stacks size limit to 512mb

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -278,6 +278,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/admission",
         "//pkg/util/admission/admissionpb",
+        "//pkg/util/allstacks",
         "//pkg/util/buildutil",
         "//pkg/util/contextutil",
         "//pkg/util/envutil",


### PR DESCRIPTION
We sometimes run into the pprof goroutine profile's internal 64MB limit[^1]
during support escalations. If we want all stacks, we want all stacks. Make it
so. (allstacks has a 512MB limit).

[^1]: https://cockroachlabs.slack.com/archives/C0159JK877C/p1682623929725279

Epic: none
Release note: None
