### PR TITLE
kvstorage: number stores separately from node IDs

### DIFF
--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -34,8 +34,12 @@ import (
 const FirstNodeID = roachpb.NodeID(1)
 
 // FirstStoreID is the StoreID assigned to the first store on the node with ID
-// FirstNodeID.
-const FirstStoreID = roachpb.StoreID(1)
+// FirstNodeID. We use a different value than FirstNodeID to reduce the chance
+// that folk will accidentally assume that store and node IDs are equivalent.
+const FirstStoreID = roachpb.StoreID(123)
+
+// StoreIDIncrement is the increment between subsequent store IDs.
+const StoreIDIncrement = 3
 
 // InitEngine writes a new store ident to the underlying engine. To
 // ensure that no crufty data already exists in the engine, it scans

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -67,7 +67,7 @@ func WriteInitialClusterData(
 
 	nodeIDVal.SetInt(int64(kvstorage.FirstNodeID))
 	// The caller will initialize the stores with ids FirstStoreID, ..., FirstStoreID+numStores-1.
-	storeIDVal.SetInt(int64(kvstorage.FirstStoreID) + int64(numStores) - 1)
+	storeIDVal.SetInt(int64(kvstorage.FirstStoreID) + kvstorage.StoreIDIncrement*(int64(numStores)-1))
 	// The last range has id = len(splits) + 1
 	rangeIDVal.SetInt(int64(len(splits) + 1))
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -290,11 +290,11 @@ func allocateNodeID(ctx context.Context, db *kv.DB) (roachpb.NodeID, error) {
 func allocateStoreIDs(
 	ctx context.Context, nodeID roachpb.NodeID, count int64, db *kv.DB,
 ) (roachpb.StoreID, error) {
-	val, err := kv.IncrementValRetryable(ctx, db, keys.StoreIDGenerator, count)
+	val, err := kv.IncrementValRetryable(ctx, db, keys.StoreIDGenerator, count*kvstorage.StoreIDIncrement)
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to allocate %d store IDs for node %d", count, nodeID)
 	}
-	return roachpb.StoreID(val - count + 1), nil
+	return roachpb.StoreID(val - kvstorage.StoreIDIncrement*(count-1)), nil
 }
 
 // GetBootstrapSchema returns the schema which will be used to bootstrap a new
@@ -732,7 +732,7 @@ func (n *Node) initializeAdditionalStores(
 				log.Warningf(ctx, "error doing initial gossiping: %s", err)
 			}
 
-			sIdent.StoreID++
+			sIdent.StoreID += kvstorage.StoreIDIncrement
 		}
 	}
 


### PR DESCRIPTION
Informs #102967.

We recently discovered that a lot of our observability surfaces have created confusion -- or rather, a mistaken assumption -- that store IDs and node IDs are interchangeable.

As we start to see more and more deployments with multiple stores per node, this assumption gets invalidated more and more often, with gross correctness results in interpreting metrics and other observability data.

To improve this situation, this commit changes the store numbering to start at 123. In addition, it increases the stride between store IDs to 3 to ensure that the difference between node ID and store ID doesn't appear to be simple in the common case.

Release note (backward-incompatible change): CockroachDB now uses a different mechanism to number stores, separate from the allocation of node IDs. While the two concepts have historically always be different, it is possible that some audiences were confused and mistakenly assumed they were interchangeable. Any previous automation built on top of that assumption should be adjusted to relate a store ID back to the node ID using the node/store metatadata.