### PR TITLE
ui: show alert during upgrade

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -541,13 +541,14 @@ export const clusterPreserveDowngradeOptionOvertimeSelector = createSelector(
     }
     const lastUpdatedTime = moment.unix(longToInt(lastUpdated.seconds));
     const diff = moment.duration(moment().diff(lastUpdatedTime)).asHours();
-    const maximumSetTime = 48;
-    if (diff < maximumSetTime) {
+    if (diff <= 0) {
       return undefined;
     }
     return {
       level: AlertLevel.WARNING,
-      title: `Cluster setting cluster.preserve_downgrade_option has been set for greater than ${maximumSetTime} hours`,
+      title: `Cluster setting cluster.preserve_downgrade_option has been set for ${diff.toFixed(
+        1,
+      )} hours`,
       text: `You can see a list of all nodes and their versions below.
         Once all cluster nodes have been upgraded, and you have validated the stability and performance of
         your workload on the new version, you must reset the cluster.preserve_downgrade_option cluster


### PR DESCRIPTION
Previosuly, an alert was being displayed on DB Console only if the upgrade was happening for more than 48hrs.
This commit updates the alert to show as soon as the cluster setting `cluster.preserve_downgrade_option` is set, making it easier to identify when an upgrade is happening.

Fixes #66987

<img width="1664" alt="Screenshot 2023-05-08 at 2 21 06 PM" src="https://user-images.githubusercontent.com/1017486/236901905-1a1a15ab-55ee-44e3-a633-fb8ed3a6c2ca.png">


Release note (ui change): Show alert on DB Console Overview page when the cluster setting `cluster.preserve_downgrade_option` is set, no longer waiting 48hrs to show.