### PR TITLE
sql: add `backup_type`, `on_error` and `on_wait` columns to SHOW SCHEDULES

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
@@ -8,14 +8,14 @@ create schedule datatest for backup into 'nodelocal://1/example-schedule' recurr
 ----
 
 let $fullID $incID
-with schedules as (show schedules) select id from schedules where label='datatest' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select id from schedules where label='datatest' order by backup_type asc;
 ----
 
 query-sql
-with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached"
-$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached"
+BACKUP INTO 'nodelocal://1/example-schedule' WITH detached
+BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached
 
 # Can't use the same command twice.
 
@@ -40,10 +40,10 @@ alter backup schedule $incID set with execution locality = 'region=us-east-1'
 ----
 
 query-sql
-with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = false, detached, execution locality = 'region=us-east-1'"
-$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = false, detached, execution locality = 'region=us-east-1'"
+BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = false, detached, execution locality = 'region=us-east-1'
+BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = false, detached, execution locality = 'region=us-east-1'
 
 # Change an option and set another.
 
@@ -52,10 +52,10 @@ alter backup schedule $incID set with revision_history = true, set with executio
 ----
 
 query-sql
-with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached"
-$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached"
+BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached
+BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached
 
 # Add an incompatible option
 
@@ -72,10 +72,10 @@ alter backup schedule $incID set with kms = ('aws:///key1?region=r1', 'aws:///ke
 ----
 
 query-sql
-with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), incremental_location = 'inc'"
-$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), incremental_location = 'inc'"
+BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), incremental_location = 'inc'
+BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), incremental_location = 'inc'
 
 # Set options to empty (unset).
 
@@ -84,10 +84,10 @@ alter backup schedule $incID set with kms = '', set with incremental_location = 
 ----
 
 query-sql
-with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
-$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
+BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached
+BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached
 
 # Setting DETACHED throws an error.
 
@@ -102,20 +102,20 @@ alter backup schedule $incID set with detached = false;
 regex matches error
 
 query-sql
-with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
-$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
+BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached
+BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached
 
 exec-sql
 alter backup schedule $incID set with include_all_secondary_tenants = true
 ----
 
 query-sql
-with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached, include_all_secondary_tenants = true"
-$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached, include_all_secondary_tenants = true"
+BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached, include_all_secondary_tenants = true
+BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached, include_all_secondary_tenants = true
 
 
 exec-sql
@@ -123,21 +123,21 @@ create schedule 'with-secondary' for backup into 'nodelocal://1/example-schedule
 ----
 
 let $withSecondaryFullID $withSecondaryIncID
-with schedules as (show schedules) select id from schedules where label='with-secondary' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select id from schedules where label='with-secondary' order by backup_type asc;
 ----
 
 query-sql
-with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='with-secondary' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select command from schedules where label='with-secondary' order by backup_type asc;
 ----
-$withSecondaryFullID "BACKUP INTO 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = true"
-$withSecondaryIncID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = true"
+BACKUP INTO 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = true
+BACKUP INTO LATEST IN 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = true
 
 exec-sql
 alter backup schedule $withSecondaryIncID set with Include_all_secondary_tenants = false
 ----
 
 query-sql
-with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='with-secondary' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select command from schedules where label='with-secondary' order by backup_type asc;
 ----
-$withSecondaryFullID "BACKUP INTO 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = false"
-$withSecondaryIncID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = false"
+BACKUP INTO 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = false
+BACKUP INTO LATEST IN 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = false

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/schedule-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/schedule-options
@@ -8,11 +8,11 @@ create schedule datatest for backup into 'nodelocal://1/example-schedule' recurr
 ----
 
 let $fullID $incID
-with schedules as (show schedules) select id from schedules where label='datatest' order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select id from schedules where label='datatest' order by backup_type asc;
 ----
 
 query-sql
-with schedules as (show schedules) select label from schedules where id in ($fullID, $incID) order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select label from schedules where id in ($fullID, $incID) order by backup_type asc;
 ----
 datatest
 datatest
@@ -22,7 +22,7 @@ alter backup schedule $fullID set label 'datatest2'
 ----
 
 query-sql
-with schedules as (show schedules) select label from schedules where id in ($fullID, $incID) order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select label from schedules where id in ($fullID, $incID) order by backup_type asc;
 ----
 datatest2
 datatest2
@@ -32,10 +32,10 @@ alter backup schedule $fullID set into 'nodelocal://1/example-schedule-2'
 ----
 
 query-sql
-with schedules as (show schedules) select command->'backup_statement' from schedules where id in ($fullID, $incID) order by command->>'backup_type' asc;
+with schedules as (show schedules for backup) select command, backup_type from schedules where id in ($fullID, $incID) order by backup_type asc;
 ----
