### PR TITLE
kv: test for refresh failures in `TestTxnCoordSenderRetries`

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -2054,7 +2054,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 	}
 
 	type expect struct {
-		expClientRefresh               bool   // pre-emptive or reactive client-side refresh
+		expClientRefreshSuccess        bool   // pre-emptive or reactive client-side refresh success
 		expClientAutoRetryAfterRefresh bool   // auto-retries of batches after client-side refresh
 		expClientRestart               bool   // client-side txn restart
 		expServerRefresh               bool   // server-side refresh
@@ -2087,7 +2087,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive refresh before commit.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2117,7 +2117,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive (no-op) refresh before commit.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2135,7 +2135,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive (no-op) refresh before commit.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2168,7 +2168,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive (no-op) refresh before commit.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2184,7 +2184,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive refresh before commit.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2241,7 +2241,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive refresh before get.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2261,7 +2261,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive refresh before scan.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2282,7 +2282,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive refresh before commit.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2303,7 +2303,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive refresh before commit.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2324,7 +2324,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// perIsoLevel mechanism.
 			perIsoLevel: map[isolation.Level]*expect{
 				isolation.Serializable: {
-					expClientRefresh:               true,
+					expClientRefreshSuccess:        true,
 					expClientAutoRetryAfterRefresh: true,
 				},
 			},
@@ -2343,7 +2343,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// Read-only request (Scan) prevents server-side refresh.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -2414,7 +2414,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive refresh before commit.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2454,7 +2454,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive refresh before commit.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2480,7 +2480,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			priorReads: true,
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -2540,7 +2540,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			// No retry, preemptive refresh before Get.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -2634,7 +2634,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			priorReads: true,
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -2684,7 +2684,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			priorReads: true,
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -2710,7 +2710,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			priorReads: true,
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true, // fails on first attempt at cput with write too old
 				// Succeeds on second attempt.
 			},
@@ -2744,7 +2744,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			priorReads: true,
 			// Expect a transaction coord retry, which should succeed.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -2838,7 +2838,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			priorReads: true,
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 				expOnePhaseCommit:              true,
 			},
@@ -2853,7 +2853,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return err
 			},
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 				expOnePhaseCommit:              true,
 			},
@@ -2868,7 +2868,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return err
 			},
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 				expOnePhaseCommit:              true,
 			},
@@ -2885,7 +2885,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return txn.Run(ctx, b)
 			},
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 				expOnePhaseCommit:              true,
 			},
@@ -2907,7 +2907,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return err
 			},
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true, // can refresh
 			},
 		},
@@ -3039,7 +3039,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// refresh.
 			allIsoLevels: &expect{
 				expServerRefresh:               true,
-				expClientRefresh:               false,
+				expClientRefreshSuccess:        false,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -3060,7 +3060,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// result, it does not qualify for the implicit commit condition and
 			// requires a client-side refresh.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3102,7 +3102,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return txn.CommitInBatch(ctx, b) // both puts will succeed, et will retry from get
 			},
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3122,7 +3122,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return txn.CommitInBatch(ctx, b) // both puts will succeed, et will retry
 			},
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3143,7 +3143,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// refresh.
 			allIsoLevels: &expect{
 				expServerRefresh:               true,
-				expClientRefresh:               false,
+				expClientRefreshSuccess:        false,
 				expClientAutoRetryAfterRefresh: false,
 			},
 		},
@@ -3164,7 +3164,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// requires a client-side refresh.
 			allIsoLevels: &expect{
 				expServerRefresh:               true,
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3184,7 +3184,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// client-side refresh.
 			allIsoLevels: &expect{
 				expServerRefresh:               false,
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3204,7 +3204,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// client-side refresh.
 			allIsoLevels: &expect{
 				expServerRefresh:               false,
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3284,7 +3284,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return txn.Commit(ctx)
 			},
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3336,7 +3336,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			filter: newUncertaintyFilter(roachpb.Key("ac")),
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3385,7 +3385,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// requires a client-side refresh.
 			allIsoLevels: &expect{
 				expServerRefresh:               true,
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3431,7 +3431,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// requires a client-side refresh.
 			allIsoLevels: &expect{
 				expServerRefresh:               true,
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3444,7 +3444,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			filter: newUncertaintyFilter(roachpb.Key("c")),
 			// Expect a transaction coord retry, which should succeed.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3457,7 +3457,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			filter: newUncertaintyFilter(roachpb.Key("c")),
 			// Expect a transaction coord retry, which should succeed.
 			allIsoLevels: &expect{
-				expClientRefresh:               true,
+				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
 			},
 		},
@@ -3602,7 +3602,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 		}
 
 		// Verify metrics.
-		require.Equal(t, exp.expClientRefresh, metrics.ClientRefreshSuccess.Count() != 0, "TxnMetrics.ClientRefreshSuccess")
+		require.Equal(t, exp.expClientRefreshSuccess, metrics.ClientRefreshSuccess.Count() != 0, "TxnMetrics.ClientRefreshSuccess")
 		require.Equal(t, exp.expClientAutoRetryAfterRefresh, metrics.ClientRefreshAutoRetries.Count() != 0, "TxnMetrics.ClientRefreshAutoRetries")
 		require.Equal(t, exp.expServerRefresh, metrics.ServerRefreshSuccess.Count() != 0, "TxnMetrics.ServerRefreshSuccess")
 		require.Equal(t, exp.expClientRestart, metrics.Restarts.TotalSum() != 0, "TxnMetrics.Restarts")


### PR DESCRIPTION
This commit adds explicit testing of refresh failures to `TestTxnCoordSenderRetries`, as suggested in #102086.

Epic: None
Release note: None