### PR TITLE
roachprod: fix a data race in propagateDiskLabels (GCE)

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -815,18 +815,23 @@ func (p *Provider) Create(
 	time = strings.ToLower(strings.ReplaceAll(time, ":", "_"))
 	m[vm.TagCreated] = time
 
-	var sb strings.Builder
+	var labelPairs []string
+	addLabel := func(key, value string) {
+		labelPairs = append(labelPairs, fmt.Sprintf("%s=%s", key, value))
+	}
+
 	for key, value := range opts.CustomLabels {
-		_, ok := m[key]
+		_, ok := m[strings.ToLower(key)]
 		if ok {
 			return fmt.Errorf("duplicate label name defined: %s", key)
 		}
-		fmt.Fprintf(&sb, "%s=%s,", key, value)
+		addLabel(key, value)
 	}
 	for key, value := range m {
-		fmt.Fprintf(&sb, "%s=%s,", key, value)
+		addLabel(key, value)
 	}
-	labels := sb.String()
+	labels := strings.Join(labelPairs, ",")
+
 	args = append(args, "--labels", labels)
 	args = append(args, "--metadata-from-file", fmt.Sprintf("startup-script=%s", filename))
 	args = append(args, "--project", project)
@@ -876,18 +881,18 @@ func propagateDiskLabels(
 	var g errgroup.Group
 
 	l.Printf("Propagating labels across all disks")
+	argsPrefix := []string{"compute", "disks", "update"}
+	argsPrefix = append(argsPrefix, "--update-labels", labels)
+	argsPrefix = append(argsPrefix, "--project", project)
 
 	for zone, zoneHosts := range zoneToHostNames {
-		zoneArg := []string{"--zone", zone}
+		argsPrefix = append(argsPrefix, "--zone", zone)
 
 		for _, host := range zoneHosts {
-			args := []string{"compute", "disks", "update"}
-			args = append(args, "--update-labels", labels[:len(labels)-1])
-			args = append(args, "--project", project)
-			args = append(args, zoneArg...)
 			host := host
 
 			g.Go(func() error {
+				args := append([]string(nil), argsPrefix...)
 				// N.B. boot disk has the same name as the host.
 				bootDiskArgs := append(args, host)
 				cmd := exec.Command("gcloud", bootDiskArgs...)
@@ -901,6 +906,7 @@ func propagateDiskLabels(
 
 			if !opts.SSDOpts.UseLocalSSD {
 				g.Go(func() error {
+					args := append([]string(nil), argsPrefix...)
 					// N.B. additional persistent disks are suffixed with the offset, starting at 1.
 					persistentDiskArgs := append(args, fmt.Sprintf("%s-1", host))
 					cmd := exec.Command("gcloud", persistentDiskArgs...)


### PR DESCRIPTION
A recent change [1] has added label propagation to all attached disks. Its GCE implementation execs
`gcloud compute disks update --update-labels ...`
for every attached disk, in a separate goroutine.

The implementation has a data race owing to the shared backing array being appended to from different goroutines. As a result of the data race, the same disk name may end up being updated (via gcloud), yielding yet another data race. The latter uses a label fingerprint before the update as an optimistic lock. Thus, if two updates both grab the initially empty fingerprint, one of them will fail.

The change fixes the data race thereby ensuring the same disk name is updated exactly once.

Epic: none
Release note: None

[1] https://github.com/cockroachdb/cockroach/pull/99423