### PR TITLE
storage: don't write intents on write-too-old errors

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -2589,9 +2589,10 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *kv.Txn) error {
 				return txn.CPut(ctx, "a", "cput", kvclientutils.StrToCPutExistingValue("put"))
 			},
+			// The transaction performs a server-side refresh due to the write-write
+			// conflict and then succeeds during its CPut.
 			allIsoLevels: &expect{
-				expClientAutoRetryAfterRefresh: false,              // fails on first attempt at cput
-				expFailure:                     "unexpected value", // the failure we get is a condition failed error
+				expServerRefresh: true,
 			},
 		},
 		{
@@ -2779,9 +2780,10 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *kv.Txn) error {
 				return txn.InitPut(ctx, "iput", "put2", false)
 			},
-			// No txn coord retry as we get condition failed error.
+			// The transaction performs a server-side refresh due to the write-write
+			// conflict and then succeeds during its InitPut.
 			allIsoLevels: &expect{
-				expFailure: "unexpected value", // the failure we get is a condition failed error
+				expServerRefresh: true,
 			},
 		},
 		{
@@ -2796,8 +2798,10 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *kv.Txn) error {
 				return txn.InitPut(ctx, "iput", "put2", true)
 			},
+			// The transaction performs a server-side refresh due to the write-write
+			// conflict and then succeeds during its InitPut.
 			allIsoLevels: &expect{
-				expFailure: "unexpected value", // condition failed error when failing on tombstones
+				expServerRefresh: true,
 			},
 		},
 		{

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1719,8 +1719,7 @@ func replayTransactionalWrite(
 //
 // The returned boolean indicates whether the put replaced an existing live key
 // (including one written previously by the same transaction). This is evaluated
-// at the transaction's read timestamp, and may not be valid when
-// `WriteTooOldError` is returned having written at a higher timestamp.
+// at the transaction's read timestamp.
 // TODO(erikgrinaker): This return value exists solely because valueFn incurs an
 // additional seek via maybeGetValue(). In most cases we have already read the
 // value via other means, e.g. mvccGetMetadata(). We should restructure the code
@@ -1846,7 +1845,6 @@ func mvccPutInternal(
 		IntentHistory: buf.meta.IntentHistory,
 	}
 
-	var maybeTooOldErr error
 	var prevIsValue bool
 	var prevValSize int64
 	var exReplaced bool
@@ -2061,19 +2059,11 @@ func mvccPutInternal(
 				buf.newMeta.IntentHistory = nil
 			}
 		} else if readTimestamp.LessEq(metaTimestamp) {
-			// This is the case where we're trying to write under a committed
-			// value. Obviously we can't do that, but we can increment our
-			// timestamp to one logical tick past the existing value and go on
-			// to write, but then also return a write-too-old error indicating
-			// what the timestamp ended up being. This timestamp can then be
-			// used to increment the txn timestamp and be returned with the
-			// response.
-			//
-			// For this to work, this function needs to complete its mutation to
-			// the Writer even if it plans to return a write-too-old error. This
-			// allows logic that lives in evaluateBatch to determine what to do
-			// with the error and whether it should prevent the batch from being
-			// proposed or not.
+			// This is the case where we're trying to write under a committed value.
+			// Obviously we can't do that. We return a write-too-old error indicating
+			// the earliest valid timestamp that the writer would be able to perform
+			// such a write. This timestamp can then be used to increment the txn
+			// timestamp.
 			//
 			// NB: even if metaTimestamp is less than writeTimestamp, we can't
 			// avoid the WriteTooOld error if metaTimestamp is equal to or
@@ -2083,28 +2073,28 @@ func mvccPutInternal(
 			// instead of allowing their transactions to continue and be retried
 			// before committing.
 			writeTimestamp.Forward(metaTimestamp.Next())
-			maybeTooOldErr = kvpb.NewWriteTooOldError(readTimestamp, writeTimestamp, key)
-			// If we're in a transaction, always get the value at the orig
-			// timestamp. Outside of a transaction, the read timestamp advances
-			// to the the latest value's timestamp + 1 as well. The new
-			// timestamp is returned to the caller in maybeTooOldErr. Because
-			// we're outside of a transaction, we'll never actually commit this
-			// value, but that's a concern of evaluateBatch and not here.
-			if txn == nil {
-				readTimestamp = writeTimestamp
-			}
-			// Inject a function to inspect the existing value at readTimestamp and
-			// populate exReplaced.
-			exReplacedFn := func(exVal optionalValue) (roachpb.Value, error) {
-				exReplaced = exVal.IsPresent()
-				if valueFn != nil {
-					return valueFn(exVal)
+			writeTooOldErr := kvpb.NewWriteTooOldError(readTimestamp, writeTimestamp, key)
+			{
+				// NOTE TO REVIEWERS: the code currently favors ConditionFailedErrors
+				// over WriteTooOldErrors, and jumps through some hoops to make sure
+				// that this works correctly. The following commit will remove this
+				// behavior and update tests accordingly. For this commit, we keep the
+				// existing behavior to avoid multiple moving parts.
+
+				// If we're in a transaction, always get the value at the orig
+				// timestamp. Outside of a transaction, the read timestamp advances
+				// to the the latest value's timestamp + 1 as well. The new
+				// timestamp is returned to the caller in maybeTooOldErr. Because
+				// we're outside of a transaction, we'll never actually commit this
+				// value, but that's a concern of evaluateBatch and not here.
+				if txn == nil {
+					readTimestamp = writeTimestamp
 				}
-				return value, nil // pass through original value
+				if _, err = maybeGetValue(ctx, iter, key, value, ok, readTimestamp, valueFn); err != nil {
+					return false, err
+				}
 			}
-			if value, err = maybeGetValue(ctx, iter, key, value, ok, readTimestamp, exReplacedFn); err != nil {
-				return false, err
-			}
+			return false, writeTooOldErr
 		} else {
 			if value, err = maybeGetValue(ctx, iter, key, value, ok, readTimestamp, valueFn); err != nil {
 				return false, err
@@ -2228,7 +2218,7 @@ func mvccPutInternal(
 	}
 	writer.LogLogicalOp(logicalOp, logicalOpDetails)
 
-	return exReplaced, maybeTooOldErr
+	return exReplaced, nil
 }
 
 // MVCCIncrement fetches the value for key, and assuming the value is

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -348,49 +348,24 @@ func TestMVCCGetWithValueHeader(t *testing.T) {
 // TestMVCCWriteWithOlderTimestampAfterDeletionOfNonexistentKey tests a write
 // that comes after a delete on a nonexistent key, with the write holding a
 // timestamp earlier than the delete timestamp. The delete must write a
-// tombstone with its timestamp in order to push the write's timestamp.
+// tombstone with its timestamp in order to prevent the write from succeeding.
 func TestMVCCWriteWithOlderTimestampAfterDeletionOfNonexistentKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if _, err := MVCCDelete(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, nil); err != nil {
-		t.Fatal(err)
-	}
+	_, err := MVCCDelete(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, nil)
+	require.NoError(t, err)
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); !testutils.IsError(
-		err, "write for key \"/db1\" at timestamp 0.000000001,0 too old; must write at or above 0.000000003,1",
-	) {
-		t.Fatal(err)
-	}
+	err = MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil)
+	require.ErrorAs(t, err, new(*kvpb.WriteTooOldError))
+	require.Regexp(t, err, "WriteTooOldError: write for key \"/db1\" at timestamp 0.000000001,0 too old; must write at or above 0.000000003,1")
 
-	valueRes, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2},
-		MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	// The attempted write at ts(1,0) was performed at ts(3,1), so we should
-	// not see it at ts(2,0).
-	if valueRes.Value != nil {
-		t.Fatalf("value present at TS = %s", valueRes.Value.Timestamp)
-	}
-
-	// Read the latest version which will be the value written with the timestamp pushed.
-	valueRes, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 4},
-		MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if valueRes.Value == nil {
-		t.Fatal("value doesn't exist")
-	}
-	if !bytes.Equal(valueRes.Value.RawBytes, value1.RawBytes) {
-		t.Errorf("expected %q; got %q", value1.RawBytes, valueRes.Value.RawBytes)
-	}
-	if expTS := (hlc.Timestamp{WallTime: 3, Logical: 1}); valueRes.Value.Timestamp != expTS {
-		t.Fatalf("timestamp was not pushed: %s, expected %s", valueRes.Value.Timestamp, expTS)
-	}
+	// The attempted write at ts(1,0) failed, so we should not be able to see it.
+	valueRes, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{})
+	require.NoError(t, err)
+	require.False(t, valueRes.Value.IsPresent())
 }
 
 func TestMVCCInlineWithTxn(t *testing.T) {
@@ -2854,46 +2829,30 @@ func TestMVCCConditionalPutOldTimestamp(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value2, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	// Check nothing is written if the value doesn't match.
+	// Check that a condition failed error is thrown if the value doesn't match.
 	err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, value3, value1.TagAndDataBytes(), CPutFailIfMissing, nil)
-	if err == nil {
-		t.Errorf("unexpected success on conditional put")
-	}
-	if !errors.HasType(err, (*kvpb.ConditionFailedError)(nil)) {
-		t.Errorf("unexpected error on conditional put: %+v", err)
-	}
+	require.ErrorAs(t, err, new(*kvpb.ConditionFailedError))
 
 	// But if value does match the most recently written version, we'll get
-	// a write too old error but still write updated value.
+	// a write too old error.
 	err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, value3, value2.TagAndDataBytes(), CPutFailIfMissing, nil)
