### PR TITLE
release-22.1: backupccl: create fake protos for synthetic schemas for logging

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -833,16 +833,16 @@ func backupPlanHook(
 		if !initialDetails.FullCluster {
 			descriptorProtos := make([]descpb.Descriptor, 0, len(targetDescs))
 			for _, desc := range targetDescs {
-				descriptorProtos = append(descriptorProtos, *desc.DescriptorProto())
+				descriptorProtos = append(descriptorProtos, *getDescriptorProtoForLogging(desc))
 			}
 			initialDetails.ResolvedTargets = descriptorProtos
 
 			for _, desc := range descsByTablePattern {
-				initialDetails.RequestedTargets = append(initialDetails.RequestedTargets, *desc.DescriptorProto())
+				initialDetails.RequestedTargets = append(initialDetails.RequestedTargets, *getDescriptorProtoForLogging(desc))
 			}
 
 			for _, desc := range requestedDBs {
-				initialDetails.RequestedTargets = append(initialDetails.RequestedTargets, *desc.DescriptorProto())
+				initialDetails.RequestedTargets = append(initialDetails.RequestedTargets, *getDescriptorProtoForLogging(desc))
 			}
 		}
 

--- a/pkg/ccl/backupccl/backup_telemetry.go
+++ b/pkg/ccl/backupccl/backup_telemetry.go
@@ -320,10 +320,10 @@ func logRestoreTelemetry(
 ) {
 	var requestedTargets []descpb.Descriptor
 	for _, desc := range descsByTablePattern {
-		requestedTargets = append(requestedTargets, *desc.DescriptorProto())
+		requestedTargets = append(requestedTargets, *getDescriptorProtoForLogging(desc))
 	}
 	for _, desc := range restoreDBs {
-		requestedTargets = append(requestedTargets, *desc.DescriptorProto())
+		requestedTargets = append(requestedTargets, *getDescriptorProtoForLogging(desc))
 	}
 
 	largestScope := getLargestScope(details.DescriptorCoverage == tree.AllDescriptors, requestedTargets)
@@ -461,4 +461,22 @@ func logJobCompletion(
 	}
 
 	log.StructuredEvent(ctx, event)
+}
+
+func getDescriptorProtoForLogging(desc catalog.Descriptor) *descpb.Descriptor {
+	if schema, ok := desc.(catalog.SchemaDescriptor); ok {
+		if schema.SchemaKind() != catalog.SchemaUserDefined {
+			return &descpb.Descriptor{Union: &descpb.Descriptor_Schema{Schema: makeSyntheticSchemaDescForLogging(schema)}}
+		}
+	}
+
+	return desc.DescriptorProto()
+}
+func makeSyntheticSchemaDescForLogging(sc catalog.SchemaDescriptor) *descpb.SchemaDescriptor {
+	return &descpb.SchemaDescriptor{
+		ID:       sc.GetID(),
+		ParentID: sc.GetParentID(),
+		Version:  sc.GetVersion(),
+		Name:     sc.GetName(),
+	}
 }

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -10082,6 +10082,67 @@ func TestBackupRestoreTelemetryEvents(t *testing.T) {
 	requireRecoveryEvent(t, beforeRestore.UnixNano(), restoreJobEventType, expectedRestoreFailEvent)
 }
 
+// TestBackupRestoreTelemetryForPublicSchema tests that backup and restore
+// events are logged if the target is the public schema for the system database.
+func TestBackupRestoreTelemetryForPublicSchema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.ScopeWithoutShowLogs(t).Close(t)
+
+	defer jobs.TestingSetProgressThresholds()()
+
+	baseDir := "testdata"
+	args := base.TestServerArgs{ExternalIODir: baseDir, Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
+	params := base.TestClusterArgs{ServerArgs: args}
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, 1,
+		InitManualReplication, params)
+	defer cleanupFn()
+
+	// Execute a BACKUP for the system.public schema and verify the telemetry
+	// event.
+	beforeBackup := timeutil.Now()
+	loc1 := "userfile:///eventlogging?COCKROACH_LOCALITY=default"
+	sqlDB.Exec(t, `BACKUP system.public.* INTO $1 AS OF SYSTEM TIME '-1ms' WITH revision_history`, loc1)
+
+	expectedBackupEvent := eventpb.RecoveryEvent{
+		CommonEventDetails: eventpb.CommonEventDetails{
+			EventType: "recovery_event",
+		},
+		RecoveryType:            backupEventType,
+		TargetScope:             schemaScope.String(),
+		TargetCount:             1,
+		DestinationSubdirType:   standardSubdirType,
+		DestinationStorageTypes: []string{"userfile"},
+		DestinationAuthTypes:    []string{"specified"},
+		AsOfInterval:            -1 * time.Millisecond.Nanoseconds(),
+		WithRevisionHistory:     true,
+	}
+
+	requireRecoveryEvent(t, beforeBackup.UnixNano(), backupEventType, expectedBackupEvent)
+
+	sqlDB.Exec(t, "CREATE DATABASE restore_system")
+
+	// Execute a RESTORE of the system.public schema and verify the telemetry
+	// event.
+	beforeRestore := timeutil.Now()
+	restoreQuery := `RESTORE system.public.* FROM LATEST IN $1 WITH into_db=$2`
+	sqlDB.Exec(t, restoreQuery, loc1, "restore_system")
+
+	expectedRestoreEvent := eventpb.RecoveryEvent{
+		CommonEventDetails: eventpb.CommonEventDetails{
+			EventType: "recovery_event",
+		},
+		RecoveryType:            restoreEventType,
+		TargetScope:             schemaScope.String(),
+		TargetCount:             1,
+		DestinationSubdirType:   latestSubdirType,
+		DestinationStorageTypes: []string{"userfile"},
+		DestinationAuthTypes:    []string{"specified"},
+		Options:                 []string{telemetryOptionIntoDB},
+	}
+
+	requireRecoveryEvent(t, beforeRestore.UnixNano(), restoreEventType, expectedRestoreEvent)
+}
+
 // This is a regression test ensuring that the spans represented by views are
 // not included in backups when their descriptors are included in descriptor
 // revisions.

--- a/pkg/ccl/backupccl/testdata/backup-restore/system-public-schema
+++ b/pkg/ccl/backupccl/testdata/backup-restore/system-public-schema
@@ -1,0 +1,17 @@
+# Test that backing up and restoring the public schema from the system database
+# succeeds.
+
+new-server name=s1 allow-implicit-access
+----
+
+exec-sql
+CREATE DATABASE restoredb;
+----
+
+exec-sql
+BACKUP system.public.* INTO 'userfile:///test';
+----
+
+exec-sql
+RESTORE system.public.* FROM latest IN 'userfile:///test' WITH into_db='restoredb';
+----


### PR DESCRIPTION
Currently, the backup job relies on passing a descriptor protobuf for every target of the backup during planning in order to log the backup telemetry event at the start of the job. This unfortunately means that synthetic schemas, which do not have protobuf descriptors, would not be able to be logged with this method and would currently cause a panic. This patch creates some fake schema protobufs for synthetic schemas so they can be logged by telemetry without panicking.

Fixes #96252

Release note (bug fix): fix a bug where backup and restore would panic if the target is a synthetic schema such as system.public.