### PR TITLE
kv, server: deflake TestHotRangesStats test

### DIFF
--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -108,6 +108,8 @@ func NewReplicaAccumulator(dims ...load.Dimension) *RRAccumulator {
 		dims: map[load.Dimension]*rrPriorityQueue{},
 	}
 	for _, dim := range dims {
+		// Reassign dim variable to ensure correct values is captured down below in val() func.
+		dim := dim
 		res.dims[dim] = &rrPriorityQueue{}
 		res.dims[dim].val = func(r CandidateReplica) float64 {
 			return r.RangeUsageInfo().Load().Dim(dim)
@@ -151,7 +153,6 @@ type RRAccumulator struct {
 func (a *RRAccumulator) AddReplica(repl CandidateReplica) {
 	for dim := range a.dims {
 		a.addReplicaForDimension(repl, dim)
-
 	}
 }
 
@@ -224,77 +225,68 @@ func (pq *rrPriorityQueue) Pop() interface{} {
 type ReplicaRankingMap struct {
 	mu struct {
 		syncutil.Mutex
-		items RRAccumulatorByTenant
+		dimAccumulators *RRAccumulatorByTenant
+		// byDims map keeps last computed values per tenant.
+		byDims map[roachpb.TenantID][]CandidateReplica
 	}
 }
 
 // NewReplicaRankingsMap returns a new ReplicaRankingMap struct.
 func NewReplicaRankingsMap() *ReplicaRankingMap {
-	return &ReplicaRankingMap{}
+	rr := &ReplicaRankingMap{}
+	rr.mu.byDims = map[roachpb.TenantID][]CandidateReplica{}
+	rr.mu.dimAccumulators = NewTenantReplicaAccumulator()
+	return rr
 }
 
 // NewTenantReplicaAccumulator returns a new RRAccumulatorByTenant.
-func NewTenantReplicaAccumulator() *RRAccumulatorByTenant {
-	return &RRAccumulatorByTenant{}
+func NewTenantReplicaAccumulator(dims ...load.Dimension) *RRAccumulatorByTenant {
+	return &RRAccumulatorByTenant{
+		dims:   dims,
+		accums: map[roachpb.TenantID]*RRAccumulator{},
+	}
 }
 
 // Update sets the accumulator for replica tracking to be the passed in value.
 func (rr *ReplicaRankingMap) Update(acc *RRAccumulatorByTenant) {
 	rr.mu.Lock()
-	rr.mu.items = *acc
+	rr.mu.dimAccumulators = acc
 	rr.mu.Unlock()
 }
 
-// TopQPS returns the highest QPS CandidateReplicas that are tracked.
-func (rr *ReplicaRankingMap) TopQPS(tenantID roachpb.TenantID) []CandidateReplica {
+// TopLoad returns the highest load CandidateReplicas that are tracked.
+func (rr *ReplicaRankingMap) TopLoad(
+	tenantID roachpb.TenantID, dimension load.Dimension,
+) []CandidateReplica {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
-	r, ok := rr.mu.items[tenantID]
+	r, ok := rr.mu.dimAccumulators.accums[tenantID]
 	if !ok {
 		return []CandidateReplica{}
 	}
-	if r.Len() > 0 {
-		r.entries = consumeAccumulator(&r)
-		rr.mu.items[tenantID] = r
+	if dim, ok := r.dims[dimension]; ok && dim.Len() > 0 {
+		rr.mu.byDims[tenantID] = consumeAccumulator(dim)
 	}
-	return r.entries
+	return rr.mu.byDims[tenantID]
 }
 
 // RRAccumulatorByTenant accumulates replicas per tenant to update the replicas tracked by ReplicaRankingMap.
 // It should be used in the same way as RRAccumulator (see doc string).
-type RRAccumulatorByTenant map[roachpb.TenantID]rrPriorityQueue
+type RRAccumulatorByTenant struct {
+	accums map[roachpb.TenantID]*RRAccumulator
+	dims   []load.Dimension
+}
 
 // AddReplica adds a replica to the replica accumulator.
-func (a RRAccumulatorByTenant) AddReplica(repl CandidateReplica) {
-	// Do not consider ranges as hot when they are accessed once or less times.
-	if repl.RangeUsageInfo().QueriesPerSecond <= 1 {
-		return
-	}
-
+func (ra RRAccumulatorByTenant) AddReplica(repl CandidateReplica) {
 	tID, ok := repl.Repl().TenantID()
 	if !ok {
 		return
 	}
-
-	r, ok := a[tID]
+	acc, ok := ra.accums[tID]
 	if !ok {
-		q := rrPriorityQueue{
-			val: func(r CandidateReplica) float64 { return r.RangeUsageInfo().QueriesPerSecond },
-		}
-		heap.Push(&q, repl)
-		a[tID] = q
-		return
+		acc = NewReplicaAccumulator(ra.dims...)
 	}
-
-	if r.Len() < numTopReplicasToTrack {
-		heap.Push(&r, repl)
-		a[tID] = r
-		return
-	}
-
-	if repl.RangeUsageInfo().QueriesPerSecond > r.entries[0].RangeUsageInfo().QueriesPerSecond {
-		heap.Pop(&r)
-		heap.Push(&r, repl)
-		a[tID] = r
-	}
+	acc.AddReplica(repl)
+	ra.accums[tID] = acc
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2663,7 +2663,9 @@ func (s *Store) Capacity(ctx context.Context, useCached bool) (roachpb.StoreCapa
 	// and rebalancing. By default rebalancing uses CPU whilst the UI will use
 	// QPS.
 	rankingsAccumulator := NewReplicaAccumulator(load.CPU, load.Queries)
-	rankingsByTenantAccumulator := NewTenantReplicaAccumulator()
+	// rankingsByTenantAccumulator collects top replicas by QPS only as far as it is
+	// used in Db Console only.
+	rankingsByTenantAccumulator := NewTenantReplicaAccumulator(load.Queries)
 
 	// Query the current L0 sublevels and record the updated maximum to metrics.
 	l0SublevelsMax = int64(syncutil.LoadFloat64(&s.metrics.l0SublevelsWindowedMax))
@@ -3236,7 +3238,7 @@ func (s *Store) HottestReplicas() []HotReplicaInfo {
 // tenant ID. It works identically as HottestReplicas func with only exception that
 // hottest replicas are grouped by tenant ID.
 func (s *Store) HottestReplicasByTenant(tenantID roachpb.TenantID) []HotReplicaInfo {
-	topQPS := s.replRankingsByTenant.TopQPS(tenantID)
+	topQPS := s.replRankingsByTenant.TopLoad(tenantID, load.Queries)
 	return mapToHotReplicasInfo(topQPS)
 }
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
+	aload "github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/load"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
@@ -2583,6 +2584,53 @@ func TestStoreBadRequests(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStore_HottestReplicasByTenant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	store, _ := createTestStore(ctx, t, testStoreOpts{createSystemRanges: true}, stopper)
+
+	type testData struct {
+		tenantID uint64
+		qps      float64
+	}
+
+	td := []testData{{1, 2}, {1, 3}, {1, 4}, {1, 5},
+		{2, 1}, {2, 2}, {2, 3}, {2, 4}}
+
+	acc := NewTenantReplicaAccumulator(aload.Queries)
+
+	for i, c := range td {
+		cr := candidateReplica{
+			Replica: &Replica{RangeID: roachpb.RangeID(i)},
+			usage:   allocator.RangeUsageInfo{QueriesPerSecond: c.qps},
+		}
+		cr.mu.tenantID = roachpb.MustMakeTenantID(c.tenantID)
+		acc.AddReplica(cr)
+	}
+
+	store.replRankingsByTenant.Update(acc)
+
+	hotReplicas := store.HottestReplicasByTenant(roachpb.MustMakeTenantID(1))
+	require.NotNil(t, hotReplicas)
+	require.Equal(t, 4, len(hotReplicas))
+
+	// Test requesting hottest replicas asynchronously to detect data race.
+	iterationsNum := 100
+	wg := sync.WaitGroup{}
+	wg.Add(iterationsNum)
+	for i := 0; i < iterationsNum; i++ {
+		go func() {
+			require.NotNil(t, store.HottestReplicasByTenant(roachpb.MustMakeTenantID(1)))
+			require.NotNil(t, store.HottestReplicasByTenant(roachpb.MustMakeTenantID(2)))
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }
 
 // fakeRangeQueue implements the rangeQueue interface and


### PR DESCRIPTION
kv, server: rewrite hot ranges stats collection per tenant
This patch includes following changes
- refactor RRAccumulatorByTenant and ReplicaRankingMap to follow the
same pattern as RRAccumulator and RRAccumulator accumulator respectively;
- collect hottest replicas per tenant and per QPS and CPU rebalance objectives;
- resolve data race issues

Resolves: #101994

Release note: None

Epic: CRDB-25476