### PR TITLE
*: customize the timeouts used by unit tests in `Bazel Essential CI`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -51,6 +51,8 @@ test:test --test_env=TZ=
 # If those values are updated, the script should be updated accordingly.
 test:race --test_timeout=1200,6000,18000,72000
 
+# CI uses a custom timeout for enormous targets.
+test:use_ci_timeouts --test_timeout=60,300,900,900 --define=use_ci_timeouts=true
 # CI should always run with `--config=ci` or `--config=cinolint`.
 # Prefer the first to the second unless some other job will handle linting the
 # same code you're building.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -355,10 +355,10 @@ load(
 go_repository(
     name = "com_github_bazelbuild_buildtools",
     importpath = "github.com/bazelbuild/buildtools",
-    sha256 = "a9ef5103739dfb5ed2a5b47ab1654842a89695812e4af09e57d7015a5caf97e0",
-    strip_prefix = "buildtools",
+    sha256 = "d71a889e3bc50cc8b9d42c859e15a74f7c8d10b6786f8dd82f08f2bf24e5bdc6",
+    strip_prefix = "bazelbuild-buildtools-b182fc4",
     urls = [
-        "https://storage.googleapis.com/public-bazel-artifacts/gomod/github.com/bazelbuild/buildtools/v0.0.0-20200718160251-b1667ff58f71/buildtools-v0.0.0-20200718160251-b1667ff58f71.tar.gz",
+        "https://storage.googleapis.com/public-bazel-artifacts/gomod/github.com/bazelbuild/buildtools/v6.1.2-0-gb182fc4/bazelbuild-buildtools-v6.1.2-0-gb182fc4.tar.gz",
     ],
 )
 

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -1171,7 +1171,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/public-bazel-artifacts/go/20230214-214430/go1.19.4.linux-arm64.tar.gz": "6bb5752483c0d145b91199e5cc1352960d926850e75864dea16282337b0d92fe",
     "https://storage.googleapis.com/public-bazel-artifacts/go/20230214-214430/go1.19.4.windows-amd64.tar.gz": "0f37edf2a6663db33c8f67ee36e21a7eb391fbf35d494299f6a81a59e294f4a0",
     "https://storage.googleapis.com/public-bazel-artifacts/go/20230427-165819/go1.19.8fips.linux-amd64.tar.gz": "8170fd871cb61dc771ec1f309451b31a73d5aca3410dfa9d952672ae2be4ac9e",
-    "https://storage.googleapis.com/public-bazel-artifacts/gomod/github.com/bazelbuild/buildtools/v0.0.0-20200718160251-b1667ff58f71/buildtools-v0.0.0-20200718160251-b1667ff58f71.tar.gz": "a9ef5103739dfb5ed2a5b47ab1654842a89695812e4af09e57d7015a5caf97e0",
+    "https://storage.googleapis.com/public-bazel-artifacts/gomod/github.com/bazelbuild/buildtools/v6.1.2-0-gb182fc4/bazelbuild-buildtools-v6.1.2-0-gb182fc4.tar.gz": "d71a889e3bc50cc8b9d42c859e15a74f7c8d10b6786f8dd82f08f2bf24e5bdc6",
     "https://storage.googleapis.com/public-bazel-artifacts/java/railroad/rr-1.63-java8.zip": "d2791cd7a44ea5be862f33f5a9b3d40aaad9858455828ebade7007ad7113fb41",
     "https://storage.googleapis.com/public-bazel-artifacts/js/node/v16.13.0/node-v16.13.0-darwin-arm64.tar.gz": "46d83fc0bd971db5050ef1b15afc44a6665dee40bd6c1cbaec23e1b40fa49e6d",
     "https://storage.googleapis.com/public-bazel-artifacts/js/node/v16.13.0/node-v16.13.0-darwin-x64.tar.gz": "37e09a8cf2352f340d1204c6154058d81362fef4ec488b0197b2ce36b3f0367a",

--- a/build/teamcity/cockroach/ci/tests/unit_tests_ccl_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_ccl_impl.sh
@@ -15,6 +15,6 @@ if tc_release_branch; then
   EXTRA_PARAMS=" --flaky_test_attempts=3" 
 fi
 
-$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=cinolint -c fastbuild \
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=cinolint --config=use_ci_timeouts -c fastbuild \
                                   //pkg:ccl_tests \
                                    --profile=/artifacts/profile.gz $EXTRA_PARAMS

