### PR TITLE
opt: copy ordering choice columns

### DIFF
--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -657,12 +657,15 @@ func (oc *OrderingChoice) AppendCol(id opt.ColumnID, descending bool) {
 }
 
 // Copy returns a complete copy of this instance, with a private version of the
-// ordering column array.
+// ordering column slice.
 func (oc *OrderingChoice) Copy() OrderingChoice {
 	var other OrderingChoice
 	other.Optional = oc.Optional.Copy()
 	other.Columns = make([]OrderingColumnChoice, len(oc.Columns))
 	copy(other.Columns, oc.Columns)
+	for i := range other.Columns {
+		other.Columns[i].Group = other.Columns[i].Group.Copy()
+	}
 	return other
 }
 

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -703,7 +703,7 @@ func (o *Optimizer) enforceProps(
 }
 
 // optimizeEnforcer optimizes and costs the enforcer. getEnforcer is used to
-// reset the enforcer after recusing in optimizeGroup, since the current group
+// reset the enforcer after recursing in optimizeGroup, since the current group
 // and its children may use the same SortExpr to avoid allocations.
 func (o *Optimizer) optimizeEnforcer(
 	state *groupState,


### PR DESCRIPTION
#### opt: copy ordering choice columns

This commit fixes a long-standing bug in `OrderingChoice.Copy` in which
the `Group` columns were not being copied. As far as we now, this has
caused no user-facing bugs, but it does not follow `Copy`'s description
that the new `OrderingChoice` has a "private" version of the ordering
column slice, and column sets shared between `OrderingChoice`s could
lead to future bugs.

Epic: None

Release note: None

#### opt: fix typo in comment

Release note: None
