### PR TITLE
docgen: add EXPLAIN, EXPLAIN ANALYZE options to diagrams

### DIFF
--- a/docs/generated/sql/bnf/explain_analyze_stmt.bnf
+++ b/docs/generated/sql/bnf/explain_analyze_stmt.bnf
@@ -1,7 +1,7 @@
 explain_stmt ::=
 	'EXPLAIN' explainable_stmt
-	| 'EXPLAIN' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' explainable_stmt
+	| 'EXPLAIN' '(' ( 'PLAN' | 'VERBOSE' | 'TYPES' | 'DEBUG' | 'REDACT' | 'DISTSQL') ( ( ',' ( 'PLAN' | 'VERBOSE' | 'TYPES' | 'DEBUG' | 'REDACT' | 'DISTSQL') ) )* ')' explainable_stmt
 	| 'EXPLAIN' 'ANALYZE' explainable_stmt
 	| 'EXPLAIN' 'ANALYSE' explainable_stmt
-	| 'EXPLAIN' 'ANALYZE' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' explainable_stmt
-	| 'EXPLAIN' 'ANALYSE' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' explainable_stmt
+	| 'EXPLAIN' 'ANALYZE' '(' ( 'PLAN' | 'VERBOSE' | 'TYPES' | 'DEBUG' | 'REDACT' | 'DISTSQL') ( ( ',' ( 'PLAN' | 'VERBOSE' | 'TYPES' | 'DEBUG' | 'REDACT' | 'DISTSQL') ) )* ')' explainable_stmt
+	| 'EXPLAIN' 'ANALYSE' '(' ( 'PLAN' | 'VERBOSE' | 'TYPES' | 'DEBUG' | 'REDACT' | 'DISTSQL') ( ( ',' ( 'PLAN' | 'VERBOSE' | 'TYPES' | 'DEBUG' | 'REDACT' | 'DISTSQL') ) )* ')' explainable_stmt

--- a/docs/generated/sql/bnf/explain_stmt.bnf
+++ b/docs/generated/sql/bnf/explain_stmt.bnf
@@ -1,3 +1,3 @@
 explain_stmt ::=
 	'EXPLAIN' explainable_stmt
-	| 'EXPLAIN' '(' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' | 'VEC' ) ( ( ',' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' | 'VEC' ) ) )* ')' explainable_stmt
+	| 'EXPLAIN' '(' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'ENV' | 'MEMO' | 'REDACT' | 'DISTSQL' | 'VEC' ) ( ( ',' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'ENV' | 'MEMO' | 'REDACT' | 'DISTSQL' | 'VEC' ) ) )* ')' explainable_stmt

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -1000,7 +1000,7 @@ var specs = []stmtSpec{
 		name:   "explain_stmt",
 		inline: []string{"explain_option_list"},
 		replace: map[string]string{
-			"explain_option_name": "( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' | 'VEC' )",
+			"explain_option_name": "( 'VERBOSE' | 'TYPES' | 'OPT' | 'ENV' | 'MEMO' | 'REDACT' | 'DISTSQL' | 'VEC' )",
 		},
 		exclude: []*regexp.Regexp{
 			regexp.MustCompile("'ANALYZE'"),
@@ -1012,7 +1012,7 @@ var specs = []stmtSpec{
 		stmt:   "explain_stmt",
 		inline: []string{"explain_option_list"},
 		replace: map[string]string{
-			"explain_option_name": "( 'PLAN' | 'DISTSQL' | 'DEBUG' )",
+			"explain_option_name": "( 'PLAN' | 'VERBOSE' | 'TYPES' | 'DEBUG' | 'REDACT' | 'DISTSQL')",
 		},
 		unlink: []string{"'DISTSQL'"},
 	},


### PR DESCRIPTION
Add various `EXPLAIN` and `EXPLAIN ANALYZE` options that were documented but not exposed in the SQL diagrams. Also add `REDACT`, which will be documented with https://github.com/cockroachdb/docs/pull/16929.

Epic: none

Release note: none

Release justification: non-production code change