-	if err == nil {
-		t.Errorf("unexpected success on conditional put")
-	}
-	if !errors.HasType(err, (*kvpb.WriteTooOldError)(nil)) {
-		t.Errorf("unexpected error on conditional put: %+v", err)
-	}
-	// Verify new value was actually written at (3, 1).
-	ts := hlc.Timestamp{WallTime: 3, Logical: 1}
+	require.ErrorAs(t, err, new(*kvpb.WriteTooOldError))
+
+	// Either way, no new value is written.
+	ts := hlc.Timestamp{WallTime: 3}
 	valueRes, err := MVCCGet(ctx, engine, testKey1, ts, MVCCGetOptions{})
-	if err != nil || valueRes.Value.Timestamp != ts || !bytes.Equal(value3.RawBytes, valueRes.Value.RawBytes) {
-		t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
-			err, valueRes.Value.Timestamp, ts, value3.RawBytes, valueRes.Value.RawBytes)
-	}
+	require.NoError(t, err)
+	require.Equal(t, value2.RawBytes, valueRes.Value.RawBytes)
 }
 
-// TestMVCCMultiplePutOldTimestamp tests a case where multiple
-// transactional Puts occur to the same key, but with older timestamps
-// than a pre-existing key. The first should generate a
-// WriteTooOldError and write at a higher timestamp. The second should
-// avoid the WriteTooOldError but also write at the higher timestamp.
+// TestMVCCMultiplePutOldTimestamp tests a case where multiple transactional
+// Puts occur to the same key, but with older timestamps than a pre-existing
+// key. The first should generate a WriteTooOldError and fail to write. The
+// second should avoid the WriteTooOldError and write at the higher timestamp.
 func TestMVCCMultiplePutOldTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2903,45 +2862,33 @@ func TestMVCCMultiplePutOldTimestamp(t *testing.T) {
 	defer engine.Close()
 
 	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value1, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	// Verify the first txn Put returns a write too old error, but the
-	// intent is written at the advanced timestamp.
+	// Verify the first txn Put returns a write too old error and does not
+	// write a new value.
 	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
 	txn.Sequence++
 	err = MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn)
