### PR TITLE
kvserver: distribute `COCKROACH_SCHEDULER_CONCURRENCY` across stores

### DIFF
--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -251,6 +251,9 @@ func newRaftScheduler(
 		if i < numWorkers%numShards { // distribute remainder
 			shardWorkers++
 		}
+		if shardWorkers <= 0 {
+			shardWorkers = 1 // ensure we always have a worker
+		}
 		shard := &raftSchedulerShard{
 			state:      map[roachpb.RangeID]raftScheduleState{},
 			numWorkers: shardWorkers,

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -360,7 +360,8 @@ func TestNewSchedulerShards(t *testing.T) {
 		// NB: We balance workers across shards instead of filling up shards. We
 		// assume ranges are evenly distributed across shards, and want ranges to
 		// have about the same number of workers available on average.
-		{0, 0, []int{0}},
+		{-1, -1, []int{1}},
+		{0, 0, []int{1}},
 		{1, -1, []int{1}},
 		{1, 0, []int{1}},
 		{1, 1, []int{1}},

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -439,7 +439,7 @@ func runSchedulerEnqueueRaftTicks(
 	a := log.MakeTestingAmbientContext(stopper.Tracer())
 	m := newStoreMetrics(metric.TestSampleInterval)
 	p := newTestProcessor()
-	s := newRaftScheduler(a, m, p, numWorkers, storeSchedulerShardSize, 5)
+	s := newRaftScheduler(a, m, p, numWorkers, defaultRaftSchedulerShardSize, 5)
 
 	// raftTickLoop keeps unquiesced ranges in a map, so we do the same.
 	ranges := make(map[roachpb.RangeID]struct{})

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -113,22 +113,25 @@ const (
 	replicaQueueExtraSize = 10
 )
 
-var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
-	// For small machines, we scale the scheduler concurrency by the number of
-	// CPUs. 8*NumCPU was determined in 9a68241 (April 2017) as the optimal
-	// concurrency level on 8 CPU machines. For larger machines, we've seen
-	// (#56851) that this scaling curve can be too aggressive and lead to too much
-	// contention in the Raft scheduler, so we cap the concurrency level at 96.
-	//
-	// As of November 2020, this default value could be re-tuned.
+// defaultRaftSchedulerConcurrency specifies the default number of Raft
+// scheduler worker goroutines.
+//
+// For small machines, we scale the scheduler concurrency by the number of
+// CPUs. 8*NumCPU was determined in 9a68241 (April 2017) as the optimal
+// concurrency level on 8 CPU machines. For larger machines, we've seen
+// (#56851) that this scaling curve can be too aggressive and lead to too much
+// contention in the Raft scheduler, so we cap the concurrency level at 96.
+//
+// As of November 2020, this default value could be re-tuned.
+var defaultRaftSchedulerConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_SCHEDULER_CONCURRENCY", min(8*runtime.GOMAXPROCS(0), 96))
 
-// storeSchedulerShardSize specifies the maximum number of scheduler worker
-// goroutines per mutex shard. By default, we spin up 8 workers per CPU core,
-// capped at 96, so 16 is equivalent to 2 CPUs per shard, or a maximum of 6
-// shards. This significantly relieves contention at high core counts, while
-// also avoiding starvation by excessive sharding.
-var storeSchedulerShardSize = envutil.EnvOrDefaultInt("COCKROACH_SCHEDULER_SHARD_SIZE", 16)
+// defaultRaftSchedulerShardSize specifies the default maximum number of
+// scheduler worker goroutines per mutex shard. By default, we spin up 8 workers
+// per CPU core, capped at 96, so 16 is equivalent to 2 CPUs per shard, or a
+// maximum of 6 shards. This significantly relieves contention at high core
+// counts, while also avoiding starvation by excessive sharding.
+var defaultRaftSchedulerShardSize = envutil.EnvOrDefaultInt("COCKROACH_SCHEDULER_SHARD_SIZE", 16)
 
 var logSSTInfoTicks = envutil.EnvOrDefaultInt(
 	"COCKROACH_LOG_SST_INFO_TICKS_INTERVAL", 60)
@@ -1067,6 +1070,14 @@ type StoreConfig struct {
 	// Note that node Decommissioning events are always logged.
 	LogRangeAndNodeEvents bool
 
+	// RaftSchedulerConcurrency specifies the number of Raft scheduler workers
+	// for this store. Values < 1 imply 1.
+	RaftSchedulerConcurrency int
+
+	// RaftSchedulerShardSize specifies the maximum number of Raft scheduler
+	// workers per mutex shard. Values < 1 imply 1.
+	RaftSchedulerShardSize int
+
 	// RaftEntryCacheSize is the size in bytes of the Raft log entry cache
 	// shared by all Raft groups managed by the store.
 	RaftEntryCacheSize uint64
@@ -1163,6 +1174,7 @@ func (sc *StoreConfig) Valid() bool {
 	return sc.Clock != nil && sc.Transport != nil &&
 		sc.RaftTickInterval != 0 && sc.RaftHeartbeatIntervalTicks > 0 &&
 		sc.RaftElectionTimeoutTicks > 0 && sc.RaftReproposalTimeoutTicks > 0 &&
+		sc.RaftSchedulerConcurrency > 0 && sc.RaftSchedulerShardSize > 0 &&
 		sc.ScanInterval >= 0 && sc.AmbientCtx.Tracer != nil
 }
 
@@ -1174,6 +1186,12 @@ func (sc *StoreConfig) SetDefaults() {
 
 	if sc.CoalescedHeartbeatsInterval == 0 {
 		sc.CoalescedHeartbeatsInterval = sc.RaftTickInterval / 2
+	}
+	if sc.RaftSchedulerConcurrency == 0 {
+		sc.RaftSchedulerConcurrency = defaultRaftSchedulerConcurrency
+	}
+	if sc.RaftSchedulerShardSize == 0 {
+		sc.RaftSchedulerShardSize = defaultRaftSchedulerShardSize
 	}
 	if sc.RaftEntryCacheSize == 0 {
 		sc.RaftEntryCacheSize = defaultRaftEntryCacheSize
@@ -1300,8 +1318,8 @@ func NewStore(
 	s.draining.Store(false)
 	// NB: buffer up to RaftElectionTimeoutTicks in Raft scheduler to avoid
 	// unnecessary elections when ticks are temporarily delayed and piled up.
-	s.scheduler = newRaftScheduler(cfg.AmbientCtx, s.metrics, s, storeSchedulerConcurrency,
-		storeSchedulerShardSize, cfg.RaftElectionTimeoutTicks)
+	s.scheduler = newRaftScheduler(cfg.AmbientCtx, s.metrics, s,
+		cfg.RaftSchedulerConcurrency, cfg.RaftSchedulerShardSize, cfg.RaftElectionTimeoutTicks)
 
 	s.syncWaiter = logstore.NewSyncWaiterLoop()
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -114,7 +114,9 @@ const (
 )
 
 // defaultRaftSchedulerConcurrency specifies the default number of Raft
-// scheduler worker goroutines.
+// scheduler worker goroutines. These are evenly distributed across stores,
+// rounded up such that all stores have the same number of workers (10 workers
+// across 3 stores yields 4 workers per store or 12 in total).
 //
 // For small machines, we scale the scheduler concurrency by the number of
 // CPUs. 8*NumCPU was determined in 9a68241 (April 2017) as the optimal
@@ -278,7 +280,7 @@ func testStoreConfig(clock *hlc.Clock, version roachpb.Version) StoreConfig {
 	sc.RaftElectionTimeoutTicks = 3
 	sc.RaftReproposalTimeoutTicks = 5
 	sc.RaftTickInterval = 100 * time.Millisecond
-	sc.SetDefaults()
+	sc.SetDefaults(1 /* numStores */)
 	return sc
 }
 
@@ -1181,7 +1183,7 @@ func (sc *StoreConfig) Valid() bool {
 // SetDefaults initializes unset fields in StoreConfig to values
 // suitable for use on a local network.
 // TODO(tschottdorf): see if this ought to be configurable via flags.
-func (sc *StoreConfig) SetDefaults() {
+func (sc *StoreConfig) SetDefaults(numStores int) {
 	sc.RaftConfig.SetDefaults()
 
 	if sc.CoalescedHeartbeatsInterval == 0 {
@@ -1189,6 +1191,12 @@ func (sc *StoreConfig) SetDefaults() {
 	}
 	if sc.RaftSchedulerConcurrency == 0 {
 		sc.RaftSchedulerConcurrency = defaultRaftSchedulerConcurrency
+		// If we have more than one store, evenly divide the default workers across
+		// stores, since the default value is a function of CPU count and should not
+		// scale with the number of stores.
+		if numStores > 1 && sc.RaftSchedulerConcurrency > 1 {
+			sc.RaftSchedulerConcurrency = (sc.RaftSchedulerConcurrency-1)/numStores + 1 // ceil division
+		}
 	}
 	if sc.RaftSchedulerShardSize == 0 {
 		sc.RaftSchedulerShardSize = defaultRaftSchedulerShardSize

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1222,9 +1222,6 @@ func (sc *StoreConfig) Tracer() *tracing.Tracer {
 func NewStore(
 	ctx context.Context, cfg StoreConfig, eng storage.Engine, nodeDesc *roachpb.NodeDescriptor,
 ) *Store {
-	// TODO(tschottdorf): find better place to set these defaults.
-	cfg.SetDefaults()
-
 	if !cfg.Valid() {
 		log.Fatalf(ctx, "invalid store configuration: %+v", &cfg)
 	}

--- a/pkg/kv/kvserver/store_gossip_test.go
+++ b/pkg/kv/kvserver/store_gossip_test.go
@@ -69,7 +69,7 @@ func TestStoreGossipDeltaTrigger(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			cfg := &StoreConfig{}
-			cfg.SetDefaults()
+			cfg.SetDefaults(1 /* numStores */)
 			sg := NewStoreGossip(nil, nil, cfg.TestingKnobs.GossipTestingKnobs)
 			sg.cachedCapacity.cached = tc.cached
 			sg.cachedCapacity.lastGossiped = tc.lastGossiped

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -453,6 +453,40 @@ func TestIterateIDPrefixKeys(t *testing.T) {
 	}
 }
 
+// TestStoreConfigSetDefaults checks that StoreConfig.SetDefaults() sets proper
+// defaults based on numStores.
+func TestStoreConfigSetDefaultsNumStores(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testcases := map[string]struct {
+		conc        int
+		defaultConc int
+		numStores   int
+		expectConc  int
+	}{
+		"zero default is retained":         {defaultConc: 0, numStores: 4, expectConc: 0},
+		"negative default is retained":     {defaultConc: -1, numStores: 4, expectConc: -1},
+		"zero stores retains default":      {defaultConc: 4, expectConc: 4},
+		"explicit value not distributed":   {conc: 4, numStores: 2, expectConc: 4},
+		"explicit value overrides default": {conc: 4, defaultConc: 16, numStores: 2, expectConc: 4},
+		"default value is distributed":     {defaultConc: 16, numStores: 4, expectConc: 4},
+		"default value uses ceil division": {defaultConc: 16, numStores: 5, expectConc: 4},
+		"all stores have at least 1":       {defaultConc: 4, numStores: 10, expectConc: 1},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			defer func(original int) {
+				defaultRaftSchedulerConcurrency = original // restore global default
+			}(defaultRaftSchedulerConcurrency)
+			defaultRaftSchedulerConcurrency = tc.defaultConc
+			cfg := StoreConfig{RaftSchedulerConcurrency: tc.conc}
+			cfg.SetDefaults(tc.numStores)
+			require.Equal(t, tc.expectConc, cfg.RaftSchedulerConcurrency)
+		})
+	}
+}
+
 // TestStoreInitAndBootstrap verifies store initialization and bootstrap.
 func TestStoreInitAndBootstrap(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -770,7 +770,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if storeTestingKnobs := cfg.TestingKnobs.Store; storeTestingKnobs != nil {
 		storeCfg.TestingKnobs = *storeTestingKnobs.(*kvserver.StoreTestingKnobs)
 	}
-	storeCfg.SetDefaults()
+	storeCfg.SetDefaults(len(engines))
 
 	systemTenantNameContainer := roachpb.NewTenantNameContainer(catconstants.SystemTenantName)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -767,10 +767,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		SnapshotSendLimit:        cfg.SnapshotSendLimit,
 		RangeLogWriter:           rangeLogWriter,
 	}
-
 	if storeTestingKnobs := cfg.TestingKnobs.Store; storeTestingKnobs != nil {
 		storeCfg.TestingKnobs = *storeTestingKnobs.(*kvserver.StoreTestingKnobs)
 	}
+	storeCfg.SetDefaults()
 
 	systemTenantNameContainer := roachpb.NewTenantNameContainer(catconstants.SystemTenantName)
 


### PR DESCRIPTION
**kvserver: ensure at least 1 Raft scheduler worker**

Previously, it was possible to create a Raft scheduler with no workers by setting `COCKROACH_SCHEDULER_CONCURRENCY=0`. This patch ensures we always create at least 1 worker per scheduler.

Release note: None
  
**kvserver: pass Raft scheduler workers via `StoreConfig`**

Release note: None
  
**kvserver: move `StoreConfig.SetDefaults()` out of `NewStore()`**

Release note: None
  
**kvserver: distribute `COCKROACH_SCHEDULER_CONCURRENCY` across stores**

`COCKROACH_SCHEDULER_CONCURRENCY` defaults to 8 per CPU core, capped at 96, to avoid putting excessive pressure on the Go scheduler. However, it was applied individually to each store, which means that nodes with e.g. 10 stores would run up to 960 workers. This can lead to scheduler thrashing, as well as excessive memory usage since it also serves to bound the amount of data pulled into memory for concurrent Raft ready processing.

This patch instead divides the worker count across stores.

Resolves #102838.

Epic: none
Release note (ops change): the default Raft scheduler concurrency, controlled by `COCKROACH_SCHEDULER_CONCURRENCY` and defaulting to 8 per CPU core capped at 96, is now divided evenly across stores instead of applying individually per store. This avoids excessive Go scheduler pressure and memory usage on nodes with many stores. The common case of 1 store per node is not affected.