### PR TITLE
sql: add stats to telemetry sampled query event

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2930,6 +2930,28 @@ contains common SQL event/execution details.
 | `TotalScanRowsWithoutForecastsEstimate` | Total number of rows read by all scans in the query, as estimated by the optimizer without using forecasts. | no |
 | `NanosSinceStatsForecasted` | The greatest quantity of nanoseconds that have passed since the forecast time (or until the forecast time, if it is in the future, in which case it will be negative) for any table with forecasted stats scanned by this query. | no |
 | `Indexes` | The list of indexes used by this query. | no |
+| `CpuTimeNanos` | Collects the cumulative CPU time spent executing SQL operations in nanoseconds. Currently, it is only collected for statements without mutations that have a vectorized plan. | no |
+| `KvGrpcCalls` | The number of grpc calls done to get data form KV nodes | no |
+| `KvTimeNanos` | Cumulated time spent waiting for a KV request. This includes disk IO time and potentially network time (if any of the keys are not local). | no |
+| `ServiceLatencyNanos` | The time to service the query, from start of parse to end of execute. | no |
+| `OverheadLatencyNanos` | The difference between service latency and the sum of parse latency + plan latency + run latency . | no |
+| `RunLatencyNanos` | The time to run the query and fetch or compute the result rows. | no |
+| `PlanLatencyNanos` | The time to transform the AST into a logical query plan. | no |
+| `IdleLatencyNanos` | The time between statement executions in a transaction | no |
+| `ParseLatencyNanos` | The time to transform the SQL string into an abstract syntax tree (AST). | no |
+| `MvccStepCount` | StepCount collects the number of times the iterator moved forward or backward over the DB's underlying storage keyspace. For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go. | no |
+| `MvccStepCountInternal` | StepCountInternal collects the number of times the iterator moved forward or backward over LSM internal keys. For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go. | no |
+| `MvccSeekCount` | SeekCount collects the number of times the iterator moved to a specific key/value pair in the DB's underlying storage keyspace. For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go. | no |
+| `MvccSeekCountInternal` | SeekCountInternal collects the number of times the iterator moved to a specific LSM internal key. For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go. | no |
+| `MvccBlockBytes` | BlockBytes collects the bytes in the loaded SSTable data blocks. For details, see pebble.InternalIteratorStats. | no |
+| `MvccBlockBytesInCache` | BlockBytesInCache collects the subset of BlockBytes in the block cache. For details, see pebble.InternalIteratorStats. | no |
+| `MvccKeyBytes` | KeyBytes collects the bytes in keys that were iterated over. For details, see pebble.InternalIteratorStats. | no |
+| `MvccValueBytes` | ValueBytes collects the bytes in values that were iterated over. For details, see pebble.InternalIteratorStats. | no |
+| `MvccPointCount` | PointCount collects the count of point keys iterated over. For details, see pebble.InternalIteratorStats. | no |
+| `MvccPointsCoveredByRangeTombstones` | PointsCoveredByRangeTombstones collects the count of point keys that were iterated over that were covered by range tombstones. For details, see pebble.InternalIteratorStats and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
+| `MvccRangeKeyCount` | RangeKeyCount collects the count of range keys encountered during iteration. For details, see pebble.RangeKeyIteratorStats and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
+| `MvccRangeKeyContainedPoints` | RangeKeyContainedPoints collects the count of point keys encountered within the bounds of a range key. For details, see pebble.RangeKeyIteratorStats and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
+| `MvccRangeKeySkippedPoints` | RangeKeySkippedPoints collects the count of the subset of ContainedPoints point keys that were skipped during iteration due to range-key masking. For details, see pkg/storage/engine.go, pebble.RangeKeyIteratorStats, and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
 
 
 #### Common fields

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2736,6 +2736,7 @@ func (ex *connExecutor) execCopyOut(
 			ex.server.TelemetryLoggingMetrics,
 			stmtFingerprintID,
 			&stats,
+			ex.statsCollector,
 		)
 	}()
 
@@ -2969,7 +2970,16 @@ func (ex *connExecutor) execCopyIn(
 			ex.planner.CurrentDatabase(),
 		)
 		var stats topLevelQueryStats
-		ex.planner.maybeLogStatement(ctx, ex.executorType, true, int(ex.state.mu.autoRetryCounter), ex.extraTxnState.txnCounter, numInsertedRows, 0 /* bulkJobId */, copyErr, ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived), &ex.extraTxnState.hasAdminRoleCache, ex.server.TelemetryLoggingMetrics, stmtFingerprintID, &stats)
+		ex.planner.maybeLogStatement(ctx, ex.executorType, true,
+			int(ex.state.mu.autoRetryCounter), ex.extraTxnState.txnCounter,
+			numInsertedRows, 0, /* bulkJobId */
+			copyErr,
+			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
+			&ex.extraTxnState.hasAdminRoleCache,
+			ex.server.TelemetryLoggingMetrics,
+			stmtFingerprintID,
+			&stats,
+			ex.statsCollector)
 	}()
 
 	var copyErr error

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1514,6 +1514,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 						ex.server.TelemetryLoggingMetrics,
 						ppInfo.dispatchToExecutionEngine.stmtFingerprintID,
 						ppInfo.dispatchToExecutionEngine.queryStats,
