### PR TITLE
linter: loopvarcapture should check interface methods

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -757,6 +757,7 @@ func registerKVScalability(r registry.Registry) {
 
 		const maxPerNodeConcurrency = 64
 		for i := nodes; i <= nodes*maxPerNodeConcurrency; i += nodes {
+			i := i // capture loop variable
 			c.Wipe(ctx, c.Range(1, nodes))
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
 

--- a/pkg/testutils/lint/passes/loopvarcapture/BUILD.bazel
+++ b/pkg/testutils/lint/passes/loopvarcapture/BUILD.bazel
@@ -25,6 +25,18 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    # N.B. We must disable CGO owing to a rather obscure failure [1].
+    #      It's surmised that the root cause is the missing CGO metadata
+    #      inside the test's runfiles directory. By disabling CGO, we're
+    #      allowing the go type checker to create a dummy object [2] without
+    #      causing a (type) resolution error.
+    #
+    # [1] https://github.com/golang/go/issues/36547
+    # [2] https://github.com/golang/tools/blob/master/go/packages/packages.go#L1056-L1064
+    #
+    env = {
+        "CGO_ENABLED": "0",
+    },
     deps = [
         ":loopvarcapture",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/loopvarcapture/loopvarcapture.go
+++ b/pkg/testutils/lint/passes/loopvarcapture/loopvarcapture.go
@@ -405,9 +405,8 @@ func (v *Visitor) visitLoopClosure(closure *ast.FuncLit) {
 // whether that call is being made to one of the functions in the
 // GoRoutineFunctions slice.
 func (v *Visitor) isGoRoutineFunction(call *ast.CallExpr) bool {
-	callee := typeutil.StaticCallee(v.pass.TypesInfo, call)
-	// call to a builtin
-	if callee == nil {
+	callee, ok := typeutil.Callee(v.pass.TypesInfo, call).(*types.Func)
+	if !ok {
 		return false
 	}
 	pkg := callee.Pkg()


### PR DESCRIPTION
The `loopvarcapture` linter is part of `roachvet`. It flags incorrect uses of loop variables captured by reference in Go routines or defer statements--a common source of data races.

In addition to checking Go routines created via the `go` keyword, the linter also checks against other (internal) APIs, which are known to create Go routines; this is specified via `GoRoutineFunctions`.

An existing bug prevented the linter from checking inside `Monitor.Go`, which are commonly used inside roachtests.
This PR fixes the linter bug as well as the pre-existing bug inside a roachtest, which this linter now detects.

This PR also removes the uncessary hack, i.e., `RunDespiteErrors`, introduced in [1]. By allowing the type checker to swallow errors, the test was susceptible to silent errors, e.g., buggy testdata. Instead, we work around by disabling CGO.

Epic: none
Fixes: #102678
Release note: None

[1] https://github.com/cockroachdb/cockroach/pull/84867#issuecomment-1200470795