### PR TITLE
sql: use lease to get qualified function name

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "rtt_analysis_test.go",
         "system_bench_test.go",
         "truncate_bench_test.go",
+        "udf_resolution_test.go",
         "validate_benchmark_data_test.go",
         "virtual_table_bench_test.go",
     ],

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -98,6 +98,7 @@ exp,benchmark
 20,Truncate/truncate_2_column_0_rows
 20,Truncate/truncate_2_column_1_rows
 20,Truncate/truncate_2_column_2_rows
+3,UDFResolution/select_from_udf
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk
 9,VirtualTableQueries/virtual_table_cache_with_point_lookups

--- a/pkg/bench/rttanalysis/udf_resolution_test.go
+++ b/pkg/bench/rttanalysis/udf_resolution_test.go
@@ -1,0 +1,24 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rttanalysis
+
+import "testing"
+
+func BenchmarkUDFResolution(b *testing.B) { reg.Run(b) }
+func init() {
+	reg.Register("UDFResolution", []RoundTripBenchTestCase{
+		{
+			Name:  "select from udf",
+			Setup: `CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;`,
+			Stmt:  `SELECT f()`,
+		},
+	})
+}

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -281,11 +281,11 @@ func (sr *schemaResolver) GetQualifiedFunctionNameByID(
 func (sr *schemaResolver) getQualifiedFunctionName(
 	ctx context.Context, fnDesc catalog.FunctionDescriptor,
 ) (*tree.FunctionName, error) {
-	dbDesc, err := sr.descCollection.ByID(sr.txn).Get().Database(ctx, fnDesc.GetParentID())
+	dbDesc, err := sr.descCollection.ByIDWithLeased(sr.txn).Get().Database(ctx, fnDesc.GetParentID())
 	if err != nil {
 		return nil, err
 	}
-	scDesc, err := sr.descCollection.ByID(sr.txn).Get().Schema(ctx, fnDesc.GetParentSchemaID())
+	scDesc, err := sr.descCollection.ByIDWithLeased(sr.txn).Get().Schema(ctx, fnDesc.GetParentSchemaID())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes: #102043

Previously we always skip lease to get a fully qualified UDF name. Before 23.1 it was not terrible because we only use qualified names in schema changers. In 23.1 we started fetching UDF name when resolving UDFs due to some schema changer needs. This is bad because the type checking hot path share the same resolution code. This commit fixes it to use the cache instead of reading from kv. Luckily that this only impact UDFs, in memory cache is always used for builtin functions.

Release note (performance improvement): this change fixed a bug where kv was read when fetching qualified name of a leased UDF.