-	if !errors.HasType(err, (*kvpb.WriteTooOldError)(nil)) {
-		t.Errorf("expected WriteTooOldError on Put; got %v", err)
-	}
-	// Verify new value was actually written at (3, 1).
-	valueRes, err := MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{Txn: txn})
-	if err != nil {
-		t.Fatal(err)
-	}
+	var wtoErr *kvpb.WriteTooOldError
+	require.ErrorAs(t, err, &wtoErr)
 	expTS := hlc.Timestamp{WallTime: 3, Logical: 1}
-	if valueRes.Value.Timestamp != expTS || !bytes.Equal(value2.RawBytes, valueRes.Value.RawBytes) {
-		t.Fatalf("expected timestamp=%s (got %s), value=%q (got %q)",
-			valueRes.Value.Timestamp, expTS, value2.RawBytes, valueRes.Value.RawBytes)
-	}
+	require.Equal(t, expTS, wtoErr.ActualTimestamp)
+	// Verify no value was written.
+	valueRes, err := MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{Txn: txn})
+	require.NoError(t, err)
+	require.Equal(t, value1.RawBytes, valueRes.Value.RawBytes)
 
-	// Put again and verify no WriteTooOldError, but timestamp should continue
-	// to be set to (3,1).
+	// Put again after advancing the txn's timestamp to the WriteTooOld error's
+	// timestamp and verify no WriteTooOldError.
+	txn.Refresh(wtoErr.ActualTimestamp)
 	txn.Sequence++
 	err = MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	// Verify new value was actually written at (3, 1).
 	valueRes, err = MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{Txn: txn})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if valueRes.Value.Timestamp != expTS || !bytes.Equal(value3.RawBytes, valueRes.Value.RawBytes) {
-		t.Fatalf("expected timestamp=%s (got %s), value=%q (got %q)",
-			valueRes.Value.Timestamp, expTS, value3.RawBytes, valueRes.Value.RawBytes)
-	}
+	require.NoError(t, err)
+	require.Equal(t, expTS, valueRes.Value.Timestamp)
+	require.Equal(t, value3.RawBytes, valueRes.Value.RawBytes)
 }
 
 func TestMVCCPutNegativeTimestampError(t *testing.T) {
@@ -2961,9 +2908,7 @@ func TestMVCCPutNegativeTimestampError(t *testing.T) {
 // TestMVCCPutOldOrigTimestampNewCommitTimestamp tests a case where a
 // transactional Put occurs to the same key, but with an older original
 // timestamp than a pre-existing key. As always, this should result in a
-// WriteTooOld error. However, in this case the transaction has a larger
-// provisional commit timestamp than the pre-existing key. It should write
-// its intent at this timestamp instead of directly above the existing key.
+// WriteTooOld error.
 func TestMVCCPutOldOrigTimestampNewCommitTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2973,13 +2918,11 @@ func TestMVCCPutOldOrigTimestampNewCommitTimestamp(t *testing.T) {
 	defer engine.Close()
 
 	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value1, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	// Perform a transactional Put with a transaction whose original timestamp is
-	// below the existing key's timestamp and whose provisional commit timestamp
-	// is above the existing key's timestamp.
+	// Perform a transactional Put with a transaction whose read timestamp is
+	// below the existing key's timestamp and whose write timestamp is above the
+	// existing key's timestamp.
 	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
 	txn.WriteTimestamp = hlc.Timestamp{WallTime: 5}
 	txn.Sequence++
@@ -2988,20 +2931,14 @@ func TestMVCCPutOldOrigTimestampNewCommitTimestamp(t *testing.T) {
 	// Verify that the Put returned a WriteTooOld with the ActualTime set to the
 	// transactions provisional commit timestamp.
 	expTS := txn.WriteTimestamp
-	if wtoErr := (*kvpb.WriteTooOldError)(nil); !errors.As(err, &wtoErr) || wtoErr.ActualTimestamp != expTS {
-		t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, wtoErr)
-	}
+	var wtoErr *kvpb.WriteTooOldError
+	require.ErrorAs(t, err, &wtoErr)
+	require.Equal(t, expTS, wtoErr.ActualTimestamp)
 
-	// Verify new value was actually written at the transaction's provisional
-	// commit timestamp.
+	// Verify no value was written.
 	valueRes, err := MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{Txn: txn})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if valueRes.Value.Timestamp != expTS || !bytes.Equal(value2.RawBytes, valueRes.Value.RawBytes) {
-		t.Fatalf("expected timestamp=%s (got %s), value=%q (got %q)",
-			valueRes.Value.Timestamp, expTS, value2.RawBytes, valueRes.Value.RawBytes)
-	}
+	require.NoError(t, err)
+	require.Equal(t, value1.RawBytes, valueRes.Value.RawBytes)
 }
 
 func TestMVCCAbortTxn(t *testing.T) {
@@ -3096,88 +3033,59 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 	// Start with epoch 1.
 	txn := *txn1
 	txn.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value1, &txn); err != nil {
-		t.Fatal(err)
-	}
+	err := MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value1, &txn)
+	require.NoError(t, err)
 	// Now write with greater timestamp and epoch 2.
 	txne2 := txn
 	txne2.Sequence++
 	txne2.Epoch = 2
 	txne2.WriteTimestamp = hlc.Timestamp{WallTime: 1}
