### PR TITLE
release-23.1: dev: add flag for extra docker args

### DIFF
--- a/pkg/cmd/dev/acceptance.go
+++ b/pkg/cmd/dev/acceptance.go
@@ -58,7 +58,7 @@ func (d *dev) acceptance(cmd *cobra.Command, commandLine []string) error {
 			return err
 		}
 		volume := mustGetFlagString(cmd, volumeFlag)
-		err = d.crossBuild(ctx, crossArgs, targets, "crosslinux", volume)
+		err = d.crossBuild(ctx, crossArgs, targets, "crosslinux", volume, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -22,6 +22,7 @@ import (
 )
 
 const volumeFlag = "volume"
+const dockerArgsFlag = "docker-args"
 
 // MakeBuilderCmd constructs the subcommand used to run
 func makeBuilderCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {
@@ -44,7 +45,7 @@ func (d *dev) builder(cmd *cobra.Command, extraArgs []string) error {
 	if len(extraArgs) == 0 {
 		tty = true
 	}
-	args, err := d.getDockerRunArgs(ctx, volume, tty)
+	args, err := d.getDockerRunArgs(ctx, volume, tty, nil)
 	args = append(args, extraArgs...)
 	if err != nil {
 		return err
@@ -56,7 +57,7 @@ func (d *dev) builder(cmd *cobra.Command, extraArgs []string) error {
 }
 
 func (d *dev) getDockerRunArgs(
-	ctx context.Context, volume string, tty bool,
+	ctx context.Context, volume string, tty bool, extraArgs []string,
 ) (args []string, err error) {
 	err = d.ensureBinaryInPath("docker")
 	if err != nil {
@@ -137,6 +138,7 @@ func (d *dev) getDockerRunArgs(
 	// is authoritative. This can result in writes to the actual underlying
 	// filesystem to be lost, but it's a cache so we don't care about that.
 	args = append(args, "-v", volume+":/home/roach:delegated")
+	args = append(args, extraArgs...)
 	args = append(args, "-u", fmt.Sprintf("%s:%s", uid, gid))
 	args = append(args, bazelImage)
 	return

--- a/pkg/cmd/dev/compose.go
+++ b/pkg/cmd/dev/compose.go
@@ -48,7 +48,7 @@ func (d *dev) compose(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 		volume := mustGetFlagString(cmd, volumeFlag)
-		err = d.crossBuild(ctx, crossArgs, targets, "crosslinux", volume)
+		err = d.crossBuild(ctx, crossArgs, targets, "crosslinux", volume, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/dev/roachprod_stress.go
+++ b/pkg/cmd/dev/roachprod_stress.go
@@ -107,7 +107,7 @@ func (d *dev) roachprodStress(cmd *cobra.Command, commandLine []string) error {
 	if race {
 		crossArgs = append(crossArgs, "--config=race")
 	}
-	err = d.crossBuild(ctx, crossArgs, targets, "crosslinux", volume)
+	err = d.crossBuild(ctx, crossArgs, targets, "crosslinux", volume, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -54,6 +54,14 @@ func mustGetFlagString(cmd *cobra.Command, name string) string {
 	return val
 }
 
+func mustGetFlagStringArray(cmd *cobra.Command, name string) []string {
+	val, err := cmd.Flags().GetStringArray(name)
+	if err != nil {
+		log.Fatalf("unexpected error: %v", err)
+	}
+	return val
+}
+
 func mustGetFlagStringSlice(cmd *cobra.Command, name string) []string {
 	val, err := cmd.Flags().GetStringSlice(name)
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #101931.

/cc @cockroachdb/release

---

In order to support git alternates an additional volume must be supplied to the
bazel support docker. The TeamCity script already supplies a utility method
called `run_bazel` which supplies the volume to support git alternates.

This change allows for extra arguments to be passed via a command line argument
to the docker invocation that is utilised for cross builds by the `dev` utility.

Resolves: #101829
Release justification: CI-only change
