### PR TITLE
sql: resolve values types after building scalars in optbuilder

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_record
+++ b/pkg/sql/logictest/testdata/logic_test/udf_record
@@ -370,3 +370,26 @@ SELECT f_amb(1, NULL);
 # and return NULL NULL.
 statement error pq: ambiguous call: f_amb\(int, unknown\), candidates are
 SELECT * FROM f_amb(1, NULL) as foo(a int, b int);
+
+subtest repro_102718
+
+statement ok
+CREATE OR REPLACE FUNCTION f_102718()
+	RETURNS RECORD
+	IMMUTABLE
+	LANGUAGE SQL
+	AS $$
+SELECT ('a',)
+$$;
+
+query TT
+SELECT
+	*
+FROM
+	(VALUES (f_102718())) AS t1 (a),
+	(VALUES ('foo'), ('bar')) AS t2 (b)
+ORDER BY
+	t1.a DESC NULLS FIRST;
+----
+(a) foo
+(a) bar

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -76,6 +76,10 @@ func (b *Builder) buildValuesClause(
 			if err != nil {
 				panic(err)
 			}
+			// UDFs modify their resolved type when built, so build the scalar before
+			// resolving the column types.
+			elems[elemPos] = b.buildScalar(texpr, inScope, nil, nil, nil)
+			elemPos += numCols
 			if typ := texpr.ResolvedType(); typ.Family() != types.UnknownFamily {
 				if colTypes[colIdx].Family() == types.UnknownFamily {
 					colTypes[colIdx] = typ
@@ -91,8 +95,6 @@ func (b *Builder) buildValuesClause(
 					colTypes[colIdx] = colTypes[colIdx].WithoutTypeModifiers()
 				}
 			}
-			elems[elemPos] = b.buildScalar(texpr, inScope, nil, nil, nil)
-			elemPos += numCols
 		}
 
 		// If we still don't have a type for the column, set it to the desired type.


### PR DESCRIPTION
Previously, we would build scalars in VALUES clauses after resolving the value column types. However, for UDFs, we modify the type if it's a record-returning function during the build. In this change we reverse the order so that we build scalars and then resolve types.

This bug was introduced by #98162.

Epic: None
Fixes: #102718

Release note: This fixes a bug in VALUES clauses containing a call to a record-returning UDF that could manifest as an internal error in some queries.