### PR TITLE
sqlsmith: support user-defined composite types in sqlsmith

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1208,40 +1208,6 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 		setup := sqlsmith.Setups[tblName](rng)
 		sqlDB.ExecMultiple(t, setup...)
 
-		// TODO: PopulateTableWithRandData doesn't work with enums
-		dropEnumQry := "ALTER TABLE seed DROP COLUMN _enum;"
-		sqlDB.Exec(t, dropEnumQry)
-
-		// Attempt to insert a few more than our target 100 values, since there's a
-		// small chance we may not succeed that many inserts.
-		numInserts := 110
-		inserts := make([]string, 0, numInserts)
-		for rows := 0; rows < 100; {
-			var err error
-			var newRows int
-			if newRows, err = randgen.PopulateTableWithRandData(rng, s.DB, tblName, numInserts, &inserts); err != nil {
-				t.Fatal(err)
-			}
-			rows += newRows
-		}
-
-		limitQry := "DELETE FROM seed WHERE rowid NOT IN (SELECT rowid FROM seed ORDER BY rowid LIMIT 100);"
-		sqlDB.Exec(t, limitQry)
-
-		// Put the enums back. enum_range('hi'::greeting)[rowid%7] will give nulls when rowid%7=0 or 6.
-		addEnumQry := "ALTER TABLE seed ADD COLUMN _enum greeting;"
-		sqlDB.Exec(t, addEnumQry)
-		populateEnumQry := "UPDATE seed SET _enum = enum_range('hi'::greeting)[rowid%7];"
-		sqlDB.Exec(t, populateEnumQry)
-		// Get values to log setup.
-		t.Logf("setup:\n%s\n%s\n%s\n%s\n%s\n%s",
-			strings.Join(setup, "\n"),
-			dropEnumQry,
-			strings.Join(inserts, "\n"),
-			limitQry,
-			addEnumQry,
-			populateEnumQry)
-
 		queryGen, err := sqlsmith.NewSmither(s.DB, rng,
 			sqlsmith.DisableWith(),
 			sqlsmith.DisableMutations(),
@@ -1256,6 +1222,32 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		defer queryGen.Close()
+
+		// Attempt to insert a few more than our target 100 values, since there's a
+		// small chance we may not succeed that many inserts.
+		var typeResolver tree.TypeReferenceResolver = queryGen
+		numInserts := 110
+		inserts := make([]string, 0, numInserts)
+		for rows := 0; rows < 100; {
+			var err error
+			var newRows int
+			if newRows, err = randgen.PopulateTableWithRandData(
+				rng, s.DB, tblName, numInserts, &inserts, typeResolver,
+			); err != nil {
+				t.Fatal(err)
+			}
+			rows += newRows
+		}
+
+		limitQry := "DELETE FROM seed WHERE rowid NOT IN (SELECT rowid FROM seed ORDER BY rowid LIMIT 100);"
+		sqlDB.Exec(t, limitQry)
+
+		// Get values to log setup.
+		t.Logf("setup:\n%s\n%s\n%s",
+			strings.Join(setup, "\n"),
+			strings.Join(inserts, "\n"),
+			limitQry)
+
 		numNonTrivialTestRuns := 0
 		n := 100
 		whereClausesChecked := make(map[string]struct{}, n)

--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -127,6 +127,7 @@ go_test(
         "//pkg/crosscluster/replicationutils",
         "//pkg/crosscluster/streamclient",
         "//pkg/crosscluster/streamclient/randclient",
+        "//pkg/internal/sqlsmith",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/kv",

--- a/pkg/crosscluster/logical/udf_row_processor_test.go
+++ b/pkg/crosscluster/logical/udf_row_processor_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationtestutils"
+	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -80,9 +81,18 @@ func TestUDFWithRandomTables(t *testing.T) {
 	runnerA.Exec(t, "SET plan_cache_mode=force_generic_plan")
 
 	sqlA := s.SQLConn(t, serverutils.DBName("a"))
+
+	// Use a smither as a type resolver for PopulateTableWithRandData.
+	var typeResolver tree.TypeReferenceResolver
+	smither, err := sqlsmith.NewSmither(sqlA, rng)
+	require.NoError(t, err)
+	defer smither.Close()
+	typeResolver = smither
+
 	numInserts := 20
-	_, err := randgen.PopulateTableWithRandData(rng,
-		sqlA, tableName, numInserts, nil)
+	_, err = randgen.PopulateTableWithRandData(
+		rng, sqlA, tableName, numInserts, nil, typeResolver,
+	)
 	require.NoError(t, err)
 
 	dbAURL, cleanup := s.PGUrl(t, serverutils.DBName("a"))

--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -113,7 +113,13 @@ func makeCreateSchema(s *Smither) (tree.Statement, bool) {
 }
 
 func makeCreateTable(s *Smither) (tree.Statement, bool) {
-	table := randgen.RandCreateTable(context.Background(), s.rnd, "", 0, randgen.TableOptNone)
+	seedTypes := randgen.SeedTypes
+	if s.types != nil {
+		seedTypes = s.types.seedTypes
+	}
+	table := randgen.RandCreateTableWithTypes(
+		context.Background(), s.rnd, "", 0, randgen.TableOptNone, seedTypes,
+	)
 	schemaOrd := s.rnd.Intn(len(s.schemas))
 	schema := s.schemas[schemaOrd]
 	table.Table = tree.MakeTableNameWithSchema(tree.Name(s.dbName), schema.SchemaName, s.name("tab"))
@@ -417,10 +423,12 @@ func makeCreateType(s *Smither) (tree.Statement, bool) {
 	name := s.name("typ")
 
 	if s.coin() {
-		return randgen.RandCreateEnumType(s.rnd, string(name), letters), true
+		stmt, _ := randgen.RandCreateEnumType(s.rnd, string(name), letters)
+		return stmt, true
 	}
 
-	return randgen.RandCreateCompositeType(s.rnd, string(name), letters), true
+	stmt, _ := randgen.RandCreateCompositeType(s.rnd, string(name), letters)
+	return stmt, true
 }
 
 func makeDropType(s *Smither) (tree.Statement, bool) {

--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -579,12 +579,12 @@ func makeAlterDatabasePlacement(s *Smither) (tree.Statement, bool) {
 }
 
 func makeAlterTypeDropValue(s *Smither) (tree.Statement, bool) {
-	enumVal, udtName, ok := s.getRandUserDefinedTypeLabel()
+	enumVal, enumName, ok := s.getRandEnumVal()
 	if !ok {
 		return nil, false
 	}
 	return &tree.AlterType{
-		Type: udtName.ToUnresolvedObjectName(),
+		Type: enumName.ToUnresolvedObjectName(),
 		Cmd: &tree.AlterTypeDropValue{
 			Val: *enumVal,
 		},
@@ -592,12 +592,12 @@ func makeAlterTypeDropValue(s *Smither) (tree.Statement, bool) {
 }
 
 func makeAlterTypeAddValue(s *Smither) (tree.Statement, bool) {
-	_, udtName, ok := s.getRandUserDefinedTypeLabel()
+	_, enumName, ok := s.getRandEnumVal()
 	if !ok {
 		return nil, false
 	}
 	return &tree.AlterType{
-		Type: udtName.ToUnresolvedObjectName(),
+		Type: enumName.ToUnresolvedObjectName(),
 		Cmd: &tree.AlterTypeAddValue{
 			NewVal:      tree.EnumValue(s.name("added_val")),
 			IfNotExists: true,
@@ -606,12 +606,12 @@ func makeAlterTypeAddValue(s *Smither) (tree.Statement, bool) {
 }
 
 func makeAlterTypeRenameValue(s *Smither) (tree.Statement, bool) {
-	enumVal, udtName, ok := s.getRandUserDefinedTypeLabel()
+	enumVal, enumName, ok := s.getRandEnumVal()
 	if !ok {
 		return nil, false
 	}
 	return &tree.AlterType{
-		Type: udtName.ToUnresolvedObjectName(),
+		Type: enumName.ToUnresolvedObjectName(),
 		Cmd: &tree.AlterTypeRenameValue{
 			OldVal: *enumVal,
 			NewVal: tree.EnumValue(s.name("renamed_val")),
@@ -620,7 +620,7 @@ func makeAlterTypeRenameValue(s *Smither) (tree.Statement, bool) {
 }
 
 func makeAlterTypeRenameType(s *Smither) (tree.Statement, bool) {
-	_, udtName, ok := s.getRandUserDefinedTypeLabel()
+	_, udtName, ok := s.getRandUserDefinedType()
 	if !ok {
 		return nil, false
 	}

--- a/pkg/internal/sqlsmith/scope.go
+++ b/pkg/internal/sqlsmith/scope.go
@@ -10,11 +10,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
-// colRef refers to a named result column. If it is from a table, def is
-// populated.
+// colRef refers to a named result column.
 type colRef struct {
 	typ  *types.T
 	item *tree.ColumnItem
+	// TODO(michae2): Add ColumnAccessExpr as an alternative form of column
+	// reference (for accessing individual fields of composite types).
 }
 
 func (c *colRef) typedExpr() tree.TypedExpr {

--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -167,6 +167,7 @@ func randTablesN(r *rand.Rand, n int, prefix string, isMultiRegion bool) []strin
 const (
 	seedTable = `
 BEGIN; CREATE TYPE greeting AS ENUM ('hello', 'howdy', 'hi', 'good day', 'morning'); COMMIT;
+BEGIN; CREATE TYPE dimensions AS (length INT, width INT, height INT); COMMIT;
 BEGIN;
 CREATE TABLE IF NOT EXISTS seed AS
 	SELECT
@@ -186,7 +187,8 @@ CREATE TABLE IF NOT EXISTS seed AS
 		substring('00000000-0000-0000-0000-' || g::STRING || '00000000000', 1, 36)::UUID AS _uuid,
 		'0.0.0.0'::INET + g AS _inet,
 		g::STRING::JSONB AS _jsonb,
-		enum_range('hello'::greeting)[g] as _enum
+		enum_range('hello'::greeting)[g] as _enum,
+		(g, g, g)::dimensions AS _composite
 	FROM
 		generate_series(1, 5) AS g;
 COMMIT;

--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
 // Setup generates a SQL query that can be executed to initialize a database
@@ -128,13 +129,30 @@ func randTablesN(r *rand.Rand, n int, prefix string, isMultiRegion bool) []strin
 	// based on them nondeterministic, so disable stats forecasting.
 	stmts = append(stmts, `SET CLUSTER SETTING sql.stats.forecasts.enabled = false;`)
 
+	// Create some random types to use in tables.
+	numTypes := r.Intn(5) + 1
+	seedTypes := make([]*types.T, numTypes, numTypes+len(randgen.SeedTypes))
+	for i := range seedTypes {
+		name := fmt.Sprintf("rand_typ_%d", i)
+		if r.Intn(2) == 0 {
+			stmt, typ := randgen.RandCreateEnumType(r, name, letters)
+			stmts = append(stmts, stmt.String())
+			seedTypes[i] = typ
+		} else {
+			stmt, typ := randgen.RandCreateCompositeType(r, name, letters)
+			stmts = append(stmts, stmt.String())
+			seedTypes[i] = typ
+		}
+	}
+	seedTypes = append(seedTypes, randgen.SeedTypes...)
+
 	// Create the random tables.
 	opt := randgen.TableOptCrazyNames
 	if isMultiRegion {
 		opt |= randgen.TableOptMultiRegion
 	}
-	createTableStatements := randgen.RandCreateTables(
-		context.Background(), r, "table", n, opt, randgen.StatisticsMutator,
+	createTableStatements := randgen.RandCreateTablesWithTypes(
+		context.Background(), r, "table", n, opt, seedTypes, randgen.StatisticsMutator,
 		randgen.PartialIndexMutator, randgen.ForeignKeyMutator,
 	)
 
@@ -149,18 +167,6 @@ func randTablesN(r *rand.Rand, n int, prefix string, isMultiRegion bool) []strin
 		stmts = append(stmts, stmt)
 	}
 
-	// Create some random types as well.
-	numTypes := r.Intn(5) + 1
-	for i := 0; i < numTypes; i++ {
-		name := fmt.Sprintf("rand_typ_%d", i)
-		if r.Intn(2) == 0 {
-			stmt := randgen.RandCreateEnumType(r, name, letters)
-			stmts = append(stmts, stmt.String())
-		} else {
-			stmt := randgen.RandCreateCompositeType(r, name, letters)
-			stmts = append(stmts, stmt.String())
-		}
-	}
 	return stmts
 }
 

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -163,10 +163,10 @@ func (s *Smither) makeDesiredTypes() []*types.T {
 }
 
 type typeInfo struct {
-	udts        []*types.T
-	udtNames    []tree.TypeName
-	seedTypes   []*types.T
-	scalarTypes []*types.T
+	enums, composites         []*types.T
+	enumNames, compositeNames []tree.TypeName
+	seedTypes                 []*types.T
+	scalarTypes               []*types.T
 }
 
 // ResolveType implements the tree.TypeReferenceResolver interface.
@@ -174,9 +174,14 @@ func (s *Smither) ResolveType(
 	_ context.Context, name *tree.UnresolvedObjectName,
 ) (*types.T, error) {
 	key := tree.MakeSchemaQualifiedTypeName(name.Schema(), name.Object())
-	for i, typeName := range s.types.udtNames {
+	for i, typeName := range s.types.enumNames {
 		if typeName == key {
-			return s.types.udts[i], nil
+			return s.types.enums[i], nil
+		}
+	}
+	for i, typeName := range s.types.compositeNames {
+		if typeName == key {
+			return s.types.composites[i], nil
 		}
 	}
 	return nil, errors.Newf("type name %s not found by smither", name.Object())

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -175,6 +175,7 @@ go_test(
         "//pkg/col/coldata",
         "//pkg/config",
         "//pkg/config/zonepb",
+        "//pkg/internal/sqlsmith",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobstest",

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -199,8 +199,8 @@ func TestRandomParquetExports(t *testing.T) {
 			numTables   = 20
 		)
 
-		stmts := randgen.RandCreateTables(
-			ctx, rng, tablePrefix, numTables, randgen.TableOptNone,
+		stmts := randgen.RandCreateTablesWithTypes(
+			ctx, rng, tablePrefix, numTables, randgen.TableOptNone, randgen.SeedTypes,
 			randgen.PartialIndexMutator, randgen.ForeignKeyMutator,
 		)
 

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -210,9 +211,16 @@ func TestRandomParquetExports(t *testing.T) {
 		}
 		sqlDB.Exec(t, sb.String())
 
+		// Use a smither as a type resolver for PopulateTableWithRandData.
+		var typeResolver tree.TypeReferenceResolver
+		smither, err := sqlsmith.NewSmither(db, rng)
+		require.NoError(t, err)
+		defer smither.Close()
+		typeResolver = smither
+
 		for i = 0; i < numTables; i++ {
 			tableName = string(stmts[i].(*tree.CreateTable).Table.ObjectName)
-			numRows, err := randgen.PopulateTableWithRandData(rng, db, tableName, 20, nil)
+			numRows, err := randgen.PopulateTableWithRandData(rng, db, tableName, 20, nil, typeResolver)
 			require.NoError(t, err)
 			if numRows > 5 {
 				// Ensure the table only contains columns supported by EXPORT Parquet. If an

--- a/pkg/sql/importer/read_import_avro_logical_test.go
+++ b/pkg/sql/importer/read_import_avro_logical_test.go
@@ -284,7 +284,9 @@ func TestImportAvroLogicalTypes(t *testing.T) {
 	rng, _ := randutil.NewTestRand()
 	success := false
 	for i := 1; i <= 5; i++ {
-		numRowsInserted, err := randgen.PopulateTableWithRandData(rng, db, origTableName, 30, nil)
+		numRowsInserted, err := randgen.PopulateTableWithRandData(
+			rng, db, origTableName, 30, nil /* inserts */, nil, /* typeResolver */
+		)
 		require.NoError(t, err)
 		if numRowsInserted > 5 {
 			success = true

--- a/pkg/sql/randgen/BUILD.bazel
+++ b/pkg/sql/randgen/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/rowenc/valueside",
         "//pkg/sql/sem/cast",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sem/tree/treebin",

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -44,19 +46,24 @@ func MakeSchemaName(ifNotExists bool, schema string, authRole tree.RoleSpec) *tr
 	}
 }
 
-// RandCreateEnumType creates a random CREATE TYPE <type_name> AS ENUM statement.
-// The resulting type's name will be name, the enum members will
-// be random strings generated from alphabet.
-func RandCreateEnumType(rng *rand.Rand, name, alphabet string) tree.Statement {
+// RandCreateEnumType creates a random CREATE TYPE <type_name> AS ENUM
+// statement. The resulting type's name will be name, the enum members will be
+// random strings generated from alphabet. RandCreateEnumType also returns a
+// partial *types.T which represents the type that will be created. This
+// *types.T does not have correct OID or metadata, but should be enough for
+// RandCreateTableWithTypes to work with.
+func RandCreateEnumType(rng *rand.Rand, name, alphabet string) (tree.Statement, *types.T) {
 	numLabels := rng.Intn(6) + 1
 	labels := make(tree.EnumValueList, numLabels)
-	labelsMap := make(map[string]struct{})
+	labelsMap := make(map[string]struct{}, numLabels)
+	members := make([]string, numLabels)
 
 	for i := 0; i < numLabels; {
 		s := util.RandString(rng, rng.Intn(6)+1, alphabet)
 		if _, ok := labelsMap[s]; !ok {
 			labels[i] = tree.EnumValue(s)
 			labelsMap[s] = struct{}{}
+			members[i] = s
 			i++
 		}
 	}
@@ -65,27 +72,49 @@ func RandCreateEnumType(rng *rand.Rand, name, alphabet string) tree.Statement {
 	if err != nil {
 		panic(err)
 	}
-	return &tree.CreateType{
+	stmt := &tree.CreateType{
 		TypeName:   un,
 		Variety:    tree.Enum,
 		EnumLabels: labels,
 	}
+
+	// Create a partial *types.T with the enum members. The OID and physical
+	// representation won't be correct, but this partial type should be enough for
+	// RandCreateTableWithTypes to work with.
+	typ := types.MakeEnum(catid.TypeIDToOID(descpb.ID(1)), catid.TypeIDToOID(descpb.ID(2)))
+	typ.TypeMeta = types.UserDefinedTypeMetadata{
+		Name: &types.UserDefinedTypeName{
+			Name: name,
+		},
+		EnumData: &types.EnumMetadata{
+			LogicalRepresentations: members,
+			// The physical representations don't matter in this case, but the
+			// enum related code in tree expects that the length of
+			// PhysicalRepresentations is equal to the length of LogicalRepresentations.
+			PhysicalRepresentations: make([][]byte, len(members)),
+			IsMemberReadOnly:        make([]bool, len(members)),
+		},
+	}
+	return stmt, typ
 }
 
 // RandCreateCompositeType creates a random composite type statement.
-func RandCreateCompositeType(rng *rand.Rand, name, alphabet string) tree.Statement {
-	var compositeTypeList []tree.CompositeTypeElem
-
+func RandCreateCompositeType(rng *rand.Rand, name, alphabet string) (tree.Statement, *types.T) {
 	numTypes := rng.Intn(6) + 1
-	uniqueNames := make(map[string]struct{})
+	compositeTypeList := make([]tree.CompositeTypeElem, numTypes)
+	uniqueNames := make(map[string]struct{}, numTypes)
+	contents := make([]*types.T, numTypes)
+	labels := make([]string, numTypes)
 
 	for i := 0; i < numTypes; {
 		randomName := util.RandString(rng, rng.Intn(6)+1, alphabet)
 		randomType := RandTypeFromSlice(rng, types.Scalar)
 
 		if _, ok := uniqueNames[randomName]; !ok {
-			compositeTypeList = append(compositeTypeList, tree.CompositeTypeElem{Label: tree.Name(randomName), Type: randomType})
+			compositeTypeList[i] = tree.CompositeTypeElem{Label: tree.Name(randomName), Type: randomType}
 			uniqueNames[randomName] = struct{}{}
+			contents[i] = randomType
+			labels[i] = randomName
 			i++
 		}
 	}
@@ -94,11 +123,24 @@ func RandCreateCompositeType(rng *rand.Rand, name, alphabet string) tree.Stateme
 	if err != nil {
 		panic(err)
 	}
-	return &tree.CreateType{
+	stmt := &tree.CreateType{
 		TypeName:          un,
 		Variety:           tree.Composite,
 		CompositeTypeList: compositeTypeList,
 	}
+
+	// Create a partial *types.T with the composite type elements. The OID and
+	// won't be correct, but this partial type should be enough for
+	// RandCreateTableWithTypes to work with.
+	typ := types.NewCompositeType(
+		catid.TypeIDToOID(descpb.ID(1)), catid.TypeIDToOID(descpb.ID(2)), contents, labels,
+	)
+	typ.TypeMeta = types.UserDefinedTypeMetadata{
+		Name: &types.UserDefinedTypeName{
+			Name: name,
+		},
+	}
+	return stmt, typ
 }
 
 type TableOpt uint8
@@ -116,9 +158,15 @@ func (t TableOpt) IsSet(o TableOpt) bool {
 	return t&o == o
 }
 
-// RandCreateTables creates random table definitions.
-func RandCreateTables(
-	ctx context.Context, rng *rand.Rand, prefix string, num int, opt TableOpt, mutators ...Mutator,
+// RandCreateTablesWithTypes creates random table definitions.
+func RandCreateTablesWithTypes(
+	ctx context.Context,
+	rng *rand.Rand,
+	prefix string,
+	num int,
+	opt TableOpt,
+	typs []*types.T,
+	mutators ...Mutator,
 ) []tree.Statement {
 	if num < 1 {
 		panic("at least one table required")
@@ -127,7 +175,7 @@ func RandCreateTables(
 	// Make some random tables.
 	tables := make([]tree.Statement, num)
 	for i := 0; i < num; i++ {
-		t := RandCreateTable(ctx, rng, prefix, i+1, opt)
+		t := RandCreateTableWithTypes(ctx, rng, prefix, i+1, opt, typs)
 		tables[i] = t
 	}
 
@@ -142,8 +190,15 @@ func RandCreateTables(
 func RandCreateTable(
 	ctx context.Context, rng *rand.Rand, prefix string, tableIdx int, opt TableOpt,
 ) *tree.CreateTable {
-	return RandCreateTableWithColumnIndexNumberGenerator(
-		ctx, rng, prefix, tableIdx, opt, nil, /* generateColumnIndexNumber */
+	return RandCreateTableWithTypes(ctx, rng, prefix, tableIdx, opt, SeedTypes)
+}
+
+// RandCreateTable creates a random CreateTable definition.
+func RandCreateTableWithTypes(
+	ctx context.Context, rng *rand.Rand, prefix string, tableIdx int, opt TableOpt, typs []*types.T,
+) *tree.CreateTable {
+	return randCreateTableWithColumnIndexNumberGeneratorAndTypes(
+		ctx, rng, prefix, tableIdx, opt, nil /* generateColumnIndexNumber */, typs,
 	)
 }
 
@@ -163,6 +218,20 @@ func RandCreateTableWithColumnIndexNumberGenerator(
 	opt TableOpt,
 	generateColumnIndexSuffix func() string,
 ) *tree.CreateTable {
+	return randCreateTableWithColumnIndexNumberGeneratorAndTypes(
+		ctx, rng, prefix, tableIdx, opt, generateColumnIndexSuffix, SeedTypes,
+	)
+}
+
+func randCreateTableWithColumnIndexNumberGeneratorAndTypes(
+	ctx context.Context,
+	rng *rand.Rand,
+	prefix string,
+	tableIdx int,
+	opt TableOpt,
+	generateColumnIndexSuffix func() string,
+	typs []*types.T,
+) *tree.CreateTable {
 	var name string
 	if opt.IsSet(TableOptCrazyNames) {
 		g := randident.NewNameGenerator(&nameGenCfg, rng, prefix)
@@ -171,7 +240,7 @@ func RandCreateTableWithColumnIndexNumberGenerator(
 		name = fmt.Sprintf("%s%d", prefix, tableIdx)
 	}
 	return randCreateTableWithColumnIndexNumberGeneratorAndName(
-		ctx, rng, name, tableIdx, opt, generateColumnIndexSuffix,
+		ctx, rng, name, tableIdx, opt, generateColumnIndexSuffix, typs,
 	)
 }
 
@@ -179,7 +248,7 @@ func RandCreateTableWithName(
 	ctx context.Context, rng *rand.Rand, tableName string, tableIdx int, opt TableOpt,
 ) *tree.CreateTable {
 	return randCreateTableWithColumnIndexNumberGeneratorAndName(
-		ctx, rng, tableName, tableIdx, opt, nil, /* generateColumnIndexSuffix */
+		ctx, rng, tableName, tableIdx, opt, nil /* generateColumnIndexSuffix */, SeedTypes,
 	)
 }
 
@@ -190,6 +259,7 @@ func randCreateTableWithColumnIndexNumberGeneratorAndName(
 	tableIdx int,
 	opt TableOpt,
 	generateColumnIndexSuffix func() string,
+	typs []*types.T,
 ) *tree.CreateTable {
 	// columnDefs contains the list of Columns we'll add to our table.
 	nColumns := randutil.RandIntInRange(rng, 1, 20)
@@ -210,7 +280,7 @@ func randCreateTableWithColumnIndexNumberGeneratorAndName(
 	nComputedColumns := randutil.RandIntInRange(rng, 0, (nColumns+1)/2)
 	nNormalColumns := nColumns - nComputedColumns
 	for i := 0; i < nNormalColumns; i++ {
-		columnDef := randColumnTableDef(rng, tableIdx, colSuffix(i), opt)
+		columnDef := randColumnTableDef(rng, tableIdx, colSuffix(i), opt, typs)
 		columnDefs = append(columnDefs, columnDef)
 		defs = append(defs, columnDef)
 	}
@@ -218,7 +288,7 @@ func randCreateTableWithColumnIndexNumberGeneratorAndName(
 	// Make defs for computed columns.
 	normalColDefs := columnDefs
 	for i := nNormalColumns; i < nColumns; i++ {
-		columnDef := randComputedColumnTableDef(rng, normalColDefs, tableIdx, colSuffix(i), opt)
+		columnDef := randComputedColumnTableDef(rng, normalColDefs, tableIdx, colSuffix(i), opt, typs)
 		columnDefs = append(columnDefs, columnDef)
 		defs = append(defs, columnDef)
 	}
@@ -497,7 +567,7 @@ func PopulateTableWithRandData(
 // randColumnTableDef produces a random ColumnTableDef for a non-computed
 // column, with a random type and nullability.
 func randColumnTableDef(
-	rng *rand.Rand, tableIdx int, colSuffix string, opt TableOpt,
+	rng *rand.Rand, tableIdx int, colSuffix string, opt TableOpt, typs []*types.T,
 ) *tree.ColumnTableDef {
 	var colName tree.Name
 	if opt.IsSet(TableOptCrazyNames) {
@@ -510,7 +580,7 @@ func randColumnTableDef(
 		// We make a unique name for all columns by prefixing them with the table
 		// index to make it easier to reference columns from different tables.
 		Name: colName,
-		Type: RandColumnType(rng),
+		Type: RandColumnTypeFromSlice(rng, typs),
 	}
 	// Slightly prefer non-nullable columns
 	if columnDef.Type.(*types.T).Family() == types.OidFamily {
@@ -536,8 +606,9 @@ func randComputedColumnTableDef(
 	tableIdx int,
 	colSuffix string,
 	opt TableOpt,
+	typs []*types.T,
 ) *tree.ColumnTableDef {
-	newDef := randColumnTableDef(rng, tableIdx, colSuffix, opt)
+	newDef := randColumnTableDef(rng, tableIdx, colSuffix, opt, typs)
 	newDef.Computed.Computed = true
 	newDef.Computed.Virtual = rng.Intn(2) == 0
 

--- a/pkg/sql/randgen/schema_test.go
+++ b/pkg/sql/randgen/schema_test.go
@@ -45,8 +45,8 @@ func TestPopulateTableWithRandData(t *testing.T) {
 	tablePrefix := "table"
 	numTables := 10
 
-	stmts := randgen.RandCreateTables(
-		ctx, rng, tablePrefix, numTables, randgen.TableOptNone,
+	stmts := randgen.RandCreateTablesWithTypes(
+		ctx, rng, tablePrefix, numTables, randgen.TableOptNone, randgen.SeedTypes,
 		randgen.PartialIndexMutator, randgen.ForeignKeyMutator,
 	)
 

--- a/pkg/sql/randgen/schema_test.go
+++ b/pkg/sql/randgen/schema_test.go
@@ -63,7 +63,9 @@ func TestPopulateTableWithRandData(t *testing.T) {
 	for i := 0; i < numTables; i++ {
 		tableName := string(stmts[i].(*tree.CreateTable).Table.ObjectName)
 		numRows := 30
-		numRowsInserted, err := randgen.PopulateTableWithRandData(rng, dbConn, tableName, numRows, nil)
+		numRowsInserted, err := randgen.PopulateTableWithRandData(
+			rng, dbConn, tableName, numRows, nil /* inserts */, nil, /* typeResolver */
+		)
 		require.NoError(t, err)
 		res := sqlDB.QueryStr(t, fmt.Sprintf("SELECT count(*) FROM %s", tree.NameString(tableName)))
 		require.Equal(t, fmt.Sprint(numRowsInserted), res[0][0])

--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -148,8 +148,14 @@ func RandTupleFromSlice(rng *rand.Rand, typs []*types.T) *types.T {
 // RandColumnType returns a random type that is a legal column type (e.g. no
 // nested arrays or tuples).
 func RandColumnType(rng *rand.Rand) *types.T {
+	return RandColumnTypeFromSlice(rng, SeedTypes)
+}
+
+// RandColumnType returns a random type that is a legal column type (e.g. no
+// nested arrays or tuples).
+func RandColumnTypeFromSlice(rng *rand.Rand, typs []*types.T) *types.T {
 	for {
-		typ := RandType(rng)
+		typ := RandTypeFromSlice(rng, typs)
 		if IsLegalColumnType(typ) {
 			return typ
 		}

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1345,9 +1345,9 @@ func (og *operationGenerator) createType(
 	var statement tree.Statement
 
 	if isEnum {
-		statement = randgen.RandCreateEnumType(og.params.rng, typName.Object(), letters)
+		statement, _ = randgen.RandCreateEnumType(og.params.rng, typName.Object(), letters)
 	} else {
-		statement = randgen.RandCreateCompositeType(og.params.rng, typName.Object(), letters)
+		statement, _ = randgen.RandCreateCompositeType(og.params.rng, typName.Object(), letters)
 	}
 
 	statement.(*tree.CreateType).TypeName = typName.ToUnresolvedObjectName()


### PR DESCRIPTION
The included commits add basic support for user-defined composite types to sqlsmith. This is enough to produce tables with columns of composite type that are used in inserts, updates, deletes, and selects. Notably missing are:
- accesses of individual subfields in a composite value (i.e. `(col).field` syntax)
- modification of individual subfields in a composite value, due to https://github.com/cockroachdb/cockroach/issues/102984
- alters of composite types, due to https://github.com/cockroachdb/cockroach/issues/48701

Epic: None

Release note: None