--- a/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
@@ -15,6 +15,6 @@ if tc_release_branch; then
   EXTRA_PARAMS=" --flaky_test_attempts=3" 
 fi
 
-$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=cinolint -c fastbuild \
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=cinolint --config=use_ci_timeouts -c fastbuild \
                                   //pkg:small_non_ccl_tests //pkg:medium_non_ccl_tests //pkg:large_non_ccl_tests //pkg:enormous_non_ccl_tests \
                                    --profile=/artifacts/profile.gz $EXTRA_PARAMS

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -507,3 +507,10 @@ config_setting(
     },
     visibility = ["//c-deps:__pkg__"],
 )
+
+config_setting(
+    name = "use_ci_timeouts",
+    values = {
+        "define": "use_ci_timeouts=true",
+    },
+)

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -245,14 +245,14 @@ configure_make(
     }),
     lib_source = "@krb5//:all",
     out_static_libs = LIBKRB5_LIBS,
-    postfix_script = ("""mkdir -p libkrb5/lib
+    postfix_script = """mkdir -p libkrb5/lib
 cp lib/libcom_err.a libkrb5/lib
 cp lib/libgssapi_krb5.a libkrb5/lib
 cp lib/libkrb5.a libkrb5/lib
 cp lib/libkrb5support.a libkrb5/lib
 cp lib/libk5crypto.a libkrb5/lib
 mkdir -p libkrb5/include/gssapi
-cp include/gssapi/gssapi.h libkrb5/include/gssapi"""),
+cp include/gssapi/gssapi.h libkrb5/include/gssapi""",
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -193,7 +193,10 @@ go_test(
         "tenant_backup_nemesis_test.go",
         "utils_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":backupccl"],
     shard_count = 48,

--- a/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
+++ b/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "bench_test.go",
         "multi_region_bench_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = glob(["testdata/**"]),
     shard_count = 16,
     tags = ["ccl_test"],

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -203,7 +203,10 @@ go_test(
         "testfeed_test.go",
         "validations_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     embed = [":changefeedccl"],
     shard_count = 16,
     tags = ["ccl_test"],

--- a/pkg/ccl/gssapiccl/BUILD.bazel
+++ b/pkg/ccl/gssapiccl/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     name = "gssapiccl",
     srcs = select({
         "@io_bazel_rules_go//go/platform:linux": [
-            "gssapi.go",
             "get_user.go",
+            "gssapi.go",
         ],
         "//conditions:default": ["empty.go"],
     }),
@@ -31,10 +31,10 @@ go_library(
             "//pkg/security/username",
             "//pkg/settings",
             "//pkg/sql",
-            "//pkg/sql/sem/tree",
             "//pkg/sql/pgwire",
             "//pkg/sql/pgwire/hba",
             "//pkg/sql/pgwire/identmap",
+            "//pkg/sql/sem/tree",
             "@com_github_cockroachdb_errors//:errors",
         ],
         "//conditions:default": [],

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "main_test.go",
         "tenant_upgrade_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "3node-tenant-multiregion_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "3node-tenant_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "5node_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "fakedist-disk_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "fakedist-vec-off_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "fakedist_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local-legacy-schema-changer_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local-mixed-22_2-23_1_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local-vec-off_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "multiregion-15node-5region-3azs_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "multiregion-3node-3superlongregions_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "multiregion-9node-3region-3azs-no-los_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "multiregion-9node-3region-3azs-tenant_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "multiregion-9node-3region-3azs-vec-off_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "multiregion-9node-3region-3azs_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -39,7 +39,10 @@ go_test(
         "show_test.go",
         "unique_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = glob(["testdata/**"]),
     embed = [":multiregionccl"],
     shard_count = 16,

--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -12,7 +12,10 @@ go_test(
         ":test_gen_backup_non_ccl",  # keep
         ":test_gen_ccl",  # keep
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = glob(["testdata/**"]) + [
         "//pkg/sql/schemachanger:testdata",
     ],

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -44,7 +44,10 @@ go_test(
         "tenant_migration_test.go",
         "tenant_vars_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = glob(["testdata/**"]),
     embed = [":serverccl"],
     tags = ["ccl_test"],

--- a/pkg/kv/kvnemesis/kvnemesisutil/BUILD.bazel
+++ b/pkg/kv/kvnemesis/kvnemesisutil/BUILD.bazel
@@ -11,8 +11,8 @@ go_library(
         "//build/toolchains:crdb_test": [":gen-crdb-test-on"],
         "//conditions:default": [":gen-crdb-test-off"],
     }) + [
-        "seq.go",
         "context.go",
+        "seq.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil",
     visibility = ["//visibility:public"],

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -334,7 +334,10 @@ go_test(
         "txn_recovery_integration_test.go",
         "txn_wait_queue_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
     shard_count = 48,

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -441,7 +441,10 @@ go_test(
         "user_test.go",
         "version_cluster_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = glob(["testdata/**"]),
     embed = [":server"],
     shard_count = 16,

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -705,7 +705,10 @@ go_test(
         "zone_config_test.go",
         "zone_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = glob(["testdata/**"]) + [
         "//c-deps:libgeos",
         "//pkg/sql:information_schema.go",

--- a/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "5node-disk_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/logictest/tests/5node/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "5node_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "cockroach-go-testserver-upgrade-to-master_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/cmd/cockroach-short",  # keep

--- a/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "fakedist-disk_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "fakedist-vec-off_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/logictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "fakedist_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local-legacy-schema-changer_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local-mixed-22_2-23_1_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local-vec-off_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/logictest/tests/local/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "multiregion-9node-3region-3azs_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/logictest/tests/multiregion-invalid-locality/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-invalid-locality/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "multiregion-invalid-locality_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "5node_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "fakedist-disk_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "fakedist-vec-off_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "fakedist_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep

--- a/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local-legacy-schema-changer_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local-mixed-22_2-23_1_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local-vec-off_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep

--- a/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
@@ -5,7 +5,10 @@ go_test(
     name = "local_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep

--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -22,7 +22,10 @@ go_test(
         "schemachanger_test.go",
         ":test_gen",  # keep
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [":testdata"],
     shard_count = 16,
     deps = [

--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -42,7 +42,10 @@ go_test(
         "meta_test.go",
         "parser_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = glob(["testdata/**"]),
     embed = [":metamorphic"],
     shard_count = 8,

--- a/pkg/testutils/docker/BUILD.bazel
+++ b/pkg/testutils/docker/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]) + [
         "//pkg/testutils/docker:testdata",
-        "//pkg/testutils/docker/docker-fsnotify:docker-fsnotify",
+        "//pkg/testutils/docker/docker-fsnotify",
     ],
     gotags = ["docker"],
     tags = ["integration"],

--- a/pkg/ui/workspaces/cluster-ui/BUILD.bazel
+++ b/pkg/ui/workspaces/cluster-ui/BUILD.bazel
@@ -268,8 +268,8 @@ tsc_test(
     ) + [
         "tsconfig.json",
         "tsconfig.linting.json",
-        "//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client",
         "//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl",
+        "//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client",
         "@npm_cluster_ui//@babel/parser",
         "@npm_cluster_ui//@babel/types",
         "@npm_cluster_ui//@cockroachlabs/icons",

--- a/pkg/ui/workspaces/db-console/BUILD.bazel
+++ b/pkg/ui/workspaces/db-console/BUILD.bazel
@@ -292,9 +292,9 @@ tsc_test(
     ) + [
         "tsconfig.json",
         "tsconfig.linting.json",
-        "//pkg/ui/workspaces/cluster-ui:cluster-ui",
-        "//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client",
+        "//pkg/ui/workspaces/cluster-ui",
         "//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl",
+        "//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client",
         "@npm_db_console//@babel/parser",
         "@npm_db_console//@babel/types",
         "@npm_db_console//@cockroachlabs/design-tokens",


### PR DESCRIPTION
We manage unit tests timeouts at two levels:
1. Bazel timeout, by default [60s,300s,900s,3600s] for [small,medium,large,enormous] targets.
2. Go timeout, set to 5 seconds less than the corresponding Bazel timeout [see #86363].

Previously, unit tests used the same timeouts both when running in `Bazel Essential CI` and elsewhere. As a result, enormous test targets inherited a timeout of 1 hour from Bazel's default timeout. This is way beyond the expected time needed by any test target in `Bazel Essential CI`. We can't change enormous targets to large ones for two reasons:
1. `Enormous` is also used to indicate the resources needed by a test target.
2. `Enormous` test targets may still need the large timeout when running locally.

To make this possible, we needed to support setting an `attr` value to a `select` using Buildozer. This was done in bazelbuild/buildtools#1153.

This change only affects the timeout of `enormous` test targets. It however makes it simple to customize the timeout of other test sizes if desired in the future.

Release note: None
Epic: none