### PR TITLE
c2c: skip and deflake a few unit tests

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -625,6 +625,7 @@ func TestTenantStreamingDeleteRange(t *testing.T) {
 func TestTenantStreamingMultipleNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 86206)
 
 	skip.UnderRace(t, "takes too long with multiple nodes")
 

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -159,6 +159,7 @@ func (f *pgConnReplicationFeedSource) Error() error {
 
 // startReplication starts replication stream, specified as query and its args.
 func startReplication(
+	ctx context.Context,
 	t *testing.T,
 	r *replicationtestutils.ReplicationHelper,
 	codecFactory eventDecoderFactory,
@@ -173,7 +174,7 @@ func startReplication(
 	pgxConfig, err := pgx.ParseConfig(sink.String())
 	require.NoError(t, err)
 
-	queryCtx, cancel := context.WithCancel(context.Background())
+	queryCtx, cancel := context.WithCancel(ctx)
 	conn, err := pgx.ConnectConfig(queryCtx, pgxConfig)
 	require.NoError(t, err)
 
@@ -358,7 +359,7 @@ USE d;
 
 	t.Run("stream-table-cursor-error", func(t *testing.T) {
 		skip.WithIssue(t, 102286)
-		_, feed := startReplication(t, h, makePartitionStreamDecoder,
+		_, feed := startReplication(ctx, t, h, makePartitionStreamDecoder,
 			streamPartitionQuery, streamID, encodeSpec(t, h, srcTenant, initialScanTimestamp, hlc.Timestamp{}, "t2"))
 		defer feed.Close(ctx)
 
@@ -385,7 +386,7 @@ USE d;
 	})
 
 	t.Run("stream-table", func(t *testing.T) {
-		_, feed := startReplication(t, h, makePartitionStreamDecoder,
+		_, feed := startReplication(ctx, t, h, makePartitionStreamDecoder,
 			streamPartitionQuery, streamID, encodeSpec(t, h, srcTenant, initialScanTimestamp,
 				hlc.Timestamp{}, "t1"))
 		defer feed.Close(ctx)
@@ -415,7 +416,7 @@ USE d;
 		srcTenant.SQL.Exec(t, `UPDATE d.t1 SET a = 'привет' WHERE i = 42`)
 		srcTenant.SQL.Exec(t, `UPDATE d.t1 SET b = 'мир' WHERE i = 42`)
 
-		_, feed := startReplication(t, h, makePartitionStreamDecoder,
+		_, feed := startReplication(ctx, t, h, makePartitionStreamDecoder,
 			streamPartitionQuery, streamID, encodeSpec(t, h, srcTenant, initialScanTimestamp,
 				beforeUpdateTS, "t1"))
 		defer feed.Close(ctx)
@@ -452,7 +453,7 @@ CREATE TABLE t3(
 		// Add few rows.
 		addRows(0, 10)
 
-		source, feed := startReplication(t, h, makePartitionStreamDecoder,
+		source, feed := startReplication(ctx, t, h, makePartitionStreamDecoder,
 			streamPartitionQuery, streamID, encodeSpec(t, h, srcTenant, initialScanTimestamp,
 				hlc.Timestamp{}, "t1"))
 		defer feed.Close(ctx)
@@ -479,7 +480,6 @@ CREATE TABLE t3(
 func TestStreamAddSSTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 102523)
 	h, cleanup := replicationtestutils.NewReplicationHelper(t, base.TestServerArgs{
 		// Test hangs when run within the default test tenant. Tracked with
 		// #76378.
@@ -528,7 +528,7 @@ USE d;
 		if addSSTableBeforeRangefeed {
 			srcTenant.SQL.Exec(t, fmt.Sprintf("IMPORT INTO %s CSV DATA ($1)", table), dataSrv.URL)
 		}
-		source, feed := startReplication(t, h, makePartitionStreamDecoder,
+		source, feed := startReplication(ctx, t, h, makePartitionStreamDecoder,
 			streamPartitionQuery, streamID, encodeSpec(t, h, srcTenant, initialScanTimestamp,
 				previousHighWater, table))
 		defer feed.Close(ctx)
@@ -681,7 +681,7 @@ USE d;
 
 	const streamPartitionQuery = `SELECT * FROM crdb_internal.stream_partition($1, $2)`
 	// Only subscribe to table t1 and t2, not t3.
-	source, feed := startReplication(t, h, makePartitionStreamDecoder,
+	source, feed := startReplication(ctx, t, h, makePartitionStreamDecoder,
 		streamPartitionQuery, streamID, encodeSpec(t, h, srcTenant, initialScanTimestamp,
 			hlc.Timestamp{}, "t1", "t2"))
 	defer feed.Close(ctx)

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -357,6 +357,7 @@ USE d;
 	t2Descr := desctestutils.TestingGetPublicTableDescriptor(h.SysServer.DB(), srcTenant.Codec, "d", "t2")
 
 	t.Run("stream-table-cursor-error", func(t *testing.T) {
+		skip.WithIssue(t, 102286)
 		_, feed := startReplication(t, h, makePartitionStreamDecoder,
 			streamPartitionQuery, streamID, encodeSpec(t, h, srcTenant, initialScanTimestamp, hlc.Timestamp{}, "t2"))
 		defer feed.Close(ctx)
@@ -478,6 +479,7 @@ CREATE TABLE t3(
 func TestStreamAddSSTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 102523)
 	h, cleanup := replicationtestutils.NewReplicationHelper(t, base.TestServerArgs{
 		// Test hangs when run within the default test tenant. Tracked with
 		// #76378.

--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -58,8 +58,6 @@ func interestingGoroutines() map[int64]string {
 			strings.Contains(stack, "sentry-go.(*HTTPTransport).worker") ||
 			// Ignore the opensensus worker, which is created by the event exporter.
 			strings.Contains(stack, "go.opencensus.io/stats/view.(*worker).start") ||
-			// Ignore pgconn which creates a goroutine to do an async cleanup.
-			strings.Contains(stack, "github.com/jackc/pgconn.(*PgConn).asyncClose.func1") ||
 			// Seems to be gccgo specific.
 			(runtime.Compiler == "gccgo" && strings.Contains(stack, "testing.T.Parallel")) ||
 			// Ignore intentionally long-running logging goroutines that live for the


### PR DESCRIPTION
c2c: skip a few unit tests
Informs #102523
Informs #102286
Informs #86206

Release note: none

c2c: close pgconn with correct context in test infra
When a user opens a pgx connection, they pass it a context that must be used to
close the connection, else pgx's contextWatcher will run indefinetly on a
seperate goroutine.  Previously, the `startReplication()` test helper was
initializing its own context to open pgx connection, and did not pass this
context back to the caller, and consequently, the user would close the
connection with the incorrect context, leading to a leaky goroutine.

This patch allows the user to pass a context in the startReplication(),
preventing the user from closing the connection with the wrong goroutine.

Fixes https://github.com/cockroachdb/cockroach/issues/102523

Release note: None