### PR TITLE
build: increase number of shards for `streamingest` test

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -96,6 +96,7 @@ go_test(
     args = ["-test.timeout=895s"],
     data = glob(["testdata/**"]),
     embed = [":streamingest"],
+    shard_count = 16,
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",


### PR DESCRIPTION
Epic: none
Release note: None