### PR TITLE
sql: add setting to remove default create on public schema

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1449,10 +1449,12 @@ func remapPublicSchemas(
 			return err
 		}
 
+		includeCreatePriv := sql.PublicSchemaCreatePrivilegeEnabled.Get(p.ExecCfg().SV())
+
 		db.AddSchemaToDatabase(tree.PublicSchema, descpb.DatabaseDescriptor_SchemaInfo{ID: id})
 		// Every database must be initialized with the public schema.
 		// Create the SchemaDescriptor.
-		publicSchemaPrivileges := catpb.NewPublicSchemaPrivilegeDescriptor()
+		publicSchemaPrivileges := catpb.NewPublicSchemaPrivilegeDescriptor(includeCreatePriv)
 		publicSchemaDesc := schemadesc.NewBuilder(&descpb.SchemaDescriptor{
 			ParentID:   db.GetID(),
 			Name:       tree.PublicSchema,

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -854,6 +854,7 @@ go_test(
         "//pkg/util/ctxgroup",
         "//pkg/util/duration",
         "//pkg/util/encoding",
+        "//pkg/util/envutil",
         "//pkg/util/fsm",
         "//pkg/util/hlc",
         "//pkg/util/httputil",

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -836,6 +836,15 @@ func (p *planner) canCreateOnSchema(
 		return pgerror.Newf(pgcode.InsufficientPrivilege,
 			"cannot CREATE on schema %s", scDesc.GetName())
 	case catalog.SchemaUserDefined:
+		//It is possible to reach this point while reaching the public schema so
+		////double check
+		//if scDesc.GetName() == "public" {
+		//	dbDesc, err := p.Descriptors().ByIDWithLeased(p.Txn()).WithoutNonPublic().Get().Database(ctx, dbID)
+		//	if err != nil {
+		//		return err
+		//	}
+		//	return p.CheckPrivilegeForUser(ctx, dbDesc, privilege.CREATE, user)
+		//}
 		return p.CheckPrivilegeForUser(ctx, scDesc, privilege.CREATE, user)
 	default:
 		panic(errors.AssertionFailedf("unknown schema kind %d", kind))

--- a/pkg/sql/catalog/catpb/privilege.go
+++ b/pkg/sql/catalog/catpb/privilege.go
@@ -189,15 +189,17 @@ func NewBaseDatabasePrivilegeDescriptor(owner username.SQLUsername) *PrivilegeDe
 // descriptor owned by the admin user which has CREATE and USAGE privilege for
 // the public role, and ALL privileges for superusers. It is used for the
 // public schema.
-func NewPublicSchemaPrivilegeDescriptor() *PrivilegeDescriptor {
+func NewPublicSchemaPrivilegeDescriptor(includeCreatePriv bool) *PrivilegeDescriptor {
 	// In postgres, the user "postgres" is the owner of the public schema in a
 	// newly created db. In CockroachDB, admin is our substitute for the postgres
 	// user.
 	p := NewBasePrivilegeDescriptor(username.AdminRoleName())
-	// By default, everyone has USAGE and CREATE on the public schema.
-	// Once https://github.com/cockroachdb/cockroach/issues/70266 is resolved,
-	// the public role will no longer have CREATE privileges.
-	p.Grant(username.PublicRoleName(), privilege.List{privilege.CREATE, privilege.USAGE}, false)
+
+	if includeCreatePriv {
+		p.Grant(username.PublicRoleName(), privilege.List{privilege.CREATE, privilege.USAGE}, false)
+	} else {
+		p.Grant(username.PublicRoleName(), privilege.List{privilege.USAGE}, false)
+	}
 	return p
 }
 

--- a/pkg/sql/catalog/ingesting/privileges.go
+++ b/pkg/sql/catalog/ingesting/privileges.go
@@ -111,7 +111,7 @@ func getIngestingPrivilegesForTableOrSchema(
 		switch privilegeType {
 		case privilege.Schema:
 			if desc.GetName() == tree.PublicSchema {
-				updatedPrivileges = catpb.NewPublicSchemaPrivilegeDescriptor()
+				updatedPrivileges = catpb.NewPublicSchemaPrivilegeDescriptor(true /*includeCreatePriv*/)
 			} else {
 				updatedPrivileges = catpb.NewBasePrivilegeDescriptor(user)
 			}

--- a/pkg/sql/catalog/randgen/randgen.go
+++ b/pkg/sql/catalog/randgen/randgen.go
@@ -53,7 +53,7 @@ func NewTestSchemaGenerator(
 ) TestSchemaGenerator {
 	dbPrivs := catpb.NewBaseDatabasePrivilegeDescriptor(callingUser)
 	dbDefaultPrivs := catprivilege.MakeDefaultPrivilegeDescriptor(catpb.DefaultPrivilegeDescriptor_DATABASE)
-	publicSchemaPrivs := catpb.NewPublicSchemaPrivilegeDescriptor()
+	publicSchemaPrivs := catpb.NewPublicSchemaPrivilegeDescriptor(true /*includeCreatePriv*/)
 	publicSchemaPrivs.SetOwner(callingUser)
 	g := &testSchemaGenerator{
 		rand: rand,

--- a/pkg/sql/catalog/schemadesc/public_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/public_schema_desc.go
@@ -55,7 +55,7 @@ var _ syntheticBase = publicBase{}
 func (publicBase) kindName() string                 { return "public" }
 func (publicBase) kind() catalog.ResolvedSchemaKind { return catalog.SchemaPublic }
 func (publicBase) GetPrivileges() *catpb.PrivilegeDescriptor {
-	return catpb.NewPublicSchemaPrivilegeDescriptor()
+	return catpb.NewPublicSchemaPrivilegeDescriptor(true /*includeCreatePriv*/)
 }
 
 // publicDesc is a singleton returned by GetPublicSchema.

--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/geo/geoindex",
         "//pkg/roachpb",
         "//pkg/security/username",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/privilege",
         "//pkg/sql/roleoption",

--- a/pkg/sql/opt/cat/schema.go
+++ b/pkg/sql/opt/cat/schema.go
@@ -12,7 +12,6 @@ package cat
 
 import (
 	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 )
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -381,7 +381,6 @@ var varGen = map[string]sessionVar{
 			return strconv.FormatInt(defaultIntSize.Get(sv), 10)
 		},
 	},
-
 	// See https://www.postgresql.org/docs/10/runtime-config-client.html.
 	// Supported only for pg compatibility - CockroachDB has no notion of
 	// tablespaces.


### PR DESCRIPTION
Resolves: #70266

Release note (sql change): `remove_default_create_on_public` controls whether users have default `CREATE` privileges on the public schema or not. When the setting is true users can only create tables on databases they own in the public schema. The cluster setting was added to match Postgres 15 behavior.