### PR TITLE
leaktest: ignore pgconn leaked goroutines

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -58,6 +58,10 @@ func interestingGoroutines() map[int64]string {
 			strings.Contains(stack, "sentry-go.(*HTTPTransport).worker") ||
 			// Ignore the opensensus worker, which is created by the event exporter.
 			strings.Contains(stack, "go.opencensus.io/stats/view.(*worker).start") ||
+			// Ignore pgconn which creates a goroutine to do an async cleanup.
+			strings.Contains(stack, "github.com/jackc/pgconn.(*PgConn).asyncClose.func1") ||
+			// Ignore pgconn which creates a goroutine to watch context cancellation.
+			strings.Contains(stack, "github.com/jackc/pgconn/internal/ctxwatch.(*ContextWatcher).Watch.func1") ||
 			// Seems to be gccgo specific.
 			(runtime.Compiler == "gccgo" && strings.Contains(stack, "testing.T.Parallel")) ||
 			// Ignore intentionally long-running logging goroutines that live for the


### PR DESCRIPTION
We see those in c2c unit tests when using pg connections between the 2 clusters.

Note that we already ignored one of those stack traces here https://github.com/cockroachdb/cockroach/pull/102258 and then reverted that change: https://github.com/cockroachdb/cockroach/pull/102593/commits/8ecc8f681098dcb352d8dee0c3cc03fbef80f931 but later we saw that we need to ignore both stacks because of https://github.com/cockroachdb/cockroach/issues/102672.

The first fix above was not enough, it was ignoring only one stack.

Epic: none

Fixes: #97698
Fixes: #97346
Fixes: #102672

Release note: None