### PR TITLE
release-22.2: codeowners, roachtest: merge sql-schema, sql-sessions to sql-foundations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,53 +59,53 @@
 /pkg/sql/show_create*.go     @cockroachdb/sql-syntax-prs
 /pkg/sql/types/              @cockroachdb/sql-syntax-prs
 
-/pkg/sql/crdb_internal.go    @cockroachdb/sql-sessions
-/pkg/sql/pg_catalog.go       @cockroachdb/sql-sessions
-/pkg/sql/pgwire/             @cockroachdb/sql-sessions @cockroachdb/server-prs
-/pkg/sql/pgwire/auth.go      @cockroachdb/sql-sessions @cockroachdb/server-prs @cockroachdb/prodsec
-/pkg/sql/sem/builtins/       @cockroachdb/sql-sessions
-/pkg/sql/vtable/             @cockroachdb/sql-sessions
+/pkg/sql/crdb_internal.go    @cockroachdb/sql-foundations
+/pkg/sql/pg_catalog.go       @cockroachdb/sql-foundations
+/pkg/sql/pgwire/             @cockroachdb/sql-foundations @cockroachdb/server-prs
+/pkg/sql/pgwire/auth.go      @cockroachdb/sql-foundations @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/sql/sem/builtins/       @cockroachdb/sql-foundations
+/pkg/sql/vtable/             @cockroachdb/sql-foundations
 
-/pkg/sql/sessiondata/        @cockroachdb/sql-sessions
-/pkg/sql/tests/rsg_test.go   @cockroachdb/sql-sessions
-/pkg/sql/ttl                 @cockroachdb/sql-sessions
+/pkg/sql/sessiondata/        @cockroachdb/sql-foundations
+/pkg/sql/tests/rsg_test.go   @cockroachdb/sql-foundations
+/pkg/sql/ttl                 @cockroachdb/sql-foundations
 
-/pkg/ccl/schemachangerccl/   @cockroachdb/sql-schema
-/pkg/sql/catalog/            @cockroachdb/sql-schema
+/pkg/ccl/schemachangerccl/   @cockroachdb/sql-foundations
+/pkg/sql/catalog/            @cockroachdb/sql-foundations
 /pkg/sql/catalog/multiregion @cockroachdb/multiregion
-/pkg/sql/doctor/             @cockroachdb/sql-schema
-/pkg/sql/gcjob/              @cockroachdb/sql-schema
-/pkg/sql/gcjob_test/         @cockroachdb/sql-schema
-/pkg/sql/privilege/          @cockroachdb/sql-schema
-/pkg/sql/schemachange/       @cockroachdb/sql-schema
-/pkg/sql/schemachanger/      @cockroachdb/sql-schema
-/pkg/sql/alter*.go           @cockroachdb/sql-schema
-/pkg/sql/backfill*.go        @cockroachdb/sql-schema
-/pkg/sql/create*.go          @cockroachdb/sql-schema
-/pkg/sql/database*.go        @cockroachdb/sql-schema
-/pkg/sql/drop*.go            @cockroachdb/sql-schema
-/pkg/sql/grant*.go           @cockroachdb/sql-schema
-/pkg/sql/rename*.go          @cockroachdb/sql-schema
-/pkg/sql/revoke*.go          @cockroachdb/sql-schema
-/pkg/sql/schema*.go          @cockroachdb/sql-schema
-/pkg/sql/zone*.go            @cockroachdb/sql-schema
+/pkg/sql/doctor/             @cockroachdb/sql-foundations
+/pkg/sql/gcjob/              @cockroachdb/sql-foundations
+/pkg/sql/gcjob_test/         @cockroachdb/sql-foundations
+/pkg/sql/privilege/          @cockroachdb/sql-foundations
+/pkg/sql/schemachange/       @cockroachdb/sql-foundations
+/pkg/sql/schemachanger/      @cockroachdb/sql-foundations
+/pkg/sql/alter*.go           @cockroachdb/sql-foundations
+/pkg/sql/backfill*.go        @cockroachdb/sql-foundations
+/pkg/sql/create*.go          @cockroachdb/sql-foundations
+/pkg/sql/database*.go        @cockroachdb/sql-foundations
+/pkg/sql/drop*.go            @cockroachdb/sql-foundations
+/pkg/sql/grant*.go           @cockroachdb/sql-foundations
+/pkg/sql/rename*.go          @cockroachdb/sql-foundations
+/pkg/sql/revoke*.go          @cockroachdb/sql-foundations
+/pkg/sql/schema*.go          @cockroachdb/sql-foundations
+/pkg/sql/zone*.go            @cockroachdb/sql-foundations
 
 /pkg/cli/                    @cockroachdb/cli-prs
 # last-rule-wins so bulk i/o takes userfile.go even though cli-prs takes pkg/cli
 /pkg/cli/userfile.go         @cockroachdb/disaster-recovery
 /pkg/cli/auth.go             @cockroachdb/unowned        @cockroachdb/prodsec @cockroachdb/cli-prs
 /pkg/cli/cert*.go            @cockroachdb/cli-prs        @cockroachdb/prodsec
