### PR TITLE
backupccl: return not ok during import key elision in rewriter

### DIFF
--- a/pkg/ccl/backupccl/key_rewriter_test.go
+++ b/pkg/ccl/backupccl/key_rewriter_test.go
@@ -161,9 +161,11 @@ func TestKeyRewriter(t *testing.T) {
 		key := rowenc.MakeIndexKeyPrefix(keys.SystemSQLCodec,
 			systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
 
-		// If the passed in walltime is at or above the ImportStartWalltime, an error should return
-		_, _, err = newKr.RewriteKey(key, 2)
-		require.Error(t, err, ErrImportingKeyError.Error())
+		// If the passed in walltime is at or above the ImportStartWalltime,
+		// rewriting should not have occurred.
+		_, ok, err := newKr.RewriteKey(key, 2)
+		require.NoError(t, err)
+		require.False(t, ok)
 
 		// Else, the key should get encoded normally.
 		newKey, ok, err := newKr.RewriteKey(key, 1)

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -471,19 +471,16 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 
 		key.Key, ok, err = kr.RewriteKey(key.Key, key.Timestamp.WallTime)
 
-		if errors.Is(err, ErrImportingKeyError) {
-			// The keyRewriter returns ErrImportingKeyError iff the key is part of an
-			// in-progress import. Keys from in-progress imports never get restored,
-			// since the key's table gets restored to its pre-import state. Therefore,
-			// elide ingesting this key.
-			continue
-		}
 		if err != nil {
 			return summary, err
 		}
 		if !ok {
 			// If the key rewriter didn't match this key, it's not data for the
 			// table(s) we're interested in.
+			//
+			// As an example, keys from in-progress imports never get restored,
+			// since the key's table gets restored to its pre-import state. Therefore,
+			// we elide ingesting this key.
 			if verbose {
 				log.Infof(ctx, "skipping %s %s", key.Key, value.PrettyPrint())
 			}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -119,7 +119,8 @@ var restoreStatsInsertionConcurrency = settings.RegisterIntSetting(
 func rewriteBackupSpanKey(
 	codec keys.SQLCodec, kr *KeyRewriter, key roachpb.Key,
 ) (roachpb.Key, error) {
-	newKey, rewritten, err := kr.RewriteKey(append([]byte(nil), key...), 0 /*wallTime*/)
+	newKey, rewritten, err := kr.RewriteKey(append([]byte(nil), key...),
+		0 /*wallTimeForImportElision*/)
 	if err != nil {
 		return nil, errors.NewAssertionErrorWithWrappedErrf(err,
 			"could not rewrite span start key: %s", key)

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -656,7 +656,7 @@ func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, err
 }
 
 func (sip *streamIngestionProcessor) rekey(key roachpb.Key) ([]byte, bool, error) {
-	return sip.rekeyer.RewriteKey(key, 0 /*wallTime*/)
+	return sip.rekeyer.RewriteKey(key, 0 /*wallTimeForImportElision*/)
 }
 
 func (sip *streamIngestionProcessor) bufferSST(sst *kvpb.RangeFeedSSTable) error {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -688,7 +688,7 @@ func noteKeyVal(
 	validator *streamClientValidator, keyVal roachpb.KeyValue, spec streamclient.SubscriptionToken,
 ) {
 	if validator.rekeyer != nil {
-		rekey, _, err := validator.rekeyer.RewriteKey(keyVal.Key, 0 /* wallTime*/)
+		rekey, _, err := validator.rekeyer.RewriteKey(keyVal.Key, 0 /* wallTimeForImportElision*/)
 		if err != nil {
 			panic(err.Error())
 		}


### PR DESCRIPTION
Previously, when the key rewriter encountered a key from an in progress import during restore, it would throw an error which would then be handled in the restore data processor. This patch modifies the key rewriter to now return not ok in this case, and simplifies the rewriter to always return early if a key is not ok.

Epic: none

Release note: None