### PR TITLE
sql: do not purge range cache when using follower reads

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
@@ -167,7 +167,7 @@ func (o *followerReadOracle) ChoosePreferredReplica(
 	leaseholder *roachpb.ReplicaDescriptor,
 	ctPolicy roachpb.RangeClosedTimestampPolicy,
 	queryState replicaoracle.QueryState,
-) (roachpb.ReplicaDescriptor, error) {
+) (_ roachpb.ReplicaDescriptor, ignoreMisplannedRanges bool, _ error) {
 	var oracle replicaoracle.Oracle
 	if o.useClosestOracle(txn, ctPolicy) {
 		oracle = o.closest

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -679,7 +680,7 @@ func TestOracle(t *testing.T) {
 				Clock:      clock,
 			})
 
-			res, err := o.ChoosePreferredReplica(ctx, c.txn, desc, c.lh, c.ctPolicy, replicaoracle.QueryState{})
+			res, _, err := o.ChoosePreferredReplica(ctx, c.txn, desc, c.lh, c.ctPolicy, replicaoracle.QueryState{})
 			require.NoError(t, err)
 			require.Equal(t, c.exp, res)
 		})
@@ -692,6 +693,7 @@ func TestOracle(t *testing.T) {
 // encountering this situation, and then follower reads work.
 func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	// The test uses follower_read_timestamp().
@@ -826,6 +828,49 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Greater(t, followerReadsCountAfter, followerReadsCountBefore)
+
+	// Now verify that follower reads aren't mistakenly counted as "misplanned
+	// ranges" (#61313).
+
+	// First, run a query on n3 to populate its cache.
+	n3 := sqlutils.MakeSQLRunner(tc.Conns[2])
+	n3.Exec(t, "SELECT * from test WHERE k=1")
+	n3Cache := tc.Server(2).DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
+	entry = n3Cache.GetCached(ctx, tablePrefix, false /* inverted */)
+	require.NotNil(t, entry)
+	require.False(t, entry.Lease().Empty())
+	require.Equal(t, roachpb.StoreID(1), entry.Lease().Replica.StoreID)
+	require.Equal(t, []roachpb.ReplicaDescriptor{
+		{NodeID: 1, StoreID: 1, ReplicaID: 1},
+		{NodeID: 3, StoreID: 3, ReplicaID: 3, Type: roachpb.NON_VOTER},
+	}, entry.Desc().Replicas().Descriptors())
+
+	// Enable DistSQL so that we have a distributed plan with a single flow on
+	// n3 (local plans ignore the misplanned ranges).
+	n4.Exec(t, "SET distsql=on")
+
+	// Run a historical query and assert that it's served from the follower (n3).
+	// n4 should choose n3 to plan the TableReader on because we pretend n3 has
+	// a lower latency (see testing knob).
+
+	// Note that this query is such that the physical planning needs to fetch
+	// the ReplicaInfo twice for the same range. This allows us to verify that
+	// the cached - in the spanResolverIterator - information is correctly
+	// preserved.
+	historicalQuery = `SELECT * FROM [SELECT * FROM test WHERE k=2 UNION ALL SELECT * FROM test WHERE k=3] AS OF SYSTEM TIME follower_read_timestamp()`
+	n4.Exec(t, historicalQuery)
+	rec = <-recCh
+
+	// Sanity check that the plan was distributed.
+	require.True(t, strings.Contains(rec.String(), "creating DistSQL plan with isLocal=false"))
+	// Look at the trace and check that we've served a follower read.
+	require.True(t, kv.OnlyFollowerReads(rec), "query was not served through follower reads: %s", rec)
+	// Verify that we didn't produce the "misplanned ranges" metadata that would
+	// purge the non-stale entries from the range cache on n4.
+	require.False(t, strings.Contains(rec.String(), "clearing entries overlapping"))
+	// Also confirm that we didn't even check for the "misplanned ranges"
+	// metadata on n3.
+	require.False(t, strings.Contains(rec.String(), "checking range cache to see if range info updates should be communicated to the gateway"))
 }
 
 // TestSecondaryTenantFollowerReadsRouting ensures that secondary tenants route

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -527,6 +527,11 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 	return ds
 }
 
