### PR TITLE
roachtest: increase kv/restart/nodes=12 logging verbosity

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -962,7 +962,10 @@ func registerKVRestartImpact(r registry.Registry) {
 			nodes := c.Spec().NodeCount - 1
 			workloadNode := c.Spec().NodeCount
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
+			startOpts := option.DefaultStartOpts()
+			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
+				"--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
+			c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, nodes))
 
 			// The duration of the outage.
 			duration, err := time.ParseDuration(ifLocal(c, "20s", "10m"))


### PR DESCRIPTION
The `kv/restart/nodes=12` relies on correct allocation decisions to pass. This commit increases the logging verbosity of related components so that if/when the test fails, a root cause is easier to establish.

Informs: #102655

Epic: none

Release note: None