### PR TITLE
kv: enable trace redaction in concurrency manager data-driven test

### DIFF
--- a/pkg/kv/kvserver/concurrency/datadriven_util_test.go
+++ b/pkg/kv/kvserver/concurrency/datadriven_util_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/redact"
 )
 
 func nextUUID(counter *uint32) uuid.UUID {
@@ -238,11 +239,13 @@ func scanSingleRequest(
 	}
 }
 
-func scanTxnStatus(t *testing.T, d *datadriven.TestData) (roachpb.TransactionStatus, string) {
+func scanTxnStatus(
+	t *testing.T, d *datadriven.TestData,
+) (roachpb.TransactionStatus, redact.SafeString) {
 	var statusStr string
 	d.ScanArgs(t, "status", &statusStr)
 	status := parseTxnStatus(t, d, statusStr)
-	var verb string
+	var verb redact.SafeString
 	switch status {
 	case roachpb.COMMITTED:
 		verb = "committing"

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/barrier
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/barrier
@@ -53,7 +53,7 @@ sequence req=barrier2
 ----
 [2] sequence barrier2: sequencing request
 [2] sequence barrier2: waiting on latches without acquiring
-[2] sequence barrier2: waiting to acquire write latch {a-f}@0,0, held by read latch c@15.000000000,1
+[2] sequence barrier2: waiting to acquire write latch ‹{a-f}›@0,0, held by read latch ‹c›@15.000000000,1
 [2] sequence barrier2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=read1
@@ -96,7 +96,7 @@ sequence req=barrier1
 ----
 [2] sequence barrier1: sequencing request
 [2] sequence barrier1: waiting on latches without acquiring
-[2] sequence barrier1: waiting to acquire write latch {a-f}@0,0, held by read latch c@10.000000000,1
+[2] sequence barrier1: waiting to acquire write latch ‹{a-f}›@0,0, held by read latch ‹c›@10.000000000,1
 [2] sequence barrier1: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=read1
@@ -143,7 +143,7 @@ sequence req=barrier1
 ----
 [2] sequence barrier1: sequencing request
 [2] sequence barrier1: waiting on latches without acquiring
-[2] sequence barrier1: waiting to acquire write latch {a-f}@0,0, held by write latch c@10.000000000,1
+[2] sequence barrier1: waiting to acquire write latch ‹{a-f}›@0,0, held by write latch ‹c›@10.000000000,1
 [2] sequence barrier1: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -52,7 +52,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ k
+[-] acquire lock: txn 00000002 @ ‹k›
 
 debug-lock-table
 ----
@@ -96,7 +96,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ k
+[-] acquire lock: txn 00000002 @ ‹k›
 
 finish req=req2
 ----
@@ -113,7 +113,7 @@ sequence req=req3
 [2] sequence req3: acquiring latches
 [2] sequence req3: scanning lock table for conflicting locks
 [2] sequence req3: waiting in lock wait-queues
-[2] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[2] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [2] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req3: pushing timestamp of txn 00000002 above 14.000000000,1
 [2] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -124,9 +124,9 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
-[2] sequence req3: resolving intent "k" for txn 00000002 with COMMITTED status
+[2] sequence req3: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
 [2] sequence req3: lock wait-queue event: done waiting
-[2] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
+[2] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
 [2] sequence req3: acquiring latches
 [2] sequence req3: scanning lock table for conflicting locks
 [2] sequence req3: sequencing complete, returned guard
@@ -143,7 +143,7 @@ sequence req=req4
 ----
 [3] sequence req4: sequencing request
 [3] sequence req4: acquiring latches
-[3] sequence req4: waiting to acquire write latch k@10.000000000,1, held by read latch k{-2}@14.000000000,1
+[3] sequence req4: waiting to acquire write latch ‹k›@10.000000000,1, held by read latch ‹k{-2}›@14.000000000,1
 [3] sequence req4: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager
@@ -184,7 +184,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ k
+[-] acquire lock: txn 00000002 @ ‹k›
 
 finish req=req2
 ----
@@ -200,7 +200,7 @@ sequence req=req5
 [2] sequence req5: acquiring latches
 [2] sequence req5: scanning lock table for conflicting locks
 [2] sequence req5: waiting in lock wait-queues
-[2] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[2] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [2] sequence req5: pushing after 0s for: liveness detection = true, deadlock detection = false, timeout enforcement = false, priority enforcement = false
 [2] sequence req5: pushing timestamp of txn 00000002 above 14.000000000,1
 [2] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -215,7 +215,7 @@ sequence req=req6
 [3] sequence req6: acquiring latches
 [3] sequence req6: scanning lock table for conflicting locks
 [3] sequence req6: waiting in lock wait-queues
-[3] sequence req6: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 2)
+[3] sequence req6: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 2)
 [3] sequence req6: not pushing
 [3] sequence req6: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -225,14 +225,14 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn2 status=pending ts=18,1
 ----
 [-] update txn: increasing timestamp of txn2
-[2] sequence req5: resolving intent "k" for txn 00000002 with PENDING status and clock observation {1 246.000000000,0}
+[2] sequence req5: resolving intent ‹"k"› for txn 00000002 with PENDING status and clock observation {1 246.000000000,0}
 [2] sequence req5: lock wait-queue event: done waiting
-[2] sequence req5: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
+[2] sequence req5: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
 [2] sequence req5: acquiring latches
 [2] sequence req5: scanning lock table for conflicting locks
 [2] sequence req5: sequencing complete, returned guard
 [3] sequence req6: lock wait-queue event: done waiting
-[3] sequence req6: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
+[3] sequence req6: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
 [3] sequence req6: acquiring latches
 [3] sequence req6: scanning lock table for conflicting locks
 [3] sequence req6: sequencing complete, returned guard
@@ -245,13 +245,13 @@ sequence req=req7
 ----
 [4] sequence req7: sequencing request
 [4] sequence req7: acquiring latches
-[4] sequence req7: waiting to acquire write latch k@12.000000000,1, held by read latch {a-m}@14.000000000,1
+[4] sequence req7: waiting to acquire write latch ‹k›@12.000000000,1, held by read latch ‹{a-m}›@14.000000000,1
 [4] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=req5
 ----
 [-] finish req5: finishing request
-[4] sequence req7: waiting to acquire write latch k@12.000000000,1, held by read latch {c-z}@16.000000000,1
+[4] sequence req7: waiting to acquire write latch ‹k›@12.000000000,1, held by read latch ‹{c-z}›@16.000000000,1
 [4] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=req6
@@ -259,7 +259,7 @@ finish req=req6
 [-] finish req6: finishing request
 [4] sequence req7: scanning lock table for conflicting locks
 [4] sequence req7: waiting in lock wait-queues
-[4] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req7: pushing after 0s for: liveness detection = true, deadlock detection = false, timeout enforcement = false, priority enforcement = false
 [4] sequence req7: pushing txn 00000002 to abort
 [4] sequence req7: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -270,9 +270,9 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
-[4] sequence req7: resolving intent "k" for txn 00000002 with COMMITTED status
+[4] sequence req7: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
 [4] sequence req7: lock wait-queue event: done waiting
-[4] sequence req7: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
+[4] sequence req7: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
 [4] sequence req7: acquiring latches
 [4] sequence req7: scanning lock table for conflicting locks
 [4] sequence req7: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -31,7 +31,7 @@ handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn2 key=i
   intent txn=txn2 key=j
 ----
-[2] handle write intent error req1: handled conflicting intents on "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", released latches
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----
@@ -63,7 +63,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -104,19 +104,19 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
-[3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 123.000s
+[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
 [3] sequence req1: resolving a batch of 9 intent(s)
-[3] sequence req1: resolving intent "b" for txn 00000002 with ABORTED status
-[3] sequence req1: resolving intent "c" for txn 00000002 with ABORTED status
-[3] sequence req1: resolving intent "d" for txn 00000002 with ABORTED status
-[3] sequence req1: resolving intent "e" for txn 00000002 with ABORTED status
-[3] sequence req1: resolving intent "f" for txn 00000002 with ABORTED status
-[3] sequence req1: resolving intent "g" for txn 00000002 with ABORTED status
-[3] sequence req1: resolving intent "h" for txn 00000002 with ABORTED status
-[3] sequence req1: resolving intent "i" for txn 00000002 with ABORTED status
-[3] sequence req1: resolving intent "j" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"b"› for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"c"› for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"d"› for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"e"› for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"f"› for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"g"› for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"h"› for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"i"› for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"j"› for txn 00000002 with ABORTED status
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -158,7 +158,7 @@ sequence req=req1
 handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn2 key=a
 ----
-[2] handle write intent error req1: handled conflicting intents on "a", released latches
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -174,7 +174,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing txn 00000002 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -185,9 +185,9 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
-[3] sequence req1: resolving intent "a" for txn 00000002 with COMMITTED status
+[3] sequence req1: resolving intent ‹"a"› for txn 00000002 with COMMITTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 123.000s
+[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -195,7 +195,7 @@ on-txn-updated txn=txn2 status=committed
 handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn2 key=b
 ----
-[4] handle write intent error req1: handled conflicting intents on "b", released latches
+[4] handle write intent error req1: handled conflicting intents on ‹"b"›, released latches
 
 debug-lock-table
 ----
@@ -215,7 +215,7 @@ sequence req=req1
 [5] sequence req1: waiting in lock wait-queues
 [5] sequence req1: lock wait-queue event: done waiting
 [5] sequence req1: resolving a batch of 1 intent(s)
-[5] sequence req1: resolving intent "b" for txn 00000002 with COMMITTED status
+[5] sequence req1: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
 [5] sequence req1: acquiring latches
 [5] sequence req1: scanning lock table for conflicting locks
 [5] sequence req1: sequencing complete, returned guard
@@ -223,7 +223,7 @@ sequence req=req1
 handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn2 key=c
 ----
-[6] handle write intent error req1: handled conflicting intents on "c", released latches
+[6] handle write intent error req1: handled conflicting intents on ‹"c"›, released latches
 
 debug-lock-table
 ----
@@ -245,7 +245,7 @@ sequence req=req1
 [7] sequence req1: waiting in lock wait-queues
 [7] sequence req1: lock wait-queue event: done waiting
 [7] sequence req1: resolving a batch of 1 intent(s)
-[7] sequence req1: resolving intent "c" for txn 00000002 with COMMITTED status
+[7] sequence req1: resolving intent ‹"c"› for txn 00000002 with COMMITTED status
 [7] sequence req1: acquiring latches
 [7] sequence req1: scanning lock table for conflicting locks
 [7] sequence req1: sequencing complete, returned guard
@@ -294,7 +294,7 @@ handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn2 key=a
   intent txn=txn2 key=b
 ----
-[2] handle write intent error req1: handled conflicting intents on "a", "b", released latches
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, released latches
 
 debug-lock-table
 ----
@@ -318,11 +318,11 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=g dur=u
 ----
-[-] acquire lock: txn 00000002 @ g
+[-] acquire lock: txn 00000002 @ ‹g›
 
 on-lock-acquired req=req2 key=h dur=u
 ----
-[-] acquire lock: txn 00000002 @ h
+[-] acquire lock: txn 00000002 @ ‹h›
 
 finish req=req2
 ----
@@ -346,7 +346,7 @@ sequence req=req1
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: waiting in lock wait-queues
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
 [4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -372,11 +372,11 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
-[4] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
+[4] sequence req1: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [4] sequence req1: lock wait-queue event: done waiting
-[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 123.000s
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
 [4] sequence req1: resolving a batch of 1 intent(s)
-[4] sequence req1: resolving intent "b" for txn 00000002 with ABORTED status
+[4] sequence req1: resolving intent ‹"b"› for txn 00000002 with ABORTED status
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: sequencing complete, returned guard
@@ -437,7 +437,7 @@ handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn3 key=d
   intent txn=txn5 key=e
 ----
-[2] handle write intent error req1: handled conflicting intents on "c", "d", "e", released latches
+[2] handle write intent error req1: handled conflicting intents on ‹"c"›, ‹"d"›, ‹"e"›, released latches
 
 debug-lock-table
 ----
@@ -461,7 +461,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing txn 00000003 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -496,7 +496,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=a dur=u
 ----
-[-] acquire lock: txn 00000003 @ a
+[-] acquire lock: txn 00000003 @ ‹a›
 
 finish req=req3
 ----
@@ -515,7 +515,7 @@ sequence req=req4
 
 on-lock-acquired req=req4 key=b dur=u
 ----
-[-] acquire lock: txn 00000004 @ b
+[-] acquire lock: txn 00000004 @ ‹b›
 
 finish req=req4
 ----
@@ -553,7 +553,7 @@ sequence req=req2
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: waiting in lock wait-queues
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
 [6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req2: pushing timestamp of txn 00000003 above 11.000000000,1
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -590,15 +590,15 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn3 status=aborted
 ----
 [-] update txn: aborting txn3
-[3] sequence req1: resolving intent "c" for txn 00000003 with ABORTED status
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000005 holding lock @ key "e" (queuedWriters: 1, queuedReaders: 0)
-[3] sequence req1: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 123.000s
+[3] sequence req1: resolving intent ‹"c"› for txn 00000003 with ABORTED status
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000005 holding lock @ key ‹"e"› (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req1: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 123.000s
 [3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing txn 00000005 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
-[6] sequence req2: resolving intent "a" for txn 00000003 with ABORTED status
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "b" (queuedWriters: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "a" for 123.000s
+[6] sequence req2: resolving intent ‹"a"› for txn 00000003 with ABORTED status
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"b"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
 [6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req2: pushing timestamp of txn 00000004 above 11.000000000,1
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -631,11 +631,11 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn4 status=aborted
 ----
 [-] update txn: aborting txn4
-[6] sequence req2: resolving intent "b" for txn 00000004 with ABORTED status
+[6] sequence req2: resolving intent ‹"b"› for txn 00000004 with ABORTED status
 [6] sequence req2: lock wait-queue event: done waiting
-[6] sequence req2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 123.000s
+[6] sequence req2: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"b"› for 123.000s
 [6] sequence req2: resolving a batch of 1 intent(s)
-[6] sequence req2: resolving intent "d" for txn 00000003 with ABORTED status
+[6] sequence req2: resolving intent ‹"d"› for txn 00000003 with ABORTED status
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: sequencing complete, returned guard
@@ -662,9 +662,9 @@ finish req=req2
 on-txn-updated txn=txn5 status=aborted
 ----
 [-] update txn: aborting txn5
-[3] sequence req1: resolving intent "e" for txn 00000005 with ABORTED status
+[3] sequence req1: resolving intent ‹"e"› for txn 00000005 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000005-0000-0000-0000-000000000000 on "e" for 123.000s
+[3] sequence req1: conflicted with ‹00000005-0000-0000-0000-000000000000› on ‹"e"› for 123.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -28,7 +28,7 @@ sequence req=req1
 handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn2 key=a
 ----
-[2] handle write intent error req1: handled conflicting intents on "a", released latches
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -42,7 +42,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -64,9 +64,9 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
-[3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 123.000s
+[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -103,16 +103,16 @@ handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn2 key=j
 ----
 [5] handle write intent error req2: resolving a batch of 9 intent(s)
-[5] handle write intent error req2: resolving intent "b" for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent "c" for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent "d" for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent "e" for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent "f" for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent "g" for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent "h" for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent "i" for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent "j" for txn 00000002 with ABORTED status
-[5] handle write intent error req2: handled conflicting intents on "b", "c", "d", "e", "f", "g", "h", "i", "j", released latches
+[5] handle write intent error req2: resolving intent ‹"b"› for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent ‹"c"› for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent ‹"d"› for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent ‹"e"› for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent ‹"f"› for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent ‹"g"› for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent ‹"h"› for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent ‹"i"› for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent ‹"j"› for txn 00000002 with ABORTED status
+[5] handle write intent error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -57,15 +57,15 @@ sequence req=req3w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ a
+[-] acquire lock: txn 00000001 @ ‹a›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ b
+[-] acquire lock: txn 00000002 @ ‹b›
 
 on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn 00000003 @ c
+[-] acquire lock: txn 00000003 @ ‹c›
 
 finish req=req1w
 ----
@@ -111,7 +111,7 @@ sequence req=req1r
 [4] sequence req1r: acquiring latches
 [4] sequence req1r: scanning lock table for conflicting locks
 [4] sequence req1r: waiting in lock wait-queues
-[4] sequence req1r: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1r: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedWriters: 0, queuedReaders: 1)
 [4] sequence req1r: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req1r: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1r: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -122,7 +122,7 @@ sequence req=req2r
 [5] sequence req2r: acquiring latches
 [5] sequence req2r: scanning lock table for conflicting locks
 [5] sequence req2r: waiting in lock wait-queues
-[5] sequence req2r: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 0, queuedReaders: 1)
+[5] sequence req2r: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedWriters: 0, queuedReaders: 1)
 [5] sequence req2r: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req2r: pushing timestamp of txn 00000003 above 10.000000000,1
 [5] sequence req2r: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -135,7 +135,7 @@ sequence req=req3r
 [6] sequence req3r: acquiring latches
 [6] sequence req3r: scanning lock table for conflicting locks
 [6] sequence req3r: waiting in lock wait-queues
-[6] sequence req3r: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req3r: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
 [6] sequence req3r: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req3r: pushing timestamp of txn 00000001 above 10.000000000,1
 [6] sequence req3r: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -165,11 +165,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [4] sequence req1r: detected pusher aborted
-[4] sequence req1r: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
+[4] sequence req1r: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [4] sequence req1r: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
-[6] sequence req3r: resolving intent "a" for txn 00000001 with ABORTED status
+[6] sequence req3r: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [6] sequence req3r: lock wait-queue event: done waiting
-[6] sequence req3r: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
+[6] sequence req3r: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [6] sequence req3r: acquiring latches
 [6] sequence req3r: scanning lock table for conflicting locks
 [6] sequence req3r: sequencing complete, returned guard
@@ -182,9 +182,9 @@ finish req=req3r
 on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
-[5] sequence req2r: resolving intent "c" for txn 00000003 with COMMITTED status
+[5] sequence req2r: resolving intent ‹"c"› for txn 00000003 with COMMITTED status
 [5] sequence req2r: lock wait-queue event: done waiting
-[5] sequence req2r: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
+[5] sequence req2r: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
 [5] sequence req2r: acquiring latches
 [5] sequence req2r: scanning lock table for conflicting locks
 [5] sequence req2r: sequencing complete, returned guard
@@ -267,15 +267,15 @@ sequence req=req3w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ a
+[-] acquire lock: txn 00000001 @ ‹a›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ b
+[-] acquire lock: txn 00000002 @ ‹b›
 
 on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn 00000003 @ c
+[-] acquire lock: txn 00000003 @ ‹c›
 
 finish req=req1w
 ----
@@ -325,7 +325,7 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
-[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4w: pushing txn 00000001 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -336,7 +336,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
-[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedWriters: 1, queuedReaders: 0)
 [5] sequence req1w2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req1w2: pushing txn 00000002 to abort
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -347,7 +347,7 @@ sequence req=req2w2
 [6] sequence req2w2: acquiring latches
 [6] sequence req2w2: scanning lock table for conflicting locks
 [6] sequence req2w2: waiting in lock wait-queues
-[6] sequence req2w2: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req2w2: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedWriters: 1, queuedReaders: 0)
 [6] sequence req2w2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req2w2: pushing txn 00000003 to abort
 [6] sequence req2w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -360,7 +360,7 @@ sequence req=req3w2
 [7] sequence req3w2: acquiring latches
 [7] sequence req3w2: scanning lock table for conflicting locks
 [7] sequence req3w2: waiting in lock wait-queues
-[7] sequence req3w2: lock wait-queue event: wait for txn 00000001 holding lock @ key "a" (queuedWriters: 2, queuedReaders: 0)
+[7] sequence req3w2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedWriters: 2, queuedReaders: 0)
 [7] sequence req3w2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [7] sequence req3w2: pushing txn 00000001 to abort
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -390,18 +390,18 @@ num=3
 on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
-[4] sequence req4w: resolving intent "a" for txn 00000001 with ABORTED status
+[4] sequence req4w: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [4] sequence req4w: lock wait-queue event: done waiting
-[4] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
+[4] sequence req4w: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: sequencing complete, returned guard
 [5] sequence req1w2: detected pusher aborted
-[5] sequence req1w2: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
+[5] sequence req1w2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
-[7] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
-[7] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "a" (queuedWriters: 1, queuedReaders: 0)
-[7] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
+[7] sequence req3w2: resolving intent ‹"a"› for txn 00000001 with ABORTED status
+[7] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"a"› (queuedWriters: 1, queuedReaders: 0)
+[7] sequence req3w2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [7] sequence req3w2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [7] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -411,7 +411,7 @@ finish req=req4w
 ----
 [-] finish req4w: finishing request
 [7] sequence req3w2: lock wait-queue event: done waiting
-[7] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 0.000s
+[7] sequence req3w2: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [7] sequence req3w2: acquiring latches
 [7] sequence req3w2: scanning lock table for conflicting locks
 [7] sequence req3w2: sequencing complete, returned guard
@@ -424,9 +424,9 @@ finish req=req3w2
 on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
-[6] sequence req2w2: resolving intent "c" for txn 00000003 with COMMITTED status
+[6] sequence req2w2: resolving intent ‹"c"› for txn 00000003 with COMMITTED status
 [6] sequence req2w2: lock wait-queue event: done waiting
-[6] sequence req2w2: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
+[6] sequence req2w2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
 [6] sequence req2w2: acquiring latches
 [6] sequence req2w2: scanning lock table for conflicting locks
 [6] sequence req2w2: sequencing complete, returned guard
@@ -511,15 +511,15 @@ sequence req=req3w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ a
+[-] acquire lock: txn 00000001 @ ‹a›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ b
+[-] acquire lock: txn 00000002 @ ‹b›
 
 on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn 00000003 @ c
+[-] acquire lock: txn 00000003 @ ‹c›
 
 finish req=req1w
 ----
@@ -554,7 +554,7 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
-[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4w: pushing txn 00000002 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -562,9 +562,9 @@ sequence req=req4w
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
-[4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
-[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
+[4] sequence req4w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
+[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [4] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -600,7 +600,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
-[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"b"› (queuedWriters: 1, queuedReaders: 0)
 [5] sequence req1w2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req1w2: pushing txn 00000004 to detect request deadlock
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -613,7 +613,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
-[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedWriters: 1, queuedReaders: 0)
 [6] sequence req3w2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req3w2: pushing txn 00000001 to abort
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -643,10 +643,10 @@ on-txn-updated txn=txn4 status=aborted
 ----
 [-] update txn: aborting txn4
 [4] sequence req4w: detected pusher aborted
-[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
+[4] sequence req4w: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
 [4] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [5] sequence req1w2: lock wait-queue event: done waiting
-[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 0.000s
+[5] sequence req1w2: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: sequencing complete, returned guard
@@ -659,9 +659,9 @@ finish req=req1w2
 on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
-[6] sequence req3w2: resolving intent "a" for txn 00000001 with COMMITTED status
+[6] sequence req3w2: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
+[6] sequence req3w2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -746,15 +746,15 @@ sequence req=req3w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ a
+[-] acquire lock: txn 00000001 @ ‹a›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ b
+[-] acquire lock: txn 00000002 @ ‹b›
 
 on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn 00000003 @ c
+[-] acquire lock: txn 00000003 @ ‹c›
 
 finish req=req1w
 ----
@@ -789,7 +789,7 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
-[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4w: pushing txn 00000002 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -797,9 +797,9 @@ sequence req=req4w
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
-[4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
-[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
+[4] sequence req4w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
+[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [4] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -835,7 +835,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
-[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"b"› (queuedWriters: 1, queuedReaders: 0)
 [5] sequence req1w2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req1w2: pushing txn 00000004 to detect request deadlock
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -848,7 +848,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
-[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedWriters: 1, queuedReaders: 0)
 [6] sequence req3w2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req3w2: pushing txn 00000001 to abort
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -878,11 +878,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [5] sequence req1w2: detected pusher aborted
-[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 0.000s
+[5] sequence req1w2: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
-[6] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
+[6] sequence req3w2: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
+[6] sequence req3w2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -895,9 +895,9 @@ finish req=req3w2
 on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
-[4] sequence req4w: resolving intent "c" for txn 00000003 with COMMITTED status
+[4] sequence req4w: resolving intent ‹"c"› for txn 00000003 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: done waiting
-[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
+[4] sequence req4w: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: sequencing complete, returned guard
@@ -988,15 +988,15 @@ sequence req=req3w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ a
+[-] acquire lock: txn 00000001 @ ‹a›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ b
+[-] acquire lock: txn 00000002 @ ‹b›
 
 on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn 00000003 @ c
+[-] acquire lock: txn 00000003 @ ‹c›
 
 finish req=req1w
 ----
@@ -1036,7 +1036,7 @@ sequence req=req5w
 [4] sequence req5w: acquiring latches
 [4] sequence req5w: scanning lock table for conflicting locks
 [4] sequence req5w: waiting in lock wait-queues
-[4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req5w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req5w: pushing txn 00000002 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1047,7 +1047,7 @@ sequence req=req4w
 [5] sequence req4w: acquiring latches
 [5] sequence req4w: scanning lock table for conflicting locks
 [5] sequence req4w: waiting in lock wait-queues
-[5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedWriters: 1, queuedReaders: 0)
 [5] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req4w: pushing txn 00000001 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1055,9 +1055,9 @@ sequence req=req4w
 on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
-[5] sequence req4w: resolving intent "a" for txn 00000001 with COMMITTED status
-[5] sequence req4w: lock wait-queue event: wait for txn 00000002 holding lock @ key "b" (queuedWriters: 2, queuedReaders: 0)
-[5] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
+[5] sequence req4w: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
+[5] sequence req4w: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedWriters: 2, queuedReaders: 0)
+[5] sequence req4w: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [5] sequence req4w: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req4w: pushing txn 00000002 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1065,15 +1065,15 @@ on-txn-updated txn=txn1 status=committed
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
-[4] sequence req5w: resolving intent "b" for txn 00000002 with COMMITTED status
-[4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req5w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
+[4] sequence req5w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
+[4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req5w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [4] sequence req5w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req5w: pushing txn 00000003 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
-[5] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
-[5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000005 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
-[5] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
+[5] sequence req4w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
+[5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000005 running request @ key ‹"b"› (queuedWriters: 1, queuedReaders: 0)
+[5] sequence req4w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [5] sequence req4w: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req4w: pushing txn 00000005 to detect request deadlock
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1110,7 +1110,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
-[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"a"› (queuedWriters: 1, queuedReaders: 0)
 [6] sequence req3w2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1140,10 +1140,10 @@ on-txn-updated txn=txn4 status=aborted
 ----
 [-] update txn: aborting txn4
 [5] sequence req4w: detected pusher aborted
-[5] sequence req4w: conflicted with 00000005-0000-0000-0000-000000000000 on "b" for 0.000s
+[5] sequence req4w: conflicted with ‹00000005-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [5] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 0.000s
+[6] sequence req3w2: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -1156,9 +1156,9 @@ finish req=req3w2
 on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
-[4] sequence req5w: resolving intent "c" for txn 00000003 with COMMITTED status
+[4] sequence req5w: resolving intent ‹"c"› for txn 00000003 with COMMITTED status
 [4] sequence req5w: lock wait-queue event: done waiting
-[4] sequence req5w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
+[4] sequence req5w: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
 [4] sequence req5w: acquiring latches
 [4] sequence req5w: scanning lock table for conflicting locks
 [4] sequence req5w: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -70,7 +70,7 @@ sequence req=req1
 # NOTE: replicated locks are not immediately stored in the lock-table.
 on-lock-acquired req=req1 key=k dur=r
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req1
 ----
@@ -132,7 +132,7 @@ sequence req=req4
 handle-write-intent-error req=req4 lease-seq=3
   intent txn=txn3 key=k
 ----
-[4] handle write intent error req4: handled conflicting intents on "k", released latches
+[4] handle write intent error req4: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -146,7 +146,7 @@ sequence req=req4
 [5] sequence req4: acquiring latches
 [5] sequence req4: scanning lock table for conflicting locks
 [5] sequence req4: waiting in lock wait-queues
-[5] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[5] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [5] sequence req4: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req4: pushing timestamp of txn 00000003 above 10.000000000,0
 [5] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -154,8 +154,8 @@ sequence req=req4
 handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k
 ----
-[6] handle write intent error req2: intent on "k" discovered but not added to disabled lock table
-[6] handle write intent error req2: handled conflicting intents on "k", released latches
+[6] handle write intent error req2: intent on ‹"k"› discovered but not added to disabled lock table
+[6] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -172,7 +172,7 @@ sequence req=req2
 [7] sequence req2: acquiring latches
 [7] sequence req2: scanning lock table for conflicting locks
 [7] sequence req2: waiting in lock wait-queues
-[7] sequence req2: lock wait-queue event: wait for txn 00000003 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 2)
+[7] sequence req2: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 2)
 [7] sequence req2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [7] sequence req2: pushing timestamp of txn 00000003 above 10.000000000,0
 [7] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -180,15 +180,15 @@ sequence req=req2
 on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
-[5] sequence req4: resolving intent "k" for txn 00000003 with COMMITTED status
+[5] sequence req4: resolving intent ‹"k"› for txn 00000003 with COMMITTED status
 [5] sequence req4: lock wait-queue event: done waiting
-[5] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 0.000s
+[5] sequence req4: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [5] sequence req4: acquiring latches
 [5] sequence req4: scanning lock table for conflicting locks
 [5] sequence req4: sequencing complete, returned guard
-[7] sequence req2: resolving intent "k" for txn 00000003 with COMMITTED status
+[7] sequence req2: resolving intent ‹"k"› for txn 00000003 with COMMITTED status
 [7] sequence req2: lock wait-queue event: done waiting
-[7] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 0.000s
+[7] sequence req2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [7] sequence req2: acquiring latches
 [7] sequence req2: scanning lock table for conflicting locks
 [7] sequence req2: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -23,7 +23,7 @@ sequence req=req1
 handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn1 key=k
 ----
-[2] handle write intent error req1: handled conflicting intents on "k", released latches
+[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -37,7 +37,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 12.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -45,9 +45,9 @@ sequence req=req1
 on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
-[3] sequence req1: resolving intent "k" for txn 00000001 with ABORTED status
+[3] sequence req1: resolving intent ‹"k"› for txn 00000001 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[3] sequence req1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -90,8 +90,8 @@ sequence req=req1
 handle-write-intent-error req=req1 lease-seq=2
   intent txn=txn1 key=k
 ----
-[2] handle write intent error req1: intent on "k" discovered but not added to disabled lock table
-[2] handle write intent error req1: handled conflicting intents on "k", released latches
+[2] handle write intent error req1: intent on ‹"k"› discovered but not added to disabled lock table
+[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
 
 sequence req=req1
 ----
@@ -139,8 +139,8 @@ sequence req=req1
 handle-write-intent-error req=req1 lease-seq=2
   intent txn=txn1 key=k
 ----
-[2] handle write intent error req1: intent on "k" discovered but not added to disabled lock table
-[2] handle write intent error req1: handled conflicting intents on "k", released latches
+[2] handle write intent error req1: intent on ‹"k"› discovered but not added to disabled lock table
+[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
 
 sequence req=req1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
@@ -42,19 +42,19 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=kSSINormal1
 ----
-[-] acquire lock: txn 00000001 @ kSSINormal1
+[-] acquire lock: txn 00000001 @ ‹kSSINormal1›
 
 on-lock-acquired req=req1 key=kSSINormal2
 ----
-[-] acquire lock: txn 00000001 @ kSSINormal2
+[-] acquire lock: txn 00000001 @ ‹kSSINormal2›
 
 on-lock-acquired req=req1 key=kSSINormal3
 ----
-[-] acquire lock: txn 00000001 @ kSSINormal3
+[-] acquire lock: txn 00000001 @ ‹kSSINormal3›
 
 on-lock-acquired req=req1 key=kSSINormal4
 ----
-[-] acquire lock: txn 00000001 @ kSSINormal4
+[-] acquire lock: txn 00000001 @ ‹kSSINormal4›
 
 finish req=req1
 ----
@@ -76,19 +76,19 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=kSSIHigh1
 ----
-[-] acquire lock: txn 00000002 @ kSSIHigh1
+[-] acquire lock: txn 00000002 @ ‹kSSIHigh1›
 
 on-lock-acquired req=req2 key=kSSIHigh2
 ----
-[-] acquire lock: txn 00000002 @ kSSIHigh2
+[-] acquire lock: txn 00000002 @ ‹kSSIHigh2›
 
 on-lock-acquired req=req2 key=kSSIHigh3
 ----
-[-] acquire lock: txn 00000002 @ kSSIHigh3
+[-] acquire lock: txn 00000002 @ ‹kSSIHigh3›
 
 on-lock-acquired req=req2 key=kSSIHigh4
 ----
-[-] acquire lock: txn 00000002 @ kSSIHigh4
+[-] acquire lock: txn 00000002 @ ‹kSSIHigh4›
 
 finish req=req2
 ----
@@ -110,19 +110,19 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=kRCNormal1
 ----
-[-] acquire lock: txn 00000003 @ kRCNormal1
+[-] acquire lock: txn 00000003 @ ‹kRCNormal1›
 
 on-lock-acquired req=req3 key=kRCNormal2
 ----
-[-] acquire lock: txn 00000003 @ kRCNormal2
+[-] acquire lock: txn 00000003 @ ‹kRCNormal2›
 
 on-lock-acquired req=req3 key=kRCNormal3
 ----
-[-] acquire lock: txn 00000003 @ kRCNormal3
+[-] acquire lock: txn 00000003 @ ‹kRCNormal3›
 
 on-lock-acquired req=req3 key=kRCNormal4
 ----
-[-] acquire lock: txn 00000003 @ kRCNormal4
+[-] acquire lock: txn 00000003 @ ‹kRCNormal4›
 
 finish req=req3
 ----
@@ -144,19 +144,19 @@ sequence req=req4
 
 on-lock-acquired req=req4 key=kRCHigh1
 ----
-[-] acquire lock: txn 00000004 @ kRCHigh1
+[-] acquire lock: txn 00000004 @ ‹kRCHigh1›
 
 on-lock-acquired req=req4 key=kRCHigh2
 ----
-[-] acquire lock: txn 00000004 @ kRCHigh2
+[-] acquire lock: txn 00000004 @ ‹kRCHigh2›
 
 on-lock-acquired req=req4 key=kRCHigh3
 ----
-[-] acquire lock: txn 00000004 @ kRCHigh3
+[-] acquire lock: txn 00000004 @ ‹kRCHigh3›
 
 on-lock-acquired req=req4 key=kRCHigh4
 ----
-[-] acquire lock: txn 00000004 @ kRCHigh4
+[-] acquire lock: txn 00000004 @ ‹kRCHigh4›
 
 finish req=req4
 ----
@@ -216,7 +216,7 @@ sequence req=req5
 [5] sequence req5: acquiring latches
 [5] sequence req5: scanning lock table for conflicting locks
 [5] sequence req5: waiting in lock wait-queues
-[5] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kSSINormal1" (queuedWriters: 0, queuedReaders: 1)
+[5] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kSSINormal1"› (queuedWriters: 0, queuedReaders: 1)
 [5] sequence req5: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req5: pushing timestamp of txn 00000001 above 10.000000000,1
 [5] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -236,9 +236,9 @@ new-request name=req6 txn=txnSSIHighPusher ts=11,1
 
 sequence req=req6
 ----
-[5] sequence req5: resolving intent "kSSINormal1" for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
+[5] sequence req5: resolving intent ‹"kSSINormal1"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
 [5] sequence req5: lock wait-queue event: done waiting
-[5] sequence req5: conflicted with 00000001-0000-0000-0000-000000000000 on "kSSINormal1" for 0.000s
+[5] sequence req5: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kSSINormal1"› for 0.000s
 [5] sequence req5: acquiring latches
 [5] sequence req5: scanning lock table for conflicting locks
 [5] sequence req5: sequencing complete, returned guard
@@ -246,13 +246,13 @@ sequence req=req6
 [6] sequence req6: acquiring latches
 [6] sequence req6: scanning lock table for conflicting locks
 [6] sequence req6: waiting in lock wait-queues
-[6] sequence req6: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kSSINormal2" (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req6: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kSSINormal2"› (queuedWriters: 0, queuedReaders: 1)
 [6] sequence req6: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [6] sequence req6: pushing timestamp of txn 00000001 above 11.000000000,1
 [6] sequence req6: pusher pushed pushee to 11.000000000,2
-[6] sequence req6: resolving intent "kSSINormal2" for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
+[6] sequence req6: resolving intent ‹"kSSINormal2"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
 [6] sequence req6: lock wait-queue event: done waiting
-[6] sequence req6: conflicted with 00000001-0000-0000-0000-000000000000 on "kSSINormal2" for 0.000s
+[6] sequence req6: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kSSINormal2"› for 0.000s
 [6] sequence req6: acquiring latches
 [6] sequence req6: scanning lock table for conflicting locks
 [6] sequence req6: sequencing complete, returned guard
@@ -283,13 +283,13 @@ sequence req=req7
 [7] sequence req7: acquiring latches
 [7] sequence req7: scanning lock table for conflicting locks
 [7] sequence req7: waiting in lock wait-queues
-[7] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kSSINormal3" (queuedWriters: 0, queuedReaders: 1)
+[7] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kSSINormal3"› (queuedWriters: 0, queuedReaders: 1)
 [7] sequence req7: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [7] sequence req7: pushing timestamp of txn 00000001 above 12.000000000,1
 [7] sequence req7: pusher pushed pushee to 12.000000000,2
-[7] sequence req7: resolving intent "kSSINormal3" for txn 00000001 with PENDING status and clock observation {1 123.000000000,5}
+[7] sequence req7: resolving intent ‹"kSSINormal3"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,5}
 [7] sequence req7: lock wait-queue event: done waiting
-[7] sequence req7: conflicted with 00000001-0000-0000-0000-000000000000 on "kSSINormal3" for 0.000s
+[7] sequence req7: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kSSINormal3"› for 0.000s
 [7] sequence req7: acquiring latches
 [7] sequence req7: scanning lock table for conflicting locks
 [7] sequence req7: sequencing complete, returned guard
@@ -316,13 +316,13 @@ sequence req=req8
 [8] sequence req8: acquiring latches
 [8] sequence req8: scanning lock table for conflicting locks
 [8] sequence req8: waiting in lock wait-queues
-[8] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kSSINormal4" (queuedWriters: 0, queuedReaders: 1)
+[8] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kSSINormal4"› (queuedWriters: 0, queuedReaders: 1)
 [8] sequence req8: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [8] sequence req8: pushing timestamp of txn 00000001 above 13.000000000,1
 [8] sequence req8: pusher pushed pushee to 13.000000000,2
-[8] sequence req8: resolving intent "kSSINormal4" for txn 00000001 with PENDING status and clock observation {1 123.000000000,7}
+[8] sequence req8: resolving intent ‹"kSSINormal4"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,7}
 [8] sequence req8: lock wait-queue event: done waiting
-[8] sequence req8: conflicted with 00000001-0000-0000-0000-000000000000 on "kSSINormal4" for 0.000s
+[8] sequence req8: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kSSINormal4"› for 0.000s
 [8] sequence req8: acquiring latches
 [8] sequence req8: scanning lock table for conflicting locks
 [8] sequence req8: sequencing complete, returned guard
@@ -385,7 +385,7 @@ sequence req=req9
 [9] sequence req9: acquiring latches
 [9] sequence req9: scanning lock table for conflicting locks
 [9] sequence req9: waiting in lock wait-queues
-[9] sequence req9: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kSSIHigh1" (queuedWriters: 0, queuedReaders: 1)
+[9] sequence req9: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kSSIHigh1"› (queuedWriters: 0, queuedReaders: 1)
 [9] sequence req9: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [9] sequence req9: pushing timestamp of txn 00000002 above 10.000000000,1
 [9] sequence req9: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -408,7 +408,7 @@ sequence req=req10
 [10] sequence req10: acquiring latches
 [10] sequence req10: scanning lock table for conflicting locks
 [10] sequence req10: waiting in lock wait-queues
-[10] sequence req10: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kSSIHigh2" (queuedWriters: 0, queuedReaders: 1)
+[10] sequence req10: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kSSIHigh2"› (queuedWriters: 0, queuedReaders: 1)
 [10] sequence req10: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [10] sequence req10: pushing timestamp of txn 00000002 above 11.000000000,1
 [10] sequence req10: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -431,7 +431,7 @@ sequence req=req11
 [11] sequence req11: acquiring latches
 [11] sequence req11: scanning lock table for conflicting locks
 [11] sequence req11: waiting in lock wait-queues
-[11] sequence req11: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kSSIHigh3" (queuedWriters: 0, queuedReaders: 1)
+[11] sequence req11: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kSSIHigh3"› (queuedWriters: 0, queuedReaders: 1)
 [11] sequence req11: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [11] sequence req11: pushing timestamp of txn 00000002 above 12.000000000,1
 [11] sequence req11: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -451,21 +451,21 @@ new-request name=req12 txn=txnRCHighPusher ts=13,1
 
 sequence req=req12
 ----
-[9] sequence req9: resolving intent "kSSIHigh1" for txn 00000002 with PENDING status and clock observation {1 123.000000000,9}
+[9] sequence req9: resolving intent ‹"kSSIHigh1"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,9}
 [9] sequence req9: lock wait-queue event: done waiting
-[9] sequence req9: conflicted with 00000002-0000-0000-0000-000000000000 on "kSSIHigh1" for 0.000s
+[9] sequence req9: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kSSIHigh1"› for 0.000s
 [9] sequence req9: acquiring latches
 [9] sequence req9: scanning lock table for conflicting locks
 [9] sequence req9: sequencing complete, returned guard
-[10] sequence req10: resolving intent "kSSIHigh2" for txn 00000002 with PENDING status and clock observation {1 123.000000000,11}
+[10] sequence req10: resolving intent ‹"kSSIHigh2"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,11}
 [10] sequence req10: lock wait-queue event: done waiting
-[10] sequence req10: conflicted with 00000002-0000-0000-0000-000000000000 on "kSSIHigh2" for 0.000s
+[10] sequence req10: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kSSIHigh2"› for 0.000s
 [10] sequence req10: acquiring latches
 [10] sequence req10: scanning lock table for conflicting locks
 [10] sequence req10: sequencing complete, returned guard
-[11] sequence req11: resolving intent "kSSIHigh3" for txn 00000002 with PENDING status and clock observation {1 123.000000000,13}
+[11] sequence req11: resolving intent ‹"kSSIHigh3"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,13}
 [11] sequence req11: lock wait-queue event: done waiting
-[11] sequence req11: conflicted with 00000002-0000-0000-0000-000000000000 on "kSSIHigh3" for 0.000s
+[11] sequence req11: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kSSIHigh3"› for 0.000s
 [11] sequence req11: acquiring latches
 [11] sequence req11: scanning lock table for conflicting locks
 [11] sequence req11: sequencing complete, returned guard
@@ -473,13 +473,13 @@ sequence req=req12
 [12] sequence req12: acquiring latches
 [12] sequence req12: scanning lock table for conflicting locks
 [12] sequence req12: waiting in lock wait-queues
-[12] sequence req12: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kSSIHigh4" (queuedWriters: 0, queuedReaders: 1)
+[12] sequence req12: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kSSIHigh4"› (queuedWriters: 0, queuedReaders: 1)
 [12] sequence req12: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [12] sequence req12: pushing timestamp of txn 00000002 above 13.000000000,1
 [12] sequence req12: pusher pushed pushee to 13.000000000,2
-[12] sequence req12: resolving intent "kSSIHigh4" for txn 00000002 with PENDING status and clock observation {1 123.000000000,15}
+[12] sequence req12: resolving intent ‹"kSSIHigh4"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,15}
 [12] sequence req12: lock wait-queue event: done waiting
-[12] sequence req12: conflicted with 00000002-0000-0000-0000-000000000000 on "kSSIHigh4" for 0.000s
+[12] sequence req12: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kSSIHigh4"› for 0.000s
 [12] sequence req12: acquiring latches
 [12] sequence req12: scanning lock table for conflicting locks
 [12] sequence req12: sequencing complete, returned guard
@@ -553,13 +553,13 @@ sequence req=req13
 [13] sequence req13: acquiring latches
 [13] sequence req13: scanning lock table for conflicting locks
 [13] sequence req13: waiting in lock wait-queues
-[13] sequence req13: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kRCNormal1" (queuedWriters: 0, queuedReaders: 1)
+[13] sequence req13: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kRCNormal1"› (queuedWriters: 0, queuedReaders: 1)
 [13] sequence req13: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [13] sequence req13: pushing timestamp of txn 00000003 above 10.000000000,1
 [13] sequence req13: pusher pushed pushee to 10.000000000,2
-[13] sequence req13: resolving intent "kRCNormal1" for txn 00000003 with PENDING status and clock observation {1 123.000000000,17}
+[13] sequence req13: resolving intent ‹"kRCNormal1"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,17}
 [13] sequence req13: lock wait-queue event: done waiting
-[13] sequence req13: conflicted with 00000003-0000-0000-0000-000000000000 on "kRCNormal1" for 0.000s
+[13] sequence req13: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kRCNormal1"› for 0.000s
 [13] sequence req13: acquiring latches
 [13] sequence req13: scanning lock table for conflicting locks
 [13] sequence req13: sequencing complete, returned guard
@@ -585,13 +585,13 @@ sequence req=req14
 [14] sequence req14: acquiring latches
 [14] sequence req14: scanning lock table for conflicting locks
 [14] sequence req14: waiting in lock wait-queues
-[14] sequence req14: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kRCNormal2" (queuedWriters: 0, queuedReaders: 1)
+[14] sequence req14: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kRCNormal2"› (queuedWriters: 0, queuedReaders: 1)
 [14] sequence req14: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [14] sequence req14: pushing timestamp of txn 00000003 above 11.000000000,1
 [14] sequence req14: pusher pushed pushee to 11.000000000,2
-[14] sequence req14: resolving intent "kRCNormal2" for txn 00000003 with PENDING status and clock observation {1 123.000000000,19}
+[14] sequence req14: resolving intent ‹"kRCNormal2"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,19}
 [14] sequence req14: lock wait-queue event: done waiting
-[14] sequence req14: conflicted with 00000003-0000-0000-0000-000000000000 on "kRCNormal2" for 0.000s
+[14] sequence req14: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kRCNormal2"› for 0.000s
 [14] sequence req14: acquiring latches
 [14] sequence req14: scanning lock table for conflicting locks
 [14] sequence req14: sequencing complete, returned guard
@@ -617,13 +617,13 @@ sequence req=req15
 [15] sequence req15: acquiring latches
 [15] sequence req15: scanning lock table for conflicting locks
 [15] sequence req15: waiting in lock wait-queues
-[15] sequence req15: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kRCNormal3" (queuedWriters: 0, queuedReaders: 1)
+[15] sequence req15: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kRCNormal3"› (queuedWriters: 0, queuedReaders: 1)
 [15] sequence req15: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [15] sequence req15: pushing timestamp of txn 00000003 above 12.000000000,1
 [15] sequence req15: pusher pushed pushee to 12.000000000,2
-[15] sequence req15: resolving intent "kRCNormal3" for txn 00000003 with PENDING status and clock observation {1 123.000000000,21}
+[15] sequence req15: resolving intent ‹"kRCNormal3"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,21}
 [15] sequence req15: lock wait-queue event: done waiting
-[15] sequence req15: conflicted with 00000003-0000-0000-0000-000000000000 on "kRCNormal3" for 0.000s
+[15] sequence req15: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kRCNormal3"› for 0.000s
 [15] sequence req15: acquiring latches
 [15] sequence req15: scanning lock table for conflicting locks
 [15] sequence req15: sequencing complete, returned guard
@@ -649,13 +649,13 @@ sequence req=req16
 [16] sequence req16: acquiring latches
 [16] sequence req16: scanning lock table for conflicting locks
 [16] sequence req16: waiting in lock wait-queues
-[16] sequence req16: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kRCNormal4" (queuedWriters: 0, queuedReaders: 1)
+[16] sequence req16: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kRCNormal4"› (queuedWriters: 0, queuedReaders: 1)
 [16] sequence req16: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [16] sequence req16: pushing timestamp of txn 00000003 above 13.000000000,1
 [16] sequence req16: pusher pushed pushee to 13.000000000,2
-[16] sequence req16: resolving intent "kRCNormal4" for txn 00000003 with PENDING status and clock observation {1 123.000000000,23}
+[16] sequence req16: resolving intent ‹"kRCNormal4"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,23}
 [16] sequence req16: lock wait-queue event: done waiting
-[16] sequence req16: conflicted with 00000003-0000-0000-0000-000000000000 on "kRCNormal4" for 0.000s
+[16] sequence req16: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kRCNormal4"› for 0.000s
 [16] sequence req16: acquiring latches
 [16] sequence req16: scanning lock table for conflicting locks
 [16] sequence req16: sequencing complete, returned guard
@@ -717,13 +717,13 @@ sequence req=req17
 [17] sequence req17: acquiring latches
 [17] sequence req17: scanning lock table for conflicting locks
 [17] sequence req17: waiting in lock wait-queues
-[17] sequence req17: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "kRCHigh1" (queuedWriters: 0, queuedReaders: 1)
+[17] sequence req17: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"kRCHigh1"› (queuedWriters: 0, queuedReaders: 1)
 [17] sequence req17: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [17] sequence req17: pushing timestamp of txn 00000004 above 10.000000000,1
 [17] sequence req17: pusher pushed pushee to 10.000000000,2
-[17] sequence req17: resolving intent "kRCHigh1" for txn 00000004 with PENDING status and clock observation {1 123.000000000,25}
+[17] sequence req17: resolving intent ‹"kRCHigh1"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,25}
 [17] sequence req17: lock wait-queue event: done waiting
-[17] sequence req17: conflicted with 00000004-0000-0000-0000-000000000000 on "kRCHigh1" for 0.000s
+[17] sequence req17: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"kRCHigh1"› for 0.000s
 [17] sequence req17: acquiring latches
 [17] sequence req17: scanning lock table for conflicting locks
 [17] sequence req17: sequencing complete, returned guard
@@ -749,13 +749,13 @@ sequence req=req18
 [18] sequence req18: acquiring latches
 [18] sequence req18: scanning lock table for conflicting locks
 [18] sequence req18: waiting in lock wait-queues
-[18] sequence req18: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "kRCHigh2" (queuedWriters: 0, queuedReaders: 1)
+[18] sequence req18: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"kRCHigh2"› (queuedWriters: 0, queuedReaders: 1)
 [18] sequence req18: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [18] sequence req18: pushing timestamp of txn 00000004 above 11.000000000,1
 [18] sequence req18: pusher pushed pushee to 11.000000000,2
-[18] sequence req18: resolving intent "kRCHigh2" for txn 00000004 with PENDING status and clock observation {1 123.000000000,27}
+[18] sequence req18: resolving intent ‹"kRCHigh2"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,27}
 [18] sequence req18: lock wait-queue event: done waiting
-[18] sequence req18: conflicted with 00000004-0000-0000-0000-000000000000 on "kRCHigh2" for 0.000s
+[18] sequence req18: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"kRCHigh2"› for 0.000s
 [18] sequence req18: acquiring latches
 [18] sequence req18: scanning lock table for conflicting locks
 [18] sequence req18: sequencing complete, returned guard
@@ -781,13 +781,13 @@ sequence req=req19
 [19] sequence req19: acquiring latches
 [19] sequence req19: scanning lock table for conflicting locks
 [19] sequence req19: waiting in lock wait-queues
-[19] sequence req19: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "kRCHigh3" (queuedWriters: 0, queuedReaders: 1)
+[19] sequence req19: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"kRCHigh3"› (queuedWriters: 0, queuedReaders: 1)
 [19] sequence req19: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [19] sequence req19: pushing timestamp of txn 00000004 above 12.000000000,1
 [19] sequence req19: pusher pushed pushee to 12.000000000,2
-[19] sequence req19: resolving intent "kRCHigh3" for txn 00000004 with PENDING status and clock observation {1 123.000000000,29}
+[19] sequence req19: resolving intent ‹"kRCHigh3"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,29}
 [19] sequence req19: lock wait-queue event: done waiting
-[19] sequence req19: conflicted with 00000004-0000-0000-0000-000000000000 on "kRCHigh3" for 0.000s
+[19] sequence req19: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"kRCHigh3"› for 0.000s
 [19] sequence req19: acquiring latches
 [19] sequence req19: scanning lock table for conflicting locks
 [19] sequence req19: sequencing complete, returned guard
@@ -813,13 +813,13 @@ sequence req=req20
 [20] sequence req20: acquiring latches
 [20] sequence req20: scanning lock table for conflicting locks
 [20] sequence req20: waiting in lock wait-queues
-[20] sequence req20: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "kRCHigh4" (queuedWriters: 0, queuedReaders: 1)
+[20] sequence req20: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"kRCHigh4"› (queuedWriters: 0, queuedReaders: 1)
 [20] sequence req20: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [20] sequence req20: pushing timestamp of txn 00000004 above 13.000000000,1
 [20] sequence req20: pusher pushed pushee to 13.000000000,2
-[20] sequence req20: resolving intent "kRCHigh4" for txn 00000004 with PENDING status and clock observation {1 123.000000000,31}
+[20] sequence req20: resolving intent ‹"kRCHigh4"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,31}
 [20] sequence req20: lock wait-queue event: done waiting
-[20] sequence req20: conflicted with 00000004-0000-0000-0000-000000000000 on "kRCHigh4" for 0.000s
+[20] sequence req20: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"kRCHigh4"› for 0.000s
 [20] sequence req20: acquiring latches
 [20] sequence req20: scanning lock table for conflicting locks
 [20] sequence req20: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -30,11 +30,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 on-lock-acquired req=req1 key=k2
 ----
-[-] acquire lock: txn 00000001 @ k2
+[-] acquire lock: txn 00000001 @ ‹k2›
 
 finish req=req1
 ----
@@ -53,7 +53,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k3
 ----
-[-] acquire lock: txn 00000002 @ k3
+[-] acquire lock: txn 00000002 @ ‹k3›
 
 finish req=req2
 ----
@@ -70,7 +70,7 @@ sequence req=req3
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k2" (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k2"› (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -103,12 +103,12 @@ sequence req=reqTimeout1
 [4] sequence reqTimeout1: acquiring latches
 [4] sequence reqTimeout1: scanning lock table for conflicting locks
 [4] sequence reqTimeout1: waiting in lock wait-queues
-[4] sequence reqTimeout1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence reqTimeout1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [4] sequence reqTimeout1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = true, priority enforcement = false
 [4] sequence reqTimeout1: pushing txn 00000001 to check if abandoned
 [4] sequence reqTimeout1: pushee not abandoned
-[4] sequence reqTimeout1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
-[4] sequence reqTimeout1: sequencing complete, returned error: conflicting intents on "k" [reason=lock_timeout]
+[4] sequence reqTimeout1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence reqTimeout1: sequencing complete, returned error: conflicting intents on ‹"k"› [reason=lock_timeout]
 
 # -------------------------------------------------------------
 # Read-only request with lock timeout hits abandoned lock.
@@ -118,9 +118,9 @@ sequence req=reqTimeout1
 on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
-[3] sequence req3: resolving intent "k2" for txn 00000001 with COMMITTED status
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k3" (queuedWriters: 1, queuedReaders: 0)
-[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 0.000s
+[3] sequence req3: resolving intent ‹"k2"› for txn 00000001 with COMMITTED status
+[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k3"› (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k2"› for 0.000s
 [3] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -163,10 +163,10 @@ sequence req=reqTimeout2
 [6] sequence reqTimeout2: acquiring latches
 [6] sequence reqTimeout2: scanning lock table for conflicting locks
 [6] sequence reqTimeout2: waiting in lock wait-queues
-[6] sequence reqTimeout2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k2" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence reqTimeout2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k2"› (queuedWriters: 1, queuedReaders: 0)
 [6] sequence reqTimeout2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = true, priority enforcement = false
-[6] sequence reqTimeout2: conflicted with 00000003-0000-0000-0000-000000000000 on "k2" for 0.000s
-[6] sequence reqTimeout2: sequencing complete, returned error: conflicting intents on "k2" [reason=lock_timeout]
+[6] sequence reqTimeout2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k2"› for 0.000s
+[6] sequence reqTimeout2: sequencing complete, returned error: conflicting intents on ‹"k2"› [reason=lock_timeout]
 
 # -------------------------------------------------------------
 # Read-only request with lock timeout discovers lock. The
@@ -187,7 +187,7 @@ sequence req=reqTimeout3
 handle-write-intent-error req=reqTimeout3 lease-seq=1
   intent txn=txn2 key=k4
 ----
-[8] handle write intent error reqTimeout3: handled conflicting intents on "k4", released latches
+[8] handle write intent error reqTimeout3: handled conflicting intents on ‹"k4"›, released latches
 
 sequence req=reqTimeout3
 ----
@@ -195,12 +195,12 @@ sequence req=reqTimeout3
 [9] sequence reqTimeout3: acquiring latches
 [9] sequence reqTimeout3: scanning lock table for conflicting locks
 [9] sequence reqTimeout3: waiting in lock wait-queues
-[9] sequence reqTimeout3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k4" (queuedWriters: 0, queuedReaders: 1)
+[9] sequence reqTimeout3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k4"› (queuedWriters: 0, queuedReaders: 1)
 [9] sequence reqTimeout3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = true, priority enforcement = false
 [9] sequence reqTimeout3: pushing txn 00000002 to check if abandoned
 [9] sequence reqTimeout3: pushee not abandoned
-[9] sequence reqTimeout3: conflicted with 00000002-0000-0000-0000-000000000000 on "k4" for 0.000s
-[9] sequence reqTimeout3: sequencing complete, returned error: conflicting intents on "k4" [reason=lock_timeout]
+[9] sequence reqTimeout3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k4"› for 0.000s
+[9] sequence reqTimeout3: sequencing complete, returned error: conflicting intents on ‹"k4"› [reason=lock_timeout]
 
 debug-lock-table
 ----
@@ -223,9 +223,9 @@ num=3
 on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
-[3] sequence req3: resolving intent "k3" for txn 00000002 with ABORTED status
+[3] sequence req3: resolving intent ‹"k3"› for txn 00000002 with ABORTED status
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k3" for 0.000s
+[3] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k3"› for 0.000s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard
@@ -244,7 +244,7 @@ sequence req=reqTimeout4
 handle-write-intent-error req=reqTimeout4 lease-seq=1
   intent txn=txn2 key=k5
 ----
-[11] handle write intent error reqTimeout4: handled conflicting intents on "k5", released latches
+[11] handle write intent error reqTimeout4: handled conflicting intents on ‹"k5"›, released latches
 
 sequence req=reqTimeout4
 ----
@@ -254,7 +254,7 @@ sequence req=reqTimeout4
 [12] sequence reqTimeout4: waiting in lock wait-queues
 [12] sequence reqTimeout4: lock wait-queue event: done waiting
 [12] sequence reqTimeout4: resolving a batch of 1 intent(s)
-[12] sequence reqTimeout4: resolving intent "k5" for txn 00000002 with ABORTED status
+[12] sequence reqTimeout4: resolving intent ‹"k5"› for txn 00000002 with ABORTED status
 [12] sequence reqTimeout4: acquiring latches
 [12] sequence reqTimeout4: scanning lock table for conflicting locks
 [12] sequence reqTimeout4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
@@ -17,7 +17,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=d
 ----
-[-] acquire lock: txn 00000001 @ d
+[-] acquire lock: txn 00000001 @ ‹d›
 
 debug-lock-table
 ----
@@ -89,7 +89,7 @@ sequence req=req3 eval-kind=pess-after-opt
 [4] sequence req3: optimistic failed, so waiting for latches
 [4] sequence req3: scanning lock table for conflicting locks
 [4] sequence req3: waiting in lock wait-queues
-[4] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "d" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"d"› (queuedWriters: 0, queuedReaders: 1)
 [4] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req3: pushing timestamp of txn 00000001 above 12.000000000,1
 [4] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -98,9 +98,9 @@ sequence req=req3 eval-kind=pess-after-opt
 on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
-[4] sequence req3: resolving intent "d" for txn 00000001 with COMMITTED status
+[4] sequence req3: resolving intent ‹"d"› for txn 00000001 with COMMITTED status
 [4] sequence req3: lock wait-queue event: done waiting
-[4] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "d" for 0.000s
+[4] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
 [4] sequence req3: acquiring latches
 [4] sequence req3: scanning lock table for conflicting locks
 [4] sequence req3: sequencing complete, returned guard
@@ -172,7 +172,7 @@ sequence req=req6 eval-kind=pess-after-opt
 ----
 [8] sequence req6: re-sequencing request after optimistic sequencing failed
 [8] sequence req6: optimistic failed, so waiting for latches
-[8] sequence req6: waiting to acquire read latch {a-e}@12.000000000,1, held by write latch d@10.000000000,1
+[8] sequence req6: waiting to acquire read latch ‹{a-e}›@12.000000000,1, held by write latch ‹d›@10.000000000,1
 [8] sequence req6: blocked on select in spanlatch.(*Manager).waitForSignal
 
 # req4 finishing releases the latch and allows req6 to proceed.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err
@@ -27,7 +27,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch {b-f}@11.000000000,1, held by write latch c@10.000000000,0
+[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1, held by write latch ‹c›@10.000000000,0
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0
@@ -38,13 +38,13 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch e@11.000000000,0, held by read latch {b-f}@11.000000000,1
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0, held by read latch ‹{b-f}›@11.000000000,1
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=putc
 ----
 [-] poison putc: poisoning request
-[2] sequence readbf: sequencing complete, returned error: encountered poisoned latch c@10.000000000,0
+[2] sequence readbf: sequencing complete, returned error: encountered poisoned latch ‹c›@10.000000000,0
 [3] sequence pute: scanning lock table for conflicting locks
 [3] sequence pute: sequencing complete, returned guard
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err_indirect
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err_indirect
@@ -26,7 +26,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch {b-f}@11.000000000,1, held by write latch c@10.000000000,0
+[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1, held by write latch ‹c›@10.000000000,0
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0
@@ -37,7 +37,7 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch e@11.000000000,0, held by read latch {b-f}@11.000000000,1
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0, held by read latch ‹{b-f}›@11.000000000,1
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=putc
@@ -45,7 +45,7 @@ poison req=putc
 [-] poison putc: poisoning request
 [2] sequence readbf: encountered poisoned latch; continuing to wait
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
-[3] sequence pute: sequencing complete, returned error: encountered poisoned latch {b-f}@11.000000000,1
+[3] sequence pute: sequencing complete, returned error: encountered poisoned latch ‹{b-f}›@11.000000000,1
 
 finish req=putc
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_disjoint
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_disjoint
@@ -26,7 +26,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch {b-f}@11.000000000,1, held by write latch c@10.000000000,0
+[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1, held by write latch ‹c›@10.000000000,0
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0 poison-policy=wait
@@ -37,13 +37,13 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch e@11.000000000,0, held by read latch {b-f}@11.000000000,1
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0, held by read latch ‹{b-f}›@11.000000000,1
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=putc
 ----
 [-] poison putc: poisoning request
-[2] sequence readbf: sequencing complete, returned error: encountered poisoned latch c@10.000000000,0
+[2] sequence readbf: sequencing complete, returned error: encountered poisoned latch ‹c›@10.000000000,0
 [3] sequence pute: scanning lock table for conflicting locks
 [3] sequence pute: sequencing complete, returned guard
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_overlapping
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_overlapping
@@ -26,7 +26,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch {b-f}@11.000000000,1, held by write latch c@10.000000000,0
+[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1, held by write latch ‹c›@10.000000000,0
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=put2 ts=11,0 poison-policy=wait
@@ -37,13 +37,13 @@ sequence req=put2
 ----
 [3] sequence put2: sequencing request
 [3] sequence put2: acquiring latches
-[3] sequence put2: waiting to acquire write latch c@11.000000000,0, held by write latch c@10.000000000,0
+[3] sequence put2: waiting to acquire write latch ‹c›@11.000000000,0, held by write latch ‹c›@10.000000000,0
 [3] sequence put2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=put1
 ----
 [-] poison put1: poisoning request
-[2] sequence readbf: sequencing complete, returned error: encountered poisoned latch c@10.000000000,0
+[2] sequence readbf: sequencing complete, returned error: encountered poisoned latch ‹c›@10.000000000,0
 [3] sequence put2: encountered poisoned latch; continuing to wait
 [3] sequence put2: blocked on select in spanlatch.(*Manager).waitForSignal
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
@@ -43,11 +43,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=kLow1
 ----
-[-] acquire lock: txn 00000001 @ kLow1
+[-] acquire lock: txn 00000001 @ ‹kLow1›
 
 on-lock-acquired req=req1 key=kLow2
 ----
-[-] acquire lock: txn 00000001 @ kLow2
+[-] acquire lock: txn 00000001 @ ‹kLow2›
 
 finish req=req1
 ----
@@ -67,11 +67,11 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=kNormal1
 ----
-[-] acquire lock: txn 00000002 @ kNormal1
+[-] acquire lock: txn 00000002 @ ‹kNormal1›
 
 on-lock-acquired req=req2 key=kNormal2
 ----
-[-] acquire lock: txn 00000002 @ kNormal2
+[-] acquire lock: txn 00000002 @ ‹kNormal2›
 
 finish req=req2
 ----
@@ -91,11 +91,11 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=kHigh1
 ----
-[-] acquire lock: txn 00000003 @ kHigh1
+[-] acquire lock: txn 00000003 @ ‹kHigh1›
 
 on-lock-acquired req=req3 key=kHigh2
 ----
-[-] acquire lock: txn 00000003 @ kHigh2
+[-] acquire lock: txn 00000003 @ ‹kHigh2›
 
 finish req=req3
 ----
@@ -137,16 +137,16 @@ sequence req=req4
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: waiting in lock wait-queues
-[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kLow1" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kLow1"› (queuedWriters: 0, queuedReaders: 1)
 [4] sequence req4: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing timestamp of txn 00000001 above 10.000000000,1
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req5
 ----
-[4] sequence req4: resolving intent "kLow1" for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
+[4] sequence req4: resolving intent ‹"kLow1"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
 [4] sequence req4: lock wait-queue event: done waiting
-[4] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "kLow1" for 0.000s
+[4] sequence req4: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kLow1"› for 0.000s
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: sequencing complete, returned guard
@@ -154,13 +154,13 @@ sequence req=req5
 [5] sequence req5: acquiring latches
 [5] sequence req5: scanning lock table for conflicting locks
 [5] sequence req5: waiting in lock wait-queues
-[5] sequence req5: lock wait-queue event: wait for txn 00000001 holding lock @ key "kLow1" (queuedWriters: 0, queuedReaders: 2)
+[5] sequence req5: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"kLow1"› (queuedWriters: 0, queuedReaders: 2)
 [5] sequence req5: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [5] sequence req5: pushing timestamp of txn 00000001 above 10.000000000,1
 [5] sequence req5: pusher pushed pushee to 10.000000000,2
-[5] sequence req5: resolving intent "kLow1" for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
+[5] sequence req5: resolving intent ‹"kLow1"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
 [5] sequence req5: lock wait-queue event: done waiting
-[5] sequence req5: conflicted with 00000001-0000-0000-0000-000000000000 on "kLow1" for 0.000s
+[5] sequence req5: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kLow1"› for 0.000s
 [5] sequence req5: acquiring latches
 [5] sequence req5: scanning lock table for conflicting locks
 [5] sequence req5: sequencing complete, returned guard
@@ -209,16 +209,16 @@ sequence req=req6
 [6] sequence req6: acquiring latches
 [6] sequence req6: scanning lock table for conflicting locks
 [6] sequence req6: waiting in lock wait-queues
-[6] sequence req6: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kLow2" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req6: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kLow2"› (queuedWriters: 1, queuedReaders: 0)
 [6] sequence req6: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req6: pushing txn 00000001 to abort
 [6] sequence req6: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req7
 ----
-[6] sequence req6: resolving intent "kLow2" for txn 00000001 with ABORTED status
+[6] sequence req6: resolving intent ‹"kLow2"› for txn 00000001 with ABORTED status
 [6] sequence req6: lock wait-queue event: done waiting
-[6] sequence req6: conflicted with 00000001-0000-0000-0000-000000000000 on "kLow2" for 0.000s
+[6] sequence req6: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kLow2"› for 0.000s
 [6] sequence req6: acquiring latches
 [6] sequence req6: scanning lock table for conflicting locks
 [6] sequence req6: sequencing complete, returned guard
@@ -226,13 +226,13 @@ sequence req=req7
 [7] sequence req7: acquiring latches
 [7] sequence req7: scanning lock table for conflicting locks
 [7] sequence req7: waiting in lock wait-queues
-[7] sequence req7: lock wait-queue event: wait for txn 00000001 holding lock @ key "kLow2" (queuedWriters: 2, queuedReaders: 0)
+[7] sequence req7: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"kLow2"› (queuedWriters: 2, queuedReaders: 0)
 [7] sequence req7: pushing after 0s for: liveness detection = false, deadlock detection = false, timeout enforcement = false, priority enforcement = true
 [7] sequence req7: pushing txn 00000001 to abort
 [7] sequence req7: pusher aborted pushee
-[7] sequence req7: resolving intent "kLow2" for txn 00000001 with ABORTED status
-[7] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "kLow2" (queuedWriters: 1, queuedReaders: 0)
-[7] sequence req7: conflicted with 00000001-0000-0000-0000-000000000000 on "kLow2" for 0.000s
+[7] sequence req7: resolving intent ‹"kLow2"› for txn 00000001 with ABORTED status
+[7] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"kLow2"› (queuedWriters: 1, queuedReaders: 0)
+[7] sequence req7: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kLow2"› for 0.000s
 [7] sequence req7: pushing after 0s for: liveness detection = false, deadlock detection = false, timeout enforcement = false, priority enforcement = true
 [7] sequence req7: pushing txn 00000004 to detect request deadlock
 [7] sequence req7: pusher aborted pushee
@@ -242,7 +242,7 @@ finish req=req6
 ----
 [-] finish req6: finishing request
 [7] sequence req7: lock wait-queue event: done waiting
-[7] sequence req7: conflicted with 00000004-0000-0000-0000-000000000000 on "kLow2" for 0.000s
+[7] sequence req7: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"kLow2"› for 0.000s
 [7] sequence req7: acquiring latches
 [7] sequence req7: scanning lock table for conflicting locks
 [7] sequence req7: sequencing complete, returned guard
@@ -285,16 +285,16 @@ sequence req=req8
 [8] sequence req8: acquiring latches
 [8] sequence req8: scanning lock table for conflicting locks
 [8] sequence req8: waiting in lock wait-queues
-[8] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kNormal1" (queuedWriters: 0, queuedReaders: 1)
+[8] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kNormal1"› (queuedWriters: 0, queuedReaders: 1)
 [8] sequence req8: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [8] sequence req8: pushing timestamp of txn 00000002 above 10.000000000,1
 [8] sequence req8: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req9
 ----
-[8] sequence req8: resolving intent "kNormal1" for txn 00000002 with PENDING status and clock observation {1 123.000000000,6}
+[8] sequence req8: resolving intent ‹"kNormal1"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,6}
 [8] sequence req8: lock wait-queue event: done waiting
-[8] sequence req8: conflicted with 00000002-0000-0000-0000-000000000000 on "kNormal1" for 0.000s
+[8] sequence req8: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kNormal1"› for 0.000s
 [8] sequence req8: acquiring latches
 [8] sequence req8: scanning lock table for conflicting locks
 [8] sequence req8: sequencing complete, returned guard
@@ -302,13 +302,13 @@ sequence req=req9
 [9] sequence req9: acquiring latches
 [9] sequence req9: scanning lock table for conflicting locks
 [9] sequence req9: waiting in lock wait-queues
-[9] sequence req9: lock wait-queue event: wait for txn 00000002 holding lock @ key "kNormal1" (queuedWriters: 0, queuedReaders: 2)
+[9] sequence req9: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"kNormal1"› (queuedWriters: 0, queuedReaders: 2)
 [9] sequence req9: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [9] sequence req9: pushing timestamp of txn 00000002 above 10.000000000,1
 [9] sequence req9: pusher pushed pushee to 10.000000000,2
-[9] sequence req9: resolving intent "kNormal1" for txn 00000002 with PENDING status and clock observation {1 123.000000000,8}
+[9] sequence req9: resolving intent ‹"kNormal1"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,8}
 [9] sequence req9: lock wait-queue event: done waiting
-[9] sequence req9: conflicted with 00000002-0000-0000-0000-000000000000 on "kNormal1" for 0.000s
+[9] sequence req9: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kNormal1"› for 0.000s
 [9] sequence req9: acquiring latches
 [9] sequence req9: scanning lock table for conflicting locks
 [9] sequence req9: sequencing complete, returned guard
@@ -355,16 +355,16 @@ sequence req=req10
 [10] sequence req10: acquiring latches
 [10] sequence req10: scanning lock table for conflicting locks
 [10] sequence req10: waiting in lock wait-queues
-[10] sequence req10: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kNormal2" (queuedWriters: 1, queuedReaders: 0)
+[10] sequence req10: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kNormal2"› (queuedWriters: 1, queuedReaders: 0)
 [10] sequence req10: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [10] sequence req10: pushing txn 00000002 to abort
 [10] sequence req10: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req11
 ----
-[10] sequence req10: resolving intent "kNormal2" for txn 00000002 with ABORTED status
+[10] sequence req10: resolving intent ‹"kNormal2"› for txn 00000002 with ABORTED status
 [10] sequence req10: lock wait-queue event: done waiting
-[10] sequence req10: conflicted with 00000002-0000-0000-0000-000000000000 on "kNormal2" for 0.000s
+[10] sequence req10: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kNormal2"› for 0.000s
 [10] sequence req10: acquiring latches
 [10] sequence req10: scanning lock table for conflicting locks
 [10] sequence req10: sequencing complete, returned guard
@@ -372,13 +372,13 @@ sequence req=req11
 [11] sequence req11: acquiring latches
 [11] sequence req11: scanning lock table for conflicting locks
 [11] sequence req11: waiting in lock wait-queues
-[11] sequence req11: lock wait-queue event: wait for txn 00000002 holding lock @ key "kNormal2" (queuedWriters: 2, queuedReaders: 0)
+[11] sequence req11: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"kNormal2"› (queuedWriters: 2, queuedReaders: 0)
 [11] sequence req11: pushing after 0s for: liveness detection = false, deadlock detection = false, timeout enforcement = false, priority enforcement = true
 [11] sequence req11: pushing txn 00000002 to abort
 [11] sequence req11: pusher aborted pushee
-[11] sequence req11: resolving intent "kNormal2" for txn 00000002 with ABORTED status
-[11] sequence req11: lock wait-queue event: wait for (distinguished) txn 00000007 running request @ key "kNormal2" (queuedWriters: 1, queuedReaders: 0)
-[11] sequence req11: conflicted with 00000002-0000-0000-0000-000000000000 on "kNormal2" for 0.000s
+[11] sequence req11: resolving intent ‹"kNormal2"› for txn 00000002 with ABORTED status
+[11] sequence req11: lock wait-queue event: wait for (distinguished) txn 00000007 running request @ key ‹"kNormal2"› (queuedWriters: 1, queuedReaders: 0)
+[11] sequence req11: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kNormal2"› for 0.000s
 [11] sequence req11: pushing after 0s for: liveness detection = false, deadlock detection = false, timeout enforcement = false, priority enforcement = true
 [11] sequence req11: pushing txn 00000007 to detect request deadlock
 [11] sequence req11: pusher aborted pushee
@@ -388,7 +388,7 @@ finish req=req10
 ----
 [-] finish req10: finishing request
 [11] sequence req11: lock wait-queue event: done waiting
-[11] sequence req11: conflicted with 00000007-0000-0000-0000-000000000000 on "kNormal2" for 0.000s
+[11] sequence req11: conflicted with ‹00000007-0000-0000-0000-000000000000› on ‹"kNormal2"› for 0.000s
 [11] sequence req11: acquiring latches
 [11] sequence req11: scanning lock table for conflicting locks
 [11] sequence req11: sequencing complete, returned guard
@@ -429,7 +429,7 @@ sequence req=req12
 [12] sequence req12: acquiring latches
 [12] sequence req12: scanning lock table for conflicting locks
 [12] sequence req12: waiting in lock wait-queues
-[12] sequence req12: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kHigh1" (queuedWriters: 0, queuedReaders: 1)
+[12] sequence req12: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kHigh1"› (queuedWriters: 0, queuedReaders: 1)
 [12] sequence req12: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [12] sequence req12: pushing timestamp of txn 00000003 above 10.000000000,1
 [12] sequence req12: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -440,7 +440,7 @@ sequence req=req13
 [13] sequence req13: acquiring latches
 [13] sequence req13: scanning lock table for conflicting locks
 [13] sequence req13: waiting in lock wait-queues
-[13] sequence req13: lock wait-queue event: wait for txn 00000003 holding lock @ key "kHigh1" (queuedWriters: 0, queuedReaders: 2)
+[13] sequence req13: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"kHigh1"› (queuedWriters: 0, queuedReaders: 2)
 [13] sequence req13: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [13] sequence req13: pushing timestamp of txn 00000003 above 10.000000000,1
 [13] sequence req13: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -448,15 +448,15 @@ sequence req=req13
 on-txn-updated txn=txnHighPushee status=pending ts=10,2
 ----
 [-] update txn: increasing timestamp of txnHighPushee
-[12] sequence req12: resolving intent "kHigh1" for txn 00000003 with PENDING status and clock observation {1 123.000000000,11}
+[12] sequence req12: resolving intent ‹"kHigh1"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,11}
 [12] sequence req12: lock wait-queue event: done waiting
-[12] sequence req12: conflicted with 00000003-0000-0000-0000-000000000000 on "kHigh1" for 0.000s
+[12] sequence req12: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kHigh1"› for 0.000s
 [12] sequence req12: acquiring latches
 [12] sequence req12: scanning lock table for conflicting locks
 [12] sequence req12: sequencing complete, returned guard
-[13] sequence req13: resolving intent "kHigh1" for txn 00000003 with PENDING status and clock observation {1 123.000000000,13}
+[13] sequence req13: resolving intent ‹"kHigh1"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,13}
 [13] sequence req13: lock wait-queue event: done waiting
-[13] sequence req13: conflicted with 00000003-0000-0000-0000-000000000000 on "kHigh1" for 0.000s
+[13] sequence req13: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kHigh1"› for 0.000s
 [13] sequence req13: acquiring latches
 [13] sequence req13: scanning lock table for conflicting locks
 [13] sequence req13: sequencing complete, returned guard
@@ -501,7 +501,7 @@ sequence req=req14
 [14] sequence req14: acquiring latches
 [14] sequence req14: scanning lock table for conflicting locks
 [14] sequence req14: waiting in lock wait-queues
-[14] sequence req14: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kHigh2" (queuedWriters: 1, queuedReaders: 0)
+[14] sequence req14: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kHigh2"› (queuedWriters: 1, queuedReaders: 0)
 [14] sequence req14: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [14] sequence req14: pushing txn 00000003 to abort
 [14] sequence req14: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -512,21 +512,21 @@ sequence req=req15
 [15] sequence req15: acquiring latches
 [15] sequence req15: scanning lock table for conflicting locks
 [15] sequence req15: waiting in lock wait-queues
-[15] sequence req15: lock wait-queue event: wait for txn 00000003 holding lock @ key "kHigh2" (queuedWriters: 2, queuedReaders: 0)
+[15] sequence req15: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"kHigh2"› (queuedWriters: 2, queuedReaders: 0)
 [15] sequence req15: not pushing
 [15] sequence req15: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 on-txn-updated txn=txnHighPushee status=committed
 ----
 [-] update txn: committing txnHighPushee
-[14] sequence req14: resolving intent "kHigh2" for txn 00000003 with COMMITTED status
+[14] sequence req14: resolving intent ‹"kHigh2"› for txn 00000003 with COMMITTED status
 [14] sequence req14: lock wait-queue event: done waiting
-[14] sequence req14: conflicted with 00000003-0000-0000-0000-000000000000 on "kHigh2" for 0.000s
+[14] sequence req14: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kHigh2"› for 0.000s
 [14] sequence req14: acquiring latches
 [14] sequence req14: scanning lock table for conflicting locks
 [14] sequence req14: sequencing complete, returned guard
-[15] sequence req15: lock wait-queue event: wait for (distinguished) txn 00000008 running request @ key "kHigh2" (queuedWriters: 1, queuedReaders: 0)
-[15] sequence req15: conflicted with 00000003-0000-0000-0000-000000000000 on "kHigh2" for 0.000s
+[15] sequence req15: lock wait-queue event: wait for (distinguished) txn 00000008 running request @ key ‹"kHigh2"› (queuedWriters: 1, queuedReaders: 0)
+[15] sequence req15: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kHigh2"› for 0.000s
 [15] sequence req15: pushing after 0s for: liveness detection = false, deadlock detection = false, timeout enforcement = false, priority enforcement = true
 [15] sequence req15: pushing txn 00000008 to detect request deadlock
 [15] sequence req15: pusher aborted pushee
@@ -536,7 +536,7 @@ finish req=req14
 ----
 [-] finish req14: finishing request
 [15] sequence req15: lock wait-queue event: done waiting
-[15] sequence req15: conflicted with 00000008-0000-0000-0000-000000000000 on "kHigh2" for 0.000s
+[15] sequence req15: conflicted with ‹00000008-0000-0000-0000-000000000000› on ‹"kHigh2"› for 0.000s
 [15] sequence req15: acquiring latches
 [15] sequence req15: scanning lock table for conflicting locks
 [15] sequence req15: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
@@ -34,7 +34,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req1
 ----
@@ -50,7 +50,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [2] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: pushing txn 00000001 to abort
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -65,7 +65,7 @@ sequence req=req3
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
-[3] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 2, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -80,7 +80,7 @@ sequence req=req4
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: waiting in lock wait-queues
-[4] sequence req4: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 3, queuedReaders: 0)
+[4] sequence req4: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 3, queuedReaders: 0)
 [4] sequence req4: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing txn 00000001 to abort
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -112,7 +112,7 @@ sequence req=req5r
 [5] sequence req5r: acquiring latches
 [5] sequence req5r: scanning lock table for conflicting locks
 [5] sequence req5r: waiting in lock wait-queues
-[5] sequence req5r: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 3, queuedReaders: 1)
+[5] sequence req5r: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 3, queuedReaders: 1)
 [5] sequence req5r: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req5r: pushing timestamp of txn 00000001 above 10.000000000,1
 [5] sequence req5r: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -120,27 +120,27 @@ sequence req=req5r
 on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
-[2] sequence req2: resolving intent "k" for txn 00000001 with COMMITTED status
+[2] sequence req2: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
-[3] sequence req3: resolving intent "k" for txn 00000001 with COMMITTED status
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
-[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[3] sequence req3: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
+[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 running request @ key ‹"k"› (queuedWriters: 2, queuedReaders: 0)
+[3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [3] sequence req3: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000002 to detect request deadlock
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
-[4] sequence req4: resolving intent "k" for txn 00000001 with COMMITTED status
-[4] sequence req4: lock wait-queue event: wait for txn 00000002 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
-[4] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[4] sequence req4: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
+[4] sequence req4: lock wait-queue event: wait for txn 00000002 running request @ key ‹"k"› (queuedWriters: 2, queuedReaders: 0)
+[4] sequence req4: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence req4: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing txn 00000002 to detect request deadlock
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
-[5] sequence req5r: resolving intent "k" for txn 00000001 with COMMITTED status
+[5] sequence req5r: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [5] sequence req5r: lock wait-queue event: done waiting
-[5] sequence req5r: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[5] sequence req5r: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [5] sequence req5r: acquiring latches
 [5] sequence req5r: scanning lock table for conflicting locks
 [5] sequence req5r: sequencing complete, returned guard
@@ -151,12 +151,12 @@ finish req=req5r
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ k
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[-] acquire lock: txn 00000002 @ ‹k›
+[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedWriters: 2, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
-[4] sequence req4: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[4] sequence req4: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedWriters: 2, queuedReaders: 0)
 [4] sequence req4: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing txn 00000002 to abort
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -190,8 +190,8 @@ sequence req=req5w
 [6] sequence req5w: acquiring latches
 [6] sequence req5w: scanning lock table for conflicting locks
 [6] sequence req5w: waiting in lock wait-queues
-[6] sequence req5w: lock wait-queue event: wait-queue maximum length exceeded @ key "k" with length 2
-[6] sequence req5w: sequencing complete, returned error: conflicting intents on "k" [reason=lock_wait_queue_max_length_exceeded]
+[6] sequence req5w: lock wait-queue event: wait-queue maximum length exceeded @ key ‹"k"› with length 2
+[6] sequence req5w: sequencing complete, returned error: conflicting intents on ‹"k"› [reason=lock_wait_queue_max_length_exceeded]
 
 # -------------------------------------------------------------
 # Cleanup.
@@ -200,15 +200,15 @@ sequence req=req5w
 on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
-[3] sequence req3: resolving intent "k" for txn 00000002 with ABORTED status
+[3] sequence req3: resolving intent ‹"k"› for txn 00000002 with ABORTED status
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 0.000s
+[3] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard
-[4] sequence req4: resolving intent "k" for txn 00000002 with ABORTED status
-[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req4: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 0.000s
+[4] sequence req4: resolving intent ‹"k"› for txn 00000002 with ABORTED status
+[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence req4: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing txn 00000003 to detect request deadlock
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -217,7 +217,7 @@ finish req=req3
 ----
 [-] finish req3: finishing request
 [4] sequence req4: lock wait-queue event: done waiting
-[4] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 0.000s
+[4] sequence req4: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -65,11 +65,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 on-lock-acquired req=req1 key=k2
 ----
-[-] acquire lock: txn 00000001 @ k2
+[-] acquire lock: txn 00000001 @ ‹k2›
 
 finish req=req1
 ----
@@ -93,7 +93,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [2] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -113,7 +113,7 @@ on-lease-updated leaseholder=false lease-seq=2
 ----
 [-] transfer lease: released
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -125,8 +125,8 @@ num=0
 handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k
 ----
-[3] handle write intent error req2: intent on "k" discovered but not added to disabled lock table
-[3] handle write intent error req2: handled conflicting intents on "k", released latches
+[3] handle write intent error req2: intent on ‹"k"› discovered but not added to disabled lock table
+[3] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -158,7 +158,7 @@ sequence req=req2
 handle-write-intent-error req=req2 lease-seq=2
   intent txn=txn1 key=k
 ----
-[6] handle write intent error req2: handled conflicting intents on "k", released latches
+[6] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -174,7 +174,7 @@ sequence req=req2
 [7] sequence req2: acquiring latches
 [7] sequence req2: scanning lock table for conflicting locks
 [7] sequence req2: waiting in lock wait-queues
-[7] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[7] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [7] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [7] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -191,16 +191,16 @@ sequence req=reqRes1
 
 on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
-[-] update lock: committing txn 00000001 @ k
+[-] update lock: committing txn 00000001 @ ‹k›
 [7] sequence req2: lock wait-queue event: done waiting
-[7] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[7] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [7] sequence req2: acquiring latches
-[7] sequence req2: waiting to acquire read latch k2@10.000000000,1, held by write latch k2@10.000000000,1
+[7] sequence req2: waiting to acquire read latch ‹k2›@10.000000000,1, held by write latch ‹k2›@10.000000000,1
 [7] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 on-lock-updated req=reqRes1 txn=txn1 key=k2 status=committed
 ----
-[-] update lock: committing txn 00000001 @ k2
+[-] update lock: committing txn 00000001 @ ‹k2›
 
 finish req=reqRes1
 ----
@@ -216,7 +216,7 @@ num=1
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ k
+[-] acquire lock: txn 00000002 @ ‹k›
 
 debug-lock-table
 ----
@@ -255,8 +255,8 @@ sequence req=req3
 handle-write-intent-error req=req3 lease-seq=2
   intent txn=txn1 key=k
 ----
-[10] handle write intent error req3: intent on "k" discovered but not added to disabled lock table
-[10] handle write intent error req3: handled conflicting intents on "k", released latches
+[10] handle write intent error req3: intent on ‹"k"› discovered but not added to disabled lock table
+[10] handle write intent error req3: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -272,7 +272,7 @@ sequence req=req3
 handle-write-intent-error req=req3 lease-seq=4
   intent txn=txn2 key=k
 ----
-[12] handle write intent error req3: handled conflicting intents on "k", released latches
+[12] handle write intent error req3: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -288,7 +288,7 @@ sequence req=req3
 [13] sequence req3: acquiring latches
 [13] sequence req3: scanning lock table for conflicting locks
 [13] sequence req3: waiting in lock wait-queues
-[13] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[13] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [13] sequence req3: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [13] sequence req3: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -304,11 +304,11 @@ sequence req=reqRes2
 
 on-lock-updated req=reqRes2 txn=txn2 key=k status=committed
 ----
-[-] update lock: committing txn 00000002 @ k
+[-] update lock: committing txn 00000002 @ ‹k›
 [13] sequence req3: lock wait-queue event: done waiting
-[13] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 0.000s
+[13] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [13] sequence req3: acquiring latches
-[13] sequence req3: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
+[13] sequence req3: waiting to acquire write latch ‹k›@10.000000000,1, held by write latch ‹k›@10.000000000,1
 [13] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes2
@@ -325,7 +325,7 @@ num=1
 
 on-lock-acquired req=req3 key=k
 ----
-[-] acquire lock: txn 00000003 @ k
+[-] acquire lock: txn 00000003 @ ‹k›
 
 debug-lock-table
 ----
@@ -378,7 +378,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req1
 ----
@@ -400,7 +400,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [2] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -417,7 +417,7 @@ on-split
 ----
 [-] split range: complete
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -429,7 +429,7 @@ num=0
 handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k
 ----
-[3] handle write intent error req2: handled conflicting intents on "k", released latches
+[3] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -445,7 +445,7 @@ sequence req=req2
 [4] sequence req2: acquiring latches
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: waiting in lock wait-queues
-[4] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -461,11 +461,11 @@ sequence req=reqRes1
 
 on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
-[-] update lock: committing txn 00000001 @ k
+[-] update lock: committing txn 00000001 @ ‹k›
 [4] sequence req2: lock wait-queue event: done waiting
-[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[4] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence req2: acquiring latches
-[4] sequence req2: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
+[4] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1, held by write latch ‹k›@10.000000000,1
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes1
@@ -482,7 +482,7 @@ num=1
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ k
+[-] acquire lock: txn 00000002 @ ‹k›
 
 debug-lock-table
 ----
@@ -549,7 +549,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req1
 ----
@@ -571,7 +571,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [2] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -595,7 +595,7 @@ on-merge
 ----
 [-] merge range: complete
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -606,7 +606,7 @@ num=0
 
 on-lock-acquired req=req3 key=k2
 ----
-[-] acquire lock: txn 00000003 @ k2
+[-] acquire lock: txn 00000003 @ ‹k2›
 
 debug-lock-table
 ----
@@ -619,8 +619,8 @@ finish req=req3
 handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k
 ----
-[4] handle write intent error req2: intent on "k" discovered but not added to disabled lock table
-[4] handle write intent error req2: handled conflicting intents on "k", released latches
+[4] handle write intent error req2: intent on ‹"k"› discovered but not added to disabled lock table
+[4] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
 
 sequence req=req2
 ----
@@ -648,7 +648,7 @@ sequence req=req2
 handle-write-intent-error req=req2 lease-seq=2
   intent txn=txn1 key=k
 ----
-[7] handle write intent error req2: handled conflicting intents on "k", released latches
+[7] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -664,7 +664,7 @@ sequence req=req2
 [8] sequence req2: acquiring latches
 [8] sequence req2: scanning lock table for conflicting locks
 [8] sequence req2: waiting in lock wait-queues
-[8] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[8] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [8] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [8] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -680,11 +680,11 @@ sequence req=reqRes1
 
 on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
-[-] update lock: committing txn 00000001 @ k
+[-] update lock: committing txn 00000001 @ ‹k›
 [8] sequence req2: lock wait-queue event: done waiting
-[8] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[8] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [8] sequence req2: acquiring latches
-[8] sequence req2: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
+[8] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1, held by write latch ‹k›@10.000000000,1
 [8] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes1
@@ -701,7 +701,7 @@ num=1
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ k
+[-] acquire lock: txn 00000002 @ ‹k›
 
 debug-lock-table
 ----
@@ -754,7 +754,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req1
 ----
@@ -776,7 +776,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [2] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -793,7 +793,7 @@ on-snapshot-applied
 ----
 [-] snapshot replica: applied
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -805,7 +805,7 @@ num=0
 handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k
 ----
-[3] handle write intent error req2: handled conflicting intents on "k", released latches
+[3] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -821,7 +821,7 @@ sequence req=req2
 [4] sequence req2: acquiring latches
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: waiting in lock wait-queues
-[4] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -837,11 +837,11 @@ sequence req=reqRes1
 
 on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
-[-] update lock: committing txn 00000001 @ k
+[-] update lock: committing txn 00000001 @ ‹k›
 [4] sequence req2: lock wait-queue event: done waiting
-[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[4] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence req2: acquiring latches
-[4] sequence req2: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
+[4] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1, held by write latch ‹k›@10.000000000,1
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes1
@@ -858,7 +858,7 @@ num=1
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ k
+[-] acquire lock: txn 00000002 @ ‹k›
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/slow_latch_observability
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/slow_latch_observability
@@ -28,7 +28,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch {b-f}@11.000000000,1, held by write latch c@10.000000000,0
+[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1, held by write latch ‹c›@10.000000000,0
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0
@@ -39,7 +39,7 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch e@11.000000000,0, held by read latch {b-f}@11.000000000,1
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0, held by read latch ‹{b-f}›@11.000000000,1
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=putc

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -25,7 +25,7 @@ sequence req=req1
 handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn1 key=k
 ----
-[2] handle write intent error req1: handled conflicting intents on "k", released latches
+[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -39,7 +39,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -47,9 +47,9 @@ sequence req=req1
 on-txn-updated txn=txn1 status=pending ts=15,2
 ----
 [-] update txn: increasing timestamp of txn1
-[3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
+[3] sequence req1: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[3] sequence req1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -91,7 +91,7 @@ sequence req=req1
 handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn1 key=k
 ----
-[2] handle write intent error req1: handled conflicting intents on "k", released latches
+[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -105,7 +105,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 135.000000000,0
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -113,9 +113,9 @@ sequence req=req1
 on-txn-updated txn=txn1 status=pending ts=135,1
 ----
 [-] update txn: increasing timestamp of txn1
-[3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status and clock observation {1 135.000000000,1}
+[3] sequence req1: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,1}
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[3] sequence req1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -160,7 +160,7 @@ sequence req=req1
 handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn1 key=k
 ----
-[2] handle write intent error req1: handled conflicting intents on "k", released latches
+[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -174,7 +174,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 150.000000000,1?
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -182,9 +182,9 @@ sequence req=req1
 on-txn-updated txn=txn1 status=pending ts=150,2?
 ----
 [-] update txn: increasing timestamp of txn1
-[3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status and clock observation {1 135.000000000,2}
+[3] sequence req1: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,2}
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[3] sequence req1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -235,7 +235,7 @@ sequence req=req1
 handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn1 key=k
 ----
-[2] handle write intent error req1: handled conflicting intents on "k", released latches
+[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -249,7 +249,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -288,7 +288,7 @@ sequence req=req2-retry
 [5] sequence req2-retry: acquiring latches
 [5] sequence req2-retry: scanning lock table for conflicting locks
 [5] sequence req2-retry: waiting in lock wait-queues
-[5] sequence req2-retry: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 2)
+[5] sequence req2-retry: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 2)
 [5] sequence req2-retry: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req2-retry: pushing timestamp of txn 00000001 above 15.000000000,1
 [5] sequence req2-retry: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -297,15 +297,15 @@ sequence req=req2-retry
 on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
-[3] sequence req1: resolving intent "k" for txn 00000001 with COMMITTED status
+[3] sequence req1: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[3] sequence req1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
-[5] sequence req2-retry: resolving intent "k" for txn 00000001 with COMMITTED status
+[5] sequence req2-retry: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [5] sequence req2-retry: lock wait-queue event: done waiting
-[5] sequence req2-retry: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[5] sequence req2-retry: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [5] sequence req2-retry: acquiring latches
 [5] sequence req2-retry: scanning lock table for conflicting locks
 [5] sequence req2-retry: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -37,7 +37,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req1
 ----
@@ -49,7 +49,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [2] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -70,9 +70,9 @@ num=1
 on-txn-updated txn=txn1 status=pending ts=12,2
 ----
 [-] update txn: increasing timestamp of txn1
-[2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
+[2] sequence req2: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -103,7 +103,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=k seq=1
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req3
 ----
@@ -156,7 +156,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req1
 ----
@@ -168,7 +168,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [2] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -189,9 +189,9 @@ num=1
 on-txn-updated txn=txn1 status=pending ts=12,2
 ----
 [-] update txn: increasing timestamp of txn1
-[2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
+[2] sequence req2: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -226,7 +226,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req3
 ----
@@ -284,7 +284,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k dur=u
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req1
 ----
@@ -296,7 +296,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [2] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -317,9 +317,9 @@ num=1
 on-txn-updated txn=txn1 status=pending ts=12,2
 ----
 [-] update txn: increasing timestamp of txn1
-[2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status and clock observation {1 123.000000000,5}
+[2] sequence req2: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,5}
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -353,7 +353,7 @@ sequence req=req4
 [3] sequence req4: acquiring latches
 [3] sequence req4: scanning lock table for conflicting locks
 [3] sequence req4: waiting in lock wait-queues
-[3] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req4: pushing after 0s for: liveness detection = true, deadlock detection = false, timeout enforcement = false, priority enforcement = false
 [3] sequence req4: pushing txn 00000001 to abort
 [3] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -371,7 +371,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=k seq=1 dur=r
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=req3
 ----
@@ -390,9 +390,9 @@ num=1
 on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
-[3] sequence req4: resolving intent "k" for txn 00000001 with COMMITTED status
+[3] sequence req4: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [3] sequence req4: lock wait-queue event: done waiting
-[3] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[3] sequence req4: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [3] sequence req4: acquiring latches
 [3] sequence req4: scanning lock table for conflicting locks
 [3] sequence req4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -34,7 +34,7 @@ sequence req=reqFirstLock
 
 on-lock-acquired req=reqFirstLock key=k dur=r
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 finish req=reqFirstLock
 ----
@@ -52,7 +52,7 @@ sequence req=reqWaiter
 handle-write-intent-error req=reqWaiter lease-seq=1
  intent txn=txnWriter key=k
 ----
-[3] handle write intent error reqWaiter: handled conflicting intents on "k", released latches
+[3] handle write intent error reqWaiter: handled conflicting intents on ‹"k"›, released latches
 
 sequence req=reqWaiter
 ----
@@ -60,7 +60,7 @@ sequence req=reqWaiter
 [4] sequence reqWaiter: acquiring latches
 [4] sequence reqWaiter: scanning lock table for conflicting locks
 [4] sequence reqWaiter: waiting in lock wait-queues
-[4] sequence reqWaiter: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence reqWaiter: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [4] sequence reqWaiter: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence reqWaiter: pushing txn 00000001 to abort
 [4] sequence reqWaiter: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -83,7 +83,7 @@ sequence req=reqSecondLock
 
 on-lock-acquired req=reqSecondLock key=k2 dur=u
 ----
-[-] acquire lock: txn 00000001 @ k2
+[-] acquire lock: txn 00000001 @ ‹k2›
 
 finish req=reqSecondLock
 ----
@@ -99,11 +99,11 @@ debug-advance-clock ts=123
 on-txn-updated txn=txnWriter status=aborted
 ----
 [-] update txn: aborting txnWriter
-[4] sequence reqWaiter: resolving intent "k" for txn 00000001 with ABORTED status
-[4] sequence reqWaiter: lock wait-queue event: wait elsewhere for txn 00000001 @ key "k"
+[4] sequence reqWaiter: resolving intent ‹"k"› for txn 00000001 with ABORTED status
+[4] sequence reqWaiter: lock wait-queue event: wait elsewhere for txn 00000001 @ key ‹"k"›
 [4] sequence reqWaiter: pushing txn 00000001 to abort
-[4] sequence reqWaiter: resolving intent "k" for txn 00000001 with ABORTED status
-[4] sequence reqWaiter: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 123.000s
+[4] sequence reqWaiter: resolving intent ‹"k"› for txn 00000001 with ABORTED status
+[4] sequence reqWaiter: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
 [4] sequence reqWaiter: acquiring latches
 [4] sequence reqWaiter: scanning lock table for conflicting locks
 [4] sequence reqWaiter: sequencing complete, returned guard
@@ -156,15 +156,15 @@ sequence req=reqThreeKeyWriter
 
 on-lock-acquired req=reqThreeKeyWriter key=k1 dur=r
 ----
-[-] acquire lock: txn 00000003 @ k1
+[-] acquire lock: txn 00000003 @ ‹k1›
 
 on-lock-acquired req=reqThreeKeyWriter key=k2 dur=r
 ----
-[-] acquire lock: txn 00000003 @ k2
+[-] acquire lock: txn 00000003 @ ‹k2›
 
 on-lock-acquired req=reqThreeKeyWriter key=k3 dur=r
 ----
-[-] acquire lock: txn 00000003 @ k3
+[-] acquire lock: txn 00000003 @ ‹k3›
 
 finish req=reqThreeKeyWriter
 ----
@@ -194,7 +194,7 @@ handle-write-intent-error req=reqTwoKeyWaiter lease-seq=1
  intent txn=txnThreeKeyWriter key=k1
  intent txn=txnThreeKeyWriter key=k2
 ----
-[9] handle write intent error reqTwoKeyWaiter: handled conflicting intents on "k1", "k2", released latches
+[9] handle write intent error reqTwoKeyWaiter: handled conflicting intents on ‹"k1"›, ‹"k2"›, released latches
 
 sequence req=reqTwoKeyWaiter
 ----
@@ -202,7 +202,7 @@ sequence req=reqTwoKeyWaiter
 [10] sequence reqTwoKeyWaiter: acquiring latches
 [10] sequence reqTwoKeyWaiter: scanning lock table for conflicting locks
 [10] sequence reqTwoKeyWaiter: waiting in lock wait-queues
-[10] sequence reqTwoKeyWaiter: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "k1" (queuedWriters: 0, queuedReaders: 1)
+[10] sequence reqTwoKeyWaiter: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"k1"› (queuedWriters: 0, queuedReaders: 1)
 [10] sequence reqTwoKeyWaiter: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [10] sequence reqTwoKeyWaiter: pushing timestamp of txn 00000003 above 20.000000000,1
 [10] sequence reqTwoKeyWaiter: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -225,7 +225,7 @@ handle-write-intent-error req=reqThreeKeyWaiter lease-seq=1
  intent txn=txnThreeKeyWriter key=k2
  intent txn=txnThreeKeyWriter key=k3
 ----
-[11] handle write intent error reqThreeKeyWaiter: handled conflicting intents on "k1", "k2", "k3", released latches
+[11] handle write intent error reqThreeKeyWaiter: handled conflicting intents on ‹"k1"›, ‹"k2"›, ‹"k3"›, released latches
 
 sequence req=reqThreeKeyWaiter
 ----
@@ -233,7 +233,7 @@ sequence req=reqThreeKeyWaiter
 [12] sequence reqThreeKeyWaiter: acquiring latches
 [12] sequence reqThreeKeyWaiter: scanning lock table for conflicting locks
 [12] sequence reqThreeKeyWaiter: waiting in lock wait-queues
-[12] sequence reqThreeKeyWaiter: lock wait-queue event: wait for txn 00000003 holding lock @ key "k1" (queuedWriters: 0, queuedReaders: 2)
+[12] sequence reqThreeKeyWaiter: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"k1"› (queuedWriters: 0, queuedReaders: 2)
 [12] sequence reqThreeKeyWaiter: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [12] sequence reqThreeKeyWaiter: pushing timestamp of txn 00000003 above 20.000000000,1
 [12] sequence reqThreeKeyWaiter: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -256,15 +256,15 @@ num=1
 on-txn-updated txn=txnThreeKeyWriter status=pending ts=20,2
 ----
 [-] update txn: increasing timestamp of txnThreeKeyWriter
-[10] sequence reqTwoKeyWaiter: resolving intent "k1" for txn 00000003 with PENDING status and clock observation {1 246.000000000,2}
+[10] sequence reqTwoKeyWaiter: resolving intent ‹"k1"› for txn 00000003 with PENDING status and clock observation {1 246.000000000,2}
 [10] sequence reqTwoKeyWaiter: lock wait-queue event: done waiting
-[10] sequence reqTwoKeyWaiter: conflicted with 00000003-0000-0000-0000-000000000000 on "k1" for 0.000s
+[10] sequence reqTwoKeyWaiter: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k1"› for 0.000s
 [10] sequence reqTwoKeyWaiter: acquiring latches
 [10] sequence reqTwoKeyWaiter: scanning lock table for conflicting locks
 [10] sequence reqTwoKeyWaiter: sequencing complete, returned guard
-[12] sequence reqThreeKeyWaiter: resolving intent "k1" for txn 00000003 with PENDING status and clock observation {1 246.000000000,4}
+[12] sequence reqThreeKeyWaiter: resolving intent ‹"k1"› for txn 00000003 with PENDING status and clock observation {1 246.000000000,4}
 [12] sequence reqThreeKeyWaiter: lock wait-queue event: done waiting
-[12] sequence reqThreeKeyWaiter: conflicted with 00000003-0000-0000-0000-000000000000 on "k1" for 0.000s
+[12] sequence reqThreeKeyWaiter: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k1"› for 0.000s
 [12] sequence reqThreeKeyWaiter: acquiring latches
 [12] sequence reqThreeKeyWaiter: scanning lock table for conflicting locks
 [12] sequence reqThreeKeyWaiter: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -30,11 +30,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 on-lock-acquired req=req1 key=k2
 ----
-[-] acquire lock: txn 00000001 @ k2
+[-] acquire lock: txn 00000001 @ ‹k2›
 
 finish req=req1
 ----
@@ -53,7 +53,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k3
 ----
-[-] acquire lock: txn 00000002 @ k3
+[-] acquire lock: txn 00000002 @ ‹k3›
 
 finish req=req2
 ----
@@ -70,7 +70,7 @@ sequence req=req3
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k2" (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k2"› (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -103,11 +103,11 @@ sequence req=reqNoWait1
 [4] sequence reqNoWait1: acquiring latches
 [4] sequence reqNoWait1: scanning lock table for conflicting locks
 [4] sequence reqNoWait1: waiting in lock wait-queues
-[4] sequence reqNoWait1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence reqNoWait1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedWriters: 0, queuedReaders: 1)
 [4] sequence reqNoWait1: pushing txn 00000001 to check if abandoned
 [4] sequence reqNoWait1: pushee not abandoned
-[4] sequence reqNoWait1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
-[4] sequence reqNoWait1: sequencing complete, returned error: conflicting intents on "k" [reason=wait_policy]
+[4] sequence reqNoWait1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence reqNoWait1: sequencing complete, returned error: conflicting intents on ‹"k"› [reason=wait_policy]
 
 # -------------------------------------------------------------
 # Read-only request with WaitPolicy_Error hits abandoned lock.
@@ -120,9 +120,9 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
-[3] sequence req3: resolving intent "k2" for txn 00000001 with COMMITTED status
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k3" (queuedWriters: 1, queuedReaders: 0)
-[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 123.000s
+[3] sequence req3: resolving intent ‹"k2"› for txn 00000001 with COMMITTED status
+[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k3"› (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k2"› for 123.000s
 [3] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -165,9 +165,9 @@ sequence req=reqNoWait2
 [6] sequence reqNoWait2: acquiring latches
 [6] sequence reqNoWait2: scanning lock table for conflicting locks
 [6] sequence reqNoWait2: waiting in lock wait-queues
-[6] sequence reqNoWait2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k2" (queuedWriters: 1, queuedReaders: 0)
-[6] sequence reqNoWait2: conflicted with 00000003-0000-0000-0000-000000000000 on "k2" for 0.000s
-[6] sequence reqNoWait2: sequencing complete, returned error: conflicting intents on "k2" [reason=wait_policy]
+[6] sequence reqNoWait2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k2"› (queuedWriters: 1, queuedReaders: 0)
+[6] sequence reqNoWait2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k2"› for 0.000s
+[6] sequence reqNoWait2: sequencing complete, returned error: conflicting intents on ‹"k2"› [reason=wait_policy]
 
 # -------------------------------------------------------------
 # Read-only request with WaitPolicy_Error discovers lock. The
@@ -188,7 +188,7 @@ sequence req=reqNoWait3
 handle-write-intent-error req=reqNoWait3 lease-seq=1
   intent txn=txn2 key=k4
 ----
-[8] handle write intent error reqNoWait3: handled conflicting intents on "k4", released latches
+[8] handle write intent error reqNoWait3: handled conflicting intents on ‹"k4"›, released latches
 
 sequence req=reqNoWait3
 ----
@@ -196,11 +196,11 @@ sequence req=reqNoWait3
 [9] sequence reqNoWait3: acquiring latches
 [9] sequence reqNoWait3: scanning lock table for conflicting locks
 [9] sequence reqNoWait3: waiting in lock wait-queues
-[9] sequence reqNoWait3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k4" (queuedWriters: 0, queuedReaders: 1)
+[9] sequence reqNoWait3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k4"› (queuedWriters: 0, queuedReaders: 1)
 [9] sequence reqNoWait3: pushing txn 00000002 to check if abandoned
 [9] sequence reqNoWait3: pushee not abandoned
-[9] sequence reqNoWait3: conflicted with 00000002-0000-0000-0000-000000000000 on "k4" for 0.000s
-[9] sequence reqNoWait3: sequencing complete, returned error: conflicting intents on "k4" [reason=wait_policy]
+[9] sequence reqNoWait3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k4"› for 0.000s
+[9] sequence reqNoWait3: sequencing complete, returned error: conflicting intents on ‹"k4"› [reason=wait_policy]
 
 debug-lock-table
 ----
@@ -226,9 +226,9 @@ debug-advance-clock ts=123
 on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
-[3] sequence req3: resolving intent "k3" for txn 00000002 with ABORTED status
+[3] sequence req3: resolving intent ‹"k3"› for txn 00000002 with ABORTED status
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k3" for 123.000s
+[3] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k3"› for 123.000s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard
@@ -247,7 +247,7 @@ sequence req=reqNoWait4
 handle-write-intent-error req=reqNoWait4 lease-seq=1
   intent txn=txn2 key=k5
 ----
-[11] handle write intent error reqNoWait4: handled conflicting intents on "k5", released latches
+[11] handle write intent error reqNoWait4: handled conflicting intents on ‹"k5"›, released latches
 
 sequence req=reqNoWait4
 ----
@@ -257,7 +257,7 @@ sequence req=reqNoWait4
 [12] sequence reqNoWait4: waiting in lock wait-queues
 [12] sequence reqNoWait4: lock wait-queue event: done waiting
 [12] sequence reqNoWait4: resolving a batch of 1 intent(s)
-[12] sequence reqNoWait4: resolving intent "k5" for txn 00000002 with ABORTED status
+[12] sequence reqNoWait4: resolving intent ‹"k5"› for txn 00000002 with ABORTED status
 [12] sequence reqNoWait4: acquiring latches
 [12] sequence reqNoWait4: scanning lock table for conflicting locks
 [12] sequence reqNoWait4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
@@ -30,11 +30,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ k
+[-] acquire lock: txn 00000001 @ ‹k›
 
 on-lock-acquired req=req1 key=k2
 ----
-[-] acquire lock: txn 00000001 @ k2
+[-] acquire lock: txn 00000001 @ ‹k2›
 
 finish req=req1
 ----
@@ -53,7 +53,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k3
 ----
-[-] acquire lock: txn 00000002 @ k3
+[-] acquire lock: txn 00000002 @ ‹k3›
 
 finish req=req2
 ----
@@ -72,7 +72,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=k4
 ----
-[-] acquire lock: txn 00000003 @ k4
+[-] acquire lock: txn 00000003 @ ‹k4›
 
 finish req=req3
 ----
@@ -88,7 +88,7 @@ sequence req=req4
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: waiting in lock wait-queues
-[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "k4" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"k4"› (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing txn 00000003 to abort
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -96,9 +96,9 @@ sequence req=req4
 on-txn-updated txn=txn3 status=aborted
 ----
 [-] update txn: aborting txn3
-[4] sequence req4: resolving intent "k4" for txn 00000003 with ABORTED status
+[4] sequence req4: resolving intent ‹"k4"› for txn 00000003 with ABORTED status
 [4] sequence req4: lock wait-queue event: done waiting
-[4] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k4" for 0.000s
+[4] sequence req4: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k4"› for 0.000s
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
@@ -35,7 +35,7 @@ sequence req=reqOld
 
 on-lock-acquired req=reqOld key=k
 ----
-[-] acquire lock: txn 00000002 @ k
+[-] acquire lock: txn 00000002 @ ‹k›
 
 finish req=reqOld
 ----
@@ -47,7 +47,7 @@ sequence req=reqTxn1
 [2] sequence reqTxn1: acquiring latches
 [2] sequence reqTxn1: scanning lock table for conflicting locks
 [2] sequence reqTxn1: waiting in lock wait-queues
-[2] sequence reqTxn1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence reqTxn1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
 [2] sequence reqTxn1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence reqTxn1: pushing txn 00000002 to abort
 [2] sequence reqTxn1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -58,7 +58,7 @@ sequence req=reqTxnMiddle
 [3] sequence reqTxnMiddle: acquiring latches
 [3] sequence reqTxnMiddle: scanning lock table for conflicting locks
 [3] sequence reqTxnMiddle: waiting in lock wait-queues
-[3] sequence reqTxnMiddle: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[3] sequence reqTxnMiddle: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedWriters: 2, queuedReaders: 0)
 [3] sequence reqTxnMiddle: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence reqTxnMiddle: pushing txn 00000002 to abort
 [3] sequence reqTxnMiddle: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -69,7 +69,7 @@ sequence req=reqTxn2
 [4] sequence reqTxn2: acquiring latches
 [4] sequence reqTxn2: scanning lock table for conflicting locks
 [4] sequence reqTxn2: waiting in lock wait-queues
-[4] sequence reqTxn2: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 3, queuedReaders: 0)
+[4] sequence reqTxn2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedWriters: 3, queuedReaders: 0)
 [4] sequence reqTxn2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence reqTxn2: pushing txn 00000002 to abort
 [4] sequence reqTxn2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -80,21 +80,21 @@ debug-advance-clock ts=123
 on-txn-updated txn=txnOld status=committed
 ----
 [-] update txn: committing txnOld
-[2] sequence reqTxn1: resolving intent "k" for txn 00000002 with COMMITTED status
+[2] sequence reqTxn1: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
 [2] sequence reqTxn1: lock wait-queue event: done waiting
-[2] sequence reqTxn1: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
+[2] sequence reqTxn1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
 [2] sequence reqTxn1: acquiring latches
 [2] sequence reqTxn1: scanning lock table for conflicting locks
 [2] sequence reqTxn1: sequencing complete, returned guard
-[3] sequence reqTxnMiddle: resolving intent "k" for txn 00000002 with COMMITTED status
-[3] sequence reqTxnMiddle: lock wait-queue event: wait for (distinguished) txn 00000001 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
-[3] sequence reqTxnMiddle: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
+[3] sequence reqTxnMiddle: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
+[3] sequence reqTxnMiddle: lock wait-queue event: wait for (distinguished) txn 00000001 running request @ key ‹"k"› (queuedWriters: 2, queuedReaders: 0)
+[3] sequence reqTxnMiddle: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
 [3] sequence reqTxnMiddle: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence reqTxnMiddle: pushing txn 00000001 to detect request deadlock
 [3] sequence reqTxnMiddle: blocked on select in concurrency_test.(*cluster).PushTransaction
-[4] sequence reqTxn2: resolving intent "k" for txn 00000002 with COMMITTED status
-[4] sequence reqTxn2: lock wait-queue event: wait self @ key "k"
-[4] sequence reqTxn2: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
+[4] sequence reqTxn2: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
+[4] sequence reqTxn2: lock wait-queue event: wait self @ key ‹"k"›
+[4] sequence reqTxn2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
 [4] sequence reqTxn2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -117,12 +117,12 @@ finish req=reqTxn1
 ----
 [-] finish reqTxn1: finishing request
 [3] sequence reqTxnMiddle: lock wait-queue event: done waiting
-[3] sequence reqTxnMiddle: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[3] sequence reqTxnMiddle: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [3] sequence reqTxnMiddle: acquiring latches
 [3] sequence reqTxnMiddle: scanning lock table for conflicting locks
 [3] sequence reqTxnMiddle: sequencing complete, returned guard
-[4] sequence reqTxn2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence reqTxn2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[4] sequence reqTxn2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k"› (queuedWriters: 1, queuedReaders: 0)
+[4] sequence reqTxn2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence reqTxn2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence reqTxn2: pushing txn 00000003 to detect request deadlock
 [4] sequence reqTxn2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -131,7 +131,7 @@ finish req=reqTxnMiddle
 ----
 [-] finish reqTxnMiddle: finishing request
 [4] sequence reqTxn2: lock wait-queue event: done waiting
-[4] sequence reqTxn2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 0.000s
+[4] sequence reqTxn2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence reqTxn2: acquiring latches
 [4] sequence reqTxn2: scanning lock table for conflicting locks
 [4] sequence reqTxn2: sequencing complete, returned guard

--- a/pkg/kv/kvserver/spanlatch/BUILD.bazel
+++ b/pkg/kv/kvserver/spanlatch/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/kv/kvserver/spanlatch/manager.go
+++ b/pkg/kv/kvserver/spanlatch/manager.go
@@ -12,7 +12,6 @@ package spanlatch
 
 import (
 	"context"
-	"fmt"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -27,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // A Manager maintains an interval tree of key and key range latches. Latch
@@ -96,13 +96,22 @@ func (la *latch) inReadSet() bool {
 	return la.next != nil
 }
 
+// String implements the fmt.Stringer interface.
+func (la *latch) String() string {
+	return redact.StringWithoutMarkers(la)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (la *latch) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("%s@%s", la.span, la.ts)
+}
+
 //go:generate ../../../util/interval/generic/gen.sh *latch spanlatch
 
 // Methods required by util/interval/generic type contract.
 func (la *latch) ID() uint64         { return la.id }
 func (la *latch) Key() []byte        { return la.span.Key }
 func (la *latch) EndKey() []byte     { return la.span.EndKey }
-func (la *latch) String() string     { return fmt.Sprintf("%s@%s", la.span, la.ts) }
 func (la *latch) New() *latch        { return new(latch) }
 func (la *latch) SetID(v uint64)     { la.id = v }
 func (la *latch) SetKey(v []byte)    { la.span.Key = v }

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -46,6 +46,9 @@ func (a SpanAccess) String() string {
 	}
 }
 
+// SafeValue implements the redact.SafeValue interface.
+func (SpanAccess) SafeValue() {}
+
 // SpanScope divides access types into local and global keys.
 type SpanScope int
 
@@ -67,6 +70,9 @@ func (a SpanScope) String() string {
 		panic("unreachable")
 	}
 }
+
+// SafeValue implements the redact.SafeValue interface.
+func (SpanScope) SafeValue() {}
 
 // Span is used to represent a keyspan accessed by a request at a given
 // timestamp. A zero timestamp indicates it's a non-MVCC access.

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -97,6 +97,10 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb": {
 						"SnapshotRequest_Type": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset": {
+						"SpanAccess": {},
+						"SpanScope":  {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities": {
 						"ID": {},
 					},


### PR DESCRIPTION
This commit enables trace redaction in the `TestConcurrencyManagerBasic` test. Doing so ensures that all logging/tracing performed during concurrency control is properly redacting sensitive information while preserving all other information. This ensures that if/when we need these logs in a customer escalation, they will be there.

In order to make this change, the commit implements `redact.SafeFormatter` on a few different data types. Notable, it implements the interface on `waitingState`. With these changes, the only redacted information left is `roachpb.Key`s and `kvpb.ContentionEvent`s. The latter type should not be fully redacted, but it is because of #103052.

Epic: CRDB-27642
Release note: None