### PR TITLE
sql/schemachanger: use oneof for protobufs to reduce memory usage

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
@@ -310,7 +310,7 @@ func pkChangeMutationExists(desc catalog.TableDescriptor) bool {
 	// a primary index.
 	if desc.GetDeclarativeSchemaChangerState() != nil {
 		for idx, target := range desc.GetDeclarativeSchemaChangerState().Targets {
-			if target.PrimaryIndex != nil &&
+			if target.GetPrimaryIndex() != nil &&
 				desc.GetDeclarativeSchemaChangerState().CurrentStatuses[idx] != scpb.Status_PUBLIC {
 				return true
 			}

--- a/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
@@ -23,6 +23,21 @@ ElementState:
 - Database:
     databaseId: 104
   Status: PUBLIC
+- DatabaseComment:
+    comment: multi region db is good
+    databaseId: 104
+  Status: PUBLIC
+- DatabaseData:
+    databaseId: 104
+  Status: PUBLIC
+- DatabaseRegionConfig:
+    databaseId: 104
+    regionEnumTypeId: 106
+  Status: PUBLIC
+- DatabaseRoleSetting:
+    databaseId: 104
+    roleName: __placeholder_role_name__
+  Status: PUBLIC
 - Namespace:
     databaseId: 0
     descriptorId: 104
@@ -51,36 +66,12 @@ ElementState:
     userName: public
     withGrantOption: "0"
   Status: PUBLIC
-- DatabaseRegionConfig:
-    databaseId: 104
-    regionEnumTypeId: 106
-  Status: PUBLIC
-- DatabaseRoleSetting:
-    databaseId: 104
-    roleName: __placeholder_role_name__
-  Status: PUBLIC
-- DatabaseComment:
-    comment: multi region db is good
-    databaseId: 104
-  Status: PUBLIC
-- DatabaseData:
-    databaseId: 104
-  Status: PUBLIC
 
 decompose
 table_global
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
-    tableId: 110
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 110
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -121,29 +112,18 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 110
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
+- ColumnDefaultExpression:
+    columnId: 2
+    expr: unique_rowid()
+    referencedColumnIds: []
     tableId: 110
-    temporaryIndexId: 0
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
   Status: PUBLIC
-- TableZoneConfig:
-    tableId: 110
-  Status: PUBLIC
-- TableData:
-    databaseId: 104
-    tableId: 110
-  Status: PUBLIC
-- TableLocalityGlobal:
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 110
   Status: PUBLIC
 - ColumnName:
@@ -166,6 +146,11 @@ ElementState:
     name: crdb_internal_mvcc_timestamp
     tableId: 110
   Status: PUBLIC
+- ColumnNotNull:
+    columnId: 2
+    indexIdForValidation: 0
+    tableId: 110
+  Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
     columnId: 1
@@ -274,25 +259,6 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnDefaultExpression:
-    columnId: 2
-    expr: unique_rowid()
-    referencedColumnIds: []
-    tableId: 110
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- ColumnNotNull:
-    columnId: 2
-    indexIdForValidation: 0
-    tableId: 110
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: table_global_pkey
-    tableId: 110
-  Status: PUBLIC
 - IndexColumn:
     columnId: 1
     direction: ASC
@@ -317,6 +283,11 @@ ElementState:
     indexId: 1
     tableId: 110
   Status: PUBLIC
+- IndexName:
+    indexId: 1
+    name: table_global_pkey
+    tableId: 110
+  Status: PUBLIC
 - Namespace:
     databaseId: 104
     descriptorId: 110
@@ -326,6 +297,39 @@ ElementState:
 - Owner:
     descriptorId: 110
     owner: root
+  Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 110
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 110
+    schemaId: 105
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 110
+  Status: PUBLIC
+- TableData:
+    databaseId: 104
+    tableId: 110
+  Status: PUBLIC
+- TableLocalityGlobal:
+    tableId: 110
+  Status: PUBLIC
+- TableZoneConfig:
+    tableId: 110
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 110
@@ -339,25 +343,12 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 110
-    schemaId: 105
-  Status: PUBLIC
 
 decompose
 table_regional_by_table
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
-    tableId: 109
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 109
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -398,31 +389,18 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 109
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
+- ColumnDefaultExpression:
+    columnId: 2
+    expr: unique_rowid()
+    referencedColumnIds: []
     tableId: 109
-    temporaryIndexId: 0
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
   Status: PUBLIC
-- TableZoneConfig:
-    tableId: 109
-  Status: PUBLIC
-- TableData:
-    databaseId: 104
-    tableId: 109
-  Status: PUBLIC
-- TableLocalitySecondaryRegion:
-    regionEnumTypeId: 106
-    regionName: us-east2
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 109
   Status: PUBLIC
 - ColumnName:
@@ -443,6 +421,11 @@ ElementState:
 - ColumnName:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
+    tableId: 109
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 2
+    indexIdForValidation: 0
     tableId: 109
   Status: PUBLIC
 - ColumnType:
@@ -553,25 +536,6 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnDefaultExpression:
-    columnId: 2
-    expr: unique_rowid()
-    referencedColumnIds: []
-    tableId: 109
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- ColumnNotNull:
-    columnId: 2
-    indexIdForValidation: 0
-    tableId: 109
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: table_regional_by_table_pkey
-    tableId: 109
-  Status: PUBLIC
 - IndexColumn:
     columnId: 1
     direction: ASC
@@ -596,6 +560,11 @@ ElementState:
     indexId: 1
     tableId: 109
   Status: PUBLIC
+- IndexName:
+    indexId: 1
+    name: table_regional_by_table_pkey
+    tableId: 109
+  Status: PUBLIC
 - Namespace:
     databaseId: 104
     descriptorId: 109
@@ -605,6 +574,41 @@ ElementState:
 - Owner:
     descriptorId: 109
     owner: root
+  Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 109
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 109
+    schemaId: 105
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 109
+  Status: PUBLIC
+- TableData:
+    databaseId: 104
+    tableId: 109
+  Status: PUBLIC
+- TableLocalitySecondaryRegion:
+    regionEnumTypeId: 106
+    regionName: us-east2
+    tableId: 109
+  Status: PUBLIC
+- TableZoneConfig:
+    tableId: 109
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 109
@@ -618,25 +622,12 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 109
-    schemaId: 105
-  Status: PUBLIC
 
 decompose
 table_regional_by_row
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
-    tableId: 108
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 108
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -687,52 +678,26 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 108
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
-    tableId: 108
-    temporaryIndexId: 0
-  Status: PUBLIC
-- TableComment:
-    comment: regional by row is good
+- ColumnComment:
+    columnId: 1
+    comment: k is good
+    pgAttributeNum: 1
     tableId: 108
   Status: PUBLIC
-- TableZoneConfig:
+- ColumnDefaultExpression:
+    columnId: 3
+    expr: default_to_database_primary_region(gateway_region())::@100106
+    referencedColumnIds: []
     tableId: 108
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds:
+    - 106
+    - 107
   Status: PUBLIC
-- IndexZoneConfig:
-    indexId: 1
-    partitionName: us-east1
-    tableId: 108
-  Status: PUBLIC
-- IndexZoneConfig:
-    indexId: 1
-    partitionName: us-east2
-    tableId: 108
-  Status: PUBLIC
-- IndexZoneConfig:
-    indexId: 1
-    partitionName: us-east3
-    tableId: 108
-  Status: PUBLIC
-- TableData:
-    databaseId: 104
-    tableId: 108
-  Status: PUBLIC
-- TablePartitioning:
-    tableId: 108
-  Status: PUBLIC
-- TableLocalityRegionalByRow:
-    as: ""
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 108
   Status: PUBLIC
 - ColumnName:
@@ -758,6 +723,16 @@ ElementState:
 - ColumnName:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
+    tableId: 108
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 1
+    indexIdForValidation: 0
+    tableId: 108
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 3
+    indexIdForValidation: 0
     tableId: 108
   Status: PUBLIC
 - ColumnType:
@@ -898,31 +873,43 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnDefaultExpression:
-    columnId: 3
-    expr: default_to_database_primary_region(gateway_region())::@100106
-    referencedColumnIds: []
-    tableId: 108
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds:
-    - 106
-    - 107
-  Status: PUBLIC
-- ColumnComment:
+- IndexColumn:
     columnId: 1
-    comment: k is good
-    pgAttributeNum: 1
+    direction: ASC
+    implicit: false
+    indexId: 1
+    invertedKind: 0
+    kind: KEY
+    ordinalInKind: 1
     tableId: 108
   Status: PUBLIC
-- ColumnNotNull:
-    columnId: 1
-    indexIdForValidation: 0
+- IndexColumn:
+    columnId: 2
+    direction: ASC
+    implicit: false
+    indexId: 1
+    invertedKind: 0
+    kind: STORED
+    ordinalInKind: 0
     tableId: 108
   Status: PUBLIC
-- ColumnNotNull:
+- IndexColumn:
     columnId: 3
-    indexIdForValidation: 0
+    direction: ASC
+    implicit: true
+    indexId: 1
+    invertedKind: 0
+    kind: KEY
+    ordinalInKind: 0
+    tableId: 108
+  Status: PUBLIC
+- IndexComment:
+    comment: pkey is good
+    indexId: 1
+    tableId: 108
+  Status: PUBLIC
+- IndexData:
+    indexId: 1
     tableId: 108
   Status: PUBLIC
 - IndexName:
@@ -963,43 +950,19 @@ ElementState:
       range: []
     tableId: 108
   Status: PUBLIC
-- IndexComment:
-    comment: pkey is good
+- IndexZoneConfig:
     indexId: 1
+    partitionName: us-east1
     tableId: 108
   Status: PUBLIC
-- IndexColumn:
-    columnId: 1
-    direction: ASC
-    implicit: false
+- IndexZoneConfig:
     indexId: 1
-    invertedKind: 0
-    kind: KEY
-    ordinalInKind: 1
+    partitionName: us-east2
     tableId: 108
   Status: PUBLIC
-- IndexColumn:
-    columnId: 2
-    direction: ASC
-    implicit: false
+- IndexZoneConfig:
     indexId: 1
-    invertedKind: 0
-    kind: STORED
-    ordinalInKind: 0
-    tableId: 108
-  Status: PUBLIC
-- IndexColumn:
-    columnId: 3
-    direction: ASC
-    implicit: true
-    indexId: 1
-    invertedKind: 0
-    kind: KEY
-    ordinalInKind: 0
-    tableId: 108
-  Status: PUBLIC
-- IndexData:
-    indexId: 1
+    partitionName: us-east3
     tableId: 108
   Status: PUBLIC
 - Namespace:
@@ -1012,6 +975,47 @@ ElementState:
     descriptorId: 108
     owner: root
   Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 108
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 108
+    schemaId: 105
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 108
+  Status: PUBLIC
+- TableComment:
+    comment: regional by row is good
+    tableId: 108
+  Status: PUBLIC
+- TableData:
+    databaseId: 104
+    tableId: 108
+  Status: PUBLIC
+- TableLocalityRegionalByRow:
+    as: ""
+    tableId: 108
+  Status: PUBLIC
+- TablePartitioning:
+    tableId: 108
+  Status: PUBLIC
+- TableZoneConfig:
+    tableId: 108
+  Status: PUBLIC
 - UserPrivileges:
     descriptorId: 108
     privileges: "2"
@@ -1023,10 +1027,6 @@ ElementState:
     privileges: "2"
     userName: root
     withGrantOption: "2"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 108
-    schemaId: 105
   Status: PUBLIC
 
 decompose
@@ -1041,6 +1041,21 @@ ElementState:
     isMultiRegion: true
     typeId: 106
   Status: PUBLIC
+- EnumTypeValue:
+    logicalRepresentation: us-east1
+    physicalRepresentation: QA==
+    typeId: 106
+  Status: PUBLIC
+- EnumTypeValue:
+    logicalRepresentation: us-east2
+    physicalRepresentation: gA==
+    typeId: 106
+  Status: PUBLIC
+- EnumTypeValue:
+    logicalRepresentation: us-east3
+    physicalRepresentation: wA==
+    typeId: 106
+  Status: PUBLIC
 - Namespace:
     databaseId: 104
     descriptorId: 106
@@ -1050,6 +1065,10 @@ ElementState:
 - Owner:
     descriptorId: 106
     owner: root
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 106
+    schemaId: 105
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 106
@@ -1068,23 +1087,4 @@ ElementState:
     privileges: "512"
     userName: public
     withGrantOption: "0"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 106
-    schemaId: 105
-  Status: PUBLIC
-- EnumTypeValue:
-    logicalRepresentation: us-east1
-    physicalRepresentation: QA==
-    typeId: 106
-  Status: PUBLIC
-- EnumTypeValue:
-    logicalRepresentation: us-east2
-    physicalRepresentation: gA==
-    typeId: 106
-  Status: PUBLIC
-- EnumTypeValue:
-    logicalRepresentation: us-east3
-    physicalRepresentation: wA==
-    typeId: 106
   Status: PUBLIC

--- a/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
@@ -29,15 +29,6 @@ table_implicit
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
-    tableId: 104
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: fam_0_pk_a_j
-    tableId: 104
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -88,43 +79,15 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 104
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
-    tableId: 104
-    temporaryIndexId: 0
-  Status: PUBLIC
-- SecondaryIndex:
-    constraintId: 0
-    embeddedExpr: null
-    geoConfig: null
-    indexId: 2
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: true
-    isNotVisible: false
-    isUnique: false
-    sharding: null
-    sourceIndexId: 0
-    tableId: 104
-    temporaryIndexId: 0
-  Status: PUBLIC
-- TableComment:
-    comment: implicit partitioning is good
+- ColumnComment:
+    columnId: 2
+    comment: a is good
+    pgAttributeNum: 2
     tableId: 104
   Status: PUBLIC
-- TableData:
-    databaseId: 100
+- ColumnFamily:
+    familyId: 0
+    name: fam_0_pk_a_j
     tableId: 104
   Status: PUBLIC
 - ColumnName:
@@ -150,6 +113,16 @@ ElementState:
 - ColumnName:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
+    tableId: 104
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 1
+    indexIdForValidation: 0
+    tableId: 104
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 2
+    indexIdForValidation: 0
     tableId: 104
   Status: PUBLIC
 - ColumnType:
@@ -287,71 +260,6 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnComment:
-    columnId: 2
-    comment: a is good
-    pgAttributeNum: 2
-    tableId: 104
-  Status: PUBLIC
-- ColumnNotNull:
-    columnId: 1
-    indexIdForValidation: 0
-    tableId: 104
-  Status: PUBLIC
-- ColumnNotNull:
-    columnId: 2
-    indexIdForValidation: 0
-    tableId: 104
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: table_implicit_pkey
-    tableId: 104
-  Status: PUBLIC
-- IndexName:
-    indexId: 2
-    name: table_implicit_j_idx
-    tableId: 104
-  Status: PUBLIC
-- IndexPartitioning:
-    indexId: 1
-    partitioning:
-      list:
-      - name: pk_implicit
-        subpartitioning:
-          list: []
-          numColumns: 0
-          numImplicitColumns: 0
-          range: []
-        values:
-        - AwI=
-      numColumns: 1
-      numImplicitColumns: 1
-      range: []
-    tableId: 104
-  Status: PUBLIC
-- IndexPartitioning:
-    indexId: 2
-    partitioning:
-      list:
-      - name: j_implicit
-        subpartitioning:
-          list: []
-          numColumns: 0
-          numImplicitColumns: 0
-          range: []
-        values:
-        - Awo=
-      numColumns: 1
-      numImplicitColumns: 1
-      range: []
-    tableId: 104
-  Status: PUBLIC
-- IndexComment:
-    comment: pkey is good
-    indexId: 1
-    tableId: 104
-  Status: PUBLIC
 - IndexColumn:
     columnId: 1
     direction: ASC
@@ -412,12 +320,61 @@ ElementState:
     ordinalInKind: 1
     tableId: 104
   Status: PUBLIC
+- IndexComment:
+    comment: pkey is good
+    indexId: 1
+    tableId: 104
+  Status: PUBLIC
 - IndexData:
     indexId: 1
     tableId: 104
   Status: PUBLIC
 - IndexData:
     indexId: 2
+    tableId: 104
+  Status: PUBLIC
+- IndexName:
+    indexId: 1
+    name: table_implicit_pkey
+    tableId: 104
+  Status: PUBLIC
+- IndexName:
+    indexId: 2
+    name: table_implicit_j_idx
+    tableId: 104
+  Status: PUBLIC
+- IndexPartitioning:
+    indexId: 1
+    partitioning:
+      list:
+      - name: pk_implicit
+        subpartitioning:
+          list: []
+          numColumns: 0
+          numImplicitColumns: 0
+          range: []
+        values:
+        - AwI=
+      numColumns: 1
+      numImplicitColumns: 1
+      range: []
+    tableId: 104
+  Status: PUBLIC
+- IndexPartitioning:
+    indexId: 2
+    partitioning:
+      list:
+      - name: j_implicit
+        subpartitioning:
+          list: []
+          numColumns: 0
+          numImplicitColumns: 0
+          range: []
+        values:
+        - Awo=
+      numColumns: 1
+      numImplicitColumns: 1
+      range: []
     tableId: 104
   Status: PUBLIC
 - Namespace:
@@ -429,6 +386,53 @@ ElementState:
 - Owner:
     descriptorId: 104
     owner: root
+  Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 104
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 104
+    schemaId: 101
+  Status: PUBLIC
+- SecondaryIndex:
+    constraintId: 0
+    embeddedExpr: null
+    geoConfig: null
+    indexId: 2
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: true
+    isNotVisible: false
+    isUnique: false
+    sharding: null
+    sourceIndexId: 0
+    tableId: 104
+    temporaryIndexId: 0
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 104
+  Status: PUBLIC
+- TableComment:
+    comment: implicit partitioning is good
+    tableId: 104
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 104
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 104
@@ -442,25 +446,12 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 104
-    schemaId: 101
-  Status: PUBLIC
 
 decompose
 table_partitioned_index
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
-    tableId: 105
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 105
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -501,39 +492,9 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 105
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 2
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
-    tableId: 105
-    temporaryIndexId: 0
-  Status: PUBLIC
-- SecondaryIndex:
-    constraintId: 1
-    embeddedExpr: null
-    geoConfig: null
-    indexId: 2
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
-    tableId: 105
-    temporaryIndexId: 0
-  Status: PUBLIC
-- TableData:
-    databaseId: 100
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 105
   Status: PUBLIC
 - ColumnName:
@@ -554,6 +515,11 @@ ElementState:
 - ColumnName:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
+    tableId: 105
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 1
+    indexIdForValidation: 0
     tableId: 105
   Status: PUBLIC
 - ColumnType:
@@ -664,38 +630,6 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnNotNull:
-    columnId: 1
-    indexIdForValidation: 0
-    tableId: 105
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: table_partitioned_index_pkey
-    tableId: 105
-  Status: PUBLIC
-- IndexName:
-    indexId: 2
-    name: table_partitioned_index_b_key
-    tableId: 105
-  Status: PUBLIC
-- IndexPartitioning:
-    indexId: 2
-    partitioning:
-      list:
-      - name: p1
-        subpartitioning:
-          list: []
-          numColumns: 0
-          numImplicitColumns: 0
-          range: []
-        values:
-        - AwI=
-      numColumns: 1
-      numImplicitColumns: 0
-      range: []
-    tableId: 105
-  Status: PUBLIC
 - IndexColumn:
     columnId: 1
     direction: ASC
@@ -744,6 +678,33 @@ ElementState:
     indexId: 2
     tableId: 105
   Status: PUBLIC
+- IndexName:
+    indexId: 1
+    name: table_partitioned_index_pkey
+    tableId: 105
+  Status: PUBLIC
+- IndexName:
+    indexId: 2
+    name: table_partitioned_index_b_key
+    tableId: 105
+  Status: PUBLIC
+- IndexPartitioning:
+    indexId: 2
+    partitioning:
+      list:
+      - name: p1
+        subpartitioning:
+          list: []
+          numColumns: 0
+          numImplicitColumns: 0
+          range: []
+        values:
+        - AwI=
+      numColumns: 1
+      numImplicitColumns: 0
+      range: []
+    tableId: 105
+  Status: PUBLIC
 - Namespace:
     databaseId: 100
     descriptorId: 105
@@ -753,6 +714,49 @@ ElementState:
 - Owner:
     descriptorId: 105
     owner: root
+  Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 2
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 105
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 105
+    schemaId: 101
+  Status: PUBLIC
+- SecondaryIndex:
+    constraintId: 1
+    embeddedExpr: null
+    geoConfig: null
+    indexId: 2
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 105
+    temporaryIndexId: 0
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 105
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 105
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 105
@@ -765,8 +769,4 @@ ElementState:
     privileges: "2"
     userName: root
     withGrantOption: "2"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 105
-    schemaId: 101
   Status: PUBLIC

--- a/pkg/cli/testdata/declarative-rules/deprules
+++ b/pkg/cli/testdata/declarative-rules/deprules
@@ -299,7 +299,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - toAbsent($constraint-name-Target, $constraint-Target)
     - $constraint-name-Node[CurrentStatus] = ABSENT
@@ -312,7 +312,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - transient($constraint-name-Target, $constraint-Target)
     - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -325,7 +325,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - $constraint-name-Target[TargetStatus] = TRANSIENT_ABSENT
     - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -339,7 +339,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - $constraint-name-Target[TargetStatus] = ABSENT
     - $constraint-name-Node[CurrentStatus] = ABSENT
@@ -352,7 +352,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - toAbsent($constraint-Target, $constraint-name-Target)
@@ -365,7 +365,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - transient($constraint-Target, $constraint-name-Target)
@@ -378,7 +378,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -392,7 +392,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = ABSENT
@@ -1645,8 +1645,8 @@ deprules
   kind: Precedence
   to: parent-descriptor-Node
   query:
-    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaParent', '*scpb.SchemaChild']
-    - $parent-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaChild', '*scpb.SchemaParent']
+    - $parent-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinReferencedDescID($back-reference-in-parent-descriptor, $parent-descriptor, $desc-id)
     - toAbsent($back-reference-in-parent-descriptor-Target, $parent-descriptor-Target)
     - $back-reference-in-parent-descriptor-Node[CurrentStatus] = ABSENT
@@ -1658,7 +1658,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - toAbsent($column-constraint-Target, $column-Target)
@@ -1671,7 +1671,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - transient($column-constraint-Target, $column-Target)
@@ -1684,7 +1684,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - $column-constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -1698,7 +1698,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - $column-constraint-Target[TargetStatus] = ABSENT
@@ -1712,7 +1712,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - ToPublicOrTransient($dependent-Target, $column-Target)
@@ -1726,7 +1726,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - ToPublicOrTransient($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = DELETE_ONLY
@@ -1794,7 +1794,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - toAbsent($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -1807,7 +1807,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - transient($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -1820,7 +1820,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -1834,7 +1834,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = ABSENT
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -1901,7 +1901,7 @@ deprules
   to: complex-constraint-Node
   query:
     - $dependent[Type] = '*scpb.ConstraintComment'
-    - $complex-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $complex-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependent, $complex-constraint, $table-id, $constraint-id)
     - ToPublicOrTransient($dependent-Target, $complex-constraint-Target)
     - $dependent-Node[CurrentStatus] = PUBLIC
@@ -1913,7 +1913,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - toAbsent($constraint-Target, $dependent-Target)
@@ -1926,7 +1926,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - transient($constraint-Target, $dependent-Target)
@@ -1939,7 +1939,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -1953,7 +1953,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = ABSENT
@@ -1967,8 +1967,8 @@ deprules
   kind: Precedence
   to: referenced-descriptor-Node
   query:
-    - $cross-desc-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
-    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $cross-desc-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinReferencedDescID($cross-desc-constraint, $referenced-descriptor, $desc-id)
     - toAbsent($cross-desc-constraint-Target, $referenced-descriptor-Target)
     - $cross-desc-constraint-Node[CurrentStatus] = ABSENT
@@ -1980,8 +1980,8 @@ deprules
   kind: Precedence
   to: referencing-descriptor-Node
   query:
-    - $cross-desc-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
-    - $referencing-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $cross-desc-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
+    - $referencing-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($cross-desc-constraint, $referencing-descriptor, $desc-id)
     - toAbsent($cross-desc-constraint-Target, $referencing-descriptor-Target)
     - $cross-desc-constraint-Node[CurrentStatus] = ABSENT
@@ -2101,8 +2101,8 @@ deprules
   kind: Precedence
   to: relation-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TableData', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.IndexData', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
-    - $relation[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexData', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableData', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $relation[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($dependent, $relation, $relation-id)
     - ToPublicOrTransient($dependent-Target, $relation-Target)
     - $dependent-Node[CurrentStatus] = PUBLIC
@@ -2114,7 +2114,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - toAbsent($dependent-Target, $column-Target)
@@ -2127,7 +2127,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - transient($dependent-Target, $column-Target)
@@ -2140,7 +2140,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2154,7 +2154,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -2169,7 +2169,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -2182,7 +2182,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -2195,7 +2195,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -2209,7 +2209,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -2222,7 +2222,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - toAbsent($dependent-Target, $index-Target)
@@ -2235,7 +2235,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - transient($dependent-Target, $index-Target)
@@ -2248,7 +2248,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2262,7 +2262,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -2277,7 +2277,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -2290,7 +2290,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -2303,7 +2303,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -2317,7 +2317,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -2330,7 +2330,7 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-type-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.EnumType']
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
     - $referencing-via-type[Type] = '*scpb.ColumnType'
@@ -2344,8 +2344,8 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-attr-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaComment', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $referencing-via-attr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaComment', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - toAbsent($referenced-descriptor-Target, $referencing-via-attr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
@@ -2360,7 +2360,7 @@ deprules
     - $referenced-descriptor[Type] = '*scpb.Sequence'
     - $referenced-descriptor[DescID] = $seqID
     - $referencing-via-expr[ReferencedSequenceIDs] CONTAINS $seqID
-    - $referencing-via-expr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial', '*scpb.FunctionParamDefaultExpression']
+    - $referencing-via-expr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.FunctionParamDefaultExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-expr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-expr-Node[CurrentStatus] = ABSENT
@@ -2374,7 +2374,7 @@ deprules
     - $referenced-descriptor[Type] = '*scpb.Function'
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-function[ReferencedFunctionIDs] CONTAINS $fromDescID
-    - $referencing-via-function[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial', '*scpb.FunctionParamDefaultExpression']
+    - $referencing-via-function[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.FunctionParamDefaultExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-function-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-function-Node[CurrentStatus] = ABSENT
@@ -2385,11 +2385,11 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-type-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.EnumType']
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
     - descriptorIsNotBeingDropped-23.1($referencing-via-type)
-    - $referencing-via-type[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial', '*scpb.FunctionParamDefaultExpression']
+    - $referencing-via-type[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.FunctionParamDefaultExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-type-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-type-Node[CurrentStatus] = ABSENT
@@ -2400,8 +2400,8 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $dependent[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinOnDescID($descriptor, $dependent, $desc-id)
     - toAbsent($descriptor-Target, $dependent-Target)
     - $descriptor-Node[CurrentStatus] = DROPPED
@@ -2413,7 +2413,7 @@ deprules
   kind: PreviousStagePrecedence
   to: absent-Node
   query:
-    - $dropped[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $dropped[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $dropped[DescID] = $_
     - $dropped[Self] = $absent
     - toAbsent($dropped-Target, $absent-Target)
@@ -2426,8 +2426,8 @@ deprules
   kind: SameStagePrecedence
   to: back-reference-in-parent-descriptor-Node
   query:
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaParent', '*scpb.SchemaChild']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaChild', '*scpb.SchemaParent']
     - joinOnDescID($descriptor, $back-reference-in-parent-descriptor, $desc-id)
     - toAbsent($descriptor-Target, $back-reference-in-parent-descriptor-Target)
     - $descriptor-Node[CurrentStatus] = DROPPED
@@ -2439,8 +2439,8 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $relation[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TableData', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.IndexData', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
+    - $relation[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexData', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableData', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinOnDescID($relation, $dependent, $relation-id)
     - ToPublicOrTransient($relation-Target, $dependent-Target)
     - $relation-Node[CurrentStatus] = DESCRIPTOR_ADDED
@@ -2452,7 +2452,7 @@ deprules
   kind: SameStagePrecedence
   to: data-Node
   query:
-    - $database[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $database[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $data[Type] = '*scpb.DatabaseData'
     - joinOnDescID($database, $data, $db-id)
     - toAbsent($database-Target, $data-Target)
@@ -2507,7 +2507,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - ToPublicOrTransient($dependent-Target, $index-Target)
@@ -2575,7 +2575,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = BACKFILL_ONLY
@@ -2588,7 +2588,7 @@ deprules
   to: constraint-Node
   query:
     - $index[Type] = '*scpb.PrimaryIndex'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnDescID($index, $constraint, $table-id)
     - $index[IndexID] = $index-id-for-validation
     - $constraint[IndexID] = $index-id-for-validation
@@ -2603,7 +2603,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - toAbsent($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = VALIDATED
@@ -2616,7 +2616,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - transient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -2629,7 +2629,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = TRANSIENT_ABSENT
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -2643,7 +2643,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = ABSENT
     - $index-Node[CurrentStatus] = VALIDATED
@@ -2852,8 +2852,8 @@ deprules
   kind: Precedence
   to: descriptor-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($dependent, $descriptor, $desc-id)
     - toAbsent($dependent-Target, $descriptor-Target)
     - $dependent-Node[CurrentStatus] = ABSENT
@@ -3127,8 +3127,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - toAbsent($data-a-Target, $data-b-Target)
@@ -3141,8 +3141,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - transient($data-a-Target, $data-b-Target)
@@ -3155,8 +3155,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - $data-a-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -3170,8 +3170,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - $data-a-Target[TargetStatus] = ABSENT
@@ -3393,7 +3393,7 @@ deprules
   to: dependent-Node
   query:
     - $simple-constraint[Type] = '*scpb.ColumnNotNull'
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($simple-constraint, $dependent, $table-id, $constraint-id)
     - ToPublicOrTransient($simple-constraint-Target, $dependent-Target)
     - $simple-constraint-Node[CurrentStatus] = PUBLIC
@@ -3405,7 +3405,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $simple-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $simple-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($simple-constraint, $constraint-name, $table-id, $constraint-id)
     - ToPublicOrTransient($simple-constraint-Target, $constraint-name-Target)
@@ -3432,7 +3432,7 @@ deprules
   kind: SameStagePrecedence
   to: data-Node
   query:
-    - $table[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $table[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $data[Type] = '*scpb.TableData'
     - joinOnDescID($table, $data, $table-id)
     - toAbsent($table-Target, $data-Target)
@@ -3459,7 +3459,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] = '*scpb.TemporaryIndex'
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = DELETE_ONLY

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -1041,11 +1041,11 @@ func FindTargetIndexNameByID(desc TableDescriptor, indexID descpb.IndexID) (stri
 	// them.
 	if scState := desc.GetDeclarativeSchemaChangerState(); scState != nil {
 		for _, target := range scState.Targets {
-			if target.IndexName != nil &&
+			if indexName := target.GetIndexName(); indexName != nil &&
 				target.TargetStatus == scpb.Status_PUBLIC &&
-				target.IndexName.TableID == desc.GetID() &&
-				target.IndexName.IndexID == indexID {
-				return target.IndexName.Name, nil
+				indexName.TableID == desc.GetID() &&
+				indexName.IndexID == indexID {
+				return indexName.Name, nil
 			}
 		}
 	}

--- a/pkg/sql/schemachanger/rel/schema.go
+++ b/pkg/sql/schemachanger/rel/schema.go
@@ -215,7 +215,7 @@ func (sb *schemaBuilder) maybeAddTypeMapping(
 	for _, am := range attributeMappings {
 		for _, sel := range am.selectors {
 			fieldInfos = append(fieldInfos,
-				sb.addTypeAttrMapping(am.a, t, sel))
+				sb.addTypeAttrMapping(am.a, t, sel, am.selectorTypes, am.isOneOfElement)...)
 		}
 	}
 	sort.Slice(fieldInfos, func(i, j int) bool {
@@ -269,146 +269,183 @@ func makeFieldFlags(t reflect.Type) (fieldFlags, bool) {
 	return f, true
 }
 
-func (sb *schemaBuilder) addTypeAttrMapping(a Attr, t reflect.Type, sel string) fieldInfo {
-	offset, cur := getOffsetAndTypeFromSelector(t, sel)
-
-	flags, ok := makeFieldFlags(cur)
-	if !ok {
-		panic(errors.Errorf(
-			"selector %q of %v has unsupported type %v",
-			sel, t, cur,
-		))
-	}
-	typ := cur
-	if flags.isPtr() && flags.isScalar() {
-		typ = cur.Elem()
-	}
-	var ord ordinal
-	var sliceMemberType reflect.Type
-	if !flags.isSlice() {
-		ord = sb.maybeAddAttribute(a, typ)
+func (sb *schemaBuilder) addTypeAttrMapping(
+	a Attr, t reflect.Type, sel string, selOneOfTypes []reflect.Type, isOneOf bool,
+) (fields []fieldInfo) {
+	var offset uintptr
+	var oneOfType reflect.Type
+	if isOneOf {
+		offset, oneOfType = getOffsetAndTypeFromSelector(t, sel)
 	} else {
-		// We need to add the slice type and then return, or
-		// perhaps, add some annotation to the type that this
-		// is a slice, and it refers to xyz.
-		sb.maybeInitializeSliceMemberAttributes()
-		// Give the generated struct a field name based on the attribute name.
-		// We could use something generic like "Value" for all value fields of
-		// such structs, but this makes debugging a tad easier because you can
-		// look at the field names of the type in the debugger.
-		fieldName := "F_" + a.String()
-		sliceMemberType = makeSliceMemberType(t, typ, fieldName)
-		st := sb.maybeAddTypeMapping(sliceMemberType, []attrMapping{
-			{a: sliceSource, selectors: []string{"Source"}},
-			{a: sliceIndex, selectors: []string{"Index"}},
-			{a: a, selectors: []string{fieldName}},
-		})
-		st.isSliceMemberType = true
-		ord = sb.attrToOrdinal[a]
-		sb.sliceOrdinals = sb.sliceOrdinals.add(ord)
-		st.sliceAttr = ord
-	}
-
-	f := fieldInfo{
-		fieldFlags:      flags,
-		path:            sel,
-		attr:            ord,
-		typ:             typ,
-		sliceMemberType: sliceMemberType,
-	}
-	makeValueGetter := func(t reflect.Type, offset uintptr) func(u unsafe.Pointer) reflect.Value {
-		return func(u unsafe.Pointer) reflect.Value {
-			return reflect.NewAt(t, unsafe.Pointer(uintptr(u)+offset))
+		if len(selOneOfTypes) > 0 {
+			panic("selector type are only allowed for one of attributes.")
 		}
+		var cur reflect.Type
+		offset, cur = getOffsetAndTypeFromSelector(t, sel)
+		selOneOfTypes = []reflect.Type{cur}
 	}
-	getPtrValue := func(vg func(pointer unsafe.Pointer) reflect.Value) func(u unsafe.Pointer) interface{} {
-		return func(u unsafe.Pointer) interface{} {
-			got := vg(u)
-			if got.Elem().IsNil() {
-				return nil
-			}
-			return got.Elem().Interface()
+	for _, cur := range selOneOfTypes {
+		// For one of types, extract the value inside.
+		castType := cur
+		if isOneOf {
+			cur = cur.Elem().Field(0).Type
 		}
-	}
-	{
-		vg := makeValueGetter(cur, offset)
-		if f.isPtr() && f.isStruct() {
-			f.value = getPtrValue(vg)
-		} else if f.isSlice() {
-			f.value = func(u unsafe.Pointer) interface{} {
-				got := vg(u)
-				ge := got.Elem()
-				if ge.IsNil() || ge.Len() == 0 {
-					return nil
-				}
-				return ge.Interface()
-			}
-		} else if f.isPtr() && f.isScalar() {
-			f.value = func(u unsafe.Pointer) interface{} {
-				got := vg(u)
-				ge := got.Elem()
-				if ge.IsNil() {
-					return nil
-				}
-				return ge.Elem().Interface()
-			}
+		flags, ok := makeFieldFlags(cur)
+		if !ok {
+			panic(errors.Errorf(
+				"selector %q of %v has unsupported type %v",
+				sel, t, cur,
+			))
+		}
+		typ := cur
+		if flags.isPtr() && flags.isScalar() {
+			typ = cur.Elem()
+		}
+		var ord ordinal
+		var sliceMemberType reflect.Type
+		if !flags.isSlice() {
+			ord = sb.maybeAddAttribute(a, typ)
 		} else {
-			f.value = func(u unsafe.Pointer) interface{} {
-				return vg(u).Elem().Interface()
+			// We need to add the slice type and then return, or
+			// perhaps, add some annotation to the type that this
+			// is a slice, and it refers to xyz.
+			sb.maybeInitializeSliceMemberAttributes()
+			// Give the generated struct a field name based on the attribute name.
+			// We could use something generic like "Value" for all value fields of
+			// such structs, but this makes debugging a tad easier because you can
+			// look at the field names of the type in the debugger.
+			fieldName := "F_" + a.String()
+			sliceMemberType = makeSliceMemberType(t, typ, fieldName)
+			st := sb.maybeAddTypeMapping(sliceMemberType, []attrMapping{
+				{a: sliceSource, selectors: []string{"Source"}},
+				{a: sliceIndex, selectors: []string{"Index"}},
+				{a: a, selectors: []string{fieldName}},
+			})
+			st.isSliceMemberType = true
+			ord = sb.attrToOrdinal[a]
+			sb.sliceOrdinals = sb.sliceOrdinals.add(ord)
+			st.sliceAttr = ord
+		}
+		f := fieldInfo{
+			fieldFlags:      flags,
+			path:            sel,
+			attr:            ord,
+			typ:             typ,
+			sliceMemberType: sliceMemberType,
+		}
+		makeValueGetter := func(t reflect.Type, offset uintptr) func(u unsafe.Pointer) reflect.Value {
+			return func(u unsafe.Pointer) reflect.Value {
+				if !isOneOf {
+					return reflect.NewAt(t, unsafe.Pointer(uintptr(u)+offset))
+				} else {
+					oneOfValue := reflect.NewAt(oneOfType, unsafe.Pointer(uintptr(u)+offset))
+					innerElement := oneOfValue.Elem().Elem()
+					if innerElement.Type() == castType {
+						return innerElement.Elem().Field(0)
+					}
+					return reflect.Zero(cur)
+				}
 			}
 		}
-		switch {
-		case f.isSlice():
-			// f.inline is not defined
-		case f.isPtr() && f.isInt():
-			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+		getPtrValue := func(vg func(pointer unsafe.Pointer) reflect.Value) func(u unsafe.Pointer) interface{} {
+			return func(u unsafe.Pointer) interface{} {
 				got := vg(u)
-				if got.Elem().IsNil() {
-					return 0, false
+				// Methods will return direct references without any indirection.
+				if isOneOf {
+					if got.IsNil() {
+						return nil
+					}
+					return got.Interface()
+				} else {
+					// Otherwise, we will have the pointer wrapped in another pointer.
+					if got.Elem().IsNil() {
+						return nil
+					}
+					return got.Elem().Interface()
 				}
-				return uintptr(got.Elem().Elem().Int()), true
-			}
-		case f.isPtr() && f.isUint():
-			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
-				got := vg(u)
-				if got.Elem().IsNil() {
-					return 0, false
-				}
-				return uintptr(got.Elem().Elem().Uint()), true
-			}
-		case f.isInt():
-			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
-				return uintptr(vg(u).Elem().Int()), true
-			}
-		case f.isUint():
-			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
-				return uintptr(vg(u).Elem().Uint()), true
-			}
-		case f.isString(), f.isStruct():
-			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
-				return 0, false
 			}
 		}
-	}
-	{
-		if f.isStruct() {
-			f.comparableValue = getPtrValue(makeValueGetter(cur, offset))
-		} else if !f.isSlice() {
-			compType := getComparableType(typ)
-			if f.isPtr() && f.isScalar() {
-				compType = reflect.PtrTo(compType)
-			}
-			vg := makeValueGetter(compType, offset)
-			if f.isPtr() && f.isScalar() {
-				f.comparableValue = getPtrValue(vg)
+		{
+			vg := makeValueGetter(cur, offset)
+			if f.isPtr() && f.isStruct() {
+				f.value = getPtrValue(vg)
+			} else if f.isSlice() {
+				f.value = func(u unsafe.Pointer) interface{} {
+					got := vg(u)
+					ge := got.Elem()
+					if ge.IsNil() || ge.Len() == 0 {
+						return nil
+					}
+					return ge.Interface()
+				}
+			} else if f.isPtr() && f.isScalar() {
+				f.value = func(u unsafe.Pointer) interface{} {
+					got := vg(u)
+					ge := got.Elem()
+					if ge.IsNil() {
+						return nil
+					}
+					return ge.Elem().Interface()
+				}
 			} else {
-				f.comparableValue = func(u unsafe.Pointer) interface{} {
-					return vg(u).Interface()
+				f.value = func(u unsafe.Pointer) interface{} {
+					return vg(u).Elem().Interface()
+				}
+			}
+			switch {
+			case f.isSlice():
+				// f.inline is not defined
+			case f.isPtr() && f.isInt():
+				f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+					got := vg(u)
+					if got.Elem().IsNil() {
+						return 0, false
+					}
+					return uintptr(got.Elem().Elem().Int()), true
+				}
+			case f.isPtr() && f.isUint():
+				f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+					got := vg(u)
+					if got.Elem().IsNil() {
+						return 0, false
+					}
+					return uintptr(got.Elem().Elem().Uint()), true
+				}
+			case f.isInt():
+				f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+					return uintptr(vg(u).Elem().Int()), true
+				}
+			case f.isUint():
+				f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+					return uintptr(vg(u).Elem().Uint()), true
+				}
+			case f.isString(), f.isStruct():
+				f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+					return 0, false
 				}
 			}
 		}
+		{
+			if f.isStruct() {
+				f.comparableValue = getPtrValue(makeValueGetter(cur, offset))
+			} else if !f.isSlice() {
+				compType := getComparableType(typ)
+				if f.isPtr() && f.isScalar() {
+					compType = reflect.PtrTo(compType)
+				}
+				vg := makeValueGetter(compType, offset)
+				if f.isPtr() && f.isScalar() {
+					f.comparableValue = getPtrValue(vg)
+				} else {
+					f.comparableValue = func(u unsafe.Pointer) interface{} {
+						return vg(u).Interface()
+					}
+				}
+			}
+		}
+		fields = append(fields, f)
 	}
-	return f
+	return fields
 }
 
 // getOffsetAndTypeFromSelector takes an entity (struct pointer) type and a

--- a/pkg/sql/schemachanger/rel/schema_mappings.go
+++ b/pkg/sql/schemachanger/rel/schema_mappings.go
@@ -42,6 +42,13 @@ func EntityAttr(a Attr, selectors ...string) EntityMappingOption {
 	return attrMapping{a: a, selectors: selectors}
 }
 
+// EntityAttrOneOf defines a mapping of selector[s] to Attr for an entity.
+// The entity is a one of, so the selector covers all possible types of the
+// one of under the same name.
+func EntityAttrOneOf(a Attr, selector string, selectorTypes ...reflect.Type) EntityMappingOption {
+	return attrMapping{a: a, selectors: []string{selector}, selectorTypes: selectorTypes, isOneOfElement: true}
+}
+
 // schemaMappings defines how to map data types to Attr.
 type schemaMappings struct {
 
@@ -91,8 +98,10 @@ func (t entityMapping) apply(mappings *schemaMappings) {
 // attrMapping is used in mappings to describe how attributes are mapped to
 // struct fields as part of an entityMapping.
 type attrMapping struct {
-	a         Attr
-	selectors []string
+	a              Attr
+	selectors      []string
+	selectorTypes  []reflect.Type
+	isOneOfElement bool
 }
 
 func (a attrMapping) apply(tm *entityMapping) {

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -305,13 +305,13 @@ func TestBuildIsMemoryMonitored(t *testing.T) {
 		math.MaxInt64, /* noteworthy */
 		cluster.MakeTestingClusterSettings(),
 	)
-	monitor.Start(ctx, nil, mon.NewStandaloneBudget(1.049e+7 /* 10MiB */))
+	monitor.Start(ctx, nil, mon.NewStandaloneBudget(5*1024*1024 /* 5MiB */))
 	memAcc := monitor.MakeBoundAccount()
 	sctestutils.WithBuilderDependenciesFromTestServer(s, func(dependencies scbuild.Dependencies) {
 		stmt, err := parser.ParseOne(`DROP DATABASE defaultdb CASCADE`)
 		require.NoError(t, err)
 		_, err = scbuild.Build(ctx, dependencies, scpb.CurrentState{}, stmt.AST, &memAcc)
-		require.Regexp(t, `test-sc-build-mon: memory budget exceeded: .*`, err.Error())
+		require.ErrorContainsf(t, err, `test-sc-build-mon: memory budget exceeded:`, "got a memory usage of: %d", memAcc.Allocated())
 	})
 
 }

--- a/pkg/sql/schemachanger/scdecomp/testdata/function
+++ b/pkg/sql/schemachanger/scdecomp/testdata/function
@@ -71,44 +71,6 @@ ElementState:
         visibleType: 0
         width: 64
   Status: PUBLIC
-- Owner:
-    descriptorId: 110
-    owner: root
-  Status: PUBLIC
-- UserPrivileges:
-    descriptorId: 110
-    privileges: "2"
-    userName: admin
-    withGrantOption: "2"
-  Status: PUBLIC
-- UserPrivileges:
-    descriptorId: 110
-    privileges: "2"
-    userName: root
-    withGrantOption: "2"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 110
-    schemaId: 101
-  Status: PUBLIC
-- FunctionName:
-    functionId: 110
-    name: f
-  Status: PUBLIC
-- FunctionVolatility:
-    functionId: 110
-    volatility:
-      volatility: VOLATILE
-  Status: PUBLIC
-- FunctionLeakProof:
-    functionId: 110
-    leakProof: false
-  Status: PUBLIC
-- FunctionNullInputBehavior:
-    functionId: 110
-    nullInputBehavior:
-      nullInputBehavior: CALLED_ON_NULL_INPUT
-  Status: PUBLIC
 - FunctionBody:
     body: |-
       SELECT a FROM defaultdb.public.t;
@@ -141,4 +103,42 @@ ElementState:
     - columnIds:
       - 1
       viewId: 107
+  Status: PUBLIC
+- FunctionLeakProof:
+    functionId: 110
+    leakProof: false
+  Status: PUBLIC
+- FunctionName:
+    functionId: 110
+    name: f
+  Status: PUBLIC
+- FunctionNullInputBehavior:
+    functionId: 110
+    nullInputBehavior:
+      nullInputBehavior: CALLED_ON_NULL_INPUT
+  Status: PUBLIC
+- FunctionVolatility:
+    functionId: 110
+    volatility:
+      volatility: VOLATILE
+  Status: PUBLIC
+- Owner:
+    descriptorId: 110
+    owner: root
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 110
+    schemaId: 101
+  Status: PUBLIC
+- UserPrivileges:
+    descriptorId: 110
+    privileges: "2"
+    userName: admin
+    withGrantOption: "2"
+  Status: PUBLIC
+- UserPrivileges:
+    descriptorId: 110
+    privileges: "2"
+    userName: root
+    withGrantOption: "2"
   Status: PUBLIC

--- a/pkg/sql/schemachanger/scdecomp/testdata/other
+++ b/pkg/sql/schemachanger/scdecomp/testdata/other
@@ -28,12 +28,6 @@ sc1
 ----
 BackReferencedIDs:
 ElementState:
-- Schema:
-    isPublic: false
-    isTemporary: false
-    isVirtual: false
-    schemaId: 106
-  Status: PUBLIC
 - Namespace:
     databaseId: 104
     descriptorId: 106
@@ -43,6 +37,20 @@ ElementState:
 - Owner:
     descriptorId: 106
     owner: root
+  Status: PUBLIC
+- Schema:
+    isPublic: false
+    isTemporary: false
+    isVirtual: false
+    schemaId: 106
+  Status: PUBLIC
+- SchemaComment:
+    comment: sc1 is good
+    schemaId: 106
+  Status: PUBLIC
+- SchemaParent:
+    parentDatabaseId: 104
+    schemaId: 106
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 106
@@ -56,26 +64,12 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaParent:
-    parentDatabaseId: 104
-    schemaId: 106
-  Status: PUBLIC
-- SchemaComment:
-    comment: sc1 is good
-    schemaId: 106
-  Status: PUBLIC
 
 decompose
 public
 ----
 BackReferencedIDs:
 ElementState:
-- Schema:
-    isPublic: true
-    isTemporary: false
-    isVirtual: false
-    schemaId: 105
-  Status: PUBLIC
 - Namespace:
     databaseId: 104
     descriptorId: 105
@@ -85,6 +79,16 @@ ElementState:
 - Owner:
     descriptorId: 105
     owner: admin
+  Status: PUBLIC
+- Schema:
+    isPublic: true
+    isTemporary: false
+    isVirtual: false
+    schemaId: 105
+  Status: PUBLIC
+- SchemaParent:
+    parentDatabaseId: 104
+    schemaId: 105
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 105
@@ -104,10 +108,6 @@ ElementState:
     userName: public
     withGrantOption: "0"
   Status: PUBLIC
-- SchemaParent:
-    parentDatabaseId: 104
-    schemaId: 105
-  Status: PUBLIC
 
 decompose
 db1
@@ -118,6 +118,17 @@ BackReferencedIDs:
 ElementState:
 - Database:
     databaseId: 104
+  Status: PUBLIC
+- DatabaseComment:
+    comment: db1 is good
+    databaseId: 104
+  Status: PUBLIC
+- DatabaseData:
+    databaseId: 104
+  Status: PUBLIC
+- DatabaseRoleSetting:
+    databaseId: 104
+    roleName: __placeholder_role_name__
   Status: PUBLIC
 - Namespace:
     databaseId: 0
@@ -147,17 +158,6 @@ ElementState:
     userName: public
     withGrantOption: "0"
   Status: PUBLIC
-- DatabaseRoleSetting:
-    databaseId: 104
-    roleName: __placeholder_role_name__
-  Status: PUBLIC
-- DatabaseComment:
-    comment: db1 is good
-    databaseId: 104
-  Status: PUBLIC
-- DatabaseData:
-    databaseId: 104
-  Status: PUBLIC
 
 decompose
 typ
@@ -170,6 +170,11 @@ ElementState:
     isMultiRegion: false
     typeId: 110
   Status: PUBLIC
+- EnumTypeValue:
+    logicalRepresentation: a
+    physicalRepresentation: gA==
+    typeId: 110
+  Status: PUBLIC
 - Namespace:
     databaseId: 104
     descriptorId: 110
@@ -179,6 +184,10 @@ ElementState:
 - Owner:
     descriptorId: 110
     owner: root
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 110
+    schemaId: 106
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 110
@@ -198,15 +207,6 @@ ElementState:
     userName: public
     withGrantOption: "0"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 110
-    schemaId: 106
-  Status: PUBLIC
-- EnumTypeValue:
-    logicalRepresentation: a
-    physicalRepresentation: gA==
-    typeId: 110
-  Status: PUBLIC
 
 decompose
 v1
@@ -214,19 +214,6 @@ v1
 BackReferencedIDs:
   - 113
 ElementState:
-- View:
-    forwardReferences:
-    - columnIds:
-      - 1
-      indexId: 0
-      toId: 109
-    isMaterialized: false
-    isTemporary: false
-    usesRelationIds:
-    - 109
-    usesTypeIds: []
-    viewId: 112
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -363,6 +350,10 @@ ElementState:
     descriptorId: 112
     owner: root
   Status: PUBLIC
+- SchemaChild:
+    childObjectId: 112
+    schemaId: 106
+  Status: PUBLIC
 - UserPrivileges:
     descriptorId: 112
     privileges: "2"
@@ -375,9 +366,18 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 112
-    schemaId: 106
+- View:
+    forwardReferences:
+    - columnIds:
+      - 1
+      indexId: 0
+      toId: 109
+    isMaterialized: false
+    isTemporary: false
+    usesRelationIds:
+    - 109
+    usesTypeIds: []
+    viewId: 112
   Status: PUBLIC
 
 decompose
@@ -385,21 +385,6 @@ v2
 ----
 BackReferencedIDs:
 ElementState:
-- View:
-    forwardReferences:
-    - columnIds:
-      - 1
-      indexId: 0
-      toId: 112
-    isMaterialized: false
-    isTemporary: false
-    usesRelationIds:
-    - 112
-    usesTypeIds:
-    - 110
-    - 111
-    viewId: 113
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -578,6 +563,10 @@ ElementState:
     descriptorId: 113
     owner: root
   Status: PUBLIC
+- SchemaChild:
+    childObjectId: 113
+    schemaId: 106
+  Status: PUBLIC
 - UserPrivileges:
     descriptorId: 113
     privileges: "2"
@@ -590,7 +579,18 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 113
-    schemaId: 106
+- View:
+    forwardReferences:
+    - columnIds:
+      - 1
+      indexId: 0
+      toId: 112
+    isMaterialized: false
+    isTemporary: false
+    usesRelationIds:
+    - 112
+    usesTypeIds:
+    - 110
+    - 111
+    viewId: 113
   Status: PUBLIC

--- a/pkg/sql/schemachanger/scdecomp/testdata/sequence
+++ b/pkg/sql/schemachanger/scdecomp/testdata/sequence
@@ -15,14 +15,6 @@ seq
 BackReferencedIDs:
   - 105
 ElementState:
-- Sequence:
-    isTemporary: false
-    sequenceId: 104
-  Status: PUBLIC
-- TableData:
-    databaseId: 100
-    tableId: 104
-  Status: PUBLIC
 - Namespace:
     databaseId: 100
     descriptorId: 104
@@ -32,6 +24,18 @@ ElementState:
 - Owner:
     descriptorId: 104
     owner: root
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 104
+    schemaId: 101
+  Status: PUBLIC
+- Sequence:
+    isTemporary: false
+    sequenceId: 104
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 104
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 104
@@ -44,10 +48,6 @@ ElementState:
     privileges: "2"
     userName: root
     withGrantOption: "2"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 104
-    schemaId: 101
   Status: PUBLIC
 
 setup
@@ -60,14 +60,6 @@ otherseq
 BackReferencedIDs:
   - 105
 ElementState:
-- Sequence:
-    isTemporary: false
-    sequenceId: 106
-  Status: PUBLIC
-- TableData:
-    databaseId: 100
-    tableId: 106
-  Status: PUBLIC
 - Namespace:
     databaseId: 100
     descriptorId: 106
@@ -77,6 +69,18 @@ ElementState:
 - Owner:
     descriptorId: 106
     owner: root
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 106
+    schemaId: 101
+  Status: PUBLIC
+- Sequence:
+    isTemporary: false
+    sequenceId: 106
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 106
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 106
@@ -90,25 +94,12 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 106
-    schemaId: 101
-  Status: PUBLIC
 
 decompose
 tbl
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
-    tableId: 105
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 105
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -149,27 +140,25 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 105
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
-    tableId: 105
-    temporaryIndexId: 0
-  Status: PUBLIC
-- TableComment:
-    comment: tbl is good table
+- ColumnComment:
+    columnId: 1
+    comment: id is a identifier
+    pgAttributeNum: 1
     tableId: 105
   Status: PUBLIC
-- TableData:
-    databaseId: 100
+- ColumnDefaultExpression:
+    columnId: 2
+    expr: nextval(104:::REGCLASS)
+    referencedColumnIds: []
+    tableId: 105
+    usesFunctionIds: []
+    usesSequenceIds:
+    - 104
+    usesTypeIds: []
+  Status: PUBLIC
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 105
   Status: PUBLIC
 - ColumnName:
@@ -191,6 +180,20 @@ ElementState:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
     tableId: 105
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 1
+    indexIdForValidation: 0
+    tableId: 105
+  Status: PUBLIC
+- ColumnOnUpdateExpression:
+    columnId: 2
+    expr: 123:::INT8
+    referencedColumnIds: []
+    tableId: 105
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
@@ -300,51 +303,6 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnDefaultExpression:
-    columnId: 2
-    expr: nextval(104:::REGCLASS)
-    referencedColumnIds: []
-    tableId: 105
-    usesFunctionIds: []
-    usesSequenceIds:
-    - 104
-    usesTypeIds: []
-  Status: PUBLIC
-- ColumnOnUpdateExpression:
-    columnId: 2
-    expr: 123:::INT8
-    referencedColumnIds: []
-    tableId: 105
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- SequenceOwner:
-    columnId: 2
-    sequenceId: 106
-    tableId: 105
-  Status: PUBLIC
-- ColumnComment:
-    columnId: 1
-    comment: id is a identifier
-    pgAttributeNum: 1
-    tableId: 105
-  Status: PUBLIC
-- ColumnNotNull:
-    columnId: 1
-    indexIdForValidation: 0
-    tableId: 105
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: tbl_pkey
-    tableId: 105
-  Status: PUBLIC
-- IndexComment:
-    comment: tbl_pkey is a primary key
-    indexId: 1
-    tableId: 105
-  Status: PUBLIC
 - IndexColumn:
     columnId: 1
     direction: ASC
@@ -365,8 +323,18 @@ ElementState:
     ordinalInKind: 0
     tableId: 105
   Status: PUBLIC
+- IndexComment:
+    comment: tbl_pkey is a primary key
+    indexId: 1
+    tableId: 105
+  Status: PUBLIC
 - IndexData:
     indexId: 1
+    tableId: 105
+  Status: PUBLIC
+- IndexName:
+    indexId: 1
+    name: tbl_pkey
     tableId: 105
   Status: PUBLIC
 - Namespace:
@@ -379,6 +347,42 @@ ElementState:
     descriptorId: 105
     owner: root
   Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 105
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 105
+    schemaId: 101
+  Status: PUBLIC
+- SequenceOwner:
+    columnId: 2
+    sequenceId: 106
+    tableId: 105
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 105
+  Status: PUBLIC
+- TableComment:
+    comment: tbl is good table
+    tableId: 105
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 105
+  Status: PUBLIC
 - UserPrivileges:
     descriptorId: 105
     privileges: "2"
@@ -390,10 +394,6 @@ ElementState:
     privileges: "2"
     userName: root
     withGrantOption: "2"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 105
-    schemaId: 101
   Status: PUBLIC
 
 setup
@@ -407,15 +407,6 @@ tbl
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
-    tableId: 105
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 105
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -456,27 +447,15 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 105
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
-    tableId: 105
-    temporaryIndexId: 0
-  Status: PUBLIC
-- TableComment:
-    comment: tbl is good table
+- ColumnComment:
+    columnId: 1
+    comment: id is a identifier
+    pgAttributeNum: 1
     tableId: 105
   Status: PUBLIC
-- TableData:
-    databaseId: 100
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 105
   Status: PUBLIC
 - ColumnName:
@@ -497,6 +476,11 @@ ElementState:
 - ColumnName:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
+    tableId: 105
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 1
+    indexIdForValidation: 0
     tableId: 105
   Status: PUBLIC
 - ColumnType:
@@ -607,27 +591,6 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnComment:
-    columnId: 1
-    comment: id is a identifier
-    pgAttributeNum: 1
-    tableId: 105
-  Status: PUBLIC
-- ColumnNotNull:
-    columnId: 1
-    indexIdForValidation: 0
-    tableId: 105
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: tbl_pkey
-    tableId: 105
-  Status: PUBLIC
-- IndexComment:
-    comment: tbl_pkey is a primary key
-    indexId: 1
-    tableId: 105
-  Status: PUBLIC
 - IndexColumn:
     columnId: 1
     direction: ASC
@@ -648,8 +611,18 @@ ElementState:
     ordinalInKind: 0
     tableId: 105
   Status: PUBLIC
+- IndexComment:
+    comment: tbl_pkey is a primary key
+    indexId: 1
+    tableId: 105
+  Status: PUBLIC
 - IndexData:
     indexId: 1
+    tableId: 105
+  Status: PUBLIC
+- IndexName:
+    indexId: 1
+    name: tbl_pkey
     tableId: 105
   Status: PUBLIC
 - Namespace:
@@ -662,6 +635,37 @@ ElementState:
     descriptorId: 105
     owner: root
   Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 105
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 105
+    schemaId: 101
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 105
+  Status: PUBLIC
+- TableComment:
+    comment: tbl is good table
+    tableId: 105
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 105
+  Status: PUBLIC
 - UserPrivileges:
     descriptorId: 105
     privileges: "2"
@@ -674,24 +678,12 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 105
-    schemaId: 101
-  Status: PUBLIC
 
 decompose
 seq
 ----
 BackReferencedIDs:
 ElementState:
-- Sequence:
-    isTemporary: false
-    sequenceId: 104
-  Status: PUBLIC
-- TableData:
-    databaseId: 100
-    tableId: 104
-  Status: PUBLIC
 - Namespace:
     databaseId: 100
     descriptorId: 104
@@ -702,6 +694,18 @@ ElementState:
     descriptorId: 104
     owner: root
   Status: PUBLIC
+- SchemaChild:
+    childObjectId: 104
+    schemaId: 101
+  Status: PUBLIC
+- Sequence:
+    isTemporary: false
+    sequenceId: 104
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 104
+  Status: PUBLIC
 - UserPrivileges:
     descriptorId: 104
     privileges: "2"
@@ -713,8 +717,4 @@ ElementState:
     privileges: "2"
     userName: root
     withGrantOption: "2"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 104
-    schemaId: 101
   Status: PUBLIC

--- a/pkg/sql/schemachanger/scdecomp/testdata/table
+++ b/pkg/sql/schemachanger/scdecomp/testdata/table
@@ -29,15 +29,6 @@ parent
 BackReferencedIDs:
   - 105
 ElementState:
-- Table:
-    isTemporary: false
-    tableId: 104
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 104
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -68,23 +59,9 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 104
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
-    tableId: 104
-    temporaryIndexId: 0
-  Status: PUBLIC
-- TableData:
-    databaseId: 100
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 104
   Status: PUBLIC
 - ColumnName:
@@ -100,6 +77,11 @@ ElementState:
 - ColumnName:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
+    tableId: 104
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 1
+    indexIdForValidation: 0
     tableId: 104
   Status: PUBLIC
 - ColumnType:
@@ -183,16 +165,6 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnNotNull:
-    columnId: 1
-    indexIdForValidation: 0
-    tableId: 104
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: parent_pkey
-    tableId: 104
-  Status: PUBLIC
 - IndexColumn:
     columnId: 1
     direction: ASC
@@ -207,6 +179,11 @@ ElementState:
     indexId: 1
     tableId: 104
   Status: PUBLIC
+- IndexName:
+    indexId: 1
+    name: parent_pkey
+    tableId: 104
+  Status: PUBLIC
 - Namespace:
     databaseId: 100
     descriptorId: 104
@@ -216,6 +193,33 @@ ElementState:
 - Owner:
     descriptorId: 104
     owner: root
+  Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 104
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 104
+    schemaId: 101
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 104
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 104
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 104
@@ -229,24 +233,52 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 104
-    schemaId: 101
-  Status: PUBLIC
 
 decompose
 tbl
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
+- CheckConstraint:
+    columnIds:
+    - 1
+    constraintId: 3
+    expr: id > 0:::INT8
+    fromHashShardedColumn: false
+    indexIdForValidation: 0
+    referencedColumnIds:
+    - 1
     tableId: 105
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
   Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
+- CheckConstraint:
+    columnIds:
+    - 1
+    constraintId: 8
+    expr: '[FUNCTION 100106](id) > 1:::INT8'
+    fromHashShardedColumn: false
+    indexIdForValidation: 0
+    referencedColumnIds:
+    - 1
     tableId: 105
+    usesFunctionIds:
+    - 106
+    usesSequenceIds: []
+    usesTypeIds: []
+  Status: PUBLIC
+- CheckConstraintUnvalidated:
+    columnIds:
+    - 1
+    constraintId: 4
+    expr: id < 10:::INT8
+    referencedColumnIds:
+    - 1
+    tableId: 105
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
   Status: PUBLIC
 - Column:
     columnId: 1
@@ -298,132 +330,15 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 105
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
-    tableId: 105
-    temporaryIndexId: 0
-  Status: PUBLIC
-- SecondaryIndex:
-    constraintId: 0
-    expr: id > 0:::INT8
-    geoConfig: null
-    indexId: 2
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: false
-    referencedColumnIds:
-    - 1
-    sharding: null
-    sourceIndexId: 0
-    tableId: 105
-    temporaryIndexId: 0
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- UniqueWithoutIndexConstraint:
-    columnIds:
-    - 3
-    constraintId: 5
-    indexIdForValidation: 0
-    predicate: null
+- ColumnComment:
+    columnId: 1
+    comment: id is a identifier
+    pgAttributeNum: 1
     tableId: 105
   Status: PUBLIC
-- UniqueWithoutIndexConstraintUnvalidated:
-    columnIds:
-    - 3
-    constraintId: 6
-    predicate: null
-    tableId: 105
-  Status: PUBLIC
-- CheckConstraint:
-    columnIds:
-    - 1
-    constraintId: 3
-    expr: id > 0:::INT8
-    fromHashShardedColumn: false
-    indexIdForValidation: 0
-    referencedColumnIds:
-    - 1
-    tableId: 105
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- CheckConstraint:
-    columnIds:
-    - 1
-    constraintId: 8
-    expr: '[FUNCTION 100106](id) > 1:::INT8'
-    fromHashShardedColumn: false
-    indexIdForValidation: 0
-    referencedColumnIds:
-    - 1
-    tableId: 105
-    usesFunctionIds:
-    - 106
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- CheckConstraintUnvalidated:
-    columnIds:
-    - 1
-    constraintId: 4
-    expr: id < 10:::INT8
-    referencedColumnIds:
-    - 1
-    tableId: 105
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- ForeignKeyConstraint:
-    columnIds:
-    - 1
-    compositeKeyMatchMethod: SIMPLE
-    constraintId: 2
-    indexIdForValidation: 0
-    onDeleteAction: NO_ACTION
-    onUpdateAction: NO_ACTION
-    referencedColumnIds:
-    - 1
-    referencedTableId: 104
-    tableId: 105
-  Status: PUBLIC
-- ForeignKeyConstraintUnvalidated:
-    columnIds:
-    - 1
-    compositeKeyMatchMethod: SIMPLE
-    constraintId: 7
-    onDeleteAction: NO_ACTION
-    onUpdateAction: NO_ACTION
-    referencedColumnIds:
-    - 1
-    referencedTableId: 104
-    tableId: 105
-  Status: PUBLIC
-- TableComment:
-    comment: tbl is good table
-    tableId: 105
-  Status: PUBLIC
-- TableZoneConfig:
-    tableId: 105
-  Status: PUBLIC
-- TableData:
-    databaseId: 100
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 105
   Status: PUBLIC
 - ColumnName:
@@ -449,6 +364,16 @@ ElementState:
 - ColumnName:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
+    tableId: 105
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 1
+    indexIdForValidation: 0
+    tableId: 105
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 2
+    indexIdForValidation: 0
     tableId: 105
   Status: PUBLIC
 - ColumnType:
@@ -586,35 +511,74 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnComment:
-    columnId: 1
-    comment: id is a identifier
-    pgAttributeNum: 1
+- ConstraintComment:
+    comment: must have a parent
+    constraintId: 2
     tableId: 105
   Status: PUBLIC
-- ColumnNotNull:
-    columnId: 1
+- ConstraintComment:
+    comment: primary key
+    constraintId: 1
+    tableId: 105
+  Status: PUBLIC
+- ConstraintWithoutIndexName:
+    constraintId: 2
+    name: myfk
+    tableId: 105
+  Status: PUBLIC
+- ConstraintWithoutIndexName:
+    constraintId: 3
+    name: mycheck1
+    tableId: 105
+  Status: PUBLIC
+- ConstraintWithoutIndexName:
+    constraintId: 4
+    name: mycheck2
+    tableId: 105
+  Status: PUBLIC
+- ConstraintWithoutIndexName:
+    constraintId: 5
+    name: myuwi1
+    tableId: 105
+  Status: PUBLIC
+- ConstraintWithoutIndexName:
+    constraintId: 6
+    name: myuwi2
+    tableId: 105
+  Status: PUBLIC
+- ConstraintWithoutIndexName:
+    constraintId: 7
+    name: myfk2
+    tableId: 105
+  Status: PUBLIC
+- ConstraintWithoutIndexName:
+    constraintId: 8
+    name: mycheck3
+    tableId: 105
+  Status: PUBLIC
+- ForeignKeyConstraint:
+    columnIds:
+    - 1
+    compositeKeyMatchMethod: SIMPLE
+    constraintId: 2
     indexIdForValidation: 0
+    onDeleteAction: NO_ACTION
+    onUpdateAction: NO_ACTION
+    referencedColumnIds:
+    - 1
+    referencedTableId: 104
     tableId: 105
   Status: PUBLIC
-- ColumnNotNull:
-    columnId: 2
-    indexIdForValidation: 0
-    tableId: 105
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: tbl_pkey
-    tableId: 105
-  Status: PUBLIC
-- IndexName:
-    indexId: 2
-    name: sec
-    tableId: 105
-  Status: PUBLIC
-- IndexComment:
-    comment: tbl_pkey is a primary key
-    indexId: 1
+- ForeignKeyConstraintUnvalidated:
+    columnIds:
+    - 1
+    compositeKeyMatchMethod: SIMPLE
+    constraintId: 7
+    onDeleteAction: NO_ACTION
+    onUpdateAction: NO_ACTION
+    referencedColumnIds:
+    - 1
+    referencedTableId: 104
     tableId: 105
   Status: PUBLIC
 - IndexColumn:
@@ -677,6 +641,11 @@ ElementState:
     ordinalInKind: 0
     tableId: 105
   Status: PUBLIC
+- IndexComment:
+    comment: tbl_pkey is a primary key
+    indexId: 1
+    tableId: 105
+  Status: PUBLIC
 - IndexData:
     indexId: 1
     tableId: 105
@@ -685,49 +654,14 @@ ElementState:
     indexId: 2
     tableId: 105
   Status: PUBLIC
-- ConstraintWithoutIndexName:
-    constraintId: 2
-    name: myfk
+- IndexName:
+    indexId: 1
+    name: tbl_pkey
     tableId: 105
   Status: PUBLIC
-- ConstraintWithoutIndexName:
-    constraintId: 3
-    name: mycheck1
-    tableId: 105
-  Status: PUBLIC
-- ConstraintWithoutIndexName:
-    constraintId: 4
-    name: mycheck2
-    tableId: 105
-  Status: PUBLIC
-- ConstraintWithoutIndexName:
-    constraintId: 5
-    name: myuwi1
-    tableId: 105
-  Status: PUBLIC
-- ConstraintWithoutIndexName:
-    constraintId: 6
-    name: myuwi2
-    tableId: 105
-  Status: PUBLIC
-- ConstraintWithoutIndexName:
-    constraintId: 7
-    name: myfk2
-    tableId: 105
-  Status: PUBLIC
-- ConstraintWithoutIndexName:
-    constraintId: 8
-    name: mycheck3
-    tableId: 105
-  Status: PUBLIC
-- ConstraintComment:
-    comment: must have a parent
-    constraintId: 2
-    tableId: 105
-  Status: PUBLIC
-- ConstraintComment:
-    comment: primary key
-    constraintId: 1
+- IndexName:
+    indexId: 2
+    name: sec
     tableId: 105
   Status: PUBLIC
 - Namespace:
@@ -739,6 +673,76 @@ ElementState:
 - Owner:
     descriptorId: 105
     owner: root
+  Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 105
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 105
+    schemaId: 101
+  Status: PUBLIC
+- SecondaryIndex:
+    constraintId: 0
+    expr: id > 0:::INT8
+    geoConfig: null
+    indexId: 2
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: false
+    referencedColumnIds:
+    - 1
+    sharding: null
+    sourceIndexId: 0
+    tableId: 105
+    temporaryIndexId: 0
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 105
+  Status: PUBLIC
+- TableComment:
+    comment: tbl is good table
+    tableId: 105
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 105
+  Status: PUBLIC
+- TableZoneConfig:
+    tableId: 105
+  Status: PUBLIC
+- UniqueWithoutIndexConstraint:
+    columnIds:
+    - 3
+    constraintId: 5
+    indexIdForValidation: 0
+    predicate: null
+    tableId: 105
+  Status: PUBLIC
+- UniqueWithoutIndexConstraintUnvalidated:
+    columnIds:
+    - 3
+    constraintId: 6
+    predicate: null
+    tableId: 105
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 105
@@ -752,10 +756,6 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 105
-    schemaId: 101
-  Status: PUBLIC
 
 setup
 ALTER TABLE parent ADD COLUMN j INT CREATE FAMILY f2;
@@ -767,20 +767,6 @@ parent
 BackReferencedIDs:
   - 105
 ElementState:
-- Table:
-    isTemporary: false
-    tableId: 104
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 104
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 1
-    name: f2
-    tableId: 104
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -821,23 +807,14 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 104
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 104
-    temporaryIndexId: 0
   Status: PUBLIC
-- TableData:
-    databaseId: 100
+- ColumnFamily:
+    familyId: 1
+    name: f2
     tableId: 104
   Status: PUBLIC
 - ColumnName:
@@ -858,6 +835,11 @@ ElementState:
 - ColumnName:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
+    tableId: 104
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 1
+    indexIdForValidation: 0
     tableId: 104
   Status: PUBLIC
 - ColumnType:
@@ -968,16 +950,6 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnNotNull:
-    columnId: 1
-    indexIdForValidation: 0
-    tableId: 104
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: parent_pkey
-    tableId: 104
-  Status: PUBLIC
 - IndexColumn:
     columnId: 1
     direction: ASC
@@ -1002,6 +974,11 @@ ElementState:
     indexId: 1
     tableId: 104
   Status: PUBLIC
+- IndexName:
+    indexId: 1
+    name: parent_pkey
+    tableId: 104
+  Status: PUBLIC
 - Namespace:
     databaseId: 100
     descriptorId: 104
@@ -1011,6 +988,33 @@ ElementState:
 - Owner:
     descriptorId: 104
     owner: root
+  Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 104
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 104
+    schemaId: 101
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 104
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 104
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 104
@@ -1024,10 +1028,6 @@ ElementState:
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 104
-    schemaId: 101
-  Status: PUBLIC
 
 setup
 CREATE TYPE greeting AS ENUM ('hello');
@@ -1039,15 +1039,6 @@ greeter
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
-    tableId: 109
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 109
-  Status: PUBLIC
 - Column:
     columnId: 1
     generatedAsIdentitySequenceOption: ""
@@ -1088,23 +1079,18 @@ ElementState:
     pgAttributeNum: 4.294967295e+09
     tableId: 109
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
+- ColumnDefaultExpression:
+    columnId: 2
+    expr: unique_rowid()
+    referencedColumnIds: []
     tableId: 109
-    temporaryIndexId: 0
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
   Status: PUBLIC
-- TableData:
-    databaseId: 100
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 109
   Status: PUBLIC
 - ColumnName:
@@ -1125,6 +1111,11 @@ ElementState:
 - ColumnName:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
+    tableId: 109
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 2
+    indexIdForValidation: 0
     tableId: 109
   Status: PUBLIC
 - ColumnType:
@@ -1242,25 +1233,6 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnDefaultExpression:
-    columnId: 2
-    expr: unique_rowid()
-    referencedColumnIds: []
-    tableId: 109
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- ColumnNotNull:
-    columnId: 2
-    indexIdForValidation: 0
-    tableId: 109
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: greeter_pkey
-    tableId: 109
-  Status: PUBLIC
 - IndexColumn:
     columnId: 1
     direction: ASC
@@ -1285,6 +1257,11 @@ ElementState:
     indexId: 1
     tableId: 109
   Status: PUBLIC
+- IndexName:
+    indexId: 1
+    name: greeter_pkey
+    tableId: 109
+  Status: PUBLIC
 - Namespace:
     databaseId: 100
     descriptorId: 109
@@ -1294,6 +1271,33 @@ ElementState:
 - Owner:
     descriptorId: 109
     owner: root
+  Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 109
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 109
+    schemaId: 101
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 109
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 109
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 109
@@ -1306,8 +1310,4 @@ ElementState:
     privileges: "2"
     userName: root
     withGrantOption: "2"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 109
-    schemaId: 101
   Status: PUBLIC

--- a/pkg/sql/schemachanger/scdecomp/testdata/type
+++ b/pkg/sql/schemachanger/scdecomp/testdata/type
@@ -25,6 +25,16 @@ ElementState:
     isMultiRegion: false
     typeId: 104
   Status: PUBLIC
+- EnumTypeValue:
+    logicalRepresentation: hello
+    physicalRepresentation: QA==
+    typeId: 104
+  Status: PUBLIC
+- EnumTypeValue:
+    logicalRepresentation: hi
+    physicalRepresentation: gA==
+    typeId: 104
+  Status: PUBLIC
 - Namespace:
     databaseId: 100
     descriptorId: 104
@@ -34,6 +44,10 @@ ElementState:
 - Owner:
     descriptorId: 104
     owner: root
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 104
+    schemaId: 101
   Status: PUBLIC
 - UserPrivileges:
     descriptorId: 104
@@ -53,34 +67,27 @@ ElementState:
     userName: public
     withGrantOption: "0"
   Status: PUBLIC
-- SchemaChild:
-    childObjectId: 104
-    schemaId: 101
-  Status: PUBLIC
-- EnumTypeValue:
-    logicalRepresentation: hello
-    physicalRepresentation: QA==
-    typeId: 104
-  Status: PUBLIC
-- EnumTypeValue:
-    logicalRepresentation: hi
-    physicalRepresentation: gA==
-    typeId: 104
-  Status: PUBLIC
 
 decompose
 tbl
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
+- CheckConstraint:
+    columnIds:
+    - 3
+    - 5
+    constraintId: 2
+    expr: s::STRING = name
+    fromHashShardedColumn: false
+    indexIdForValidation: 0
+    referencedColumnIds:
+    - 3
+    - 5
     tableId: 108
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 108
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
   Status: PUBLIC
 - Column:
     columnId: 1
@@ -152,75 +159,9 @@ ElementState:
     pgAttributeNum: 5
     tableId: 108
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
-    tableId: 108
-    temporaryIndexId: 0
-  Status: PUBLIC
-- SecondaryIndex:
-    constraintId: 0
-    expr: g::STRING = 'hi':::STRING
-    geoConfig: null
-    indexId: 2
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: false
-    referencedColumnIds:
-    - 2
-    sharding: null
-    sourceIndexId: 0
-    tableId: 108
-    temporaryIndexId: 0
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- UniqueWithoutIndexConstraint:
-    columnIds:
-    - 5
-    constraintId: 3
-    indexIdForValidation: 0
-    predicate:
-      expr: x'80':::@100104::STRING = 'hi':::STRING
-      referencedColumnIds: []
-      usesFunctionIds: []
-      usesSequenceIds: []
-      usesTypeIds:
-      - 104
-      - 105
-    tableId: 108
-  Status: PUBLIC
-- CheckConstraint:
-    columnIds:
-    - 3
-    - 5
-    constraintId: 2
-    expr: s::STRING = name
-    fromHashShardedColumn: false
-    indexIdForValidation: 0
-    referencedColumnIds:
-    - 3
-    - 5
-    tableId: 108
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- TableData:
-    databaseId: 100
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 108
   Status: PUBLIC
 - ColumnName:
@@ -256,6 +197,16 @@ ElementState:
 - ColumnName:
     columnId: 5
     name: name
+    tableId: 108
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 1
+    indexIdForValidation: 0
+    tableId: 108
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 5
+    indexIdForValidation: 0
     tableId: 108
   Status: PUBLIC
 - ColumnType:
@@ -485,24 +436,14 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- ColumnNotNull:
-    columnId: 1
-    indexIdForValidation: 0
+- ConstraintWithoutIndexName:
+    constraintId: 2
+    name: mycheck
     tableId: 108
   Status: PUBLIC
-- ColumnNotNull:
-    columnId: 5
-    indexIdForValidation: 0
-    tableId: 108
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: tbl_pkey
-    tableId: 108
-  Status: PUBLIC
-- IndexName:
-    indexId: 2
-    name: partial
+- ConstraintWithoutIndexName:
+    constraintId: 3
+    name: myuwi
     tableId: 108
   Status: PUBLIC
 - IndexColumn:
@@ -573,14 +514,14 @@ ElementState:
     indexId: 2
     tableId: 108
   Status: PUBLIC
-- ConstraintWithoutIndexName:
-    constraintId: 2
-    name: mycheck
+- IndexName:
+    indexId: 1
+    name: tbl_pkey
     tableId: 108
   Status: PUBLIC
-- ConstraintWithoutIndexName:
-    constraintId: 3
-    name: myuwi
+- IndexName:
+    indexId: 2
+    name: partial
     tableId: 108
   Status: PUBLIC
 - Namespace:
@@ -593,6 +534,69 @@ ElementState:
     descriptorId: 108
     owner: root
   Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 108
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 108
+    schemaId: 101
+  Status: PUBLIC
+- SecondaryIndex:
+    constraintId: 0
+    expr: g::STRING = 'hi':::STRING
+    geoConfig: null
+    indexId: 2
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: false
+    referencedColumnIds:
+    - 2
+    sharding: null
+    sourceIndexId: 0
+    tableId: 108
+    temporaryIndexId: 0
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 108
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 108
+  Status: PUBLIC
+- UniqueWithoutIndexConstraint:
+    columnIds:
+    - 5
+    constraintId: 3
+    indexIdForValidation: 0
+    predicate:
+      expr: x'80':::@100104::STRING = 'hi':::STRING
+      referencedColumnIds: []
+      usesFunctionIds: []
+      usesSequenceIds: []
+      usesTypeIds:
+      - 104
+      - 105
+    tableId: 108
+  Status: PUBLIC
 - UserPrivileges:
     descriptorId: 108
     privileges: "2"
@@ -604,10 +608,6 @@ ElementState:
     privileges: "2"
     userName: root
     withGrantOption: "2"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 108
-    schemaId: 101
   Status: PUBLIC
 
 setup
@@ -634,37 +634,13 @@ ElementState:
     arrayTypeId: 110
     typeId: 109
   Status: PUBLIC
-- Namespace:
-    databaseId: 100
-    descriptorId: 109
-    name: comp
-    schemaId: 101
+- CompositeTypeAttrName:
+    compositeTypeId: 109
+    name: a
   Status: PUBLIC
-- Owner:
-    descriptorId: 109
-    owner: root
-  Status: PUBLIC
-- UserPrivileges:
-    descriptorId: 109
-    privileges: "2"
-    userName: admin
-    withGrantOption: "2"
-  Status: PUBLIC
-- UserPrivileges:
-    descriptorId: 109
-    privileges: "2"
-    userName: root
-    withGrantOption: "2"
-  Status: PUBLIC
-- UserPrivileges:
-    descriptorId: 109
-    privileges: "512"
-    userName: public
-    withGrantOption: "0"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 109
-    schemaId: 101
+- CompositeTypeAttrName:
+    compositeTypeId: 109
+    name: b
   Status: PUBLIC
 - CompositeTypeAttrType:
     closedTypeIds: []
@@ -706,13 +682,37 @@ ElementState:
       visibleType: 0
       width: 0
   Status: PUBLIC
-- CompositeTypeAttrName:
-    compositeTypeId: 109
-    name: a
+- Namespace:
+    databaseId: 100
+    descriptorId: 109
+    name: comp
+    schemaId: 101
   Status: PUBLIC
-- CompositeTypeAttrName:
-    compositeTypeId: 109
-    name: b
+- Owner:
+    descriptorId: 109
+    owner: root
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 109
+    schemaId: 101
+  Status: PUBLIC
+- UserPrivileges:
+    descriptorId: 109
+    privileges: "2"
+    userName: admin
+    withGrantOption: "2"
+  Status: PUBLIC
+- UserPrivileges:
+    descriptorId: 109
+    privileges: "2"
+    userName: root
+    withGrantOption: "2"
+  Status: PUBLIC
+- UserPrivileges:
+    descriptorId: 109
+    privileges: "512"
+    userName: public
+    withGrantOption: "0"
   Status: PUBLIC
 
 decompose
@@ -720,14 +720,19 @@ tbl2
 ----
 BackReferencedIDs:
 ElementState:
-- Table:
-    isTemporary: false
+- CheckConstraint:
+    columnIds:
+    - 2
+    constraintId: 2
+    expr: (c).b = 'foo':::STRING
+    fromHashShardedColumn: false
+    indexIdForValidation: 0
+    referencedColumnIds:
+    - 2
     tableId: 111
-  Status: PUBLIC
-- ColumnFamily:
-    familyId: 0
-    name: primary
-    tableId: 111
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
   Status: PUBLIC
 - Column:
     columnId: 1
@@ -819,58 +824,9 @@ ElementState:
     pgAttributeNum: 7
     tableId: 111
   Status: PUBLIC
-- PrimaryIndex:
-    constraintId: 1
-    geoConfig: null
-    indexId: 1
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: true
-    sharding: null
-    sourceIndexId: 0
-    tableId: 111
-    temporaryIndexId: 0
-  Status: PUBLIC
-- SecondaryIndex:
-    constraintId: 0
-    expr: (c).a = 3:::INT8
-    geoConfig: null
-    indexId: 2
-    invisibility: 0
-    isConcurrently: false
-    isCreatedExplicitly: false
-    isInverted: false
-    isNotVisible: false
-    isUnique: false
-    referencedColumnIds:
-    - 2
-    sharding: null
-    sourceIndexId: 0
-    tableId: 111
-    temporaryIndexId: 0
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- CheckConstraint:
-    columnIds:
-    - 2
-    constraintId: 2
-    expr: (c).b = 'foo':::STRING
-    fromHashShardedColumn: false
-    indexIdForValidation: 0
-    referencedColumnIds:
-    - 2
-    tableId: 111
-    usesFunctionIds: []
-    usesSequenceIds: []
-    usesTypeIds: []
-  Status: PUBLIC
-- TableData:
-    databaseId: 100
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 111
   Status: PUBLIC
 - ColumnName:
@@ -916,6 +872,16 @@ ElementState:
 - ColumnName:
     columnId: 7
     name: crdb_internal_idx_expr
+    tableId: 111
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 1
+    indexIdForValidation: 0
+    tableId: 111
+  Status: PUBLIC
+- ColumnNotNull:
+    columnId: 6
+    indexIdForValidation: 0
     tableId: 111
   Status: PUBLIC
 - ColumnType:
@@ -1329,24 +1295,9 @@ ElementState:
       visibleType: 0
       width: 64
   Status: PUBLIC
-- ColumnNotNull:
-    columnId: 1
-    indexIdForValidation: 0
-    tableId: 111
-  Status: PUBLIC
-- ColumnNotNull:
-    columnId: 6
-    indexIdForValidation: 0
-    tableId: 111
-  Status: PUBLIC
-- IndexName:
-    indexId: 1
-    name: tbl2_pkey
-    tableId: 111
-  Status: PUBLIC
-- IndexName:
-    indexId: 2
-    name: comppartial
+- ConstraintWithoutIndexName:
+    constraintId: 2
+    name: compcheck
     tableId: 111
   Status: PUBLIC
 - IndexColumn:
@@ -1427,9 +1378,14 @@ ElementState:
     indexId: 2
     tableId: 111
   Status: PUBLIC
-- ConstraintWithoutIndexName:
-    constraintId: 2
-    name: compcheck
+- IndexName:
+    indexId: 1
+    name: tbl2_pkey
+    tableId: 111
+  Status: PUBLIC
+- IndexName:
+    indexId: 2
+    name: comppartial
     tableId: 111
   Status: PUBLIC
 - Namespace:
@@ -1442,6 +1398,54 @@ ElementState:
     descriptorId: 111
     owner: root
   Status: PUBLIC
+- PrimaryIndex:
+    constraintId: 1
+    geoConfig: null
+    indexId: 1
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: true
+    sharding: null
+    sourceIndexId: 0
+    tableId: 111
+    temporaryIndexId: 0
+  Status: PUBLIC
+- SchemaChild:
+    childObjectId: 111
+    schemaId: 101
+  Status: PUBLIC
+- SecondaryIndex:
+    constraintId: 0
+    expr: (c).a = 3:::INT8
+    geoConfig: null
+    indexId: 2
+    invisibility: 0
+    isConcurrently: false
+    isCreatedExplicitly: false
+    isInverted: false
+    isNotVisible: false
+    isUnique: false
+    referencedColumnIds:
+    - 2
+    sharding: null
+    sourceIndexId: 0
+    tableId: 111
+    temporaryIndexId: 0
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
+  Status: PUBLIC
+- Table:
+    isTemporary: false
+    tableId: 111
+  Status: PUBLIC
+- TableData:
+    databaseId: 100
+    tableId: 111
+  Status: PUBLIC
 - UserPrivileges:
     descriptorId: 111
     privileges: "2"
@@ -1453,8 +1457,4 @@ ElementState:
     privileges: "2"
     userName: root
     withGrantOption: "2"
-  Status: PUBLIC
-- SchemaChild:
-    childObjectId: 111
-    schemaId: 101
   Status: PUBLIC

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -49,102 +49,102 @@ option (gogoproto.equal_all) = true;
 // yet undergone any status changes. In any case, that kind of hackery is best
 // kept at a minimum.
 message ElementProto {
-  option (gogoproto.onlyone) = true;
+  oneof element_one_of {
+    // Top-level elements.
+    // A.k.a descriptor-elements.
+    // These elements own a corresponding descriptor in the catalog.
+    Database database = 1;
+    Schema schema = 2;
+    View view = 3;
+    Sequence sequence = 4;
+    Table table = 5;
+    EnumType enum_type = 6;
+    AliasType alias_type = 7;
+    CompositeType composite_type = 8;
+    Function function = 9;
 
-  // Top-level elements.
-  // A.k.a descriptor-elements.
-  // These elements own a corresponding descriptor in the catalog.
-  Database database = 1;
-  Schema schema = 2;
-  View view = 3;
-  Sequence sequence = 4;
-  Table table = 5;
-  EnumType enum_type = 6;
-  AliasType alias_type = 7;
-  CompositeType composite_type = 8;
-  Function function = 9;
-
-  // Relation elements.
-  ColumnFamily column_family = 20 [(gogoproto.moretags) = "parent:\"Table\""];
-  Column column = 21 [(gogoproto.moretags) = "parent:\"Table, View\""];
-  PrimaryIndex primary_index = 22 [(gogoproto.moretags) = "parent:\"Table, View\""];
-  SecondaryIndex secondary_index = 23 [(gogoproto.moretags) = "parent:\"Table, View\""];
-  TemporaryIndex temporary_index = 24 [(gogoproto.moretags) = "parent:\"Table, View\""];
-  UniqueWithoutIndexConstraint unique_without_index_constraint = 25 [(gogoproto.moretags) = "parent:\"Table\""];
-  UniqueWithoutIndexConstraintUnvalidated unique_without_index_constraint_unvalidated = 171 [(gogoproto.moretags) = "parent:\"Table\""];
-  CheckConstraint check_constraint = 26 [(gogoproto.moretags) = "parent:\"Table\""];
-  CheckConstraintUnvalidated check_constraint_unvalidated = 170 [(gogoproto.moretags) = "parent:\"Table\""];
-  ForeignKeyConstraint foreign_key_constraint = 27 [(gogoproto.moretags) = "parent:\"Table\""];
-  ForeignKeyConstraintUnvalidated foreign_key_constraint_not_valid = 172 [(gogoproto.moretags) = "parent:\"Table\""];
-  TableComment table_comment = 28 [(gogoproto.moretags) = "parent:\"Table, View, Sequence\""];
-  RowLevelTTL row_level_ttl = 29 [(gogoproto.customname) = "RowLevelTTL", (gogoproto.moretags) = "parent:\"Table\""];
-  TableZoneConfig table_zone_config = 121 [(gogoproto.moretags) = "parent:\"Table, View\""];
-  IndexZoneConfig index_zone_config = 122 [(gogoproto.moretags) = "parent:\"Index\""];
-  TableData table_data = 131 [(gogoproto.customname) = "TableData", (gogoproto.moretags) = "parent:\"Table, View, Sequence\""];
-  TablePartitioning table_partitioning = 132 [(gogoproto.customname) = "TablePartitioning", (gogoproto.moretags) = "parent:\"Table\""];
+    // Relation elements.
+    ColumnFamily column_family = 20 [(gogoproto.moretags) = "parent:\"Table\""];
+    Column column = 21 [(gogoproto.moretags) = "parent:\"Table, View\""];
+    PrimaryIndex primary_index = 22 [(gogoproto.moretags) = "parent:\"Table, View\""];
+    SecondaryIndex secondary_index = 23 [(gogoproto.moretags) = "parent:\"Table, View\""];
+    TemporaryIndex temporary_index = 24 [(gogoproto.moretags) = "parent:\"Table, View\""];
+    UniqueWithoutIndexConstraint unique_without_index_constraint = 25 [(gogoproto.moretags) = "parent:\"Table\""];
+    UniqueWithoutIndexConstraintUnvalidated unique_without_index_constraint_unvalidated = 171 [(gogoproto.moretags) = "parent:\"Table\""];
+    CheckConstraint check_constraint = 26 [(gogoproto.moretags) = "parent:\"Table\""];
+    CheckConstraintUnvalidated check_constraint_unvalidated = 170 [(gogoproto.moretags) = "parent:\"Table\""];
+    ForeignKeyConstraint foreign_key_constraint = 27 [(gogoproto.moretags) = "parent:\"Table\""];
+    ForeignKeyConstraintUnvalidated foreign_key_constraint_unvalidated = 172 [(gogoproto.moretags) = "parent:\"Table\""];
+    TableComment table_comment = 28 [(gogoproto.moretags) = "parent:\"Table, View, Sequence\""];
+    RowLevelTTL row_level_ttl = 29 [(gogoproto.customname) = "RowLevelTTL", (gogoproto.moretags) = "parent:\"Table\""];
+    TableZoneConfig table_zone_config = 121 [(gogoproto.moretags) = "parent:\"Table, View\""];
+    IndexZoneConfig index_zone_config = 122 [(gogoproto.moretags) = "parent:\"Index\""];
+    TableData table_data = 131 [(gogoproto.customname) = "TableData", (gogoproto.moretags) = "parent:\"Table, View, Sequence\""];
+    TablePartitioning table_partitioning = 132 [(gogoproto.customname) = "TablePartitioning", (gogoproto.moretags) = "parent:\"Table\""];
   TableSchemaLocked table_schema_locked = 133 [(gogoproto.customname) = "TableSchemaLocked", (gogoproto.moretags) = "parent:\"Table\""];
 
-  // Multi-region elements.
-  TableLocalityGlobal locality_global = 110 [(gogoproto.moretags) = "parent:\"Table\""];
-  TableLocalityPrimaryRegion locality_primary_region = 111 [(gogoproto.moretags) = "parent:\"Table\""];
-  TableLocalitySecondaryRegion locality_secondary_region = 112 [(gogoproto.moretags) = "parent:\"Table\""];
-  TableLocalityRegionalByRow locality_regional_by_row = 113 [(gogoproto.moretags) = "parent:\"Table\""];
+    // Multi-region elements.
+    TableLocalityGlobal table_locality_global = 110 [(gogoproto.moretags) = "parent:\"Table\""];
+    TableLocalityPrimaryRegion table_locality_primary_region = 111 [(gogoproto.moretags) = "parent:\"Table\""];
+    TableLocalitySecondaryRegion table_locality_secondary_region = 112 [(gogoproto.moretags) = "parent:\"Table\""];
+    TableLocalityRegionalByRow table_locality_regional_by_row = 113 [(gogoproto.moretags) = "parent:\"Table\""];
 
-  // Column elements.
-  ColumnName column_name = 30 [(gogoproto.moretags) = "parent:\"Column\""];
-  ColumnType column_type = 31 [(gogoproto.moretags) = "parent:\"Column\""];
-  ColumnDefaultExpression column_default_expression = 32 [(gogoproto.moretags) = "parent:\"Column\""];
-  ColumnOnUpdateExpression column_on_update_expression = 33 [(gogoproto.moretags) = "parent:\"Column\""];
-  SequenceOwner sequence_owner = 34 [(gogoproto.moretags) = "parent:\"Column\""];
-  ColumnComment column_comment = 35 [(gogoproto.moretags) = "parent:\"Column\""];
-  ColumnNotNull column_not_null = 36 [(gogoproto.moretags) = "parent:\"Column\""];
+    // Column elements.
+    ColumnName column_name = 30 [(gogoproto.moretags) = "parent:\"Column\""];
+    ColumnType column_type = 31 [(gogoproto.moretags) = "parent:\"Column\""];
+    ColumnDefaultExpression column_default_expression = 32 [(gogoproto.moretags) = "parent:\"Column\""];
+    ColumnOnUpdateExpression column_on_update_expression = 33 [(gogoproto.moretags) = "parent:\"Column\""];
+    SequenceOwner sequence_owner = 34 [(gogoproto.moretags) = "parent:\"Column\""];
+    ColumnComment column_comment = 35 [(gogoproto.moretags) = "parent:\"Column\""];
+    ColumnNotNull column_not_null = 36 [(gogoproto.moretags) = "parent:\"Column\""];
 
-  // Index elements.
-  IndexName index_name = 40 [(gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex\""];
-  IndexPartitioning index_partitioning = 41 [(gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex\""];
-  SecondaryIndexPartial secondary_index_partial = 42 [(gogoproto.moretags) = "parent:\"SecondaryIndex\""];
-  IndexComment index_comment = 43 [(gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex\""];
-  IndexColumn index_column = 44 [(gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex, TemporaryIndex, Column\""];
-  IndexData index_data = 45 [(gogoproto.customname) = "IndexData", (gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex, TemporaryIndex\""];
+    // Index elements.
+    IndexName index_name = 40 [(gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex\""];
+    IndexPartitioning index_partitioning = 41 [(gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex\""];
+    SecondaryIndexPartial secondary_index_partial = 42 [(gogoproto.moretags) = "parent:\"SecondaryIndex\""];
+    IndexComment index_comment = 43 [(gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex\""];
+    IndexColumn index_column = 44 [(gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex, TemporaryIndex, Column\""];
+    IndexData index_data = 45 [(gogoproto.customname) = "IndexData", (gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex, TemporaryIndex\""];
 
-  // Constraint elements.
-  ConstraintWithoutIndexName constraint_name = 51 [(gogoproto.moretags) = "parent:\"UniqueWithoutIndexConstraint, CheckConstraint, ForeignKeyConstraint\""];
-  ConstraintComment constraint_comment = 52 [(gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex, UniqueWithoutIndexConstraint, CheckConstraint, ForeignKeyConstraint\""];
+    // Constraint elements.
+    ConstraintWithoutIndexName constraint_without_index_name = 51 [(gogoproto.moretags) = "parent:\"UniqueWithoutIndexConstraint, CheckConstraint, ForeignKeyConstraint\""];
+    ConstraintComment constraint_comment = 52 [(gogoproto.moretags) = "parent:\"PrimaryIndex, SecondaryIndex, UniqueWithoutIndexConstraint, CheckConstraint, ForeignKeyConstraint\""];
 
-  // Common elements.
-  Namespace namespace = 60 [(gogoproto.moretags) = "parent:\"Table, View, Sequence, Database, Schema, AliasType, EnumType\""];
-  Owner owner = 61 [(gogoproto.moretags) = "parent:\"Table, View, Sequence, Database, Schema, AliasType, EnumType\""];
-  UserPrivileges user_privileges = 62 [(gogoproto.moretags) = "parent:\"Table, View, Sequence, Database, Schema, AliasType, EnumType\""];
+    // Common elements.
+    Namespace namespace = 60 [(gogoproto.moretags) = "parent:\"Table, View, Sequence, Database, Schema, AliasType, EnumType\""];
+    Owner owner = 61 [(gogoproto.moretags) = "parent:\"Table, View, Sequence, Database, Schema, AliasType, EnumType\""];
+    UserPrivileges user_privileges = 62 [(gogoproto.moretags) = "parent:\"Table, View, Sequence, Database, Schema, AliasType, EnumType\""];
 
-  // Database elements.
-  DatabaseRegionConfig database_region_config = 80 [(gogoproto.moretags) = "parent:\"Database\""];
-  DatabaseRoleSetting database_role_setting = 81 [(gogoproto.moretags) = "parent:\"Database\""];
-  DatabaseComment database_comment = 82 [(gogoproto.moretags) = "parent:\"Database\""];
-  DatabaseData database_data = 83 [(gogoproto.customname) = "DatabaseData", (gogoproto.moretags) = "parent:\"Database\""];
+    // Database elements.
+    DatabaseRegionConfig database_region_config = 80 [(gogoproto.moretags) = "parent:\"Database\""];
+    DatabaseRoleSetting database_role_setting = 81 [(gogoproto.moretags) = "parent:\"Database\""];
+    DatabaseComment database_comment = 82 [(gogoproto.moretags) = "parent:\"Database\""];
+    DatabaseData database_data = 83 [(gogoproto.customname) = "DatabaseData", (gogoproto.moretags) = "parent:\"Database\""];
 
-  // Schema elements.
-  SchemaParent schema_parent = 90 [(gogoproto.moretags) = "parent:\"Schema\""];
-  SchemaComment schema_comment = 91 [(gogoproto.moretags) = "parent:\"Schema\""];
+    // Schema elements.
+    SchemaParent schema_parent = 90 [(gogoproto.moretags) = "parent:\"Schema\""];
+    SchemaComment schema_comment = 91 [(gogoproto.moretags) = "parent:\"Schema\""];
 
-  // SchemaChild elements.
-  SchemaChild schema_child = 100 [(gogoproto.moretags) = "parent:\"AliasType, EnumType, Table, View, Sequence\""];
+    // SchemaChild elements.
+    SchemaChild schema_child = 100 [(gogoproto.moretags) = "parent:\"AliasType, EnumType, Table, View, Sequence\""];
 
-  // Enum type elements.
-  EnumTypeValue enum_type_value = 120 [(gogoproto.moretags) = "parent:\"EnumType\""];
+    // Enum type elements.
+    EnumTypeValue enum_type_value = 120 [(gogoproto.moretags) = "parent:\"EnumType\""];
 
-  // Composite type elements.
-  CompositeTypeAttrType composite_type_attr_type = 140 [(gogoproto.moretags) = "parent:\"CompositeType\""];
-  CompositeTypeAttrName composite_type_attr_name = 141 [(gogoproto.moretags) = "parent:\"CompositeType\""];
+    // Composite type elements.
+    CompositeTypeAttrType composite_type_attr_type = 140 [(gogoproto.moretags) = "parent:\"CompositeType\""];
+    CompositeTypeAttrName composite_type_attr_name = 141 [(gogoproto.moretags) = "parent:\"CompositeType\""];
 
-  // Function elements.
-  FunctionName function_name = 160 [(gogoproto.moretags) = "parent:\"Function\""];
-  FunctionVolatility function_volatility = 161 [(gogoproto.moretags) = "parent:\"Function\""];
-  FunctionLeakProof function_leak_proof = 162 [(gogoproto.moretags) = "parent:\"Function\""];
-  FunctionNullInputBehavior function_null_input_behavior = 163 [(gogoproto.moretags) = "parent:\"Function\""];
-  FunctionBody function_body = 164 [(gogoproto.moretags) = "parent:\"Function\""];
-  FunctionParamDefaultExpression function_param_default = 165 [(gogoproto.moretags) = "parent:\"Function\""];
+    // Function elements.
+    FunctionName function_name = 160 [(gogoproto.moretags) = "parent:\"Function\""];
+    FunctionVolatility function_volatility = 161 [(gogoproto.moretags) = "parent:\"Function\""];
+    FunctionLeakProof function_leak_proof = 162 [(gogoproto.moretags) = "parent:\"Function\""];
+    FunctionNullInputBehavior function_null_input_behavior = 163 [(gogoproto.moretags) = "parent:\"Function\""];
+    FunctionBody function_body = 164 [(gogoproto.moretags) = "parent:\"Function\""];
+    FunctionParamDefaultExpression function_param_default_expression = 165 [(gogoproto.moretags) = "parent:\"Function\""];
 
-  // Next element group start id: 180
+    // Next element group start id: 180
+  }
 }
 
 // TypeT is a wrapper for a types.T which contains its user-defined type ID

--- a/pkg/sql/schemachanger/scpb/elements_generated.go
+++ b/pkg/sql/schemachanger/scpb/elements_generated.go
@@ -12,12 +12,19 @@
 
 package scpb
 
+import "fmt"
+
 type ElementStatusIterator interface {
 	ForEachElementStatus(fn func(current Status, target TargetStatus, e Element))
 }
 
 
 func (e AliasType) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_AliasType) Element() Element {
+	return e.AliasType
+}
 
 // ForEachAliasType iterates over elements of type AliasType.
 func ForEachAliasType(
@@ -50,6 +57,11 @@ func FindAliasType(b ElementStatusIterator) (current Status, target TargetStatus
 
 func (e CheckConstraint) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_CheckConstraint) Element() Element {
+	return e.CheckConstraint
+}
+
 // ForEachCheckConstraint iterates over elements of type CheckConstraint.
 func ForEachCheckConstraint(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *CheckConstraint),
@@ -80,6 +92,11 @@ func FindCheckConstraint(b ElementStatusIterator) (current Status, target Target
 }
 
 func (e CheckConstraintUnvalidated) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_CheckConstraintUnvalidated) Element() Element {
+	return e.CheckConstraintUnvalidated
+}
 
 // ForEachCheckConstraintUnvalidated iterates over elements of type CheckConstraintUnvalidated.
 func ForEachCheckConstraintUnvalidated(
@@ -112,6 +129,11 @@ func FindCheckConstraintUnvalidated(b ElementStatusIterator) (current Status, ta
 
 func (e Column) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_Column) Element() Element {
+	return e.Column
+}
+
 // ForEachColumn iterates over elements of type Column.
 func ForEachColumn(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *Column),
@@ -142,6 +164,11 @@ func FindColumn(b ElementStatusIterator) (current Status, target TargetStatus, e
 }
 
 func (e ColumnComment) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_ColumnComment) Element() Element {
+	return e.ColumnComment
+}
 
 // ForEachColumnComment iterates over elements of type ColumnComment.
 func ForEachColumnComment(
@@ -174,6 +201,11 @@ func FindColumnComment(b ElementStatusIterator) (current Status, target TargetSt
 
 func (e ColumnDefaultExpression) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_ColumnDefaultExpression) Element() Element {
+	return e.ColumnDefaultExpression
+}
+
 // ForEachColumnDefaultExpression iterates over elements of type ColumnDefaultExpression.
 func ForEachColumnDefaultExpression(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *ColumnDefaultExpression),
@@ -204,6 +236,11 @@ func FindColumnDefaultExpression(b ElementStatusIterator) (current Status, targe
 }
 
 func (e ColumnFamily) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_ColumnFamily) Element() Element {
+	return e.ColumnFamily
+}
 
 // ForEachColumnFamily iterates over elements of type ColumnFamily.
 func ForEachColumnFamily(
@@ -236,6 +273,11 @@ func FindColumnFamily(b ElementStatusIterator) (current Status, target TargetSta
 
 func (e ColumnName) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_ColumnName) Element() Element {
+	return e.ColumnName
+}
+
 // ForEachColumnName iterates over elements of type ColumnName.
 func ForEachColumnName(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *ColumnName),
@@ -266,6 +308,11 @@ func FindColumnName(b ElementStatusIterator) (current Status, target TargetStatu
 }
 
 func (e ColumnNotNull) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_ColumnNotNull) Element() Element {
+	return e.ColumnNotNull
+}
 
 // ForEachColumnNotNull iterates over elements of type ColumnNotNull.
 func ForEachColumnNotNull(
@@ -298,6 +345,11 @@ func FindColumnNotNull(b ElementStatusIterator) (current Status, target TargetSt
 
 func (e ColumnOnUpdateExpression) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_ColumnOnUpdateExpression) Element() Element {
+	return e.ColumnOnUpdateExpression
+}
+
 // ForEachColumnOnUpdateExpression iterates over elements of type ColumnOnUpdateExpression.
 func ForEachColumnOnUpdateExpression(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *ColumnOnUpdateExpression),
@@ -328,6 +380,11 @@ func FindColumnOnUpdateExpression(b ElementStatusIterator) (current Status, targ
 }
 
 func (e ColumnType) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_ColumnType) Element() Element {
+	return e.ColumnType
+}
 
 // ForEachColumnType iterates over elements of type ColumnType.
 func ForEachColumnType(
@@ -360,6 +417,11 @@ func FindColumnType(b ElementStatusIterator) (current Status, target TargetStatu
 
 func (e CompositeType) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_CompositeType) Element() Element {
+	return e.CompositeType
+}
+
 // ForEachCompositeType iterates over elements of type CompositeType.
 func ForEachCompositeType(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *CompositeType),
@@ -390,6 +452,11 @@ func FindCompositeType(b ElementStatusIterator) (current Status, target TargetSt
 }
 
 func (e CompositeTypeAttrName) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_CompositeTypeAttrName) Element() Element {
+	return e.CompositeTypeAttrName
+}
 
 // ForEachCompositeTypeAttrName iterates over elements of type CompositeTypeAttrName.
 func ForEachCompositeTypeAttrName(
@@ -422,6 +489,11 @@ func FindCompositeTypeAttrName(b ElementStatusIterator) (current Status, target 
 
 func (e CompositeTypeAttrType) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_CompositeTypeAttrType) Element() Element {
+	return e.CompositeTypeAttrType
+}
+
 // ForEachCompositeTypeAttrType iterates over elements of type CompositeTypeAttrType.
 func ForEachCompositeTypeAttrType(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *CompositeTypeAttrType),
@@ -452,6 +524,11 @@ func FindCompositeTypeAttrType(b ElementStatusIterator) (current Status, target 
 }
 
 func (e ConstraintComment) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_ConstraintComment) Element() Element {
+	return e.ConstraintComment
+}
 
 // ForEachConstraintComment iterates over elements of type ConstraintComment.
 func ForEachConstraintComment(
@@ -484,6 +561,11 @@ func FindConstraintComment(b ElementStatusIterator) (current Status, target Targ
 
 func (e ConstraintWithoutIndexName) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_ConstraintWithoutIndexName) Element() Element {
+	return e.ConstraintWithoutIndexName
+}
+
 // ForEachConstraintWithoutIndexName iterates over elements of type ConstraintWithoutIndexName.
 func ForEachConstraintWithoutIndexName(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *ConstraintWithoutIndexName),
@@ -514,6 +596,11 @@ func FindConstraintWithoutIndexName(b ElementStatusIterator) (current Status, ta
 }
 
 func (e Database) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_Database) Element() Element {
+	return e.Database
+}
 
 // ForEachDatabase iterates over elements of type Database.
 func ForEachDatabase(
@@ -546,6 +633,11 @@ func FindDatabase(b ElementStatusIterator) (current Status, target TargetStatus,
 
 func (e DatabaseComment) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_DatabaseComment) Element() Element {
+	return e.DatabaseComment
+}
+
 // ForEachDatabaseComment iterates over elements of type DatabaseComment.
 func ForEachDatabaseComment(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *DatabaseComment),
@@ -576,6 +668,11 @@ func FindDatabaseComment(b ElementStatusIterator) (current Status, target Target
 }
 
 func (e DatabaseData) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_DatabaseData) Element() Element {
+	return e.DatabaseData
+}
 
 // ForEachDatabaseData iterates over elements of type DatabaseData.
 func ForEachDatabaseData(
@@ -608,6 +705,11 @@ func FindDatabaseData(b ElementStatusIterator) (current Status, target TargetSta
 
 func (e DatabaseRegionConfig) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_DatabaseRegionConfig) Element() Element {
+	return e.DatabaseRegionConfig
+}
+
 // ForEachDatabaseRegionConfig iterates over elements of type DatabaseRegionConfig.
 func ForEachDatabaseRegionConfig(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *DatabaseRegionConfig),
@@ -638,6 +740,11 @@ func FindDatabaseRegionConfig(b ElementStatusIterator) (current Status, target T
 }
 
 func (e DatabaseRoleSetting) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_DatabaseRoleSetting) Element() Element {
+	return e.DatabaseRoleSetting
+}
 
 // ForEachDatabaseRoleSetting iterates over elements of type DatabaseRoleSetting.
 func ForEachDatabaseRoleSetting(
@@ -670,6 +777,11 @@ func FindDatabaseRoleSetting(b ElementStatusIterator) (current Status, target Ta
 
 func (e EnumType) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_EnumType) Element() Element {
+	return e.EnumType
+}
+
 // ForEachEnumType iterates over elements of type EnumType.
 func ForEachEnumType(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *EnumType),
@@ -700,6 +812,11 @@ func FindEnumType(b ElementStatusIterator) (current Status, target TargetStatus,
 }
 
 func (e EnumTypeValue) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_EnumTypeValue) Element() Element {
+	return e.EnumTypeValue
+}
 
 // ForEachEnumTypeValue iterates over elements of type EnumTypeValue.
 func ForEachEnumTypeValue(
@@ -732,6 +849,11 @@ func FindEnumTypeValue(b ElementStatusIterator) (current Status, target TargetSt
 
 func (e ForeignKeyConstraint) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_ForeignKeyConstraint) Element() Element {
+	return e.ForeignKeyConstraint
+}
+
 // ForEachForeignKeyConstraint iterates over elements of type ForeignKeyConstraint.
 func ForEachForeignKeyConstraint(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *ForeignKeyConstraint),
@@ -762,6 +884,11 @@ func FindForeignKeyConstraint(b ElementStatusIterator) (current Status, target T
 }
 
 func (e ForeignKeyConstraintUnvalidated) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_ForeignKeyConstraintUnvalidated) Element() Element {
+	return e.ForeignKeyConstraintUnvalidated
+}
 
 // ForEachForeignKeyConstraintUnvalidated iterates over elements of type ForeignKeyConstraintUnvalidated.
 func ForEachForeignKeyConstraintUnvalidated(
@@ -794,6 +921,11 @@ func FindForeignKeyConstraintUnvalidated(b ElementStatusIterator) (current Statu
 
 func (e Function) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_Function) Element() Element {
+	return e.Function
+}
+
 // ForEachFunction iterates over elements of type Function.
 func ForEachFunction(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *Function),
@@ -824,6 +956,11 @@ func FindFunction(b ElementStatusIterator) (current Status, target TargetStatus,
 }
 
 func (e FunctionBody) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_FunctionBody) Element() Element {
+	return e.FunctionBody
+}
 
 // ForEachFunctionBody iterates over elements of type FunctionBody.
 func ForEachFunctionBody(
@@ -856,6 +993,11 @@ func FindFunctionBody(b ElementStatusIterator) (current Status, target TargetSta
 
 func (e FunctionLeakProof) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_FunctionLeakProof) Element() Element {
+	return e.FunctionLeakProof
+}
+
 // ForEachFunctionLeakProof iterates over elements of type FunctionLeakProof.
 func ForEachFunctionLeakProof(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *FunctionLeakProof),
@@ -886,6 +1028,11 @@ func FindFunctionLeakProof(b ElementStatusIterator) (current Status, target Targ
 }
 
 func (e FunctionName) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_FunctionName) Element() Element {
+	return e.FunctionName
+}
 
 // ForEachFunctionName iterates over elements of type FunctionName.
 func ForEachFunctionName(
@@ -918,6 +1065,11 @@ func FindFunctionName(b ElementStatusIterator) (current Status, target TargetSta
 
 func (e FunctionNullInputBehavior) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_FunctionNullInputBehavior) Element() Element {
+	return e.FunctionNullInputBehavior
+}
+
 // ForEachFunctionNullInputBehavior iterates over elements of type FunctionNullInputBehavior.
 func ForEachFunctionNullInputBehavior(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *FunctionNullInputBehavior),
@@ -948,6 +1100,11 @@ func FindFunctionNullInputBehavior(b ElementStatusIterator) (current Status, tar
 }
 
 func (e FunctionParamDefaultExpression) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_FunctionParamDefaultExpression) Element() Element {
+	return e.FunctionParamDefaultExpression
+}
 
 // ForEachFunctionParamDefaultExpression iterates over elements of type FunctionParamDefaultExpression.
 func ForEachFunctionParamDefaultExpression(
@@ -980,6 +1137,11 @@ func FindFunctionParamDefaultExpression(b ElementStatusIterator) (current Status
 
 func (e FunctionVolatility) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_FunctionVolatility) Element() Element {
+	return e.FunctionVolatility
+}
+
 // ForEachFunctionVolatility iterates over elements of type FunctionVolatility.
 func ForEachFunctionVolatility(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *FunctionVolatility),
@@ -1010,6 +1172,11 @@ func FindFunctionVolatility(b ElementStatusIterator) (current Status, target Tar
 }
 
 func (e IndexColumn) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_IndexColumn) Element() Element {
+	return e.IndexColumn
+}
 
 // ForEachIndexColumn iterates over elements of type IndexColumn.
 func ForEachIndexColumn(
@@ -1042,6 +1209,11 @@ func FindIndexColumn(b ElementStatusIterator) (current Status, target TargetStat
 
 func (e IndexComment) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_IndexComment) Element() Element {
+	return e.IndexComment
+}
+
 // ForEachIndexComment iterates over elements of type IndexComment.
 func ForEachIndexComment(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *IndexComment),
@@ -1072,6 +1244,11 @@ func FindIndexComment(b ElementStatusIterator) (current Status, target TargetSta
 }
 
 func (e IndexData) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_IndexData) Element() Element {
+	return e.IndexData
+}
 
 // ForEachIndexData iterates over elements of type IndexData.
 func ForEachIndexData(
@@ -1104,6 +1281,11 @@ func FindIndexData(b ElementStatusIterator) (current Status, target TargetStatus
 
 func (e IndexName) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_IndexName) Element() Element {
+	return e.IndexName
+}
+
 // ForEachIndexName iterates over elements of type IndexName.
 func ForEachIndexName(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *IndexName),
@@ -1134,6 +1316,11 @@ func FindIndexName(b ElementStatusIterator) (current Status, target TargetStatus
 }
 
 func (e IndexPartitioning) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_IndexPartitioning) Element() Element {
+	return e.IndexPartitioning
+}
 
 // ForEachIndexPartitioning iterates over elements of type IndexPartitioning.
 func ForEachIndexPartitioning(
@@ -1166,6 +1353,11 @@ func FindIndexPartitioning(b ElementStatusIterator) (current Status, target Targ
 
 func (e IndexZoneConfig) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_IndexZoneConfig) Element() Element {
+	return e.IndexZoneConfig
+}
+
 // ForEachIndexZoneConfig iterates over elements of type IndexZoneConfig.
 func ForEachIndexZoneConfig(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *IndexZoneConfig),
@@ -1196,6 +1388,11 @@ func FindIndexZoneConfig(b ElementStatusIterator) (current Status, target Target
 }
 
 func (e Namespace) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_Namespace) Element() Element {
+	return e.Namespace
+}
 
 // ForEachNamespace iterates over elements of type Namespace.
 func ForEachNamespace(
@@ -1228,6 +1425,11 @@ func FindNamespace(b ElementStatusIterator) (current Status, target TargetStatus
 
 func (e Owner) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_Owner) Element() Element {
+	return e.Owner
+}
+
 // ForEachOwner iterates over elements of type Owner.
 func ForEachOwner(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *Owner),
@@ -1258,6 +1460,11 @@ func FindOwner(b ElementStatusIterator) (current Status, target TargetStatus, el
 }
 
 func (e PrimaryIndex) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_PrimaryIndex) Element() Element {
+	return e.PrimaryIndex
+}
 
 // ForEachPrimaryIndex iterates over elements of type PrimaryIndex.
 func ForEachPrimaryIndex(
@@ -1290,6 +1497,11 @@ func FindPrimaryIndex(b ElementStatusIterator) (current Status, target TargetSta
 
 func (e RowLevelTTL) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_RowLevelTTL) Element() Element {
+	return e.RowLevelTTL
+}
+
 // ForEachRowLevelTTL iterates over elements of type RowLevelTTL.
 func ForEachRowLevelTTL(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *RowLevelTTL),
@@ -1320,6 +1532,11 @@ func FindRowLevelTTL(b ElementStatusIterator) (current Status, target TargetStat
 }
 
 func (e Schema) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_Schema) Element() Element {
+	return e.Schema
+}
 
 // ForEachSchema iterates over elements of type Schema.
 func ForEachSchema(
@@ -1352,6 +1569,11 @@ func FindSchema(b ElementStatusIterator) (current Status, target TargetStatus, e
 
 func (e SchemaChild) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_SchemaChild) Element() Element {
+	return e.SchemaChild
+}
+
 // ForEachSchemaChild iterates over elements of type SchemaChild.
 func ForEachSchemaChild(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *SchemaChild),
@@ -1382,6 +1604,11 @@ func FindSchemaChild(b ElementStatusIterator) (current Status, target TargetStat
 }
 
 func (e SchemaComment) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_SchemaComment) Element() Element {
+	return e.SchemaComment
+}
 
 // ForEachSchemaComment iterates over elements of type SchemaComment.
 func ForEachSchemaComment(
@@ -1414,6 +1641,11 @@ func FindSchemaComment(b ElementStatusIterator) (current Status, target TargetSt
 
 func (e SchemaParent) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_SchemaParent) Element() Element {
+	return e.SchemaParent
+}
+
 // ForEachSchemaParent iterates over elements of type SchemaParent.
 func ForEachSchemaParent(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *SchemaParent),
@@ -1444,6 +1676,11 @@ func FindSchemaParent(b ElementStatusIterator) (current Status, target TargetSta
 }
 
 func (e SecondaryIndex) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_SecondaryIndex) Element() Element {
+	return e.SecondaryIndex
+}
 
 // ForEachSecondaryIndex iterates over elements of type SecondaryIndex.
 func ForEachSecondaryIndex(
@@ -1476,6 +1713,11 @@ func FindSecondaryIndex(b ElementStatusIterator) (current Status, target TargetS
 
 func (e SecondaryIndexPartial) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_SecondaryIndexPartial) Element() Element {
+	return e.SecondaryIndexPartial
+}
+
 // ForEachSecondaryIndexPartial iterates over elements of type SecondaryIndexPartial.
 func ForEachSecondaryIndexPartial(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *SecondaryIndexPartial),
@@ -1506,6 +1748,11 @@ func FindSecondaryIndexPartial(b ElementStatusIterator) (current Status, target 
 }
 
 func (e Sequence) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_Sequence) Element() Element {
+	return e.Sequence
+}
 
 // ForEachSequence iterates over elements of type Sequence.
 func ForEachSequence(
@@ -1538,6 +1785,11 @@ func FindSequence(b ElementStatusIterator) (current Status, target TargetStatus,
 
 func (e SequenceOwner) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_SequenceOwner) Element() Element {
+	return e.SequenceOwner
+}
+
 // ForEachSequenceOwner iterates over elements of type SequenceOwner.
 func ForEachSequenceOwner(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *SequenceOwner),
@@ -1568,6 +1820,11 @@ func FindSequenceOwner(b ElementStatusIterator) (current Status, target TargetSt
 }
 
 func (e Table) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_Table) Element() Element {
+	return e.Table
+}
 
 // ForEachTable iterates over elements of type Table.
 func ForEachTable(
@@ -1600,6 +1857,11 @@ func FindTable(b ElementStatusIterator) (current Status, target TargetStatus, el
 
 func (e TableComment) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_TableComment) Element() Element {
+	return e.TableComment
+}
+
 // ForEachTableComment iterates over elements of type TableComment.
 func ForEachTableComment(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *TableComment),
@@ -1630,6 +1892,11 @@ func FindTableComment(b ElementStatusIterator) (current Status, target TargetSta
 }
 
 func (e TableData) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_TableData) Element() Element {
+	return e.TableData
+}
 
 // ForEachTableData iterates over elements of type TableData.
 func ForEachTableData(
@@ -1662,6 +1929,11 @@ func FindTableData(b ElementStatusIterator) (current Status, target TargetStatus
 
 func (e TableLocalityGlobal) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_TableLocalityGlobal) Element() Element {
+	return e.TableLocalityGlobal
+}
+
 // ForEachTableLocalityGlobal iterates over elements of type TableLocalityGlobal.
 func ForEachTableLocalityGlobal(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *TableLocalityGlobal),
@@ -1692,6 +1964,11 @@ func FindTableLocalityGlobal(b ElementStatusIterator) (current Status, target Ta
 }
 
 func (e TableLocalityPrimaryRegion) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_TableLocalityPrimaryRegion) Element() Element {
+	return e.TableLocalityPrimaryRegion
+}
 
 // ForEachTableLocalityPrimaryRegion iterates over elements of type TableLocalityPrimaryRegion.
 func ForEachTableLocalityPrimaryRegion(
@@ -1724,6 +2001,11 @@ func FindTableLocalityPrimaryRegion(b ElementStatusIterator) (current Status, ta
 
 func (e TableLocalityRegionalByRow) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_TableLocalityRegionalByRow) Element() Element {
+	return e.TableLocalityRegionalByRow
+}
+
 // ForEachTableLocalityRegionalByRow iterates over elements of type TableLocalityRegionalByRow.
 func ForEachTableLocalityRegionalByRow(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *TableLocalityRegionalByRow),
@@ -1754,6 +2036,11 @@ func FindTableLocalityRegionalByRow(b ElementStatusIterator) (current Status, ta
 }
 
 func (e TableLocalitySecondaryRegion) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_TableLocalitySecondaryRegion) Element() Element {
+	return e.TableLocalitySecondaryRegion
+}
 
 // ForEachTableLocalitySecondaryRegion iterates over elements of type TableLocalitySecondaryRegion.
 func ForEachTableLocalitySecondaryRegion(
@@ -1786,6 +2073,11 @@ func FindTableLocalitySecondaryRegion(b ElementStatusIterator) (current Status, 
 
 func (e TablePartitioning) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_TablePartitioning) Element() Element {
+	return e.TablePartitioning
+}
+
 // ForEachTablePartitioning iterates over elements of type TablePartitioning.
 func ForEachTablePartitioning(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *TablePartitioning),
@@ -1816,6 +2108,11 @@ func FindTablePartitioning(b ElementStatusIterator) (current Status, target Targ
 }
 
 func (e TableSchemaLocked) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_TableSchemaLocked) Element() Element {
+	return e.TableSchemaLocked
+}
 
 // ForEachTableSchemaLocked iterates over elements of type TableSchemaLocked.
 func ForEachTableSchemaLocked(
@@ -1848,6 +2145,11 @@ func FindTableSchemaLocked(b ElementStatusIterator) (current Status, target Targ
 
 func (e TableZoneConfig) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_TableZoneConfig) Element() Element {
+	return e.TableZoneConfig
+}
+
 // ForEachTableZoneConfig iterates over elements of type TableZoneConfig.
 func ForEachTableZoneConfig(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *TableZoneConfig),
@@ -1878,6 +2180,11 @@ func FindTableZoneConfig(b ElementStatusIterator) (current Status, target Target
 }
 
 func (e TemporaryIndex) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_TemporaryIndex) Element() Element {
+	return e.TemporaryIndex
+}
 
 // ForEachTemporaryIndex iterates over elements of type TemporaryIndex.
 func ForEachTemporaryIndex(
@@ -1910,6 +2217,11 @@ func FindTemporaryIndex(b ElementStatusIterator) (current Status, target TargetS
 
 func (e UniqueWithoutIndexConstraint) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_UniqueWithoutIndexConstraint) Element() Element {
+	return e.UniqueWithoutIndexConstraint
+}
+
 // ForEachUniqueWithoutIndexConstraint iterates over elements of type UniqueWithoutIndexConstraint.
 func ForEachUniqueWithoutIndexConstraint(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *UniqueWithoutIndexConstraint),
@@ -1940,6 +2252,11 @@ func FindUniqueWithoutIndexConstraint(b ElementStatusIterator) (current Status, 
 }
 
 func (e UniqueWithoutIndexConstraintUnvalidated) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_UniqueWithoutIndexConstraintUnvalidated) Element() Element {
+	return e.UniqueWithoutIndexConstraintUnvalidated
+}
 
 // ForEachUniqueWithoutIndexConstraintUnvalidated iterates over elements of type UniqueWithoutIndexConstraintUnvalidated.
 func ForEachUniqueWithoutIndexConstraintUnvalidated(
@@ -1972,6 +2289,11 @@ func FindUniqueWithoutIndexConstraintUnvalidated(b ElementStatusIterator) (curre
 
 func (e UserPrivileges) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_UserPrivileges) Element() Element {
+	return e.UserPrivileges
+}
+
 // ForEachUserPrivileges iterates over elements of type UserPrivileges.
 func ForEachUserPrivileges(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *UserPrivileges),
@@ -2003,6 +2325,11 @@ func FindUserPrivileges(b ElementStatusIterator) (current Status, target TargetS
 
 func (e View) element() {}
 
+// Element implements ElementGetter.
+func (e * ElementProto_View) Element() Element {
+	return e.View
+}
+
 // ForEachView iterates over elements of type View.
 func ForEachView(
 	b ElementStatusIterator, fn func(current Status, target TargetStatus, e *View),
@@ -2030,4 +2357,294 @@ func FindView(b ElementStatusIterator) (current Status, target TargetStatus, ele
 		}
 	})
 	return current, target, element
+}//
+// SetElements sets the element inside the protobuf.
+func (e* ElementProto) SetElement(element Element) {
+	switch t := element.(type) {
+		default:
+			panic(fmt.Sprintf("unknown type %T", t))
+
+		case *AliasType:
+			e.ElementOneOf = &ElementProto_AliasType{ AliasType: t}
+		case *CheckConstraint:
+			e.ElementOneOf = &ElementProto_CheckConstraint{ CheckConstraint: t}
+		case *CheckConstraintUnvalidated:
+			e.ElementOneOf = &ElementProto_CheckConstraintUnvalidated{ CheckConstraintUnvalidated: t}
+		case *Column:
+			e.ElementOneOf = &ElementProto_Column{ Column: t}
+		case *ColumnComment:
+			e.ElementOneOf = &ElementProto_ColumnComment{ ColumnComment: t}
+		case *ColumnDefaultExpression:
+			e.ElementOneOf = &ElementProto_ColumnDefaultExpression{ ColumnDefaultExpression: t}
+		case *ColumnFamily:
+			e.ElementOneOf = &ElementProto_ColumnFamily{ ColumnFamily: t}
+		case *ColumnName:
+			e.ElementOneOf = &ElementProto_ColumnName{ ColumnName: t}
+		case *ColumnNotNull:
+			e.ElementOneOf = &ElementProto_ColumnNotNull{ ColumnNotNull: t}
+		case *ColumnOnUpdateExpression:
+			e.ElementOneOf = &ElementProto_ColumnOnUpdateExpression{ ColumnOnUpdateExpression: t}
+		case *ColumnType:
+			e.ElementOneOf = &ElementProto_ColumnType{ ColumnType: t}
+		case *CompositeType:
+			e.ElementOneOf = &ElementProto_CompositeType{ CompositeType: t}
+		case *CompositeTypeAttrName:
+			e.ElementOneOf = &ElementProto_CompositeTypeAttrName{ CompositeTypeAttrName: t}
+		case *CompositeTypeAttrType:
+			e.ElementOneOf = &ElementProto_CompositeTypeAttrType{ CompositeTypeAttrType: t}
+		case *ConstraintComment:
+			e.ElementOneOf = &ElementProto_ConstraintComment{ ConstraintComment: t}
+		case *ConstraintWithoutIndexName:
+			e.ElementOneOf = &ElementProto_ConstraintWithoutIndexName{ ConstraintWithoutIndexName: t}
+		case *Database:
+			e.ElementOneOf = &ElementProto_Database{ Database: t}
+		case *DatabaseComment:
+			e.ElementOneOf = &ElementProto_DatabaseComment{ DatabaseComment: t}
+		case *DatabaseData:
+			e.ElementOneOf = &ElementProto_DatabaseData{ DatabaseData: t}
+		case *DatabaseRegionConfig:
+			e.ElementOneOf = &ElementProto_DatabaseRegionConfig{ DatabaseRegionConfig: t}
+		case *DatabaseRoleSetting:
+			e.ElementOneOf = &ElementProto_DatabaseRoleSetting{ DatabaseRoleSetting: t}
+		case *EnumType:
+			e.ElementOneOf = &ElementProto_EnumType{ EnumType: t}
+		case *EnumTypeValue:
+			e.ElementOneOf = &ElementProto_EnumTypeValue{ EnumTypeValue: t}
+		case *ForeignKeyConstraint:
+			e.ElementOneOf = &ElementProto_ForeignKeyConstraint{ ForeignKeyConstraint: t}
+		case *ForeignKeyConstraintUnvalidated:
+			e.ElementOneOf = &ElementProto_ForeignKeyConstraintUnvalidated{ ForeignKeyConstraintUnvalidated: t}
+		case *Function:
+			e.ElementOneOf = &ElementProto_Function{ Function: t}
+		case *FunctionBody:
+			e.ElementOneOf = &ElementProto_FunctionBody{ FunctionBody: t}
+		case *FunctionLeakProof:
+			e.ElementOneOf = &ElementProto_FunctionLeakProof{ FunctionLeakProof: t}
+		case *FunctionName:
+			e.ElementOneOf = &ElementProto_FunctionName{ FunctionName: t}
+		case *FunctionNullInputBehavior:
+			e.ElementOneOf = &ElementProto_FunctionNullInputBehavior{ FunctionNullInputBehavior: t}
+		case *FunctionParamDefaultExpression:
+			e.ElementOneOf = &ElementProto_FunctionParamDefaultExpression{ FunctionParamDefaultExpression: t}
+		case *FunctionVolatility:
+			e.ElementOneOf = &ElementProto_FunctionVolatility{ FunctionVolatility: t}
+		case *IndexColumn:
+			e.ElementOneOf = &ElementProto_IndexColumn{ IndexColumn: t}
+		case *IndexComment:
+			e.ElementOneOf = &ElementProto_IndexComment{ IndexComment: t}
+		case *IndexData:
+			e.ElementOneOf = &ElementProto_IndexData{ IndexData: t}
+		case *IndexName:
+			e.ElementOneOf = &ElementProto_IndexName{ IndexName: t}
+		case *IndexPartitioning:
+			e.ElementOneOf = &ElementProto_IndexPartitioning{ IndexPartitioning: t}
+		case *IndexZoneConfig:
+			e.ElementOneOf = &ElementProto_IndexZoneConfig{ IndexZoneConfig: t}
+		case *Namespace:
+			e.ElementOneOf = &ElementProto_Namespace{ Namespace: t}
+		case *Owner:
+			e.ElementOneOf = &ElementProto_Owner{ Owner: t}
+		case *PrimaryIndex:
+			e.ElementOneOf = &ElementProto_PrimaryIndex{ PrimaryIndex: t}
+		case *RowLevelTTL:
+			e.ElementOneOf = &ElementProto_RowLevelTTL{ RowLevelTTL: t}
+		case *Schema:
+			e.ElementOneOf = &ElementProto_Schema{ Schema: t}
+		case *SchemaChild:
+			e.ElementOneOf = &ElementProto_SchemaChild{ SchemaChild: t}
+		case *SchemaComment:
+			e.ElementOneOf = &ElementProto_SchemaComment{ SchemaComment: t}
+		case *SchemaParent:
+			e.ElementOneOf = &ElementProto_SchemaParent{ SchemaParent: t}
+		case *SecondaryIndex:
+			e.ElementOneOf = &ElementProto_SecondaryIndex{ SecondaryIndex: t}
+		case *SecondaryIndexPartial:
+			e.ElementOneOf = &ElementProto_SecondaryIndexPartial{ SecondaryIndexPartial: t}
+		case *Sequence:
+			e.ElementOneOf = &ElementProto_Sequence{ Sequence: t}
+		case *SequenceOwner:
+			e.ElementOneOf = &ElementProto_SequenceOwner{ SequenceOwner: t}
+		case *Table:
+			e.ElementOneOf = &ElementProto_Table{ Table: t}
+		case *TableComment:
+			e.ElementOneOf = &ElementProto_TableComment{ TableComment: t}
+		case *TableData:
+			e.ElementOneOf = &ElementProto_TableData{ TableData: t}
+		case *TableLocalityGlobal:
+			e.ElementOneOf = &ElementProto_TableLocalityGlobal{ TableLocalityGlobal: t}
+		case *TableLocalityPrimaryRegion:
+			e.ElementOneOf = &ElementProto_TableLocalityPrimaryRegion{ TableLocalityPrimaryRegion: t}
+		case *TableLocalityRegionalByRow:
+			e.ElementOneOf = &ElementProto_TableLocalityRegionalByRow{ TableLocalityRegionalByRow: t}
+		case *TableLocalitySecondaryRegion:
+			e.ElementOneOf = &ElementProto_TableLocalitySecondaryRegion{ TableLocalitySecondaryRegion: t}
+		case *TablePartitioning:
+			e.ElementOneOf = &ElementProto_TablePartitioning{ TablePartitioning: t}
+		case *TableSchemaLocked:
+			e.ElementOneOf = &ElementProto_TableSchemaLocked{ TableSchemaLocked: t}
+		case *TableZoneConfig:
+			e.ElementOneOf = &ElementProto_TableZoneConfig{ TableZoneConfig: t}
+		case *TemporaryIndex:
+			e.ElementOneOf = &ElementProto_TemporaryIndex{ TemporaryIndex: t}
+		case *UniqueWithoutIndexConstraint:
+			e.ElementOneOf = &ElementProto_UniqueWithoutIndexConstraint{ UniqueWithoutIndexConstraint: t}
+		case *UniqueWithoutIndexConstraintUnvalidated:
+			e.ElementOneOf = &ElementProto_UniqueWithoutIndexConstraintUnvalidated{ UniqueWithoutIndexConstraintUnvalidated: t}
+		case *UserPrivileges:
+			e.ElementOneOf = &ElementProto_UserPrivileges{ UserPrivileges: t}
+		case *View:
+			e.ElementOneOf = &ElementProto_View{ View: t}}
+}
+//
+// GetElementOneOfProtos returns all one of protos.
+func GetElementOneOfProtos() []interface{} {
+	return []interface{} {
+
+	((*ElementProto_AliasType)(nil)),
+	((*ElementProto_CheckConstraint)(nil)),
+	((*ElementProto_CheckConstraintUnvalidated)(nil)),
+	((*ElementProto_Column)(nil)),
+	((*ElementProto_ColumnComment)(nil)),
+	((*ElementProto_ColumnDefaultExpression)(nil)),
+	((*ElementProto_ColumnFamily)(nil)),
+	((*ElementProto_ColumnName)(nil)),
+	((*ElementProto_ColumnNotNull)(nil)),
+	((*ElementProto_ColumnOnUpdateExpression)(nil)),
+	((*ElementProto_ColumnType)(nil)),
+	((*ElementProto_CompositeType)(nil)),
+	((*ElementProto_CompositeTypeAttrName)(nil)),
+	((*ElementProto_CompositeTypeAttrType)(nil)),
+	((*ElementProto_ConstraintComment)(nil)),
+	((*ElementProto_ConstraintWithoutIndexName)(nil)),
+	((*ElementProto_Database)(nil)),
+	((*ElementProto_DatabaseComment)(nil)),
+	((*ElementProto_DatabaseData)(nil)),
+	((*ElementProto_DatabaseRegionConfig)(nil)),
+	((*ElementProto_DatabaseRoleSetting)(nil)),
+	((*ElementProto_EnumType)(nil)),
+	((*ElementProto_EnumTypeValue)(nil)),
+	((*ElementProto_ForeignKeyConstraint)(nil)),
+	((*ElementProto_ForeignKeyConstraintUnvalidated)(nil)),
+	((*ElementProto_Function)(nil)),
+	((*ElementProto_FunctionBody)(nil)),
+	((*ElementProto_FunctionLeakProof)(nil)),
+	((*ElementProto_FunctionName)(nil)),
+	((*ElementProto_FunctionNullInputBehavior)(nil)),
+	((*ElementProto_FunctionParamDefaultExpression)(nil)),
+	((*ElementProto_FunctionVolatility)(nil)),
+	((*ElementProto_IndexColumn)(nil)),
+	((*ElementProto_IndexComment)(nil)),
+	((*ElementProto_IndexData)(nil)),
+	((*ElementProto_IndexName)(nil)),
+	((*ElementProto_IndexPartitioning)(nil)),
+	((*ElementProto_IndexZoneConfig)(nil)),
+	((*ElementProto_Namespace)(nil)),
+	((*ElementProto_Owner)(nil)),
+	((*ElementProto_PrimaryIndex)(nil)),
+	((*ElementProto_RowLevelTTL)(nil)),
+	((*ElementProto_Schema)(nil)),
+	((*ElementProto_SchemaChild)(nil)),
+	((*ElementProto_SchemaComment)(nil)),
+	((*ElementProto_SchemaParent)(nil)),
+	((*ElementProto_SecondaryIndex)(nil)),
+	((*ElementProto_SecondaryIndexPartial)(nil)),
+	((*ElementProto_Sequence)(nil)),
+	((*ElementProto_SequenceOwner)(nil)),
+	((*ElementProto_Table)(nil)),
+	((*ElementProto_TableComment)(nil)),
+	((*ElementProto_TableData)(nil)),
+	((*ElementProto_TableLocalityGlobal)(nil)),
+	((*ElementProto_TableLocalityPrimaryRegion)(nil)),
+	((*ElementProto_TableLocalityRegionalByRow)(nil)),
+	((*ElementProto_TableLocalitySecondaryRegion)(nil)),
+	((*ElementProto_TablePartitioning)(nil)),
+	((*ElementProto_TableSchemaLocked)(nil)),
+	((*ElementProto_TableZoneConfig)(nil)),
+	((*ElementProto_TemporaryIndex)(nil)),
+	((*ElementProto_UniqueWithoutIndexConstraint)(nil)),
+	((*ElementProto_UniqueWithoutIndexConstraintUnvalidated)(nil)),
+	((*ElementProto_UserPrivileges)(nil)),
+	((*ElementProto_View)(nil)),}
+}
+//
+// GetElementTypes returns all element types. 
+func GetElementTypes() []interface{} {
+
+	return []interface{} {
+
+	((*AliasType)(nil)),
+	((*CheckConstraint)(nil)),
+	((*CheckConstraintUnvalidated)(nil)),
+	((*Column)(nil)),
+	((*ColumnComment)(nil)),
+	((*ColumnDefaultExpression)(nil)),
+	((*ColumnFamily)(nil)),
+	((*ColumnName)(nil)),
+	((*ColumnNotNull)(nil)),
+	((*ColumnOnUpdateExpression)(nil)),
+	((*ColumnType)(nil)),
+	((*CompositeType)(nil)),
+	((*CompositeTypeAttrName)(nil)),
+	((*CompositeTypeAttrType)(nil)),
+	((*ConstraintComment)(nil)),
+	((*ConstraintWithoutIndexName)(nil)),
+	((*Database)(nil)),
+	((*DatabaseComment)(nil)),
+	((*DatabaseData)(nil)),
+	((*DatabaseRegionConfig)(nil)),
+	((*DatabaseRoleSetting)(nil)),
+	((*EnumType)(nil)),
+	((*EnumTypeValue)(nil)),
+	((*ForeignKeyConstraint)(nil)),
+	((*ForeignKeyConstraintUnvalidated)(nil)),
+	((*Function)(nil)),
+	((*FunctionBody)(nil)),
+	((*FunctionLeakProof)(nil)),
+	((*FunctionName)(nil)),
+	((*FunctionNullInputBehavior)(nil)),
+	((*FunctionParamDefaultExpression)(nil)),
+	((*FunctionVolatility)(nil)),
+	((*IndexColumn)(nil)),
+	((*IndexComment)(nil)),
+	((*IndexData)(nil)),
+	((*IndexName)(nil)),
+	((*IndexPartitioning)(nil)),
+	((*IndexZoneConfig)(nil)),
+	((*Namespace)(nil)),
+	((*Owner)(nil)),
+	((*PrimaryIndex)(nil)),
+	((*RowLevelTTL)(nil)),
+	((*Schema)(nil)),
+	((*SchemaChild)(nil)),
+	((*SchemaComment)(nil)),
+	((*SchemaParent)(nil)),
+	((*SecondaryIndex)(nil)),
+	((*SecondaryIndexPartial)(nil)),
+	((*Sequence)(nil)),
+	((*SequenceOwner)(nil)),
+	((*Table)(nil)),
+	((*TableComment)(nil)),
+	((*TableData)(nil)),
+	((*TableLocalityGlobal)(nil)),
+	((*TableLocalityPrimaryRegion)(nil)),
+	((*TableLocalityRegionalByRow)(nil)),
+	((*TableLocalitySecondaryRegion)(nil)),
+	((*TablePartitioning)(nil)),
+	((*TableSchemaLocked)(nil)),
+	((*TableZoneConfig)(nil)),
+	((*TemporaryIndex)(nil)),
+	((*UniqueWithoutIndexConstraint)(nil)),
+	((*UniqueWithoutIndexConstraintUnvalidated)(nil)),
+	((*UserPrivileges)(nil)),
+	((*View)(nil)),}
+}
+//
+// ForEachElementType loops over each element type
+func ForEachElementType(fn func(e Element) error) error {
+	for _, e := range GetElementTypes() {
+		if err := fn(e.(Element)); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/sql/schemachanger/scpb/migration.go
+++ b/pkg/sql/schemachanger/scpb/migration.go
@@ -16,7 +16,7 @@ import "github.com/cockroachdb/cockroach/pkg/clusterversion"
 // for deprecation.
 func HasDeprecatedElements(version clusterversion.ClusterVersion, target Target) bool {
 	if version.IsActive(clusterversion.V23_1_SchemaChangerDeprecatedIndexPredicates) &&
-		target.SecondaryIndexPartial != nil {
+		target.GetSecondaryIndexPartial() != nil {
 		return true
 	}
 	return false
@@ -28,11 +28,11 @@ func migrateTargetElement(targets []Target, idx int) {
 	switch t := targetToMigrate.Element().(type) {
 	case *SecondaryIndexPartial:
 		for _, target := range targets {
-			if target.SecondaryIndex != nil &&
-				target.SecondaryIndex.TableID == t.TableID &&
-				target.SecondaryIndex.IndexID == t.IndexID &&
+			if secondaryIndex := target.GetSecondaryIndex(); secondaryIndex != nil &&
+				secondaryIndex.TableID == t.TableID &&
+				secondaryIndex.IndexID == t.IndexID &&
 				target.TargetStatus == targetToMigrate.TargetStatus {
-				target.SecondaryIndex.EmbeddedExpr = &t.Expression
+				secondaryIndex.EmbeddedExpr = &t.Expression
 				break
 			}
 		}

--- a/pkg/sql/schemachanger/scpb/state.go
+++ b/pkg/sql/schemachanger/scpb/state.go
@@ -128,12 +128,16 @@ type Element interface {
 	element()
 }
 
+type ElementGetter interface {
+	Element() Element
+}
+
 //go:generate go run element_generator.go --in elements.proto --out elements_generated.go
 //go:generate go run element_uml_generator.go --out uml/table.puml
 
 // Element returns an Element from its wrapper for serialization.
 func (e *ElementProto) Element() Element {
-	return e.GetValue().(Element)
+	return e.GetElementOneOf().(ElementGetter).Element()
 }
 
 // MakeTarget constructs a new Target. The passed elem must be one of the oneOf
@@ -145,9 +149,7 @@ func MakeTarget(status TargetStatus, elem Element, metadata *TargetMetadata) Tar
 	if metadata != nil {
 		t.Metadata = *protoutil.Clone(metadata).(*TargetMetadata)
 	}
-	if !t.SetValue(elem) {
-		panic(errors.Errorf("unknown element type %T", elem))
-	}
+	t.SetElement(elem)
 	return t
 }
 

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -1,102 +1,8 @@
 @startuml
-object Database
-
-Database :  DatabaseID
-
-object Schema
-
-Schema :  SchemaID
-Schema :  IsTemporary
-Schema :  IsPublic
-Schema :  IsVirtual
-
-object View
-
-View :  ViewID
-View : []UsesTypeIDs
-View : []UsesRelationIDs
-View : []ForwardReferences
-View :  IsTemporary
-View :  IsMaterialized
-
-object Sequence
-
-Sequence :  SequenceID
-Sequence :  IsTemporary
-
-object Table
-
-Table :  TableID
-Table :  IsTemporary
-
-object EnumType
-
-EnumType :  TypeID
-EnumType :  ArrayTypeID
-EnumType :  IsMultiRegion
-
 object AliasType
 
 AliasType :  TypeID
 AliasType :  TypeT
-
-object CompositeType
-
-CompositeType :  TypeID
-CompositeType :  ArrayTypeID
-
-object Function
-
-Function :  FunctionID
-Function : []Params
-Function :  ReturnSet
-Function :  ReturnType
-
-object ColumnFamily
-
-ColumnFamily :  TableID
-ColumnFamily :  FamilyID
-ColumnFamily :  Name
-
-object Column
-
-Column :  TableID
-Column :  ColumnID
-Column :  IsHidden
-Column :  IsInaccessible
-Column :  GeneratedAsIdentityType
-Column :  GeneratedAsIdentitySequenceOption
-Column :  PgAttributeNum
-Column :  IsSystemColumn
-
-object PrimaryIndex
-
-PrimaryIndex :  Index
-
-object SecondaryIndex
-
-SecondaryIndex :  Index
-SecondaryIndex :  EmbeddedExpr
-
-object TemporaryIndex
-
-TemporaryIndex :  Index
-TemporaryIndex :  IsUsingSecondaryEncoding
-
-object UniqueWithoutIndexConstraint
-
-UniqueWithoutIndexConstraint :  TableID
-UniqueWithoutIndexConstraint :  ConstraintID
-UniqueWithoutIndexConstraint : []ColumnIDs
-UniqueWithoutIndexConstraint :  Predicate
-UniqueWithoutIndexConstraint :  IndexIDForValidation
-
-object UniqueWithoutIndexConstraintUnvalidated
-
-UniqueWithoutIndexConstraintUnvalidated :  TableID
-UniqueWithoutIndexConstraintUnvalidated :  ConstraintID
-UniqueWithoutIndexConstraintUnvalidated : []ColumnIDs
-UniqueWithoutIndexConstraintUnvalidated :  Predicate
 
 object CheckConstraint
 
@@ -113,6 +19,127 @@ CheckConstraintUnvalidated :  TableID
 CheckConstraintUnvalidated :  ConstraintID
 CheckConstraintUnvalidated : []ColumnIDs
 CheckConstraintUnvalidated :  Expression
+
+object Column
+
+Column :  TableID
+Column :  ColumnID
+Column :  IsHidden
+Column :  IsInaccessible
+Column :  GeneratedAsIdentityType
+Column :  GeneratedAsIdentitySequenceOption
+Column :  PgAttributeNum
+Column :  IsSystemColumn
+
+object ColumnComment
+
+ColumnComment :  TableID
+ColumnComment :  ColumnID
+ColumnComment :  Comment
+ColumnComment :  PgAttributeNum
+
+object ColumnDefaultExpression
+
+ColumnDefaultExpression :  TableID
+ColumnDefaultExpression :  ColumnID
+ColumnDefaultExpression :  Expression
+
+object ColumnFamily
+
+ColumnFamily :  TableID
+ColumnFamily :  FamilyID
+ColumnFamily :  Name
+
+object ColumnName
+
+ColumnName :  TableID
+ColumnName :  ColumnID
+ColumnName :  Name
+
+object ColumnNotNull
+
+ColumnNotNull :  TableID
+ColumnNotNull :  ColumnID
+ColumnNotNull :  IndexIDForValidation
+
+object ColumnOnUpdateExpression
+
+ColumnOnUpdateExpression :  TableID
+ColumnOnUpdateExpression :  ColumnID
+ColumnOnUpdateExpression :  Expression
+
+object ColumnType
+
+ColumnType :  TableID
+ColumnType :  FamilyID
+ColumnType :  ColumnID
+ColumnType :  TypeT
+ColumnType :  IsNullable
+ColumnType :  ComputeExpr
+ColumnType :  IsVirtual
+ColumnType :  ElementCreationMetadata
+
+object CompositeType
+
+CompositeType :  TypeID
+CompositeType :  ArrayTypeID
+
+object CompositeTypeAttrName
+
+CompositeTypeAttrName :  CompositeTypeID
+CompositeTypeAttrName :  Name
+
+object CompositeTypeAttrType
+
+CompositeTypeAttrType :  CompositeTypeID
+CompositeTypeAttrType :  TypeT
+
+object ConstraintComment
+
+ConstraintComment :  TableID
+ConstraintComment :  ConstraintID
+ConstraintComment :  Comment
+
+object ConstraintWithoutIndexName
+
+ConstraintWithoutIndexName :  TableID
+ConstraintWithoutIndexName :  ConstraintID
+ConstraintWithoutIndexName :  Name
+
+object Database
+
+Database :  DatabaseID
+
+object DatabaseComment
+
+DatabaseComment :  DatabaseID
+DatabaseComment :  Comment
+
+object DatabaseData
+
+DatabaseData :  DatabaseID
+
+object DatabaseRegionConfig
+
+DatabaseRegionConfig :  DatabaseID
+DatabaseRegionConfig :  RegionEnumTypeID
+
+object DatabaseRoleSetting
+
+DatabaseRoleSetting :  DatabaseID
+DatabaseRoleSetting :  RoleName
+
+object EnumType
+
+EnumType :  TypeID
+EnumType :  ArrayTypeID
+EnumType :  IsMultiRegion
+
+object EnumTypeValue
+
+EnumTypeValue :  TypeID
+EnumTypeValue : []PhysicalRepresentation
+EnumTypeValue :  LogicalRepresentation
 
 object ForeignKeyConstraint
 
@@ -137,105 +164,70 @@ ForeignKeyConstraintUnvalidated :  OnUpdateAction
 ForeignKeyConstraintUnvalidated :  OnDeleteAction
 ForeignKeyConstraintUnvalidated :  CompositeKeyMatchMethod
 
-object TableComment
+object Function
 
-TableComment :  TableID
-TableComment :  Comment
+Function :  FunctionID
+Function : []Params
+Function :  ReturnSet
+Function :  ReturnType
 
-object RowLevelTTL
+object FunctionBody
 
-RowLevelTTL :  TableID
-RowLevelTTL :  RowLevelTTL
+FunctionBody :  FunctionID
+FunctionBody :  Body
+FunctionBody :  Lang
+FunctionBody : []UsesTables
+FunctionBody : []UsesViews
+FunctionBody : []UsesSequenceIDs
+FunctionBody : []UsesTypeIDs
 
-object TableZoneConfig
+object FunctionLeakProof
 
-TableZoneConfig :  TableID
+FunctionLeakProof :  FunctionID
+FunctionLeakProof :  LeakProof
 
-object IndexZoneConfig
+object FunctionName
 
-IndexZoneConfig :  TableID
-IndexZoneConfig :  IndexID
-IndexZoneConfig :  PartitionName
+FunctionName :  FunctionID
+FunctionName :  Name
 
-object TableData
+object FunctionNullInputBehavior
 
-TableData :  TableID
-TableData :  DatabaseID
+FunctionNullInputBehavior :  FunctionID
+FunctionNullInputBehavior :  NullInputBehavior
 
-object TablePartitioning
+object FunctionParamDefaultExpression
 
-TablePartitioning :  TableID
+FunctionParamDefaultExpression :  FunctionID
+FunctionParamDefaultExpression :  Ordinal
+FunctionParamDefaultExpression :  Expression
 
-object TableSchemaLocked
+object FunctionVolatility
 
-TableSchemaLocked :  TableID
+FunctionVolatility :  FunctionID
+FunctionVolatility :  Volatility
 
-object TableLocalityGlobal
+object IndexColumn
 
-TableLocalityGlobal :  TableID
+IndexColumn :  TableID
+IndexColumn :  IndexID
+IndexColumn :  ColumnID
+IndexColumn :  OrdinalInKind
+IndexColumn :  Kind
+IndexColumn :  Direction
+IndexColumn :  Implicit
+IndexColumn :  InvertedKind
 
-object TableLocalityPrimaryRegion
+object IndexComment
 
-TableLocalityPrimaryRegion :  TableID
+IndexComment :  TableID
+IndexComment :  IndexID
+IndexComment :  Comment
 
-object TableLocalitySecondaryRegion
+object IndexData
 
-TableLocalitySecondaryRegion :  TableID
-TableLocalitySecondaryRegion :  RegionEnumTypeID
-TableLocalitySecondaryRegion :  RegionName
-
-object TableLocalityRegionalByRow
-
-TableLocalityRegionalByRow :  TableID
-TableLocalityRegionalByRow :  As
-
-object ColumnName
-
-ColumnName :  TableID
-ColumnName :  ColumnID
-ColumnName :  Name
-
-object ColumnType
-
-ColumnType :  TableID
-ColumnType :  FamilyID
-ColumnType :  ColumnID
-ColumnType :  TypeT
-ColumnType :  IsNullable
-ColumnType :  ComputeExpr
-ColumnType :  IsVirtual
-ColumnType :  ElementCreationMetadata
-
-object ColumnDefaultExpression
-
-ColumnDefaultExpression :  TableID
-ColumnDefaultExpression :  ColumnID
-ColumnDefaultExpression :  Expression
-
-object ColumnOnUpdateExpression
-
-ColumnOnUpdateExpression :  TableID
-ColumnOnUpdateExpression :  ColumnID
-ColumnOnUpdateExpression :  Expression
-
-object SequenceOwner
-
-SequenceOwner :  SequenceID
-SequenceOwner :  TableID
-SequenceOwner :  ColumnID
-
-object ColumnComment
-
-ColumnComment :  TableID
-ColumnComment :  ColumnID
-ColumnComment :  Comment
-ColumnComment :  PgAttributeNum
-
-object ColumnNotNull
-
-ColumnNotNull :  TableID
-ColumnNotNull :  ColumnID
-ColumnNotNull :  IndexIDForValidation
+IndexData :  TableID
+IndexData :  IndexID
 
 object IndexName
 
@@ -249,45 +241,11 @@ IndexPartitioning :  TableID
 IndexPartitioning :  IndexID
 IndexPartitioning :  PartitioningDescriptor
 
-object SecondaryIndexPartial
+object IndexZoneConfig
 
-SecondaryIndexPartial :  TableID
-SecondaryIndexPartial :  IndexID
-SecondaryIndexPartial :  Expression
-
-object IndexComment
-
-IndexComment :  TableID
-IndexComment :  IndexID
-IndexComment :  Comment
-
-object IndexColumn
-
-IndexColumn :  TableID
-IndexColumn :  IndexID
-IndexColumn :  ColumnID
-IndexColumn :  OrdinalInKind
-IndexColumn :  Kind
-IndexColumn :  Direction
-IndexColumn :  Implicit
-IndexColumn :  InvertedKind
-
-object IndexData
-
-IndexData :  TableID
-IndexData :  IndexID
-
-object ConstraintWithoutIndexName
-
-ConstraintWithoutIndexName :  TableID
-ConstraintWithoutIndexName :  ConstraintID
-ConstraintWithoutIndexName :  Name
-
-object ConstraintComment
-
-ConstraintComment :  TableID
-ConstraintComment :  ConstraintID
-ConstraintComment :  Comment
+IndexZoneConfig :  TableID
+IndexZoneConfig :  IndexID
+IndexZoneConfig :  PartitionName
 
 object Namespace
 
@@ -301,6 +259,125 @@ object Owner
 Owner :  DescriptorID
 Owner :  Owner
 
+object PrimaryIndex
+
+PrimaryIndex :  Index
+
+object RowLevelTTL
+
+RowLevelTTL :  TableID
+RowLevelTTL :  RowLevelTTL
+
+object Schema
+
+Schema :  SchemaID
+Schema :  IsTemporary
+Schema :  IsPublic
+Schema :  IsVirtual
+
+object SchemaChild
+
+SchemaChild :  ChildObjectID
+SchemaChild :  SchemaID
+
+object SchemaComment
+
+SchemaComment :  SchemaID
+SchemaComment :  Comment
+
+object SchemaParent
+
+SchemaParent :  SchemaID
+SchemaParent :  ParentDatabaseID
+
+object SecondaryIndex
+
+SecondaryIndex :  Index
+SecondaryIndex :  EmbeddedExpr
+
+object SecondaryIndexPartial
+
+SecondaryIndexPartial :  TableID
+SecondaryIndexPartial :  IndexID
+SecondaryIndexPartial :  Expression
+
+object Sequence
+
+Sequence :  SequenceID
+Sequence :  IsTemporary
+
+object SequenceOwner
+
+SequenceOwner :  SequenceID
+SequenceOwner :  TableID
+SequenceOwner :  ColumnID
+
+object Table
+
+Table :  TableID
+Table :  IsTemporary
+
+object TableComment
+
+TableComment :  TableID
+TableComment :  Comment
+
+object TableData
+
+TableData :  TableID
+TableData :  DatabaseID
+
+object TableLocalityGlobal
+
+TableLocalityGlobal :  TableID
+
+object TableLocalityPrimaryRegion
+
+TableLocalityPrimaryRegion :  TableID
+
+object TableLocalityRegionalByRow
+
+TableLocalityRegionalByRow :  TableID
+TableLocalityRegionalByRow :  As
+
+object TableLocalitySecondaryRegion
+
+TableLocalitySecondaryRegion :  TableID
+TableLocalitySecondaryRegion :  RegionEnumTypeID
+TableLocalitySecondaryRegion :  RegionName
+
+object TablePartitioning
+
+TablePartitioning :  TableID
+
+object TableSchemaLocked
+
+TableSchemaLocked :  TableID
+
+object TableZoneConfig
+
+TableZoneConfig :  TableID
+
+object TemporaryIndex
+
+TemporaryIndex :  Index
+TemporaryIndex :  IsUsingSecondaryEncoding
+
+object UniqueWithoutIndexConstraint
+
+UniqueWithoutIndexConstraint :  TableID
+UniqueWithoutIndexConstraint :  ConstraintID
+UniqueWithoutIndexConstraint : []ColumnIDs
+UniqueWithoutIndexConstraint :  Predicate
+UniqueWithoutIndexConstraint :  IndexIDForValidation
+
+object UniqueWithoutIndexConstraintUnvalidated
+
+UniqueWithoutIndexConstraintUnvalidated :  TableID
+UniqueWithoutIndexConstraintUnvalidated :  ConstraintID
+UniqueWithoutIndexConstraintUnvalidated : []ColumnIDs
+UniqueWithoutIndexConstraintUnvalidated :  Predicate
+
 object UserPrivileges
 
 UserPrivileges :  DescriptorID
@@ -308,152 +385,63 @@ UserPrivileges :  UserName
 UserPrivileges :  Privileges
 UserPrivileges :  WithGrantOption
 
-object DatabaseRegionConfig
+object View
 
-DatabaseRegionConfig :  DatabaseID
-DatabaseRegionConfig :  RegionEnumTypeID
+View :  ViewID
+View : []UsesTypeIDs
+View : []UsesRelationIDs
+View : []ForwardReferences
+View :  IsTemporary
+View :  IsMaterialized
 
-object DatabaseRoleSetting
-
-DatabaseRoleSetting :  DatabaseID
-DatabaseRoleSetting :  RoleName
-
-object DatabaseComment
-
-DatabaseComment :  DatabaseID
-DatabaseComment :  Comment
-
-object DatabaseData
-
-DatabaseData :  DatabaseID
-
-object SchemaParent
-
-SchemaParent :  SchemaID
-SchemaParent :  ParentDatabaseID
-
-object SchemaComment
-
-SchemaComment :  SchemaID
-SchemaComment :  Comment
-
-object SchemaChild
-
-SchemaChild :  ChildObjectID
-SchemaChild :  SchemaID
-
-object EnumTypeValue
-
-EnumTypeValue :  TypeID
-EnumTypeValue : []PhysicalRepresentation
-EnumTypeValue :  LogicalRepresentation
-
-object CompositeTypeAttrType
-
-CompositeTypeAttrType :  CompositeTypeID
-CompositeTypeAttrType :  TypeT
-
-object CompositeTypeAttrName
-
-CompositeTypeAttrName :  CompositeTypeID
-CompositeTypeAttrName :  Name
-
-object FunctionName
-
-FunctionName :  FunctionID
-FunctionName :  Name
-
-object FunctionVolatility
-
-FunctionVolatility :  FunctionID
-FunctionVolatility :  Volatility
-
-object FunctionLeakProof
-
-FunctionLeakProof :  FunctionID
-FunctionLeakProof :  LeakProof
-
-object FunctionNullInputBehavior
-
-FunctionNullInputBehavior :  FunctionID
-FunctionNullInputBehavior :  NullInputBehavior
-
-object FunctionBody
-
-FunctionBody :  FunctionID
-FunctionBody :  Body
-FunctionBody :  Lang
-FunctionBody : []UsesTables
-FunctionBody : []UsesViews
-FunctionBody : []UsesSequenceIDs
-FunctionBody : []UsesTypeIDs
-
-object FunctionParamDefaultExpression
-
-FunctionParamDefaultExpression :  FunctionID
-FunctionParamDefaultExpression :  Ordinal
-FunctionParamDefaultExpression :  Expression
-
-Table <|-- ColumnFamily
-Table <|-- Column
-View <|-- Column
-Table <|-- PrimaryIndex
-View <|-- PrimaryIndex
-Table <|-- SecondaryIndex
-View <|-- SecondaryIndex
-Table <|-- TemporaryIndex
-View <|-- TemporaryIndex
-Table <|-- UniqueWithoutIndexConstraint
-Table <|-- UniqueWithoutIndexConstraintUnvalidated
 Table <|-- CheckConstraint
 Table <|-- CheckConstraintUnvalidated
-Table <|-- ForeignKeyConstraint
-Table <|-- ForeignKeyConstraintUnvalidated
-Table <|-- TableComment
-View <|-- TableComment
-Sequence <|-- TableComment
-Table <|-- RowLevelTTL
-Table <|-- TableZoneConfig
-View <|-- TableZoneConfig
-Index <|-- IndexZoneConfig
-Table <|-- TableData
-View <|-- TableData
-Sequence <|-- TableData
-Table <|-- TablePartitioning
-Table <|-- TableSchemaLocked
-Table <|-- TableLocalityGlobal
-Table <|-- TableLocalityPrimaryRegion
-Table <|-- TableLocalitySecondaryRegion
-Table <|-- TableLocalityRegionalByRow
-Column <|-- ColumnName
-Column <|-- ColumnType
-Column <|-- ColumnDefaultExpression
-Column <|-- ColumnOnUpdateExpression
-Column <|-- SequenceOwner
+Table <|-- Column
+View <|-- Column
 Column <|-- ColumnComment
+Column <|-- ColumnDefaultExpression
+Table <|-- ColumnFamily
+Column <|-- ColumnName
 Column <|-- ColumnNotNull
-PrimaryIndex <|-- IndexName
-SecondaryIndex <|-- IndexName
-PrimaryIndex <|-- IndexPartitioning
-SecondaryIndex <|-- IndexPartitioning
-SecondaryIndex <|-- SecondaryIndexPartial
-PrimaryIndex <|-- IndexComment
-SecondaryIndex <|-- IndexComment
-PrimaryIndex <|-- IndexColumn
-SecondaryIndex <|-- IndexColumn
-TemporaryIndex <|-- IndexColumn
-Column <|-- IndexColumn
-PrimaryIndex <|-- IndexData
-SecondaryIndex <|-- IndexData
-TemporaryIndex <|-- IndexData
-UniqueWithoutIndexConstraint <|-- ConstraintWithoutIndexName
-CheckConstraint <|-- ConstraintWithoutIndexName
-ForeignKeyConstraint <|-- ConstraintWithoutIndexName
+Column <|-- ColumnOnUpdateExpression
+Column <|-- ColumnType
+CompositeType <|-- CompositeTypeAttrName
+CompositeType <|-- CompositeTypeAttrType
 PrimaryIndex <|-- ConstraintComment
 SecondaryIndex <|-- ConstraintComment
 UniqueWithoutIndexConstraint <|-- ConstraintComment
 CheckConstraint <|-- ConstraintComment
 ForeignKeyConstraint <|-- ConstraintComment
+UniqueWithoutIndexConstraint <|-- ConstraintWithoutIndexName
+CheckConstraint <|-- ConstraintWithoutIndexName
+ForeignKeyConstraint <|-- ConstraintWithoutIndexName
+Database <|-- DatabaseComment
+Database <|-- DatabaseData
+Database <|-- DatabaseRegionConfig
+Database <|-- DatabaseRoleSetting
+EnumType <|-- EnumTypeValue
+Table <|-- ForeignKeyConstraint
+Table <|-- ForeignKeyConstraintUnvalidated
+Function <|-- FunctionBody
+Function <|-- FunctionLeakProof
+Function <|-- FunctionName
+Function <|-- FunctionNullInputBehavior
+Function <|-- FunctionParamDefaultExpression
+Function <|-- FunctionVolatility
+PrimaryIndex <|-- IndexColumn
+SecondaryIndex <|-- IndexColumn
+TemporaryIndex <|-- IndexColumn
+Column <|-- IndexColumn
+PrimaryIndex <|-- IndexComment
+SecondaryIndex <|-- IndexComment
+PrimaryIndex <|-- IndexData
+SecondaryIndex <|-- IndexData
+TemporaryIndex <|-- IndexData
+PrimaryIndex <|-- IndexName
+SecondaryIndex <|-- IndexName
+PrimaryIndex <|-- IndexPartitioning
+SecondaryIndex <|-- IndexPartitioning
+Index <|-- IndexZoneConfig
 Table <|-- Namespace
 View <|-- Namespace
 Sequence <|-- Namespace
@@ -468,6 +456,38 @@ Database <|-- Owner
 Schema <|-- Owner
 AliasType <|-- Owner
 EnumType <|-- Owner
+Table <|-- PrimaryIndex
+View <|-- PrimaryIndex
+Table <|-- RowLevelTTL
+AliasType <|-- SchemaChild
+EnumType <|-- SchemaChild
+Table <|-- SchemaChild
+View <|-- SchemaChild
+Sequence <|-- SchemaChild
+Schema <|-- SchemaComment
+Schema <|-- SchemaParent
+Table <|-- SecondaryIndex
+View <|-- SecondaryIndex
+SecondaryIndex <|-- SecondaryIndexPartial
+Column <|-- SequenceOwner
+Table <|-- TableComment
+View <|-- TableComment
+Sequence <|-- TableComment
+Table <|-- TableData
+View <|-- TableData
+Sequence <|-- TableData
+Table <|-- TableLocalityGlobal
+Table <|-- TableLocalityPrimaryRegion
+Table <|-- TableLocalityRegionalByRow
+Table <|-- TableLocalitySecondaryRegion
+Table <|-- TablePartitioning
+Table <|-- TableSchemaLocked
+Table <|-- TableZoneConfig
+View <|-- TableZoneConfig
+Table <|-- TemporaryIndex
+View <|-- TemporaryIndex
+Table <|-- UniqueWithoutIndexConstraint
+Table <|-- UniqueWithoutIndexConstraintUnvalidated
 Table <|-- UserPrivileges
 View <|-- UserPrivileges
 Sequence <|-- UserPrivileges
@@ -475,24 +495,4 @@ Database <|-- UserPrivileges
 Schema <|-- UserPrivileges
 AliasType <|-- UserPrivileges
 EnumType <|-- UserPrivileges
-Database <|-- DatabaseRegionConfig
-Database <|-- DatabaseRoleSetting
-Database <|-- DatabaseComment
-Database <|-- DatabaseData
-Schema <|-- SchemaParent
-Schema <|-- SchemaComment
-AliasType <|-- SchemaChild
-EnumType <|-- SchemaChild
-Table <|-- SchemaChild
-View <|-- SchemaChild
-Sequence <|-- SchemaChild
-EnumType <|-- EnumTypeValue
-CompositeType <|-- CompositeTypeAttrType
-CompositeType <|-- CompositeTypeAttrName
-Function <|-- FunctionName
-Function <|-- FunctionVolatility
-Function <|-- FunctionLeakProof
-Function <|-- FunctionNullInputBehavior
-Function <|-- FunctionBody
-Function <|-- FunctionParamDefaultExpression
 @enduml

--- a/pkg/sql/schemachanger/scplan/internal/opgen/register_test.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/register_test.go
@@ -12,28 +12,18 @@ package opgen
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 )
 
 func TestOpGen(t *testing.T) {
-	var elementProto scpb.ElementProto
-	elementProtoType := reflect.ValueOf(elementProto).Type()
-	fieldIndexes := make([]int, elementProtoType.NumField())
-	for i, n := 0, elementProtoType.NumField(); i < n; i++ {
-		fieldIndexes[i] = i
-	}
-	sort.Slice(fieldIndexes, func(i, j int) bool {
-		return elementProtoType.Field(fieldIndexes[i]).Name < elementProtoType.Field(fieldIndexes[j]).Name
-	})
-	for _, i := range fieldIndexes {
-		field := elementProtoType.Field(i)
-		t.Run(field.Name, func(t *testing.T) {
+	_ = scpb.ForEachElementType(func(e scpb.Element) error {
+		field := reflect.TypeOf(e)
+		t.Run(field.Name(), func(t *testing.T) {
 			var adds, drops, transients []target
 			for _, tg := range opRegistry.targets {
-				if reflect.ValueOf(tg.e).Type() == field.Type {
+				if reflect.ValueOf(tg.e).Type() == field {
 					switch tg.status {
 					case scpb.Status_PUBLIC:
 						adds = append(adds, tg)
@@ -45,11 +35,12 @@ func TestOpGen(t *testing.T) {
 				}
 			}
 			if len(adds) != 1 && len(transients) != 1 {
-				t.Errorf("expected one registered adding spec for %s, instead found %d", field.Name, len(adds))
+				t.Errorf("expected one registered adding spec for %s, instead found %d", field.Name(), len(adds))
 			}
 			if len(drops) != 1 {
-				t.Errorf("expected one registered dropping spec for %s, instead found %d", field.Name, len(drops))
+				t.Errorf("expected one registered dropping spec for %s, instead found %d", field.Name(), len(drops))
 			}
 		})
-	}
+		return nil
+	})
 }

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
@@ -51,7 +51,6 @@ go_test(
         "//pkg/sql/schemachanger/rel",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan/internal/opgen",
-        "//pkg/sql/schemachanger/scplan/internal/rules",
         "//pkg/sql/schemachanger/screl",
         "//pkg/sql/types",
         "//pkg/testutils/datapathutils",

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/assertions_test.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/assertions_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/opgen"
-	. "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -43,7 +42,7 @@ func TestRuleAssertions(t *testing.T) {
 		nameParts := strings.Split(fullName, "rules.")
 		shortName := nameParts[len(nameParts)-1]
 		t.Run(shortName, func(t *testing.T) {
-			_ = ForEachElement(func(e scpb.Element) error {
+			_ = scpb.ForEachElementType(func(e scpb.Element) error {
 				e = nonNilElement(e)
 				if err := fn(e); err != nil {
 					t.Errorf("%T: %+v", e, err)

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_two_version.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_two_version.go
@@ -103,7 +103,7 @@ func init() {
 			panic(err)
 		}
 	}
-	_ = ForEachElement(func(el scpb.Element) error {
+	_ = scpb.ForEachElementType(func(el scpb.Element) error {
 		if !isSubjectTo2VersionInvariant(el) {
 			return nil
 		}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -296,7 +296,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - toAbsent($constraint-name-Target, $constraint-Target)
     - $constraint-name-Node[CurrentStatus] = ABSENT
@@ -309,7 +309,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - transient($constraint-name-Target, $constraint-Target)
     - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -322,7 +322,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - $constraint-name-Target[TargetStatus] = TRANSIENT_ABSENT
     - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -336,7 +336,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - $constraint-name-Target[TargetStatus] = ABSENT
     - $constraint-name-Node[CurrentStatus] = ABSENT
@@ -349,7 +349,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - toAbsent($constraint-Target, $constraint-name-Target)
@@ -362,7 +362,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - transient($constraint-Target, $constraint-name-Target)
@@ -375,7 +375,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -389,7 +389,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = ABSENT
@@ -1642,8 +1642,8 @@ deprules
   kind: Precedence
   to: parent-descriptor-Node
   query:
-    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaParent', '*scpb.SchemaChild']
-    - $parent-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaChild', '*scpb.SchemaParent']
+    - $parent-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinReferencedDescID($back-reference-in-parent-descriptor, $parent-descriptor, $desc-id)
     - toAbsent($back-reference-in-parent-descriptor-Target, $parent-descriptor-Target)
     - $back-reference-in-parent-descriptor-Node[CurrentStatus] = ABSENT
@@ -1655,7 +1655,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - toAbsent($column-constraint-Target, $column-Target)
@@ -1668,7 +1668,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - transient($column-constraint-Target, $column-Target)
@@ -1681,7 +1681,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - $column-constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -1695,7 +1695,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - $column-constraint-Target[TargetStatus] = ABSENT
@@ -1709,7 +1709,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - ToPublicOrTransient($dependent-Target, $column-Target)
@@ -1723,7 +1723,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - ToPublicOrTransient($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = DELETE_ONLY
@@ -1791,7 +1791,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - toAbsent($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -1804,7 +1804,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - transient($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -1817,7 +1817,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -1831,7 +1831,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = ABSENT
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -1898,7 +1898,7 @@ deprules
   to: complex-constraint-Node
   query:
     - $dependent[Type] = '*scpb.ConstraintComment'
-    - $complex-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $complex-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependent, $complex-constraint, $table-id, $constraint-id)
     - ToPublicOrTransient($dependent-Target, $complex-constraint-Target)
     - $dependent-Node[CurrentStatus] = PUBLIC
@@ -1910,7 +1910,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - toAbsent($constraint-Target, $dependent-Target)
@@ -1923,7 +1923,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - transient($constraint-Target, $dependent-Target)
@@ -1936,7 +1936,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -1950,7 +1950,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = ABSENT
@@ -1964,8 +1964,8 @@ deprules
   kind: Precedence
   to: referenced-descriptor-Node
   query:
-    - $cross-desc-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
-    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $cross-desc-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinReferencedDescID($cross-desc-constraint, $referenced-descriptor, $desc-id)
     - toAbsent($cross-desc-constraint-Target, $referenced-descriptor-Target)
     - $cross-desc-constraint-Node[CurrentStatus] = ABSENT
@@ -1977,8 +1977,8 @@ deprules
   kind: Precedence
   to: referencing-descriptor-Node
   query:
-    - $cross-desc-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
-    - $referencing-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $cross-desc-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
+    - $referencing-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($cross-desc-constraint, $referencing-descriptor, $desc-id)
     - toAbsent($cross-desc-constraint-Target, $referencing-descriptor-Target)
     - $cross-desc-constraint-Node[CurrentStatus] = ABSENT
@@ -2098,8 +2098,8 @@ deprules
   kind: Precedence
   to: relation-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TableData', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.IndexData', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
-    - $relation[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexData', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableData', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $relation[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($dependent, $relation, $relation-id)
     - ToPublicOrTransient($dependent-Target, $relation-Target)
     - $dependent-Node[CurrentStatus] = PUBLIC
@@ -2111,7 +2111,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - toAbsent($dependent-Target, $column-Target)
@@ -2124,7 +2124,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - transient($dependent-Target, $column-Target)
@@ -2137,7 +2137,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2151,7 +2151,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -2166,7 +2166,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -2179,7 +2179,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -2192,7 +2192,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -2206,7 +2206,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -2219,7 +2219,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - toAbsent($dependent-Target, $index-Target)
@@ -2232,7 +2232,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - transient($dependent-Target, $index-Target)
@@ -2245,7 +2245,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2259,7 +2259,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -2274,7 +2274,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -2287,7 +2287,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -2300,7 +2300,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -2314,7 +2314,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -2327,7 +2327,7 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-type-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.EnumType']
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
     - $referencing-via-type[Type] = '*scpb.ColumnType'
@@ -2341,8 +2341,8 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-attr-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaComment', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $referencing-via-attr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaComment', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - toAbsent($referenced-descriptor-Target, $referencing-via-attr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
@@ -2357,7 +2357,7 @@ deprules
     - $referenced-descriptor[Type] = '*scpb.Sequence'
     - $referenced-descriptor[DescID] = $seqID
     - $referencing-via-expr[ReferencedSequenceIDs] CONTAINS $seqID
-    - $referencing-via-expr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial', '*scpb.FunctionParamDefaultExpression']
+    - $referencing-via-expr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.FunctionParamDefaultExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-expr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-expr-Node[CurrentStatus] = ABSENT
@@ -2371,7 +2371,7 @@ deprules
     - $referenced-descriptor[Type] = '*scpb.Function'
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-function[ReferencedFunctionIDs] CONTAINS $fromDescID
-    - $referencing-via-function[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial', '*scpb.FunctionParamDefaultExpression']
+    - $referencing-via-function[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.FunctionParamDefaultExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-function-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-function-Node[CurrentStatus] = ABSENT
@@ -2382,11 +2382,11 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-type-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.EnumType']
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
     - descriptorIsNotBeingDropped-23.1($referencing-via-type)
-    - $referencing-via-type[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial', '*scpb.FunctionParamDefaultExpression']
+    - $referencing-via-type[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.FunctionParamDefaultExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-type-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-type-Node[CurrentStatus] = ABSENT
@@ -2397,8 +2397,8 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $dependent[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinOnDescID($descriptor, $dependent, $desc-id)
     - toAbsent($descriptor-Target, $dependent-Target)
     - $descriptor-Node[CurrentStatus] = DROPPED
@@ -2410,7 +2410,7 @@ deprules
   kind: PreviousStagePrecedence
   to: absent-Node
   query:
-    - $dropped[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $dropped[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $dropped[DescID] = $_
     - $dropped[Self] = $absent
     - toAbsent($dropped-Target, $absent-Target)
@@ -2423,8 +2423,8 @@ deprules
   kind: SameStagePrecedence
   to: back-reference-in-parent-descriptor-Node
   query:
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaParent', '*scpb.SchemaChild']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaChild', '*scpb.SchemaParent']
     - joinOnDescID($descriptor, $back-reference-in-parent-descriptor, $desc-id)
     - toAbsent($descriptor-Target, $back-reference-in-parent-descriptor-Target)
     - $descriptor-Node[CurrentStatus] = DROPPED
@@ -2436,8 +2436,8 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $relation[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TableData', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.IndexData', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
+    - $relation[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexData', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableData', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinOnDescID($relation, $dependent, $relation-id)
     - ToPublicOrTransient($relation-Target, $dependent-Target)
     - $relation-Node[CurrentStatus] = DESCRIPTOR_ADDED
@@ -2449,7 +2449,7 @@ deprules
   kind: SameStagePrecedence
   to: data-Node
   query:
-    - $database[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $database[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $data[Type] = '*scpb.DatabaseData'
     - joinOnDescID($database, $data, $db-id)
     - toAbsent($database-Target, $data-Target)
@@ -2504,7 +2504,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - ToPublicOrTransient($dependent-Target, $index-Target)
@@ -2572,7 +2572,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = BACKFILL_ONLY
@@ -2585,7 +2585,7 @@ deprules
   to: constraint-Node
   query:
     - $index[Type] = '*scpb.PrimaryIndex'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnDescID($index, $constraint, $table-id)
     - $index[IndexID] = $index-id-for-validation
     - $constraint[IndexID] = $index-id-for-validation
@@ -2600,7 +2600,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - toAbsent($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = VALIDATED
@@ -2613,7 +2613,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - transient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -2626,7 +2626,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = TRANSIENT_ABSENT
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -2640,7 +2640,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = ABSENT
     - $index-Node[CurrentStatus] = VALIDATED
@@ -2849,8 +2849,8 @@ deprules
   kind: Precedence
   to: descriptor-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($dependent, $descriptor, $desc-id)
     - toAbsent($dependent-Target, $descriptor-Target)
     - $dependent-Node[CurrentStatus] = ABSENT
@@ -3124,8 +3124,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - toAbsent($data-a-Target, $data-b-Target)
@@ -3138,8 +3138,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - transient($data-a-Target, $data-b-Target)
@@ -3152,8 +3152,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - $data-a-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -3167,8 +3167,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - $data-a-Target[TargetStatus] = ABSENT
@@ -3390,7 +3390,7 @@ deprules
   to: dependent-Node
   query:
     - $simple-constraint[Type] = '*scpb.ColumnNotNull'
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($simple-constraint, $dependent, $table-id, $constraint-id)
     - ToPublicOrTransient($simple-constraint-Target, $dependent-Target)
     - $simple-constraint-Node[CurrentStatus] = PUBLIC
@@ -3402,7 +3402,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $simple-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $simple-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($simple-constraint, $constraint-name, $table-id, $constraint-id)
     - ToPublicOrTransient($simple-constraint-Target, $constraint-name-Target)
@@ -3429,7 +3429,7 @@ deprules
   kind: SameStagePrecedence
   to: data-Node
   query:
-    - $table[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $table[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $data[Type] = '*scpb.TableData'
     - joinOnDescID($table, $data, $table-id)
     - toAbsent($table-Target, $data-Target)
@@ -3456,7 +3456,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] = '*scpb.TemporaryIndex'
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = DELETE_ONLY
@@ -3778,7 +3778,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - toAbsent($constraint-name-Target, $constraint-Target)
     - $constraint-name-Node[CurrentStatus] = ABSENT
@@ -3791,7 +3791,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - transient($constraint-name-Target, $constraint-Target)
     - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -3804,7 +3804,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - $constraint-name-Target[TargetStatus] = TRANSIENT_ABSENT
     - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -3818,7 +3818,7 @@ deprules
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
     - $constraint-name-Target[TargetStatus] = ABSENT
     - $constraint-name-Node[CurrentStatus] = ABSENT
@@ -3831,7 +3831,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - toAbsent($constraint-Target, $constraint-name-Target)
@@ -3844,7 +3844,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - transient($constraint-Target, $constraint-name-Target)
@@ -3857,7 +3857,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -3871,7 +3871,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = ABSENT
@@ -5124,8 +5124,8 @@ deprules
   kind: Precedence
   to: parent-descriptor-Node
   query:
-    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaParent', '*scpb.SchemaChild']
-    - $parent-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaChild', '*scpb.SchemaParent']
+    - $parent-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinReferencedDescID($back-reference-in-parent-descriptor, $parent-descriptor, $desc-id)
     - toAbsent($back-reference-in-parent-descriptor-Target, $parent-descriptor-Target)
     - $back-reference-in-parent-descriptor-Node[CurrentStatus] = ABSENT
@@ -5137,7 +5137,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - toAbsent($column-constraint-Target, $column-Target)
@@ -5150,7 +5150,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - transient($column-constraint-Target, $column-Target)
@@ -5163,7 +5163,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - $column-constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -5177,7 +5177,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - $column-constraint-Target[TargetStatus] = ABSENT
@@ -5191,7 +5191,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - ToPublicOrTransient($dependent-Target, $column-Target)
@@ -5205,7 +5205,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - ToPublicOrTransient($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = DELETE_ONLY
@@ -5273,7 +5273,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - toAbsent($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -5286,7 +5286,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - transient($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -5299,7 +5299,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -5313,7 +5313,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = ABSENT
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -5380,7 +5380,7 @@ deprules
   to: complex-constraint-Node
   query:
     - $dependent[Type] = '*scpb.ConstraintComment'
-    - $complex-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $complex-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependent, $complex-constraint, $table-id, $constraint-id)
     - ToPublicOrTransient($dependent-Target, $complex-constraint-Target)
     - $dependent-Node[CurrentStatus] = PUBLIC
@@ -5392,7 +5392,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - toAbsent($constraint-Target, $dependent-Target)
@@ -5405,7 +5405,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - transient($constraint-Target, $dependent-Target)
@@ -5418,7 +5418,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -5432,7 +5432,7 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - $dependent[Type] = '*scpb.ConstraintComment'
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = ABSENT
@@ -5446,8 +5446,8 @@ deprules
   kind: Precedence
   to: referenced-descriptor-Node
   query:
-    - $cross-desc-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
-    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $cross-desc-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinReferencedDescID($cross-desc-constraint, $referenced-descriptor, $desc-id)
     - toAbsent($cross-desc-constraint-Target, $referenced-descriptor-Target)
     - $cross-desc-constraint-Node[CurrentStatus] = ABSENT
@@ -5459,8 +5459,8 @@ deprules
   kind: Precedence
   to: referencing-descriptor-Node
   query:
-    - $cross-desc-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
-    - $referencing-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $cross-desc-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
+    - $referencing-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($cross-desc-constraint, $referencing-descriptor, $desc-id)
     - toAbsent($cross-desc-constraint-Target, $referencing-descriptor-Target)
     - $cross-desc-constraint-Node[CurrentStatus] = ABSENT
@@ -5580,8 +5580,8 @@ deprules
   kind: Precedence
   to: relation-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TableData', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.IndexData', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
-    - $relation[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexData', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableData', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $relation[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($dependent, $relation, $relation-id)
     - ToPublicOrTransient($dependent-Target, $relation-Target)
     - $dependent-Node[CurrentStatus] = PUBLIC
@@ -5593,7 +5593,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - toAbsent($dependent-Target, $column-Target)
@@ -5606,7 +5606,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - transient($dependent-Target, $column-Target)
@@ -5619,7 +5619,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -5633,7 +5633,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -5648,7 +5648,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -5661,7 +5661,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -5674,7 +5674,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -5688,7 +5688,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -5701,7 +5701,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - toAbsent($dependent-Target, $index-Target)
@@ -5714,7 +5714,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - transient($dependent-Target, $index-Target)
@@ -5727,7 +5727,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -5741,7 +5741,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -5756,7 +5756,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -5769,7 +5769,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -5782,7 +5782,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
     - $dependents-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -5796,7 +5796,7 @@ deprules
   to: constraint-Node
   query:
     - $dependents[Type] = '*scpb.ConstraintComment'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated']
+    - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
     - $dependents-Node[CurrentStatus] = ABSENT
@@ -5809,7 +5809,7 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-type-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.EnumType']
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
     - $referencing-via-type[Type] = '*scpb.ColumnType'
@@ -5823,8 +5823,8 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-attr-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaComment', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $referencing-via-attr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaComment', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - toAbsent($referenced-descriptor-Target, $referencing-via-attr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
@@ -5839,7 +5839,7 @@ deprules
     - $referenced-descriptor[Type] = '*scpb.Sequence'
     - $referenced-descriptor[DescID] = $seqID
     - $referencing-via-expr[ReferencedSequenceIDs] CONTAINS $seqID
-    - $referencing-via-expr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial', '*scpb.FunctionParamDefaultExpression']
+    - $referencing-via-expr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.FunctionParamDefaultExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-expr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-expr-Node[CurrentStatus] = ABSENT
@@ -5853,7 +5853,7 @@ deprules
     - $referenced-descriptor[Type] = '*scpb.Function'
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-function[ReferencedFunctionIDs] CONTAINS $fromDescID
-    - $referencing-via-function[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial', '*scpb.FunctionParamDefaultExpression']
+    - $referencing-via-function[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.FunctionParamDefaultExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-function-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-function-Node[CurrentStatus] = ABSENT
@@ -5864,11 +5864,11 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-type-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.EnumType']
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
     - descriptorIsNotBeingDropped-23.1($referencing-via-type)
-    - $referencing-via-type[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial', '*scpb.FunctionParamDefaultExpression']
+    - $referencing-via-type[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.FunctionParamDefaultExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-type-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-type-Node[CurrentStatus] = ABSENT
@@ -5879,8 +5879,8 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $dependent[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinOnDescID($descriptor, $dependent, $desc-id)
     - toAbsent($descriptor-Target, $dependent-Target)
     - $descriptor-Node[CurrentStatus] = DROPPED
@@ -5892,7 +5892,7 @@ deprules
   kind: PreviousStagePrecedence
   to: absent-Node
   query:
-    - $dropped[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $dropped[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $dropped[DescID] = $_
     - $dropped[Self] = $absent
     - toAbsent($dropped-Target, $absent-Target)
@@ -5905,8 +5905,8 @@ deprules
   kind: SameStagePrecedence
   to: back-reference-in-parent-descriptor-Node
   query:
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaParent', '*scpb.SchemaChild']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $back-reference-in-parent-descriptor[Type] IN ['*scpb.SchemaChild', '*scpb.SchemaParent']
     - joinOnDescID($descriptor, $back-reference-in-parent-descriptor, $desc-id)
     - toAbsent($descriptor-Target, $back-reference-in-parent-descriptor-Target)
     - $descriptor-Node[CurrentStatus] = DROPPED
@@ -5918,8 +5918,8 @@ deprules
   kind: Precedence
   to: dependent-Node
   query:
-    - $relation[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TableData', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.IndexData', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
+    - $relation[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexData', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableData', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinOnDescID($relation, $dependent, $relation-id)
     - ToPublicOrTransient($relation-Target, $dependent-Target)
     - $relation-Node[CurrentStatus] = DESCRIPTOR_ADDED
@@ -5931,7 +5931,7 @@ deprules
   kind: SameStagePrecedence
   to: data-Node
   query:
-    - $database[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $database[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $data[Type] = '*scpb.DatabaseData'
     - joinOnDescID($database, $data, $db-id)
     - toAbsent($database-Target, $data-Target)
@@ -5986,7 +5986,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - ToPublicOrTransient($dependent-Target, $index-Target)
@@ -6054,7 +6054,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = BACKFILL_ONLY
@@ -6067,7 +6067,7 @@ deprules
   to: constraint-Node
   query:
     - $index[Type] = '*scpb.PrimaryIndex'
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnDescID($index, $constraint, $table-id)
     - $index[IndexID] = $index-id-for-validation
     - $constraint[IndexID] = $index-id-for-validation
@@ -6082,7 +6082,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - toAbsent($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = VALIDATED
@@ -6095,7 +6095,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - transient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -6108,7 +6108,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = TRANSIENT_ABSENT
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -6122,7 +6122,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = ABSENT
     - $index-Node[CurrentStatus] = VALIDATED
@@ -6331,8 +6331,8 @@ deprules
   kind: Precedence
   to: descriptor-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.IndexZoneConfig', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.ColumnNotNull', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName', '*scpb.FunctionName', '*scpb.FunctionVolatility', '*scpb.FunctionLeakProof', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionBody', '*scpb.FunctionParamDefaultExpression']
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionParamDefaultExpression', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($dependent, $descriptor, $desc-id)
     - toAbsent($dependent-Target, $descriptor-Target)
     - $dependent-Node[CurrentStatus] = ABSENT
@@ -6606,8 +6606,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - toAbsent($data-a-Target, $data-b-Target)
@@ -6620,8 +6620,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - transient($data-a-Target, $data-b-Target)
@@ -6634,8 +6634,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - $data-a-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -6649,8 +6649,8 @@ deprules
   kind: SameStagePrecedence
   to: data-b-Node
   query:
-    - $data-a[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
-    - $data-b[Type] IN ['*scpb.TableData', '*scpb.IndexData', '*scpb.DatabaseData']
+    - $data-a[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
+    - $data-b[Type] IN ['*scpb.DatabaseData', '*scpb.IndexData', '*scpb.TableData']
     - joinOnDescID($data-a, $data-b, $desc-id)
     - SmallerIDsFirst(scpb.Element, scpb.Element)($data-a, $data-b)
     - $data-a-Target[TargetStatus] = ABSENT
@@ -6872,7 +6872,7 @@ deprules
   to: dependent-Node
   query:
     - $simple-constraint[Type] = '*scpb.ColumnNotNull'
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($simple-constraint, $dependent, $table-id, $constraint-id)
     - ToPublicOrTransient($simple-constraint-Target, $dependent-Target)
     - $simple-constraint-Node[CurrentStatus] = PUBLIC
@@ -6884,7 +6884,7 @@ deprules
   kind: Precedence
   to: constraint-name-Node
   query:
-    - $simple-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
+    - $simple-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
     - joinOnConstraintID($simple-constraint, $constraint-name, $table-id, $constraint-id)
     - ToPublicOrTransient($simple-constraint-Target, $constraint-name-Target)
@@ -6911,7 +6911,7 @@ deprules
   kind: SameStagePrecedence
   to: data-Node
   query:
-    - $table[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+    - $table[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $data[Type] = '*scpb.TableData'
     - joinOnDescID($table, $data, $table-id)
     - toAbsent($table-Target, $data-Target)
@@ -6938,7 +6938,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] = '*scpb.TemporaryIndex'
-    - $dependent[Type] IN ['*scpb.IndexZoneConfig', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = DELETE_ONLY

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/oprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/oprules
@@ -14,7 +14,7 @@ ToPublicOrTransient($target1, $target2):
     - $target2[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
 descriptorIsNotBeingDropped-23.1($element):
     not-join:
-        - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType', '*scpb.Function']
+        - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
         - joinTarget($descriptor, $descriptor-Target)
         - joinOnDescID($descriptor, $element, $id)
         - $descriptor-Target[TargetStatus] = ABSENT

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -12,7 +12,6 @@ package rules
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -268,35 +267,19 @@ var (
 		})
 )
 
-// ForEachElement executes a function for each element type.
-func ForEachElement(fn func(element scpb.Element) error) error {
-	var ep scpb.ElementProto
-	vep := reflect.ValueOf(ep)
-	for i := 0; i < vep.NumField(); i++ {
-		e := vep.Field(i).Interface().(scpb.Element)
-		if err := fn(e); err != nil {
-			return iterutil.Map(err)
-		}
-	}
-	return nil
-}
-
 // ForEachElementInActiveVersion executes a function for each element supported within
 // the current active version.
 func ForEachElementInActiveVersion(
 	version clusterversion.ClusterVersion, fn func(element scpb.Element) error,
 ) error {
-	var ep scpb.ElementProto
-	vep := reflect.ValueOf(ep)
-	for i := 0; i < vep.NumField(); i++ {
-		e := vep.Field(i).Interface().(scpb.Element)
+	return scpb.ForEachElementType(func(e scpb.Element) error {
 		if version.IsActive(screl.MinElementVersion(e)) {
 			if err := fn(e); err != nil {
 				return iterutil.Map(err)
 			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 type elementTypePredicate = func(e scpb.Element) bool

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_two_version.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_two_version.go
@@ -103,7 +103,7 @@ func init() {
 			panic(err)
 		}
 	}
-	_ = ForEachElement(func(el scpb.Element) error {
+	_ = scpb.ForEachElementType(func(el scpb.Element) error {
 		if !isSubjectTo2VersionInvariant(el) {
 			return nil
 		}

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/deprules
@@ -14,7 +14,7 @@ ToPublicOrTransient($target1, $target2):
     - $target2[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
 descriptorIsNotBeingDropped-22.2($element):
     not-join:
-        - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+        - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.Database', '*scpb.EnumType', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
         - joinTarget($descriptor, $descriptor-Target)
         - joinOnDescID($descriptor, $element, $id)
         - $descriptor-Target[TargetStatus] = ABSENT
@@ -1256,7 +1256,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - ToPublicOrTransient($dependent-Target, $column-Target)
@@ -1270,7 +1270,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - ToPublicOrTransient($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = DELETE_ONLY
@@ -1338,7 +1338,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - toAbsent($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -1351,7 +1351,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - transient($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -1364,7 +1364,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -1378,7 +1378,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = ABSENT
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -1418,8 +1418,8 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
     - toAbsent($dependent-Target, $constraint-Target)
     - $dependent-Node[CurrentStatus] = ABSENT
@@ -1431,8 +1431,8 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
     - transient($dependent-Target, $constraint-Target)
     - $dependent-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -1444,8 +1444,8 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
     - $dependent-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -1458,8 +1458,8 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
     - $dependent-Target[TargetStatus] = ABSENT
     - $dependent-Node[CurrentStatus] = ABSENT
@@ -1472,7 +1472,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
     - toAbsent($dependent-Target, $constraint-Target)
@@ -1485,7 +1485,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
     - transient($dependent-Target, $constraint-Target)
@@ -1498,7 +1498,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -1512,7 +1512,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -1526,8 +1526,8 @@ deprules
   kind: SameStagePrecedence
   to: dependent-Node
   query:
-    - $constraint[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint']
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - ToPublicOrTransient($constraint-Target, $dependent-Target)
     - $constraint-Node[CurrentStatus] = PUBLIC
@@ -1539,7 +1539,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - toAbsent($dependent-Target, $column-Target)
@@ -1552,7 +1552,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - transient($dependent-Target, $column-Target)
@@ -1565,7 +1565,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -1579,7 +1579,7 @@ deprules
   kind: Precedence
   to: column-Node
   query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -1593,7 +1593,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - toAbsent($dependent-Target, $index-Target)
@@ -1606,7 +1606,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - transient($dependent-Target, $index-Target)
@@ -1619,7 +1619,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -1633,7 +1633,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -1647,7 +1647,7 @@ deprules
   kind: PreviousTransactionPrecedence
   to: absent-Node
   query:
-    - $dropped[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+    - $dropped[Type] IN ['*scpb.AliasType', '*scpb.Database', '*scpb.EnumType', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $dropped[DescID] = $_
     - $dropped[Self] = $absent
     - toAbsent($dropped-Target, $absent-Target)
@@ -1660,7 +1660,7 @@ deprules
   kind: PreviousStagePrecedence
   to: dropped-Node
   query:
-    - $txn_dropped[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+    - $txn_dropped[Type] IN ['*scpb.AliasType', '*scpb.Database', '*scpb.EnumType', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $txn_dropped[DescID] = $_
     - $txn_dropped[Self] = $dropped
     - toAbsent($txn_dropped-Target, $dropped-Target)
@@ -1673,8 +1673,8 @@ deprules
   kind: SameStagePrecedence
   to: dependent-Node
   query:
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.Database', '*scpb.EnumType', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableZoneConfig', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UserPrivileges']
     - joinOnDescID($descriptor, $dependent, $desc-id)
     - toAbsent($descriptor-Target, $dependent-Target)
     - $descriptor-Node[CurrentStatus] = DROPPED
@@ -1687,8 +1687,8 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-attr-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
-    - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.SchemaChild', '*scpb.EnumTypeValue']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.Database', '*scpb.EnumType', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
+    - $referencing-via-attr[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableZoneConfig', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UserPrivileges']
     - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - toAbsent($referenced-descriptor-Target, $referencing-via-attr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
@@ -1704,7 +1704,7 @@ deprules
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-Target, $referenced-descriptor-Node)
     - $referenced-descriptor[DescID] = $seqID
     - $referencing-via-expr[ReferencedSequenceIDs] CONTAINS $seqID
-    - $referencing-via-expr[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial']
+    - $referencing-via-expr[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-expr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-expr-Node[CurrentStatus] = ABSENT
@@ -1715,11 +1715,11 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-type-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.EnumType', '*scpb.AliasType']
+    - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.EnumType']
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-Target, $referenced-descriptor-Node)
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
-    - $referencing-via-type[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial']
+    - $referencing-via-type[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-type-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-type-Node[CurrentStatus] = ABSENT
@@ -1730,7 +1730,7 @@ deprules
   kind: SameStagePrecedence
   to: idx-or-col-Node
   query:
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+    - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.Database', '*scpb.EnumType', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $idx-or-col[Type] IN ['*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnDescID($descriptor, $idx-or-col, $desc-id)
     - toAbsent($descriptor-Target, $idx-or-col-Target)
@@ -1758,7 +1758,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - ToPublicOrTransient($dependent-Target, $index-Target)
@@ -1772,7 +1772,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = BACKFILL_ONLY
@@ -1798,7 +1798,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - toAbsent($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = VALIDATED
@@ -1811,7 +1811,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - transient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -1824,7 +1824,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = TRANSIENT_ABSENT
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -1838,7 +1838,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = ABSENT
     - $index-Node[CurrentStatus] = VALIDATED
@@ -2180,7 +2180,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] = '*scpb.TemporaryIndex'
-    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = DELETE_ONLY

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/oprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/oprules
@@ -14,7 +14,7 @@ ToPublicOrTransient($target1, $target2):
     - $target2[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
 descriptorIsNotBeingDropped-22.2($element):
     not-join:
-        - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+        - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.Database', '*scpb.EnumType', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
         - joinTarget($descriptor, $descriptor-Target)
         - joinOnDescID($descriptor, $element, $id)
         - $descriptor-Target[TargetStatus] = ABSENT
@@ -162,7 +162,7 @@ oprules
 - name: skip element removal ops on descriptor drop
   from: dep-Node
   query:
-    - $desc[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+    - $desc[Type] IN ['*scpb.AliasType', '*scpb.Database', '*scpb.EnumType', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - $dep[Type] IN ['*scpb.ColumnFamily', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.EnumTypeValue']
     - joinOnDescID($desc, $dep, $desc-id)
     - joinTarget($desc, $desc-Target)

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -32,11 +32,11 @@ func MustQuery(clauses ...rel.Clause) *rel.Query {
 	return q
 }
 
-var elementProtoElementSelectors = func() (selectors []string) {
-	elementProtoType := reflect.TypeOf((*scpb.ElementProto)(nil)).Elem()
-	selectors = make([]string, elementProtoType.NumField())
-	for i := 0; i < elementProtoType.NumField(); i++ {
-		selectors[i] = elementProtoType.Field(i).Name
+var elementProtoElementTypes = func() (selectors []reflect.Type) {
+	oneOfProtos := scpb.GetElementOneOfProtos()
+	selectors = make([]reflect.Type, 0, len(oneOfProtos))
+	for _, proto := range oneOfProtos {
+		selectors = append(selectors, reflect.TypeOf(proto))
 	}
 	return selectors
 }()
@@ -402,7 +402,7 @@ var Schema = rel.MustSchema("screl", append(
 	),
 	rel.EntityMapping(t((*scpb.Target)(nil)),
 		rel.EntityAttr(TargetStatus, "TargetStatus"),
-		rel.EntityAttr(Element, elementProtoElementSelectors...),
+		rel.EntityAttrOneOf(Element, "ElementOneOf", elementProtoElementTypes...),
 	),
 )...)
 

--- a/pkg/sql/schemachanger/screl/scalars_test.go
+++ b/pkg/sql/schemachanger/screl/scalars_test.go
@@ -24,25 +24,26 @@ import (
 
 // TestAllElementsHaveDescID ensures that all element types have a DescID.
 func TestAllElementsHaveDescID(t *testing.T) {
-	forEachElementType(func(elem scpb.Element) {
+	forEachNewElementType(t, func(elem scpb.Element) {
 		require.Equalf(t, descpb.ID(0), GetDescID(elem), "elem %T", elem)
 	})
 }
 
 func TestAllElementsHaveMinVersion(t *testing.T) {
-	forEachElementType(func(elem scpb.Element) {
+	forEachNewElementType(t, func(elem scpb.Element) {
 		// If `elem` does not have a min version, the following function call will panic.
 		MinElementVersion(elem)
 	})
 }
 
-func forEachElementType(f func(element scpb.Element)) {
-	typ := reflect.TypeOf((*scpb.ElementProto)(nil)).Elem()
-	for i := 0; i < typ.NumField(); i++ {
-		field := typ.Field(i)
-		elem := reflect.New(field.Type.Elem()).Interface().(scpb.Element)
-		f(elem)
-	}
+// ForEachElement executes a function for each element type.
+func forEachNewElementType(t *testing.T, fn func(element scpb.Element)) {
+	require.NoError(t,
+		scpb.ForEachElementType(func(e scpb.Element) error {
+			newElem := reflect.New(reflect.TypeOf(e).Elem())
+			fn(newElem.Interface().(scpb.Element))
+			return nil
+		}))
 }
 
 func TestAllDescIDsAndContainsDescID(t *testing.T) {

--- a/pkg/sql/schemachanger/screl/walk_test.go
+++ b/pkg/sql/schemachanger/screl/walk_test.go
@@ -31,14 +31,14 @@ import (
 func TestWalk(t *testing.T) {
 	// Sanity check that we don't panic or anything dumb on all the elements.
 	t.Run("all elements work", func(t *testing.T) {
-		typ := reflect.TypeOf((*scpb.ElementProto)(nil)).Elem()
-		for i := 0; i < typ.NumField(); i++ {
-			f := typ.Field(i)
-			elem := reflect.New(f.Type.Elem()).Interface().(scpb.Element)
+		_ = scpb.ForEachElementType(func(e scpb.Element) error {
+			typ := reflect.TypeOf(e)
+			elem := reflect.New(typ.Elem()).Interface().(scpb.Element)
 			require.NoError(t, WalkDescIDs(elem, func(id *catid.DescID) error { return nil }))
 			require.NoError(t, WalkTypes(elem, func(id *types.T) error { return nil }))
 			require.NoError(t, WalkExpressions(elem, func(id *catpb.Expression) error { return nil }))
-		}
+			return nil
+		})
 	})
 
 	t.Run("errors propagate", func(t *testing.T) {

--- a/pkg/sql/schemachanger/sctest/decomp.go
+++ b/pkg/sql/schemachanger/sctest/decomp.go
@@ -107,10 +107,10 @@ func marshalResult(
 			// Compute the struct field index of the element in the ElementProto
 			// to sort the elements in order of appearance in that message.
 			var ep scpb.ElementProto
-			ep.SetValue(e)
-			v := reflect.ValueOf(ep)
-			for i := 0; i < v.NumField(); i++ {
-				if !v.Field(i).IsNil() {
+			ep.SetElement(e)
+			v := reflect.ValueOf(ep.ElementOneOf).Elem()
+			for i, elemTypes := range scpb.GetElementOneOfProtos() {
+				if reflect.TypeOf(elemTypes).Elem() == v.Type() {
 					rank[e] = i
 					break
 				}


### PR DESCRIPTION
Previously, the declarative schema changer had Element messages would be implemented as a union which stores a pointer to each possible element. This could lead to scenarios where we would run out of memory with a large number of database objects in drop scenarios. To address this, this patch switches these messages over to a protobuf which is wire compatible and stores a single pointer to the target element type.

Release note: None

Epic: CRDB-25378