-	if err := MVCCPut(ctx, engine, nil, testKey1, txne2.ReadTimestamp, hlc.ClockTimestamp{}, value2, &txne2); err != nil {
-		t.Fatal(err)
-	}
+	err = MVCCPut(ctx, engine, nil, testKey1, txne2.ReadTimestamp, hlc.ClockTimestamp{}, value2, &txne2)
+	require.NoError(t, err)
 	// Try a write with an earlier timestamp; this is just ignored.
 	txne2.Sequence++
 	txne2.WriteTimestamp = hlc.Timestamp{WallTime: 1}
-	if err := MVCCPut(ctx, engine, nil, testKey1, txne2.ReadTimestamp, hlc.ClockTimestamp{}, value1, &txne2); err != nil {
-		t.Fatal(err)
-	}
-	// Try a write with an earlier epoch; again ignored.
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value1, &txn); err == nil {
-		t.Fatal("unexpected success of a write with an earlier epoch")
-	}
+	err = MVCCPut(ctx, engine, nil, testKey1, txne2.ReadTimestamp, hlc.ClockTimestamp{}, value1, &txne2)
+	require.NoError(t, err)
+	// Try a write with an earlier epoch; ignored with error.
+	err = MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value1, &txn)
+	require.Error(t, err)
+	require.Regexp(t, "put with epoch 1 came after put with epoch 2 in txn", err)
 	// Try a write with different value using both later timestamp and epoch.
 	txne2.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey1, txne2.ReadTimestamp, hlc.ClockTimestamp{}, value3, &txne2); err != nil {
-		t.Fatal(err)
-	}
+	err = MVCCPut(ctx, engine, nil, testKey1, txne2.ReadTimestamp, hlc.ClockTimestamp{}, value3, &txne2)
+	require.NoError(t, err)
 	// Resolve the intent.
 	txne2Commit := txne2
 	txne2Commit.Status = roachpb.COMMITTED
 	txne2Commit.WriteTimestamp = hlc.Timestamp{WallTime: 1}
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+	_, _, _, err = MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(&txne2Commit, roachpb.Span{Key: testKey1}),
-		MVCCResolveWriteIntentOptions{}); err != nil {
-		t.Fatal(err)
-	}
+		MVCCResolveWriteIntentOptions{})
+	require.NoError(t, err)
 
 	expTS := txne2Commit.WriteTimestamp.Next()
 
 	// Now try writing an earlier value without a txn--should get WriteTooOldError.
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, value4, nil)
-	if wtoErr := (*kvpb.WriteTooOldError)(nil); !errors.As(err, &wtoErr) {
-		t.Fatal("unexpected success")
-	} else if wtoErr.ActualTimestamp != expTS {
-		t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, wtoErr.ActualTimestamp)
-	}
-	// Verify value was actually written at (1, 1).
-	valueRes, err := MVCCGet(ctx, engine, testKey1, expTS, MVCCGetOptions{})
-	if err != nil || valueRes.Value.Timestamp != expTS || !bytes.Equal(value4.RawBytes, valueRes.Value.RawBytes) {
-		t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
-			err, valueRes.Value.Timestamp, expTS, value4.RawBytes, valueRes.Value.RawBytes)
-	}
-	// Now write an intent with exactly the same timestamp--ties also get WriteTooOldError.
-	err = MVCCPut(ctx, engine, nil, testKey1, txn2.ReadTimestamp, hlc.ClockTimestamp{}, value5, txn2)
-	intentTS := expTS.Next()
-	if wtoErr := (*kvpb.WriteTooOldError)(nil); !errors.As(err, &wtoErr) {
-		t.Fatal("unexpected success")
-	} else if wtoErr.ActualTimestamp != intentTS {
-		t.Fatalf("expected write too old error with actual ts %s; got %s", intentTS, wtoErr.ActualTimestamp)
-	}
-	// Verify intent value was actually written at (1, 2).
-	valueRes, err = MVCCGet(ctx, engine, testKey1, intentTS, MVCCGetOptions{Txn: txn2})
-	if err != nil || valueRes.Value.Timestamp != intentTS || !bytes.Equal(value5.RawBytes, valueRes.Value.RawBytes) {
-		t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
-			err, valueRes.Value.Timestamp, intentTS, value5.RawBytes, valueRes.Value.RawBytes)
-	}
+	err = MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, value4, nil)
+	var wtoErr *kvpb.WriteTooOldError
+	require.ErrorAs(t, err, &wtoErr)
+	require.Equal(t, expTS, wtoErr.ActualTimestamp)
+	// Verify no value was written.
+	valueRes, err := MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, txne2Commit.WriteTimestamp, valueRes.Value.Timestamp)
+	require.Equal(t, value3.RawBytes, valueRes.Value.RawBytes)
+
 	// Attempt to read older timestamp; should fail.
 	valueRes, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 0}, MVCCGetOptions{})
