### PR TITLE
pkg/util/log: unify explicit flush of network and file sinks

### DIFF
--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -663,7 +663,7 @@ func requireRecoveryEvent(
 	expected eventpb.RecoveryEvent,
 ) {
 	testutils.SucceedsSoon(t, func() error {
-		log.FlushFileSinks()
+		log.Flush()
 		entries, err := log.FetchEntriesFromFiles(
 			startTime,
 			math.MaxInt64,

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1802,7 +1802,7 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 
 	cdcTest(t, testFn)
 
-	log.FlushFileSinks()
+	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1, regexp.MustCompile("cdc ux violation"),
 		log.WithFlattenedSensitiveData)
 	if err != nil {
@@ -2172,7 +2172,7 @@ func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 
 	cdcTestWithSystem(t, testFn, feedTestEnterpriseSinks)
 
-	log.FlushFileSinks()
+	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("cdc ux violation"), log.WithFlattenedSensitiveData)
 	if err != nil {
@@ -2358,7 +2358,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 
 	cdcTestWithSystem(t, testFn)
 
-	log.FlushFileSinks()
+	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("cdc ux violation"), log.WithFlattenedSensitiveData)
 	if err != nil {
@@ -2410,7 +2410,7 @@ func TestChangefeedSchemaChangeBackfillScope(t *testing.T) {
 	}
 
 	cdcTestWithSystem(t, testFn)
-	log.FlushFileSinks()
+	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("cdc ux violation"), log.WithFlattenedSensitiveData)
 	if err != nil {
@@ -2517,7 +2517,7 @@ func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 	}
 
 	cdcTest(t, testFn)
-	log.FlushFileSinks()
+	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("cdc ux violation"), log.WithFlattenedSensitiveData)
 	if err != nil {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1041,7 +1041,7 @@ var cmLogRe = regexp.MustCompile(`event_log\.go`)
 func checkStructuredLogs(t *testing.T, eventType string, startTime int64) []string {
 	var matchingEntries []string
 	testutils.SucceedsSoon(t, func() error {
-		log.FlushFileSinks()
+		log.Flush()
 		entries, err := log.FetchEntriesFromFiles(startTime,
 			math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -47,7 +47,7 @@ func TestChangefeedNemeses(t *testing.T) {
 	// nemeses_test.go:39: pq: unimplemented: operation is
 	// unsupported in multi-tenancy mode
 	cdcTest(t, testFn, feedTestNoTenants)
-	log.FlushFileSinks()
+	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("cdc ux violation"), log.WithFlattenedSensitiveData)
 	if err != nil {

--- a/pkg/ccl/telemetryccl/telemetry_logging_test.go
+++ b/pkg/ccl/telemetryccl/telemetry_logging_test.go
@@ -107,7 +107,7 @@ func TestTelemetryLogRegions(t *testing.T) {
 		sqlDB.Exec(t, tc.query)
 	}
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -322,7 +322,7 @@ func TestBulkJobTelemetryLogging(t *testing.T) {
 		execTimestamp++
 	}
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	var filteredSampleQueries []logpb.Entry
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -528,7 +528,7 @@ func TestClientAddrOverride(t *testing.T) {
 			t.Run("check-server-log-uses-override", func(t *testing.T) {
 				// Wait for the disconnection event in logs.
 				testutils.SucceedsSoon(t, func() error {
-					log.FlushFileSinks()
+					log.Flush()
 					entries, err := log.FetchEntriesFromFiles(testStartTime.UnixNano(), math.MaxInt64, 10000, sessionTerminatedRe,
 						log.WithMarkedSensitiveData)
 					if err != nil {
@@ -541,7 +541,7 @@ func TestClientAddrOverride(t *testing.T) {
 				})
 
 				// Now we want to check that the logging tags are also updated.
-				log.FlushFileSinks()
+				log.Flush()
 				entries, err := log.FetchEntriesFromFiles(testStartTime.UnixNano(), math.MaxInt64, 10000, authLogFileRe,
 					log.WithMarkedSensitiveData)
 				if err != nil {

--- a/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
+++ b/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
@@ -505,7 +505,7 @@ func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 
 	checkGCBlockedByPTS := func(t *testing.T, sj *jobs.StartableJob, tenID uint64) {
 		testutils.SucceedsSoon(t, func() error {
-			log.FlushFileSinks()
+			log.Flush()
 			entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 				regexp.MustCompile(fmt.Sprintf("GC TTL for dropped tenant %d has expired, but protected timestamp record\\(s\\)", tenID)),
 				log.WithFlattenedSensitiveData)

--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -76,7 +76,7 @@ func runConnectInit(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	// Ensure that log files are populated when the process terminates.
-	defer log.FlushFileSinks()
+	defer log.Flush()
 
 	peers := []string(serverCfg.JoinList)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/cli/debug_send_kv_batch_test.go
+++ b/pkg/cli/debug_send_kv_batch_test.go
@@ -123,7 +123,7 @@ func TestSendKVBatch(t *testing.T) {
 		require.JSONEq(t, jsonResponse, output)
 
 		// Check that a structured log event was emitted.
-		log.FlushFileSinks()
+		log.Flush()
 		entries, err := log.FetchEntriesFromFiles(start.UnixNano(), timeutil.Now().UnixNano(), 1,
 			regexp.MustCompile("debug_send_kv_batch"), log.WithFlattenedSensitiveData)
 		require.NoError(t, err)

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -376,7 +376,7 @@ func runDemoInternal(
 	}
 
 	// Ensure the last few entries in the log files are flushed at the end.
-	defer log.FlushFileSinks()
+	defer log.Flush()
 
 	return sqlCtx.Run(ctx, conn)
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -771,7 +771,7 @@ func createAndStartServerAsync(
 
 	go func() {
 		// Ensure that the log files see the startup messages immediately.
-		defer log.FlushFileSinks()
+		defer log.Flush()
 		// If anything goes dramatically wrong, use Go's panic/recover
 		// mechanism to intercept the panic and log the panic details to
 		// the error reporting server.
@@ -1524,7 +1524,7 @@ func reportReadinessExternally(ctx context.Context, cmd *cobra.Command, waitForI
 	// Ensure the configuration logging is written to disk in case a
 	// process is waiting for the sdnotify readiness to read important
 	// information from there.
-	log.FlushFileSinks()
+	log.Flush()
 
 	// Signal readiness. This unblocks the process when running with
 	// --background or under systemd.

--- a/pkg/jobs/jobstest/logutils.go
+++ b/pkg/jobs/jobstest/logutils.go
@@ -36,7 +36,7 @@ func CheckEmittedEvents(
 ) {
 	// Check that the structured event was logged.
 	testutils.SucceedsSoon(t, func() error {
-		log.FlushFileSinks()
+		log.Flush()
 		entries, err := log.FetchEntriesFromFiles(startTime,
 			math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)
 		if err != nil {

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -543,7 +543,7 @@ SELECT unnest(execution_errors)
 		t *testing.T, id jobspb.JobID, status jobs.Status,
 		from, to time.Time, cause string,
 	) {
-		log.FlushFileSinks()
+		log.Flush()
 		entries, err := log.FetchEntriesFromFiles(
 			from.UnixNano(), to.UnixNano(), 2,
 			regexp.MustCompile(fmt.Sprintf(

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -645,7 +645,7 @@ func TestCorruptData(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		log.FlushFileSinks()
+		log.Flush()
 		entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 100, msg,
 			log.WithFlattenedSensitiveData)
 		require.NoError(t, err)
@@ -732,7 +732,7 @@ func TestCorruptData(t *testing.T) {
 		require.Nil(t, got)
 		_, err = pts.GetState(ctx)
 		require.NoError(t, err)
-		log.FlushFileSinks()
+		log.Flush()
 
 		entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 100, msg,
 			log.WithFlattenedSensitiveData)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13530,7 +13530,7 @@ func TestProposalNotAcknowledgedOrReproposedAfterApplication(t *testing.T) {
 	if _, pErr := tc.repl.Send(ctx, ba); pErr != nil {
 		t.Fatal(pErr)
 	}
-	log.FlushFileSinks()
+	log.Flush()
 
 	stopper.Quiesce(ctx)
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -884,7 +884,7 @@ func TestReplicateQueueTracingOnError(t *testing.T) {
 
 	// Flush logs and get log messages from replicate_queue.go since just
 	// before calling store.Enqueue(..).
-	log.FlushFileSinks()
+	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(testStartTs.UnixNano(),
 		math.MaxInt64, 100, regexp.MustCompile(`replicate_queue\.go`), log.WithMarkedSensitiveData)
 	require.NoError(t, err)

--- a/pkg/security/certmgr/cert_manager_test.go
+++ b/pkg/security/certmgr/cert_manager_test.go
@@ -57,7 +57,7 @@ var cmLogRe = regexp.MustCompile(`event_log\.go`)
 
 // Check that the structured event was logged.
 func checkLogStructEntry(t *testing.T, expectSuccess bool, beforeReload time.Time) error {
-	log.FlushFileSinks()
+	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(beforeReload.UnixNano(),
 		math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)
 	if err != nil {

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -201,7 +201,7 @@ func TestRotateCerts(t *testing.T) {
 	// the moment the structured logging event is actually
 	// written to the log file.
 	testutils.SucceedsSoon(t, func() error {
-		log.FlushFileSinks()
+		log.Flush()
 		entries, err := log.FetchEntriesFromFiles(beforeReload.UnixNano(),
 			math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)
 		if err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -592,7 +592,7 @@ func TestPersistHLCUpperBound(t *testing.T) {
 	var fatal bool
 	defer log.ResetExitFunc()
 	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
-		defer log.FlushFileSinks()
+		defer log.Flush()
 		if r == exit.FatalError() {
 			fatal = true
 		}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1238,7 +1238,7 @@ func (s *statusServer) LogFilesList(
 		}
 		return status.LogFilesList(ctx, req)
 	}
-	log.FlushFileSinks()
+	log.Flush()
 	logFiles, err := log.ListLogFiles()
 	if err != nil {
 		return nil, serverError(ctx, err)
@@ -1278,7 +1278,7 @@ func (s *statusServer) LogFile(
 	inputEditMode := log.SelectEditMode(req.Redact, log.KeepRedactable)
 
 	// Ensure that the latest log entries are available in files.
-	log.FlushFileSinks()
+	log.Flush()
 
 	// Read the logs.
 	reader, err := log.GetLogReader(req.File)
@@ -1408,7 +1408,7 @@ func (s *statusServer) Logs(
 	}
 
 	// Ensure that the latest log entries are available in files.
-	log.FlushFileSinks()
+	log.Flush()
 
 	// Read the logs.
 	entries, err := log.FetchEntriesFromFiles(

--- a/pkg/server/status/runtime_stats_test.go
+++ b/pkg/server/status/runtime_stats_test.go
@@ -44,7 +44,7 @@ func TestStructuredEventLogging(t *testing.T) {
 	time.Sleep(10 * time.Second)
 
 	// Ensure that the entry hits the OS so it can be read back below.
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(testStartTs.UnixNano(),
 		math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)

--- a/pkg/server/structlogging/hot_ranges_log_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_test.go
@@ -84,7 +84,7 @@ func TestHotRangesStats(t *testing.T) {
 	})
 
 	testutils.SucceedsWithin(t, func() error {
-		log.FlushFileSinks()
+		log.Flush()
 		entries, err := log.FetchEntriesFromFiles(
 			0,
 			math.MaxInt64,

--- a/pkg/sql/admin_audit_log_test.go
+++ b/pkg/sql/admin_audit_log_test.go
@@ -73,7 +73,7 @@ func TestAdminAuditLogBasic(t *testing.T) {
 	db.Exec(t, `SELECT 1;`)
 
 	var selectAdminRe = regexp.MustCompile(`"EventType":"admin_query","Statement":"SELECT ‹1›","Tag":"SELECT","User":"root"`)
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 10000, selectAdminRe,
 		log.WithMarkedSensitiveData)
@@ -124,7 +124,7 @@ func TestAdminAuditLogRegularUser(t *testing.T) {
 
 	var selectRe = regexp.MustCompile(`SELECT 1`)
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 10000, selectRe,
 		log.WithMarkedSensitiveData)
@@ -180,7 +180,7 @@ COMMIT;
 		},
 	}
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -275,7 +275,7 @@ COMMIT;
 		},
 	}
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -319,7 +319,7 @@ COMMIT;
 		t.Fatal(err)
 	}
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err = log.FetchEntriesFromFiles(
 		0,

--- a/pkg/sql/event_log_test.go
+++ b/pkg/sql/event_log_test.go
@@ -82,7 +82,7 @@ func TestStructuredEventLogging(t *testing.T) {
 	}
 
 	// Ensure that the entries hit the OS so they can be read back below.
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(testStartTs.UnixNano(),
 		math.MaxInt64, 10000, execLogRe, log.WithMarkedSensitiveData)
@@ -736,7 +736,7 @@ func TestPerfLogging(t *testing.T) {
 		}
 
 		var logRe = regexp.MustCompile(tc.logRe)
-		log.FlushFileSinks()
+		log.Flush()
 		entries, err := log.FetchEntriesFromFiles(
 			start, math.MaxInt64, 1000, logRe, log.WithMarkedSensitiveData,
 		)

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -734,7 +734,7 @@ func TestClientAddrOverride(t *testing.T) {
 			t.Run("check-server-log-uses-override", func(t *testing.T) {
 				// Wait for the disconnection event in logs.
 				testutils.SucceedsSoon(t, func() error {
-					log.FlushFileSinks()
+					log.Flush()
 					entries, err := log.FetchEntriesFromFiles(testStartTime.UnixNano(), math.MaxInt64, 10000, sessionTerminatedRe,
 						log.WithMarkedSensitiveData)
 					if err != nil {
@@ -747,7 +747,7 @@ func TestClientAddrOverride(t *testing.T) {
 				})
 
 				// Now we want to check that the logging tags are also updated.
-				log.FlushFileSinks()
+				log.Flush()
 				entries, err := log.FetchEntriesFromFiles(testStartTime.UnixNano(), math.MaxInt64, 10000, authLogFileRe,
 					log.WithMarkedSensitiveData)
 				if err != nil {

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -281,7 +281,7 @@ func checkNumTotalEntriesAndNumIndexEntries(
 	expectedIndividualIndexEntries int,
 	scheduleCompleteChan chan struct{},
 ) error {
-	log.FlushFileSinks()
+	log.Flush()
 	// Fetch log entries.
 	entries, err := log.FetchEntriesFromFiles(
 		0,

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -365,7 +365,7 @@ func TestTelemetryLogging(t *testing.T) {
 		}
 	}
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -672,7 +672,7 @@ func TestNoTelemetryLogOnTroubleshootMode(t *testing.T) {
 		db.Exec(t, tc.query)
 	}
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -876,7 +876,7 @@ func TestTelemetryLogJoinTypesAndAlgorithms(t *testing.T) {
 		db.Exec(t, tc.query)
 	}
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -1131,7 +1131,7 @@ func TestTelemetryScanCounts(t *testing.T) {
 		db.Exec(t, tc.query)
 	}
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -1245,7 +1245,7 @@ $$`
 
 	db.Exec(t, stmt)
 
-	log.FlushFileSinks()
+	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,

--- a/pkg/upgrade/upgrades/schema_changes_external_test.go
+++ b/pkg/upgrade/upgrades/schema_changes_external_test.go
@@ -510,7 +510,7 @@ func testMigrationWithFailures(
 			})
 			if test.waitForMigrationRestart {
 				// Ensure that we have observed the expected number of ignored schema change jobs.
-				log.FlushFileSinks()
+				log.Flush()
 				entries, err := log.FetchEntriesFromFiles(
 					0, math.MaxInt64, 10000,
 					regexp.MustCompile("skipping.*operation as the schema change already exists."),

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -438,7 +438,7 @@ func TestHLCEnforceWallTimeWithinBoundsInNow(t *testing.T) {
 	var fatal bool
 	defer log.ResetExitFunc()
 	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
-		defer log.FlushFileSinks()
+		defer log.Flush()
 		if r == exit.FatalError() {
 			fatal = true
 		}
@@ -487,7 +487,7 @@ func TestHLCEnforceWallTimeWithinBoundsInUpdate(t *testing.T) {
 	var fatal bool
 	defer log.ResetExitFunc()
 	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
-		defer log.FlushFileSinks()
+		defer log.Flush()
 		if r == exit.FatalError() {
 			fatal = true
 		}

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -651,7 +651,7 @@ func TestFileSeverityFilter(t *testing.T) {
 	Infof(context.Background(), "test1")
 	Errorf(context.Background(), "test2")
 
-	FlushFileSinks()
+	Flush()
 
 	debugFileSink := debugFileSinkInfo.sink.(*fileSink)
 	contents, err := os.ReadFile(debugFileSink.getFileName(t))

--- a/pkg/util/log/doc.go
+++ b/pkg/util/log/doc.go
@@ -83,10 +83,10 @@
 //
 // # Output
 //
-// Log output is buffered and written periodically using FlushFileSinks.
-// Programs should call FlushFileSinks before exiting to guarantee all
+// Log output is buffered and written periodically using Flush.
+// Programs should call Flush before exiting to guarantee all
 // log output is written to files. Note that buffered network sinks also
-// exist. If you'd like to flush these as well, call FlushAllSync.
+// exist. If you'd like to flush these as well, call Flush.
 //
 // By default, all log statements write to files in a temporary directory.
 // This package provides several flags that modify this behavior.

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -67,7 +67,7 @@ type fileSink struct {
 	// name generator for log files.
 	nameGenerator fileNameGenerator
 
-	// bufferedWrites if false calls file.FlushFileSinks on every log
+	// bufferedWrites if false calls file.Flush on every log
 	// write. This can be set per-logger e.g. for audit logging.
 	//
 	// Note that synchronization for all log files simultaneously can

--- a/pkg/util/log/file_log_gc_test.go
+++ b/pkg/util/log/file_log_gc_test.go
@@ -158,7 +158,7 @@ func testLogGC(t *testing.T, fileSink *fileSink, logFn func(ctx context.Context,
 	const newLogFiles = 20
 	for i := 1; i < newLogFiles; i++ {
 		logFn(context.Background(), fmt.Sprint(i))
-		FlushFileSinks()
+		Flush()
 	}
 	if _, err := expectFileCount(newLogFiles); err != nil {
 		t.Fatal(err)
@@ -169,7 +169,7 @@ func testLogGC(t *testing.T, fileSink *fileSink, logFn func(ctx context.Context,
 
 	// Emit a log line which will rotate the files and trigger GC.
 	logFn(context.Background(), "final")
-	FlushFileSinks()
+	Flush()
 
 	succeedsSoon(t, func() error {
 		_, err := expectFileCount(expectedFilesAfterGC)

--- a/pkg/util/log/formats_test.go
+++ b/pkg/util/log/formats_test.go
@@ -79,7 +79,7 @@ func TestFormatRedaction(t *testing.T) {
 							defer cleanupFn()
 
 							Infof(ctx, "safe2 %s", "secret3")
-							FlushFileSinks()
+							Flush()
 
 							contents, err := os.ReadFile(getDebugLogFileName(t))
 							require.NoError(t, err)

--- a/pkg/util/log/log_flush.go
+++ b/pkg/util/log/log_flush.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 )
 
@@ -27,42 +28,66 @@ type flushSyncWriter interface {
 	io.Writer
 }
 
-// FlushFileSinks explicitly flushes all pending log file I/O.
-// See also flushDaemon() that manages background (asynchronous)
-// flushes, and signalFlusher() that manages flushes in reaction to a
-// user signal.
-func FlushFileSinks() {
-	_ = logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
-		l.lockAndFlushAndMaybeSync(true /*doSync*/)
-		return nil
-	})
-}
+// flushActive indicates if a current Flush() is executing. If true,
+// additional calls to Flush() will be a noop and return early, until
+// the current Flush() call has completed.
+var flushActive syncutil.AtomicBool
 
-// FlushAllSync explicitly flushes all asynchronous buffered logging sinks,
+// Flush explicitly flushes all asynchronous buffered logging sinks,
 // including pending log file I/O and buffered network sinks.
 //
 // NB: This is a synchronous operation, and will block until all flushes
 // have completed. Generally only recommended for use in crash reporting
 // scenarios.
-func FlushAllSync() {
-	FlushFileSinks()
+//
+// When flushing buffered network logging sinks, each sink is given a
+// 5-second timeout before we move on to attempt flushing the next.
+func Flush() {
+	if flushActive.Swap(true) {
+		return
+	}
+	defer flushActive.Swap(false)
+
+	// Flush all file sinks.
+	_ = logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
+		l.lockAndFlushAndMaybeSync(true /*doSync*/)
+		return nil
+	})
+
+	// Flush all buffered network sinks.
 	_ = logging.allSinkInfos.iterBufferedSinks(func(bs *bufferedSink) error {
-		// Trigger a synchronous flush by calling output on the bufferedSink
-		// with a `forceSync` option.
-		err := bs.output([]byte{}, sinkOutputOptions{forceSync: true})
-		if err != nil {
-			// We don't want to let errors to stop us from iterating and flushing
-			// the remaining buffered log sinks. Nor do we want to log the error
-			// using the logging system, as it's unlikely to make it to the
-			// destination sink anyway (there's a good chance we're flushing
-			// as part of handling a panic). Display the error and continue.
-			fmt.Printf("Error draining buffered log sink: %v\n", err)
+		doneCh := make(chan struct{})
+		// Set a timer, so we don't prevent the process from exiting if the
+		// child sink is unavailable & the request hangs.
+		timer := time.NewTimer(5 * time.Second)
+		go func() {
+			// Trigger a synchronous flush by calling output on the bufferedSink
+			// with a `forceSync` option.
+			err := bs.output([]byte{}, sinkOutputOptions{forceSync: true})
+			if err != nil {
+				// We don't want to let errors to stop us from iterating and flushing
+				// the remaining buffered log sinks. Nor do we want to log the error
+				// using the logging system, as it's unlikely to make it to the
+				// destination sink anyway (there's a good chance we're flushing
+				// as part of handling a panic). Display the error.
+				fmt.Fprintf(OrigStderr, "error draining buffered log sink: %v\n", err)
+			}
+			doneCh <- struct{}{}
+		}()
+
+		select {
+		case <-doneCh:
+		case <-timer.C:
+			fmt.Fprintf(OrigStderr, "timed out draining buffered log sink: %T\n", bs.child)
 		}
+		// In the event of errors or timeouts, we still want to attempt to flush
+		// any remaining buffered sinks. Return nil so the iterator can continue.
 		return nil
 	})
 }
 
 func init() {
+	flushActive.Set(false)
 	go flushDaemon()
 	go signalFlusher()
 }
@@ -86,7 +111,7 @@ const syncWarnDuration = 10 * time.Second
 // flushDaemon periodically flushes and syncs the log file buffers.
 // This manages both the primary and secondary loggers.
 //
-// FlushFileSinks propagates the in-memory buffer inside CockroachDB to the
+// Flush propagates the in-memory buffer inside CockroachDB to the
 // in-memory buffer(s) of the OS. The flush is relatively frequent so
 // that a human operator can see "up to date" logging data in the log
 // file.
@@ -122,7 +147,7 @@ func signalFlusher() {
 	ch := sysutil.RefreshSignaledChan()
 	for sig := range ch {
 		Ops.Infof(context.Background(), "%s received, flushing logs", sig)
-		FlushFileSinks()
+		Flush()
 	}
 }
 
@@ -134,5 +159,5 @@ func signalFlusher() {
 func StartAlwaysFlush() {
 	logging.flushWrites.Set(true)
 	// There may be something in the buffers already; flush it.
-	FlushFileSinks()
+	Flush()
 }

--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -192,7 +192,7 @@ func ReportPanic(ctx context.Context, sv *settings.Values, r interface{}, depth 
 
 	// Ensure that the logs are flushed before letting a panic
 	// terminate the server.
-	log.FlushAllSync()
+	log.Flush()
 }
 
 // PanicAsError turns r into an error if it is not one already.

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -71,7 +71,7 @@ func TestSecondaryLog(t *testing.T) {
 	Infof(context.Background(), "test2")
 
 	// Make sure the content made it to disk.
-	FlushFileSinks()
+	Flush()
 
 	// Check that the messages indeed made it to different files.
 
@@ -151,7 +151,7 @@ func TestListLogFilesIncludeSecondaryLogs(t *testing.T) {
 	// Emit some logging and ensure the files gets created.
 	ctx := context.Background()
 	Sessions.Infof(ctx, "story time")
-	FlushFileSinks()
+	Flush()
 
 	results, err := ListLogFiles()
 	if err != nil {

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -365,7 +365,7 @@ func (l *TestLogScope) Rotate(t tShim) {
 	t.Helper()
 	t.Logf("-- test log scope file rotation --")
 	// Ensure remaining logs are written.
-	FlushFileSinks()
+	Flush()
 
 	if err := logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
 		l.mu.Lock()
@@ -387,7 +387,7 @@ func (l *TestLogScope) Close(t tShim) {
 	t.Logf("-- test log scope end --")
 
 	// Ensure any remaining logs are written to files.
-	FlushFileSinks()
+	Flush()
 
 	if l.logDir != "" {
 		defer func() {


### PR DESCRIPTION
Ref: https://github.com/cockroachdb/cockroach/pull/101562

both for files *and* network sinks, such as fluent-servers.

I received some feedback that we shouldn't divide these flush operations based on sink type, and instead we should unify the flush operation to flush both (as the crash reporter already does).

The existing function to flush just the file sinks is quite widely used. Introducing flushing of network sinks begs the question, "What if this adds to the runtime of code using this explicit flush mechanism?"

Well, the existing FlushFileSinks calls fsync() [1] with F_FULLFSYNC [2]. IIUC, this means that it already is a blocking operation as the fsync() call will wait for the buffered data to be written to permanent storage (not just the disk cache). Given that, I think any caller of this function already assumes it's a blocking operation and therefore should be tolerant of that.

[1]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fsync.2.html
[2]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html#//apple_ref/doc/man/2/fcntl

Nonetheless, we implement a timeout mechanism for the flushing of the buffered network sinks as an added protection.

Fixes: https://github.com/cockroachdb/cockroach/issues/101369