### PR TITLE
kvserver,storepool: misc rebalance logging improvements

### DIFF
--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -1087,7 +1087,7 @@ func MakeStoreList(descriptors []roachpb.StoreDescriptor) StoreList {
 func (sl StoreList) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf,
-		"  candidate: avg-ranges=%v avg-leases=%v avg-disk-usage=%v avg-queries-per-second=%v avg-store-cpu-per-second=%v",
+		"  candidate: avg-ranges=%.2f avg-leases=%.2f avg-disk-usage=%s avg-queries-per-second=%.2f avg-store-cpu-per-second=%s",
 		sl.CandidateRanges.Mean,
 		sl.CandidateLeases.Mean,
 		humanizeutil.IBytes(int64(sl.candidateLogicalBytes.Mean)),

--- a/pkg/kv/kvserver/rebalance_objective.go
+++ b/pkg/kv/kvserver/rebalance_objective.go
@@ -92,6 +92,17 @@ const (
 	LBRebalancingCPU
 )
 
+// LoadBasedRebalancingObjectiveMap maps the LoadBasedRebalancingObjective enum
+// value to a string.
+var LoadBasedRebalancingObjectiveMap map[int64]string = map[int64]string{
+	int64(LBRebalancingQueries): "qps",
+	int64(LBRebalancingCPU):     "cpu",
+}
+
+func (lbro LBRebalancingObjective) String() string {
+	return LoadBasedRebalancingObjectiveMap[int64(lbro)]
+}
+
 // LoadBasedRebalancingObjective is a cluster setting that defines the load
 // balancing objective of the cluster.
 var LoadBasedRebalancingObjective = settings.RegisterEnumSetting(
@@ -101,10 +112,7 @@ var LoadBasedRebalancingObjective = settings.RegisterEnumSetting(
 		"the cluster will attempt to balance qps among stores, if set to "+
 		"`cpu` the cluster will attempt to balance cpu usage among stores",
 	"cpu",
-	map[int64]string{
-		int64(LBRebalancingQueries): "qps",
-		int64(LBRebalancingCPU):     "cpu",
-	},
+	LoadBasedRebalancingObjectiveMap,
 ).WithPublic()
 
 // ToDimension returns the equivalent allocator load dimension of a rebalancing

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -282,6 +282,9 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 				continue
 			}
 			objective := sr.RebalanceObjective()
+			sr.AddLogTag("obj", objective)
+			ctx = sr.AnnotateCtx(ctx)
+
 			hottestRanges := sr.replicaRankings.TopLoad(objective.ToDimension())
 			options := sr.scorerOptions(ctx, objective.ToDimension())
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, mode)


### PR DESCRIPTION
The store list string returned the mean leases, ranges and
queries-per-second float values without limiting the number of decimal
places. This led to log lines with needlessly long decimals:

`avg-ranges=40.66666666666667... avg-leases=10.166666666666666...`

This PR updates the store list string formatting to 2 decimal
places for float values.

Previously, the easiest method of determining the current rebalance
objective from logs was to view the cluster setting and check for
logging indicating a mixed version cluster - this was cumbersome.

This PR annotates the ctx in the store rebalancer loop with an
additional tag: `obj`. The `obj` tag indicates the current rebalance
objective, either `cpu` or `qps` currently.

resolves: https://github.com/cockroachdb/cockroach/issues/102812


Release note: None