### PR TITLE
changefeedccl: Terminate retries when loosing claim

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1223,7 +1223,8 @@ func (b *changefeedResumer) resumeWithRetries(
 		}
 
 		// All other errors retry.
-		log.Warningf(ctx, `WARNING: CHANGEFEED job %d encountered retryable error: %v`, jobID, err)
+		log.Warningf(ctx, `WARNING: CHANGEFEED job %d encountered retryable error: %v (attempt %d)`,
+			jobID, err, 1+r.CurrentAttempt())
 		lastRunStatusUpdate = b.setJobRunningStatus(ctx, lastRunStatusUpdate, "retryable error: %s", err)
 		if metrics, ok := execCfg.JobRegistry.MetricsStruct().Changefeed.(*Metrics); ok {
 			sli, err := metrics.getSLIMetrics(details.Opts[changefeedbase.OptMetricsScope])
@@ -1236,8 +1237,11 @@ func (b *changefeedResumer) resumeWithRetries(
 		// been updated by the changeFrontier processor since the flow started.
 		reloadedJob, reloadErr := execCfg.JobRegistry.LoadClaimedJob(ctx, jobID)
 		if reloadErr != nil {
-			if ctx.Err() != nil {
+			switch {
+			case ctx.Err() != nil:
 				return ctx.Err()
+			case jobs.HasJobNotFoundError(reloadErr):
+				return reloadErr
 			}
 			log.Warningf(ctx, `CHANGEFEED job %d could not reload job progress; `+
 				`continuing from last known high-water of %s: %v`,


### PR DESCRIPTION
Inhibit changefeed retries if attempt to reload the job indicates that the job is not found -- that is, the node lost the job claim.

Epic: None
Release note: None