-"BACKUP INTO 'nodelocal://1/example-schedule-2' WITH detached"
-"BACKUP INTO LATEST IN 'nodelocal://1/example-schedule-2' WITH detached"
+BACKUP INTO 'nodelocal://1/example-schedule-2' WITH detached FULL
+BACKUP INTO LATEST IN 'nodelocal://1/example-schedule-2' WITH detached INCREMENTAL
 
 # Alter the `on_previous_running` schedule option to test that incremental
 # schedules always have their configuration set to wait.
@@ -44,42 +44,39 @@ alter backup schedule $fullID set schedule option on_previous_running = 'start';
 ----
 
 query-sql
-with schedules as (select * from system.scheduled_jobs)
-select crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true, false)
-from schedules
-where schedule_id in ($fullID, $incID)
-order by crdb_internal.pb_to_json('cockroach.jobs.jobspb.ExecutionArguments', execution_args, true, true)->'args'->>'backup_type' asc;
+select on_error, on_wait
+from [show schedules for backup]
+where id in ($fullID, $incID)
+order by backup_type asc;
 ----
-{"onError": "RETRY_SCHED", "wait": "NO_WAIT"}
-{"onError": "RETRY_SCHED", "wait": "WAIT"}
+RETRY_SCHED NO_WAIT
+RETRY_SCHED WAIT
 
 exec-sql
 alter backup schedule $fullID set schedule option on_previous_running = 'skip';
 ----
 
 query-sql
-with schedules as (select * from system.scheduled_jobs)
-select crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true, false)
-from schedules
-where schedule_id in ($fullID, $incID)
-order by crdb_internal.pb_to_json('cockroach.jobs.jobspb.ExecutionArguments', execution_args, true, true)->'args'->>'backup_type' asc;
+select on_error, on_wait
+from [show schedules for backup]
+where id in ($fullID, $incID)
+order by backup_type asc;
 ----
-{"onError": "RETRY_SCHED", "wait": "SKIP"}
-{"onError": "RETRY_SCHED", "wait": "WAIT"}
+RETRY_SCHED SKIP
+RETRY_SCHED WAIT
 
 exec-sql
 alter backup schedule $fullID set schedule option on_previous_running = 'wait';
 ----
 
 query-sql
-with schedules as (select * from system.scheduled_jobs)
-select crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true, false)
-from schedules
-where schedule_id in ($fullID, $incID)
-order by crdb_internal.pb_to_json('cockroach.jobs.jobspb.ExecutionArguments', execution_args, true, true)->'args'->>'backup_type' asc;
+select on_error, on_wait
+from [show schedules for backup]
+where id in ($fullID, $incID)
+order by backup_type asc;
 ----
-{"onError": "RETRY_SCHED", "wait": "WAIT"}
-{"onError": "RETRY_SCHED", "wait": "WAIT"}
+RETRY_SCHED WAIT
+RETRY_SCHED WAIT
 
 
 # Hard to validate these, so settle for checking they execute without errors.

--- a/pkg/sql/delegate/show_schedules.go
+++ b/pkg/sql/delegate/show_schedules.go
@@ -38,6 +38,8 @@ WHERE status='%s' AND created_by_type='%s' AND created_by_id=schedule_id
 ) AS jobsRunning`, jobs.StatusRunning, jobs.CreatedByScheduledJobs),
 		"owner",
 		"created",
+		"crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true)->>'wait' as on_wait",
+		"crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true)->>'onError' as on_error",
 	}
 
 	var whereExprs []string
@@ -55,6 +57,8 @@ WHERE status='%s' AND created_by_type='%s' AND created_by_id=schedule_id
 			"executor_type = '%s'", tree.ScheduledBackupExecutor.InternalName()))
 		columnExprs = append(columnExprs, fmt.Sprintf(
 			"%s->>'backup_statement' AS command", commandColumn))
+		columnExprs = append(columnExprs, fmt.Sprintf(
+			"(CASE WHEN %s->>'backup_type' IS NULL THEN 'FULL' ELSE 'INCREMENTAL' END) AS backup_type", commandColumn))
 	case tree.ScheduledSQLStatsCompactionExecutor:
 		whereExprs = append(whereExprs, fmt.Sprintf(
 			"executor_type = '%s'", tree.ScheduledSQLStatsCompactionExecutor.InternalName()))


### PR DESCRIPTION
This change adds two new columns to the output of `SHOW SCHEDULES`:
- on_wait
- on_error

These columns surface the schedule options that each schedule was created with.

Additionally, this change adds a third column to the output of `SHOW SCHEDULES FOR BACKUP` which is the `backup_type`. This is either `FULL` or `INCREMENTAL`.

Release note (sql change): `SHOW SCHEDULES` now surfaces the schedule options with which the schedules were created. `SHOW SCHEDULES FOR BACKUP` additionally surfaces if the schedule is a full or incremental backup schedule.

Epic: CC-6253