+						ex.statsCollector,
 					)
 				},
 			})
@@ -1540,6 +1541,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 				ex.server.TelemetryLoggingMetrics,
 				stmtFingerprintID,
 				&stats,
+				ex.statsCollector,
 			)
 		}
 	}()

--- a/pkg/sql/telemetry_logging.go
+++ b/pkg/sql/telemetry_logging.go
@@ -93,7 +93,6 @@ func (t *TelemetryLoggingMetrics) maybeUpdateLastEmittedTime(
 	defer t.mu.Unlock()
 
 	lastEmittedTime := t.mu.lastEmittedTime
-
 	if float64(newTime.Sub(lastEmittedTime))*1e-9 >= requiredSecondsElapsed {
 		t.mu.lastEmittedTime = newTime
 		return true

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -4579,6 +4579,204 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, ']')
 	}
 
+	if m.CpuTimeNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"CpuTimeNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.CpuTimeNanos), 10)
+	}
+
+	if m.KvGrpcCalls != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"KvGrpcCalls\":"...)
+		b = strconv.AppendInt(b, int64(m.KvGrpcCalls), 10)
+	}
+
+	if m.KvTimeNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"KvTimeNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.KvTimeNanos), 10)
+	}
+
+	if m.ServiceLatencyNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ServiceLatencyNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.ServiceLatencyNanos), 10)
+	}
+
+	if m.OverheadLatencyNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"OverheadLatencyNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.OverheadLatencyNanos), 10)
+	}
+
+	if m.RunLatencyNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RunLatencyNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.RunLatencyNanos), 10)
+	}
+
+	if m.PlanLatencyNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"PlanLatencyNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.PlanLatencyNanos), 10)
+	}
+
+	if m.IdleLatencyNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IdleLatencyNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.IdleLatencyNanos), 10)
+	}
+
+	if m.ParseLatencyNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ParseLatencyNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.ParseLatencyNanos), 10)
+	}
+
+	if m.MvccStepCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccStepCount\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccStepCount), 10)
+	}
+
+	if m.MvccStepCountInternal != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccStepCountInternal\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccStepCountInternal), 10)
+	}
+
+	if m.MvccSeekCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccSeekCount\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccSeekCount), 10)
+	}
+
+	if m.MvccSeekCountInternal != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccSeekCountInternal\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccSeekCountInternal), 10)
+	}
+
+	if m.MvccBlockBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccBlockBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccBlockBytes), 10)
+	}
+
+	if m.MvccBlockBytesInCache != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccBlockBytesInCache\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccBlockBytesInCache), 10)
+	}
+
+	if m.MvccKeyBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccKeyBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccKeyBytes), 10)
+	}
+
+	if m.MvccValueBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccValueBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccValueBytes), 10)
+	}
+
+	if m.MvccPointCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccPointCount\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccPointCount), 10)
+	}
+
+	if m.MvccPointsCoveredByRangeTombstones != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccPointsCoveredByRangeTombstones\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccPointsCoveredByRangeTombstones), 10)
+	}
+
+	if m.MvccRangeKeyCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccRangeKeyCount\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccRangeKeyCount), 10)
+	}
+
+	if m.MvccRangeKeyContainedPoints != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccRangeKeyContainedPoints\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccRangeKeyContainedPoints), 10)
+	}
+
+	if m.MvccRangeKeySkippedPoints != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MvccRangeKeySkippedPoints\":"...)
+		b = strconv.AppendInt(b, int64(m.MvccRangeKeySkippedPoints), 10)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -27,6 +27,7 @@ import "util/log/logpb/event.proto";
 // The comment at the top has a specific format for the doc generator.
 // *Really look at doc.go before modifying this file.*
 
