### PR TITLE
kv: extend lock acquisition struct to include more information

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -643,19 +643,30 @@ type lockTable interface {
 	// AcquireLock informs the lockTable that a new lock was acquired or an
 	// existing lock was updated.
 	//
-	// The provided TxnMeta must be the same one used when the request scanned
-	// the lockTable initially. It must only be called in the evaluation phase
-	// before calling Dequeue, which means all the latches needed by the request
-	// are held. The key must be in the request's SpanSet with the appropriate
-	// SpanAccess: currently the strength is always Exclusive, so the span
-	// containing this key must be SpanReadWrite. This contract ensures that the
-	// lock is not held in a conflicting manner by a different transaction.
-	// Acquiring a lock that is already held by this transaction upgrades the
-	// lock's timestamp and strength, if necessary.
+	// The TxnMeta associated with the lock acquisition must be the same one used
+	// when the request scanned the lockTable initially. It must only be called in
+	// the evaluation phase, before calling Dequeue, which means all latches
+	// needed by the request are held. The key must be in the request's lock span
+	// set with the appropriate strength. Currently, the only strength with which a
+	// lock can be acquired is Intent[1]. This contract ensures that the lock is
+	// not held in a conflicting manner by a different transaction.
+	// Acquiring a lock that is already held by a transaction upgrades the lock's
+	// timestamp and strength. Any prior sequence numbers at which the lock was
+	// previously held and has since been rolled back are no longer tracked as
+	// well.
+	//
+	// [1] We are in an intermediate state where KV ignores lock strength supplied
+	// by SQL and acquires all locks with Intent locking strength. Notably, this
+	// includes in-memory Exclusive locks acquired for `SELECT FOR UPDATE` queries
+	// as well. While the Intent strength verbiage might be a bit surprising,
+	// there is no meaningful difference when it comes to conflict resolution
+	// between a lock and a request. This is a temporary state, which is bound to
+	// change as we go about supporting additional locking strengths in the lock
+	// table.
 	//
 	// For replicated locks, this must be called after the corresponding write
 	// intent has been applied to the replicated state machine.
-	AcquireLock(*enginepb.TxnMeta, roachpb.Key, lock.Strength, lock.Durability) error
+	AcquireLock(*roachpb.LockAcquisition) error
 
 	// UpdateLocks informs the lockTable that an existing lock or range of locks
 	// was either updated or released.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -514,7 +514,7 @@ func (m *managerImpl) HandleTransactionPushError(
 
 // OnLockAcquired implements the LockManager interface.
 func (m *managerImpl) OnLockAcquired(ctx context.Context, acq *roachpb.LockAcquisition) {
-	if err := m.lt.AcquireLock(&acq.Txn, acq.Key, lock.Exclusive, acq.Durability); err != nil {
+	if err := m.lt.AcquireLock(acq); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
 }

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1959,7 +1959,16 @@ func AsIntents(txn *enginepb.TxnMeta, keys []Key) []Intent {
 // MakeLockAcquisition makes a lock acquisition message from the given
 // txn, key, and durability level.
 func MakeLockAcquisition(txn *Transaction, key Key, dur lock.Durability) LockAcquisition {
-	return LockAcquisition{Span: Span{Key: key}, Txn: txn.TxnMeta, Durability: dur}
+	return LockAcquisition{
+		Span:       Span{Key: key},
+		Txn:        txn.TxnMeta,
+		Durability: dur,
+		// TODO(arul): The lock table only supports/expects locks with Intent lock
+		// strength. This will change once we generalize the lock table for
+		// different strengths.
+		Strength:       lock.Intent,
+		IgnoredSeqNums: txn.IgnoredSeqNums,
+	}
 }
 
 // MakeLockUpdate makes a lock update from the given txn and span.

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -543,11 +543,15 @@ message Intent {
 }
 
 // A LockAcquisition represents the action of a Transaction acquiring a lock
-// with a specified durability level over a Span of keys.
+// with a specified durability level and strength over a Span of keys.
 message LockAcquisition {
   Span span = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   storage.enginepb.TxnMeta txn = 2 [(gogoproto.nullable) = false];
   kv.kvserver.concurrency.lock.Durability durability = 3;
+  kv.kvserver.concurrency.lock.Strength strength = 4;
+  // IgnoredSeqNums is a list of sequence numbers that have been rolled back
+  // by the transaction at the time of the lock acquisition.
+  repeated storage.enginepb.IgnoredSeqNumRange ignored_seqnums = 5 [(gogoproto.nullable) = false, (gogoproto.customname) = "IgnoredSeqNums"];
 }
 
 // A LockUpdate is a Span together with Transaction state. LockUpdate messages


### PR DESCRIPTION
This patch extends the `roachpb.LockAcquisition` struct to include more information -- namely the strength with which the lock is being acquired and there are any ignored sequence numbers for the transaction acquiring the lock.

For now, the strength is statically initialized to `lock.Intent`. We'll generalize this as we go about supporting multiple lock strengths in the lock table.

The `AcquireLock` codepath is then changed to accept a `roachpb.LockAcquisition` struct. This doesn't change any functionality yet, but will enable us to rollback savepoints on lock acquisition and support multiple lock strengths in the lock table in upcoming patches.

Informs ##102269
Informs #102270

Release note: None