### PR TITLE
sql: fixes flaky TestSQLStatsCompactor

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -132,6 +132,7 @@ func TestTenantStatusAPI(t *testing.T) {
 	})
 
 	t.Run("tenant_span_stats", func(t *testing.T) {
+		skip.UnderDeadlockWithIssue(t, 99770)
 		testTenantSpanStats(ctx, t, testHelper)
 	})
 


### PR DESCRIPTION
The TestSQLStatsCompactor validates the amount of scans done by the
compactor test. The new activity update job will also do a scan on the
stats table which can cause the count to be off. This disables the
update job to avoid any conflict. The test ran for 15k run under stress
with deadlock detection without any failures. 

tenant_span_stats test is being skipped under deadlock, because it
causes a race condition resulting in a flaky.

Epic: none
closes: https://github.com/cockroachdb/cockroach/issues/102022
Informs: https://github.com/cockroachdb/cockroach/issues/99770

Release note: None