### PR TITLE
sql/stats: collect automatic table statistics on the system.jobs table

### DIFF
--- a/pkg/jobs/utils.go
+++ b/pkg/jobs/utils.go
@@ -59,7 +59,7 @@ func RunningJobExists(
 SELECT
   id
 FROM
-  system.jobs@jobs_status_created_idx
+  system.jobs
 WHERE
 	job_type IN ` + typeStrs + ` AND
   status IN ` + NonTerminalStatusTupleString + `

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -568,7 +568,7 @@ FROM
 		AS OF SYSTEM TIME '-%s'
 WHERE
 	tbl.database_name IS NOT NULL
-	AND tbl.table_id NOT IN (%d, %d, %d, %d)  -- excluded system tables
+	AND tbl.table_id NOT IN (%d, %d, %d)  -- excluded system tables
 	AND tbl.drop_time IS NULL
 	AND (
 			crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', d.descriptor, false)->'table'->>'viewQuery'
@@ -652,7 +652,7 @@ func (r *Refresher) ensureAllTables(
 	getAllTablesQuery := fmt.Sprintf(
 		getAllTablesTemplateSQL,
 		initialTableCollectionDelay,
-		keys.TableStatisticsTableID, keys.LeaseTableID, keys.JobsTableID, keys.ScheduledJobsTableID,
+		keys.TableStatisticsTableID, keys.LeaseTableID, keys.ScheduledJobsTableID,
 		autoStatsPredicate, systemTablesPredicate,
 	)
 	r.getApplicableTables(ctx, getAllTablesQuery,

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -201,8 +201,8 @@ func TestEnsureAllTablesQueries(t *testing.T) {
 	require.NoError(t, cache.Start(ctx, keys.SystemSQLCodec, s.RangeFeedFactory().(*rangefeed.Factory)))
 	r := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */)
 
-	// Exclude the 4 system tables which don't use autostats.
-	systemTablesWithStats := bootstrap.NumSystemTablesForSystemTenant - 4
+	// Exclude the 3 system tables which don't use autostats.
+	systemTablesWithStats := bootstrap.NumSystemTablesForSystemTenant - 3
 	numUserTablesWithStats := 2
 
 	// This now includes 36 system tables as well as the 2 created above.
@@ -280,7 +280,7 @@ func checkAllTablesCount(ctx context.Context, systemTables bool, expected int, r
 	getAllTablesQuery := fmt.Sprintf(
 		getAllTablesTemplateSQL,
 		collectionDelay,
-		keys.TableStatisticsTableID, keys.LeaseTableID, keys.JobsTableID, keys.ScheduledJobsTableID,
+		keys.TableStatisticsTableID, keys.LeaseTableID, keys.ScheduledJobsTableID,
 		autoStatsEnabledOrNotSpecifiedPredicate, systemTablesPredicate,
 	)
 	r.getApplicableTables(ctx, getAllTablesQuery,
@@ -297,7 +297,7 @@ func checkExplicitlyEnabledTablesCount(ctx context.Context, expected int, r *Ref
 	getTablesWithAutoStatsExplicitlyEnabledQuery := fmt.Sprintf(
 		getAllTablesTemplateSQL,
 		collectionDelay,
-		keys.TableStatisticsTableID, keys.LeaseTableID, keys.JobsTableID, keys.ScheduledJobsTableID,
+		keys.TableStatisticsTableID, keys.LeaseTableID, keys.ScheduledJobsTableID,
 		explicitlyEnabledTablesPredicate, autoStatsOnSystemTablesEnabledPredicate,
 	)
 	r.getApplicableTables(ctx, getTablesWithAutoStatsExplicitlyEnabledQuery,


### PR DESCRIPTION
Fixes #102213

Release note (performance improvement): We now automatically collect table statistics on the `system.jobs` table, which will enable the optimizer to produce better query plans for internal queries that access the `system.jobs` table. This may result in better performance of the system.