### PR TITLE
util/log: switch license for crdb-v2 log parsing to Apache

### DIFF
--- a/pkg/util/log/format_crdb_v2.go
+++ b/pkg/util/log/format_crdb_v2.go
@@ -7,6 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
+//
+// This file is also published under the Apache License; use either
+// one of BSL and Apache:
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
 package log
 


### PR DESCRIPTION
... in order to make this code more easily copiable by other projects.
In particular, I want to use cockroach logs as an example in a data
visualization tool.

Release note: None
Epic: None

cc @dhartunian @bdarnell