### PR TITLE
build: update nogo config to lint more generated code

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -1,10 +1,10 @@
 {
     "assign": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         }
     },
     "composites": {
@@ -12,17 +12,20 @@
             "cockroach/pkg/.*_test.go$": "many existing failures"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "copylocks": {
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "deepequalerrors": {
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         },
         "exclude_files": {
             "_test\\.go$": "tests"
@@ -30,22 +33,24 @@
     },
     "errcheck": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code",
-            "cockroach/pkg/testutils/lint/lint_test.go": "not really sure why this is failing honestly"
+            "pkg/.*_generated\\.go$": "generated code",
+            "cockroach/bazel-out/.*/testmain\\.go$": "generated test main file by rules_go"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "errcmp": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code",
+            "pkg/.*_generated\\.go$": "generated code",
+            "cockroach/bazel-out/.*/testmain\\.go$": "generated test main file by rules_go",
             "cockroach/pkg/cmd/github-pull-request-make/main.go": "invalid direct cast on error object",
             "cockroach/pkg/kv/kvclient/kvcoord/lock_spans_over_budget_error\\.go$": "invalid direct cast on error object",
             "cockroach/pkg/kv/kvpb/batch_generated-gen\\.go$": "invalid direct cast on error object",
@@ -58,59 +63,68 @@
             "cockroach/pkg/cloud/gcp/gcs_retry\\.go$": "invalid direct cast on error object"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "errwrap": {
-      "exclude_files": {
-        ".*\\.pb\\.go$": "generated code",
-        ".*\\.pb\\.gw\\.go$": "generated code"
-      },
-      "only_files": {
-        "cockroach/pkg/.*$": "first-party code"
-      }
+        "exclude_files": {
+            ".*\\.pb\\.go$": "generated code",
+            ".*\\.pb\\.gw\\.go$": "generated code"
+        },
+        "only_files": {
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
+        }
     },
     "fmtsafe": {
         "exclude_files": {
+            "pkg/.*\\.eg\\.go$": "generated code",
             "cockroach/pkg/roachprod/logger/log\\.go$": "format argument is not a constant expression",
-            "cockroach/pkg/util/log/channels\\.go$": "format argument is not a constant expression"
+            "cockroach/pkg/util/log/channels\\.go$": "format argument is not a constant expression",
+            "pkg/util/log/log_channels_generated\\.go$": "format argument is not a constant expression"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "grpcconnclose": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "hash": {
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "lostcancel": {
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "nilness": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code",
+            "pkg/.*_generated\\.go$": "generated code",
             "/_cgo_gotypes.go$": "cgo generated code",
             "_test\\.go$": "tests"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "printf": {
@@ -118,7 +132,8 @@
             "funcs": "ErrEvent,ErrEventf,Error,Errorf,ErrorfDepth,Event,Eventf,Fatal,Fatalf,FatalfDepth,Info,Infof,InfofDepth,AssertionFailedf,AssertionFailedWithDepthf,NewAssertionErrorWithWrappedErrf,DangerousStatementf,pgerror.New,pgerror.NewWithDepthf,pgerror.Newf,SetDetailf,SetHintf,Unimplemented,Unimplementedf,UnimplementedWithDepthf,UnimplementedWithIssueDetailf,UnimplementedWithIssuef,VEvent,VEventf,Warning,Warningf,WarningfDepth,Wrapf,WrapWithDepthf,redact.Fprint,redact.Fprintf,redact.Sprint,redact.Sprintf"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "returncheck": {
@@ -127,595 +142,650 @@
             "cockroach/pkg/kv/txn_external_test.go": "existing failure"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "returnerrcheck": {
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1000": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1001": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1002": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1003": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1004": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1005": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1006": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1007": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1008": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1009": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1010": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1011": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1012": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1016": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1017": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1018": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1019": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1020": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1021": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1023": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1024": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1025": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1028": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1029": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1030": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1031": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1032": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1033": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1034": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1035": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1036": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1037": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1038": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1039": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1040": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1000": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1001": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1002": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1003": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1004": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1005": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1006": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1007": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1008": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1010": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1011": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1012": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1013": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1014": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1015": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1016": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1017": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1018": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1019": {
@@ -723,10 +793,12 @@
             "cockroach/pkg/kv/kvpb/api_test.go$": "same package that grpc-go imports",
             "cockroach/pkg/rpc/codec.go$": "rpc/codec.go imports the same proto package that grpc-go imports (as of crdb@dd87d1145 and grpc-go@7b167fd6).",
             "cockroach/pkg/rpc/stats_handler.go$": "Using deprecated WireLength call",
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code",
+            "pkg/.*_generated\\.go$": "generated code",
+            "pkg/roachprod/vm/aws/embedded\\.go$": "generated code",
+            "pkg/security/securitytest/embedded\\.go$": "generated code",
             "pkg/sql/conn_executor.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
             "pkg/sql/instrumentation.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
             "pkg/sql/planner.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
@@ -746,1033 +818,1133 @@
             "pkg/build/bazel/bazel\\.go$": "Runfile function deprecated"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1020": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1021": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1023": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1024": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1025": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1026": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1027": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1028": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1029": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1030": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA2000": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA2001": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA2002": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA2003": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA3000": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA3001": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4000": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4001": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4003": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4004": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4005": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4006": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4008": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4009": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4010": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4011": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4012": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4013": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4014": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4015": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4016": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4017": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4018": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4019": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4020": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4021": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4022": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4023": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4024": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4025": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4026": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4027": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4028": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4029": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4030": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4031": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5000": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5001": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5002": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5003": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5004": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5005": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5007": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5008": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5009": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5010": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5011": {
         "exclude_files": {
             "_test\\.go$": "tests",
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5012": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA6000": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA6001": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA6002": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA6003": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA6005": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9001": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9002": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9003": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9004": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9005": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9006": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9007": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9008": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1000": {
         "exclude_files": {
             "cockroach/pkg/.*$": "skipped in default staticcheck config",
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code",
+            "pkg/sql/roleoption": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1001": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code",
+            "pkg/.*_generated\\.go$": "generated code",
             "cockroach/pkg/sql/schemachanger/scplan/internal/rules/.*/.*.go$":  "schema changer rules"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroachdb_cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1003": {
         "exclude_files": {
             "cockroach/pkg/.*$": "skipped in default staticcheck config",
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1005": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1006": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1008": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1011": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1011": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1012": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1013": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1015": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1016": {
         "exclude_files": {
             "cockroach/pkg/.*$": "skipped in default staticcheck config",
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1017": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1018": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1019": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1020": {
         "exclude_files": {
             "cockroach/pkg/.*$": "skipped in default staticcheck config",
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1021": {
         "exclude_files": {
             "cockroach/pkg/.*$": "skipped in default staticcheck config",
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1022": {
         "exclude_files": {
             "cockroach/pkg/.*$": "skipped in default staticcheck config",
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1023": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "shadow": {
+       "exclude_files": {
+            "pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.og\\.go$": "generated code"
+        },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "stdmethods": {
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "stringintconv": {
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "structtag": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         }
     },
     "testinggoroutine": {
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         },
         "exclude_files": {
             "_test\\.go$": "tests"
@@ -1780,23 +1952,26 @@
     },
     "unconvert": {
         "exclude_files": {
-            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
+            "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "U1000": {
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "unreachable": {
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "unsafeptr": {
@@ -1804,7 +1979,8 @@
             "cockroach/pkg/sql/colexec/colexechash/hash\\.go$": "re-implements runtime.noescape for efficient hashing"
         },
         "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code",
+            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     }
 }

--- a/pkg/base/license.go
+++ b/pkg/base/license.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package base exposes basic utilities used across cockroach.
 package base
 
 import (

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -6,6 +6,7 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
+// Package backupccl implements backup logic.
 package backupccl
 
 import (

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -6,6 +6,8 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
+// Package schemafeed provides SchemaFeed, which can be used to track schema
+// updates.
 package schemafeed
 
 import (

--- a/pkg/ccl/sqlproxyccl/proxy.go
+++ b/pkg/ccl/sqlproxyccl/proxy.go
@@ -6,6 +6,7 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
+// Package sqlproxyccl implements a server to proxy SQL connections.
 package sqlproxyccl
 
 import (

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package coldata exposes utilities for handling columnarized data.
 package coldata
 
 import (

--- a/pkg/config/field.go
+++ b/pkg/config/field.go
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package config contains basic utilities and data definitions for zone
+// configuration.
 package config
 
 import "github.com/cockroachdb/redact"

--- a/pkg/kv/kvnemesis/kvnemesisutil/context.go
+++ b/pkg/kv/kvnemesis/kvnemesisutil/context.go
@@ -7,8 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-//
 
+// Package kvnemesisutil provides basic utilities for kvnemesis.
 package kvnemesisutil
 
 import "context"

--- a/pkg/kv/kvpb/data.go
+++ b/pkg/kv/kvpb/data.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package kvpb contains basic utilities for the kv layer.
 package kvpb
 
 import (

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package sidetransport contains definitions for the sidetransport layer of
+// the kvserver.
 package sidetransport
 
 import (

--- a/pkg/multitenant/tenantcapabilities/capability.go
+++ b/pkg/multitenant/tenantcapabilities/capability.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package tenantcapabilities describes the privileges allotted to tenants.
 package tenantcapabilities
 
 import (

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package aws provides functionality for the aws provider.
 package aws
 
 import (

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package spanconfigstore exposes utilities for storing and retrieving
+// SpanConfigs associated with a single span.
 package spanconfigstore
 
 import (

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package catalogkeys describes keys used by the SQL catalog.
 package catalogkeys
 
 import (

--- a/pkg/sql/catalog/descpb/descriptor.go
+++ b/pkg/sql/catalog/descpb/descriptor.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package descpb exposes the "Descriptor" type and related utilities.
 package descpb
 
 import (

--- a/pkg/sql/colconv/batch.go
+++ b/pkg/sql/colconv/batch.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package colconv exposes utilities for working with vectorized columns.
 package colconv
 
 import (

--- a/pkg/sql/colexec/colexeccmp/default_cmp_expr.go
+++ b/pkg/sql/colexec/colexeccmp/default_cmp_expr.go
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package colexeccmp exposes some comparison definitions for vectorized
+// operations.
 package colexeccmp
 
 import (

--- a/pkg/sql/colexec/colexecspan/span_assembler.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package colexecspan implements utilities for manipulating spans.
 package colexecspan
 
 import (

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package colfetcher implements logic for fetching kv's and forming table rows
+// for an arbitrary number of tables.
 package colfetcher
 
 import (

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package execinfra contains the common interfaces for colexec and rowexec.
 package execinfra
 
 import (

--- a/pkg/sql/lexbase/encode.go
+++ b/pkg/sql/lexbase/encode.go
@@ -17,6 +17,7 @@
 
 // This code was derived from https://github.com/youtube/vitess.
 
+// Package lexbase contains utilities for lexing sql.
 package lexbase
 
 import (

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package explain implements "explaining" for cockroach.
 package explain
 
 import (

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package exec contains execution-related utilities. (See README.md.)
 package exec
 
 import (

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package memo exposes logic for `Memo`, the central data structure for `opt`.
 package memo
 
 import (

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package norm implements normalization for queries.
 package norm
 
 import (

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package xform contains logic for transforming SQL queries.
 package xform
 
 import (

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package parser contains exposes a SQL parser for cockroach.
 package parser
 
 import (

--- a/pkg/sql/plpgsql/parser/lexbase/utils.go
+++ b/pkg/sql/plpgsql/parser/lexbase/utils.go
@@ -8,4 +8,5 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package lexbase contains utilities for lexing plpgsql.
 package lexbase

--- a/pkg/sql/plpgsql/parser/parse.go
+++ b/pkg/sql/plpgsql/parser/parse.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package parser exposes a parser for plpgsql.
 package parser
 
 import (

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package privilege outlines the basic privilege system for cockroach.
 package privilege
 
 import (

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// schemachange contains utilities describing type conversions.
 package schemachange
 
 import (

--- a/pkg/sql/schemachanger/rel/internal/comparetest/schema.go
+++ b/pkg/sql/schemachanger/rel/internal/comparetest/schema.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package comparetest exposes a reltest.Suite.
 package comparetest
 
 import (

--- a/pkg/sql/schemachanger/rel/internal/cyclegraphtest/schema.go
+++ b/pkg/sql/schemachanger/rel/internal/cyclegraphtest/schema.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package cyclegraphtest contains test utilities and a "Suite" for reltest.
 package cyclegraphtest
 
 import (

--- a/pkg/sql/schemachanger/rel/internal/entitynodetest/schema.go
+++ b/pkg/sql/schemachanger/rel/internal/entitynodetest/schema.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package entitynodetest exposes a reltest.Suite.
 package entitynodetest
 
 import (

--- a/pkg/sql/schemachanger/scop/ops.go
+++ b/pkg/sql/schemachanger/scop/ops.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package scop describes ops within a schema change.
 package scop
 
 // Op represents an action to be taken on a single descriptor.

--- a/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package scgraph contains utilities for describing a schema change operation
+// as a graph of screl nodes.
 package scgraph
 
 import (

--- a/pkg/storage/pebbleiter/BUILD.bazel
+++ b/pkg/storage/pebbleiter/BUILD.bazel
@@ -7,7 +7,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 # keep
 go_library(
     name = "pebbleiter",
-    srcs = select({
+    srcs = ["pebbleiter.go"] + select({
         "//build/toolchains:crdb_test": [":gen-crdb-test-on"],
         "//conditions:default": [":gen-crdb-test-off"],
     }),

--- a/pkg/util/buildutil/crdb_test_off.go
+++ b/pkg/util/buildutil/crdb_test_off.go
@@ -11,6 +11,7 @@
 //go:build !crdb_test || crdb_test_off
 // +build !crdb_test crdb_test_off
 
+// Package buildutil provides a constant CrdbTestBuild.
 package buildutil
 
 // CrdbTestBuild is a flag that is set to true if the binary was compiled

--- a/pkg/util/buildutil/crdb_test_on.go
+++ b/pkg/util/buildutil/crdb_test_on.go
@@ -11,6 +11,7 @@
 //go:build crdb_test && !crdb_test_off
 // +build crdb_test,!crdb_test_off
 
+// Package buildutil provides a constant CrdbTestBuild.
 package buildutil
 
 // CrdbTestBuild is a flag that is set to true if the binary was compiled

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package encoding exposes some utilities for encoding data as bytes.
 package encoding
 
 import (

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package schemachange implements the schemachange workload.
 package schemachange
 
 import (


### PR DESCRIPTION
To date we have used a regex like `cockroach/pkg/.*/.*\\.go` to identify
first-party code, which does find our checked-in code, but does *not*
match generated code, which is not staged at that path in the Bazel
sandbox. Instead, these generated files are generally found in
`bazel-out/.../bin`. In places where we've set `only_files`, in addition
to the original regex, we add another regex to capture these generated
files.

Many packages are now (correctly) being flagged as missing package-level
comments. In these cases I have added a very short package-level
comment.

Closes https://github.com/cockroachdb/cockroach/issues/102191.

Epic: none
Release note: None