### PR TITLE
release-22.2: backupccl: skip TestBackupTenantImportingTable

### DIFF
--- a/pkg/ccl/backupccl/backup_tenant_test.go
+++ b/pkg/ccl/backupccl/backup_tenant_test.go
@@ -36,6 +36,7 @@ import (
 func TestBackupTenantImportingTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 97071)
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1,


### PR DESCRIPTION
Release note: none.

Release justification: no.

Epic: none.