### PR TITLE
build: mark tests broken under remote execution as `no-remote-exec`

### DIFF
--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -43,7 +43,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":coldata"],
-    tags = ["no-remote"],  # keep
+    tags = ["no-remote-exec"],  # keep
     deps = [
         "//pkg/col/coldatatestutils",
         "//pkg/sql/colconv",

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -153,7 +153,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":kvcoord"],
     shard_count = 16,
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//build/bazelutil:noop",
         "//pkg/base",

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -70,7 +70,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":roachpb"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/cli/exit",
         "//pkg/keys",

--- a/pkg/server/diagnostics/BUILD.bazel
+++ b/pkg/server/diagnostics/BUILD.bazel
@@ -58,7 +58,7 @@ go_test(
         "update_checker_test.go",
     ],
     args = ["-test.timeout=295s"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         ":diagnostics",
         "//pkg/base",

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -60,7 +60,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":catalog"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/dbdesc",

--- a/pkg/sql/colexec/colexecbase/BUILD.bazel
+++ b/pkg/sql/colexec/colexecbase/BUILD.bazel
@@ -55,7 +55,7 @@ go_test(
         "simple_project_test.go",
     ],
     args = ["-test.timeout=295s"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         ":colexecbase",
         "//pkg/col/coldata",

--- a/pkg/sql/colexec/colexechash/BUILD.bazel
+++ b/pkg/sql/colexec/colexechash/BUILD.bazel
@@ -40,7 +40,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexechash"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecjoin/BUILD.bazel
+++ b/pkg/sql/colexec/colexecjoin/BUILD.bazel
@@ -50,7 +50,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecjoin"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecproj/BUILD.bazel
+++ b/pkg/sql/colexec/colexecproj/BUILD.bazel
@@ -46,7 +46,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecproj"],  # keep
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecsel/BUILD.bazel
+++ b/pkg/sql/colexec/colexecsel/BUILD.bazel
@@ -41,7 +41,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecsel"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecspan/BUILD.bazel
+++ b/pkg/sql/colexec/colexecspan/BUILD.bazel
@@ -44,7 +44,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecspan"],  # keep
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecutils/BUILD.bazel
+++ b/pkg/sql/colexec/colexecutils/BUILD.bazel
@@ -52,7 +52,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecutils"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecwindow/BUILD.bazel
+++ b/pkg/sql/colexec/colexecwindow/BUILD.bazel
@@ -58,7 +58,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecwindow"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -84,7 +84,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colflow"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/col/coldata",

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -93,7 +93,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":execinfra"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -69,7 +69,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":flowinfra"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/ccl/kvccl/kvtenantccl",

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -148,7 +148,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":rowexec"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/gossip",

--- a/pkg/sql/rowflow/BUILD.bazel
+++ b/pkg/sql/rowflow/BUILD.bazel
@@ -44,7 +44,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":rowflow"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/keys",

--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -34,7 +34,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":stmtdiagnostics"],
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/keys",


### PR DESCRIPTION
`no-remote` implies both `no-remote-cache` and `no-remote-exec`. `no-remote-exec` is in fact what we want here; remote caching is fine for these tests.

Epic: CRDB-17165
Release note: None