### PR TITLE
backupccl: fix backup restore tests for public schema to expect an error

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -10147,7 +10147,11 @@ func TestBackupRestoreTelemetryForPublicSchema(t *testing.T) {
 	// event.
 	beforeRestore := timeutil.Now()
 	restoreQuery := `RESTORE system.public.* FROM LATEST IN $1 WITH into_db=$2`
-	sqlDB.Exec(t, restoreQuery, loc1, "restore_system")
+
+	// This particular restore should error out due to the fact that we don't
+	// restore some system tables such as the leases table. The expected key
+	// rewriter error is just the first error that we encounter.
+	sqlDB.ExpectErr(t, "no rewrite for span", restoreQuery, loc1, "restore_system")
 
 	expectedRestoreEvent := eventpb.RecoveryEvent{
 		CommonEventDetails: logpb.CommonEventDetails{

--- a/pkg/ccl/backupccl/testdata/backup-restore/system-public-schema
+++ b/pkg/ccl/backupccl/testdata/backup-restore/system-public-schema
@@ -1,5 +1,5 @@
 # Test that backing up and restoring the public schema from the system database
-# succeeds.
+# does not panic.
 
 new-server name=s1 allow-implicit-access
 ----
@@ -12,6 +12,10 @@ exec-sql
 BACKUP system.public.* INTO 'userfile:///test';
 ----
 
-exec-sql
+# This particular restore should error out due to the fact that we don't
+# restore some system tables such as the leases table. The expected key
+# rewriter error is just the first error that we encounter.
+exec-sql expect-error-regex=(no rewrite for span)
 RESTORE system.public.* FROM latest IN 'userfile:///test' WITH into_db='restoredb';
 ----
+regex matches error


### PR DESCRIPTION
Fix TestBackupRestoreTelemetryForPublicSchema and public-system-schema to expect a key rewriter error.

Fixes: #102834

Release note: None