### PR TITLE
sql: support CREATE TABLE ... PARTITION BY ... AS ...

### DIFF
--- a/docs/generated/sql/bnf/create_table_as_stmt.bnf
+++ b/docs/generated/sql/bnf/create_table_as_stmt.bnf
@@ -1,5 +1,5 @@
 create_table_as_stmt ::=
-	'CREATE' opt_persistence_temp_table 'TABLE' table_name '(' column_name create_as_col_qual_list ( ( ',' column_name create_as_col_qual_list | ',' family_def | ',' create_as_constraint_def ) )* ')' opt_with_storage_parameter_list 'AS' select_stmt 'ON' 'COMMIT' 'PRESERVE' 'ROWS'
-	| 'CREATE' opt_persistence_temp_table 'TABLE' table_name  opt_with_storage_parameter_list 'AS' select_stmt 'ON' 'COMMIT' 'PRESERVE' 'ROWS'
-	| 'CREATE' opt_persistence_temp_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' column_name create_as_col_qual_list ( ( ',' column_name create_as_col_qual_list | ',' family_def | ',' create_as_constraint_def ) )* ')' opt_with_storage_parameter_list 'AS' select_stmt 'ON' 'COMMIT' 'PRESERVE' 'ROWS'
-	| 'CREATE' opt_persistence_temp_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name  opt_with_storage_parameter_list 'AS' select_stmt 'ON' 'COMMIT' 'PRESERVE' 'ROWS'
+	'CREATE' opt_persistence_temp_table 'TABLE' table_name '(' column_name create_as_col_qual_list ( ( ',' column_name create_as_col_qual_list | ',' family_def | ',' create_as_constraint_def ) )* ')' opt_partition_by_table opt_with_storage_parameter_list 'AS' select_stmt 'ON' 'COMMIT' 'PRESERVE' 'ROWS'
+	| 'CREATE' opt_persistence_temp_table 'TABLE' table_name  opt_partition_by_table opt_with_storage_parameter_list 'AS' select_stmt 'ON' 'COMMIT' 'PRESERVE' 'ROWS'
+	| 'CREATE' opt_persistence_temp_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' column_name create_as_col_qual_list ( ( ',' column_name create_as_col_qual_list | ',' family_def | ',' create_as_constraint_def ) )* ')' opt_partition_by_table opt_with_storage_parameter_list 'AS' select_stmt 'ON' 'COMMIT' 'PRESERVE' 'ROWS'
+	| 'CREATE' opt_persistence_temp_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name  opt_partition_by_table opt_with_storage_parameter_list 'AS' select_stmt 'ON' 'COMMIT' 'PRESERVE' 'ROWS'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1905,8 +1905,8 @@ create_table_stmt ::=
 	| 'CREATE' opt_persistence_temp_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' opt_table_elem_list ')' opt_partition_by_table opt_table_with opt_create_table_on_commit opt_locality
 
 create_table_as_stmt ::=
-	'CREATE' opt_persistence_temp_table 'TABLE' table_name create_as_opt_col_list opt_table_with 'AS' select_stmt opt_create_table_on_commit
-	| 'CREATE' opt_persistence_temp_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name create_as_opt_col_list opt_table_with 'AS' select_stmt opt_create_table_on_commit
+	'CREATE' opt_persistence_temp_table 'TABLE' table_name create_as_opt_col_list opt_partition_by_table opt_table_with 'AS' select_stmt opt_create_table_on_commit
+	| 'CREATE' opt_persistence_temp_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name create_as_opt_col_list opt_partition_by_table opt_table_with 'AS' select_stmt opt_create_table_on_commit
 
 create_type_stmt ::=
 	'CREATE' 'TYPE' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -3,6 +3,160 @@
 statement ok
 SET create_table_with_schema_locked=false
 