+// LatencyFunc returns the LatencyFunc of the DistSender.
+func (ds *DistSender) LatencyFunc() LatencyFunc {
+	return ds.latencyFunc
+}
+
 // DisableFirstRangeUpdates disables updates of the first range via
 // gossip. Used by tests which want finer control of the contents of the range
 // cache.

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1163,12 +1163,25 @@ func (dsp *DistSQLPlanner) checkInstanceHealthAndVersionSystem(
 func (dsp *DistSQLPlanner) PartitionSpans(
 	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
 ) ([]SpanPartition, error) {
+	partitions, _, err := dsp.partitionSpansEx(ctx, planCtx, spans)
+	return partitions, err
+}
+
+// partitionSpansEx is the same as PartitionSpans but additionally returns a
+// boolean indicating whether the misplanned ranges metadata should not be
+// generated.
+func (dsp *DistSQLPlanner) partitionSpansEx(
+	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
+) (_ []SpanPartition, ignoreMisplannedRanges bool, _ error) {
 	if len(spans) == 0 {
-		return nil, errors.AssertionFailedf("no spans")
+		return nil, false, errors.AssertionFailedf("no spans")
 	}
 	if planCtx.isLocal {
-		// If we're planning locally, map all spans to the gateway.
-		return []SpanPartition{{dsp.gatewaySQLInstanceID, spans}}, nil
+		// If we're planning locally, map all spans to the gateway. Note that we
+		// always ignore misplanned ranges for local-only plans, and we choose
+		// to return `true` to explicitly highlight this fact, yet the boolean
+		// doesn't really matter.
+		return []SpanPartition{{dsp.gatewaySQLInstanceID, spans}}, true /* ignoreMisplannedRanges */, nil
 	}
 	if dsp.useGossipPlanning(ctx, planCtx) {
 		return dsp.deprecatedPartitionSpansSystem(ctx, planCtx, spans)
@@ -1197,6 +1210,7 @@ func (dsp *DistSQLPlanner) partitionSpan(
 	partitions []SpanPartition,
 	nodeMap map[base.SQLInstanceID]int,
 	getSQLInstanceIDForKVNodeID func(roachpb.NodeID) base.SQLInstanceID,
+	ignoreMisplannedRanges *bool,
 ) (_ []SpanPartition, lastPartitionIdx int, _ error) {
 	it := planCtx.spanIter
 	// rSpan is the span we are currently partitioning.
@@ -1218,10 +1232,11 @@ func (dsp *DistSQLPlanner) partitionSpan(
 		if !it.Valid() {
 			return nil, 0, it.Error()
 		}
-		replDesc, err := it.ReplicaInfo(ctx)
+		replDesc, ignore, err := it.ReplicaInfo(ctx)
 		if err != nil {
 			return nil, 0, err
 		}
+		*ignoreMisplannedRanges = *ignoreMisplannedRanges || ignore
 		desc := it.Desc()
 		if log.V(1) {
 			descCpy := desc // don't let desc escape
@@ -1286,7 +1301,7 @@ func (dsp *DistSQLPlanner) partitionSpan(
 // for a system tenant.
 func (dsp *DistSQLPlanner) deprecatedPartitionSpansSystem(
 	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
-) (partitions []SpanPartition, _ error) {
+) (partitions []SpanPartition, ignoreMisplannedRanges bool, _ error) {
 	nodeMap := make(map[base.SQLInstanceID]int)
 	resolver := func(nodeID roachpb.NodeID) base.SQLInstanceID {
 		return dsp.deprecatedSQLInstanceIDForKVNodeIDSystem(ctx, planCtx, nodeID)
@@ -1294,13 +1309,13 @@ func (dsp *DistSQLPlanner) deprecatedPartitionSpansSystem(
 	for _, span := range spans {
 		var err error
 		partitions, _, err = dsp.partitionSpan(
-			ctx, planCtx, span, partitions, nodeMap, resolver,
+			ctx, planCtx, span, partitions, nodeMap, resolver, &ignoreMisplannedRanges,
 		)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
-	return partitions, nil
+	return partitions, ignoreMisplannedRanges, nil
 }
 
 // partitionSpans assigns SQL instances to spans. In mixed sql and KV mode it
@@ -1311,10 +1326,10 @@ func (dsp *DistSQLPlanner) deprecatedPartitionSpansSystem(
 // the instances, and it falls back to naive round-robin assignment if not.
 func (dsp *DistSQLPlanner) partitionSpans(
 	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
-) (partitions []SpanPartition, _ error) {
+) (partitions []SpanPartition, ignoreMisplannedRanges bool, _ error) {
 	resolver, instances, err := dsp.makeInstanceResolver(ctx, planCtx.localityFilter)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	nodeMap := make(map[base.SQLInstanceID]int)
 	var lastKey roachpb.Key
@@ -1335,18 +1350,18 @@ func (dsp *DistSQLPlanner) partitionSpans(
 			lastKey = safeKey
 		}
 		partitions, lastPartitionIdx, err = dsp.partitionSpan(
-			ctx, planCtx, span, partitions, nodeMap, resolver,
+			ctx, planCtx, span, partitions, nodeMap, resolver, &ignoreMisplannedRanges,
 		)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 	if planCtx.localityFilter.Empty() {
 		if err = dsp.maybeReassignToGatewaySQLInstance(partitions, instances); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
-	return partitions, nil
+	return partitions, ignoreMisplannedRanges, nil
 }
 
 // deprecatedSQLInstanceIDForKVNodeIDSystem returns the SQL instance that should
@@ -1582,7 +1597,11 @@ func (dsp *DistSQLPlanner) getInstanceIDForScan(
 	if !it.Valid() {
 		return 0, it.Error()
 	}
-	replDesc, err := it.ReplicaInfo(ctx)
+	// Note that regardless of the second return value from ReplicaInfo method,
+	// ignoreMisplannedRanges will be set to true by the caller because the
+	// spans might cover multiple ranges, yet we're planning the scan only on a
+	// single node.
+	replDesc, _, err := it.ReplicaInfo(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -1846,7 +1865,7 @@ func (dsp *DistSQLPlanner) planTableReaders(
 		// still read too eagerly in the soft limit case. To prevent this we'll
 		// need a new mechanism on the execution side to modulate table reads.
 		// TODO(yuzefovich): add that mechanism.
-		spanPartitions, err = dsp.PartitionSpans(ctx, planCtx, info.spans)
+		spanPartitions, ignoreMisplannedRanges, err = dsp.partitionSpansEx(ctx, planCtx, info.spans)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -650,9 +650,9 @@ func (it *testSpanResolverIterator) Desc() roachpb.RangeDescriptor {
 // ReplicaInfo is part of the SpanResolverIterator interface.
 func (it *testSpanResolverIterator) ReplicaInfo(
 	_ context.Context,
-) (roachpb.ReplicaDescriptor, error) {
+) (roachpb.ReplicaDescriptor, bool, error) {
 	n := it.tsr.nodes[it.tsr.ranges[it.curRangeIdx].node-1]
-	return roachpb.ReplicaDescriptor{NodeID: n.NodeID}, nil
+	return roachpb.ReplicaDescriptor{NodeID: n.NodeID}, false, nil
 }
 
 func TestPartitionSpans(t *testing.T) {

--- a/pkg/sql/execinfra/readerbase.go
+++ b/pkg/sql/execinfra/readerbase.go
@@ -57,6 +57,12 @@ func MisplannedRanges(
 		if err != nil {
 			panic(err)
 		}
+		if rSpan.EndKey == nil {
+			// GetCachedOverlapping simply ignores spans if EndKey is not set.
+			// Here we have a point span, so we explicitly set the EndKey
+			// accordingly.
+			rSpan.EndKey = rSpan.Key.Next()
+		}
 		overlapping := rdc.GetCachedOverlapping(ctx, rSpan)
 
 		for _, ri := range overlapping {

--- a/pkg/sql/physicalplan/fake_span_resolver.go
+++ b/pkg/sql/physicalplan/fake_span_resolver.go
@@ -224,7 +224,7 @@ func (fit *fakeSpanResolverIterator) Desc() roachpb.RangeDescriptor {
 // ReplicaInfo is part of the SpanResolverIterator interface.
 func (fit *fakeSpanResolverIterator) ReplicaInfo(
 	_ context.Context,
-) (roachpb.ReplicaDescriptor, error) {
+) (roachpb.ReplicaDescriptor, bool, error) {
 	n := fit.ranges[0].replica
-	return roachpb.ReplicaDescriptor{NodeID: n.NodeID}, nil
+	return roachpb.ReplicaDescriptor{NodeID: n.NodeID}, false, nil
 }

--- a/pkg/sql/physicalplan/fake_span_resolver_test.go
+++ b/pkg/sql/physicalplan/fake_span_resolver_test.go
@@ -72,7 +72,7 @@ func TestFakeSpanResolver(t *testing.T) {
 				t.Fatal(it.Error())
 			}
 			desc := it.Desc()
-			rinfo, err := it.ReplicaInfo(ctx)
+			rinfo, _, err := it.ReplicaInfo(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/physicalplan/replicaoracle/oracle.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle.go
@@ -74,6 +74,10 @@ type Oracle interface {
 	// When the range's closed timestamp policy is known, it is passed in.
 	// Otherwise, the default closed timestamp policy is provided.
 	//
+	// ignoreMisplannedRanges boolean indicates whether the placement of the
+	// TableReaders according to this replica choice should **not** result in
+	// creating of Ranges ProducerMetadata.
+	//
 	// A RangeUnavailableError can be returned if there's no information in gossip
 	// about any of the nodes that might be tried.
 	ChoosePreferredReplica(
@@ -83,7 +87,7 @@ type Oracle interface {
 		leaseholder *roachpb.ReplicaDescriptor,
 		ctPolicy roachpb.RangeClosedTimestampPolicy,
 		qState QueryState,
-	) (roachpb.ReplicaDescriptor, error)
+	) (_ roachpb.ReplicaDescriptor, ignoreMisplannedRanges bool, _ error)
 }
 
 // OracleFactory creates an oracle from a Config.
@@ -115,13 +119,21 @@ var oracleFactories = map[Policy]OracleFactory{}
 // done by an oracle on behalf of one particular query.
 type QueryState struct {
 	RangesPerNode  util.FastIntMap
-	AssignedRanges map[roachpb.RangeID]roachpb.ReplicaDescriptor
+	AssignedRanges map[roachpb.RangeID]ReplicaDescriptorEx
+}
+
+// ReplicaDescriptorEx is a small extension of the roachpb.ReplicaDescriptor
+// that also stores whether this replica info should be ignored for the purposes
+// of misplanned ranges.
+type ReplicaDescriptorEx struct {
+	ReplDesc               roachpb.ReplicaDescriptor
+	IgnoreMisplannedRanges bool
 }
 
 // MakeQueryState creates an initialized QueryState.
 func MakeQueryState() QueryState {
 	return QueryState{
-		AssignedRanges: make(map[roachpb.RangeID]roachpb.ReplicaDescriptor),
+		AssignedRanges: make(map[roachpb.RangeID]ReplicaDescriptorEx),
 	}
 }
 
@@ -142,12 +154,12 @@ func (o *randomOracle) ChoosePreferredReplica(
 	_ *roachpb.ReplicaDescriptor,
 	_ roachpb.RangeClosedTimestampPolicy,
 	_ QueryState,
-) (roachpb.ReplicaDescriptor, error) {
+) (roachpb.ReplicaDescriptor, bool, error) {
 	replicas, err := replicaSliceOrErr(ctx, o.nodeDescs, desc, kvcoord.OnlyPotentialLeaseholders)
 	if err != nil {
-		return roachpb.ReplicaDescriptor{}, err
+		return roachpb.ReplicaDescriptor{}, false, err
 	}
-	return replicas[rand.Intn(len(replicas))].ReplicaDescriptor, nil
+	return replicas[rand.Intn(len(replicas))].ReplicaDescriptor, false, nil
 }
 
 type closestOracle struct {
@@ -180,18 +192,22 @@ func (o *closestOracle) ChoosePreferredReplica(
 	ctx context.Context,
 	_ *kv.Txn,
 	desc *roachpb.RangeDescriptor,
-	_ *roachpb.ReplicaDescriptor,
+	leaseholder *roachpb.ReplicaDescriptor,
 	_ roachpb.RangeClosedTimestampPolicy,
 	_ QueryState,
-) (roachpb.ReplicaDescriptor, error) {
+) (_ roachpb.ReplicaDescriptor, ignoreMisplannedRanges bool, _ error) {
 	// We know we're serving a follower read request, so consider all non-outgoing
 	// replicas.
 	replicas, err := replicaSliceOrErr(ctx, o.nodeDescs, desc, kvcoord.AllExtantReplicas)
 	if err != nil {
-		return roachpb.ReplicaDescriptor{}, err
+		return roachpb.ReplicaDescriptor{}, false, err
 	}
 	replicas.OptimizeReplicaOrder(o.nodeID, o.latencyFunc, o.locality)
-	return replicas[0].ReplicaDescriptor, nil
+	repl := replicas[0].ReplicaDescriptor
+	// There are no "misplanned" ranges if we know the leaseholder, and we're
+	// deliberately choosing non-leaseholder.
+	ignoreMisplannedRanges = leaseholder != nil && leaseholder.NodeID != repl.NodeID
+	return repl, ignoreMisplannedRanges, nil
 }
 
 // maxPreferredRangesPerLeaseHolder applies to the binPackingOracle.
@@ -240,15 +256,15 @@ func (o *binPackingOracle) ChoosePreferredReplica(
 	leaseholder *roachpb.ReplicaDescriptor,
 	_ roachpb.RangeClosedTimestampPolicy,
 	queryState QueryState,
-) (roachpb.ReplicaDescriptor, error) {
+) (_ roachpb.ReplicaDescriptor, ignoreMisplannedRanges bool, _ error) {
 	// If we know the leaseholder, we choose it.
 	if leaseholder != nil {
-		return *leaseholder, nil
+		return *leaseholder, false, nil
 	}
 
 	replicas, err := replicaSliceOrErr(ctx, o.nodeDescs, desc, kvcoord.OnlyPotentialLeaseholders)
 	if err != nil {
-		return roachpb.ReplicaDescriptor{}, err
+		return roachpb.ReplicaDescriptor{}, false, err
 	}
 	replicas.OptimizeReplicaOrder(o.nodeID, o.latencyFunc, o.locality)
 
@@ -258,7 +274,7 @@ func (o *binPackingOracle) ChoosePreferredReplica(
 	for i, repl := range replicas {
 		assignedRanges := queryState.RangesPerNode.GetDefault(int(repl.NodeID))
 		if assignedRanges != 0 && assignedRanges < o.maxPreferredRangesPerLeaseHolder {
-			return repl.ReplicaDescriptor, nil
+			return repl.ReplicaDescriptor, false, nil
 		}
 		if assignedRanges < minLoad {
 			leastLoadedIdx = i
@@ -268,7 +284,7 @@ func (o *binPackingOracle) ChoosePreferredReplica(
 	// Either no replica was assigned any previous ranges, or all replicas are
 	// full. Use the least-loaded one (if all the load is 0, then the closest
 	// replica is returned).
-	return replicas[leastLoadedIdx].ReplicaDescriptor, nil
+	return replicas[leastLoadedIdx].ReplicaDescriptor, false, nil
 }
 
 // replicaSliceOrErr returns a ReplicaSlice for the given range descriptor.
@@ -309,18 +325,18 @@ func (o preferFollowerOracle) ChoosePreferredReplica(
 	ctx context.Context,
 	_ *kv.Txn,
 	desc *roachpb.RangeDescriptor,
-	_ *roachpb.ReplicaDescriptor,
+	leaseholder *roachpb.ReplicaDescriptor,
 	_ roachpb.RangeClosedTimestampPolicy,
 	_ QueryState,
-) (roachpb.ReplicaDescriptor, error) {
+) (_ roachpb.ReplicaDescriptor, ignoreMisplannedRanges bool, _ error) {
 	replicas, err := replicaSliceOrErr(ctx, o.nodeDescs, desc, kvcoord.AllExtantReplicas)
 	if err != nil {
-		return roachpb.ReplicaDescriptor{}, err
+		return roachpb.ReplicaDescriptor{}, false, err
 	}
 
 	leaseholders, err := replicaSliceOrErr(ctx, o.nodeDescs, desc, kvcoord.OnlyPotentialLeaseholders)
 	if err != nil {
-		return roachpb.ReplicaDescriptor{}, err
+		return roachpb.ReplicaDescriptor{}, false, err
 	}
 	leaseholderNodeIDs := make(map[roachpb.NodeID]bool, len(leaseholders))
 	for i := range leaseholders {
@@ -332,5 +348,9 @@ func (o preferFollowerOracle) ChoosePreferredReplica(
 	})
 
 	// TODO: Pick a random replica from replicas[:len(replicas)-len(leaseholders)]
-	return replicas[0].ReplicaDescriptor, nil
+	repl := replicas[0].ReplicaDescriptor
+	// There are no "misplanned" ranges if we know the leaseholder, and we're
+	// deliberately choosing non-leaseholder.
+	ignoreMisplannedRanges = leaseholder != nil && leaseholder.NodeID != repl.NodeID
+	return repl, ignoreMisplannedRanges, nil
 }

--- a/pkg/sql/physicalplan/replicaoracle/oracle_test.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle_test.go
@@ -62,7 +62,7 @@ func TestClosest(t *testing.T) {
 		rand.Shuffle(len(internalReplicas), func(i, j int) {
 			internalReplicas[i], internalReplicas[j] = internalReplicas[j], internalReplicas[i]
 		})
-		info, err := o.ChoosePreferredReplica(
+		info, ignoreMisplannedRanges, err := o.ChoosePreferredReplica(
 			ctx,
 			nil, /* txn */
 			&roachpb.RangeDescriptor{
@@ -77,6 +77,9 @@ func TestClosest(t *testing.T) {
 		}
 		if info.NodeID != 2 {
 			t.Fatalf("Failed to choose node 2, got %v", info.NodeID)
+		}
+		if ignoreMisplannedRanges {
+			t.Fatalf("Expected ignoreMisplannedRanges to be false since nil leaseholder was provided")
 		}
 	})
 }
@@ -136,7 +139,7 @@ func TestPreferFollower(t *testing.T) {
 	rand.Shuffle(len(internalReplicas), func(i, j int) {
 		internalReplicas[i], internalReplicas[j] = internalReplicas[j], internalReplicas[i]
 	})
-	info, err := o.ChoosePreferredReplica(
+	info, _, err := o.ChoosePreferredReplica(
 		ctx,
 		nil, /* txn */
 		&roachpb.RangeDescriptor{

--- a/pkg/sql/physicalplan/span_resolver.go
+++ b/pkg/sql/physicalplan/span_resolver.go
@@ -142,12 +142,13 @@ func NewSpanResolver(
 	return &spanResolver{
 		st: st,
 		oracle: replicaoracle.NewOracle(policy, replicaoracle.Config{
-			NodeDescs:  nodeDescs,
-			NodeID:     nodeID,
-			Locality:   locality,
-			Settings:   st,
-			Clock:      clock,
-			RPCContext: rpcCtx,
+			NodeDescs:   nodeDescs,
+			NodeID:      nodeID,
+			Locality:    locality,
+			Settings:    st,
+			Clock:       clock,
+			RPCContext:  rpcCtx,
+			LatencyFunc: distSender.LatencyFunc(),
 		}),
 		distSender: distSender,
 	}

--- a/pkg/sql/physicalplan/span_resolver.go
+++ b/pkg/sql/physicalplan/span_resolver.go
@@ -114,9 +114,14 @@ type SpanResolverIterator interface {
 
 	// ReplicaInfo returns information about the replica that has been picked for
 	// the current range.
+	//
+	// ignoreMisplannedRanges boolean indicates whether the placement of the
+	// TableReaders according to this replica choice should **not** result in
+	// creating of Ranges ProducerMetadata.
+	//
 	// A RangeUnavailableError is returned if there's no information in nodeDescs
 	// about any of the replicas.
-	ReplicaInfo(ctx context.Context) (roachpb.ReplicaDescriptor, error)
+	ReplicaInfo(ctx context.Context) (_ roachpb.ReplicaDescriptor, ignoreMisplannedRanges bool, _ error)
 }
 
 // spanResolver implements SpanResolver.
@@ -273,7 +278,7 @@ func (it *spanResolverIterator) Desc() roachpb.RangeDescriptor {
 // ReplicaInfo is part of the SpanResolverIterator interface.
 func (it *spanResolverIterator) ReplicaInfo(
 	ctx context.Context,
-) (roachpb.ReplicaDescriptor, error) {
+) (roachpb.ReplicaDescriptor, bool, error) {
 	if !it.Valid() {
 		panic(it.Error())
 	}
@@ -281,16 +286,19 @@ func (it *spanResolverIterator) ReplicaInfo(
 	// If we've assigned the range before, return that assignment.
 	rngID := it.it.Desc().RangeID
 	if repl, ok := it.queryState.AssignedRanges[rngID]; ok {
-		return repl, nil
+		return repl.ReplDesc, repl.IgnoreMisplannedRanges, nil
 	}
 
-	repl, err := it.oracle.ChoosePreferredReplica(
+	repl, ignoreMisplannedRanges, err := it.oracle.ChoosePreferredReplica(
 		ctx, it.txn, it.it.Desc(), it.it.Leaseholder(), it.it.ClosedTimestampPolicy(), it.queryState)
 	if err != nil {
-		return roachpb.ReplicaDescriptor{}, err
+		return roachpb.ReplicaDescriptor{}, false, err
 	}
 	prev := it.queryState.RangesPerNode.GetDefault(int(repl.NodeID))
 	it.queryState.RangesPerNode.Set(int(repl.NodeID), prev+1)
-	it.queryState.AssignedRanges[rngID] = repl
-	return repl, nil
+	it.queryState.AssignedRanges[rngID] = replicaoracle.ReplicaDescriptorEx{
+		ReplDesc:               repl,
+		IgnoreMisplannedRanges: ignoreMisplannedRanges,
+	}
+	return repl, ignoreMisplannedRanges, nil
 }

--- a/pkg/sql/physicalplan/span_resolver_test.go
+++ b/pkg/sql/physicalplan/span_resolver_test.go
@@ -402,7 +402,7 @@ func resolveSpans(
 			if !it.Valid() {
 				return nil, it.Error()
 			}
-			repl, err := it.ReplicaInfo(ctx)
+			repl, _, err := it.ReplicaInfo(ctx)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Previously, when we used the closest replica oracle and happened to pick a follower for a distributed plan, the TableReaders would still produce "misplanned ranges" metadata. This would then lead to purging the range cache of supposedly stale entries on the gateway even though the entries weren't stale. This is now fixed by setting `ignoreMisplannedRanges` flag on the TableReader spec.

One of the approaches to solve this issue mentioned propagating a set of `ClientRangeInfo`s as part of the TableReader spec, but that seems more complicated and much more involved than this one, so the simpler approach was chosen. In particular, for that idea to work we'd need to include all Infos for all ranges intersecting with the spans to read (which can be non-trivial in size) as well as to add code on the TableReader side to compare the gateway's `ClientRangeInfo` with the range cache of the node where the TableReader was placed.

Fixes: #61313.

Release note: None