### PR TITLE
release-22.2: ui: improvements on sort warning

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.11",
+  "version": "22.2.12",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -83,6 +83,7 @@ import {
   getSortLabel,
   getSortColumn,
   getSubsetWarning,
+  getReqSortColumn,
 } from "src/util/sqlActivityConstants";
 import { SearchCriteria } from "src/searchCriteria/searchCriteria";
 import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
@@ -317,6 +318,17 @@ export class StatementsPage extends React.Component<
       columnTitle: getSortColumn(this.state.reqSortSetting),
     };
     this.changeSortSetting(ss);
+  };
+
+  onUpdateSortSettingAndApply = (): void => {
+    this.setState(
+      {
+        reqSortSetting: getReqSortColumn(this.props.sortSetting.columnTitle),
+      },
+      () => {
+        this.updateRequestParams();
+      },
+    );
   };
 
   resetPagination = (): void => {
@@ -655,6 +667,10 @@ export class StatementsPage extends React.Component<
       this.props.reqSortSetting,
       "Statement",
     );
+    const showSortWarning =
+      !this.isSortSettingSameAsReqSort() &&
+      this.hasReqSortOption() &&
+      data.length == this.props.limit;
 
     return (
       <>
@@ -726,15 +742,15 @@ export class StatementsPage extends React.Component<
             onRemoveFilter={this.onSubmitFilters}
             onClearFilters={this.onClearFilters}
           />
-          {!this.isSortSettingSameAsReqSort() && (
+          {showSortWarning && (
             <InlineAlert
               intent="warning"
               title={getSubsetWarning(
                 "statement",
                 this.props.limit,
                 sortSettingLabel,
-                this.hasReqSortOption(),
                 this.props.sortSetting.columnTitle as StatisticTableColumnKeys,
+                this.onUpdateSortSettingAndApply,
               )}
               className={cx("margin-bottom")}
             />

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -80,6 +80,7 @@ import {
   getSortLabel,
   getSortColumn,
   getSubsetWarning,
+  getReqSortColumn,
 } from "src/util/sqlActivityConstants";
 import { SearchCriteria } from "src/searchCriteria/searchCriteria";
 import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
@@ -425,6 +426,17 @@ export class TransactionsPage extends React.Component<
     this.onChangeSortSetting(ss);
   };
 
+  onUpdateSortSettingAndApply = (): void => {
+    this.setState(
+      {
+        reqSortSetting: getReqSortColumn(this.props.sortSetting.columnTitle),
+      },
+      () => {
+        this.updateRequestParams();
+      },
+    );
+  };
+
   hasReqSortOption = (): boolean => {
     return Object.values(SqlStatsSortOptions).some(
       (option: SqlStatsSortType) =>
@@ -517,6 +529,10 @@ export class TransactionsPage extends React.Component<
       this.props.reqSortSetting,
       "Transaction",
     );
+    const showSortWarning =
+      !this.isSortSettingSameAsReqSort() &&
+      this.hasReqSortOption() &&
+      transactionsToDisplay.length == this.props.limit;
 
     return (
       <>
@@ -588,15 +604,15 @@ export class TransactionsPage extends React.Component<
             onRemoveFilter={this.onSubmitFilters}
             onClearFilters={this.onClearFilters}
           />
-          {!this.isSortSettingSameAsReqSort() && (
+          {showSortWarning && (
             <InlineAlert
               intent="warning"
               title={getSubsetWarning(
                 "transaction",
                 this.props.limit,
                 sortSettingLabel,
-                this.hasReqSortOption(),
                 this.props.sortSetting.columnTitle as StatisticTableColumnKeys,
+                this.onUpdateSortSettingAndApply,
               )}
               className={cx("margin-bottom")}
             />

--- a/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.tsx
@@ -8,12 +8,17 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import React from "react";
 import { duration } from "moment";
 import { SqlStatsSortOptions, SqlStatsSortType } from "src/api/statementsApi";
 import {
   getLabel,
   StatisticTableColumnKeys,
 } from "../statsTableUtil/statsTableUtil";
+import classNames from "classnames/bind";
+import styles from "src/sqlActivity/sqlActivity.module.scss";
+
+const cx = classNames.bind(styles);
 
 export const limitOptions = [
   { value: 25, label: "25" },
@@ -55,6 +60,21 @@ export function getSortColumn(sort: SqlStatsSortType): string {
   }
 }
 
+export function getReqSortColumn(sort: string): SqlStatsSortType {
+  switch (sort) {
+    case "time":
+      return SqlStatsSortOptions.SERVICE_LAT;
+    case "executionCount":
+      return SqlStatsSortOptions.EXECUTION_COUNT;
+    case "contention":
+      return SqlStatsSortOptions.CONTENTION_TIME;
+    case "workloadPct":
+      return SqlStatsSortOptions.PCT_RUNTIME;
+    default:
+      return SqlStatsSortOptions.SERVICE_LAT;
+  }
+}
+
 export const stmtRequestSortOptions = Object.values(SqlStatsSortOptions)
   .map(sortVal => ({
     value: sortVal as SqlStatsSortType,
@@ -84,13 +104,21 @@ export function getSubsetWarning(
   type: "statement" | "transaction",
   limit: number,
   sortLabel: string,
-  showSuggestion: boolean,
   columnTitle: StatisticTableColumnKeys,
-): string {
-  const warningSuggestion = showSuggestion
-    ? `Update the search criteria to see the ${type} fingerprints 
-    sorted on ${getLabel(columnTitle, type)}.`
-    : "";
-  return `You are viewing a subset (Top ${limit}) of fingerprints by ${sortLabel}.
-    ${warningSuggestion}`;
+  onUpdateSortSettingAndApply: () => void,
+): React.ReactElement {
+  return (
+    <span className={cx("row")}>
+      {`You are viewing a subset (Top ${limit}) of fingerprints by ${sortLabel}.`}
+      &nbsp;
+      <a onClick={onUpdateSortSettingAndApply} className={cx("action")}>
+        Update the search criteria
+      </a>
+      &nbsp;
+      {`to see the ${type} fingerprints sorted on ${getLabel(
+        columnTitle,
+        type,
+      )}.`}
+    </span>
+  );
 }


### PR DESCRIPTION
Backport 1/1 commits from #101574.

/cc @cockroachdb/release

---

Fixes #101568

Previously, when you selected a column that was not the same from the Search Criteria we would show a warning. Now the warning will only show if:
- The column selected is one of the sort options
- The number of rows is the same the the limit selected (if the number is smaller, doesn't make sense to suggest a different sorting, because you're already seeing everything)

The suggestion is also clickable now, and it will update the search.

https://www.loom.com/share/da777bab7154401b9daa60d184a200f7

Release note: None

---
Release justification: small ui change, big impact