+subtest create_table_as_partition
+
+statement ok
+CREATE TABLE feature (
+  id,
+  enabled,
+  feature,
+  PRIMARY KEY (enabled, id)
+)
+PARTITION BY LIST (enabled) (
+  PARTITION on VALUES IN (true),
+  PARTITION off VALUES IN (false)
+)
+AS
+VALUES
+  (1, true, 'dark_mode'),
+  (2, false, 'beta_access')
+
+statement ok
+CREATE TABLE traffic (
+  id,
+  source,
+  page,
+  PRIMARY KEY (source, id)
+)
+PARTITION BY LIST (source) (
+  PARTITION a VALUES IN ('a'),
+  PARTITION b VALUES IN ('b'),
+  PARTITION other VALUES IN ('c', 'd', 'e')
+)
+AS
+VALUES
+  (1, 'a', 'home'),
+  (2, 'b', 'home'),
+  (3, 'c', 'index')
+
+statement ok
+CREATE TABLE orders (
+  id,
+  country,
+  state,
+  item,
+  PRIMARY KEY (country, state, id)
+)
+PARTITION BY LIST (country, state) (
+  PARTITION usa_ny VALUES IN (('us', 'ny')),
+  PARTITION usa_ca VALUES IN (('us', 'ca')),
+  PARTITION unknown VALUES IN (('unknown', 'unknown'))
+)
+AS
+SELECT 100, 'us', 'ny', 'Widget A'
+UNION
+SELECT 101, 'us', 'ca', 'Widget B'
+
+statement ok
+CREATE TABLE users_by_id (
+  id,
+  name,
+  PRIMARY KEY (id)
+)
+PARTITION BY RANGE (id) (
+  PARTITION low VALUES FROM (MINVALUE) TO (1000),
+  PARTITION high VALUES FROM (1000) TO (MAXVALUE)
+)
+AS
+VALUES
+  (500, 'Anna'),
+  (1500, 'Brian')
+
+statement ok
+CREATE TABLE sales (
+  id,
+  sale_date,
+  amount,
+  PRIMARY KEY (sale_date, id)
+)
+PARTITION BY RANGE (sale_date) (
+  PARTITION q1 VALUES FROM (DATE '2024-01-01') TO (DATE '2024-04-01'),
+  PARTITION q2 VALUES FROM (DATE '2024-04-01') TO (DATE '2024-07-01')
+)
+AS
+VALUES
+  (1, DATE '2024-02-15', 100),
+  (2, DATE '2024-06-10', 250)
+
+statement ok
+CREATE TABLE inventory (
+  item_code,
+  stock,
+  PRIMARY KEY (item_code)
+)
+PARTITION BY RANGE (item_code) (
+  PARTITION a_m VALUES FROM ('A') TO ('N'),
+  PARTITION n_z VALUES FROM ('N') TO (MAXVALUE)
+)
+AS
+VALUES
+  ('Apple123', 1),
+  ('Zebra999', 2)
+
+statement ok
+CREATE TABLE students (
+  id,
+  name,
+  country,
+  expected_graduation_date,
+  PRIMARY KEY (country, expected_graduation_date, id)
+)
+PARTITION BY LIST (country)(
+    PARTITION australia VALUES IN ('AU','NZ')
+      PARTITION BY RANGE (expected_graduation_date) (
+        PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
+        PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+      ),
+    PARTITION north_america VALUES IN ('US','CA')
+      PARTITION BY RANGE (expected_graduation_date) (
+        PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
+        PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+      )
+)
+AS
+VALUES
+  (1, 'Alice', 'AU', DATE '2017-08-15'),
+  (2, 'Bob', 'US', DATE '2017-08-15')
+
+statement error declared partition columns \(c\) do not match first 1 columns in index being partitioned \(rowid\)
+CREATE TABLE a (a)
+PARTITION BY LIST (c) (
+   PARTITION p1 VALUES IN (1)
+)
+AS
+SELECT 1
+
+statement ok
+CREATE TABLE IF NOT EXISTS users_nothing (
+  id,
+  username,
+  PRIMARY KEY(username, id)
+)
+PARTITION BY NOTHING
+WITH (ttl = 'on', ttl_expire_after = '5 minutes')
+AS
+SELECT 1, 'Alice'
+UNION ALL
+SELECT 2, 'Bob'
+ON COMMIT PRESERVE ROWS
+
+statement ok
+ALTER TABLE users_nothing
+PARTITION BY LIST (username) (
+  PARTITION a VALUES IN ('Alice'),
+  PARTITION b VALUES IN ('Bob')
+)
+
 subtest regression_42858
 
 statement ok

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -11066,29 +11066,31 @@ storage_parameter_list:
   }
 
 create_table_as_stmt:
-  CREATE opt_persistence_temp_table TABLE table_name create_as_opt_col_list opt_table_with AS select_stmt opt_create_as_data opt_create_table_on_commit
+  CREATE opt_persistence_temp_table TABLE table_name create_as_opt_col_list opt_partition_by_table opt_table_with AS select_stmt opt_create_as_data opt_create_table_on_commit
   {
     name := $4.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateTable{
       Table: name,
       IfNotExists: false,
       Defs: $5.tblDefs(),
-      AsSource: $8.slct(),
-      StorageParams: $6.storageParams(),
-      OnCommit: $10.createTableOnCommitSetting(),
+      AsSource: $9.slct(),
+      PartitionByTable: $6.partitionByTable(),
+      StorageParams: $7.storageParams(),
+      OnCommit: $11.createTableOnCommitSetting(),
       Persistence: $2.persistence(),
     }
   }
-| CREATE opt_persistence_temp_table TABLE IF NOT EXISTS table_name create_as_opt_col_list opt_table_with AS select_stmt opt_create_as_data opt_create_table_on_commit
+| CREATE opt_persistence_temp_table TABLE IF NOT EXISTS table_name create_as_opt_col_list opt_partition_by_table opt_table_with AS select_stmt opt_create_as_data opt_create_table_on_commit
   {
     name := $7.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateTable{
       Table: name,
       IfNotExists: true,
       Defs: $8.tblDefs(),
-      AsSource: $11.slct(),
-      StorageParams: $9.storageParams(),
-      OnCommit: $13.createTableOnCommitSetting(),
+      AsSource: $12.slct(),
+      PartitionByTable: $9.partitionByTable(),
+      StorageParams: $10.storageParams(),
+      OnCommit: $14.createTableOnCommitSetting(),
       Persistence: $2.persistence(),
     }
   }

--- a/pkg/sql/parser/testdata/create_table
+++ b/pkg/sql/parser/testdata/create_table
@@ -1895,6 +1895,249 @@ CREATE TABLE a (UNIQUE (b) PARTITION BY LIST (c) (PARTITION d VALUES IN ((1)))) 
 CREATE TABLE a (UNIQUE (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (_))) -- literals removed
 CREATE TABLE _ (UNIQUE (_) PARTITION BY LIST (_) (PARTITION _ VALUES IN (1))) -- identifiers removed
 
