### PR TITLE
builtins: implement to_char(date, string)

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -659,6 +659,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="to_char"></a><code>to_char(date: <a href="date.html">date</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert an date to a string assuming the ISO, MDY DateStyle.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="to_char"></a><code>to_char(date: <a href="date.html">date</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert a timestamp with time zone to a string using the given format.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="to_char"></a><code>to_char(interval: <a href="interval.html">interval</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert an interval to a string assuming the Postgres IntervalStyle.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="to_char"></a><code>to_char(interval: <a href="interval.html">interval</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert an interval to a string using the given format.</p>

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1936,12 +1936,13 @@ ORDER BY pk
 statement error only ISO style is supported
 SELECT to_char_with_style(now()::date, 'postgres')
 
-query TT
+query TTT
 SELECT
   to_char('2020-01-02 01:02:03'::date),
+  to_char('2020-01-02'::date, 'YYYY-MM-DD HH24:MI:SS.FF6'),
   to_char_with_style('2020-01-02 01:02:03'::date, 'DMY')
 ----
-2020-01-02  2020-01-02
+2020-01-02  2020-01-02 00:00:00.000000  2020-01-02
 
 statement ok
 CREATE TABLE time_datestyle_parse(pk SERIAL PRIMARY KEY, s string);

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2411,6 +2411,22 @@ var regularBuiltins = map[string]builtinDefinition{
 			Info:       "Convert an date to a string assuming the ISO, MDY DateStyle.",
 			Volatility: volatility.Immutable,
 		},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "date", Typ: types.Date}, {Name: "format", Typ: types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ context.Context, ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				d := tree.MustBeDDate(args[0])
+				f := tree.MustBeDString(args[1])
+				t, err := d.ToTime()
+				if err != nil {
+					return nil, err
+				}
+				s, err := tochar.TimeToChar(t, ctx.ToCharFormatCache, string(f))
+				return tree.NewDString(s), err
+			},
+			Info:       "Convert a timestamp with time zone to a string using the given format.",
+			Volatility: volatility.Stable,
+		},
 	),
 
 	"to_char_with_style": makeBuiltin(

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2381,6 +2381,7 @@ var builtinOidsArray = []string{
 	2408: `crdb_internal.job_execution_details(job_id: int) -> jsonb`,
 	2409: `st_bdpolyfromtext(str: string, srid: int) -> geometry`,
 	2410: `crdb_internal.pretty_value(raw_value: bytes) -> string`,
+	2411: `to_char(date: date, format: string) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
Release note (sql change): Introduce the `to_char(date, format)` builtin variant, which converts a given date to a string using the given format string.

Informs #3781

(if we had implicit casts this wouldnt be an issue!)