### PR TITLE
release-23.1: roachtest: add `failover` variants with expiration leases

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -19,6 +19,7 @@ import (
 	"os/user"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -585,6 +586,20 @@ of nodes, outputting a line whenever a change is detected:
 	}),
 }
 
+var signalCmd = &cobra.Command{
+	Use:   "signal <cluster> <signal>",
+	Short: "send signal to cluster",
+	Long:  "Send a POSIX signal to the nodes in a cluster, specified by its integer code.",
+	Args:  cobra.ExactArgs(2),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		sig, err := strconv.ParseInt(args[1], 10, 8)
+		if err != nil {
+			return errors.Wrapf(err, "invalid signal argument")
+		}
+		return roachprod.Signal(context.Background(), config.Logger, args[0], int(sig))
+	}),
+}
+
 var wipeCmd = &cobra.Command{
 	Use:   "wipe <cluster>",
 	Short: "wipe a cluster",
@@ -1085,6 +1100,7 @@ func main() {
 		startTenantCmd,
 		initCmd,
 		runCmd,
+		signalCmd,
 		wipeCmd,
 		reformatCmd,
 		installCmd,
@@ -1114,7 +1130,7 @@ func main() {
 
 	// Add help about specifying nodes
 	for _, cmd := range []*cobra.Command{
-		getCmd, putCmd, runCmd, startCmd, statusCmd, stopCmd,
+		getCmd, putCmd, runCmd, startCmd, statusCmd, stopCmd, signalCmd,
 		wipeCmd, pgurlCmd, adminurlCmd, sqlCmd, installCmd,
 	} {
 		if cmd.Long == "" {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1948,6 +1948,33 @@ func (c *clusterImpl) Stop(
 	}
 }
 
+// SignalE sends a signal to the given nodes.
+func (c *clusterImpl) SignalE(
+	ctx context.Context, l *logger.Logger, sig int, nodes ...option.Option,
+) error {
+	if ctx.Err() != nil {
+		return errors.Wrap(ctx.Err(), "cluster.Signal")
+	}
+	if c.spec.NodeCount == 0 {
+		return nil // unit tests
+	}
+	return errors.Wrap(roachprod.Signal(ctx, l, c.MakeNodes(nodes...), sig), "cluster.Signal")
+}
+
+// Signal is like SignalE, except instead of returning an error, it does
+// c.t.Fatal(). c.t needs to be set.
+func (c *clusterImpl) Signal(
+	ctx context.Context, l *logger.Logger, sig int, nodes ...option.Option,
+) {
+	if c.t.Failed() {
+		// If the test has failed, don't try to limp along.
+		return
+	}
+	if err := c.SignalE(ctx, l, sig, nodes...); err != nil {
+		c.t.Fatal(err)
+	}
+}
+
 // WipeE wipes a subset of the nodes in a cluster. See cluster.Start() for a
 // description of the nodes parameter.
 func (c *clusterImpl) WipeE(ctx context.Context, l *logger.Logger, nodes ...option.Option) error {

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -54,6 +54,8 @@ type Cluster interface {
 	Start(ctx context.Context, l *logger.Logger, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option)
 	StopE(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option) error
 	Stop(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option)
+	SignalE(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option) error
+	Signal(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option)
 	StopCockroachGracefullyOnNode(ctx context.Context, l *logger.Logger, node int) error
 	NewMonitor(context.Context, ...option.Option) Monitor
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -411,13 +411,29 @@ func (c *SyncedCluster) newSession(
 func (c *SyncedCluster) Stop(
 	ctx context.Context, l *logger.Logger, sig int, wait bool, maxWait int,
 ) error {
-	if sig == 9 {
-		// `kill -9` without wait is never what a caller wants. See #77334.
-		wait = true
-	}
 	display := fmt.Sprintf("%s: stopping", c.Name)
 	if wait {
 		display += " and waiting"
+	}
+	return c.kill(ctx, l, "stop", display, sig, wait, maxWait)
+}
+
+// Signal sends a signal to the CockroachDB process.
+func (c *SyncedCluster) Signal(ctx context.Context, l *logger.Logger, sig int) error {
+	display := fmt.Sprintf("%s: sending signal %d", c.Name, sig)
+	return c.kill(ctx, l, "signal", display, sig, false /* wait */, 0 /* maxWait */)
+}
+
+// kill sends the signal sig to all nodes in the cluster using the kill command.
+// cmdName and display specify the roachprod subcommand and a status message,
+// for output/logging. If wait is true, the command will wait for the processes
+// to exit, up to maxWait seconds.
+func (c *SyncedCluster) kill(
+	ctx context.Context, l *logger.Logger, cmdName, display string, sig int, wait bool, maxWait int,
+) error {
+	if sig == 9 {
+		// `kill -9` without wait is never what a caller wants. See #77334.
+		wait = true
 	}
 	return c.Parallel(l, display, len(c.Nodes), 0, func(i int) (*RunResultDetails, error) {
 		node := c.Nodes[i]
@@ -450,22 +466,23 @@ func (c *SyncedCluster) Stop(
 		// awk process match its own output from `ps`.
 		cmd := fmt.Sprintf(`
 mkdir -p %[1]s
-echo ">>> roachprod stop: $(date)" >> %[1]s/roachprod.log
-ps axeww -o pid -o command >> %[1]s/roachprod.log
+echo ">>> roachprod %[1]s: $(date)" >> %[2]s/roachprod.log
+ps axeww -o pid -o command >> %[2]s/roachprod.log
 pids=$(ps axeww -o pid -o command | \
   sed 's/export ROACHPROD=//g' | \
-  awk '/%[2]s/ { print $1 }')
+  awk '/%[3]s/ { print $1 }')
 if [ -n "${pids}" ]; then
-  kill -%[3]d ${pids}
-%[4]s
+  kill -%[4]d ${pids}
+%[5]s
 fi`,
-			c.LogDir(node),            // [1]
-			c.roachprodEnvRegex(node), // [2]
-			sig,                       // [3]
-			waitCmd,                   // [4]
+			cmdName,                   // [1]
+			c.LogDir(node),            // [2]
+			c.roachprodEnvRegex(node), // [3]
+			sig,                       // [4]
+			waitCmd,                   // [5]
 		)
 
-		sess := c.newSession(l, node, cmd, withDebugName("node-stop"))
+		sess := c.newSession(l, node, cmd, withDebugName("node-"+cmdName))
 		defer sess.Close()
 
 		out, cmdErr := sess.CombinedOutput(ctx)

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -739,6 +739,18 @@ func Stop(ctx context.Context, l *logger.Logger, clusterName string, opts StopOp
 	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.MaxWait)
 }
 
+// Signal sends a signal to nodes in the cluster.
+func Signal(ctx context.Context, l *logger.Logger, clusterName string, sig int) error {
+	if err := LoadClusters(); err != nil {
+		return err
+	}
+	c, err := newCluster(l, clusterName)
+	if err != nil {
+		return err
+	}
+	return c.Signal(ctx, l, sig)
+}
+
 // Init initializes the cluster.
 func Init(ctx context.Context, l *logger.Logger, clusterName string, opts install.StartOpts) error {
 	if err := LoadClusters(); err != nil {


### PR DESCRIPTION
Backport:
  * 2/2 commits from "roachtest: add `pause` failure for `failover` tests" (#97325)
  * 1/1 commits from "roachtest: disable disk stall detector for `failover/*/pause`" (#101648)
  * 1/1 commits from "roachtest: add `failover` variants with expiration leases" (#102916)

Please see individual PRs for details.

/cc @cockroachdb/release
