### PR TITLE
release-22.2: sql: fixes database list with special characters

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -471,6 +471,7 @@ go_test(
         "//pkg/util/netutil",
         "//pkg/util/netutil/addr",
         "//pkg/util/protoutil",
+        "//pkg/util/randident",
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -61,6 +61,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randident"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -379,6 +381,22 @@ func TestAdminAPIStatementDiagnosticsBundle(t *testing.T) {
 	require.Equal(t, 200, adminResp.StatusCode)
 }
 
+func generateRandomName() string {
+	rand, _ := randutil.NewTestRand()
+	cfg := randident.DefaultNameGeneratorConfig()
+	// REST api can not handle `/`. This is fixed in
+	// the UI by using sql-over-http endpoint instead.
+	cfg.Punctuate = -1
+	cfg.Finalize()
+
+	ng := randident.NewNameGenerator(
+		&cfg,
+		rand,
+		"a b%s-c.d",
+	)
+	return ng.GenerateOne(42)
+}
+
 func TestAdminAPIDatabases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -394,14 +412,15 @@ func TestAdminAPIDatabases(t *testing.T) {
 	ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
 	defer span.Finish()
 
-	const testdb = "test"
-	query := "CREATE DATABASE " + testdb
+	testDbName := generateRandomName()
+	testDbEscaped := tree.NameString(testDbName)
+	query := "CREATE DATABASE " + testDbEscaped
 	if _, err := db.Exec(query); err != nil {
 		t.Fatal(err)
 	}
 	// Test needs to revoke CONNECT on the public database to properly exercise
 	// fine-grained permissions logic.
-	if _, err := db.Exec(fmt.Sprintf("REVOKE CONNECT ON DATABASE %s FROM public", testdb)); err != nil {
+	if _, err := db.Exec(fmt.Sprintf("REVOKE CONNECT ON DATABASE %s FROM public", testDbEscaped)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec("REVOKE CONNECT ON DATABASE defaultdb FROM public"); err != nil {
@@ -420,7 +439,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 	query = fmt.Sprintf(
 		"GRANT %s ON DATABASE %s TO %s",
 		strings.Join(privileges, ", "),
-		testdb,
+		testDbEscaped,
 		authenticatedUserNameNoAdmin().SQLIdentifier(),
 	)
 	if _, err := db.Exec(query); err != nil {
@@ -440,8 +459,8 @@ func TestAdminAPIDatabases(t *testing.T) {
 		expectedDBs []string
 		isAdmin     bool
 	}{
-		{[]string{"defaultdb", "postgres", "system", testdb}, true},
-		{[]string{"postgres", testdb}, false},
+		{[]string{"defaultdb", "postgres", "system", testDbName}, true},
+		{[]string{"postgres", testDbName}, false},
 	} {
 		t.Run(fmt.Sprintf("isAdmin:%t", tc.isAdmin), func(t *testing.T) {
 			// Test databases endpoint.
@@ -459,6 +478,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 				t.Fatalf("length of result %d != expected %d", a, e)
 			}
 
+			sort.Strings(tc.expectedDBs)
 			sort.Strings(resp.Databases)
 			for i, e := range tc.expectedDBs {
 				if a := resp.Databases[i]; a != e {
@@ -468,9 +488,11 @@ func TestAdminAPIDatabases(t *testing.T) {
 
 			// Test database details endpoint.
 			var details serverpb.DatabaseDetailsResponse
+			urlEscapeDbName := url.PathEscape(testDbName)
+
 			if err := getAdminJSONProtoWithAdminOption(
 				s,
-				"databases/"+testdb,
+				"databases/"+urlEscapeDbName,
 				&details,
 				tc.isAdmin,
 			); err != nil {
@@ -511,7 +533,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 			}
 
 			// Verify Descriptor ID.
-			databaseID, err := ts.admin.queryDatabaseID(ctx, username.RootUserName(), testdb)
+			databaseID, err := ts.admin.queryDatabaseID(ctx, username.RootUserName(), testDbName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -374,6 +374,7 @@ func getDatabaseIndexRecommendations(
 		return []*serverpb.IndexRecommendation{}, err
 	}
 
+	escDBName := tree.NameString(dbName)
 	query := fmt.Sprintf(`
 		SELECT
 			ti.descriptor_id as table_id,
@@ -383,7 +384,7 @@ func getDatabaseIndexRecommendations(
 			ti.created_at
 		FROM %[1]s.crdb_internal.index_usage_statistics AS us
 		 JOIN %[1]s.crdb_internal.table_indexes AS ti ON (us.index_id = ti.index_id AND us.table_id = ti.descriptor_id AND index_type = 'secondary')
-		 JOIN %[1]s.crdb_internal.tables AS t ON (ti.descriptor_id = t.table_id AND t.database_name != 'system');`, dbName)
+		 JOIN %[1]s.crdb_internal.tables AS t ON (ti.descriptor_id = t.table_id AND t.database_name != 'system');`, escDBName)
 
 	it, err := ie.QueryIteratorEx(ctx, "db-index-recommendations", nil,
 		sessiondata.InternalExecutorOverride{


### PR DESCRIPTION
Backport 1/1 commits from #95209.

/cc @cockroachdb/release

---

The database name was not properly escaped which causes the
query to fail if the database name has a special character.
The endpoint still does not support names with `/`. This will
not be an issue since all ui is being converted to sql-over-http.

Example uri: `http://localhost:8080/_admin/v1/databases/my%20testdb`

part of: #94328

Release note (sql change): fixes databases list api when database name has special characters.

Release justification: low risk bug fix