### PR TITLE
workload: remove initial prefix from bank workload payload

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -265,7 +265,7 @@ func TestDeterministicInitialData(t *testing.T) {
 	// TODO(dan): We're starting to accumulate these various lists, bigInitialData
 	// is another. Consider moving them to be properties on the workload.Meta.
 	fingerprintGoldens := map[string]uint64{
-		`bank`:       0x7b4d519ed8bd07ce,
+		`bank`:       0xb9065bb21c3594a2,
 		`bulkingest`: 0xcf3e4028ac084aea,
 		`indexes`:    0xcbf29ce484222325,
 		`intro`:      0x81c6a8cfd9c3452a,

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -154,9 +154,7 @@ func (b *bank) Tables() []workload.Table {
 				for rowIdx := rowBegin; rowIdx < rowEnd; rowIdx++ {
 					var payload []byte
 					*a, payload = a.Alloc(b.payloadBytes, 0 /* extraCap */)
-					const initialPrefix = `initial-`
-					copy(payload[:len(initialPrefix)], []byte(initialPrefix))
-					randStringLetters(rng, payload[len(initialPrefix):])
+					randStringLetters(rng, payload)
 
 					rowOffset := rowIdx - rowBegin
 					idCol[rowOffset] = int64(rowIdx)

--- a/pkg/workload/csv_test.go
+++ b/pkg/workload/csv_test.go
@@ -37,12 +37,12 @@ func TestHandleCSV(t *testing.T) {
 	}{
 		{
 			`?rows=1`, `
-0,0,initial-dTqnRurXztAPkykhZWvsCmeJkMwRNcJAvTlNbgUEYfagEQJaHmfPsquKZUBOGwpAjPtATpGXFJkrtQCEJODSlmQctvyh`,
+0,0,dTqnRurXztAPkykhZWvsCmeJkMwRNcJAvTlNbgUEYfagEQJaHmfPsquKZUBOGwpAjPtATpGXFJkrtQCEJODSlmQctvyhWevfEafP`,
 		},
 		{
 			`?rows=5&row-start=1&row-end=3&batch-size=1`, `
-1,0,initial-vOpikzTTWxvMqnkpfEIVXgGyhZNDqvpVqpNnHawruAcIVltgbnIEIGmCDJcnkVkfVmAcutkMvRACFuUBPsZTemTDSfZT
-2,0,initial-qMvoPeRiOBXvdVQxhZUfdmehETKPXyBaVWxzMqwiStIkxfoDFygYxIDyXiaVEarcwMboFhBlCAapvKijKAyjEAhRBNZz`,
+1,0,vOpikzTTWxvMqnkpfEIVXgGyhZNDqvpVqpNnHawruAcIVltgbnIEIGmCDJcnkVkfVmAcutkMvRACFuUBPsZTemTDSfZTLdqDkrhj
+2,0,qMvoPeRiOBXvdVQxhZUfdmehETKPXyBaVWxzMqwiStIkxfoDFygYxIDyXiaVEarcwMboFhBlCAapvKijKAyjEAhRBNZzvGuJkQXu`,
 		},
 	}
 
@@ -123,8 +123,8 @@ func TestCSVRowsReader(t *testing.T) {
 	b, err := io.ReadAll(r)
 	require.NoError(t, err)
 	expected := `
-1,0,initial-vOpikzTTWxvMqnkpfEIVXgGyhZNDqvpVqpNnHawruAcIVltgbnIEIGmCDJcnkVkfVmAcutkMvRACFuUBPsZTemTDSfZT
-2,0,initial-qMvoPeRiOBXvdVQxhZUfdmehETKPXyBaVWxzMqwiStIkxfoDFygYxIDyXiaVEarcwMboFhBlCAapvKijKAyjEAhRBNZz
+1,0,vOpikzTTWxvMqnkpfEIVXgGyhZNDqvpVqpNnHawruAcIVltgbnIEIGmCDJcnkVkfVmAcutkMvRACFuUBPsZTemTDSfZTLdqDkrhj
+2,0,qMvoPeRiOBXvdVQxhZUfdmehETKPXyBaVWxzMqwiStIkxfoDFygYxIDyXiaVEarcwMboFhBlCAapvKijKAyjEAhRBNZzvGuJkQXu
 `
 	require.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(b)))
 }


### PR DESCRIPTION
An `initial-` prefix is added to the payload column of the `bank` table when the workload is initialized. It was introduced about 6 years ago [1] and its purpose at the time is not clear. There are two main problems with it:

* the `initial-` prefix suggests the payload may be updated, but that actually never happens.
* as currently implemented, it assumes that the `payload-bytes` command line flag is at least `len([]byte("initial-"))`. Passing a lower value to that command line flag leads to a panic. This is an implicit assumption that should not exist.

This changes the row generation function so that `payload-bytes` bytes are randomly generated and inserted into the `payload` column, without the `initial-` prefix.

[1] d49d5353ed9432307b806deb95acfdc9ce43c191

Epic: none

Release note: None