### PR TITLE
kv: support multiple isolation levels in `TestTxnCoordSenderRetries`

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -3169,6 +3169,46 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 		},
 		{
+			name: "multi-range batch commit with write too old after prior read (err on first range)",
+			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
+				return db.Put(ctx, "a", "value")
+			},
+			retryable: func(ctx context.Context, txn *kv.Txn) error {
+				b := txn.NewBatch()
+				b.Put("a", "put")
+				b.Put("c", "put")
+				return txn.CommitInBatch(ctx, b)
+			},
+			priorReads: true,
+			// The Put to "a" will fail, failing the parallel commit and forcing a
+			// client-side refresh.
+			allIsoLevels: &expect{
+				expServerRefresh:               false,
+				expClientRefresh:               true,
+				expClientAutoRetryAfterRefresh: true,
+			},
+		},
+		{
+			name: "multi-range batch commit with write too old after prior read (err on second range)",
+			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
+				return db.Put(ctx, "c", "value")
+			},
+			retryable: func(ctx context.Context, txn *kv.Txn) error {
+				b := txn.NewBatch()
+				b.Put("a", "put")
+				b.Put("c", "put")
+				return txn.CommitInBatch(ctx, b)
+			},
+			priorReads: true,
+			// The Put to "c" will fail, failing the parallel commit and forcing a
+			// client-side refresh.
+			allIsoLevels: &expect{
+				expServerRefresh:               false,
+				expClientRefresh:               true,
+				expClientAutoRetryAfterRefresh: true,
+			},
+		},
+		{
 			name: "multi-range batch commit with write too old and failed cput",
 			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "a", "orig")


### PR DESCRIPTION
Informs #100131.

This PR adds support to test multiple isolation levels in `TestTxnCoordSenderRetries`. This new support will be used in a future commit that introduces write-skew tolerance to Snapshot isolation transactions. For now, the tests still only exercise Serializable transactions because Snapshot transactions which cannot tolerate write skew but also don't preemptively refresh result in an unnecessarily large diff.

Epic: None
Release note: None