-	if valueRes.Value != nil || err != nil {
-		t.Fatalf("expected value nil, err nil; got %+v, %v", valueRes.Value, err)
-	}
+	require.NoError(t, err)
+	require.False(t, valueRes.Value.IsPresent())
 	// Read at correct timestamp.
 	valueRes, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if expTS := (hlc.Timestamp{WallTime: 1}); valueRes.Value.Timestamp != expTS {
-		t.Fatalf("expected timestamp %+v == %+v", valueRes.Value.Timestamp, expTS)
-	}
-	if !bytes.Equal(value3.RawBytes, valueRes.Value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value3.RawBytes, valueRes.Value.RawBytes)
-	}
+	require.NoError(t, err)
+	require.Equal(t, txne2Commit.WriteTimestamp, valueRes.Value.Timestamp)
+	require.Equal(t, value3.RawBytes, valueRes.Value.RawBytes)
 }
 
 // TestMVCCGetWithDiffEpochs writes a value first using epoch 1, then
@@ -3249,24 +3157,15 @@ func TestMVCCGetWithDiffEpochsAndTimestamps(t *testing.T) {
 	defer engine.Close()
 
 	// Write initial value without a txn at timestamp 1.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
+	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil)
+	require.NoError(t, err)
 	// Write another value without a txn at timestamp 3.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
+	err = MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value2, nil)
+	require.NoError(t, err)
 	// Now write using txn1, epoch 1.
