### PR TITLE
sql: deflake TestCreateStatsAfterSchemaChange

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -5450,6 +5450,7 @@ CREATE TABLE t.test (a INT, b INT, c JSON, d JSON);
 func TestCreateStatsAfterSchemaChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "sometimes the timer in stats.Refresher doesn't fire fast enough under race")
 
 	defer func(oldRefreshInterval, oldAsOf time.Duration) {
 		stats.DefaultRefreshInterval = oldRefreshInterval


### PR DESCRIPTION
Skip the test under race since sometimes the timer in `stats.Refresher` doesn't fire fast enough under race.

Fixes #101182

Release note: None