### PR TITLE
backupccl: test that we can backup restore synthetic schemas

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -10488,6 +10488,67 @@ func TestBackupRestoreTelemetryEvents(t *testing.T) {
 	requireRecoveryEvent(t, beforeRestore.UnixNano(), restoreJobEventType, expectedRestoreFailEvent)
 }
 
+// TestBackupRestoreTelemetryForPublicSchema tests that backup and restore
+// events are logged if the target is the public schema for the system database.
+func TestBackupRestoreTelemetryForPublicSchema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.ScopeWithoutShowLogs(t).Close(t)
+
+	defer jobs.TestingSetProgressThresholds()()
+
+	baseDir := "testdata"
+	args := base.TestServerArgs{ExternalIODir: baseDir, Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
+	params := base.TestClusterArgs{ServerArgs: args}
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, 1,
+		InitManualReplication, params)
+	defer cleanupFn()
+
+	// Execute a BACKUP for the system.public schema and verify the telemetry
+	// event.
+	beforeBackup := timeutil.Now()
+	loc1 := "userfile:///eventlogging?COCKROACH_LOCALITY=default"
+	sqlDB.Exec(t, `BACKUP system.public.* INTO $1 AS OF SYSTEM TIME '-1ms' WITH revision_history`, loc1)
+
+	expectedBackupEvent := eventpb.RecoveryEvent{
+		CommonEventDetails: logpb.CommonEventDetails{
+			EventType: "recovery_event",
+		},
+		RecoveryType:            backupEventType,
+		TargetScope:             schemaScope.String(),
+		TargetCount:             1,
+		DestinationSubdirType:   standardSubdirType,
+		DestinationStorageTypes: []string{"userfile"},
+		DestinationAuthTypes:    []string{"specified"},
+		AsOfInterval:            -1 * time.Millisecond.Nanoseconds(),
+		WithRevisionHistory:     true,
+	}
+
+	requireRecoveryEvent(t, beforeBackup.UnixNano(), backupEventType, expectedBackupEvent)
+
+	sqlDB.Exec(t, "CREATE DATABASE restore_system")
+
+	// Execute a RESTORE of the system.public schema and verify the telemetry
+	// event.
+	beforeRestore := timeutil.Now()
+	restoreQuery := `RESTORE system.public.* FROM LATEST IN $1 WITH into_db=$2`
+	sqlDB.Exec(t, restoreQuery, loc1, "restore_system")
+
+	expectedRestoreEvent := eventpb.RecoveryEvent{
+		CommonEventDetails: logpb.CommonEventDetails{
+			EventType: "recovery_event",
+		},
+		RecoveryType:            restoreEventType,
+		TargetScope:             schemaScope.String(),
+		TargetCount:             1,
+		DestinationSubdirType:   latestSubdirType,
+		DestinationStorageTypes: []string{"userfile"},
+		DestinationAuthTypes:    []string{"specified"},
+		Options:                 []string{telemetryOptionIntoDB},
+	}
+
+	requireRecoveryEvent(t, beforeRestore.UnixNano(), restoreEventType, expectedRestoreEvent)
+}
+
 // This is a regression test ensuring that the spans represented by views are
 // not included in backups when their descriptors are included in descriptor
 // revisions.

--- a/pkg/ccl/backupccl/testdata/backup-restore/system-public-schema
+++ b/pkg/ccl/backupccl/testdata/backup-restore/system-public-schema
@@ -1,0 +1,17 @@
+# Test that backing up and restoring the public schema from the system database
+# succeeds.
+
+new-server name=s1 allow-implicit-access
+----
+
+exec-sql
+CREATE DATABASE restoredb;
+----
+
+exec-sql
+BACKUP system.public.* INTO 'userfile:///test';
+----
+
+exec-sql
+RESTORE system.public.* FROM latest IN 'userfile:///test' WITH into_db='restoredb';
+----


### PR DESCRIPTION
In previous versions, having a synthetic schema as the target of a backup or restore would cause a panic as the telemetry logic requires the target to have real descriptor protos. As of 23.1, synthetic schemas do have real descriptor protos, and thus should not cause the panic. This patch adds a few tests that verify this.

Release note: None

Epic: None