-	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	// Bump epoch 1's write timestamp to timestamp 4.
-	txn1ts.WriteTimestamp = hlc.Timestamp{WallTime: 4}
-	// Expected to hit WriteTooOld error but to still lay down intent.
-	err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn1ts)
-	if wtoErr := (*kvpb.WriteTooOldError)(nil); !errors.As(err, &wtoErr) {
-		t.Fatalf("unexpectedly not WriteTooOld: %+v", err)
-	} else if expTS, actTS := txn1ts.WriteTimestamp, wtoErr.ActualTimestamp; expTS != actTS {
-		t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, actTS)
-	}
+	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 4})
+	err = MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn1ts)
+	require.NoError(t, err)
 	// Try reading using different epochs & timestamps.
 	testCases := []struct {
 		txn      *roachpb.Transaction

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
@@ -72,7 +72,6 @@ run error
 cput k=k v=v4 cond=v3 ts=123
 ----
 >> at end:
-data: "k"/124.000000000,1 -> /BYTES/v4
 data: "k"/124.000000000,0 -> {localTs=123.000000000,0}/BYTES/v3
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 123.000000000,0 too old; must write at or above 124.000000000,1
 

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
@@ -18,12 +18,11 @@ cput ts=1 k=k v=v2
 data: "k"/10.000000000,0 -> /BYTES/v1
 error: (*kvpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003v1" timestamp:<wall_time:10000000000 >
 
-# Now do a non-transactional put @t=1 with expectation of value1; will "succeed" @t=10,1 with WriteTooOld.
+# Now do a non-transactional put @t=1 with expectation of value1; will return WriteTooOld error @t=10,1.
 run error
 cput ts=1 k=k v=v2 cond=v1
 ----
 >> at end:
-data: "k"/10.000000000,1 -> /BYTES/v2
 data: "k"/10.000000000,0 -> /BYTES/v1
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 10.000000000,1
 
@@ -35,18 +34,14 @@ with t=a
 ----
 >> at end:
 txn: "a" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
-data: "k"/10.000000000,1 -> /BYTES/v2
 data: "k"/10.000000000,0 -> /BYTES/v1
 error: (*kvpb.ConditionFailedError:) unexpected value: <nil>
 
-# Now do a transactional put @t=1 with expectation of nil; will "succeed" @t=10,2 with WriteTooOld.
+# Now do a transactional put @t=1 with expectation of nil; will return WriteTooOld error @t=10,2.
 run error
 with t=a
   cput k=k v=v3
 ----
 >> at end:
-meta: "k"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,2 min=0,0 seq=0} ts=10.000000000,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k"/10.000000000,2 -> /BYTES/v3
-data: "k"/10.000000000,1 -> /BYTES/v2
 data: "k"/10.000000000,0 -> /BYTES/v1
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 10.000000000,2
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 10.000000000,1

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
@@ -1,8 +1,7 @@
-# This test verifies the differing behavior
-# of conditional puts when writing with an older timestamp than the
-# existing write. If there's no transaction, the conditional put
-# should use the latest value. When there's a transaction, then it
-# should use the value at the specified timestamp.
+# This test verifies the differing behavior of conditional puts when writing
+# with an older timestamp than the existing write. In these cases, a WriteTooOld
+# error is returned and the condition is not evaluated until after the
+# write-write conflict is resolved.
 
 run ok
 put ts=10 k=k v=v1
@@ -10,13 +9,13 @@ put ts=10 k=k v=v1
 >> at end:
 data: "k"/10.000000000,0 -> /BYTES/v1
 
-# Try a non-transactional put @t=1 with expectation of nil; should fail.
+# Try a non-transactional put @t=1 with expectation of nil; should fail with a WriteTooOld error.
 run error
 cput ts=1 k=k v=v2
 ----
 >> at end:
 data: "k"/10.000000000,0 -> /BYTES/v1
-error: (*kvpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003v1" timestamp:<wall_time:10000000000 >
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 10.000000000,1
 
 # Now do a non-transactional put @t=1 with expectation of value1; will return WriteTooOld error @t=10,1.
 run error
@@ -26,7 +25,7 @@ cput ts=1 k=k v=v2 cond=v1
 data: "k"/10.000000000,0 -> /BYTES/v1
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 10.000000000,1
 
-# Try a transactional put @t=1 with expectation of value2; should fail.
+# Try a transactional put @t=1 with expectation of value2; should fail with a WriteTooOld error.
 run error
 with t=a
   txn_begin ts=1
@@ -35,7 +34,7 @@ with t=a
 >> at end:
 txn: "a" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
 data: "k"/10.000000000,0 -> /BYTES/v1
-error: (*kvpb.ConditionFailedError:) unexpected value: <nil>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 10.000000000,1
 
 # Now do a transactional put @t=1 with expectation of nil; will return WriteTooOld error @t=10,2.
 run error

--- a/pkg/storage/testdata/mvcc_histories/deletes
+++ b/pkg/storage/testdata/mvcc_histories/deletes
@@ -98,8 +98,6 @@ with t=A
 del: "a": found key false
 >> at end:
 txn: "A" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=43.000000000,0 wto=false gul=0,0
-meta: "a"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "a"/50.000000000,0 -> /<empty>
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
@@ -128,8 +126,6 @@ with t=A
 del: "a": found key false
 >> at end:
 txn: "A" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
-meta: "a"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "a"/50.000000000,0 -> /<empty>
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
@@ -155,11 +151,9 @@ with t=A
   txn_advance ts=50
   del k=a
 ----
-del: "a": found key true
+del: "a": found key false
 >> at end:
 txn: "A" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=46.000000000,0 wto=false gul=0,0
-meta: "a"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "a"/50.000000000,0 -> /<empty>
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
@@ -188,8 +182,6 @@ with t=A
 del: "a": found key false
 >> at end:
 txn: "A" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=47.000000000,0 wto=false gul=0,0
-meta: "a"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "a"/50.000000000,0 -> /<empty>
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc

--- a/pkg/storage/testdata/mvcc_histories/increment
+++ b/pkg/storage/testdata/mvcc_histories/increment
@@ -70,7 +70,6 @@ increment k=r ts=2
 >> at end:
 meta: "k"/0,0 -> txn={id=00000000 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} ts=0,1 del=false klen=12 vlen=6 ih={{1 /INT/1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/0,1 -> /INT/2
-data: "r"/3.000000000,1 -> /INT/3
 data: "r"/3.000000000,0 -> /INT/2
 data: "r"/1.000000000,0 -> /INT/1
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "r" at timestamp 2.000000000,0 too old; must write at or above 3.000000000,1
@@ -85,9 +84,6 @@ with t=r
 txn: "r" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000000 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} ts=0,1 del=false klen=12 vlen=6 ih={{1 /INT/1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/0,1 -> /INT/2
-meta: "r"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,2 min=0,0 seq=0} ts=3.000000000,2 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "r"/3.000000000,2 -> /INT/2
-data: "r"/3.000000000,1 -> /INT/3
 data: "r"/3.000000000,0 -> /INT/2
 data: "r"/1.000000000,0 -> /INT/1
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "r" at timestamp 2.000000000,0 too old; must write at or above 3.000000000,2
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "r" at timestamp 2.000000000,0 too old; must write at or above 3.000000000,1

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
@@ -123,18 +123,15 @@ data: "j"/1.000000000,0 -> /INT/1
 stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 5.000000000,0 too old; must write at or above 5.000000000,1
 
-# Point key below range tombstones should error, but is written anyway at a
-# higher timestamp. Stats are updated correctly, even when there are
-# existing point values and tombstones below the range tombstones.
+# Point key below range tombstones should error.
 run stats error
 put k=c ts=3 v=c3
 ----
 >> put k=c ts=3 v=c3
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+stats: no change
 >> at end:
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-data: "c"/5.000000000,1 -> /BYTES/c3
 data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/2.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
@@ -144,19 +141,17 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=7 key_bytes=122 val_count=9 val_bytes=101 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=2 live_bytes=89 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; must write at or above 5.000000000,1
 
 run stats error
 put k=d ts=3 v=d3
 ----
 >> put k=d ts=3 v=d3
-stats: key_bytes=+12 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21 gc_bytes_age=-194
+stats: no change
 >> at end:
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-data: "c"/5.000000000,1 -> /BYTES/c3
-data: "d"/5.000000000,1 -> /BYTES/d3
 data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/2.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
@@ -166,21 +161,18 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=7 key_bytes=134 val_count=10 val_bytes=108 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=3 live_bytes=110 gc_bytes_age=16206 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 3.000000000,0 too old; must write at or above 5.000000000,1
 
 run stats error
 put k=e ts=3 v=e3
 ----
 >> put k=e ts=3 v=e3
-stats: key_bytes=+12 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21 gc_bytes_age=-196
+stats: no change
 >> at end:
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-data: "c"/5.000000000,1 -> /BYTES/c3
-data: "d"/5.000000000,1 -> /BYTES/d3
 data: "d"/1.000000000,0 -> /BYTES/d1
-data: "e"/5.000000000,1 -> /BYTES/e3
 data: "e"/2.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/1.000000000,0 -> /BYTES/f1
@@ -189,7 +181,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=7 key_bytes=146 val_count=11 val_bytes=115 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=4 live_bytes=131 gc_bytes_age=16010 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "e" at timestamp 3.000000000,0 too old; must write at or above 5.000000000,1
 
 # CPuts expecting a value covered by a range tombstone should error.
@@ -201,10 +193,7 @@ stats: no change
 >> at end:
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-data: "c"/5.000000000,1 -> /BYTES/c3
-data: "d"/5.000000000,1 -> /BYTES/d3
 data: "d"/1.000000000,0 -> /BYTES/d1
-data: "e"/5.000000000,1 -> /BYTES/e3
 data: "e"/2.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/1.000000000,0 -> /BYTES/f1
@@ -213,7 +202,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=7 key_bytes=146 val_count=11 val_bytes=115 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=4 live_bytes=131 gc_bytes_age=16010 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
 error: (*kvpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 >
 
 # A CPut replay of an intent expecting a value covered by a range tombstone
@@ -227,10 +216,7 @@ stats: no change
 >> at end:
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-data: "c"/5.000000000,1 -> /BYTES/c3
-data: "d"/5.000000000,1 -> /BYTES/d3
 data: "d"/1.000000000,0 -> /BYTES/d1
-data: "e"/5.000000000,1 -> /BYTES/e3
 data: "e"/2.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/1.000000000,0 -> /BYTES/f1
@@ -239,7 +225,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=7 key_bytes=146 val_count=11 val_bytes=115 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=4 live_bytes=131 gc_bytes_age=16010 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
 error: (*kvpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 >
 
 # A CPut replacing an existing but ignored intent expecting a value covered
@@ -256,10 +242,7 @@ stats: no change
 txn: "A" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0 isn=1
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-data: "c"/5.000000000,1 -> /BYTES/c3
-data: "d"/5.000000000,1 -> /BYTES/d3
 data: "d"/1.000000000,0 -> /BYTES/d1
-data: "e"/5.000000000,1 -> /BYTES/e3
 data: "e"/2.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/1.000000000,0 -> /BYTES/f1
@@ -268,7 +251,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=7 key_bytes=146 val_count=11 val_bytes=115 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=4 live_bytes=131 gc_bytes_age=16010 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
 error: (*kvpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 >
 
 # An InitPut with failOnTombstones above a range tombstone should error.
@@ -280,10 +263,7 @@ stats: no change
 >> at end:
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-data: "c"/5.000000000,1 -> /BYTES/c3
-data: "d"/5.000000000,1 -> /BYTES/d3
 data: "d"/1.000000000,0 -> /BYTES/d1
-data: "e"/5.000000000,1 -> /BYTES/e3
 data: "e"/2.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/1.000000000,0 -> /BYTES/f1
@@ -292,7 +272,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=7 key_bytes=146 val_count=11 val_bytes=115 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=4 live_bytes=131 gc_bytes_age=16010 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
 error: (*kvpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 >
 
 # An InitPut with a different value as an existing key should succeed when there's
@@ -305,10 +285,7 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21 gc_b
 >> at end:
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-data: "c"/5.000000000,1 -> /BYTES/c3
-data: "d"/5.000000000,1 -> /BYTES/d3
 data: "d"/1.000000000,0 -> /BYTES/d1
-data: "e"/5.000000000,1 -> /BYTES/e3
 data: "e"/2.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/7.000000000,0 -> /BYTES/f7
@@ -318,22 +295,18 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=7 key_bytes=158 val_count=12 val_bytes=122 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=5 live_bytes=152 gc_bytes_age=15816 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=120 val_count=9 val_bytes=101 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=2 live_bytes=89 gc_bytes_age=16206 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
 
-# An increment below a range tombstone should reset to 1 and write above it with
-# a WriteTooOldError. This should update stats correctly.
+# An increment below a range tombstone throw a WriteTooOldError.
 run stats error
 increment k=i ts=2
 ----
 >> increment k=i ts=2
-stats: key_bytes=+12 val_count=+1 val_bytes=+6 live_count=+1 live_bytes=+20 gc_bytes_age=-194
+stats: no change
 >> at end:
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-data: "c"/5.000000000,1 -> /BYTES/c3
-data: "d"/5.000000000,1 -> /BYTES/d3
 data: "d"/1.000000000,0 -> /BYTES/d1
-data: "e"/5.000000000,1 -> /BYTES/e3
 data: "e"/2.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/7.000000000,0 -> /BYTES/f7
@@ -341,10 +314,9 @@ data: "f"/1.000000000,0 -> /BYTES/f1
 meta: "g"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
-data: "i"/5.000000000,1 -> /INT/1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=7 key_bytes=170 val_count=13 val_bytes=128 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=6 live_bytes=172 gc_bytes_age=15622 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=120 val_count=9 val_bytes=101 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=2 live_bytes=89 gc_bytes_age=16206 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "i" at timestamp 2.000000000,0 too old; must write at or above 5.000000000,1
 
 # An increment above a range tombstone should reset to 1.
@@ -357,10 +329,7 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+6 live_count=+1 live_bytes=+20 gc_b
 >> at end:
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-data: "c"/5.000000000,1 -> /BYTES/c3
-data: "d"/5.000000000,1 -> /BYTES/d3
 data: "d"/1.000000000,0 -> /BYTES/d1
-data: "e"/5.000000000,1 -> /BYTES/e3
 data: "e"/2.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/7.000000000,0 -> /BYTES/f7
@@ -368,8 +337,7 @@ data: "f"/1.000000000,0 -> /BYTES/f1
 meta: "g"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
-data: "i"/5.000000000,1 -> /INT/1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/7.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=7 key_bytes=182 val_count=14 val_bytes=134 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=7 live_bytes=192 gc_bytes_age=15428 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=132 val_count=10 val_bytes=107 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=3 live_bytes=109 gc_bytes_age=16012 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_old_version
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_old_version
@@ -5,14 +5,12 @@ put k=k v=v ts=1,1
 data: "k"/1.000000000,1 -> /BYTES/v
 
 # Earlier wall time.
-# Note: a WriteTooOld "error" is returned, but really the write completed,
-# just with a different timestamp.
+# Note: a WriteTooOld "error" is returned and no write is completed.
 
 run error
 put k=k v=v2 ts=0,1
 ----
 >> at end:
-data: "k"/1.000000000,2 -> /BYTES/v2
 data: "k"/1.000000000,1 -> /BYTES/v
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 0,1 too old; must write at or above 1.000000000,2
 
@@ -22,7 +20,5 @@ run error
 put k=k v=v2 ts=1,0
 ----
 >> at end:
-data: "k"/1.000000000,3 -> /BYTES/v2
-data: "k"/1.000000000,2 -> /BYTES/v2
 data: "k"/1.000000000,1 -> /BYTES/v
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 1.000000000,3
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 1.000000000,2

--- a/pkg/storage/testdata/mvcc_histories/write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/write_too_old
@@ -22,8 +22,6 @@ with t=A
 del: "a": found key false
 >> at end:
 txn: "A" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=33.000000000,0 wto=false gul=0,0
-meta: "a"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,1 min=0,0 seq=0} ts=44.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "a"/44.000000000,1 -> /<empty>
 data: "a"/44.000000000,0 -> /BYTES/abc
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 33.000000000,0 too old; must write at or above 44.000000000,1
 
@@ -45,8 +43,6 @@ with t=B
 ----
 >> at end:
 txn: "B" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=33.000000000,0 wto=false gul=55.000000000,0
-meta: "a"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,1 min=0,0 seq=0} ts=44.000000000,1 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "a"/44.000000000,1 -> /BYTES/def
 data: "a"/44.000000000,0 -> /BYTES/abc
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 33.000000000,0 too old; must write at or above 44.000000000,1
 


### PR DESCRIPTION
Storage half of #102751.
Closes #102751.

The first commit in this PR eliminates the MVCC-level portion of the write-too-old deferral mechanism. It adjusts `mvccPutInternal` to return immediately when a write-write version conflict is encountered with a WriteTooOld error and without also writing an intent after the conflicting value. This partial-success, partial-error state is no longer needed now that KV no longer defers write-too-old error handling. As a result, we can remove the complexity.

Now that write-too-old deferral is gone, we can then also simplify the handling of conditional writes in `mvccPutInternal`.

The second commit in this PR adjusts `mvccPutInternal` to return WriteTooOld errors instead of ConditionFailedErrors when a write-write version conflict is encountered during conditional write evaluation and the write's condition is also not met. Previously, the logic favored ConditionFailed errors, which was necessary for correctness because of write-too-old deferral. This resulted in subtle logic to determine which timestamp to evaluate the condition at. It was also overly pessimistic in cases where the condition failed at the version below the write-write conflict but succeeded at the version after. This is demonstrated by some of the changes to the test cases in `TestTxnCoordSenderRetries` and `TestReplicaServersideRefreshes`.

Release note: None