### PR TITLE
release-22.2: ui: fix spacing and switch column order

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/common/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/common/index.tsx
@@ -35,6 +35,10 @@ export const selectCustomStyles = {
   singleValue: (provided: any) => ({
     ...provided,
     color: "#475872",
+    fontFamily: "Lato-Regular",
+    fontWeight: 400,
+    fontSize: "14px",
+    lineHeight: 1.5,
   }),
   indicatorSeparator: (provided: any) => ({
     ...provided,

--- a/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
@@ -55,6 +55,7 @@ h5.base-heading {
   font-style: normal;
   font-stretch: normal;
   font-size: $font-size--tall;
+  font-weight: 500;
   padding-bottom: 12px;
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
@@ -7,11 +7,25 @@
   margin-right: 10px;
   padding: 20px;
   background-color: white;
+  font-family: $font-family--lato-regular;
 }
 
 .top-area {
   z-index: 5;
   background-color: white;
+  font-family: $font-family--lato-regular;
+
+  label {
+    display: block;
+    margin-bottom: 0px;
+    font-family: $font-family--lato-regular;
+    font-size: $font-size--medium;
+    font-weight: $font-weight--light;
+  }
+
+  ul {
+    margin-bottom: 1em;
+  }
 }
 
 .timescale-small {
@@ -22,6 +36,7 @@
   color: $colors--neutral-6;
   font-family: $font-family--semi-bold;
   font-size: $font-size--medium;
+  line-height: $line-height--medium-small;
 }
 
 .margin-top-btn {

--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.tsx
@@ -63,6 +63,7 @@ export function SearchCriteria(props: SearchCriteriaProps): React.ReactElement {
     ...provided,
     width: "80px",
     border: "none",
+    lineHeight: "29px",
   });
 
   const customStylesBy = { ...customStyles };
@@ -70,6 +71,7 @@ export function SearchCriteria(props: SearchCriteriaProps): React.ReactElement {
     ...provided,
     width: "170px",
     border: "none",
+    lineHeight: "29px",
   });
 
   return (

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -118,6 +118,32 @@ function makeCommonColumns(
       sort: (stmt: AggregateStatistics) => stmt.applicationName,
     },
     {
+      name: "time",
+      title: statisticsTableTitles.time(statType),
+      className: cx("statements-table__col-latency"),
+      cell: latencyBar,
+      sort: (stmt: AggregateStatistics) => stmt.stats.service_lat.mean,
+    },
+    {
+      name: "workloadPct",
+      title: statisticsTableTitles.workloadPct(statType),
+      cell: workloadPctBarChart(
+        statements,
+        defaultBarChartOptions,
+        totalWorkload,
+      ),
+      sort: (stmt: AggregateStatistics) =>
+        (stmt.stats.service_lat.mean * longToInt(stmt.stats.count)) /
+        totalWorkload,
+    },
+    {
+      name: "contention",
+      title: statisticsTableTitles.contention(statType),
+      cell: contentionBar,
+      sort: (stmt: AggregateStatistics) =>
+        FixLong(Number(stmt.stats.exec_stats.contention_time.mean)),
+    },
+    {
       name: "rowsProcessed",
       title: statisticsTableTitles.rowsProcessed(statType),
       className: cx("statements-table__col-rows-read"),
@@ -137,20 +163,6 @@ function makeCommonColumns(
       cell: bytesReadBar,
       sort: (stmt: AggregateStatistics) =>
         FixLong(Number(stmt.stats.bytes_read.mean)),
-    },
-    {
-      name: "time",
-      title: statisticsTableTitles.time(statType),
-      className: cx("statements-table__col-latency"),
-      cell: latencyBar,
-      sort: (stmt: AggregateStatistics) => stmt.stats.service_lat.mean,
-    },
-    {
-      name: "contention",
-      title: statisticsTableTitles.contention(statType),
-      cell: contentionBar,
-      sort: (stmt: AggregateStatistics) =>
-        FixLong(Number(stmt.stats.exec_stats.contention_time.mean)),
     },
     {
       name: "maxMemUsage",
@@ -173,18 +185,6 @@ function makeCommonColumns(
       cell: retryBar,
       sort: (stmt: AggregateStatistics) =>
         longToInt(stmt.stats.count) - longToInt(stmt.stats.first_attempt_count),
-    },
-    {
-      name: "workloadPct",
-      title: statisticsTableTitles.workloadPct(statType),
-      cell: workloadPctBarChart(
-        statements,
-        defaultBarChartOptions,
-        totalWorkload,
-      ),
-      sort: (stmt: AggregateStatistics) =>
-        (stmt.stats.service_lat.mean * longToInt(stmt.stats.count)) /
-        totalWorkload,
     },
     {
       name: "regionNodes",


### PR DESCRIPTION
Backport 1/1 commits from #102650.

/cc @cockroachdb/release

---

Part Of #102374

Previously, the style was being overwritten on CC Console, so this commit adds all the missing styles already inherited on DB Console, that was not explicitly set.

Before
<img width="955" alt="Screenshot 2023-04-28 at 7 23 58 PM" src="https://user-images.githubusercontent.com/1017486/235269441-d51602da-8306-4354-9e97-73507f68c392.png">


After
<img width="974" alt="Screenshot 2023-04-28 at 7 24 08 PM" src="https://user-images.githubusercontent.com/1017486/235269454-532e561c-3854-4249-b015-194fa7f3f267.png">


This commit also changes the order of the columns on Statement Page to put the `% of All Runtime` more prominent and not at the end.

Release note: None

---
Release justification: UX improvements
