### PR TITLE
release-22.2: sql: add support for re-using lease cache for audit logging

### DIFF
--- a/pkg/bench/rttanalysis/audit_bench_test.go
+++ b/pkg/bench/rttanalysis/audit_bench_test.go
@@ -21,5 +21,10 @@ func init() {
 							ALTER TABLE audit_table EXPERIMENTAL_AUDIT SET READ WRITE;`,
 			Stmt: "SELECT * from audit_table",
 		},
+		{
+			Name:  "select from a non-audit table",
+			Setup: `CREATE TABLE audit_table(a INT);`,
+			Stmt:  "SELECT * from audit_table",
+		},
 	})
 }

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -27,7 +27,8 @@ exp,benchmark
 7,AlterTableUnsplit/alter_table_unsplit_at_1_value
 9,AlterTableUnsplit/alter_table_unsplit_at_2_values
 11,AlterTableUnsplit/alter_table_unsplit_at_3_values
-5,Audit/select_from_an_audit_table
+3,Audit/select_from_a_non-audit_table
+3,Audit/select_from_an_audit_table
 12,CreateRole/create_role_with_1_option
 15,CreateRole/create_role_with_2_options
 18,CreateRole/create_role_with_3_options

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -193,7 +193,7 @@ func (sr *schemaResolver) getQualifiedTableName(
 			Required:       true,
 			IncludeOffline: true,
 			IncludeDropped: true,
-			AvoidLeased:    true,
+			AvoidLeased:    sr.skipDescriptorCache,
 		})
 	switch {
 	case scDesc != nil:


### PR DESCRIPTION
Previously, we still incorrectly skipped the lease cached when resolving schemas for table names. We
recently backported changes to use leased descriptors for this resolution, but unfortunately, it only applied to the database descriptors. This patch applies the same lease descriptor usage for schema descriptors.

Informs: #99475

Release note (performance improvement): audit logging could incur extra latency when resolving table/view/sequence names.

Release justification: low risk and addresses a performance issue for audit logging to be usable on multi-region