### PR TITLE
sql: clean up some TODOs and simplify copy Close

### DIFF
--- a/pkg/sql/colenc/encode_test.go
+++ b/pkg/sql/colenc/encode_test.go
@@ -87,9 +87,6 @@ func TestEncoderEqualityDatums(t *testing.T) {
 		// enum Datums) is left to the copy data driven tests. Also
 		// check constraints and partial index support.
 
-		// TODO: tsvector
-		// TODO: covering secondary indexes?
-
 		{"a INT ARRAY PRIMARY KEY", []tree.Datum{randgen.RandArray(rng, types.MakeArray(types.Int), 2)}, nil},
 		{"i INT PRIMARY KEY, a INT ARRAY", []tree.Datum{tree.NewDInt(1234), randgen.RandArray(rng, types.MakeArray(types.Int), 2)}, nil},
 		{"i INT PRIMARY KEY, a INT ARRAY UNIQUE", []tree.Datum{tree.NewDInt(1234), randgen.RandArray(rng, types.MakeArray(types.Int), 2)}, nil},

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -494,10 +494,11 @@ type copyTxnOpt struct {
 }
 
 func (c *copyMachine) Close(ctx context.Context) {
-	c.rows.Close(ctx)
-	// TODO(cucaroach): if this isn't close'd the Stop below errors out
-	// saying there's 10240 bytes left, investigate.
-	c.rowsMemAcc.Close(ctx)
+	if c.vectorized {
+		c.rowsMemAcc.Close(ctx)
+	} else {
+		c.rows.Close(ctx)
+	}
 	c.bufMemAcc.Close(ctx)
 	c.copyMon.Stop(ctx)
 }


### PR DESCRIPTION
colenc testing:

- tsvector is tested via TestEncoderEqualityRand, so that's done
- colenc.encodeSecondaryIndex delegates to colenc.encodePK if type
is "primary" with a comment about "covering indexes", I thought there
might be a way to test it but I was wrong so this is untested/dead code.
Primary indexes are only ever encountered in rowenc.EncodeSecondaryIndex
when backfill calls rowenc.EncodeSecondaryIndexes to encode all
indexes in one go, since this doesn't apply to copy there's no way to
test it, but leave the code in looking forward to the day when backfill
uses vectorized encoder. Basically I was just confused about the
covering index commentary and thought a secondary index could use the
primary index encoding in some cases.

copyMachine.Close:

There was some confusion around when rowsMemAcc was closed
via the c.rows RowContainer and when it needed to be closed directly,
make it clearer it only needs to be closed explicity in vectorized case
and we don't need to close c.rows under vectorized at all (in the non
vectorized case c.rows wraps rowsMemAcc).

Epic: None
Release note: None
