### PR TITLE
release-22.2: sql: fix contentionRegistry.Start() location

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -769,7 +769,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		cfg.sqlStatusServer.TxnIDResolution,
 		&contentionMetrics,
 	)
-	contentionRegistry.Start(ctx, cfg.stopper)
 
 	storageEngineClient := kvserver.NewStorageEngineClient(cfg.nodeDialer)
 
@@ -1286,6 +1285,7 @@ func (s *SQLServer) preStart(
 	s.temporaryObjectCleaner.Start(ctx, stopper)
 	s.distSQLServer.Start()
 	s.pgServer.Start(ctx, stopper)
+	s.execCfg.ContentionRegistry.Start(ctx, stopper)
 	if err := s.statsRefresher.Start(ctx, stopper, stats.DefaultRefreshInterval); err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #98486.

/cc @cockroachdb/release

---

The contentionRegistry.Start() in server/server_sql.go is moved to preStart function.

Epic: none
Closes: #98443

Release note: none
Release justification: bug fix