### PR TITLE
release-22.1: sql: fix panic in SHOW HISTOGRAM due to type hydration

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1629,3 +1629,22 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE t1]
         "row_count": 0
     }
 ]
+
+# Regression test for #100909. Ensure enum is hydrated in SHOW HISTOGRAM.
+statement ok
+CREATE TYPE enum1 as ENUM ('hello', 'hi');
+CREATE TABLE t100909 (x int, y enum1);
+INSERT INTO t100909 VALUES (1, 'hello'), (2, 'hello'), (3, 'hi');
+
+statement ok
+CREATE STATISTICS s1 ON y FROM t100909;
+
+let $hist_id_1
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE t100909] WHERE statistics_name = 's1'
+
+query TIRI colnames
+SHOW HISTOGRAM $hist_id_1
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+'hello'      0           0                    2
+'hi'         0           0                    1

--- a/pkg/sql/show_histogram.go
+++ b/pkg/sql/show_histogram.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -75,6 +77,10 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 			}
 
 			v := p.newContainerValuesNode(showHistogramColumns, 0)
+			resolver := descs.NewDistSQLTypeResolver(p.Descriptors(), p.txn)
+			if err := typedesc.EnsureTypeIsHydrated(ctx, histogram.ColumnType, &resolver); err != nil {
+				return nil, err
+			}
 			for _, b := range histogram.Buckets {
 				ed, _, err := rowenc.EncDatumFromBuffer(
 					histogram.ColumnType, descpb.DatumEncoding_ASCENDING_KEY, b.UpperBound,


### PR DESCRIPTION
Backport 1/1 commits from #102827.

/cc @cockroachdb/release

---

Fixes #100909

Release note (bug fix): Fixed an issue where running `SHOW HISTOGRAM` to see the histogram for an enum-type column could cause a panic and crash the cockroach process. This issue has existed since v20.2.0 and is now fixed.

---

Release justification: low-risk bug fix to fix a node-crashing panic