### PR TITLE
storage: lock database before initializing encryption-at-rest 

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -117,6 +117,7 @@ go_library(
         "pgx.go",
         "pgx_blocklist.go",
         "pop.go",
+        "process_lock.go",
         "psycopg.go",
         "psycopg_blocklist.go",
         "query_comparison_util.go",

--- a/pkg/cmd/roachtest/tests/process_lock.go
+++ b/pkg/cmd/roachtest/tests/process_lock.go
@@ -1,0 +1,159 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+// registerProcessLock registers the process lock test.
+func registerProcessLock(r registry.Registry) {
+	const runDuration = 5 * time.Minute
+	r.Add(registry.TestSpec{
+		Name:    "process-lock",
+		Owner:   registry.OwnerStorage,
+		Cluster: r.MakeClusterSpec(4, spec.ReuseNone()),
+		// Encryption is implemented within the virtual filesystem layer,
+		// just like disk-health monitoring. It's important to exercise
+		// encryption-at-rest to ensure we don't corrupt the encryption-at-rest
+		// data during a concurrent process start.
+		EncryptionSupport: registry.EncryptionMetamorphic,
+		Timeout:           2 * runDuration,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			startOpts := option.DefaultStartOpts()
+			startSettings := install.MakeClusterSettings()
+			startSettings.Env = append(startSettings.Env, "COCKROACH_AUTO_BALLAST=false")
+
+			t.Status("starting cluster")
+			c.Put(ctx, t.Cockroach(), "./cockroach")
+			c.Start(ctx, t.L(), startOpts, startSettings, c.Range(1, 3))
+
+			// Wait for upreplication.
+			conn := c.Conn(ctx, t.L(), 2)
+			defer conn.Close()
+			require.NoError(t, conn.PingContext(ctx))
+			require.NoError(t, WaitFor3XReplication(ctx, t, conn))
+
+			c.Run(ctx, c.Node(4), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+
+			seed := int64(1666467482296309000)
+			rng := randutil.NewTestRandWithSeed(seed)
+
+			t.Status("starting workload")
+			m := c.NewMonitor(ctx, c.Range(1, 3))
+			m.Go(func(ctx context.Context) error {
+				c.Run(ctx, c.Node(4), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
+					`--duration %s --concurrency 512 --max-rate 4096 --tolerate-errors `+
+					` --min-block-bytes=1024 --max-block-bytes=1024 `+
+					`{pgurl:1-3}`, runDuration.String()))
+				return nil
+			})
+			m.Go(func(ctx context.Context) error {
+				// Query /proc/ on each of the nodes to retrieve the exact
+				// command used to start the node. This is more future proof
+				// than trying to reconstruct the command deposited into the
+				// start script.
+				var startCommands [3]string
+				var storeFlags [3]string
+				var enterpriseEncryption [3]string
+				for n := 1; n <= 3; n++ {
+					// On each node, find the cockroach process's pid by
+					// grepping for `./cockroach start` in ps's output, and
+					// grabbing the first field after stripping leading
+					// whitespace. Then, use this pid cat /proc/<pid>/cmdline.
+					result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(n),
+						"cat /proc/`ps -eo pid,args | grep -E '([0-9]+) ./cockroach start' |  sed 's/^ *//' | cut -d ' ' -f 1`/cmdline")
+					if err != nil {
+						return err
+					}
+					// Arguments in /proc/<pid>/cmdline are NUL-delimited.
+					args := strings.Split(result.Stdout, "\x00")
+					var cmd bytes.Buffer
+					fmt.Fprint(&cmd, args[0])
+					for i := 1; i < len(args); i++ {
+						if strings.ContainsRune(args[i], ' ') {
+							// Quote any arguments that contain spaces.
+							fmt.Fprintf(&cmd, " \"%s\"", args[i])
+						} else {
+							fmt.Fprintf(&cmd, " %s", args[i])
+						}
+
+						// Save the store flags that we'll need to run manual
+						// store commands.
+						if args[i] == "--store" {
+							storeFlags[n-1] = args[i] + " " + args[i+1]
+						}
+						if args[i] == "--enterprise-encryption" {
+							enterpriseEncryption[n-1] = args[i] + " " + args[i+1]
+						}
+					}
+					startCommands[n-1] = cmd.String()
+					t.L().PrintfCtx(ctx, "Retrieved n%d's start command: %s", n, startCommands[n-1])
+				}
+
+				done := time.After(runDuration)
+				ticker := time.NewTicker(time.Second)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-done:
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-ticker.C:
+						// Pick a random node.
+						n := randutil.RandIntInRange(rng, 1, 4)
+
+						// Pick a random operation to run.
+						ops := []func(){
+							func() {
+								// Try to start the node again.
+								err := c.RunE(ctx, c.Node(n), startCommands[n-1])
+								t.L().PrintfCtx(ctx, "Attempt to start cockroach process on n%d while another cockroach process is still running; error expected: %v", n, err)
+							},
+							func() {
+								// Try to perform a manual compaction.
+								err := c.RunE(ctx, c.Node(n), fmt.Sprintf("./cockroach debug compact /mnt/data1/cockroach %s", enterpriseEncryption[n-1]))
+								t.L().PrintfCtx(ctx, "Attempt to manual compact store on n%d while another cockroach process is still running; error expected: %v", n, err)
+							},
+							func() {
+								// Restart the node. This verifies that the
+								// other operations that were performed
+								// concurrently with the running process did not
+								// corrupt the on-disk state.
+								m.ExpectDeath()
+								c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(n))
+								c.Start(ctx, t.L(), startOpts, startSettings, c.Node(n))
+								m.ResetDeaths()
+							},
+						}
+						ops[randutil.RandIntInRange(rng, 0, len(ops))]()
+					}
+				}
+			})
+
+			m.Wait()
+		},
+	})
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -97,6 +97,7 @@ func RegisterTests(r registry.Registry) {
 	registerPgjdbc(r)
 	registerPgx(r)
 	registerPop(r)
+	registerProcessLock(r)
 	registerPsycopg(r)
 	registerQueue(r)
 	registerQuitTransfersLeases(r)

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -757,6 +757,7 @@ type Pebble struct {
 	properties   roachpb.StoreProperties
 	settings     *cluster.Settings
 	encryption   *EncryptionEnv
+	fileLock     *pebble.Lock
 	fileRegistry *PebbleFileRegistry
 
 	// Stats updated by pebble.EventListener invocations, and returned in
@@ -939,6 +940,27 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 			filesystemCloser.Close()
 		}
 	}()
