### PR TITLE
kvserver: enable closed timestamp update smearing

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -70,7 +70,7 @@ var RangeFeedSmearInterval = settings.RegisterDurationSetting(
 		"closed-timestamp updates to some rangefeeds; "+
 		"set to 0 to use kv.rangefeed.closed_timestamp_refresh_interval"+
 		"capped at kv.rangefeed.closed_timestamp_refresh_interval",
-	0,
+	1*time.Millisecond,
 	settings.NonNegativeDuration,
 )
 

--- a/pkg/kv/kvserver/store_rangefeed_test.go
+++ b/pkg/kv/kvserver/store_rangefeed_test.go
@@ -35,15 +35,31 @@ func TestRangeFeedUpdaterConf(t *testing.T) {
 		want    [2]time.Duration // {refresh, smear}
 		waitErr error
 	}{{
-		want: [...]time.Duration{200 * time.Millisecond, 200 * time.Millisecond}, // default
+		want: [...]time.Duration{200 * time.Millisecond, 1 * time.Millisecond}, // default
 	}, {
-		// By default RangeFeedRefreshInterval picks up SideTransportCloseInterval,
-		// and RangeFeedSmearInterval picks up RangeFeedRefreshInterval.
+		// By default, RangeFeedSmearInterval is 1ms.
+		updates: []*settings.DurationSetting{RangeFeedRefreshInterval},
+		updVals: []time.Duration{100 * time.Millisecond},
+		want:    [...]time.Duration{100 * time.Millisecond, 1 * time.Millisecond},
+	}, {
+		// When zero, RangeFeedSmearInterval picks up RangeFeedRefreshInterval.
+		updates: []*settings.DurationSetting{RangeFeedRefreshInterval, RangeFeedSmearInterval},
+		updVals: []time.Duration{100 * time.Millisecond, 0},
+		want:    [...]time.Duration{100 * time.Millisecond, 100 * time.Millisecond},
+	}, {
+		// When zero, RangeFeedSmearInterval picks up RangeFeedRefreshInterval,
+		// which is defaulted at SideTransportCloseInterval.
+		updates: []*settings.DurationSetting{RangeFeedSmearInterval},
+		updVals: []time.Duration{0},
+		want:    [...]time.Duration{200 * time.Millisecond, 200 * time.Millisecond},
+	}, {
+		// By default, RangeFeedRefreshInterval picks up SideTransportCloseInterval.
 		updates: []*settings.DurationSetting{closedts.SideTransportCloseInterval},
 		updVals: []time.Duration{10 * time.Millisecond},
-		want:    [...]time.Duration{10 * time.Millisecond, 10 * time.Millisecond},
+		want:    [...]time.Duration{10 * time.Millisecond, 1 * time.Millisecond},
 	}, {
-		// By default RangeFeedRefreshInterval picks up SideTransportCloseInterval.
+		// By default, RangeFeedRefreshInterval picks up SideTransportCloseInterval.
+		// Zero value is not a valid configuration though.
 		updates: []*settings.DurationSetting{closedts.SideTransportCloseInterval},
 		updVals: []time.Duration{0},
 		want:    [...]time.Duration{0, 0},
@@ -55,18 +71,13 @@ func TestRangeFeedUpdaterConf(t *testing.T) {
 		want:    [...]time.Duration{0, 0},
 		waitErr: context.DeadlineExceeded,
 	}, {
-		// By default RangeFeedSmearInterval picks up RangeFeedRefreshInterval.
-		updates: []*settings.DurationSetting{RangeFeedRefreshInterval},
-		updVals: []time.Duration{100 * time.Millisecond},
-		want:    [...]time.Duration{100 * time.Millisecond, 100 * time.Millisecond},
-	}, {
 		updates: []*settings.DurationSetting{RangeFeedRefreshInterval, RangeFeedSmearInterval},
-		updVals: []time.Duration{100 * time.Millisecond, 1 * time.Millisecond},
-		want:    [...]time.Duration{100 * time.Millisecond, 1 * time.Millisecond},
+		updVals: []time.Duration{100 * time.Millisecond, 5 * time.Millisecond},
+		want:    [...]time.Duration{100 * time.Millisecond, 5 * time.Millisecond},
 	}, {
 		updates: []*settings.DurationSetting{RangeFeedSmearInterval},
-		updVals: []time.Duration{1 * time.Millisecond},
-		want:    [...]time.Duration{200 * time.Millisecond, 1 * time.Millisecond},
+		updVals: []time.Duration{5 * time.Millisecond},
+		want:    [...]time.Duration{200 * time.Millisecond, 5 * time.Millisecond},
 	}, {
 		// Misconfigurations (potentially transient) are handled gracefully.
 		updates: []*settings.DurationSetting{closedts.SideTransportCloseInterval,


### PR DESCRIPTION
This commit sets the `kv.rangefeed.closed_timestamp_smear_interval` cluster setting default to 1ms.

Fixes #100105
Epic: none
Release note (performance improvement): this change enables the pacing mechanism in rangefeed closed timestamp notifications, by setting the default "kv.rangefeed.closed_timestamp_smear_interval" cluster setting to 1ms. This makes rangefeed closed timestamp delivery more uniform / less spikey, which reduces its impact on Go scheduler and, ultimately, foreground SQL latencies.