### PR TITLE
sql,persistedsqlstats: prevent a deadlock during shutdown

### DIFF
--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -92,14 +92,12 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 
 	flushDoneSignal := make(chan struct{})
 	defer func() {
-		statsFlush.SetFlushDoneCallback(nil)
+		statsFlush.SetFlushDoneSignalCh(nil)
 		close(flushDoneSignal)
 	}()
 
+	statsFlush.SetFlushDoneSignalCh(flushDoneSignal)
 	for {
-		statsFlush.SetFlushDoneCallback(func() {
-			flushDoneSignal <- struct{}{}
-		})
 		select {
 		case <-flushDoneSignal:
 			// A flush was done. Set the timer and wait for it to complete.

--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -66,13 +66,16 @@ var sqlStatsActivityMaxPersistedRows = settings.RegisterIntSetting(
 
 const numberOfTopColumns = 6
 
+// sqlActivityUpdateJob is responsible for translating the data in the
+// statement/txn statistics tables into the statement/txn _activity_
+// tables.
 type sqlActivityUpdateJob struct {
 	job *jobs.Job
 }
 
 // Resume implements the jobs.sqlActivityUpdateJob interface.
 // The SQL activity job runs AS a forever-running background job
-// and runs the SqlActivityUpdater according to sql.stats.activity.flush.interval.
+// and runs the sqlActivityUpdater according to sql.stats.activity.flush.interval.
 func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{}) (jobErr error) {
 	log.Infof(ctx, "starting sql stats activity flush job")
 	// The sql activity update job is a forever running background job.
@@ -85,7 +88,7 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 	stopper := execCtx.ExecCfg().DistSQLSrv.Stopper
 	settings := execCtx.ExecCfg().Settings
 	statsFlush := execCtx.ExecCfg().InternalDB.server.sqlStats
-	metrics := execCtx.ExecCfg().JobRegistry.MetricsStruct().JobSpecificMetrics[jobspb.TypeAutoUpdateSQLActivity].(ActivityUpdaterMetrics)
+	metrics := execCtx.ExecCfg().JobRegistry.MetricsStruct().JobSpecificMetrics[jobspb.TypeAutoUpdateSQLActivity].(activityUpdaterMetrics)
 
 	flushDoneSignal := make(chan struct{})
 	defer func() {
@@ -101,7 +104,7 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 		case <-flushDoneSignal:
 			// A flush was done. Set the timer and wait for it to complete.
 			if enabled.Get(&settings.SV) {
-				updater := NewSqlActivityUpdater(settings, execCtx.ExecCfg().InternalDB)
+				updater := newSqlActivityUpdater(settings, execCtx.ExecCfg().InternalDB)
 				if err := updater.TransferStatsToActivity(ctx); err != nil {
 					log.Warningf(ctx, "error running sql activity updater job: %v", err)
 					metrics.numErrors.Inc(1)
@@ -115,14 +118,14 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 	}
 }
 
-type ActivityUpdaterMetrics struct {
+type activityUpdaterMetrics struct {
 	numErrors *metric.Counter
 }
 
-func (m ActivityUpdaterMetrics) MetricStruct() {}
+func (m activityUpdaterMetrics) MetricStruct() {}
 
 func newActivityUpdaterMetrics() metric.Struct {
-	return ActivityUpdaterMetrics{
+	return activityUpdaterMetrics{
 		numErrors: metric.NewCounter(metric.Metadata{
 			Name:        "jobs.metrics.task_failed",
 			Help:        "Number of metrics sql activity updater tasks that failed",
@@ -156,20 +159,20 @@ func init() {
 	)
 }
 
-// NewSqlActivityUpdater returns a new instance of SqlActivityUpdater.
-func NewSqlActivityUpdater(setting *cluster.Settings, db isql.DB) *SqlActivityUpdater {
-	return &SqlActivityUpdater{
+// newSqlActivityUpdater returns a new instance of sqlActivityUpdater.
+func newSqlActivityUpdater(setting *cluster.Settings, db isql.DB) *sqlActivityUpdater {
+	return &sqlActivityUpdater{
 		st: setting,
 		db: db,
 	}
 }
 
-type SqlActivityUpdater struct {
+type sqlActivityUpdater struct {
 	st *cluster.Settings
 	db isql.DB
 }
 
-func (u *SqlActivityUpdater) TransferStatsToActivity(ctx context.Context) error {
+func (u *sqlActivityUpdater) TransferStatsToActivity(ctx context.Context) error {
 	// Get the config and pass it around to avoid any issue of it changing
 	// in the middle of the execution.
 	maxRowPersistedRows := sqlStatsActivityMaxPersistedRows.Get(&u.st.SV)
@@ -213,7 +216,7 @@ func (u *SqlActivityUpdater) TransferStatsToActivity(ctx context.Context) error 
 // transferAllStats is used to transfer all the stats FROM
 // system.statement_statistics and system.transaction_statistics
 // to system.statement_activity and system.transaction_activity
-func (u *SqlActivityUpdater) transferAllStats(
+func (u *sqlActivityUpdater) transferAllStats(
 	ctx context.Context,
 	aggTs time.Time,
 	totalStmtClusterExecCount int64,
@@ -326,7 +329,7 @@ INTO system.public.statement_activity (aggregated_ts, fingerprint_id, transactio
 // transferTopStats is used to transfer top N stats FROM
 // system.statement_statistics and system.transaction_statistics
 // to system.statement_activity and system.transaction_activity
-func (u *SqlActivityUpdater) transferTopStats(
+func (u *sqlActivityUpdater) transferTopStats(
 	ctx context.Context,
 	aggTs time.Time,
 	topLimit int64,
@@ -518,7 +521,7 @@ INTO system.public.statement_activity
 // system.statement_statistics and system.transaction_statistics.
 // It also gets the total execution count for the specified aggregated
 // timestamp.
-func (u *SqlActivityUpdater) getAostExecutionCount(
+func (u *sqlActivityUpdater) getAostExecutionCount(
 	ctx context.Context, aggTs time.Time,
 ) (
 	stmtRowCount int64,
@@ -561,7 +564,7 @@ func (u *SqlActivityUpdater) getAostExecutionCount(
 	return stmtRowCount, txnRowCount, totalStmtClusterExecCount, totalTxnClusterExecCount, err
 }
 
-func (u *SqlActivityUpdater) getExecutionCountFromRow(
+func (u *sqlActivityUpdater) getExecutionCountFromRow(
 	ctx context.Context, iter isql.Rows,
 ) (rowCount int64, totalExecutionCount int64, err error) {
 	ok, err := iter.Next(ctx)
@@ -583,7 +586,7 @@ func (u *SqlActivityUpdater) getExecutionCountFromRow(
 
 // ComputeAggregatedTs returns the aggregation timestamp to assign
 // in-memory SQL stats during storage or aggregation.
-func (u *SqlActivityUpdater) computeAggregatedTs(sv *settings.Values) time.Time {
+func (u *sqlActivityUpdater) computeAggregatedTs(sv *settings.Values) time.Time {
 	interval := persistedsqlstats.SQLStatsAggregationInterval.Get(sv)
 
 	now := timeutil.Now()
@@ -593,7 +596,7 @@ func (u *SqlActivityUpdater) computeAggregatedTs(sv *settings.Values) time.Time 
 
 // compactActivityTables is used delete rows FROM the activity tables
 // to keep the tables under the specified config limit.
-func (u *SqlActivityUpdater) compactActivityTables(ctx context.Context, maxRowCount int64) error {
+func (u *sqlActivityUpdater) compactActivityTables(ctx context.Context, maxRowCount int64) error {
 	rowCount, err := u.getTableRowCount(ctx, "system.statement_activity")
 	if err != nil {
 		return err
@@ -639,7 +642,7 @@ WHERE aggregated_ts not in (SELECT distinct aggregated_ts FROM system.statement_
 // system.statement_statistics and system.transaction_statistics.
 // It also gets the total execution count for the specified aggregated
 // timestamp.
-func (u *SqlActivityUpdater) getTableRowCount(
+func (u *sqlActivityUpdater) getTableRowCount(
 	ctx context.Context, tableName string,
 ) (rowCount int64, retErr error) {
 	query := fmt.Sprintf(`

--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -30,9 +30,9 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 
-// enabled the stats activity flush job.
-var enabled = settings.RegisterBoolSetting(
-	settings.SystemOnly,
+// sqlStatsActivityFlushEnabled the stats activity flush job.
+var sqlStatsActivityFlushEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.stats.activity.flush.enabled",
 	"enable the flush to the system statement and transaction activity tables",
 	true)
@@ -103,7 +103,7 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 		select {
 		case <-flushDoneSignal:
 			// A flush was done. Set the timer and wait for it to complete.
-			if enabled.Get(&settings.SV) {
+			if sqlStatsActivityFlushEnabled.Get(&settings.SV) {
 				updater := newSqlActivityUpdater(settings, execCtx.ExecCfg().InternalDB)
 				if err := updater.TransferStatsToActivity(ctx); err != nil {
 					log.Warningf(ctx, "error running sql activity updater job: %v", err)

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -93,7 +93,7 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 
 	execCfg := srv.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
-	updater := NewSqlActivityUpdater(st, execCfg.InternalDB)
+	updater := newSqlActivityUpdater(st, execCfg.InternalDB)
 
 	// Transient failures from AOST queries: https://github.com/cockroachdb/cockroach/issues/97840
 	testutils.SucceedsWithin(t, func() error {
@@ -238,7 +238,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	updater := NewSqlActivityUpdater(st, execCfg.InternalDB)
+	updater := newSqlActivityUpdater(st, execCfg.InternalDB)
 
 	appNamePrefix := "TestSqlActivityUpdateJobLoop"
 	// Generate 100 unique rows for statistics tables

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// Flush flushes in-memory sql stats into system table. Any errors encountered
+// Flush flushes in-memory sql stats into a system table. Any errors encountered
 // during the flush will be logged as warning.
 func (s *PersistedSQLStats) Flush(ctx context.Context) {
 	now := s.getTimeNow()

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -68,7 +68,7 @@ type PersistedSQLStats struct {
 	// exceeded.
 	memoryPressureSignal chan struct{}
 
-	// Use the signal the flush completed.
+	// Used to signal the flush completed.
 	flushDoneCallback func()
 	flushMutex        syncutil.Mutex
 
@@ -173,7 +173,7 @@ func (s *PersistedSQLStats) startSQLStatsFlushLoop(ctx context.Context, stopper 
 			case <-s.memoryPressureSignal:
 				// We are experiencing memory pressure, so we flush SQL stats to disk
 				// immediately, rather than waiting the full flush interval, in an
-				// attempt to relieve some of that pressure
+				// attempt to relieve some of that pressure.
 			case <-resetIntervalChanged:
 				// In this case, we would restart the loop without performing any flush
 				// and recalculate the flush interval in the for-loop's post statement.


### PR DESCRIPTION
Fixes #102574.

Prior to this change, the coordination between the stats flusher
task (an async stopper task) and the activity flusher job was
performed using a two-step process:

- the stats persistence task offered to call a callback _function_
  every time a flush would complete.
- the job would _reconfigure the callback function_ on each iteration.
- the function was writing to a channel that was subsequently
  read by the job iteration body.

This approach was defective in 3 ways:

1. if the job iteration body would exit (e.g. due to a server drain)
   *after* it installed the callback fn, but *before* the stats flusher
   would read and call the callback fn, a window of time existed
   where a deadlock could occur:
   - the stats flusher retrieves the pointer to the caller fn
     but doesn't call it yet.
   - the job loop exits. From then on it will not read from the
     channel any more.
   - the stats flusher attempts to write to the channel.
     A deadlock occurs.

   (This was seen during testing. See https://github.com/cockroachdb/cockroach/issues/102574)

   The fix here is to always jointly `select` the write to the channel
   and also a read from the drain/stopper signals, to abort the
   channel operation if a shutdown is requested.

2. the stats flusher task was holding the mutex locked while
   performing the channel write. This is generally bad code hygiene
   as it forces the code maintainer to double-check whether the lock
   and channel operations don't mutually interlock.

   The fix is to use the mutex to retrieve the channel reference, and
   then write to the channel while the mutex is not held any more.

3. the API between the two was defining a *callback function* where
   really just a notification channel was needed.

   The fix here is to simplify the API.

Release note: None