### PR TITLE
CODEOWNERS: reassign protectedts to KV

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -309,7 +309,7 @@
 /pkg/kv/kvserver/logstore/              @cockroachdb/repl-prs
 /pkg/kv/kvserver/loqrecovery/           @cockroachdb/repl-prs
 /pkg/kv/kvserver/multiqueue/            @cockroachdb/kv-prs
-/pkg/kv/kvserver/protectedts/           @cockroachdb/repl-prs
+/pkg/kv/kvserver/protectedts/           @cockroachdb/kv-prs
 /pkg/kv/kvserver/rangefeed/             @cockroachdb/repl-prs
 /pkg/kv/kvserver/rangelog/              @cockroachdb/kv-prs
 /pkg/kv/kvserver/rditer/                @cockroachdb/repl-prs


### PR DESCRIPTION
Epic: none
Release note: None