### PR TITLE
changefeedccl: fix webhook sink retries

### DIFF
--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -782,6 +782,7 @@ func getSinkConfigFromJson(
 
 	retryCfg.MaxRetries = int(cfg.Retry.Max)
 	retryCfg.InitialBackoff = time.Duration(cfg.Retry.Backoff)
+	retryCfg.MaxBackoff = 30 * time.Second
 	return cfg.Flush, retryCfg, nil
 }
 

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -219,6 +219,7 @@ func (s *deprecatedWebhookSink) getWebhookSinkConfig(
 
 	retryCfg.MaxRetries = int(cfg.Retry.Max)
 	retryCfg.InitialBackoff = time.Duration(cfg.Retry.Backoff)
+	retryCfg.MaxBackoff = 30 * time.Second
 	return cfg.Flush, retryCfg, nil
 }
 
@@ -444,7 +445,8 @@ func (s *deprecatedWebhookSink) splitAndSendBatch(batch []deprecatedMessagePaylo
 	return nil
 }
 
-// flushWorkers sends flush request to each worker and waits for each one to acknowledge.
+// flushWorkers sends flush request to each worker and waits for each one to
+// acknowledge.
 func (s *deprecatedWebhookSink) flushWorkers(done chan struct{}) error {
 	for i := 0; i < len(s.eventsChans); i++ {
 		// Ability to write a nil message to events channel indicates that
@@ -603,7 +605,8 @@ func (s *deprecatedWebhookSink) workerIndex(key []byte) uint32 {
 	return crc32.ChecksumIEEE(key) % uint32(s.parallelism)
 }
 
-// exitWorkersWithError saves the first error message encountered by webhook workers,
+// exitWorkersWithError saves the first error message encountered by webhook
+// workers,
 // and requests all workers to terminate.
 func (s *deprecatedWebhookSink) exitWorkersWithError(err error) {
 	// errChan has buffer size 1, first error will be saved to the buffer and


### PR DESCRIPTION
Release note (bug fix): The `Retry.Max` field of the
`webhook_sink_config` option for changefeeds was not correctly
defined in the docs. The existing docs mention that it is "The
maximum amount of time the sink will retry a single HTTP request
to send a batch", but this is incorrect. It actually represents
the maximum number of retries which will be attempted when
sending a batch in an HTTP request fails.

Also, before this change, there was a bug where the maximum time
we would wait before retrying was 4 seconds regardless of
`Retry.Max`. With this change, the new maximum retry time is
30 seconds. We will keep doubling the initial backoff
every time we retry until the maximum of 30 seconds is reached.

Example:

If `Retry.Max = 4` and the initial backoff is 10 seconds,
at most 4 retries will be performed with the backoff times
10, 20, 30, 30 seconds respectively.

Fixes: https://github.com/cockroachdb/cockroach/issues/102467
Epic: None