### PR TITLE
kvserver: deflake TestRangefeedCheckpointsRecoverFromLeaseExpiration

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1359,12 +1359,14 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 		tc.GetFirstStoreFromServer(t, 1).GetStoreConfig().RangeLeaseRenewalDuration().Nanoseconds() +
 			time.Second.Nanoseconds(),
 	)
+	var firstLease roachpb.Lease
 	testutils.SucceedsSoon(t, func() error {
 		repl := tc.GetFirstStoreFromServer(t, 1).LookupReplica(roachpb.RKey(scratchKey))
 		leaseStatus := repl.CurrentLeaseStatus(ctx)
 		if leaseStatus.Lease.Type() != roachpb.LeaseEpoch {
 			return errors.Errorf("lease still an expiration based lease")
 		}
+		firstLease = leaseStatus.Lease
 		return nil
 	})
 
@@ -1389,10 +1391,17 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 	require.Equal(t, int64(1), nudged)
 
 	// Check that n2 renewed its lease, like the test intended.
+	// Unfortunately this is flaky and it's not so clear how to fix it.
+	// See: https://github.com/cockroachdb/cockroach/issues/102169
+	// But even if the lease is on n1 the rangefeed shouldn't have errored.
 	li, _, err := tc.FindRangeLeaseEx(ctx, desc, nil)
 	require.NoError(t, err)
-	require.True(t, li.Current().OwnedBy(n2.GetFirstStoreID()))
-	require.Equal(t, int64(2), li.Current().Epoch)
+	curLease := li.Current()
+	t.Logf("lease before expiration: %s", firstLease)
+	t.Logf("lease after expiration: %s", curLease)
+	if curLease.OwnedBy(n2.GetFirstStoreID()) {
+		require.Equal(t, int64(2), curLease.Epoch)
+	}
 
 	// Make sure the RangeFeed hasn't errored.
 	select {


### PR DESCRIPTION
It was relying on the raft leader not moving but, as we know, it can move.
Weaken the test to tolerate this as making it robust is going to be tricky and
subject to future breakage.

Fixes https://github.com/cockroachdb/cockroach/issues/102169.

Epic: none
Release note: None
