### PR TITLE
ccl/sqlproxyccl: add a tenant metadata watcher to the directory cache

### DIFF
--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -978,9 +978,17 @@ var _ tenant.DirectoryCache = &testTenantDirectoryCache{}
 // testTenantDirectoryCache is a test implementation of the tenant directory
 // cache.
 type testTenantDirectoryCache struct {
+	lookupTenantFn        func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error)
 	lookupTenantPodsFn    func(ctx context.Context, tenantID roachpb.TenantID, clusterName string) ([]*tenant.Pod, error)
 	trylookupTenantPodsFn func(ctx context.Context, tenantID roachpb.TenantID) ([]*tenant.Pod, error)
 	reportFailureFn       func(ctx context.Context, tenantID roachpb.TenantID, addr string) error
+}
+
+// LookupTenant implements the tenant.DirectoryCache interface.
+func (r *testTenantDirectoryCache) LookupTenant(
+	ctx context.Context, tenantID roachpb.TenantID,
+) (*tenant.Tenant, error) {
+	return r.lookupTenantFn(ctx, tenantID)
 }
 
 // LookupTenantPods implements the tenant.DirectoryCache interface.

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -367,8 +367,7 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn net.Conn) 
 	// correctly parsing the IP address here.
 	ipAddr, _, err := addr.SplitHostPort(fe.Conn.RemoteAddr().String(), "")
 	if err != nil {
-		clientErr := withCode(errors.New(
-			"unexpected connection address"), codeParamsRoutingFailed)
+		clientErr := withCode(errors.New("unexpected connection address"), codeParamsRoutingFailed)
 		log.Errorf(ctx, "could not parse address: %v", err.Error())
 		updateMetricsAndSendErrToClient(clientErr, fe.Conn, handler.metrics)
 		return clientErr

--- a/pkg/ccl/sqlproxyccl/tenant/directory.proto
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.proto
@@ -50,11 +50,7 @@ message Pod {
   string addr = 1;
   // State gives the current status of the tenant pod.
   PodState state = 3;
-  // Load is a number in the range [0, 1] indicating the current amount of load
-  // experienced by this tenant pod.
-  //
-  // TODO(jaylim-crl): Remove the Load field since it is now unused.
-  float Load = 4;
+  reserved 4;
   // StateTimestamp represents the timestamp that the state was last updated.
   google.protobuf.Timestamp stateTimestamp = 5 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
 }

--- a/pkg/ccl/sqlproxyccl/tenant/directory.proto
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.proto
@@ -151,8 +151,10 @@ service Directory {
   // does not exist, GetTenant returns a GRPC NotFound error.
   rpc GetTenant(GetTenantRequest) returns (GetTenantResponse);
   // WatchTenants gets a stream of tenant metadata change notifications.
-  // Notifications are sent when a tenant is created, destroyed, or modified.
-  // When WatchTenants is first called, it returns notifications for all
-  // existing tenants.
+  // Notifications are sent when a tenant is created or modified. When
+  // WatchTenants is first called, it returns notifications for all existing
+  // tenants.
+  //
+  // Note that this does not return a notification for deleted tenants.
   rpc WatchTenants(WatchTenantsRequest) returns (stream WatchTenantsResponse);
 }

--- a/pkg/ccl/sqlproxyccl/tenant/directory.proto
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.proto
@@ -15,6 +15,7 @@ import "google/protobuf/timestamp.proto";
 
 // PodState gives the current state of a tenant pod, so that the proxy knows
 // how/where to route traffic.
+//
 // NOTE: This is not the same as the Kubernetes Pod Status.
 enum PodState {
   option (gogoproto.goproto_enum_prefix) = false;
@@ -74,7 +75,7 @@ message ListPodsResponse {
 // WatchPodsRequest is empty as we want to get all notifications.
 message WatchPodsRequest {}
 
-// WatchPodsResponse represents the notifications that the server sends to
+// WatchPodsResponse represents the pod notifications that the server sends to
 // its clients when clients want to monitor the directory server activity.
 message WatchPodsResponse {
   // Pod describes the tenant pod which has been added, modified, or deleted.
@@ -93,6 +94,14 @@ message EnsurePodRequest {
 message EnsurePodResponse {
 }
 
+// Tenant contains information about a tenant, such as its name and ID.
+message Tenant {
+  // TenantID identifies the tenant.
+  uint64 tenant_id = 1 [(gogoproto.customname) = "TenantID"];
+  // ClusterName is the name of the tenant's cluster.
+  string cluster_name = 2;
+}
+
 // GetTenantRequest is used by a client to request from the sever metadata
 // related to a given tenant.
 message GetTenantRequest {
@@ -103,7 +112,22 @@ message GetTenantRequest {
 // GetTenantResponse is sent back when a client requests metadata for a tenant.
 message GetTenantResponse {
   // ClusterName is the name of the tenant's cluster.
-  string cluster_name = 1; // add more metadata if needed
+  //
+  // TODO(jaylim-crl): Remove this field once it is no longer used.
+  string cluster_name = 1;
+  // Tenant describes the tenant that is being requested.
+  Tenant tenant = 2;
+}
+
+// WatchTenantsRequest is empty as we want to get all notifications.
+message WatchTenantsRequest {}
+
+// WatchTenantsResponse represents the tenant notifications that the server
+// sends to its clients when clients want to monitor the directory server
+// activity.
+message WatchTenantsResponse {
+  // Tenant describes the tenant which has been added, modified, or deleted.
+  Tenant tenant = 1;
 }
 
 // Directory specifies a service that keeps track and manages tenant backends,
@@ -126,4 +150,9 @@ service Directory {
   // GetTenant is used to fetch the metadata of a specific tenant. If the tenant
   // does not exist, GetTenant returns a GRPC NotFound error.
   rpc GetTenant(GetTenantRequest) returns (GetTenantResponse);
+  // WatchTenants gets a stream of tenant metadata change notifications.
+  // Notifications are sent when a tenant is created, destroyed, or modified.
+  // When WatchTenants is first called, it returns notifications for all
+  // existing tenants.
+  rpc WatchTenants(WatchTenantsRequest) returns (stream WatchTenantsResponse);
 }

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
@@ -455,9 +455,9 @@ func (d *directoryCache) updateTenantEntry(ctx context.Context, pod *Pod) {
 	case RUNNING, DRAINING:
 		// Add entries of RUNNING and DRAINING pods if they are not already present.
 		if entry.AddPod(pod) {
-			log.Infof(ctx, "added IP address %s with load %.3f for tenant %d", pod.Addr, pod.Load, pod.TenantID)
+			log.Infof(ctx, "added IP address %s for tenant %d", pod.Addr, pod.TenantID)
 		} else {
-			log.Infof(ctx, "updated IP address %s with load %.3f for tenant %d", pod.Addr, pod.Load, pod.TenantID)
+			log.Infof(ctx, "updated IP address %s for tenant %d", pod.Addr, pod.TenantID)
 		}
 	case DELETING:
 		// Remove addresses of DELETING pods.

--- a/pkg/ccl/sqlproxyccl/tenant/entry.go
+++ b/pkg/ccl/sqlproxyccl/tenant/entry.go
@@ -80,7 +80,14 @@ func (e *tenantEntry) Initialize(ctx context.Context, client DirectoryClient) er
 			return
 		}
 
-		e.ClusterName = tenantResp.ClusterName
+		// TODO(jaylim-crl): Once tenant directories have been updated to return
+		// the Tenant field, the `else` block can be removed. We should also
+		// return an error if the Tenant field is nil then.
+		if tenantResp.Tenant != nil {
+			e.ClusterName = tenantResp.Tenant.ClusterName
+		} else {
+			e.ClusterName = tenantResp.ClusterName
+		}
 	})
 
 	// If Initialize has already been called, return any error that occurred.

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
@@ -38,10 +38,9 @@ var _ tenant.DirectoryServer = (*TestDirectoryServer)(nil)
 
 // Process stores information about a running tenant process.
 type Process struct {
-	Stopper  *stop.Stopper
-	Cmd      *exec.Cmd
-	SQL      net.Addr
-	FakeLoad float32
+	Stopper *stop.Stopper
+	Cmd     *exec.Cmd
+	SQL     net.Addr
 }
 
 // NewSubStopper creates a new stopper that will be stopped when either the
@@ -315,12 +314,11 @@ func (s *TestDirectoryServer) listLocked(
 		return &tenant.ListPodsResponse{}, nil
 	}
 	resp := tenant.ListPodsResponse{}
-	for addr, proc := range processByAddr {
+	for addr := range processByAddr {
 		resp.Pods = append(resp.Pods, &tenant.Pod{
 			TenantID:       req.TenantID,
 			Addr:           addr.String(),
 			State:          tenant.RUNNING,
-			Load:           proc.FakeLoad,
 			StateTimestamp: timeutil.Now(),
 		})
 	}
@@ -342,7 +340,6 @@ func (s *TestDirectoryServer) registerInstanceLocked(tenantID uint64, process *P
 			TenantID:       tenantID,
 			Addr:           process.SQL.String(),
 			State:          tenant.RUNNING,
-			Load:           process.FakeLoad,
 			StateTimestamp: timeutil.Now(),
 		},
 	})
@@ -390,7 +387,7 @@ func (s *TestDirectoryServer) startTenantLocked(
 	if err != nil {
 		return nil, err
 	}
-	process := &Process{SQL: sqlListener.Addr(), FakeLoad: 0.01}
+	process := &Process{SQL: sqlListener.Addr()}
 	args := s.args
 	if len(args) == 0 {
 		args = append(args,

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
@@ -128,6 +128,19 @@ func (d *TestSimpleDirectoryServer) GetTenant(
 	return &tenant.GetTenantResponse{}, nil
 }
 
+// WatchTenants is a no-op for the simple directory.
+//
+// WatchTenants implements the tenant.DirectoryServer interface.
+func (d *TestSimpleDirectoryServer) WatchTenants(
+	req *tenant.WatchTenantsRequest, server tenant.Directory_WatchTenantsServer,
+) error {
+	// Insted of returning right away, we block until context is done.
+	// This prevents the proxy server from constantly trying to establish
+	// a watch in test environments, causing spammy logs.
+	<-server.Context().Done()
+	return nil
+}
+
 // DeleteTenant marks the given tenant as deleted, so that a NotFound error
 // will be returned for certain directory server endpoints. This also changes
 // the behavior of ListPods so no pods are returned.

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
@@ -52,9 +52,9 @@ func NewTestSimpleDirectoryServer(podAddr string) (*TestSimpleDirectoryServer, *
 	return dir, grpcServer
 }
 
-// ListPods returns a list with a single RUNNING pod. The load of the pod will
-// always be zero, and the address of the pod will be the same regardless of
-// tenant ID. If the tenant has been deleted, no pods will be returned.
+// ListPods returns a list with a single RUNNING pod. The address of the pod
+// will be the same regardless of tenant ID. If the tenant has been deleted, no
+// pods will be returned.
 //
 // ListPods implements the tenant.DirectoryServer interface.
 func (d *TestSimpleDirectoryServer) ListPods(

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
@@ -72,6 +72,10 @@ type TestStaticDirectoryServer struct {
 		// eventListeners stores a list of listeners that are watching changes
 		// to pods through WatchPods.
 		eventListeners *list.List
+
+		// tenantEventListeners stores a list of listeners that are watching
+		// changes to tenants through WatchTenants.
+		tenantEventListeners *list.List
 	}
 }
 
@@ -88,6 +92,7 @@ func NewTestStaticDirectoryServer(
 	dir.mu.tenants = make(map[roachpb.TenantID][]*tenant.Pod)
 	dir.mu.tenantNames = make(map[roachpb.TenantID]string)
 	dir.mu.eventListeners = list.New()
+	dir.mu.tenantEventListeners = list.New()
 	return dir
 }
 
@@ -148,7 +153,7 @@ func (d *TestStaticDirectoryServer) WatchPods(
 	chElement := addListener(c)
 
 	return stopper.RunTask(
-		context.Background(),
+		server.Context(),
 		"watch-pods-server",
 		func(ctx context.Context) {
 			defer func() {
@@ -213,7 +218,74 @@ func (d *TestStaticDirectoryServer) GetTenant(
 	if _, ok := d.mu.tenants[tenantID]; !ok {
 		return nil, status.Errorf(codes.NotFound, "tenant does not exist")
 	}
-	return &tenant.GetTenantResponse{ClusterName: d.mu.tenantNames[tenantID]}, nil
+
+	return &tenant.GetTenantResponse{
+		Tenant: &tenant.Tenant{
+			TenantID:    tenantID.ToUint64(),
+			ClusterName: d.mu.tenantNames[tenantID],
+		},
+	}, nil
+}
+
+// WatchTenants allows callers to monitor for tenant update events.
+//
+// WatchTenants implements the tenant.DirectoryServer interface.
+func (d *TestStaticDirectoryServer) WatchTenants(
+	req *tenant.WatchTenantsRequest, server tenant.Directory_WatchTenantsServer,
+) error {
+	d.process.Lock()
+	stopper := d.process.stopper
+	d.process.Unlock()
+
+	// This cannot happen unless WatchTenants was called directly, which we
+	// shouldn't since it is meant to be called through a GRPC client.
+	if stopper == nil {
+		return status.Errorf(codes.FailedPrecondition, "directory server has not been started")
+	}
+
+	addListener := func(ch chan *tenant.WatchTenantsResponse) *list.Element {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		return d.mu.tenantEventListeners.PushBack(ch)
+	}
+	removeListener := func(e *list.Element) chan *tenant.WatchTenantsResponse {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		return d.mu.tenantEventListeners.Remove(e).(chan *tenant.WatchTenantsResponse)
+	}
+
+	// Construct the channel with a small buffer to allow for a burst of
+	// notifications, and a slow receiver.
+	c := make(chan *tenant.WatchTenantsResponse, 10)
+	chElement := addListener(c)
+
+	return stopper.RunTask(
+		server.Context(),
+		"watch-tenants-server",
+		func(ctx context.Context) {
+			defer func() {
+				if ch := removeListener(chElement); ch != nil {
+					close(ch)
+				}
+			}()
+
+			for watch := true; watch; {
+				select {
+				case e, ok := <-c:
+					// Channel was closed.
+					if !ok {
+						watch = false
+						break
+					}
+					if err := server.Send(e); err != nil {
+						watch = false
+					}
+				case <-stopper.ShouldQuiesce():
+					watch = false
+				}
+			}
+		},
+	)
 }
 
 // CreateTenant creates a tenant with the given tenant ID in the directory
@@ -225,8 +297,15 @@ func (d *TestStaticDirectoryServer) CreateTenant(tenantID roachpb.TenantID, clus
 	if _, ok := d.mu.tenants[tenantID]; ok {
 		return
 	}
+
 	d.mu.tenants[tenantID] = make([]*tenant.Pod, 0)
 	d.mu.tenantNames[tenantID] = clusterName
+
+	// Emit an event that the tenant has been created.
+	d.notifyTenantUpdateLocked(&tenant.Tenant{
+		TenantID:    tenantID.ToUint64(),
+		ClusterName: clusterName,
+	})
 }
 
 // DeleteTenant ensures that the tenant with the given tenant ID has been
@@ -431,6 +510,27 @@ func (d *TestStaticDirectoryServer) notifyPodUpdateLocked(pod *tenant.Pod) {
 			e = e.Next()
 			ch := d.mu.eventListeners.Remove(eToClose)
 			close(ch.(chan *tenant.WatchPodsResponse))
+		}
+	}
+}
+
+// notifyTenantUpdateLocked sends a tenant update event to all WatchTenants listeners.
+func (d *TestStaticDirectoryServer) notifyTenantUpdateLocked(t *tenant.Tenant) {
+	// Make a copy of the tenant to prevent race issues.
+	copyTenant := *t
+	res := &tenant.WatchTenantsResponse{Tenant: &copyTenant}
+
+	for e := d.mu.tenantEventListeners.Front(); e != nil; {
+		select {
+		case e.Value.(chan *tenant.WatchTenantsResponse) <- res:
+			e = e.Next()
+		default:
+			// The receiver is unable to consume fast enough. Close the channel
+			// and remove it from the list.
+			eToClose := e
+			e = e.Next()
+			ch := d.mu.tenantEventListeners.Remove(eToClose)
+			close(ch.(chan *tenant.WatchTenantsResponse))
 		}
 	}
 }


### PR DESCRIPTION
Most of these changes prepare us for updating the tenant metadata list to include
IP allowlist and private endpoint entries. `LookupTenant` will be called by the ACL 
watcher during connection startup time (and periodically later on).

#### ccl/sqlproxyccl: remove the Load field from the Pod proto message 

The Load field has been deprecated for months, and is no longer being used
in production. The tenant directory implementation is no longer emitting pod
loads. This commit addresses an old TODO.

Release note: None

#### ccl/sqlproxyccl: return Tenant proto message in GetTenant and add WatchTenants

This commit adds a new Tenant proto message, which will replace the existing
fields in the response of GetTenant. At the same time, we add a new
WatchTenants method on the directory server interface. This is needed to
support adding more fields (e.g. IP Allowlist and Private Endpoints) to the
tenant object which are dynamic.

Release note: None

#### ccl/sqlproxyccl: add LookupTenant and metadata watcher to the directory cache

Previously, the directory cache will only invoke GetTenant once during tenant
initialization since the cluster name is static throughout the lifetime of a
tenant. Given that we plan to add IP and private endpoint entries to the
tenant's spec, we need a mechanism that fetches the up-to-date list during
connection time.

This commit changes the behavior of Initialize for the tenant entry to invoke
GetTenant if and only if it hasn't been called within the past 5 seconds. A
tenant watcher has been added to update the tenant entry on a best-effort
basis.

Release note: None

Epic: none