### PR TITLE
kv: eliminate write-too-old deferral mechanism

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -3211,13 +3211,13 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return txn.CommitInBatch(ctx, b)
 			},
 			priorReads: true,
-			// The Put to "c" will fail, failing the parallel commit and forcing a
-			// parallel commit auto-retry and preemptive client-side refresh.
+			// The Put to "c" will fail, failing the parallel commit with an error and
+			// forcing a client-side refresh and auto-retry of the full batch.
 			allIsoLevels: &expect{
 				expServerRefresh:               false,
 				expClientRefreshSuccess:        true,
-				expClientAutoRetryAfterRefresh: false,
-				expParallelCommitAutoRetry:     true,
+				expClientAutoRetryAfterRefresh: true,
+				expParallelCommitAutoRetry:     false,
 			},
 		},
 		{

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -98,23 +98,6 @@ func IsReadOnly(args Request) bool {
 	return (flags&isRead) != 0 && (flags&isWrite) == 0
 }
 
-// IsBlindWrite returns true iff the request is a blind-write. A request is a
-// blind-write if it is a write that does not observe any key-value state when
-// modifying that state (such as puts and deletes). This is in contrast with
-// read-write requests, which do observe key-value state when modifying the
-// state and may base their modifications off of this existing state (such as
-// conditional puts and increments).
-//
-// As a result of being "blind", blind-writes are allowed to be more freely
-// re-ordered with other writes. In practice, this means that they can be
-// evaluated with a read timestamp below another write and a write timestamp
-// above that write without needing to re-evaluate. This allows the WriteTooOld
-// error that is generated during such an occurrence to be deferred.
-func IsBlindWrite(args Request) bool {
-	flags := args.flags()
-	return (flags&isRead) == 0 && (flags&isWrite) != 0
-}
-
 // IsTransactional returns true if the request may be part of a
 // transaction.
 func IsTransactional(args Request) bool {

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -928,11 +928,11 @@ func NewWriteTooOldError(operationTS, actualTS hlc.Timestamp, key roachpb.Key) *
 
 func (e *WriteTooOldError) SafeFormatError(p errors.Printer) (next error) {
 	if len(e.Key) > 0 {
-		p.Printf("WriteTooOldError: write for key %s at timestamp %s too old; wrote at %s",
+		p.Printf("WriteTooOldError: write for key %s at timestamp %s too old; must write at or above %s",
 			e.Key, e.Timestamp, e.ActualTimestamp)
 		return nil
 	}
-	p.Printf("WriteTooOldError: write at timestamp %s too old; wrote at %s",
+	p.Printf("WriteTooOldError: write at timestamp %s too old; must write at or above %s",
 		e.Timestamp, e.ActualTimestamp)
 	return nil
 }

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -348,17 +348,12 @@ message WriteIntentError {
 
 // A WriteTooOldError indicates that a write encountered a versioned
 // value newer than its timestamp, making it impossible to rewrite
-// history. The write is instead done at actual timestamp, which is
-// the timestamp of the existing version+1.
-//
-// If a blind write request (see IsBlindWrite) returns a WriteTooOld
-// error during evaluation (in pkg/kvserver/batcheval), it must also
-// complete its work and return a valid result. This allows callers to
-// optionally defer the WriteTooOldError until later in the transaction
-// by instead bumping the transaction's write timestamp, setting the
-// transaction's WriteTooOld flag, and dropping the error.
+// history. The write must instead be done at or later than actual
+// timestamp, which is the timestamp of the existing version+1.
 message WriteTooOldError {
   optional util.hlc.Timestamp timestamp = 1 [(gogoproto.nullable) = false];
+  // TODO(nvanbenschoten): now that WriteTooOld errors no longer accompany
+  // successful writes, this name is confusing. Rename the field.
   optional util.hlc.Timestamp actual_timestamp = 2 [(gogoproto.nullable) = false];
   // One of the keys at which this error was encountered. There's
   // no need to return new WriteTooOldErrors for each colliding key; the key

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -232,7 +232,7 @@ func TestErrorRedaction(t *testing.T) {
 		},
 		{
 			err:    &WriteTooOldError{},
-			expect: "WriteTooOldError: write at timestamp 0,0 too old; wrote at 0,0",
+			expect: "WriteTooOldError: write at timestamp 0,0 too old; must write at or above 0,0",
 		},
 		{
 			err:    &OpRequiresTxnError{},

--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -65,11 +65,8 @@ func ConditionalPut(
 		err = storage.MVCCConditionalPut(
 			ctx, readWriter, cArgs.Stats, args.Key, ts, cArgs.Now, args.Value, args.ExpBytes, handleMissing, h.Txn)
 	}
-	// NB: even if MVCC returns an error, it may still have written an intent
-	// into the batch. This allows callers to consume errors like WriteTooOld
-	// without re-evaluating the batch. This behavior isn't particularly
-	// desirable, but while it remains, we need to assume that an intent could
-	// have been written even when an error is returned. This is harmless if the
-	// error is not consumed by the caller because the result will be discarded.
-	return result.FromAcquiredLocks(h.Txn, args.Key), err
+	if err != nil {
+		return result.Result{}, err
+	}
+	return result.FromAcquiredLocks(h.Txn, args.Key), nil
 }

--- a/pkg/kv/kvserver/batcheval/cmd_delete.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete.go
@@ -35,9 +35,12 @@ func Delete(
 	reply.FoundKey, err = storage.MVCCDelete(
 		ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, cArgs.Now, h.Txn,
 	)
+	if err != nil {
+		return result.Result{}, err
+	}
 
 	// If requested, replace point tombstones with range tombstones.
-	if cArgs.EvalCtx.EvalKnobs().UseRangeTombstonesForPointDeletes && err == nil && h.Txn == nil {
+	if cArgs.EvalCtx.EvalKnobs().UseRangeTombstonesForPointDeletes && h.Txn == nil {
 		if err := storage.ReplacePointTombstonesWithRangeTombstones(
 			ctx, spanset.DisableReadWriterAssertions(readWriter),
 			cArgs.Stats, args.Key, args.EndKey); err != nil {
@@ -45,11 +48,5 @@ func Delete(
 		}
 	}
 
-	// NB: even if MVCC returns an error, it may still have written an intent
-	// into the batch. This allows callers to consume errors like WriteTooOld
-	// without re-evaluating the batch. This behavior isn't particularly
-	// desirable, but while it remains, we need to assume that an intent could
-	// have been written even when an error is returned. This is harmless if the
-	// error is not consumed by the caller because the result will be discarded.
-	return result.FromAcquiredLocks(h.Txn, args.Key), err
+	return result.FromAcquiredLocks(h.Txn, args.Key), nil
 }

--- a/pkg/kv/kvserver/batcheval/cmd_increment.go
+++ b/pkg/kv/kvserver/batcheval/cmd_increment.go
@@ -32,14 +32,11 @@ func Increment(
 	h := cArgs.Header
 	reply := resp.(*kvpb.IncrementResponse)
 
-	newVal, err := storage.MVCCIncrement(
+	var err error
+	reply.NewValue, err = storage.MVCCIncrement(
 		ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, cArgs.Now, h.Txn, args.Increment)
-	reply.NewValue = newVal
-	// NB: even if MVCC returns an error, it may still have written an intent
-	// into the batch. This allows callers to consume errors like WriteTooOld
-	// without re-evaluating the batch. This behavior isn't particularly
-	// desirable, but while it remains, we need to assume that an intent could
-	// have been written even when an error is returned. This is harmless if the
-	// error is not consumed by the caller because the result will be discarded.
-	return result.FromAcquiredLocks(h.Txn, args.Key), err
+	if err != nil {
+		return result.Result{}, err
+	}
+	return result.FromAcquiredLocks(h.Txn, args.Key), nil
 }

--- a/pkg/kv/kvserver/batcheval/cmd_init_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_init_put.go
@@ -44,11 +44,8 @@ func InitPut(
 		err = storage.MVCCInitPut(
 			ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, cArgs.Now, args.Value, args.FailOnTombstones, h.Txn)
 	}
-	// NB: even if MVCC returns an error, it may still have written an intent
-	// into the batch. This allows callers to consume errors like WriteTooOld
-	// without re-evaluating the batch. This behavior isn't particularly
-	// desirable, but while it remains, we need to assume that an intent could
-	// have been written even when an error is returned. This is harmless if the
-	// error is not consumed by the caller because the result will be discarded.
-	return result.FromAcquiredLocks(h.Txn, args.Key), err
+	if err != nil {
+		return result.Result{}, err
+	}
+	return result.FromAcquiredLocks(h.Txn, args.Key), nil
 }

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -60,11 +60,8 @@ func Put(
 	} else {
 		err = storage.MVCCPut(ctx, readWriter, ms, args.Key, ts, cArgs.Now, args.Value, h.Txn)
 	}
-	// NB: even if MVCC returns an error, it may still have written an intent
-	// into the batch. This allows callers to consume errors like WriteTooOld
-	// without re-evaluating the batch. This behavior isn't particularly
-	// desirable, but while it remains, we need to assume that an intent could
-	// have been written even when an error is returned. This is harmless if the
-	// error is not consumed by the caller because the result will be discarded.
-	return result.FromAcquiredLocks(h.Txn, args.Key), err
+	if err != nil {
+		return result.Result{}, err
+	}
+	return result.FromAcquiredLocks(h.Txn, args.Key), nil
 }

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -215,25 +215,11 @@ func evaluateBatch(
 
 	var mergedResult result.Result
 
-	// WriteTooOldErrors have particular handling. When a request encounters the
-	// error, we'd like to lay down an intent in order to avoid writers being
-	// starved. So, for blind writes, we swallow the error and instead we set the
-	// WriteTooOld flag on the response. For non-blind writes (e.g. CPut), we
-	// can't do that and so we just return the WriteTooOldError - see note on
-	// IsRead() stanza below. Upon receiving either a WriteTooOldError or a
-	// response with the WriteTooOld flag set, the client will attempt to bump
-	// the txn's read timestamp through a refresh. If successful, the client
-	// will retry this batch (in both cases).
-	//
-	// In any case, evaluation of the current batch always continue after a
-	// WriteTooOldError in order to find out if there's more conflicts and chose
-	// a final write timestamp.
-	var writeTooOldState struct {
-		err *kvpb.WriteTooOldError
-		// cantDeferWTOE is set when a WriteTooOldError cannot be deferred past the
-		// end of the current batch.
-		cantDeferWTOE bool
-	}
+	// WriteTooOldErrors have particular handling. Evaluation of the current batch
+	// continues after a WriteTooOldError in order to find out if there's more
+	// conflicts and chose the highest timestamp to return for more efficient
+	// retries.
+	var deferredWriteTooOldErr *kvpb.WriteTooOldError
 
 	// Only collect the scan stats if the tracing is enabled.
 	var ss *kvpb.ScanStats
@@ -253,6 +239,17 @@ func evaluateBatch(
 	for index, union := range baReqs {
 		// Execute the command.
 		args := union.GetInner()
+
+		if deferredWriteTooOldErr != nil && args.Method() == kvpb.EndTxn {
+			// ... unless we have been deferring a WriteTooOld error and have now
+			// reached an EndTxn request. In such cases, break and return the error.
+			// The transaction needs to handle the WriteTooOld error before it tries
+			// to commit. This short-circuiting is not necessary for correctness as
+			// the write batch will be discarded in favor of the deferred error, but
+			// we don't want to bother with potentially expensive EndTxn evaluation if
+			// we know the result will be thrown away.
+			break
+		}
 
 		if baHeader.Txn != nil {
 			// Set the Request's sequence number on the TxnMeta for this
@@ -325,79 +322,6 @@ func evaluateBatch(
 			reply.SetHeader(headerCopy)
 		}
 
-		if err != nil {
-			// If an EndTxn wants to restart because of a write too old, we
-			// might have a better error to return to the client.
-			if retErr := (*kvpb.TransactionRetryError)(nil); errors.As(err, &retErr) &&
-				retErr.Reason == kvpb.RETRY_WRITE_TOO_OLD &&
-				args.Method() == kvpb.EndTxn && writeTooOldState.err != nil {
-				err = writeTooOldState.err
-				// Don't defer this error. We could perhaps rely on the client observing
-				// the WriteTooOld flag and retry the batch, but we choose not too.
-				writeTooOldState.cantDeferWTOE = true
-			} else if wtoErr := (*kvpb.WriteTooOldError)(nil); errors.As(err, &wtoErr) {
-				// We got a WriteTooOldError. We continue on to run all
-				// commands in the batch in order to determine the highest
-				// timestamp for more efficient retries. If the batch is
-				// transactional, we continue to lay down intents so that
-				// other concurrent overlapping transactions are forced
-				// through intent resolution and the chances of this batch
-				// succeeding when it will be retried are increased.
-				if writeTooOldState.err != nil {
-					writeTooOldState.err.ActualTimestamp.Forward(
-						wtoErr.ActualTimestamp)
-				} else {
-					writeTooOldState.err = wtoErr
-				}
-
-				// For read-write requests that observe key-value state, we don't have
-				// the option of leaving an intent behind when they encounter a
-				// WriteTooOldError, so we have to return an error instead of a response
-				// with the WriteTooOld flag set (which would also leave intents
-				// behind). These requests need to be re-evaluated at the bumped
-				// timestamp in order for their results to be valid. The current
-				// evaluation resulted in an result that could well be different from
-				// what the request would return if it were evaluated at the bumped
-				// timestamp, which would cause the request to be rejected if it were
-				// sent again with the same sequence number after a refresh.
-				//
-				// Similarly, for read-only requests that encounter a WriteTooOldError,
-				// we don't have the option of returning a response with the WriteTooOld
-				// flag set because a response is not even generated in tandem with the
-				// WriteTooOldError. We could fix this and then allow WriteTooOldErrors
-				// to be deferred in these cases, but doing so would buy more into the
-				// extremely error-prone approach of retuning responses and errors
-				// together throughout the MVCC read path. Doing so is not desirable as
-				// it has repeatedly caused bugs in the past. Instead, we'd like to get
-				// rid of this pattern entirely and instead address the TODO below.
-				//
-				// TODO(andrei): What we really want to do here is either speculatively
-				// evaluate the request at the bumped timestamp and return that
-				// speculative result, or leave behind an unreplicated lock that won't
-				// prevent the request for evaluating again at the same sequence number
-				// but at a bumped timestamp.
-				if !kvpb.IsBlindWrite(args) {
-					writeTooOldState.cantDeferWTOE = true
-				}
-
-				if baHeader.Txn != nil {
-					log.VEventf(ctx, 2, "setting WriteTooOld because of key: %s. wts: %s -> %s",
-						args.Header().Key, baHeader.Txn.WriteTimestamp, wtoErr.ActualTimestamp)
-					baHeader.Txn.WriteTimestamp.Forward(wtoErr.ActualTimestamp)
-					baHeader.Txn.WriteTooOld = true
-				} else {
-					// For non-transactional requests, there's nowhere to defer the error
-					// to. And the request has to fail because non-transactional batches
-					// should read and write at the same timestamp.
-					writeTooOldState.cantDeferWTOE = true
-				}
-
-				// Clear error; we're done processing the WTOE for now and we'll return
-				// to considering it below after we've evaluated all requests.
-				err = nil
-			}
-		}
-
 		// Even on error, we need to propagate the result of evaluation.
 		//
 		// TODO(tbg): find out if that's true and why and improve the comment.
@@ -409,12 +333,38 @@ func evaluateBatch(
 			)
 		}
 
+		// Handle errors thrown by evaluation, either eagerly or through deferral.
 		if err != nil {
-			pErr := kvpb.NewErrorWithTxn(err, baHeader.Txn)
-			// Initialize the error index.
-			pErr.SetErrorIndex(int32(index))
+			var wtoErr *kvpb.WriteTooOldError
+			switch {
+			case errors.As(err, &wtoErr):
+				// We got a WriteTooOldError. We continue on to run all commands in the
+				// batch in order to determine the highest timestamp for more efficient
+				// retries.
+				if deferredWriteTooOldErr != nil {
+					deferredWriteTooOldErr.ActualTimestamp.Forward(wtoErr.ActualTimestamp)
+				} else {
+					deferredWriteTooOldErr = wtoErr
+				}
 
-			return nil, mergedResult, pErr
+				if baHeader.Txn != nil {
+					log.VEventf(ctx, 2, "advancing write timestamp due to "+
+						"WriteTooOld error on key: %s. wts: %s -> %s",
+						args.Header().Key, baHeader.Txn.WriteTimestamp, wtoErr.ActualTimestamp)
+					baHeader.Txn.WriteTimestamp.Forward(wtoErr.ActualTimestamp)
+				}
+
+				// Clear error and fall through to the success path; we're done
+				// processing the error for now. We'll return it below after we've
+				// evaluated all requests.
+				err = nil
+
+			default:
+				// For all other error types, immediately propagate the error.
+				pErr := kvpb.NewErrorWithTxn(err, baHeader.Txn)
+				pErr.SetErrorIndex(int32(index))
+				return nil, mergedResult, pErr
+			}
 		}
 
 		// If the last request was carried out with a limit, subtract the number
@@ -449,20 +399,16 @@ func evaluateBatch(
 	}
 
 	// If we made it here, there was no error during evaluation, with the exception of
-	// a deferred WTOE. If it can't be deferred - return it now; otherwise it is swallowed.
-	// Note that we don't attach an Index to the returned Error.
+	// a deferred WriteTooOld error. Return that now.
 	//
 	// TODO(tbg): we could attach the index of the first WriteTooOldError seen, but does
 	// that buy us anything?
-	if writeTooOldState.cantDeferWTOE {
+	if deferredWriteTooOldErr != nil {
 		// NB: we can't do any error wrapping here yet due to compatibility with 20.2 nodes;
 		// there needs to be an ErrorDetail here.
-		return nil, mergedResult, kvpb.NewErrorWithTxn(writeTooOldState.err, baHeader.Txn)
+		// TODO(nvanbenschoten): this comment is now stale. Address it.
+		return nil, mergedResult, kvpb.NewErrorWithTxn(deferredWriteTooOldErr, baHeader.Txn)
 	}
-
-	// The batch evaluation will not return an error (i.e. either everything went
-	// fine or we're deferring a WriteTooOldError by having bumped
-	// baHeader.Txn.WriteTimestamp).
 
 	// Update the batch response timestamp field to the timestamp at which the
 	// batch's reads were evaluated.
@@ -553,12 +499,13 @@ func evaluateCommand(
 	return pd, err
 }
 
-// canDoServersideRetry looks at the error produced by evaluating ba (or the
-// WriteTooOldFlag in br.Txn if there's no error) and decides if it's possible
-// to retry the batch evaluation at a higher timestamp. Retrying is sometimes
-// possible in case of some retriable errors which ask for higher timestamps:
-// for transactional requests, retrying is possible if the transaction had not
-// performed any prior reads that need refreshing.
+// canDoServersideRetry looks at the error produced by evaluating ba and decides
+// if it's possible to retry the batch evaluation at a higher timestamp.
+//
+// Retrying is sometimes possible in case of some retriable errors which ask for
+// higher timestamps. For transactional requests, retrying is possible if the
+// transaction had not performed any prior reads that need refreshing. For
+// non-transactional requests, retrying is always possible.
 //
 // This function is called both below and above latching, which is indicated by
 // the concurrency guard argument. The concurrency guard, if not nil, indicates
@@ -578,10 +525,12 @@ func canDoServersideRetry(
 	ctx context.Context,
 	pErr *kvpb.Error,
 	ba *kvpb.BatchRequest,
-	br *kvpb.BatchResponse,
 	g *concurrency.Guard,
 	deadline hlc.Timestamp,
 ) bool {
+	if pErr == nil {
+		log.Fatalf(ctx, "canDoServersideRetry called without error")
+	}
 	if ba.Txn != nil {
 		if !ba.CanForwardReadTimestamp {
 			return false
@@ -597,22 +546,12 @@ func canDoServersideRetry(
 
 	var newTimestamp hlc.Timestamp
 	if ba.Txn != nil {
-		if pErr != nil {
-			var ok bool
-			ok, newTimestamp = kvpb.TransactionRefreshTimestamp(pErr)
-			if !ok {
-				return false
-			}
-		} else {
-			if !br.Txn.WriteTooOld {
-				log.Fatalf(ctx, "expected the WriteTooOld flag to be set")
-			}
-			newTimestamp = br.Txn.WriteTimestamp
+		var ok bool
+		ok, newTimestamp = kvpb.TransactionRefreshTimestamp(pErr)
+		if !ok {
+			return false
 		}
 	} else {
-		if pErr == nil {
-			log.Fatalf(ctx, "canDoServersideRetry called for non-txn request without error")
-		}
 		switch tErr := pErr.GetDetail().(type) {
 		case *kvpb.WriteTooOldError:
 			newTimestamp = tErr.RetryTimestamp()

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -470,7 +470,7 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 		// retry at a higher timestamp because it is not isolated at higher
 		// timestamps.
 		latchesHeld := g != nil
-		if !latchesHeld || !canDoServersideRetry(ctx, pErr, ba, br, g, hlc.Timestamp{}) {
+		if !latchesHeld || !canDoServersideRetry(ctx, pErr, ba, g, hlc.Timestamp{}) {
 			// TODO(aayush,arul): These metrics are incorrect at the moment since
 			// hitting this branch does not mean that we won't serverside retry, it
 			// just means that we will have to reacquire latches.

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -806,7 +806,7 @@ func (r *Replica) handleReadWithinUncertaintyIntervalError(
 	// Attempt a server-side retry of the request. Note that we pass nil for
 	// latchSpans, because we have already released our latches and plan to
 	// re-acquire them if the retry is allowed.
-	if !canDoServersideRetry(ctx, pErr, ba, nil /* br */, nil /* g */, hlc.Timestamp{} /* deadline */) {
+	if !canDoServersideRetry(ctx, pErr, ba, nil /* g */, hlc.Timestamp{} /* deadline */) {
 		r.store.Metrics().ReadWithinUncertaintyIntervalErrorServerSideRetryFailure.Inc(1)
 		return nil, pErr
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -4733,13 +4733,19 @@ func TestRPCRetryProtectionInTxn(t *testing.T) {
 
 		// Replay the request. It initially tries to execute as a 1PC transaction,
 		// but will fail because of a WriteTooOldError that pushes the transaction.
-		// This forces the txn to execute normally, at which point it fails because
-		// the EndTxn is detected to be a duplicate.
+		// This forces the txn to execute normally, at which point it fails, either
+		// because of a WriteTooOld error, if it cannot server-side refresh, or
+		// because the EndTxn is detected to be a duplicate, if it can server-side
+		// refresh to avoid the WriteTooOld error. Either way, it fails.
 		_, pErr = tc.Sender().Send(ctx, ba)
 		require.NotNil(t, pErr)
-		require.Regexp(t,
-			`TransactionAbortedError\(ABORT_REASON_RECORD_ALREADY_WRITTEN_POSSIBLE_REPLAY\)`,
-			pErr)
+		var expRx string
+		if noPriorReads {
+			expRx = `TransactionAbortedError\(ABORT_REASON_RECORD_ALREADY_WRITTEN_POSSIBLE_REPLAY\)`
+		} else {
+			expRx = `WriteTooOldError`
+		}
+		require.Regexp(t, expRx, pErr)
 	})
 }
 
@@ -4817,7 +4823,7 @@ func TestBatchRetryCantCommitIntents(t *testing.T) {
 	// Send a put for keyA.
 	ba := &kvpb.BatchRequest{}
 	put := putArgs(key, []byte("value"))
-	ba.Header = kvpb.Header{Txn: txn}
+	ba.Header = kvpb.Header{Txn: txn, CanForwardReadTimestamp: true}
 	ba.Add(&put)
 	assignSeqNumsForReqs(txn, &put)
 	if err := ba.SetActiveTimestamp(tc.Clock()); err != nil {
@@ -4866,10 +4872,12 @@ func TestBatchRetryCantCommitIntents(t *testing.T) {
 	}
 
 	// Now replay put for key A; this succeeds as there's nothing to detect
-	// the replay. The WriteTooOld flag will be set though.
+	// the replay and server-side refreshes were permitted. The transaction's
+	// timestamp will be pushed due to the server-side refresh.
+	preReplayTxn := ba.Txn.Clone()
 	br, pErr = tc.Sender().Send(ctx, ba)
 	require.NoError(t, pErr.GoError())
-	require.True(t, br.Txn.WriteTooOld)
+	require.True(t, preReplayTxn.ReadTimestamp.Less(br.Txn.ReadTimestamp))
 
 	// Intent should have been created.
 	gArgs := getArgs(key)

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -667,21 +667,13 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 
 		batch, br, res, pErr = r.evaluateWriteBatchWrapper(ctx, idKey, rec, ms, ba, g, st, ui)
 
-		var success bool
-		if pErr == nil {
-			wto := br.Txn != nil && br.Txn.WriteTooOld
-			success = !wto
-		} else {
-			success = false
-		}
-
 		// Allow one retry only; a non-txn batch containing overlapping
 		// spans will always experience WriteTooOldError.
-		if success || retries > 0 {
+		if pErr == nil || retries > 0 {
 			break
 		}
 		// If we can retry, set a higher batch timestamp and continue.
-		if !canDoServersideRetry(ctx, pErr, ba, br, g, deadline) {
+		if !canDoServersideRetry(ctx, pErr, ba, g, deadline) {
 			r.store.Metrics().WriteEvaluationServerSideRetryFailure.Inc(1)
 			break
 		} else {

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -454,6 +454,9 @@ message Transaction {
   // with a bumped write timestamp, so this flag is only telling us that a
   // refresh is less likely to succeed than in other cases where
   // ReadTimestamp != WriteTimestamp.
+  //
+  // TODO(nvanbenschoten): this flag is no longer assigned by v23.2 nodes.
+  // Remove it when compatibility with v23.1 nodes is no longer a concern.
   bool write_too_old = 12;
   // Set of spans that the transaction has acquired locks within. These are
   // spans which must be resolved on txn completion. Note that these spans

--- a/pkg/storage/metamorphic/testdata/sample.meta
+++ b/pkg/storage/metamorphic/testdata/sample.meta
@@ -151,7 +151,7 @@ mvcc_put(engine, t3, "yggswhfeyqv"/6, etewicdmbq) -> ok
 iterator_seekge(iter2, "wbpcepef"/6) -> valid = false
 mvcc_get(engine, "uwdvyohbpsgcr"/6, t2) -> val = <nil>, intent = <nil>
 ingest("rfdgrsmg"/6, "gukoaxqohrakhx"/4, "tjbotfrbtxoyta"/6, "tjbotfrbtxoyta"/6, "snoojmhoaqte"/6) -> ok
-mvcc_put(engine, t3, "tjbotfrbtxoyta"/6, svyqs) -> error: WriteTooOldError: write for key "tjbotfrbtxoyta" at timestamp 0.000000005,0 too old; wrote at 0.000000006,1
+mvcc_put(engine, t3, "tjbotfrbtxoyta"/6, svyqs) -> error: WriteTooOldError: write for key "tjbotfrbtxoyta" at timestamp 0.000000005,0 too old; must write at or above 0.000000006,1
 mvcc_put(engine, t2, "gukoaxqohrakhx"/4, edqawhknloa) -> ok
 mvcc_put(engine, t3, "qpdaulhik"/6, rkuhimkl) -> ok
 mvcc_reverse_scan("snoojmhoaqte"/6, "yggswhfeyqv"/6, t2, 0.5142, 0.1074, false, true) -> kvs = [{"wbpcepef" {[0 0 0 0 3 104 104 103 108 100 113 108 116 117 100 109 103 114] 0.000000003,0}} {"tktluohcljr" {[0 0 0 0 3 117 109 113 116 107 119 117 113 108 112] 0.000000003,0}}], intents = [], resumeSpan = <nil>, numBytes = 88, numKeys = 2

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -360,7 +360,7 @@ func TestMVCCWriteWithOlderTimestampAfterDeletionOfNonexistentKey(t *testing.T) 
 	}
 
 	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); !testutils.IsError(
-		err, "write for key \"/db1\" at timestamp 0.000000001,0 too old; wrote at 0.000000003,1",
+		err, "write for key \"/db1\" at timestamp 0.000000001,0 too old; must write at or above 0.000000003,1",
 	) {
 		t.Fatal(err)
 	}

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
@@ -74,7 +74,7 @@ cput k=k v=v4 cond=v3 ts=123
 >> at end:
 data: "k"/124.000000000,1 -> /BYTES/v4
 data: "k"/124.000000000,0 -> {localTs=123.000000000,0}/BYTES/v3
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 123.000000000,0 too old; wrote at 124.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 123.000000000,0 too old; must write at or above 124.000000000,1
 
 # Reset for next test
 

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
@@ -25,7 +25,7 @@ cput ts=1 k=k v=v2 cond=v1
 >> at end:
 data: "k"/10.000000000,1 -> /BYTES/v2
 data: "k"/10.000000000,0 -> /BYTES/v1
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; wrote at 10.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 10.000000000,1
 
 # Try a transactional put @t=1 with expectation of value2; should fail.
 run error
@@ -49,4 +49,4 @@ meta: "k"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "k"/10.000000000,2 -> /BYTES/v3
 data: "k"/10.000000000,1 -> /BYTES/v2
 data: "k"/10.000000000,0 -> /BYTES/v1
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; wrote at 10.000000000,2
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 10.000000000,2

--- a/pkg/storage/testdata/mvcc_histories/delete_range
+++ b/pkg/storage/testdata/mvcc_histories/delete_range
@@ -137,7 +137,7 @@ data: "c/123"/47.000000000,0 -> /<empty>
 data: "c/123"/44.000000000,0 -> /BYTES/abc
 data: "d"/44.000000000,0 -> /BYTES/abc
 data: "d/123"/44.000000000,0 -> /BYTES/abc
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 46.000000000,0 too old; wrote at 47.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 46.000000000,0 too old; must write at or above 47.000000000,1
 
 run ok
 txn_remove t=A

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate
@@ -149,7 +149,7 @@ data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
 stats: key_count=9 key_bytes=174 val_count=13 val_bytes=118 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=4 live_bytes=132 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 5.000000000,0 too old; wrote at 5.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 5.000000000,0 too old; must write at or above 5.000000000,1
 
 # error encountering range key at k4.
 # a tombstones should not get written to j4 or q4 since
@@ -185,7 +185,7 @@ data: "i"/7.000000000,0 -> /BYTES/i7
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
 stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=6 live_bytes=174 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 # At this point the keyspace looks like this:
 # 7                                [i7]

--- a/pkg/storage/testdata/mvcc_histories/deletes
+++ b/pkg/storage/testdata/mvcc_histories/deletes
@@ -105,7 +105,7 @@ data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
 data: "a"/44.000000000,0 -> /<empty>
 data: "b"/49.000000000,0 -> /<empty>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 43.000000000,0 too old; wrote at 50.000000000,0
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 43.000000000,0 too old; must write at or above 50.000000000,0
 
 run ok
 with t=A
@@ -135,7 +135,7 @@ data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
 data: "a"/44.000000000,0 -> /<empty>
 data: "b"/49.000000000,0 -> /<empty>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 44.000000000,0 too old; wrote at 50.000000000,0
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 44.000000000,0 too old; must write at or above 50.000000000,0
 
 run ok
 with t=A
@@ -165,7 +165,7 @@ data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
 data: "a"/44.000000000,0 -> /<empty>
 data: "b"/49.000000000,0 -> /<empty>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 46.000000000,0 too old; wrote at 50.000000000,0
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 46.000000000,0 too old; must write at or above 50.000000000,0
 
 run ok
 with t=A
@@ -195,7 +195,7 @@ data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
 data: "a"/44.000000000,0 -> /<empty>
 data: "b"/49.000000000,0 -> /<empty>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 47.000000000,0 too old; wrote at 50.000000000,0
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 47.000000000,0 too old; must write at or above 50.000000000,0
 
 run ok
 with t=A

--- a/pkg/storage/testdata/mvcc_histories/increment
+++ b/pkg/storage/testdata/mvcc_histories/increment
@@ -73,7 +73,7 @@ data: "k"/0,1 -> /INT/2
 data: "r"/3.000000000,1 -> /INT/3
 data: "r"/3.000000000,0 -> /INT/2
 data: "r"/1.000000000,0 -> /INT/1
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "r" at timestamp 2.000000000,0 too old; wrote at 3.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "r" at timestamp 2.000000000,0 too old; must write at or above 3.000000000,1
 
 # Ditto with transactional.
 run error
@@ -90,4 +90,4 @@ data: "r"/3.000000000,2 -> /INT/2
 data: "r"/3.000000000,1 -> /INT/3
 data: "r"/3.000000000,0 -> /INT/2
 data: "r"/1.000000000,0 -> /INT/1
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "r" at timestamp 2.000000000,0 too old; wrote at 3.000000000,2
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "r" at timestamp 2.000000000,0 too old; must write at or above 3.000000000,2

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
@@ -121,7 +121,7 @@ data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
 stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 5.000000000,0 too old; wrote at 5.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 5.000000000,0 too old; must write at or above 5.000000000,1
 
 # Point key below range tombstones should error, but is written anyway at a
 # higher timestamp. Stats are updated correctly, even when there are
@@ -145,7 +145,7 @@ data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
 stats: key_count=7 key_bytes=122 val_count=9 val_bytes=101 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=2 live_bytes=89 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; wrote at 5.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; must write at or above 5.000000000,1
 
 run stats error
 put k=d ts=3 v=d3
@@ -167,7 +167,7 @@ data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
 stats: key_count=7 key_bytes=134 val_count=10 val_bytes=108 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=3 live_bytes=110 gc_bytes_age=16206 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 3.000000000,0 too old; wrote at 5.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 3.000000000,0 too old; must write at or above 5.000000000,1
 
 run stats error
 put k=e ts=3 v=e3
@@ -190,7 +190,7 @@ data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
 stats: key_count=7 key_bytes=146 val_count=11 val_bytes=115 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=4 live_bytes=131 gc_bytes_age=16010 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "e" at timestamp 3.000000000,0 too old; wrote at 5.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "e" at timestamp 3.000000000,0 too old; must write at or above 5.000000000,1
 
 # CPuts expecting a value covered by a range tombstone should error.
 run stats error
@@ -345,7 +345,7 @@ data: "i"/5.000000000,1 -> /INT/1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
 stats: key_count=7 key_bytes=170 val_count=13 val_bytes=128 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=6 live_bytes=172 gc_bytes_age=15622 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "i" at timestamp 2.000000000,0 too old; wrote at 5.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "i" at timestamp 2.000000000,0 too old; must write at or above 5.000000000,1
 
 # An increment above a range tombstone should reset to 1.
 run stats ok

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
@@ -331,25 +331,25 @@ run error
 get k=c ts=1 failOnMoreRecent
 ----
 get: "c" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 1.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 1.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 get k=c ts=2 failOnMoreRecent
 ----
 get: "c" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 2.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 2.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 get k=c ts=3 failOnMoreRecent
 ----
 get: "c" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 get k=c ts=4 failOnMoreRecent
 ----
 get: "c" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 run ok
 get k=c ts=5 failOnMoreRecent
@@ -380,13 +380,13 @@ run error
 get k=g ts=3 failOnMoreRecent
 ----
 get: "g" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "g" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "g" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 get k=g ts=4 failOnMoreRecent
 ----
 get: "g" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "g" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "g" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 run ok
 get k=g ts=5 failOnMoreRecent

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
@@ -383,13 +383,13 @@ run error
 scan k=a end=d ts=3 failOnMoreRecent
 ----
 scan: "a"-"d" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 scan k=a end=d ts=4 failOnMoreRecent
 ----
 scan: "a"-"d" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 run ok
 scan k=a end=d ts=5 failOnMoreRecent
@@ -401,25 +401,25 @@ run error
 scan k=c end=d ts=1 failOnMoreRecent
 ----
 scan: "c"-"d" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 1.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 1.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 scan k=c end=d ts=2 failOnMoreRecent
 ----
 scan: "c"-"d" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 2.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 2.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 scan k=c end=d ts=3 failOnMoreRecent
 ----
 scan: "c"-"d" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 scan k=c end=d ts=4 failOnMoreRecent
 ----
 scan: "c"-"d" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 run ok
 scan k=c end=d ts=5 failOnMoreRecent
@@ -450,13 +450,13 @@ run error
 scan k=g end=h ts=3 failOnMoreRecent
 ----
 scan: "g"-"h" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "g" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "g" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 scan k=g end=h ts=4 failOnMoreRecent
 ----
 scan: "g"-"h" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "g" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "g" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 run ok
 scan k=g end=h ts=5 failOnMoreRecent

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
@@ -122,7 +122,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 del_range_ts k=a end=b ts=4
@@ -141,7 +141,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 del_range_ts k=e end=g ts=3
@@ -160,7 +160,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "f" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "f" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 # Writing at or below existing range tombstones should return a WriteTooOldError,
 # regardless of how they overlap.
@@ -181,7 +181,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 del_range_ts k=k end=p ts=4
@@ -200,7 +200,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 del_range_ts k=j end=m ts=3
@@ -219,7 +219,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 del_range_ts k=o end=q ts=3
@@ -238,7 +238,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "o" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "o" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 del_range_ts k=j end=q ts=3
@@ -257,7 +257,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 del_range_ts k=k end=n ts=3
@@ -276,7 +276,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 # Writing below intents should return a WriteIntentError, both when above and
 # below the intent timestamp and any existing values.

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
@@ -70,7 +70,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "e" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "e" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 del_range_ts k=f end=g ts=3 idempotent
@@ -91,7 +91,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "f" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "f" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 del_range_ts k=l end=m ts=3 idempotent
@@ -112,7 +112,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "l" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "l" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 # Writing at the timestamp of a point or range key errors.
 run error
@@ -134,7 +134,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "e" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "e" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 del_range_ts k=l end=m ts=4 idempotent
@@ -155,7 +155,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "l" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "l" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 # Writing below intents error.
 run error

--- a/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
+++ b/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
@@ -37,7 +37,7 @@ run error
 get k=k1 ts=9,0 failOnMoreRecent
 ----
 get: "k1" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 9.000000000,0 too old; wrote at 10.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 9.000000000,0 too old; must write at or above 10.000000000,1
 
 run ok
 get k=k1 ts=10,0
@@ -48,7 +48,7 @@ run error
 get k=k1 ts=10,0 failOnMoreRecent
 ----
 get: "k1" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; wrote at 10.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; must write at or above 10.000000000,1
 
 run ok
 get k=k1 ts=11,0
@@ -69,7 +69,7 @@ run error
 scan k=k1 end=k2 ts=9,0 failOnMoreRecent
 ----
 scan: "k1"-"k2" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 9.000000000,0 too old; wrote at 10.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 9.000000000,0 too old; must write at or above 10.000000000,1
 
 run ok
 scan k=k1 end=k2 ts=10,0
@@ -80,7 +80,7 @@ run error
 scan k=k1 end=k2 ts=10,0 failOnMoreRecent
 ----
 scan: "k1"-"k2" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; wrote at 10.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; must write at or above 10.000000000,1
 
 run ok
 scan k=k1 end=k2 ts=11,0
@@ -180,7 +180,7 @@ run error
 scan k=k1 end=k3 ts=9,0 failOnMoreRecent
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 9.000000000,0 too old; wrote at 10.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 9.000000000,0 too old; must write at or above 10.000000000,1
 
 run error
 scan k=k1 end=k3 ts=10,0
@@ -192,7 +192,7 @@ run error
 scan k=k1 end=k3 ts=10,0 failOnMoreRecent
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; wrote at 10.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; must write at or above 10.000000000,1
 
 run error
 scan k=k1 end=k3 ts=11,0
@@ -241,16 +241,16 @@ run error
 scan k=a end=b_next ts=9,0 failOnMoreRecent
 ----
 scan: "a"-"b_next" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 9.000000000,0 too old; wrote at 13.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 9.000000000,0 too old; must write at or above 13.000000000,1
 
 run error
 scan k=a end=c_next ts=9,0 failOnMoreRecent
 ----
 scan: "a"-"c_next" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 9.000000000,0 too old; wrote at 13.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 9.000000000,0 too old; must write at or above 13.000000000,1
 
 run error
 scan k=b end=c_next ts=9,0 failOnMoreRecent
 ----
 scan: "b"-"c_next" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "b" at timestamp 9.000000000,0 too old; wrote at 13.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "b" at timestamp 9.000000000,0 too old; must write at or above 13.000000000,1

--- a/pkg/storage/testdata/mvcc_histories/skip_locked
+++ b/pkg/storage/testdata/mvcc_histories/skip_locked
@@ -620,7 +620,7 @@ run error
 get ts=10 k=k1 skipLocked failOnMoreRecent
 ----
 get: "k1" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; wrote at 11.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; must write at or above 11.000000000,1
 
 run ok
 get ts=10 k=k2 skipLocked failOnMoreRecent
@@ -644,25 +644,25 @@ run error
 get ts=10 k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 10.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 10.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=10 k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=10 k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 10.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 10.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 get ts=11 k=k1 skipLocked failOnMoreRecent
 ----
 get: "k1" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 11.000000000,0 too old; wrote at 11.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 11.000000000,0 too old; must write at or above 11.000000000,1
 
 run ok
 get ts=11 k=k2 skipLocked failOnMoreRecent
@@ -686,19 +686,19 @@ run error
 get ts=11 k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 11.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 11.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=11 k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 11.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 11.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=11 k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 11.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 11.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=12 k=k1 skipLocked failOnMoreRecent
@@ -727,19 +727,19 @@ run error
 get ts=12 k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=12 k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=12 k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=12 t=A k=k1 skipLocked failOnMoreRecent
@@ -768,19 +768,19 @@ run error
 get ts=12 t=A k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=12 t=A k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=12 t=A k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=13 k=k1 skipLocked failOnMoreRecent
@@ -809,19 +809,19 @@ run error
 get ts=13 k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=13 k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=13 k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=13 t=B k=k1 skipLocked failOnMoreRecent
@@ -849,19 +849,19 @@ run error
 get ts=13 t=B k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=13 t=B k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=13 t=B k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=14 k=k1 skipLocked failOnMoreRecent
@@ -890,19 +890,19 @@ run error
 get ts=14 k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=14 k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=14 k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=14 t=C k=k1 skipLocked failOnMoreRecent
@@ -930,19 +930,19 @@ run error
 get ts=14 t=C k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=14 t=C k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=14 t=C k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=15 k=k1 skipLocked failOnMoreRecent
@@ -971,19 +971,19 @@ run error
 get ts=15 k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=15 k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=15 k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=15 t=D k=k1 skipLocked failOnMoreRecent
@@ -1012,19 +1012,19 @@ run error
 get ts=15 t=D k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=15 t=D k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=15 t=D k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=16 k=k1 skipLocked failOnMoreRecent
@@ -1053,19 +1053,19 @@ run error
 get ts=16 k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=16 k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=16 k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=16 t=E k=k1 skipLocked failOnMoreRecent
@@ -1093,19 +1093,19 @@ run error
 get ts=16 t=E k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=16 t=E k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=16 t=E k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=17 k=k1 skipLocked failOnMoreRecent
@@ -1134,19 +1134,19 @@ run error
 get ts=17 k=k5 skipLocked failOnMoreRecent
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=17 k=k1 end=k6 skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
 scan ts=17 k=k1 end=k6 reverse skipLocked failOnMoreRecent
 ----
 scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; wrote at 17.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
 get ts=18 k=k1 skipLocked failOnMoreRecent

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_old_version
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_old_version
@@ -14,7 +14,7 @@ put k=k v=v2 ts=0,1
 >> at end:
 data: "k"/1.000000000,2 -> /BYTES/v2
 data: "k"/1.000000000,1 -> /BYTES/v
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 0,1 too old; wrote at 1.000000000,2
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 0,1 too old; must write at or above 1.000000000,2
 
 # Earlier logical time.
 
@@ -25,4 +25,4 @@ put k=k v=v2 ts=1,0
 data: "k"/1.000000000,3 -> /BYTES/v2
 data: "k"/1.000000000,2 -> /BYTES/v2
 data: "k"/1.000000000,1 -> /BYTES/v
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; wrote at 1.000000000,3
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 1.000000000,3

--- a/pkg/storage/testdata/mvcc_histories/write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/write_too_old
@@ -25,7 +25,7 @@ txn: "A" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.
 meta: "a"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,1 min=0,0 seq=0} ts=44.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/44.000000000,1 -> /<empty>
 data: "a"/44.000000000,0 -> /BYTES/abc
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 33.000000000,0 too old; wrote at 44.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 33.000000000,0 too old; must write at or above 44.000000000,1
 
 run ok
 resolve_intent t=A k=a status=ABORTED
@@ -48,7 +48,7 @@ txn: "B" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.
 meta: "a"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,1 min=0,0 seq=0} ts=44.000000000,1 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/44.000000000,1 -> /BYTES/def
 data: "a"/44.000000000,0 -> /BYTES/abc
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 33.000000000,0 too old; wrote at 44.000000000,1
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 33.000000000,0 too old; must write at or above 44.000000000,1
 
 run ok
 resolve_intent t=B k=a status=ABORTED


### PR DESCRIPTION
KV half of #102751.

This commit eliminates the write-too-old deferral mechanism, where blind-write BatchRequests that hit a WriteTooOld error would successfully write intents and then return a Transaction proto with the WriteTooOld flag to the client. The client would then immediately refresh to remove this flag. However, in the intermediate period, the written intents would act as locks to ensure that if the refresh succeeded, the writer would have exclusive access to the previously written keys and would not hit a WriteTooOld error on its next attempt.

The rationale for the removal of this mechanism is outlined in #102751. At a high-level, the mechanism is complex, error-prone, and sufficiently unnecessary today due to unreplicated locks and server-side refreshes. It also interacts poorly with weak isolation levels, which further motivates its removal.

Cases where the write-too-old deferral mechanism is still hypothetically useful are difficult to construct, especially from SQL's limited use of KV. They require the following conditions to all hold:

1. a blind-writing BatchRequest (containing Put or Delete, but not ConditionalPut)
2. a BatchRequest without the CanForwardReadTimestamp flag (needs client-side refresh)
3. a write-write conflict that will not cause a refresh to fail

These requirement are almost always contradictory. A write-write conflict implies a failed refresh if the refresher has already read the conflicting key. So the cases where this mechanism help are limited to those where the writer has not already read the conflicting key. However, SQL rarely issues blind-write KV requests keys that it has not already read. The cases where this might come up are fast-path DELETE statements that issue DeleteRequest (not DeleteRangeRequest) and fast-path UPSERT statements that write all columns in a table. If either of these are heavily contended and take place in multi-statement transactions that previously read, this mechanism could help. However, I suspect that these scenarios are very uncommon. If customers do see them, they can avoid problems by using SELECT FOR UPDATE earlier in the transaction or by using Read Committed (which effectively resets the CanForwardReadTimestamp flag on each statement boundary).

The commit does not yet remove the Transaction.WriteTooOld field, as this must remain until compatibility with v23.1 nodes is no longer a concern.

Release note: None