### PR TITLE
release-22.2: sql: fix assignment casts of arrays

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -13,7 +13,9 @@ CREATE TABLE assn_cast (
   t timestamp,
   d DECIMAL(10, 0),
   a DECIMAL(10, 0)[],
-  s STRING
+  s STRING,
+  ca CHAR[],
+  vba VARBIT(1)[]
 )
 
 statement ok
@@ -271,6 +273,24 @@ SELECT s FROM assn_cast WHERE s IS NOT NULL
 ----
 1
 2
+
+statement error pgcode 22001 value too long for type CHAR
+INSERT INTO assn_cast(ca) VALUES (ARRAY['foo', 'a'])
+
+statement ok
+PREPARE insert_ca AS INSERT INTO assn_cast(ca) VALUES ($1)
+
+statement error pgcode 22001 value too long for type CHAR
+EXECUTE insert_ca(ARRAY['a', 'foo'])
+
+statement error pgcode 22001 bit string length 2 too large for type VARBIT\(1\)
+INSERT INTO assn_cast(vba) VALUES (ARRAY[B'11', B'1'])
+
+statement ok
+PREPARE insert_vba AS INSERT INTO assn_cast(vba) VALUES ($1)
+
+statement error pgcode 22001 bit string length 2 too large for type VARBIT\(1\)
+EXECUTE insert_vba(ARRAY[B'1', B'11'])
 
 # Tests for assignment casts of DEFAULT expressions.
 subtest assignment_casts_default


### PR DESCRIPTION
Backport 1/6 commits from #102491.

/cc @cockroachdb/release

---

#### sql: fix assignment casts of arrays

This commit fixes a bug that caused incorrect results for assignment
casts of array types. Previously, the array's elements were casted as an
explicit cast, not an assignment cast. This allowed values to be
inserted into an array column that did not conform to the type.

Fixes #102412

Release note (bug fix): A bug has been fixed that allowed values to be
inserted into an `ARRAY`-type column that did not conform to the
inner-type of the array. For example, it was possible to insert
`ARRAY['foo']` into a column of type `CHAR(1)[]`. This could cause
incorrect results when querying the table. The insert now errors, which
is expected. This bug was present since v21.1.

---

Release justification: Fix for a correctness bug related to assignment
casts.
