### PR TITLE
release-23.1: kvserver: bump split pkg timeout 

### DIFF
--- a/pkg/kv/kvserver/split/BUILD.bazel
+++ b/pkg/kv/kvserver/split/BUILD.bazel
@@ -23,14 +23,14 @@ go_library(
 
 go_test(
     name = "split_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "decider_test.go",
         "load_based_splitter_test.go",
         "unweighted_finder_test.go",
         "weighted_finder_test.go",
     ],
-    args = ["-test.timeout=55s"],
+    args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":split"],
     deps = [


### PR DESCRIPTION
Backport 1/3 commits from #102870.

/cc @cockroachdb/release

---

We backported https://github.com/cockroachdb/cockroach/pull/102482 to 23.1.

This test times out on smaller machines.

Bump timeout to fix.

Fixes: #103020

----

Release justification: test flake fix - increase timeout.

