### PR TITLE
pkg/server/status: remove leftover debug log statement.

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2269,7 +2269,6 @@ func (s *systemStatusServer) TenantRanges(
 
 	tID, ok := roachpb.ClientTenantFromContext(ctx)
 	if !ok {
-		log.Infof(ctx, "COULD NOT FIND TENANT ID")
 		return nil, status.Error(codes.Internal, "no tenant ID found in context")
 	}
 


### PR DESCRIPTION
This log statement was accidentally merged as part of https://github.com/cockroachdb/cockroach/pull/88353.

This patch simply removes the log line.

Release note: none

Epic: CRDB-12182