### PR TITLE
tenantcostclient: deflake TestWaitingRU

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -813,12 +813,17 @@ func TestWaitingRU(t *testing.T) {
 
 		var doneCount int64
 		for i := 0; i < count; i++ {
+			require.NoError(t, ctrl.OnRequestWait(ctx))
+		}
+		for i := 0; i < count; i++ {
 			go func(i int) {
-				require.NoError(t, ctrl.OnRequestWait(ctx))
 				require.NoError(t, ctrl.OnResponseWait(ctx, req, resp))
 				atomic.AddInt64(&doneCount, 1)
 			}(i)
 		}
+
+		// Allow some responses to queue up before refilling the available RUs.
+		time.Sleep(time.Millisecond)
 
 		// If available RUs drop below -1K, then multiple responses must be waiting.
 		succeeded := false


### PR DESCRIPTION
This commit makes `TestWaitingRU` more deterministic by executing all 20 calls to `OnRequestWait` before starting the 20 goroutines that call `OnResponseWait`. It also adds some sleep time after starting the goroutines to give the responses time to queue.

Fixes #95547

Release note: None