### PR TITLE
Revert "Merge pull request #102468 from cockroachdb/blathers/backport…

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -50,7 +50,6 @@ go_library(
         "//pkg/util/log/severity",
         "//pkg/util/metric",
         "//pkg/util/netutil",
-        "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -543,10 +542,6 @@ type ContextOptions struct {
 	// node-to-node connections and prevents one-way partitions from occurring by
 	// turing them into two-way partitions.
 	NeedsDialback bool
-
-	// PreferSRVLookup indicates whether SRV records are preferred over A/AAAA
-	// records when dialing network targets.
-	PreferSRVLookup bool
 }
 
 func (c ContextOptions) validate() error {
@@ -1834,12 +1829,6 @@ func (rpcCtx *Context) dialOptsNetwork(
 	// which is only definitely provided during dial.
 	dialer := onlyOnceDialer{}
 	dialerFunc := dialer.dial
-	if rpcCtx.ContextOptions.PreferSRVLookup {
-		dialer := &srvResolvingDialer{
-			dialerFunc: dialerFunc,
-		}
-		dialerFunc = dialer.dial
-	}
 	if rpcCtx.Knobs.InjectedLatencyOracle != nil {
 		latency := rpcCtx.Knobs.InjectedLatencyOracle.GetLatency(target)
 		log.VEventf(ctx, 1, "connecting with simulated latency %dms",
@@ -2017,25 +2006,6 @@ func (ald *artificialLatencyDialer) dial(ctx context.Context, addr string) (net.
 		enabled: ald.enabled,
 		readBuf: new(bytes.Buffer),
 	}, nil
-}
-
-// srvResolvingDialer first queries SRV records for addr, and dials
-// a random member of the result.
-// If the result is empty, it dials the addr directly.
-type srvResolvingDialer struct {
-	dialerFunc dialerFunc
-}
-
-func (srd *srvResolvingDialer) dial(ctx context.Context, addr string) (net.Conn, error) {
-	addrs, err := netutil.SRV(ctx, addr)
-	if err != nil {
-		return nil, err
-	}
-	if len(addrs) == 0 {
-		// If SRV lookup returns empty, we fallback to addr.
-		addrs = []string{addr}
-	}
-	return srd.dialerFunc(ctx, addrs[int(randutil.FastUint32())%len(addrs)])
 }
 
 type delayingListener struct {

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -2746,50 +2746,5 @@ func TestHeartbeatDialback(t *testing.T) {
 	}
 }
 
-// TestSRVResolvingDialer tests srvResolvingDialer dials the correct target if SRV query
-// is successful, and dials the input target directly if SRV query returns empty records.
-func TestSRVResolvingDialer(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	ctx := context.Background()
-
-	t.Run("success SRV lookup", func(t *testing.T) {
-		expected := &net.SRV{
-			Target: "test",
-			Port:   123,
-		}
-		defer netutil.TestingOverrideSRVLookupFn(func(service, proto, name string) (string, []*net.SRV, error) {
-			return "", []*net.SRV{expected}, nil
-		})()
-
-		dialed := false
-		dial := func(ctx context.Context, addr string) (net.Conn, error) {
-			dialed = true
-			require.Equal(t, fmt.Sprintf("%s:%d", expected.Target, expected.Port), addr)
-			return nil, nil
-		}
-		dialer := &srvResolvingDialer{dialerFunc: dial}
-		_, err := dialer.dial(ctx, "srvquery")
-		require.NoError(t, err)
-		require.True(t, dialed)
-	})
-
-	t.Run("empty SRV lookup", func(t *testing.T) {
-		defer netutil.TestingOverrideSRVLookupFn(func(service, proto, name string) (string, []*net.SRV, error) {
-			return "", []*net.SRV{}, nil
-		})()
-		expected := "test-expected"
-		dialed := false
-		dial := func(ctx context.Context, addr string) (net.Conn, error) {
-			dialed = true
-			require.Equal(t, expected, addr)
-			return nil, nil
-		}
-		dialer := &srvResolvingDialer{dialerFunc: dial}
-		_, err := dialer.dial(ctx, expected)
-		require.NoError(t, err)
-		require.True(t, dialed)
-	})
-}
-
 // TODO(baptist): Add a test using TestCluster to verify this works in a full
 // integration test.

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -530,6 +530,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/log/logpb",
         "//pkg/util/metric",
+        "//pkg/util/netutil",
         "//pkg/util/netutil/addr",
         "//pkg/util/protoutil",
         "//pkg/util/randident",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -954,9 +955,27 @@ func (cfg *Config) parseGossipBootstrapAddresses(
 		}
 
 		if cfg.JoinPreferSRVRecords {
-			// We will use the port in the SRV records.
-			bootstrapAddresses = append(bootstrapAddresses, util.MakeUnresolvedAddr("tcp", address))
-			continue
+			// The following code substitutes the entry in --join by the
+			// result of SRV resolution, if suitable SRV records are found
+			// for that name.
+			//
+			// TODO(knz): Delay this lookup. The logic for "regular" addresses
+			// is delayed until the point the connection is attempted, so that
+			// fresh DNS records are used for a new connection. This makes
+			// it possible to update DNS records without restarting the node.
+			// The SRV logic here does not have this property (yet).
+			srvAddrs, err := netutil.SRV(ctx, address)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(srvAddrs) > 0 {
+				for _, sa := range srvAddrs {
+					bootstrapAddresses = append(bootstrapAddresses,
+						util.MakeUnresolvedAddrWithDefaults("tcp", sa, base.DefaultPort))
+				}
+				continue
+			}
 		}
 
 		// Otherwise, use the address.

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -12,6 +12,7 @@ package server
 
 import (
 	"context"
+	"net"
 	"os"
 	"reflect"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
@@ -238,8 +240,11 @@ func TestParseBootstrapResolvers(t *testing.T) {
 
 	t.Run("srv", func(t *testing.T) {
 		cfg.JoinPreferSRVRecords = true
-		const srvName = "srv-name"
-		cfg.JoinList = append(base.JoinListType(nil), srvName)
+		cfg.JoinList = append(base.JoinListType(nil), "othername")
+
+		defer netutil.TestingOverrideSRVLookupFn(func(service, proto, name string) (string, []*net.SRV, error) {
+			return "cluster", []*net.SRV{{Target: expectedName, Port: 111}}, nil
+		})()
 
 		addresses, err := cfg.parseGossipBootstrapAddresses(context.Background())
 		if err != nil {
@@ -248,15 +253,18 @@ func TestParseBootstrapResolvers(t *testing.T) {
 		if len(addresses) != 1 {
 			t.Fatalf("expected 1 address, got %# v", pretty.Formatter(addresses))
 		}
-		host, port, err := addr.SplitHostPort(addresses[0].String(), "defaultPort")
+		host, port, err := addr.SplitHostPort(addresses[0].String(), "UNKNOWN")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if port != "defaultPort" {
-			t.Fatalf("unexpected port defined in resover: %# v", pretty.Formatter(addresses))
+		if port == "UNKNOWN" {
+			t.Fatalf("expected port defined in resover: %# v", pretty.Formatter(addresses))
 		}
-		if host != srvName {
-			t.Errorf("expected host %q, got %q", srvName, host)
+		if port != "111" {
+			t.Fatalf("expected port 111 from SRV, got %q", port)
+		}
+		if host != expectedName {
+			t.Errorf("expected name %q, got %q", expectedName, host)
 		}
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -320,7 +320,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		},
 		TenantRPCAuthorizer: authorizer,
 		NeedsDialback:       true,
-		PreferSRVLookup:     cfg.JoinPreferSRVRecords,
 	}
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {
 		serverKnobs := knobs.(*TestingKnobs)


### PR DESCRIPTION
…-release-23.1-101855"

This reverts commit 299125916ad8be627cca8e6154921ca346bf49c6, reversing changes made to c641ece03109c0614af28e7533f8b6c88e870945.

This PR reverts the behavior introduced in #101855.

See PR: https://github.com/cockroachdb/cockroach/pull/102698

While the cluster still works after https://github.com/cockroachdb/cockroach/pull/101855,
it doesn't work well in normal k8s DNS setup.
RPCs can still be sent to ports other than
the grpc port.

The issue is a pod's advertised addr's
SRV records contain all ports that are
configured in the pod's spec.ports.
This normally contains sql, and http
ports in addition to grpc port.
The behavior introduced in https://github.com/cockroachdb/cockroach/pull/101855
can cause 2/3 of the rpcs to fail in
this situation.

GH issue: https://github.com/cockroachdb/cockroach/issues/102415
Jira issue: [CRDB-27433](https://cockroachlabs.atlassian.net/browse/CRDB-27433)
Epic: none

Release note: none