-/pkg/cli/demo*.go            @cockroachdb/sql-sessions @cockroachdb/server-prs @cockroachdb/cli-prs
-/pkg/cli/democluster         @cockroachdb/sql-sessions @cockroachdb/server-prs @cockroachdb/cli-prs
+/pkg/cli/demo*.go            @cockroachdb/sql-foundations @cockroachdb/server-prs @cockroachdb/cli-prs
+/pkg/cli/democluster         @cockroachdb/sql-foundations @cockroachdb/server-prs @cockroachdb/cli-prs
 /pkg/cli/debug*.go           @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/debug_job_trace*.go @cockroachdb/jobs-prs
-/pkg/cli/doctor*.go          @cockroachdb/sql-schema     @cockroachdb/cli-prs
+/pkg/cli/doctor*.go          @cockroachdb/sql-foundations     @cockroachdb/cli-prs
 /pkg/cli/import_test.go      @cockroachdb/disaster-recovery        @cockroachdb/cli-prs
-/pkg/cli/sql*.go             @cockroachdb/sql-sessions @cockroachdb/cli-prs
-/pkg/cli/clisqlshell/        @cockroachdb/sql-sessions @cockroachdb/cli-prs
-/pkg/cli/clisqlclient/       @cockroachdb/sql-sessions @cockroachdb/cli-prs
-/pkg/cli/clisqlcfg/          @cockroachdb/sql-sessions @cockroachdb/cli-prs
-/pkg/cli/clisqlexec/         @cockroachdb/sql-sessions @cockroachdb/cli-prs
+/pkg/cli/sql*.go             @cockroachdb/sql-foundations @cockroachdb/cli-prs
+/pkg/cli/clisqlshell/        @cockroachdb/sql-foundations @cockroachdb/cli-prs
+/pkg/cli/clisqlclient/       @cockroachdb/sql-foundations @cockroachdb/cli-prs
+/pkg/cli/clisqlcfg/          @cockroachdb/sql-foundations @cockroachdb/cli-prs
+/pkg/cli/clisqlexec/         @cockroachdb/sql-foundations @cockroachdb/cli-prs
 /pkg/cli/start*.go           @cockroachdb/cli-prs        @cockroachdb/server-prs
 /pkg/cli/mt_proxy.go         @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
 /pkg/cli/mt_start_sql.go     @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
@@ -137,7 +137,7 @@
 /pkg/server/node_http*.go                @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/node_tenant*go               @cockroachdb/obs-inf-prs @cockroachdb/multi-tenant @cockroachdb/server-prs
 /pkg/server/node_tombstone*.go           @cockroachdb/kv-prs      @cockroachdb/server-prs
