### PR TITLE
util/parquet: add compression options

### DIFF
--- a/pkg/util/parquet/BUILD.bazel
+++ b/pkg/util/parquet/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/util/timeofday",
         "//pkg/util/uuid",
         "@com_github_apache_arrow_go_v11//parquet",
+        "@com_github_apache_arrow_go_v11//parquet/compress",
         "@com_github_apache_arrow_go_v11//parquet/file",
         "@com_github_apache_arrow_go_v11//parquet/schema",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
This change updates the parquet writer to be able to use
GZIP, ZSTD, SNAPPY, and BROTLI compression codecs. By
default, no compression is used. LZO and LZ4 are unsupported
by the library.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-15071
Informs: https://github.com/cockroachdb/cockroach/issues/99028
Release note: None