+error
+CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT 1
+----
+at or near "as": syntax error
+DETAIL: source SQL:
+CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT 1
+                                                                                    ^
+
+parse
+CREATE TABLE a (b) PARTITION BY NOTHING AS SELECT b
+----
+CREATE TABLE a (b) AS SELECT b -- normalized!
+CREATE TABLE a (b) AS SELECT (b) -- fully parenthesized
+CREATE TABLE a (b) AS SELECT b -- literals removed
+CREATE TABLE _ (_) AS SELECT _ -- identifiers removed
+
+parse
+CREATE TABLE a (b) PARTITION ALL BY NOTHING AS SELECT b
+----
+CREATE TABLE a (b) AS SELECT b -- normalized!
+CREATE TABLE a (b) AS SELECT (b) -- fully parenthesized
+CREATE TABLE a (b) AS SELECT b -- literals removed
+CREATE TABLE _ (_) AS SELECT _ -- identifiers removed
+
+parse
+CREATE TABLE a (b) PARTITION BY LIST (b) (PARTITION p1 VALUES IN (1, DEFAULT), PARTITION p2 VALUES IN ((1, 2), (3, 4))) AS SELECT b
+----
+CREATE TABLE a (b) AS SELECT b -- normalized!
+CREATE TABLE a (b) AS SELECT (b) -- fully parenthesized
+CREATE TABLE a (b) AS SELECT b -- literals removed
+CREATE TABLE _ (_) AS SELECT _ -- identifiers removed
+
+
+parse
+CREATE TABLE a (b) PARTITION ALL BY LIST (b) (PARTITION p1 VALUES IN (1, DEFAULT), PARTITION p2 VALUES IN ((1, 2), (3, 4))) AS SELECT b
+----
+CREATE TABLE a (b) AS SELECT b -- normalized!
+CREATE TABLE a (b) AS SELECT (b) -- fully parenthesized
+CREATE TABLE a (b) AS SELECT b -- literals removed
+CREATE TABLE _ (_) AS SELECT _ -- identifiers removed
+
+parse
+CREATE TABLE a (b, c, d) PARTITION BY LIST (b) (
+	PARTITION p1 VALUES IN (1) PARTITION BY LIST (c) (
+		PARTITION p1_1 VALUES IN (3), PARTITION p1_2 VALUES IN (4, 5)
+	), PARTITION p2 VALUES IN (6) PARTITION BY RANGE (c) (
+		PARTITION p2_1 VALUES FROM (7) TO (8) PARTITION BY LIST (d) (
+			PARTITION p2_1_1 VALUES IN (8)
+		)
+	)
+)
+AS
+SELECT b, c, d
+----
+CREATE TABLE a (b, c, d) AS SELECT b, c, d -- normalized!
+CREATE TABLE a (b, c, d) AS SELECT (b), (c), (d) -- fully parenthesized
+CREATE TABLE a (b, c, d) AS SELECT b, c, d -- literals removed
+CREATE TABLE _ (_, _, _) AS SELECT _, _, _ -- identifiers removed
+
+
+parse
+CREATE TABLE a (b) PARTITION BY RANGE (b) (
+   PARTITION p1 VALUES FROM (MINVALUE) TO (1),
+   PARTITION p2 VALUES FROM (2, MAXVALUE) TO (4, 4),
+   PARTITION p3 VALUES FROM (4, 4) TO (MAXVALUE))
+AS
+SELECT 1
+----
+CREATE TABLE a (b) AS SELECT 1 -- normalized!
+CREATE TABLE a (b) AS SELECT (1) -- fully parenthesized
+CREATE TABLE a (b) AS SELECT _ -- literals removed
+CREATE TABLE _ (_) AS SELECT 1 -- identifiers removed
+
+parse
+CREATE TABLE a (b) PARTITION ALL BY RANGE (b) (
+  PARTITION p1 VALUES FROM (MINVALUE) TO (1),
+  PARTITION p2 VALUES FROM (2, MAXVALUE) TO (4, 4),
+  PARTITION p3 VALUES FROM (4, 4) TO (MAXVALUE))
+AS
+SELECT 1
+----
+CREATE TABLE a (b) AS SELECT 1 -- normalized!
+CREATE TABLE a (b) AS SELECT (1) -- fully parenthesized
+CREATE TABLE a (b) AS SELECT _ -- literals removed
+CREATE TABLE _ (_) AS SELECT 1 -- identifiers removed
+
+error
+CREATE TABLE IF NOT EXISTS a () PARTITION BY LIST (b) (PARTITION c VALUES IN (1))
+AS
+SELECT 1
+----
+at or near "as": syntax error
+DETAIL: source SQL:
+CREATE TABLE IF NOT EXISTS a () PARTITION BY LIST (b) (PARTITION c VALUES IN (1))
+AS
+^
+
+error
+CREATE TABLE a (INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT 1
+----
+at or near "as": syntax error
+DETAIL: source SQL:
+CREATE TABLE a (INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT 1
+                                                                             ^
+
+error
+CREATE TABLE a (INVERTED INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT 1
+----
+at or near "as": syntax error
+DETAIL: source SQL:
+CREATE TABLE a (INVERTED INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT 1
+                                                                                      ^
+
+error
+CREATE TABLE a (UNIQUE (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT a
+----
+at or near "as": syntax error
+DETAIL: source SQL:
+CREATE TABLE a (UNIQUE (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT a
+                                                                              ^
+
+parse
+CREATE TABLE IF NOT EXISTS a (b) PARTITION BY NOTHING AS SELECT b
+----
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT b -- normalized!
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT (b) -- fully parenthesized
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT b -- literals removed
+CREATE TABLE IF NOT EXISTS _ (_) AS SELECT _ -- identifiers removed
+
+parse
+CREATE TABLE IF NOT EXISTS a (b) PARTITION ALL BY NOTHING AS SELECT b
+----
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT b -- normalized!
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT (b) -- fully parenthesized
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT b -- literals removed
+CREATE TABLE IF NOT EXISTS _ (_) AS SELECT _ -- identifiers removed
+
+error
+CREATE TABLE IF NOT EXISTS a (UNIQUE INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))
+----
+at or near "EOF": syntax error
+DETAIL: source SQL:
+CREATE TABLE IF NOT EXISTS a (UNIQUE INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))
+                                                                                                ^
+HINT: try \h CREATE TABLE
+
+parse
+CREATE TABLE IF NOT EXISTS a (b) PARTITION BY LIST (b) (PARTITION p1 VALUES IN (1, DEFAULT), PARTITION p2 VALUES IN ((1, 2), (3, 4))) AS SELECT b
+----
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT b -- normalized!
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT (b) -- fully parenthesized
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT b -- literals removed
+CREATE TABLE IF NOT EXISTS _ (_) AS SELECT _ -- identifiers removed
+
+
+parse
+CREATE TABLE IF NOT EXISTS a (b) PARTITION ALL BY LIST (b) (PARTITION p1 VALUES IN (1, DEFAULT), PARTITION p2 VALUES IN ((1, 2), (3, 4))) AS SELECT b
+----
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT b -- normalized!
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT (b) -- fully parenthesized
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT b -- literals removed
+CREATE TABLE IF NOT EXISTS _ (_) AS SELECT _ -- identifiers removed
+
+parse
+CREATE TABLE IF NOT EXISTS a (b, c, d) PARTITION BY LIST (b) (
+	PARTITION p1 VALUES IN (1) PARTITION BY LIST (c) (
+		PARTITION p1_1 VALUES IN (3), PARTITION p1_2 VALUES IN (4, 5)
+	), PARTITION p2 VALUES IN (6) PARTITION BY RANGE (c) (
+		PARTITION p2_1 VALUES FROM (7) TO (8) PARTITION BY LIST (d) (
+			PARTITION p2_1_1 VALUES IN (8)
+		)
+	)
+)
+AS
+SELECT b, c, d
+----
+CREATE TABLE IF NOT EXISTS a (b, c, d) AS SELECT b, c, d -- normalized!
+CREATE TABLE IF NOT EXISTS a (b, c, d) AS SELECT (b), (c), (d) -- fully parenthesized
+CREATE TABLE IF NOT EXISTS a (b, c, d) AS SELECT b, c, d -- literals removed
+CREATE TABLE IF NOT EXISTS _ (_, _, _) AS SELECT _, _, _ -- identifiers removed
+
+
+parse
+CREATE TABLE IF NOT EXISTS a (b) PARTITION BY RANGE (b) (
+   PARTITION p1 VALUES FROM (MINVALUE) TO (1),
+   PARTITION p2 VALUES FROM (2, MAXVALUE) TO (4, 4),
+   PARTITION p3 VALUES FROM (4, 4) TO (MAXVALUE))
+AS
+SELECT 1
+----
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT 1 -- normalized!
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT (1) -- fully parenthesized
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT _ -- literals removed
+CREATE TABLE IF NOT EXISTS _ (_) AS SELECT 1 -- identifiers removed
+
+parse
+CREATE TABLE IF NOT EXISTS a (b) PARTITION ALL BY RANGE (b) (
+  PARTITION p1 VALUES FROM (MINVALUE) TO (1),
+  PARTITION p2 VALUES FROM (2, MAXVALUE) TO (4, 4),
+  PARTITION p3 VALUES FROM (4, 4) TO (MAXVALUE))
+AS
+SELECT 1
+----
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT 1 -- normalized!
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT (1) -- fully parenthesized
+CREATE TABLE IF NOT EXISTS a (b) AS SELECT _ -- literals removed
+CREATE TABLE IF NOT EXISTS _ (_) AS SELECT 1 -- identifiers removed
+
+error
+CREATE TABLE IF NOT EXISTS a () PARTITION BY LIST (b) (PARTITION c VALUES IN (1))
+AS
+SELECT 1
+----
+at or near "as": syntax error
+DETAIL: source SQL:
+CREATE TABLE IF NOT EXISTS a () PARTITION BY LIST (b) (PARTITION c VALUES IN (1))
+AS
+^
+
+error
+CREATE TABLE IF NOT EXISTS a (INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT 1
+----
+at or near "as": syntax error
+DETAIL: source SQL:
+CREATE TABLE IF NOT EXISTS a (INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT 1
+                                                                                           ^
+
+error
+CREATE TABLE IF NOT EXISTS a (INVERTED INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT 1
+----
+at or near "as": syntax error
+DETAIL: source SQL:
+CREATE TABLE IF NOT EXISTS a (INVERTED INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT 1
+                                                                                                    ^
+
+error
+CREATE TABLE IF NOT EXISTS a (UNIQUE (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT a
+----
+at or near "as": syntax error
+DETAIL: source SQL:
+CREATE TABLE IF NOT EXISTS a (UNIQUE (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) AS SELECT a
+                                                                                            ^
+
 parse
 CREATE INDEX ON a (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))
 ----

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1562,6 +1562,9 @@ func (node *CreateTable) FormatBody(ctx *FmtCtx) {
 			ctx.FormatNode(&node.Defs)
 			ctx.WriteByte(')')
 		}
+		if node.PartitionByTable != nil {
+			ctx.FormatNode(node.PartitionByTable)
+		}
 		if node.StorageParams != nil {
 			ctx.WriteString(` WITH (`)
 			ctx.FormatNode(&node.StorageParams)

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1252,10 +1252,10 @@ func (node *UpdateExpr) doc(p *PrettyCfg) pretty.Doc {
 func (node *CreateTable) doc(p *PrettyCfg) pretty.Doc {
 	// Final layout:
 	//
-	// CREATE [TEMP | UNLOGGED] TABLE [IF NOT EXISTS] name ( .... ) [AS]
-	//     [SELECT ...] - for CREATE TABLE AS
-	//     [INTERLEAVE ...]
+	// CREATE [TEMP | UNLOGGED] TABLE [IF NOT EXISTS] name ( .... )
 	//     [PARTITION BY ...]
+	//     [AS SELECT ...]
+	//     [INTERLEAVE ...]
 	//
 	title := pretty.Keyword("CREATE")
 	switch node.Persistence {
@@ -1275,11 +1275,6 @@ func (node *CreateTable) doc(p *PrettyCfg) pretty.Doc {
 			title = pretty.ConcatSpace(title,
 				p.bracket("(", p.Doc(&node.Defs), ")"))
 		}
-		if node.StorageParams != nil {
-			title = pretty.ConcatSpace(title, pretty.Keyword("WITH"))
-			title = pretty.ConcatSpace(title, p.bracket(`(`, p.Doc(&node.StorageParams), `)`))
-		}
-		title = pretty.ConcatSpace(title, pretty.Keyword("AS"))
 	} else {
 		title = pretty.ConcatSpace(title,
 			p.bracket("(", p.Doc(&node.Defs), ")"),
@@ -1287,13 +1282,10 @@ func (node *CreateTable) doc(p *PrettyCfg) pretty.Doc {
 	}
 
 	clauses := make([]pretty.Doc, 0, 4)
-	if node.As() {
-		clauses = append(clauses, p.Doc(node.AsSource))
-	}
 	if node.PartitionByTable != nil {
 		clauses = append(clauses, p.Doc(node.PartitionByTable))
 	}
-	if node.StorageParams != nil && !node.As() {
+	if node.StorageParams != nil {
 		clauses = append(
 			clauses,
 			pretty.ConcatSpace(
@@ -1301,6 +1293,11 @@ func (node *CreateTable) doc(p *PrettyCfg) pretty.Doc {
 				p.bracket(`(`, p.Doc(&node.StorageParams), `)`),
 			),
 		)
+	}
+	if node.As() {
+		clauses = append(clauses, pretty.Keyword("AS"))
+
+		clauses = append(clauses, p.Doc(node.AsSource))
 	}
 	switch node.OnCommit {
 	case CreateTableOnCommitUnset:


### PR DESCRIPTION
Tables can have partitioning applied to them, however this functionality was not available through the CREATE TABLE AS syntax. This commit updates the grammar to support PARTITION BY to the CREATE TABLE AS syntax, and the related
functionality.

Fixes: #20178

Release note (sql change): add support for PARTITION BY on CREATE TABLE AS