### PR TITLE
release-22.2: backupccl: don't restore sql_instances, sqlliveness or lease rows

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -327,7 +327,7 @@ func ingestWithRetries(
 		if jobs.IsPermanentJobError(err) || errors.Is(err, context.Canceled) {
 			break
 		}
-		const msgFmt = "stream ingestion waits for retrying after error %s"
+		const msgFmt = "stream ingestion waits for retrying after error: %q"
 		log.Warningf(ctx, msgFmt, err)
 		updateRunningStatus(ctx, ingestionJob, fmt.Sprintf(msgFmt, err))
 		retryCount++


### PR DESCRIPTION
Backport 1/1 commits from #102413.

/cc @cockroachdb/release

---

Restoring these rows from the old cluster can cause the restored cluster to experience error when trying to plan and run queries that run on 'all' nodes due to the old rows in these tables that track the set of nodes still appearing to be valid until they expire.

Release note: none.
Epic: none.

Release justification: bug fix, test flake.
