### PR TITLE
sql: fix alter default privileges on sequence bug

### DIFF
--- a/pkg/sql/alter_default_privileges.go
+++ b/pkg/sql/alter_default_privileges.go
@@ -32,7 +32,7 @@ import (
 
 var targetObjectToPrivilegeObject = map[privilege.TargetObjectType]privilege.ObjectType{
 	privilege.Tables:    privilege.Table,
-	privilege.Sequences: privilege.Table,
+	privilege.Sequences: privilege.Sequence,
 	privilege.Types:     privilege.Type,
 	privilege.Schemas:   privilege.Schema,
 	privilege.Functions: privilege.Function,

--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
@@ -86,3 +86,32 @@ SHOW GRANTS FOR testuser3
 database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
 test           s2           q              testuser3  ALL             false
 test           s2           t              testuser3  ALL             false
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT USAGE ON SEQUENCES TO testuser3;
+
+statement ok
+CREATE SCHEMA s3;
+CREATE SCHEMA s4;
+CREATE SEQUENCE s3.q;
+CREATE SEQUENCE s4.q;
+
+query TTTTTB colnames
+SHOW GRANTS FOR testuser, testuser2
+----
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           s            q              testuser   ALL             false
+test           s            q              testuser2  ALL             false
+test           s2           q              testuser   ALL             false
+test           s2           q              testuser2  ALL             false
+
+
+
+query TTTTTB colnames
+SHOW GRANTS FOR testuser3
+----
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           s2           q              testuser3  ALL             false
+test           s2           t              testuser3  ALL             false
+test           s3           q              testuser3  USAGE           false
+test           s4           q              testuser3  USAGE           false

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
@@ -32,7 +32,7 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
@@ -53,17 +53,17 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,foo=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/,foo=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,foo=X*/}
 3755498903  2026795574  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
-3755498903  2026795574  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {bar=U*/,foo=U*/,=U/}
 3755498903  2026795574  0                n              {bar=C*U*/,foo=C*U*/}
 3755498903  2026795574  0                f              {bar=X*/,foo=X*/}
 1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
@@ -92,7 +92,7 @@ oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 3755498903  2026795574  0                n              {}
 3755498903  2026795574  0                f              {}
 1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
@@ -116,17 +116,17 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*r*w*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
 1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
@@ -141,17 +141,17 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*w*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
 1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
@@ -164,17 +164,17 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
 1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
@@ -193,12 +193,12 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
@@ -214,12 +214,12 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
@@ -242,17 +242,17 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
 880552153   0           0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
-880552153   0           0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
+880552153   0           0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
 880552153   0           0                T              {bar=U*/,foo=U*/}
 880552153   0           0                n              {bar=C*U*/,foo=C*U*/}
 880552153   0           0                f              {bar=X*/,foo=X*/}
@@ -269,12 +269,12 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
@@ -295,12 +295,12 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
@@ -319,12 +319,12 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
@@ -345,12 +345,12 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
@@ -374,17 +374,17 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/}
 3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/}
 2709666228  2264919399  0                r              {foo=C*a*d*r*w*/}
-2709666228  2264919399  0                S              {foo=C*a*d*r*w*/}
+2709666228  2264919399  0                S              {foo=C*U*a*d*r*w*/}
 2709666228  2264919399  0                T              {foo=U*/,testuser=U*/}
 2709666228  2264919399  0                n              {foo=C*U*/}
 2709666228  2264919399  0                f              {foo=X*/}

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl_with_grant_option
@@ -39,7 +39,7 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/}
@@ -56,7 +56,7 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 1451375629  1546506610  0                r              {bar=C*a*drw*/,foo=C*a*drw*/,=r/}
-1451375629  1546506610  0                S              {bar=Ca*d*r*w/,foo=Ca*d*r*w/,=r/}
+1451375629  1546506610  0                S              {bar=CU*a*d*r*w/,foo=CU*a*d*r*w/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU*/,foo=CU*/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -73,7 +73,7 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -94,17 +94,17 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 97389596    1791217281  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
+97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
 97389596    1791217281  0                T              {bar=U*/,foo=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/,foo=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,foo=X*/}
 3755498903  2026795574  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
-3755498903  2026795574  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
+3755498903  2026795574  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
 3755498903  2026795574  0                T              {bar=U*/,foo=U*/,=U/}
 3755498903  2026795574  0                n              {bar=C*U*/,foo=C*U*/}
 3755498903  2026795574  0                f              {bar=X*/,foo=X*/}
 1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -133,7 +133,7 @@ oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 3755498903  2026795574  0                n              {}
 3755498903  2026795574  0                f              {}
 1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -170,7 +170,7 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -185,7 +185,7 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -199,7 +199,7 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}


### PR DESCRIPTION
Resolves: #102711

Release note (bug fix): `alter default privileges
... grant usage on sequences`would fail because the
 sequence object mapped to the table privilege object.
This commit changes the sequence object to map to the sequence privilege object.