-/pkg/server/pgurl/                       @cockroachdb/sql-sessions @cockroachdb/cli-prs
+/pkg/server/pgurl/                       @cockroachdb/sql-foundations @cockroachdb/cli-prs
 /pkg/server/server_http*.go              @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/server_import_ts*.go         @cockroachdb/obs-inf-prs @cockroachdb/kv-prs
 /pkg/server/serverpb/                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
@@ -194,10 +194,10 @@
 /pkg/gen/*.bzl               @cockroachdb/dev-inf-noreview
 /pkg/gen/gen.bzl             @cockroachdb/dev-inf
 
-/pkg/acceptance/             @cockroachdb/sql-sessions
+/pkg/acceptance/             @cockroachdb/sql-foundations
 /pkg/base/                   @cockroachdb/unowned @cockroachdb/kv-prs @cockroachdb/server-prs
 /pkg/bench/                  @cockroachdb/sql-queries-noreview
-/pkg/bench/rttanalysis       @cockroachdb/sql-schema
+/pkg/bench/rttanalysis       @cockroachdb/sql-foundations
 /pkg/blobs/                  @cockroachdb/disaster-recovery
 /pkg/build/                  @cockroachdb/dev-inf
 /pkg/ccl/baseccl/            @cockroachdb/cli-prs
@@ -215,7 +215,7 @@
 /pkg/ccl/multiregionccl/     @cockroachdb/multiregion
 /pkg/ccl/multitenantccl/     @cockroachdb/multi-tenant
 /pkg/ccl/oidcccl/            @cockroachdb/unowned
-/pkg/ccl/partitionccl/       @cockroachdb/sql-schema @cockroachdb/multiregion
+/pkg/ccl/partitionccl/       @cockroachdb/sql-foundations @cockroachdb/multiregion
 /pkg/ccl/serverccl/          @cockroachdb/unowned @cockroachdb/server-prs
 /pkg/ccl/serverccl/server_sql* @cockroachdb/multi-tenant @cockroachdb/server-prs
 /pkg/ccl/serverccl/tenant_*  @cockroachdb/multi-tenant @cockroachdb/server-prs
@@ -223,33 +223,33 @@
 /pkg/ccl/telemetryccl/       @cockroachdb/obs-inf-prs
 /pkg/ccl/testccl/authccl/    @cockroachdb/cloud-identity
 /pkg/ccl/testccl/sqlccl/     @cockroachdb/sql-queries
-/pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-schema
+/pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-foundations
 /pkg/ccl/testutilsccl/       @cockroachdb/test-eng-noreview
 /pkg/ccl/utilccl/            @cockroachdb/unowned @cockroachdb/server-prs
-/pkg/ccl/workloadccl/        @cockroachdb/sql-sessions-noreview
-/pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-schema
+/pkg/ccl/workloadccl/        @cockroachdb/sql-foundations-noreview
+/pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-foundations
 /pkg/clusterversion/         @cockroachdb/kv-prs-noreview
 /pkg/cmd/allocsim/           @cockroachdb/kv-prs
 /pkg/cmd/bazci/              @cockroachdb/dev-inf
 /pkg/cmd/cloudupload/        @cockroachdb/dev-inf
 /pkg/cmd/cmdutil/            @cockroachdb/dev-inf
-/pkg/cmd/cmp-protocol/       @cockroachdb/sql-sessions
-/pkg/cmd/cmp-sql/            @cockroachdb/sql-sessions
-/pkg/cmd/cmpconn/            @cockroachdb/sql-sessions
+/pkg/cmd/cmp-protocol/       @cockroachdb/sql-foundations
+/pkg/cmd/cmp-sql/            @cockroachdb/sql-foundations
+/pkg/cmd/cmpconn/            @cockroachdb/sql-foundations
 /pkg/cmd/cockroach/          @cockroachdb/cli-prs
 /pkg/cmd/cockroach-oss/      @cockroachdb/cli-prs
 /pkg/cmd/cockroach-short/    @cockroachdb/cli-prs
-/pkg/cmd/cockroach-sql/      @cockroachdb/sql-sessions @cockroachdb/cli-prs
+/pkg/cmd/cockroach-sql/      @cockroachdb/sql-foundations @cockroachdb/cli-prs
 /pkg/cmd/compile-build/      @cockroachdb/dev-inf
-/pkg/cmd/cr2pg/              @cockroachdb/sql-sessions
+/pkg/cmd/cr2pg/              @cockroachdb/sql-foundations
 /pkg/cmd/dev/                @cockroachdb/dev-inf
 /pkg/cmd/docgen/             @cockroachdb/docs
 /pkg/cmd/docs-issue-generation/ @cockroachdb/dev-inf
 /pkg/cmd/fuzz/               @cockroachdb/test-eng
-/pkg/cmd/generate-binary/    @cockroachdb/sql-sessions
+/pkg/cmd/generate-binary/    @cockroachdb/sql-foundations
 /pkg/cmd/generate-distdir/ @cockroachdb/dev-inf
 /pkg/cmd/generate-logictest/       @cockroachdb/dev-inf
-/pkg/cmd/generate-metadata-tables/ @cockroachdb/sql-sessions
+/pkg/cmd/generate-metadata-tables/ @cockroachdb/sql-foundations
 /pkg/cmd/generate-spatial-ref-sys/ @cockroachdb/geospatial
 /pkg/cmd/generate-bazel-extra/ @cockroachdb/dev-inf
 /pkg/cmd/generate-staticcheck/ @cockroachdb/dev-inf
@@ -280,7 +280,7 @@
 /pkg/cmd/roachtest/tests     @cockroachdb/test-eng-noreview
 /pkg/cmd/roachvet/           @cockroachdb/dev-inf
 /pkg/cmd/skip-test/          @cockroachdb/test-eng
-/pkg/cmd/skiperrs/           @cockroachdb/sql-sessions
+/pkg/cmd/skiperrs/           @cockroachdb/sql-foundations
 /pkg/cmd/skipped-tests/      @cockroachdb/test-eng
 /pkg/cmd/smith/              @cockroachdb/sql-queries
 /pkg/cmd/smithcmp/           @cockroachdb/sql-queries
@@ -290,11 +290,11 @@
 /pkg/cmd/uptodate/           @cockroachdb/dev-inf
 /pkg/cmd/urlcheck/           @cockroachdb/docs
 /pkg/cmd/whoownsit/          @cockroachdb/test-eng
-/pkg/cmd/workload/           @cockroachdb/sql-sessions-noreview
+/pkg/cmd/workload/           @cockroachdb/sql-foundations-noreview
 /pkg/cmd/wraprules/          @cockroachdb/obs-inf-prs-noreview
 /pkg/cmd/zerosum/            @cockroachdb/kv-noreview
 /pkg/col/                    @cockroachdb/sql-queries
-/pkg/compose/                @cockroachdb/sql-sessions
+/pkg/compose/                @cockroachdb/sql-foundations
 /pkg/config/                 @cockroachdb/kv-prs @cockroachdb/server-prs
 /pkg/docs/                   @cockroachdb/docs
 /pkg/featureflag/            @cockroachdb/cli-prs-noreview
@@ -310,7 +310,7 @@
 /pkg/keysbase/               @cockroachdb/kv-prs
 # Don't ping KV on updates to reserved descriptor IDs and such.
 /pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
-/pkg/upgrade/                @cockroachdb/kv-prs-noreview @cockroachdb/sql-schema
+/pkg/upgrade/                @cockroachdb/kv-prs-noreview @cockroachdb/sql-foundations
 /pkg/multitenant/            @cockroachdb/multi-tenant
 /pkg/release/                @cockroachdb/dev-inf
 /pkg/roachpb/.gitattributes  @cockroachdb/dev-inf
@@ -344,10 +344,10 @@
 /pkg/rpc/auth.go             @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/kv-prs @cockroachdb/prodsec
 /pkg/scheduledjobs/          @cockroachdb/jobs-prs
 /pkg/security/               @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/prodsec
-/pkg/security/clientsecopts/ @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/sql-sessions @cockroachdb/prodsec
+/pkg/security/clientsecopts/ @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/sql-foundations @cockroachdb/prodsec
 /pkg/settings/               @cockroachdb/unowned
 /pkg/spanconfig/             @cockroachdb/kv-prs
-/pkg/startupmigrations/      @cockroachdb/unowned @cockroachdb/sql-schema
+/pkg/startupmigrations/      @cockroachdb/unowned @cockroachdb/sql-foundations
 /pkg/streaming/              @cockroachdb/disaster-recovery
 /pkg/testutils/              @cockroachdb/test-eng-noreview
 /pkg/testutils/reduce/       @cockroachdb/sql-queries
@@ -363,7 +363,7 @@
 /pkg/util/grunning/          @cockroachdb/kv-prs
 /pkg/util/admission/         @cockroachdb/kv-prs
 /pkg/util/tracing            @cockroachdb/obs-inf-prs
-/pkg/workload/               @cockroachdb/sql-sessions-noreview
+/pkg/workload/               @cockroachdb/sql-foundations-noreview
 /pkg/obs/                    @cockroachdb/obs-inf-prs
 /pkg/obsservice/             @cockroachdb/obs-inf-prs
 

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -19,15 +19,13 @@
 
 cockroachdb/docs:
   triage_column_id: 3971225
-cockroachdb/sql-sessions:
+cockroachdb/sql-foundations:
   aliases:
     cockroachdb/sql-syntax-prs: other
     cockroachdb/sqlproxy-prs: other
     cockroachdb/sql-api-prs: other
-  triage_column_id: 7259065
-  label: T-sql-sessions
-cockroachdb/sql-schema:
-  triage_column_id: 8946818
+  triage_column_id: 19467489
+  label: T-sql-foundations
 cockroachdb/sql-queries:
   aliases:
     cockroachdb/sql-optimizer: other

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -145,6 +145,8 @@ func TestTransientClusterSimulateLatencies(t *testing.T) {
 	// has a very high simulated latency between each node.
 	skip.UnderRace(t)
 
+	skip.WithIssue(t, 102115, "flaky test")
+
 	demoCtx := newDemoCtx()
 	// Set up an empty 9-node cluster with simulated latencies.
 	demoCtx.SimulateLatency = true

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -16,16 +16,15 @@ type Owner string
 
 // The allowable values of Owner.
 const (
-	OwnerSQLExperience    Owner = `sql-sessions`
-	OwnerDisasterRecovery Owner = `disaster-recovery`
 	OwnerCDC              Owner = `cdc`
+	OwnerDisasterRecovery Owner = `disaster-recovery`
 	OwnerKV               Owner = `kv`
 	OwnerReplication      Owner = `replication`
 	OwnerMultiRegion      Owner = `multiregion`
 	OwnerObsInf           Owner = `obs-inf-prs`
 	OwnerServer           Owner = `server` // not currently staffed
+	OwnerSQLFoundations   Owner = `sql-foundations`
 	OwnerSQLQueries       Owner = `sql-queries`
-	OwnerSQLSchema        Owner = `sql-schema`
 	OwnerStorage          Owner = `storage`
 	OwnerTestEng          Owner = `test-eng`
 	OwnerDevInf           Owner = `dev-inf`

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -242,7 +242,7 @@ func registerActiveRecord(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:       "activerecord",
-		Owner:      registry.OwnerSQLExperience,
+		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},

--- a/pkg/cmd/roachtest/tests/alterpk.go
+++ b/pkg/cmd/roachtest/tests/alterpk.go
@@ -179,7 +179,7 @@ func registerAlterPK(r registry.Registry) {
 	}
 	r.Add(registry.TestSpec{
 		Name:  "alterpk-bank",
-		Owner: registry.OwnerSQLSchema,
+		Owner: registry.OwnerSQLFoundations,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
 		Cluster: r.MakeClusterSpec(4),
@@ -187,7 +187,7 @@ func registerAlterPK(r registry.Registry) {
 	})
 	r.Add(registry.TestSpec{
 		Name:  "alterpk-tpcc-250",
-		Owner: registry.OwnerSQLSchema,
+		Owner: registry.OwnerSQLFoundations,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
 		Cluster: r.MakeClusterSpec(4, spec.CPU(32)),
@@ -197,7 +197,7 @@ func registerAlterPK(r registry.Registry) {
 	})
 	r.Add(registry.TestSpec{
 		Name:  "alterpk-tpcc-500",
-		Owner: registry.OwnerSQLSchema,
+		Owner: registry.OwnerSQLFoundations,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
 		Cluster: r.MakeClusterSpec(4, spec.CPU(16)),

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -139,7 +139,7 @@ func registerAsyncpg(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "asyncpg",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -126,7 +126,7 @@ func dmsDescribeTasksInput(v *version.Version) *dms.DescribeReplicationTasksInpu
 func registerAWSDMS(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "awsdms",
-		Owner:   registry.OwnerSQLExperience, // TODO(otan): add a migrations OWNERS team
+		Owner:   registry.OwnerSQLFoundations, // TODO(otan): add a migrations OWNERS team
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `awsdms`},
 		Run:     runAWSDMS,

--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -118,7 +118,7 @@ func registerConnectionLatencyTest(r registry.Registry) {
 	numNodes := 3
 	r.Add(registry.TestSpec{
 		Name:  fmt.Sprintf("connection_latency/nodes=%d/certs", numNodes),
-		Owner: registry.OwnerSQLExperience,
+		Owner: registry.OwnerSQLFoundations,
 		// Add one more node for load node.
 		Cluster: r.MakeClusterSpec(numNodes+1, spec.Zones(regionUsCentral)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -134,7 +134,7 @@ func registerConnectionLatencyTest(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    fmt.Sprintf("connection_latency/nodes=%d/multiregion/certs", numMultiRegionNodes),
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.Zones(geoZonesStr)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones, false /*password*/)
@@ -143,7 +143,7 @@ func registerConnectionLatencyTest(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    fmt.Sprintf("connection_latency/nodes=%d/multiregion/password", numMultiRegionNodes),
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.Zones(geoZonesStr)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones, true /*password*/)

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -215,7 +215,7 @@ func registerDjango(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "django",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/drain.go
+++ b/pkg/cmd/roachtest/tests/drain.go
@@ -38,7 +38,7 @@ func registerDrain(r registry.Registry) {
 	{
 		r.Add(registry.TestSpec{
 			Name:    "drain/early-exit-conn-wait",
-			Owner:   registry.OwnerSQLExperience,
+			Owner:   registry.OwnerSQLFoundations,
 			Cluster: r.MakeClusterSpec(1),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runEarlyExitInConnectionWait(ctx, t, c)
@@ -47,7 +47,7 @@ func registerDrain(r registry.Registry) {
 
 		r.Add(registry.TestSpec{
 			Name:    "drain/warn-conn-wait-timeout",
-			Owner:   registry.OwnerSQLExperience,
+			Owner:   registry.OwnerSQLFoundations,
 			Cluster: r.MakeClusterSpec(1),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runWarningForConnWait(ctx, t, c)
@@ -56,7 +56,7 @@ func registerDrain(r registry.Registry) {
 
 		r.Add(registry.TestSpec{
 			Name:    "drain/not-at-quorum",
-			Owner:   registry.OwnerSQLExperience,
+			Owner:   registry.OwnerSQLFoundations,
 			Cluster: r.MakeClusterSpec(3),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runClusterNotAtQuorum(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/flowable.go
+++ b/pkg/cmd/roachtest/tests/flowable.go
@@ -104,7 +104,7 @@ func registerFlowable(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "flowable",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runFlowable(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -164,7 +164,7 @@ func registerGopg(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "gopg",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -134,7 +134,7 @@ func registerGORM(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "gorm",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `orm`},
 		Run:     runGORM,

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -235,7 +235,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 
 	r.Add(registry.TestSpec{
 		Name:       opt.testName,
-		Owner:      registry.OwnerSQLExperience,
+		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},

--- a/pkg/cmd/roachtest/tests/inverted_index.go
+++ b/pkg/cmd/roachtest/tests/inverted_index.go
@@ -26,7 +26,7 @@ import (
 func registerSchemaChangeInvertedIndex(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "schemachange/invertedindex",
-		Owner:   registry.OwnerSQLSchema,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(5),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSchemaChangeInvertedIndex(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/jasyncsql.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql.go
@@ -148,7 +148,7 @@ func registerJasyncSQL(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "jasync",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -118,7 +118,7 @@ func registerKnex(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:       "knex",
-		Owner:      registry.OwnerSQLExperience,
+		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -140,7 +140,7 @@ func registerLibPQ(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "lib/pq",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `driver`},
 		Run:     runLibPQ,

--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -132,7 +132,7 @@ func registerLiquibase(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "liquibase",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `tool`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -28,7 +28,7 @@ import (
 func registerDeclSchemaChangeCompatMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "schemachange/mixed-versions-compat",
-		Owner:   registry.OwnerSQLSchema,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if runtime.GOARCH == "arm64" {

--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -98,7 +98,7 @@ func registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r registry.R
 	// supported in the "previous" major release.
 	r.Add(registry.TestSpec{
 		Name:    "declarative_schema_changer/job-compatibility-mixed-version-V221-V222",
-		Owner:   registry.OwnerSQLSchema,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(4),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if runtime.GOARCH == "arm64" {

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -24,7 +24,7 @@ import (
 func registerSchemaChangeMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:  "schemachange/mixed-versions",
-		Owner: registry.OwnerSQLSchema,
+		Owner: registry.OwnerSQLFoundations,
 		// This tests the work done for 20.1 that made schema changes jobs and in
 		// addition prevented making any new schema changes on a mixed cluster in
 		// order to prevent bugs during upgrades.

--- a/pkg/cmd/roachtest/tests/mixed_version_user_login.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_user_login.go
@@ -26,7 +26,7 @@ import (
 func registerUserLoginMixedVersion(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "user-login/mixed-version",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Run:     runUserLoginMixedVersion,
 		Timeout: 30 * time.Minute,

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -168,7 +168,7 @@ PGSSLCERT=$HOME/certs/client.%s.crt PGSSLKEY=$HOME/certs/client.%s.key PGSSLROOT
 
 	r.Add(registry.TestSpec{
 		Name:    "node-postgres",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/pgjdbc.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc.go
@@ -211,7 +211,7 @@ func registerPgjdbc(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "pgjdbc",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -140,7 +140,7 @@ func registerPgx(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "pgx",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/pop.go
+++ b/pkg/cmd/roachtest/tests/pop.go
@@ -100,7 +100,7 @@ func registerPop(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "pop",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `orm`},
 		Run:     runPop,

--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -148,7 +148,7 @@ func registerPsycopg(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "psycopg",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -227,7 +227,7 @@ func registerRubyPG(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:       "ruby-pg",
-		Owner:      registry.OwnerSQLExperience,
+		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},

--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -163,7 +163,7 @@ func registerRustPostgres(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "rust-postgres",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -30,7 +30,7 @@ import (
 func registerSchemaChangeDuringKV(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    `schemachange/during/kv`,
-		Owner:   registry.OwnerSQLSchema,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(5),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup?AUTH=implicit`
@@ -306,7 +306,7 @@ func makeIndexAddTpccTest(
 ) registry.TestSpec {
 	return registry.TestSpec{
 		Name:    fmt.Sprintf("schemachange/index/tpcc/w=%d", warehouses),
-		Owner:   registry.OwnerSQLSchema,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: spec,
 		Timeout: length * 3,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -338,7 +338,7 @@ func makeSchemaChangeBulkIngestTest(
 ) registry.TestSpec {
 	return registry.TestSpec{
 		Name:    "schemachange/bulkingest",
-		Owner:   registry.OwnerSQLSchema,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(numNodes),
 		Timeout: length * 2,
 		// `fixtures import` (with the workload paths) is not supported in 2.1
@@ -424,7 +424,7 @@ func makeSchemaChangeDuringTPCC(
 ) registry.TestSpec {
 	return registry.TestSpec{
 		Name:    "schemachange/during/tpcc",
-		Owner:   registry.OwnerSQLSchema,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: spec,
 		Timeout: length * 3,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -39,7 +39,7 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 	geoZonesStr := strings.Join(geoZones, ",")
 	r.Add(registry.TestSpec{
 		Name:  "schemachange/random-load",
-		Owner: registry.OwnerSQLSchema,
+		Owner: registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(
 			3,
 			spec.Geo(),
@@ -83,7 +83,7 @@ func registerRandomLoadBenchSpec(r registry.Registry, b randomLoadBenchSpec) {
 
 	r.Add(registry.TestSpec{
 		Name:       name,
-		Owner:      registry.OwnerSQLSchema,
+		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(b.Nodes),
 		NativeLibs: registry.LibGEOS,
 		Skip:       "https://github.com/cockroachdb/cockroach/issues/56230",

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -138,7 +138,7 @@ func verifyTableData(node int, expected [][]int) versionStep {
 func registerSecondaryIndexesMultiVersionCluster(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "schemachange/secondary-index-multi-version",
-		Owner:   registry.OwnerSQLSchema,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(3),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if runtime.GOARCH == "arm64" {

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -151,7 +151,7 @@ func registerSequelize(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:       "sequelize",
-		Owner:      registry.OwnerSQLExperience,
+		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -37,7 +37,7 @@ var supportedSQLAlchemyTag = "2.0.2"
 func registerSQLAlchemy(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "sqlalchemy",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -180,7 +180,7 @@ func registerTypeORM(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "typeorm",
-		Owner:   registry.OwnerSQLExperience,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -31,7 +31,7 @@ func registerValidateSystemSchemaAfterVersionUpgrade(r registry.Registry) {
 	// and assert that the output matches the expected output content.
 	r.Add(registry.TestSpec{
 		Name:    "systemschema/validate-after-version-upgrade",
-		Owner:   registry.OwnerSQLSchema,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if runtime.GOARCH == "arm64" {


### PR DESCRIPTION
Backport 1/1 commits from #102785.

/cc @cockroachdb/release

---

Reflecting merge sql-schema, sql-sessions to sql-foundations in:

- [x] github CODEOWNERS
- [x] pkg/cmd/roachtest owners
- [x] TEAMS.yaml

Tests should pass once new team is created via https://github.com/cockroachlabs/crl-infrastructure/pull/775

This is a task for Part 2, below.
____

### Tasks to update: GitHub Team name + GitHub Projects + Blathers

Part 1
- [x] Create GitHub T- label: https://github.com/cockroachdb/cockroach/labels/T-sql-foundations
- [ ] Create new sql-foundations GitHub team name: https://github.com/cockroachlabs/crl-infrastructure/pull/775

Part 2

- [ ] Update Blathers: https://github.com/cockroachlabs/blathers-bot/pull/123
- [ ] Update CODEOWNERS, roachtest, TEAMS.yaml:
  - [ ] master: https://github.com/cockroachdb/cockroach/pull/102785
  - [ ] release-23.1: https://github.com/cockroachdb/cockroach/pull/102924 
  - [ ] release-22.2: https://github.com/cockroachdb/cockroach/pull/102925
- [ ] [Manual Step] To be done at same time as merging Part 2 PRs:
  - [ ] Manually rename "SQL Schema" Project to "SQL Foundations": https://github.com/cockroachdb/cockroach/projects/47

Part 3

- [ ] Remove old GitHub team names: https://github.com/cockroachlabs/crl-infrastructure/pull/776

____

Partial work for DEVINFHD-867
Release note: None
Epic: DEVINFHD-867
Release Justification: non-production code change.