### PR TITLE
sql: fix panic in SHOW HISTOGRAM due to type hydration

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2390,3 +2390,22 @@ CREATE INDEX ON xy (y) WHERE y > 5;
 
 statement error pq: table xy does not contain a non-partial forward index with y as a prefix column
 CREATE STATISTICS xy_partial_idx ON y FROM xy USING EXTREMES;
+
+# Regression test for #100909. Ensure enum is hydrated in SHOW HISTOGRAM.
+statement ok
+CREATE TYPE enum1 as ENUM ('hello', 'hi');
+CREATE TABLE t100909 (x int, y enum1);
+INSERT INTO t100909 VALUES (1, 'hello'), (2, 'hello'), (3, 'hi');
+
+statement ok
+CREATE STATISTICS s1 ON y FROM t100909;
+
+let $hist_id_1
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE t100909] WHERE statistics_name = 's1'
+
+query TIRI colnames
+SHOW HISTOGRAM $hist_id_1
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+'hello'      0           0                    2
+'hi'         0           0                    1

--- a/pkg/sql/show_histogram.go
+++ b/pkg/sql/show_histogram.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -74,6 +76,10 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 			}
 
 			v := p.newContainerValuesNode(showHistogramColumns, 0)
+			resolver := descs.NewDistSQLTypeResolver(p.descCollection, p.InternalSQLTxn().KV())
+			if err := typedesc.EnsureTypeIsHydrated(ctx, histogram.ColumnType, &resolver); err != nil {
+				return nil, err
+			}
 			for _, b := range histogram.Buckets {
 				ed, _, err := rowenc.EncDatumFromBuffer(
 					catenumpb.DatumEncoding_ASCENDING_KEY, b.UpperBound,


### PR DESCRIPTION
Fixes #100909

Release note (bug fix): Fixed an issue where running `SHOW HISTOGRAM` to see the histogram for an enum-type column could cause a panic and crash the cockroach process. This issue has existed since v20.2.0 and is now fixed.