### PR TITLE
concurrency: cleanup lock table datadriven tests

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -578,21 +578,8 @@ func TestLockTableBasic(t *testing.T) {
 				if txnS == "" {
 					txnS = fmt.Sprintf("unknown txn with ID: %v", state.txn.ID)
 				}
-				// TODO(arul): We're translating the lock strength back to guardAccess
-				// for now to reduce test churn. A followup patch should teach these
-				// datadriven tests to use lock.Strength correctly -- both in its input
-				// and output.
-				var sa spanset.SpanAccess
-				switch state.guardStrength {
-				case lock.None:
-					sa = spanset.SpanReadOnly
-				case lock.Intent:
-					sa = spanset.SpanReadWrite
-				default:
-					t.Fatalf("unexpected guard strength %s", state.guardStrength)
-				}
-				return fmt.Sprintf("%sstate=%s txn=%s key=%s held=%t guard-access=%s",
-					str, typeStr, txnS, state.key, state.held, sa)
+				return fmt.Sprintf("%sstate=%s txn=%s key=%s held=%t guard-strength=%s",
+					str, typeStr, txnS, state.key, state.held, state.guardStrength)
 
 			case "resolve-before-scanning":
 				var reqName string

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -64,7 +64,7 @@ new-txn txn=<name> ts=<int>[,<int>] epoch=<int> [seq=<int>]
 
  Creates a TxnMeta.
 
-new-request r=<name> txn=<name>|none ts=<int>[,<int>] spans=r|w@<start>[,<end>]+... [skip-locked] [max-lock-wait-queue-length=<int>]
+new-request r=<name> txn=<name>|none ts=<int>[,<int>] spans=none|shared|update|exclusive|intent@<start>[,<end>]+... [skip-locked] [max-lock-wait-queue-length=<int>]
 ----
 
  Creates a Request.
@@ -112,7 +112,7 @@ add-discovered r=<name> k=<key> txn=<name> [lease-seq=<seq>] [consult-finalized-
 
  Adds a discovered lock that is discovered by the named request.
 
-check-opt-no-conflicts r=<name> spans=r|w@<start>[,<end>]+...
+check-opt-no-conflicts r=<name> spans=none|shared|update|exclusive|intent@<start>[,<end>]+...
 ----
 no-conflicts: <bool>
 
@@ -697,28 +697,27 @@ func scanSpans(
 	lockSpans := &lockspanset.LockSpanSet{}
 	var spansStr string
 	d.ScanArgs(t, "spans", &spansStr)
-	parts := strings.Split(spansStr, "+")
-	for _, p := range parts {
-		if len(p) < 2 || p[1] != '@' {
-			d.Fatalf(t, "incorrect span with access format: %s", p)
+	lockSpanStrs := strings.Split(spansStr, "+")
+	for _, lockSpanStr := range lockSpanStrs {
+		parts := strings.Split(lockSpanStr, "@")
+		if len(parts) != 2 {
+			d.Fatalf(t, "incorrect span with strength format: %s", parts)
 		}
-		c := p[0]
-		p = p[2:]
+		strS := parts[0]
+		spanStr := parts[1]
+		str := getStrength(t, d, strS)
+		// Compute latch span access based on the supplied strength.
 		var sa spanset.SpanAccess
-		var str lock.Strength
-		// TODO(arul): Switch the datadriven input to use lock strengths instead.
-		switch c {
-		case 'r':
+		switch str {
+		case lock.None:
 			sa = spanset.SpanReadOnly
-			str = lock.None
-		case 'w':
+		case lock.Intent:
 			sa = spanset.SpanReadWrite
-			str = lock.Intent
 		default:
-			d.Fatalf(t, "incorrect span access: %c", c)
+			d.Fatalf(t, "unsupported lock strength: %s", str)
 		}
-		latchSpans.AddMVCC(sa, getSpan(t, d, p), ts)
-		lockSpans.Add(str, getSpan(t, d, p))
+		latchSpans.AddMVCC(sa, getSpan(t, d, spanStr), ts)
+		lockSpans.Add(str, getSpan(t, d, spanStr))
 	}
 	return latchSpans, lockSpans
 }
@@ -726,6 +725,10 @@ func scanSpans(
 func ScanLockStrength(t *testing.T, d *datadriven.TestData) lock.Strength {
 	var strS string
 	d.ScanArgs(t, "strength", &strS)
+	return getStrength(t, d, strS)
+}
+
+func getStrength(t *testing.T, d *datadriven.TestData, strS string) lock.Strength {
 	switch strS {
 	case "none":
 		return lock.None
@@ -735,6 +738,8 @@ func ScanLockStrength(t *testing.T, d *datadriven.TestData) lock.Strength {
 		return lock.Update
 	case "exclusive":
 		return lock.Exclusive
+	case "intent":
+		return lock.Intent
 	default:
 		d.Fatalf(t, "unknown lock strength: %s", strS)
 		return 0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
@@ -14,7 +14,7 @@ new-lock-table maxlocks=10000
 new-txn txn=txn1 ts=10,1 epoch=0 seq=1
 ----
 
-new-request r=req1 txn=txn1 ts=10,1 spans=w@a
+new-request r=req1 txn=txn1 ts=10,1 spans=intent@a
 ----
 
 scan r=req1
@@ -36,7 +36,7 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=2
 ----
 
-new-request r=req2 txn=txn1 ts=10,1 spans=w@a
+new-request r=req2 txn=txn1 ts=10,1 spans=intent@a
 ----
 
 scan r=req2
@@ -58,7 +58,7 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=4
 ----
 
-new-request r=req3 txn=txn1 ts=10,1 spans=w@a
+new-request r=req3 txn=txn1 ts=10,1 spans=intent@a
 ----
 
 scan r=req3
@@ -84,7 +84,7 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=4
 ----
 
-new-request r=req3 txn=txn1 ts=10,1 spans=w@a
+new-request r=req3 txn=txn1 ts=10,1 spans=intent@a
 ----
 
 scan r=req3
@@ -110,7 +110,7 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=2
 ----
 
-new-request r=req4 txn=txn1 ts=10,1 spans=w@a
+new-request r=req4 txn=txn1 ts=10,1 spans=intent@a
 ----
 
 scan r=req4
@@ -138,7 +138,7 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=3
 ----
 
-new-request r=req5 txn=txn1 ts=10,1 spans=w@a
+new-request r=req5 txn=txn1 ts=10,1 spans=intent@a
 ----
 
 scan r=req5
@@ -164,7 +164,7 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=5
 ----
 
-new-request r=req6 txn=txn1 ts=10,1 spans=w@a
+new-request r=req6 txn=txn1 ts=10,1 spans=intent@a
 ----
 
 scan r=req6

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
@@ -31,7 +31,7 @@ new-txn txn=txn2 ts=10 epoch=0
 new-txn txn=txn3 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10,1 spans=w@a
+new-request r=req1 txn=txn1 ts=10,1 spans=intent@a
 ----
 
 scan r=req1
@@ -50,10 +50,10 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req2 txn=txn2 ts=10,1 spans=w@a
+new-request r=req2 txn=txn2 ts=10,1 spans=intent@a
 ----
 
-new-request r=req3 txn=txn3 ts=10,1 spans=w@a
+new-request r=req3 txn=txn3 ts=10,1 spans=intent@a
 ----
 
 scan r=req2

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
@@ -79,7 +79,7 @@ new: state=doneWaiting
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=false guard-access=write
+new: state=waitForDistinguished txn=txn2 key="a" held=false guard-strength=Intent
 
 # --------------------------------
 # Setup complete, test starts here
@@ -99,7 +99,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn3 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn3 key="a" held=true guard-strength=Intent
 
 guard-state r=req3
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered_old_lease
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered_old_lease
@@ -7,7 +7,7 @@ new-txn txn=txn1 ts=10 epoch=0
 new-txn txn=txn2 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=w@a+r@b+w@c
+new-request r=req1 txn=txn1 ts=10 spans=intent@a+none@b+intent@c
 ----
 
 clear disable

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -6,7 +6,7 @@ new-txn txn=txn1 ts=10,1 epoch=0
 
 # req1 will acquire locks for txn1
 
-new-request r=req1 txn=txn1 ts=10,1 spans=r@a,b+w@c,f
+new-request r=req1 txn=txn1 ts=10,1 spans=none@a,b+intent@c,f
 ----
 
 scan r=req1
@@ -51,7 +51,7 @@ time-tick ms=200
 
 # req2 is also for txn1 and will not wait for locks that are held by self.
 
-new-request r=req2 txn=txn1 ts=10,2 spans=w@b,d+r@d,g
+new-request r=req2 txn=txn1 ts=10,2 spans=intent@b,d+none@d,g
 ----
 
 scan r=req2
@@ -89,7 +89,7 @@ new-txn txn=txn2 ts=8,12 epoch=0
 ----
 
 # A read request for txn2 does not need to wait for locks held by txn1.
-new-request r=req3 txn=txn2 ts=8,12 spans=r@a,g
+new-request r=req3 txn=txn2 ts=8,12 spans=none@a,g
 ----
 
 scan r=req3
@@ -114,7 +114,7 @@ time-tick ms=200
 # req4 from txn2 will conflict with locks on b, c since wants to write to [a, d). But does
 # not conflict with lock on e since wants to read there and the read is at a lower timestamp
 # than the lock.
-new-request r=req4 txn=txn2 ts=8,12 spans=w@a,d+r@d,g
+new-request r=req4 txn=txn2 ts=8,12 spans=intent@a,d+none@d,g
 ----
 
 scan r=req4
@@ -368,7 +368,7 @@ time-tick ms=300
 # req5 is again from transaction 1. Since it is reading from b, c, and even though txn1
 # conflicts with the reservation holder since txn1.ts > txn2.ts, reads don't wait for
 # reservations.
-new-request r=req5 txn=txn1 ts=11,1 spans=r@b+r@c
+new-request r=req5 txn=txn1 ts=11,1 spans=none@b+none@c
 ----
 
 scan r=req5
@@ -399,7 +399,7 @@ time-tick ms=100
 
 # req6 from txn1 conflicts with lock at f, and reservations at b, c.
 
-new-request r=req6 txn=txn1 ts=11,1 spans=r@f+w@b,d
+new-request r=req6 txn=txn1 ts=11,1 spans=none@f+intent@b,d
 ----
 
 scan r=req6
@@ -546,7 +546,7 @@ time-tick ms=250
 
 # req7 from txn3 only wants to write to c
 
-new-request r=req7 txn=txn3 ts=6 spans=w@c
+new-request r=req7 txn=txn3 ts=6 spans=intent@c
 ----
 
 scan r=req7
@@ -1413,7 +1413,7 @@ time-tick s=15
 ----
 
 
-new-request r=req8 txn=txn3 ts=6 spans=w@e
+new-request r=req8 txn=txn3 ts=6 spans=intent@e
 ----
 
 scan r=req8
@@ -1533,7 +1533,7 @@ topklocksbywaitduration:
 # All requests have been retired and the lock table is empty.
 # The following tests multiple requests from the same transaction.
 
-new-request r=req9 txn=txn1 ts=10,1 spans=w@c
+new-request r=req9 txn=txn1 ts=10,1 spans=intent@c
 ----
 
 scan r=req9
@@ -1646,7 +1646,7 @@ topklocksbywaitduration:
   waitdurationnanos: 0
   maxwaitdurationnanos: 0
 
-new-request r=req10 txn=txn2 ts=8,12 spans=w@c
+new-request r=req10 txn=txn2 ts=8,12 spans=intent@c
 ----
 
 scan r=req10
@@ -1657,7 +1657,7 @@ guard-state r=req10
 ----
 new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Intent
 
-new-request r=req11 txn=txn3 ts=6 spans=w@c
+new-request r=req11 txn=txn3 ts=6 spans=intent@c
 ----
 
 scan r=req11
@@ -1668,7 +1668,7 @@ guard-state r=req11
 ----
 new: state=waitFor txn=txn1 key="c" held=true guard-strength=Intent
 
-new-request r=req12 txn=txn2 ts=8,12 spans=w@c
+new-request r=req12 txn=txn2 ts=8,12 spans=intent@c
 ----
 
 scan r=req12
@@ -2163,7 +2163,7 @@ num=0
 # Tests with non-transactional requests that triggered nil pointer
 # dereference bugs.
 
-new-request r=req13 txn=txn2 ts=8,12 spans=w@c
+new-request r=req13 txn=txn2 ts=8,12 spans=intent@c
 ----
 
 scan r=req13
@@ -2176,14 +2176,14 @@ num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req14 txn=txn1 ts=9,0 spans=w@c
+new-request r=req14 txn=txn1 ts=9,0 spans=intent@c
 ----
 
 scan r=req14
 ----
 start-waiting: true
 
-new-request r=req15 txn=none ts=10,12 spans=r@c
+new-request r=req15 txn=none ts=10,12 spans=none@c
 ----
 
 scan r=req15
@@ -2202,7 +2202,7 @@ num=1
  lock: "c"
   res: req: 14, txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, seq: 0
 
-new-request r=req16 txn=none ts=10,12 spans=r@c
+new-request r=req16 txn=none ts=10,12 spans=none@c
 ----
 
 scan r=req16
@@ -2312,7 +2312,7 @@ topklocksbywaitduration:
 # transaction that eventually grabs a reservation. Triggered a bug
 # in not replacing the distinguished waiter.
 
-new-request r=req17 txn=txn1 ts=9,0 spans=w@c+w@d
+new-request r=req17 txn=txn1 ts=9,0 spans=intent@c+intent@d
 ----
 
 scan r=req17
@@ -2341,14 +2341,14 @@ num=2
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, info: unrepl epoch: 1, seqs: [0]
 
-new-request r=req18 txn=txn2 ts=10,0 spans=w@c+w@d
+new-request r=req18 txn=txn2 ts=10,0 spans=intent@c+intent@d
 ----
 
 scan r=req18
 ----
 start-waiting: true
 
-new-request r=req19 txn=txn2 ts=10,0 spans=w@d
+new-request r=req19 txn=txn2 ts=10,0 spans=intent@d
 ----
 
 scan r=req19
@@ -2628,7 +2628,7 @@ num=0
 # Reservation can be broken while holding latches because a different
 # lock is released
 
-new-request r=req20 txn=txn1 ts=10 spans=w@c
+new-request r=req20 txn=txn1 ts=10 spans=intent@c
 ----
 
 scan r=req20
@@ -2647,7 +2647,7 @@ num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
 
-new-request r=req21 txn=txn1 ts=10 spans=w@d
+new-request r=req21 txn=txn1 ts=10 spans=intent@d
 ----
 
 scan r=req21
@@ -2670,7 +2670,7 @@ num=2
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
 
-new-request r=req22 txn=txn2 ts=10 spans=w@c+w@d
+new-request r=req22 txn=txn2 ts=10 spans=intent@c+intent@d
 ----
 
 scan r=req22
@@ -2779,7 +2779,7 @@ topklocksbywaitduration:
   waitdurationnanos: 0
   maxwaitdurationnanos: 0
 
-new-request r=req23 txn=txn3 ts=10 spans=w@d
+new-request r=req23 txn=txn3 ts=10 spans=intent@d
 ----
 
 scan r=req23

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -123,7 +123,7 @@ start-waiting: true
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
 
 # 3s passes while req4 is waiting on locks on b,c
 time-tick s=3
@@ -145,7 +145,7 @@ num=3
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Intent
 
 # 1s passes while req4 continues to wait on c (and only has reservation on b)
 time-tick s=1
@@ -241,7 +241,7 @@ time-tick s=2
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn3 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn3 key="a" held=true guard-strength=Intent
 
 print
 ----
@@ -537,7 +537,7 @@ topklocksbywaitduration:
 
 guard-state r=req6
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=false guard-access=write
+new: state=waitForDistinguished txn=txn2 key="b" held=false guard-strength=Intent
 
 # 250ms passes between req6 and req7
 time-tick ms=250
@@ -571,7 +571,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=false guard-access=write
+new: state=waitForDistinguished txn=txn2 key="c" held=false guard-strength=Intent
 
 print
 ----
@@ -737,11 +737,11 @@ num=5
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn3 key="f" held=true guard-access=read
+new: state=waitForDistinguished txn=txn3 key="f" held=true guard-strength=None
 
 guard-state r=req6
 ----
-old: state=waitForDistinguished txn=txn2 key="b" held=false guard-access=write
+old: state=waitForDistinguished txn=txn2 key="b" held=false guard-strength=Intent
 
 print
 ----
@@ -948,11 +948,11 @@ num=4
 
 guard-state r=req6
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=true guard-access=write
+new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=Intent
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=true guard-access=write
+new: state=waitForDistinguished txn=txn2 key="c" held=true guard-strength=Intent
 
 print
 ----
@@ -1121,7 +1121,7 @@ new: state=doneWaiting
 
 guard-state r=req6
 ----
-old: state=waitForDistinguished txn=txn2 key="b" held=true guard-access=write
+old: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=Intent
 
 print
 ----
@@ -1377,7 +1377,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=false guard-access=write
+new: state=waitForDistinguished txn=txn1 key="c" held=false guard-strength=Intent
 
 scan r=req6
 ----
@@ -1422,7 +1422,7 @@ start-waiting: true
 
 guard-state r=req8
 ----
-new: state=waitForDistinguished txn=txn1 key="e" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="e" held=true guard-strength=Intent
 
 dequeue r=req8
 ----
@@ -1655,7 +1655,7 @@ start-waiting: true
 
 guard-state r=req10
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Intent
 
 new-request r=req11 txn=txn3 ts=6 spans=w@c
 ----
@@ -1666,7 +1666,7 @@ start-waiting: true
 
 guard-state r=req11
 ----
-new: state=waitFor txn=txn1 key="c" held=true guard-access=write
+new: state=waitFor txn=txn1 key="c" held=true guard-strength=Intent
 
 new-request r=req12 txn=txn2 ts=8,12 spans=w@c
 ----
@@ -1677,7 +1677,7 @@ start-waiting: true
 
 guard-state r=req12
 ----
-new: state=waitFor txn=txn1 key="c" held=true guard-access=write
+new: state=waitFor txn=txn1 key="c" held=true guard-strength=Intent
 
 print
 ----
@@ -1796,7 +1796,7 @@ new: state=doneWaiting
 
 guard-state r=req11
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=false guard-access=write
+new: state=waitForDistinguished txn=txn2 key="c" held=false guard-strength=Intent
 
 guard-state r=req12
 ----
@@ -1916,7 +1916,7 @@ num=1
 
 guard-state r=req11
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=true guard-access=write
+new: state=waitForDistinguished txn=txn2 key="c" held=true guard-strength=Intent
 
 # Since req10 that is also txn2 has acquired the lock, req12 does not need to wait here anymore.
 guard-state r=req12
@@ -2051,7 +2051,7 @@ num=1
 
 guard-state r=req11
 ----
-old: state=waitForDistinguished txn=txn2 key="c" held=true guard-access=write
+old: state=waitForDistinguished txn=txn2 key="c" held=true guard-strength=Intent
 
 release txn=txn2 span=b,d
 ----
@@ -2475,7 +2475,7 @@ num=2
 
 guard-state r=req18
 ----
-new: state=waitFor txn=txn1 key="d" held=true guard-access=write
+new: state=waitFor txn=txn1 key="d" held=true guard-strength=Intent
 
 print
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
@@ -81,7 +81,7 @@ start-waiting: true
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=read
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
 # Similarly, a non-transactional write at a arrives and blocks.
 
@@ -94,7 +94,7 @@ start-waiting: true
 
 guard-state r=req4
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 # txn3 tries to write to b which also has a lock held, so txn3 has to wait.
 
@@ -107,7 +107,7 @@ start-waiting: true
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
 
 print
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
@@ -14,7 +14,7 @@ new-txn txn=txn3 ts=12,1 epoch=0
 
 # txn1 acquires unreplicated exclusive locks at a and b.
 
-new-request r=req1 txn=txn1 ts=10,1 spans=w@a+w@b
+new-request r=req1 txn=txn1 ts=10,1 spans=intent@a+intent@b
 ----
 
 scan r=req1
@@ -49,7 +49,7 @@ num=2
 
 # In its next request, txn1 discovers a lock at c held by txn2.
 
-new-request r=req2 txn=txn1 ts=10,1 spans=r@c
+new-request r=req2 txn=txn1 ts=10,1 spans=none@c
 ----
 
 scan r=req2
@@ -72,7 +72,7 @@ num=3
 
 # A non-transactional read comes in at a and blocks on the lock.
 
-new-request r=req3 txn=none ts=10,1 spans=r@a
+new-request r=req3 txn=none ts=10,1 spans=none@a
 ----
 
 scan r=req3
@@ -85,7 +85,7 @@ new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
 # Similarly, a non-transactional write at a arrives and blocks.
 
-new-request r=req4 txn=none ts=10,1 spans=w@a
+new-request r=req4 txn=none ts=10,1 spans=intent@a
 ----
 
 scan r=req4
@@ -98,7 +98,7 @@ new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 # txn3 tries to write to b which also has a lock held, so txn3 has to wait.
 
-new-request r=req5 txn=txn3 ts=12,1 spans=w@b
+new-request r=req5 txn=txn3 ts=12,1 spans=intent@b
 ----
 
 scan r=req5

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -21,10 +21,10 @@ new-txn txn=txn4 ts=11,1 epoch=0
 # req1 to finish scanning. It needs to resolve the locks held by txn2, txn3.
 # -----------------------------------------------------------------------------
 
-new-request r=req1 txn=txn1 ts=10,1 spans=w@a+w@b+w@c+w@d+w@e
+new-request r=req1 txn=txn1 ts=10,1 spans=intent@a+intent@b+intent@c+intent@d+intent@e
 ----
 
-new-request r=req2 txn=txn4 ts=11,1 spans=w@c
+new-request r=req2 txn=txn4 ts=11,1 spans=intent@c
 ----
 
 scan r=req1
@@ -263,10 +263,10 @@ num=0
 # the list of locks to resolve.
 # -----------------------------------------------------------------------------
 
-new-request r=req3 txn=txn1 ts=10,1 spans=w@a+w@b+w@c
+new-request r=req3 txn=txn1 ts=10,1 spans=intent@a+intent@b+intent@c
 ----
 
-new-request r=req4 txn=txn2 ts=11,1 spans=w@b
+new-request r=req4 txn=txn2 ts=11,1 spans=intent@b
 ----
 
 scan r=req3
@@ -361,10 +361,10 @@ num=0
 # req5 notices the finalization (via pushing) and scans again and resolves.
 # -----------------------------------------------------------------------------
 
-new-request r=req5 txn=txn1 ts=12,1 spans=w@a+w@b
+new-request r=req5 txn=txn1 ts=12,1 spans=intent@a+intent@b
 ----
 
-new-request r=req6 txn=txn3 ts=12,1 spans=w@a
+new-request r=req6 txn=txn3 ts=12,1 spans=intent@a
 ----
 
 scan r=req5
@@ -491,10 +491,10 @@ num=0
 # reader.
 # -----------------------------------------------------------------------------
 
-new-request r=req7 txn=txn1 ts=12,1 spans=w@a+w@b
+new-request r=req7 txn=txn1 ts=12,1 spans=intent@a+intent@b
 ----
 
-new-request r=req8 txn=txn3 ts=12,1 spans=r@a+r@b
+new-request r=req8 txn=txn3 ts=12,1 spans=none@a+none@b
 ----
 
 scan r=req7
@@ -586,10 +586,10 @@ num=0
 # and resolves txn3 locks before req9.
 # -----------------------------------------------------------------------------
 
-new-request r=req9 txn=txn1 ts=12,1 spans=r@a+r@b+r@c+r@d
+new-request r=req9 txn=txn1 ts=12,1 spans=none@a+none@b+none@c+none@d
 ----
 
-new-request r=req10 txn=txn2 ts=12,1 spans=r@a+r@b
+new-request r=req10 txn=txn2 ts=12,1 spans=none@a+none@b
 ----
 
 scan r=req9
@@ -695,7 +695,7 @@ num=0
 # waiters.
 # -----------------------------------------------------------------------------
 
-new-request r=req11 txn=none ts=12,1 spans=w@a
+new-request r=req11 txn=none ts=12,1 spans=intent@a
 ----
 
 scan r=req11
@@ -740,7 +740,7 @@ num=0
 # when scanning.
 # -----------------------------------------------------------------------------
 
-new-request r=req12 txn=none ts=12,1 spans=r@a
+new-request r=req12 txn=none ts=12,1 spans=none@a
 ----
 
 scan r=req12

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -171,7 +171,7 @@ start-waiting: true
 
 guard-state r=req1
 ----
-new: state=waitForDistinguished txn=txn4 key="c" held=true guard-access=write
+new: state=waitForDistinguished txn=txn4 key="c" held=true guard-strength=Intent
 
 print
 ----
@@ -417,11 +417,11 @@ start-waiting: true
 
 guard-state r=req6
 ----
-new: state=waitFor txn=txn2 key="a" held=true guard-access=write
+new: state=waitFor txn=txn2 key="a" held=true guard-strength=Intent
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Intent
 
 print
 ----
@@ -452,7 +452,7 @@ num=2
 
 guard-state r=req6
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=false guard-access=write
+new: state=waitForDistinguished txn=txn1 key="a" held=false guard-strength=Intent
 
 guard-state r=req5
 ----
@@ -527,7 +527,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Intent
 
 print
 ----
@@ -641,7 +641,7 @@ start-waiting: true
 
 guard-state r=req9
 ----
-new: state=waitForDistinguished txn=txn4 key="c" held=true guard-access=read
+new: state=waitForDistinguished txn=txn4 key="c" held=true guard-strength=None
 
 print
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
@@ -19,7 +19,7 @@ clear disable
 ----
 num=0
 
-new-request r=req1 txn=txn1 ts=10,1 spans=w@a+w@c
+new-request r=req1 txn=txn1 ts=10,1 spans=intent@a+intent@c
 ----
 
 scan r=req1
@@ -58,7 +58,7 @@ num=0
 enable
 ----
 
-new-request r=req2 txn=txn1 ts=10,1 spans=w@a+w@c
+new-request r=req2 txn=txn1 ts=10,1 spans=intent@a+intent@c
 ----
 
 scan r=req2

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
@@ -83,7 +83,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Intent
 
 release txn=txn2 span=a
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -99,7 +99,7 @@ start-waiting: true
 
 guard-state r=req1
 ----
-new: state=waitForDistinguished txn=txn4 key="d" held=true guard-access=write
+new: state=waitForDistinguished txn=txn4 key="d" held=true guard-strength=Intent
 
 dequeue r=req1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -14,7 +14,7 @@ new-txn txn=txn3 ts=10 epoch=0
 new-txn txn=txn4 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=w@a,e
+new-request r=req1 txn=txn1 ts=10 spans=intent@a,e
 ----
 
 scan r=req1

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
@@ -45,7 +45,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
 
 print
 ----
@@ -125,7 +125,7 @@ start-waiting: true
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
 
 new-request r=req5 txn=txn3 ts=10 spans=w@b+w@c+r@b
 ----
@@ -136,7 +136,7 @@ start-waiting: true
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
 
 print
 ----
@@ -171,7 +171,7 @@ num=3
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Intent
 
 print
 ----
@@ -331,7 +331,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
 
 new-request r=req8 txn=none ts=10 spans=w@b+w@c+r@b
 ----
@@ -342,7 +342,7 @@ start-waiting: true
 
 guard-state r=req8
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
 
 # req9 is just to prevent the lock for "b" from being gc'd and then a new one
 # created when req7 acquires "b", which due to the old snapshot held by req8
@@ -356,7 +356,7 @@ start-waiting: true
 
 guard-state r=req9
 ----
-new: state=waitFor txn=txn1 key="b" held=true guard-access=write
+new: state=waitFor txn=txn1 key="b" held=true guard-strength=Intent
 
 print
 ----
@@ -392,7 +392,7 @@ num=3
 
 guard-state r=req8
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Intent
 
 print
 ----
@@ -472,7 +472,7 @@ num=2
 
 guard-state r=req8
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=true guard-access=read
+new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=None
 
 print
 ----
@@ -548,7 +548,7 @@ start-waiting: true
 
 guard-state r=req11
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
 
 new-request r=req12 txn=txn3 ts=10 spans=w@b+r@b
 ----
@@ -559,7 +559,7 @@ start-waiting: true
 
 guard-state r=req12
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
 
 print
 ----
@@ -639,7 +639,7 @@ start-waiting: true
 
 guard-state r=req12
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=true guard-access=write
+new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=Intent
 
 dequeue r=req11
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
@@ -17,7 +17,7 @@ new-txn txn=txn2 ts=10 epoch=0
 new-txn txn=txn3 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=w@a+w@b+w@c
+new-request r=req1 txn=txn1 ts=10 spans=intent@a+intent@b+intent@c
 ----
 
 scan r=req1
@@ -36,7 +36,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req2 txn=txn2 ts=10 spans=w@a+r@a
+new-request r=req2 txn=txn2 ts=10 spans=intent@a+none@a
 ----
 
 scan r=req2
@@ -75,7 +75,7 @@ num=0
 # broken, but ignores "b" when encounters it as reader.
 # ---------------------------------------------------------------------------------
 
-new-request r=req3 txn=txn1 ts=10 spans=w@a+w@b+w@c
+new-request r=req3 txn=txn1 ts=10 spans=intent@a+intent@b+intent@c
 ----
 
 scan r=req3
@@ -116,7 +116,7 @@ num=3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req4 txn=txn2 ts=10 spans=w@a+w@b
+new-request r=req4 txn=txn2 ts=10 spans=intent@a+intent@b
 ----
 
 scan r=req4
@@ -127,7 +127,7 @@ guard-state r=req4
 ----
 new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
 
-new-request r=req5 txn=txn3 ts=10 spans=w@b+w@c+r@b
+new-request r=req5 txn=txn3 ts=10 spans=intent@b+intent@c+none@b
 ----
 
 scan r=req5
@@ -281,7 +281,7 @@ num=0
 # previous test.
 # ---------------------------------------------------------------------------------
 
-new-request r=req6 txn=txn1 ts=10 spans=w@a+w@b+w@c
+new-request r=req6 txn=txn1 ts=10 spans=intent@a+intent@b+intent@c
 ----
 
 scan r=req6
@@ -322,7 +322,7 @@ num=3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req7 txn=txn2 ts=10 spans=w@a+w@b
+new-request r=req7 txn=txn2 ts=10 spans=intent@a+intent@b
 ----
 
 scan r=req7
@@ -333,7 +333,7 @@ guard-state r=req7
 ----
 new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
 
-new-request r=req8 txn=none ts=10 spans=w@b+w@c+r@b
+new-request r=req8 txn=none ts=10 spans=intent@b+intent@c+none@b
 ----
 
 scan r=req8
@@ -347,7 +347,7 @@ new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
 # req9 is just to prevent the lock for "b" from being gc'd and then a new one
 # created when req7 acquires "b", which due to the old snapshot held by req8
 # would not be seen until the next scan.
-new-request r=req9 txn=txn2 ts=10 spans=w@b
+new-request r=req9 txn=txn2 ts=10 spans=intent@b
 ----
 
 scan r=req9
@@ -510,7 +510,7 @@ num=0
 # it ignores the lock at "b".
 # ---------------------------------------------------------------------------------
 
-new-request r=req10 txn=txn1 ts=10 spans=w@a+w@b
+new-request r=req10 txn=txn1 ts=10 spans=intent@a+intent@b
 ----
 
 scan r=req10
@@ -539,7 +539,7 @@ num=2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req11 txn=txn2 ts=10 spans=w@a+w@b
+new-request r=req11 txn=txn2 ts=10 spans=intent@a+intent@b
 ----
 
 scan r=req11
@@ -550,7 +550,7 @@ guard-state r=req11
 ----
 new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
 
-new-request r=req12 txn=txn3 ts=10 spans=w@b+r@b
+new-request r=req12 txn=txn3 ts=10 spans=intent@b+none@b
 ----
 
 scan r=req12

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -13,7 +13,7 @@ new-txn txn=txn1 ts=10 epoch=0 seq=2
 new-txn txn=txn2 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=w@a
+new-request r=req1 txn=txn1 ts=10 spans=intent@a
 ----
 
 acquire r=req1 k=a durability=u
@@ -37,7 +37,7 @@ num=1
 new-txn txn=txn1 ts=8 epoch=0 seq=3
 ----
 
-new-request r=req2 txn=txn1 ts=8 spans=w@a
+new-request r=req2 txn=txn1 ts=8 spans=intent@a
 ----
 
 acquire r=req2 k=a durability=u
@@ -55,7 +55,7 @@ num=1
 # of uncontended replicated locks.
 # ---------------------------------------------------------------------------------
 
-new-request r=reqContend txn=none ts=10 spans=w@a
+new-request r=reqContend txn=none ts=10 spans=intent@a
 ----
 
 scan r=reqContend
@@ -84,7 +84,7 @@ num=1
 new-txn txn=txn1 ts=10 epoch=1 seq=0
 ----
 
-new-request r=req3 txn=txn1 ts=10 spans=w@a
+new-request r=req3 txn=txn1 ts=10 spans=intent@a
 ----
 
 acquire r=req3 k=a durability=u
@@ -102,7 +102,7 @@ num=1
 new-txn txn=txn1 ts=6 epoch=2 seq=0
 ----
 
-new-request r=req4 txn=txn1 ts=6 spans=w@a
+new-request r=req4 txn=txn1 ts=6 spans=intent@a
 ----
 
 acquire r=req4 k=a durability=u
@@ -115,7 +115,7 @@ num=1
 # Reader waits until the timestamp of the lock is updated.
 # ---------------------------------------------------------------------------------
 
-new-request r=req5 txn=txn2 ts=12 spans=r@a
+new-request r=req5 txn=txn2 ts=12 spans=none@a
 ----
 
 scan r=req5
@@ -138,7 +138,7 @@ num=1
 new-txn txn=txn1 ts=14 epoch=1 seq=1
 ----
 
-new-request r=req6 txn=txn1 ts=14 spans=w@a
+new-request r=req6 txn=txn1 ts=14 spans=intent@a
 ----
 
 acquire r=req6 k=a durability=r
@@ -171,7 +171,7 @@ new: state=doneWaiting
 # that the lock table is used.
 # ---------------------------------------------------------------------------------
 
-new-request r=req7 txn=txn2 ts=17 spans=r@a
+new-request r=req7 txn=txn2 ts=17 spans=none@a
 ----
 
 scan r=req7

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -124,7 +124,7 @@ start-waiting: true
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=read
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
 print
 ----
@@ -152,7 +152,7 @@ num=1
 
 guard-state r=req5
 ----
-old: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=read
+old: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
 acquire r=req6 k=a durability=u
 ----
@@ -180,7 +180,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=read
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
 add-discovered r=req7 k=a txn=txn1
 ----
@@ -193,4 +193,4 @@ num=1
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=read
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
@@ -113,11 +113,11 @@ num=1
 
 guard-state r=reqContendReader
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=read
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
 guard-state r=reqContendWriter
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 clear
 ----
@@ -164,7 +164,7 @@ start-waiting: true
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=read
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
 acquire r=req2 k=b durability=r
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
@@ -10,7 +10,7 @@ new-lock-table maxlocks=10000
 new-txn txn=txn1 ts=10 epoch=0 seq=2
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=w@a
+new-request r=req1 txn=txn1 ts=10 spans=intent@a
 ----
 
 acquire r=req1 k=a durability=r
@@ -37,7 +37,7 @@ num=0
 # causes that lock to be dropped and the readers to be released.
 # ---------------------------------------------------------------------------------
 
-new-request r=reqContendReader txn=none ts=10 spans=r@a
+new-request r=reqContendReader txn=none ts=10 spans=none@a
 ----
 
 acquire r=req1 k=a durability=u
@@ -72,7 +72,7 @@ new: state=doneWaiting
 # writers causes the lock to be retained.
 # ---------------------------------------------------------------------------------
 
-new-request r=reqContendWriter txn=none ts=10 spans=w@a
+new-request r=reqContendWriter txn=none ts=10 spans=intent@a
 ----
 
 acquire r=req1 k=a durability=u
@@ -144,7 +144,7 @@ num=1
 new-txn txn=txn2 ts=10 epoch=0 seq=0
 ----
 
-new-request r=req2 txn=txn2 ts=10 spans=w@b
+new-request r=req2 txn=txn2 ts=10 spans=intent@b
 ----
 
 acquire r=req2 k=b durability=u
@@ -155,7 +155,7 @@ num=2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req3 txn=none ts=10 spans=r@a,c
+new-request r=req3 txn=none ts=10 spans=none@a,c
 ----
 
 scan r=req3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
@@ -9,7 +9,7 @@ new-txn txn=txn1 ts=10 epoch=0
 new-txn txn=txn2 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=w@a+r@b+w@c
+new-request r=req1 txn=txn1 ts=10 spans=intent@a+none@b+intent@c
 ----
 
 scan r=req1
@@ -64,7 +64,7 @@ num=3
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
-new-request r=req2 txn=txn1 ts=10 spans=w@c
+new-request r=req2 txn=txn1 ts=10 spans=intent@c
 ----
 
 scan r=req2

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
@@ -95,7 +95,7 @@ start-waiting: true
 
 guard-state r=req1
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Intent
 
 print
 ----
@@ -131,7 +131,7 @@ num=3
 
 guard-state r=req1
 ----
-new: state=waitFor txn=txn2 key="c" held=true guard-access=write
+new: state=waitFor txn=txn2 key="c" held=true guard-strength=Intent
 
 print
 ----
@@ -163,7 +163,7 @@ num=3
 
 guard-state r=req1
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=true guard-access=read
+new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=None
 
 guard-state r=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
@@ -131,7 +131,7 @@ new: state=doneWaiting
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=false guard-access=write
+new: state=waitForDistinguished txn=txn2 key="a" held=false guard-strength=Intent
 
 guard-state r=req5
 ----
@@ -176,7 +176,7 @@ num=3
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn3 key="b" held=false guard-access=write
+new: state=waitForDistinguished txn=txn3 key="b" held=false guard-strength=Intent
 
 guard-state r=req6
 ----
@@ -249,11 +249,11 @@ start-waiting: true
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=true guard-access=write
+new: state=waitForDistinguished txn=txn2 key="c" held=true guard-strength=Intent
 
 guard-state r=req5
 ----
-new: state=waitFor txn=txn2 key="c" held=true guard-access=write
+new: state=waitFor txn=txn2 key="c" held=true guard-strength=Intent
 
 # Release the lock. The non-transactional request does not acquire the reservation.
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
@@ -11,7 +11,7 @@ new-txn txn=txn3 ts=10 epoch=0
 ----
 
 # First locks at a, b, c are acquired by txn1
-new-request r=req1 txn=txn1 ts=10 spans=w@a+w@b+w@c
+new-request r=req1 txn=txn1 ts=10 spans=intent@a+intent@b+intent@c
 ----
 
 scan r=req1
@@ -53,14 +53,14 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
 
 # Next, two different transactional requests wait at a and b.
-new-request r=req2 txn=txn2 ts=10 spans=w@a
+new-request r=req2 txn=txn2 ts=10 spans=intent@a
 ----
 
 scan r=req2
 ----
 start-waiting: true
 
-new-request r=req3 txn=txn3 ts=10 spans=w@b
+new-request r=req3 txn=txn3 ts=10 spans=intent@b
 ----
 
 scan r=req3
@@ -69,7 +69,7 @@ start-waiting: true
 
 # Next, a non-transactional request that wants to write a, b, c waits at a.
 
-new-request r=req4 txn=none ts=10 spans=w@a+w@b+w@c
+new-request r=req4 txn=none ts=10 spans=intent@a+intent@b+intent@c
 ----
 
 scan r=req4
@@ -78,7 +78,7 @@ start-waiting: true
 
 # Next, a transactional request that arrives later than the non-transactional request waits at c
 
-new-request r=req5 txn=txn3 ts=10 spans=w@c
+new-request r=req5 txn=txn3 ts=10 spans=intent@c
 ----
 
 scan r=req5
@@ -139,7 +139,7 @@ new: state=doneWaiting
 
 # Add another transactional request at a. It will wait behind the non-transactional request.
 
-new-request r=req6 txn=txn1 ts=10 spans=w@a
+new-request r=req6 txn=txn1 ts=10 spans=intent@a
 ----
 
 scan r=req6

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/optimistic
@@ -9,7 +9,7 @@ new-txn txn=txn2 ts=11,1 epoch=0
 
 # req1 will acquire locks for txn1
 
-new-request r=req1 txn=txn1 ts=10,1 spans=w@c,h
+new-request r=req1 txn=txn1 ts=10,1 spans=intent@c,h
 ----
 
 scan r=req1
@@ -42,7 +42,7 @@ num=2
  lock: "g"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req2 txn=txn2 ts=11,1 spans=r@a,d
+new-request r=req2 txn=txn2 ts=11,1 spans=none@a,d
 ----
 
 scan r=req2
@@ -61,7 +61,7 @@ num=2
  lock: "g"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req3 txn=txn2 ts=11,1 spans=r@a,d+r@f,i
+new-request r=req3 txn=txn2 ts=11,1 spans=none@a,d+none@f,i
 ----
 
 scan-opt r=req3
@@ -80,19 +80,19 @@ num=2
  lock: "g"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 
-check-opt-no-conflicts r=req3 spans=r@a,c
+check-opt-no-conflicts r=req3 spans=none@a,c
 ----
 no-conflicts: true
 
-check-opt-no-conflicts r=req3 spans=r@a,d
+check-opt-no-conflicts r=req3 spans=none@a,d
 ----
 no-conflicts: false
 
-check-opt-no-conflicts r=req3 spans=r@a,c+r@f,g
+check-opt-no-conflicts r=req3 spans=none@a,c+none@f,g
 ----
 no-conflicts: true
 
-check-opt-no-conflicts r=req3 spans=r@a,c+r@f,h
+check-opt-no-conflicts r=req3 spans=none@a,c+none@f,h
 ----
 no-conflicts: false
 
@@ -110,7 +110,7 @@ num=2
 # does not trigger a conflict.
 # ---------------------------------------------------------------------------------
 
-new-request r=req4 txn=txn2 ts=11,1 spans=r@a,i skip-locked
+new-request r=req4 txn=txn2 ts=11,1 spans=none@a,i skip-locked
 ----
 
 scan-opt r=req4
@@ -121,7 +121,7 @@ should-wait r=req4
 ----
 false
 
-check-opt-no-conflicts r=req4 spans=r@a,i
+check-opt-no-conflicts r=req4 spans=none@a,i
 ----
 no-conflicts: true
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/query
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/query
@@ -6,7 +6,7 @@ new-txn txn=txn1 ts=10,1 epoch=0
 
 # req1 will acquire locks for txn1
 
-new-request r=req1 txn=txn1 ts=10,1 spans=r@a,b+w@c,f
+new-request r=req1 txn=txn1 ts=10,1 spans=none@a,b+intent@c,f
 ----
 
 scan r=req1
@@ -51,7 +51,7 @@ num locks: 1, bytes returned: 41, resume reason: RESUME_UNKNOWN, resume span: <n
 
 # req2 is also for txn1 and will not wait for locks that are held by self.
 
-new-request r=req2 txn=txn1 ts=10,2 spans=w@b,d+r@d,g
+new-request r=req2 txn=txn1 ts=10,2 spans=intent@b,d+none@d,g
 ----
 
 scan r=req2
@@ -109,7 +109,7 @@ new-txn txn=txn2 ts=8,12 epoch=0
 # req3 from txn2 will conflict with locks on b, c since wants to write to [a, d). But does
 # not conflict with lock on e since wants to read there and the read is at a lower timestamp
 # than the lock.
-new-request r=req3 txn=txn2 ts=8,12 spans=w@a,d+r@d,g
+new-request r=req3 txn=txn2 ts=8,12 spans=intent@a,d+none@d,g
 ----
 
 scan r=req3
@@ -120,7 +120,7 @@ new-txn txn=txn3 ts=9,1 epoch=0
 ----
 
 # req4 from txn3 will conflict with locks on e since wants to write to [d, g).
-new-request r=req4 txn=txn3 ts=9,1 spans=w@d,g
+new-request r=req4 txn=txn3 ts=9,1 spans=intent@d,g
 ----
 
 scan r=req4

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
@@ -10,13 +10,13 @@ new-txn txn=txn2 ts=10 epoch=0
 new-txn txn=txn3 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=w@a
+new-request r=req1 txn=txn1 ts=10 spans=intent@a
 ----
 
-new-request r=req2 txn=txn2 ts=10 spans=w@a
+new-request r=req2 txn=txn2 ts=10 spans=intent@a
 ----
 
-new-request r=req3 txn=txn3 ts=10 spans=w@a
+new-request r=req3 txn=txn3 ts=10 spans=intent@a
 ----
 
 scan r=req1
@@ -55,7 +55,7 @@ num=1
 new-txn txn=txn4 ts=10 epoch=0
 ----
 
-new-request r=req4 txn=txn4 ts=10 spans=r@a max-lock-wait-queue-length=2
+new-request r=req4 txn=txn4 ts=10 spans=none@a max-lock-wait-queue-length=2
 ----
 
 scan r=req4
@@ -83,7 +83,7 @@ num=1
 new-txn txn=txn5 ts=10 epoch=0
 ----
 
-new-request r=req5 txn=txn5 ts=10 spans=w@a max-lock-wait-queue-length=3
+new-request r=req5 txn=txn5 ts=10 spans=intent@a max-lock-wait-queue-length=3
 ----
 
 scan r=req5
@@ -111,7 +111,7 @@ num=1
 new-txn txn=txn6 ts=10 epoch=0
 ----
 
-new-request r=req6 txn=txn6 ts=10 spans=w@a max-lock-wait-queue-length=2
+new-request r=req6 txn=txn6 ts=10 spans=intent@a max-lock-wait-queue-length=2
 ----
 
 scan r=req6
@@ -136,7 +136,7 @@ num=1
 # Same as previous two cases, but for non-transactional writes.
 # ---------------------------------------------------------------------------------
 
-new-request r=req7 txn=none ts=10 spans=w@a max-lock-wait-queue-length=3
+new-request r=req7 txn=none ts=10 spans=intent@a max-lock-wait-queue-length=3
 ----
 
 scan r=req7
@@ -157,7 +157,7 @@ num=1
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
 
-new-request r=req8 txn=none ts=10 spans=w@a max-lock-wait-queue-length=2
+new-request r=req8 txn=none ts=10 spans=intent@a max-lock-wait-queue-length=2
 ----
 
 scan r=req8

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
@@ -64,7 +64,7 @@ start-waiting: true
 
 guard-state r=req4
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-access=read
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=None
 
 dequeue r=req4
 ----
@@ -92,7 +92,7 @@ start-waiting: true
 
 guard-state r=req5
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 dequeue r=req5
 ----
@@ -120,7 +120,7 @@ start-waiting: true
 
 guard-state r=req6
 ----
-new: state=waitQueueMaxLengthExceeded txn=txn1 key="a" held=true guard-access=write
+new: state=waitQueueMaxLengthExceeded txn=txn1 key="a" held=true guard-strength=Intent
 
 dequeue r=req6
 ----
@@ -145,7 +145,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 dequeue r=req7
 ----
@@ -166,7 +166,7 @@ start-waiting: true
 
 guard-state r=req8
 ----
-new: state=waitQueueMaxLengthExceeded txn=txn1 key="a" held=true guard-access=write
+new: state=waitQueueMaxLengthExceeded txn=txn1 key="a" held=true guard-strength=Intent
 
 dequeue r=req8
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
@@ -135,7 +135,7 @@ num=3
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
 
 guard-state r=req3
 ----
@@ -248,7 +248,7 @@ new: state=doneWaiting
 
 guard-state r=req6
 ----
-new: state=waitElsewhere txn=txn1 key="c" held=true guard-access=write
+new: state=waitElsewhere txn=txn1 key="c" held=true guard-strength=Intent
 
 scan r=req7
 ----
@@ -256,4 +256,4 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn1 key="d" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="d" held=true guard-strength=Intent

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
@@ -15,7 +15,7 @@ new-txn txn=txn1 ts=10 epoch=0
 new-txn txn=txn2 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=w@a,e
+new-request r=req1 txn=txn1 ts=10 spans=intent@a,e
 ----
 
 scan r=req1
@@ -53,7 +53,7 @@ num=3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=reqContend txn=none ts=10 spans=w@c
+new-request r=reqContend txn=none ts=10 spans=intent@c
 ----
 
 scan r=reqContend
@@ -93,14 +93,14 @@ num=3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
 
-new-request r=req2 txn=txn2 ts=10 spans=w@a,c
+new-request r=req2 txn=txn2 ts=10 spans=intent@a,c
 ----
 
 scan r=req2
 ----
 start-waiting: true
 
-new-request r=req3 txn=txn2 ts=10 spans=w@a,c
+new-request r=req3 txn=txn2 ts=10 spans=intent@a,c
 ----
 
 scan r=req3
@@ -156,28 +156,28 @@ num=3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
 
-new-request r=req4 txn=txn2 ts=10 spans=r@b
+new-request r=req4 txn=txn2 ts=10 spans=none@b
 ----
 
 scan r=req4
 ----
 start-waiting: true
 
-new-request r=req5 txn=txn2 ts=10 spans=w@b
+new-request r=req5 txn=txn2 ts=10 spans=intent@b
 ----
 
 scan r=req5
 ----
 start-waiting: true
 
-new-request r=req6 txn=txn2 ts=10 spans=w@c
+new-request r=req6 txn=txn2 ts=10 spans=intent@c
 ----
 
 scan r=req6
 ----
 start-waiting: true
 
-new-request r=req7 txn=txn2 ts=10 spans=w@d
+new-request r=req7 txn=txn2 ts=10 spans=intent@d
 ----
 
 scan r=req7
@@ -213,7 +213,7 @@ num=4
    queued writers:
     active: false req: 8, txn: 00000000-0000-0000-0000-000000000002
 
-new-request r=req8 txn=txn2 ts=10 spans=w@e
+new-request r=req8 txn=txn2 ts=10 spans=intent@e
 ----
 
 scan r=req8

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -15,7 +15,7 @@ new-txn txn=txn2 ts=9,1 epoch=0
 #  e: unlocked
 #  f: reservation by txn1
 
-new-request r=req1 txn=txn1 ts=10,1 spans=w@b,d
+new-request r=req1 txn=txn1 ts=10,1 spans=intent@b,d
 ----
 
 scan r=req1
@@ -48,7 +48,7 @@ num=2
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req2 txn=txn2 ts=9,1 spans=w@c+w@f
+new-request r=req2 txn=txn2 ts=9,1 spans=intent@c+intent@f
 ----
 
 scan r=req2
@@ -93,7 +93,7 @@ num=4
  lock: "f"
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
 
-new-request r=req3 txn=txn1 ts=10,1 spans=w@f
+new-request r=req3 txn=txn1 ts=10,1 spans=intent@f
 ----
 
 scan r=req3
@@ -122,7 +122,7 @@ num=4
 # keys to skip.
 # ---------------------------------------------------------------------------------
 
-new-request r=req4 txn=txn2 ts=9,1 spans=r@a,g skip-locked
+new-request r=req4 txn=txn2 ts=9,1 spans=none@a,g skip-locked
 ----
 
 scan r=req4
@@ -198,7 +198,7 @@ num=4
 # exercise the strength=none cases again.
 # ---------------------------------------------------------------------------------
 
-new-request r=req5 txn=txn2 ts=10,1 spans=r@a,g skip-locked
+new-request r=req5 txn=txn2 ts=10,1 spans=none@a,g skip-locked
 ----
 
 scan r=req5

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -63,7 +63,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=read
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
 scan r=req3
 ----
@@ -71,7 +71,7 @@ start-waiting: true
 
 guard-state r=req3
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 scan r=req4
 ----
@@ -79,7 +79,7 @@ start-waiting: true
 
 guard-state r=req4
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-access=read
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=None
 
 scan r=req5
 ----
@@ -87,7 +87,7 @@ start-waiting: true
 
 guard-state r=req5
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 print
 ----
@@ -354,7 +354,7 @@ start-waiting: false
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn3 key="a" held=false guard-access=write
+new: state=waitForDistinguished txn=txn3 key="a" held=false guard-strength=Intent
 
 dequeue r=req3
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -14,7 +14,7 @@ new-txn txn=txn3 ts=14,1 epoch=0
 # Acquire a lock on key a at timestamp 10,1
 # -------------------------------------------------------------
 
-new-request r=req1 txn=txn1 ts=10,1 spans=w@a
+new-request r=req1 txn=txn1 ts=10,1 spans=intent@a
 ----
 
 scan r=req1
@@ -45,16 +45,16 @@ num=1
 # 4. non-transactional read-write request
 # -------------------------------------------------------------
 
-new-request r=req2 txn=txn2 ts=12,1 spans=r@a
+new-request r=req2 txn=txn2 ts=12,1 spans=none@a
 ----
 
-new-request r=req3 txn=txn3 ts=14,1 spans=w@a
+new-request r=req3 txn=txn3 ts=14,1 spans=intent@a
 ----
 
-new-request r=req4 txn=none ts=16,1 spans=r@a
+new-request r=req4 txn=none ts=16,1 spans=none@a
 ----
 
-new-request r=req5 txn=none ts=18,1 spans=w@a
+new-request r=req5 txn=none ts=18,1 spans=intent@a
 ----
 
 scan r=req2
@@ -386,7 +386,7 @@ new-lock-table maxlocks=10000
 new-txn txn=txn1 ts=10 epoch=1 seq=1
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=w@a
+new-request r=req1 txn=txn1 ts=10 spans=intent@a
 ----
 
 acquire r=req1 k=a durability=u
@@ -398,7 +398,7 @@ num=1
 new-txn txn=txn1 ts=10 epoch=1 seq=5
 ----
 
-new-request r=req2 txn=txn1 ts=10 spans=w@a
+new-request r=req2 txn=txn1 ts=10 spans=intent@a
 ----
 
 acquire r=req2 k=a durability=u
@@ -410,7 +410,7 @@ num=1
 new-txn txn=txn1 ts=10 epoch=1 seq=7
 ----
 
-new-request r=req3 txn=txn1 ts=10 spans=w@a
+new-request r=req3 txn=txn1 ts=10 spans=intent@a
 ----
 
 acquire r=req3 k=a durability=u
@@ -422,7 +422,7 @@ num=1
 new-txn txn=txn1 ts=10 epoch=1 seq=10
 ----
 
-new-request r=req4 txn=txn1 ts=10 spans=w@a
+new-request r=req4 txn=txn1 ts=10 spans=intent@a
 ----
 
 acquire r=req4 k=a durability=u

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
@@ -17,16 +17,16 @@ new-txn txn=txn2 ts=10 epoch=0
 new-txn txn=txn3 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=w@a
+new-request r=req1 txn=txn1 ts=10 spans=intent@a
 ----
 
-new-request r=req2 txn=txn2 ts=10 spans=w@a
+new-request r=req2 txn=txn2 ts=10 spans=intent@a
 ----
 
-new-request r=req3 txn=txn3 ts=10 spans=w@a
+new-request r=req3 txn=txn3 ts=10 spans=intent@a
 ----
 
-new-request r=req4 txn=txn2 ts=10 spans=w@a
+new-request r=req4 txn=txn2 ts=10 spans=intent@a
 ----
 
 scan r=req1

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
@@ -59,15 +59,15 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
 
 guard-state r=req3
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 guard-state r=req4
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 print
 ----
@@ -96,7 +96,7 @@ new: state=doneWaiting
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=false guard-access=write
+new: state=waitForDistinguished txn=txn2 key="a" held=false guard-strength=Intent
 
 guard-state r=req4
 ----
@@ -137,7 +137,7 @@ num=1
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-access=write
+new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Intent
 
 guard-state r=req4
 ----


### PR DESCRIPTION
See individual commits for details. 

Last bits of cleanup in support of https://github.com/cockroachdb/cockroach/issues/102008; the linked issue can be considered completed once this PR lands. 