### PR TITLE
streamingccl: small job loading fixes

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -186,6 +186,10 @@ func makePlan(
 			execinfrapb.Ordering{},
 		)
 
+		// NB: We schedule the frontier processor on the
+		// gateway node. The frontier process assumes this is
+		// the case so that it can load the current job with
+		// claim information.
 		gatewayNodeID, err := execCtx.ExecCfg().NodeInfo.NodeID.OptionalNodeIDErr(48274)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
This PR makes two changes:

- Uses LoadClaimedJob in the frontier processor to ensure that we are
  are only updating the job if that job is still claimed by our node.

- Uses the new InfoStorage API to avoid touching the job table when the ingestion
  processors are polling the cutover time.

We don't expect that either change should change any behaviour.

The first change should come with a test. I'm also a _little_ worried about it because if we ever
want to schedule the frontier processor on a node other than the gateway node, then we will 
need to add some complexity to the mixed-version state. 