### PR TITLE
c2c: fix rangefeed error propogration race

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/replication_helpers.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/replication_helpers.go
@@ -141,11 +141,11 @@ func (rf *ReplicationFeed) consumeUntil(
 			for {
 				msg, haveMoreRows := rf.f.Next()
 				if !haveMoreRows {
-					if rf.f.Error() != nil {
-						if errPred(rf.f.Error()) {
+					if err := rf.f.Error(); err != nil {
+						if errPred(err) {
 							return nil
 						}
-						return rf.f.Error()
+						return err
 					}
 					return errors.Newf("ran out of rows after processing %d rows", rowCount)
 				}


### PR DESCRIPTION
In the producer dist sql processor, rangefeed errors only propograte to the user if the error can be sent on a non-blocking channel. Because the channel was previously unbuffered, the dist sql processor would inadvertently swallow the error if the receiver was not actively waiting on the channel. This would then cause the sql processor to hang, as the underlying rangefeed would close after the ignored error message.

This patch buffers the errCh, guaranteeing that the first rangefeed error will be processed by the sql processor. If the rangefeed surfaces several errors while the buffered channel is full, these errors will be swallowed, which is fine, as the first error will always shut down the sql processor.

Fixes #102286

Release note: None