### PR TITLE
backupccl: support unsafe restores from future versions

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -184,6 +184,7 @@ go_test(
         "restore_mid_schema_change_test.go",
         "restore_old_sequences_test.go",
         "restore_old_versions_test.go",
+        "restore_planning_test.go",
         "restore_progress_test.go",
         "restore_span_covering_test.go",
         "schedule_pts_chaining_test.go",

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8460,7 +8460,7 @@ func TestRestoringAcrossVersions(t *testing.T) {
 
 		// Verify we reject it.
 		sqlDB.ExpectErr(t,
-			fmt.Sprintf("backup from version %s is older than the minimum restoreable version", minSupportedVersion.String()),
+			fmt.Sprintf("backup from version %s is older than the minimum restorable version", minSupportedVersion.String()),
 			`RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version'`)
 	})
 
@@ -8479,7 +8479,7 @@ func TestRestoringAcrossVersions(t *testing.T) {
 		setManifestClusterVersion(roachpb.Version{})
 
 		// Verify we reject it.
-		sqlDB.ExpectErr(t, "the backup is from a version older than our minimum restoreable version",
+		sqlDB.ExpectErr(t, "the backup is from a version older than our minimum restorable version",
 			`RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version'`)
 	})
 }

--- a/pkg/ccl/backupccl/restore_planning_test.go
+++ b/pkg/ccl/backupccl/restore_planning_test.go
@@ -1,0 +1,96 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackupManifestVersionCompatibility(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	type testCase struct {
+		name                    string
+		backupVersion           roachpb.Version
+		clusterVersion          roachpb.Version
+		minimumSupportedVersion roachpb.Version
+		expectedError           string
+	}
+
+	binaryVersion := roachpb.Version{Major: 23, Minor: 1}
+	tests := []testCase{
+		{
+			name:                    "same-version-restore",
+			backupVersion:           roachpb.Version{Major: 23, Minor: 1},
+			clusterVersion:          roachpb.Version{Major: 23, Minor: 1},
+			minimumSupportedVersion: roachpb.Version{Major: 22, Minor: 2},
+		},
+		{
+			name:                    "previous-version-restore",
+			backupVersion:           roachpb.Version{Major: 23, Minor: 1},
+			clusterVersion:          roachpb.Version{Major: 23, Minor: 1},
+			minimumSupportedVersion: roachpb.Version{Major: 22, Minor: 2},
+		},
+		{
+			name:                    "unfinalized-restore",
+			backupVersion:           roachpb.Version{Major: 23, Minor: 1},
+			clusterVersion:          roachpb.Version{Major: 22, Minor: 2},
+			minimumSupportedVersion: roachpb.Version{Major: 22, Minor: 2},
+			expectedError:           "backup from version 23.1 is newer than current version 22.2",
+		},
+		{
+			name:                    "alpha-restore",
+			backupVersion:           roachpb.Version{Major: 100022, Minor: 2, Internal: 14},
+			clusterVersion:          roachpb.Version{Major: 23, Minor: 1},
+			minimumSupportedVersion: roachpb.Version{Major: 22, Minor: 2},
+			expectedError:           "backup from version 100022.2-14 is newer than current version 23.1",
+		},
+		{
+			name:                    "old-backup",
+			backupVersion:           roachpb.Version{Major: 22, Minor: 1},
+			clusterVersion:          roachpb.Version{Major: 23, Minor: 1},
+			minimumSupportedVersion: roachpb.Version{Major: 22, Minor: 2},
+			expectedError:           "backup from version 22.1 is older than the minimum restorable version 22.2",
+		},
+		{
+			name:                    "legacy-version-backup",
+			backupVersion:           roachpb.Version{},
+			clusterVersion:          roachpb.Version{Major: 23, Minor: 1},
+			minimumSupportedVersion: roachpb.Version{Major: 22, Minor: 2},
+			expectedError:           "the backup is from a version older than our minimum restorable version 22.2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := cluster.MakeTestingClusterSettingsWithVersions(binaryVersion, tc.minimumSupportedVersion, false)
+			require.NoError(t, clusterversion.Initialize(context.Background(), tc.clusterVersion, &settings.SV))
+			version := clusterversion.MakeVersionHandleWithOverride(&settings.SV, binaryVersion, tc.minimumSupportedVersion)
+			manifest := []backuppb.BackupManifest{{ClusterVersion: tc.backupVersion}}
+
+			err := checkBackupManifestVersionCompatability(context.Background(), version, manifest /*unsafe=*/, false)
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+			}
+
+			require.NoError(t, checkBackupManifestVersionCompatability(context.Background(), version, manifest /*unsafe=*/, true))
+		})
+	}
+}


### PR DESCRIPTION
Previously, RESTORE WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION did not allow restoring a back up from a future version of CRDB. Restoring from a future version is generally unsafe, but can be useful if there are no breaking changes between the two versions. The immediate use case for this change is to support restoring database back ups from alpha multi-region serverless preview clusters onto the new pre-release 23.1 clusters.

Part of: https://cockroachlabs.atlassian.net/browse/CC-24594

Release Note: none