### PR TITLE
builtins: add ST_BdPolyFromText builtin function

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1745,6 +1745,8 @@ Precision specifies how many decimal places will be preserved in Encoded Polylin
 <tr><td><a name="st_azimuth"></a><code>st_azimuth(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the azimuth in radians of the segment defined by the given point geometries, or NULL if the two points are coincident.</p>
 <p>The azimuth is angle is referenced from north, and is positive clockwise: North = 0; East = π/2; South = π; West = 3π/2.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="st_bdpolyfromtext"></a><code>st_bdpolyfromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Polygon from multilinestring WKT with a SRID. If the input is not a multilinestring an error will be thrown.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="st_boundary"></a><code>st_boundary(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the closure of the combinatorial boundary of this Geometry.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td><td>Immutable</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5966,3 +5966,29 @@ query T
 SELECT ST_AsEWKT(ST_MakeEnvelope(30.01,50.01,72.01,52.01))
 ----
 POLYGON ((30.010000000000002 50.009999999999998, 30.010000000000002 52.009999999999998, 72.010000000000005 52.009999999999998, 72.010000000000005 50.009999999999998, 30.010000000000002 50.009999999999998))
+
+subtest st_bdpolyfromtext
+
+query TTT
+SELECT 
+  ST_AsText(ST_BdPolyFromText('MULTILINESTRING((0 0, 10 0, 10 10, 0 10, 0 0),(1 1, 1 2, 2 2, 2 1, 1 1))', 4326)),
+  ST_AsText(ST_BdPolyFromText('MULTILINESTRING((0 0, 1 0, 1 1, 0 1, 0 0))', 4326)),
+  ST_AsEWKT(ST_BdPolyFromText('MULTILINESTRING((0 0, 1 0, 1 1, 0 1, 0 0))', 4326))
+----
+POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1)) POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)) SRID=4326;POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+
+query TT
+SELECT
+  ST_AsEWKT(ST_BdPolyFromText(NULL, 4326)),
+  ST_AsEWKT(ST_BdPolyFromText('MULTILINESTRING((0 0, 10 0, 10 10, 0 10, 0 0),(1 1, 1 2, 2 2, 2 1, 1 1))', NULL))
+----
+NULL NULL
+
+statement error pq: st_bdpolyfromtext\(\): argument must be MULTILINESTRING geometry
+SELECT ST_AsText(ST_BdPolyFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))', 4326))
+
+statement error pq: st_bdpolyfromtext\(\): argument must be MULTILINESTRING geometry
+SELECT ST_AsText(ST_BdPolyFromText('LINESTRING(0 0, 1 0, 1 1, 0 1, 0 0)', 4326))
+
+statement error pq: st_bdpolyfromtext\(\): argument must be MULTILINESTRING geometry
+SELECT ST_AsText(ST_BdPolyFromText('POINT(0 0)', 4326))

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2379,6 +2379,7 @@ var builtinOidsArray = []string{
 	2406: `crdb_internal.fingerprint(span: bytes[], stripped: bool) -> int`,
 	2407: `crdb_internal.tenant_span() -> bytes[]`,
 	2408: `crdb_internal.job_execution_details(job_id: int) -> jsonb`,
+	2409: `st_bdpolyfromtext(str: string, srid: int) -> geometry`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
Closes #48801

Release note (sql change): added the ST_BdPolyFromText builtin which copies the behaviour of the PostGIS function. Takes in only a multilinestring geometry and returns a polygon. Will return an error if anything other than multilinestring is inputted and will also return an error if internally a multipolygon is created for some reason. NULL inputs also return NULL.