### PR TITLE
ttl: improve handling of TIMESTAMPTZ + INTERVAL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -33,6 +33,17 @@ CREATE TABLE tbl (id INT PRIMARY KEY) WITH (ttl_expiration_expression = 'id')
 
 subtest end
 
+# timestamptz + interval is stable, not immutable
+subtest ttl_expiration_expression_volatility_stable
+
+statement ok
+CREATE TABLE tbl_ttl_expiration_expression_volatility_stable (
+  id INT PRIMARY KEY,
+  expire_at timestamptz
+) WITH (ttl_expiration_expression = $$expire_at + '10 minutes'$$)
+
+subtest end
+
 subtest ttl_expire_after_or_ttl_expiration_expression_must_be_set
 
 statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set


### PR DESCRIPTION
Fixes #102178

`ttl_expiration_expression` used to conservatively require
`volatility.Immutable`, but now only requires `volatility.Stable` to support
one of its main use cases: `timestamptz + interval`.

The TTL job runs SELECT and DELETE statements in separate transactions so the
`ttl_expiration_expression` may be affected by changing cluster settings part
way through the job. This means that the SELECT and DELETE statements can have
different output for the same input in the same job. This should not cause
issues for the TTL job, but if it does the user can alter cluster settings
while the job is not running. If this causes rows to be skipped for deletion
during a TTL job run, they will be deleted the next time the job runs if they
are still eligible.

Some functions may also depend on session data, but the user does not have
direct control over this because the SQL statements run inside a job.

Release note (sql change): ttl_expiration_expression now allows Stable
operators/functions. This allows intervals to be directly added to
timestamptz expressions.
See https://www.postgresql.org/docs/15/xfunc-volatility.html.