+
 // SampledQuery is the SQL query event logged to the telemetry channel. It
 // contains common SQL event/execution details.
 message SampledQuery {
@@ -187,8 +188,101 @@ message SampledQuery {
   // The list of indexes used by this query.
   repeated string indexes = 51 [(gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
+  // Collects the cumulative CPU time spent executing SQL operations in
+  // nanoseconds. Currently, it is only collected for statements without
+  // mutations that have a vectorized plan.
+  int64 cpu_time_nanos  = 52 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of grpc calls done to get data form KV nodes
+  int64 kv_grpc_calls = 53 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Cumulated time spent waiting for a KV request. This includes disk IO time
+  // and potentially network time (if any of the keys are not local).
+  int64 kv_time_nanos = 54 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The time to service the query, from start of parse to end of execute.
+  int64 service_latency_nanos =      56 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The difference between service latency and the sum of parse latency + plan latency + run latency .
+  int64 overhead_latency_nanos =      57 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The time to run the query and fetch or compute the result rows.
+  int64 run_latency_nanos    =      58 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The time to transform the AST into a logical query plan.
+  int64 plan_latency_nanos    =      59 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The time between statement executions in a transaction
+  int64 idle_latency_nanos    =      60 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The time to transform the SQL string into an abstract syntax tree (AST).
+  int64 parse_latency_nanos    =      61 [(gogoproto.jsontag) = ",omitempty"];
+
+  // StepCount collects the number of times the iterator moved forward or backward over the
+  // DB's underlying storage keyspace.
+  // For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go.
+  int64 mvcc_step_count = 62 [(gogoproto.jsontag) = ",omitempty"];
+
+  // StepCountInternal collects the number of times the iterator moved forward or backward
+  // over LSM internal keys.
+  // For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go.
+  int64 mvcc_step_count_internal = 63 [(gogoproto.jsontag) = ",omitempty"];
+
+  // SeekCount collects the number of times the iterator moved to a specific key/value pair
+  // in the DB's underlying storage keyspace.
+  // For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go.
+  int64 mvcc_seek_count = 64 [(gogoproto.jsontag) = ",omitempty"];
+
+  // SeekCountInternal collects the number of times the iterator moved to a specific LSM
+  // internal key.
+  // For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go.
+  int64 mvcc_seek_count_internal = 65 [(gogoproto.jsontag) = ",omitempty"];
+
+  // BlockBytes collects the bytes in the loaded SSTable data blocks.
+  // For details, see pebble.InternalIteratorStats.
+  int64 mvcc_block_bytes = 66 [(gogoproto.jsontag) = ",omitempty"];
+
+  // BlockBytesInCache collects the subset of BlockBytes in the block cache.
+  // For details, see pebble.InternalIteratorStats.
+  int64 mvcc_block_bytes_in_cache = 67 [(gogoproto.jsontag) = ",omitempty"];
+
+  // KeyBytes collects the bytes in keys that were iterated over.
+  // For details, see pebble.InternalIteratorStats.
+  int64 mvcc_key_bytes = 68 [(gogoproto.jsontag) = ",omitempty"];
+
+  // ValueBytes collects the bytes in values that were iterated over.
+  // For details, see pebble.InternalIteratorStats.
+  int64 mvcc_value_bytes = 69 [(gogoproto.jsontag) = ",omitempty"];
+
+  // PointCount collects the count of point keys iterated over.
+  // For details, see pebble.InternalIteratorStats.
+  int64 mvcc_point_count = 70 [(gogoproto.jsontag) = ",omitempty"];
+
+  // PointsCoveredByRangeTombstones collects the count of point keys that were iterated over that
+  // were covered by range tombstones.
+  // For details, see pebble.InternalIteratorStats and
+  // https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md.
+  int64 mvcc_points_covered_by_range_tombstones = 71 [(gogoproto.jsontag) = ",omitempty"];
+
+  // RangeKeyCount collects the count of range keys encountered during iteration.
+  // For details, see pebble.RangeKeyIteratorStats and
+  // https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md.
+  int64 mvcc_range_key_count = 72 [(gogoproto.jsontag) = ",omitempty"];
+
+  // RangeKeyContainedPoints collects the count of point keys encountered within the bounds of
+  // a range key.
+  // For details, see pebble.RangeKeyIteratorStats and
+  // https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md.
+  int64 mvcc_range_key_contained_points = 73 [(gogoproto.jsontag) = ",omitempty"];
+
+  // RangeKeySkippedPoints collects the count of the subset of ContainedPoints point keys that
+  // were skipped during iteration due to range-key masking.
+  // For details, see pkg/storage/engine.go, pebble.RangeKeyIteratorStats, and
+  // https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md.
+  int64 mvcc_range_key_skipped_points = 74 [(gogoproto.jsontag) = ",omitempty"];
   reserved 12;
 }
+
 
 // CapturedIndexUsageStats
 message CapturedIndexUsageStats {


### PR DESCRIPTION
This adds the MVCC stats, cpu usage, and latency information to the telemetry sampled query event. This is needed to make it match the data available in the system statement_statistics table.

Epic: none
Closes: https://github.com/cockroachdb/cockroach/issues/89887

Release note (sql change): Adds the MVCC stats, cpu usage, and latency information to the telemetry sampled query event.