+	if !opts.ReadOnly {
+		if err := opts.FS.MkdirAll(cfg.Dir, os.ModePerm); err != nil {
+			return nil, err
+		}
+	}
+
+	// Acquire the database lock in the store directory to ensure that no other
+	// process is simultaneously accessing the same store. We manually acquire
+	// the database lock here (rather than allowing Pebble to acquire the lock)
+	// so that we hold the lock when we initialize encryption-at-rest subsystem.
+	opts.Lock, err = pebble.LockDirectory(cfg.Dir, opts.FS)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		// If we fail to open the database, release the file lock before
+		// returning.
+		if err != nil {
+			err = errors.WithSecondaryError(err, opts.Lock.Close())
+		}
+	}()
 
 	// The context dance here is done so that we have a clean context without
 	// timeouts that has a copy of the log tags.
@@ -1024,6 +1046,7 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 		properties:       storeProps,
 		settings:         cfg.Settings,
 		encryption:       encryptionEnv,
+		fileLock:         opts.Lock,
 		fileRegistry:     fileRegistry,
 		unencryptedFS:    unencryptedFS,
 		logger:           opts.LoggerAndTracer,
@@ -1309,6 +1332,7 @@ func (p *Pebble) Close() {
 	if p.closer != nil {
 		handleErr(p.closer.Close())
 	}
+	handleErr(p.fileLock.Close())
 }
 
 // aggregateIterStats is propagated to all of an engine's iterators, aggregating


### PR DESCRIPTION
**cmd/roachtest: add process-lock roachtest** 

Add a roachtest that tests accidental process restarts and debug commands run
without terminating the previous process. It exercises the file locking that
prevents concurrent modification of a store's data.

Epic: none
Informs: #98294
Release note: none

**storage: lock database before initializing encryption-at-rest** 

Previously, it was possible to corrupt the encryption-at-rest state of a store
by running commands that manipulate store state without first terminating the
store's Cockroach process. Cockroach uses a file lock to provide mutual
exclusion between processes. Previously, this file lock was acquired when the
Pebble engine was opened. The engine is opened only after the
encryption-at-rest environment has been initialized, including rotating the
file registry. This corruption required replacing the entire corrupted store.

Fix an issue whereby encryption-at-rest disk state was not protectthe file lock
that prevents

Fix #98294.
Release note (bug fix): Fix bug whereby running a debug command that
manipulates a store (eg, `debug compact`) without first terminating the node
using the store could result in corruption of the node's store if
encryption-at-rest was enabled.