### PR TITLE
kv: improve verbose logging around intent resolution in lock-table waiter

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -780,12 +780,6 @@ func (c *cluster) PushTransaction(
 func (c *cluster) ResolveIntent(
 	ctx context.Context, intent roachpb.LockUpdate, _ intentresolver.ResolveOptions,
 ) *kvpb.Error {
-	var obsStr string
-	if obs := intent.ClockWhilePending; obs != (roachpb.ObservedTimestamp{}) {
-		obsStr = fmt.Sprintf(" and clock observation {%d %v}", obs.NodeID, obs.Timestamp)
-	}
-	log.Eventf(ctx, "resolving intent %s for txn %s with %s status%s",
-		intent.Key, intent.Txn.ID.Short(), intent.Status, obsStr)
 	c.m.OnLockUpdated(ctx, &intent)
 	return nil
 }
@@ -794,7 +788,6 @@ func (c *cluster) ResolveIntent(
 func (c *cluster) ResolveIntents(
 	ctx context.Context, intents []roachpb.LockUpdate, opts intentresolver.ResolveOptions,
 ) *kvpb.Error {
-	log.Eventf(ctx, "resolving a batch of %d intent(s)", len(intents))
 	for _, intent := range intents {
 		if err := c.ResolveIntent(ctx, intent, opts); err != nil {
 			return err

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -12,6 +12,7 @@ package concurrency
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"time"
 
@@ -159,7 +160,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 		case <-newStateC:
 			timerC = nil
 			state := guard.CurState()
-			log.Eventf(ctx, "lock wait-queue event: %s", state)
+			log.VEventf(ctx, 3, "lock wait-queue event: %s", state)
 			tracer.notify(ctx, state)
 			switch state.kind {
 			case waitFor, waitForDistinguished:
@@ -230,7 +231,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 				// If the request doesn't want to perform a delayed push for any
 				// reason, continue waiting without a timer.
 				if !(livenessPush || deadlockPush || timeoutPush || priorityPush) {
-					log.Eventf(ctx, "not pushing")
+					log.VEventf(ctx, 3, "not pushing")
 					continue
 				}
 
@@ -261,7 +262,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 					delay = 0
 				}
 
-				log.Eventf(ctx, "pushing after %s for: "+
+				log.VEventf(ctx, 3, "pushing after %s for: "+
 					"liveness detection = %t, deadlock detection = %t, "+
 					"timeout enforcement = %t, priority enforcement = %t",
 					delay, livenessPush, deadlockPush, timeoutPush, priorityPush)
@@ -653,6 +654,7 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 		// after the reader's read timestamp surpasses its global uncertainty limit.
 		resolve.ClockWhilePending = beforePushObs
 	}
+	logResolveIntent(ctx, resolve)
 	opts := intentresolver.ResolveOptions{Poison: true}
 	return w.ir.ResolveIntent(ctx, resolve, opts)
 }
@@ -839,6 +841,10 @@ func (w *lockTableWaiterImpl) ResolveDeferredIntents(
 ) *Error {
 	if len(deferredResolution) == 0 {
 		return nil
+	}
+	log.VEventf(ctx, 2, "resolving a batch of %d intent(s)", len(deferredResolution))
+	for _, intent := range deferredResolution {
+		logResolveIntent(ctx, intent)
 	}
 	// See pushLockTxn for an explanation of these options.
 	opts := intentresolver.ResolveOptions{Poison: true}
@@ -1249,6 +1255,18 @@ func canPushWithPriority(req Request, s waitingState) bool {
 	}
 	pushee = s.txn.Priority
 	return txnwait.CanPushWithPriority(pusher, pushee)
+}
+
+func logResolveIntent(ctx context.Context, intent roachpb.LockUpdate) {
+	if !log.ExpensiveLogEnabled(ctx, 2) {
+		return
+	}
+	var obsStr string
+	if obs := intent.ClockWhilePending; obs != (roachpb.ObservedTimestamp{}) {
+		obsStr = fmt.Sprintf(" and clock observation {%d %v}", obs.NodeID, obs.Timestamp)
+	}
+	log.VEventf(ctx, 2, "resolving intent %s for txn %s with %s status%s",
+		intent.Key, intent.Txn.ID.Short(), intent.Status, obsStr)
 }
 
 func minDuration(a, b time.Duration) time.Duration {


### PR DESCRIPTION
This commit improves the verbose logging around state transitions and intent resolution in the lock-table waiter. This ensures that if we have access to verbose logs (e.g. through logspy), that we can understand all of what the lock-table waiter is doing.

None of these log lines are new. Some were only trace events that have been promoted to high-verbosity logging. Others were log events that were only present in the concurrency manager testing harness and have now been shifted to production code paths. Notably, both classes of logging continue to be exercised by the `TestConcurrencyManagerBasic` data-driven test.

Epic: None
Release note: None