### PR TITLE
sql: extend SHOW RANGES to include object size estimates

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1303,6 +1303,8 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="crdb_internal.tenant_span_stats"></a><code>crdb_internal.tenant_span_stats(database_id: <a href="int.html">int</a>, table_id: <a href="int.html">int</a>) &rarr; tuple{int AS database_id, int AS table_id, int AS range_count, int AS approximate_disk_<a href="bytes.html">bytes</a>, int AS live_<a href="bytes.html">bytes</a>, int AS total_<a href="bytes.html">bytes</a>, float AS live_percentage}</code></td><td><span class="funcdesc"><p>Returns statistics (range count, disk size, live range bytes, total range bytes, live range byte percentage) for the provided table id.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="crdb_internal.tenant_span_stats"></a><code>crdb_internal.tenant_span_stats(spans: tuple[]) &rarr; tuple{bytes AS start_key, bytes AS end_key, jsonb AS stats}</code></td><td><span class="funcdesc"><p>Returns SpanStats for the provided spans.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="crdb_internal.testing_callback"></a><code>crdb_internal.testing_callback(name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>For internal CRDB testing only. The function calls a callback identified by <code>name</code> registered with the server by the test.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.unary_table"></a><code>crdb_internal.unary_table() &rarr; tuple</code></td><td><span class="funcdesc"><p>Produces a virtual table containing a single row with no values.</p>

--- a/pkg/roachpb/span_stats.proto
+++ b/pkg/roachpb/span_stats.proto
@@ -42,7 +42,9 @@ message SpanStats {
   // key sorts after the range start, and whose end key sorts before the
   // range end, will have a range_count value of 1.
   int32 range_count = 2;
-  uint64 approximate_disk_bytes = 3;
+
+  // The explicit jsontag prevents 'omitempty` from being added by default.
+  uint64 approximate_disk_bytes = 3 [(gogoproto.jsontag) = "approximate_disk_bytes"];
 }
 
 message SpanStatsResponse {

--- a/pkg/sql/logictest/testdata/logic_test/show_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/show_ranges
@@ -52,10 +52,10 @@ start_key                end_key                  range_id
 /Table/6                 /Table/7                 10
 
 # Ditto, verbose form.
-query TTIFITTTTTTTI colnames
+query TTIFITTTTTTTIT colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH DETAILS] LIMIT 0
 ----
-start_key                end_key                  range_id  range_size_mb               lease_holder  lease_holder_locality  replicas  replica_localities      voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key                end_key                  range_id  range_size_mb               lease_holder  lease_holder_locality  replicas  replica_localities      voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 # Ditto, with keys.
 query TTTTITTTTTT colnames
@@ -64,10 +64,10 @@ SELECT * FROM [SHOW CLUSTER RANGES WITH KEYS] LIMIT 0
 start_key  end_key  raw_start_key  raw_end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until
 
 # Ditto, verbose + keys.
-query TTTTIFITTTTTTTI colnames
+query TTTTIFITTTTTTTIT colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH DETAILS, KEYS] LIMIT 0
 ----
-start_key  end_key  raw_start_key  raw_end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  raw_start_key  raw_end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 query TTTTII colnames
 SELECT start_key, to_hex(raw_start_key), end_key, to_hex(raw_end_key), range_id, lease_holder FROM [SHOW CLUSTER RANGES WITH DETAILS, KEYS]
@@ -94,10 +94,10 @@ SELECT * FROM [SHOW CLUSTER RANGES WITH TABLES] LIMIT 0
 ----
 start_key  end_key  range_id  database_name  schema_name  table_name  table_id  table_start_key  table_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until
 
-query TTITTTITTFITTTTTTTI colnames
+query TTITTTITTFITTTTTTTIT colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH DETAILS, TABLES] LIMIT 0
 ----
-start_key  end_key  range_id  database_name  schema_name  table_name  table_id  table_start_key  table_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  range_id  database_name  schema_name  table_name  table_id  table_start_key  table_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 query TTTTITTTITTTTTTTTTT colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH KEYS, TABLES] LIMIT 0
@@ -130,20 +130,20 @@ SELECT * FROM [SHOW CLUSTER RANGES WITH INDEXES] LIMIT 0
 ----
 start_key  end_key  range_id  database_name  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until
 
-query TTITTTITITTFITTTTTTTI colnames
+query TTITTTITITTFITTTTTTTIT colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH DETAILS, INDEXES] LIMIT 0
 ----
-start_key  end_key  range_id  database_name  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  range_id  database_name  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 query TTTTITTTITITTTTTTTTTT colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH KEYS, INDEXES] LIMIT 0
 ----
 start_key  end_key  raw_start_key  raw_end_key  range_id  database_name  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  raw_index_start_key  raw_index_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until
 
-query TTTTITTTITITTTTFITTTTTTTI colnames
+query TTTTITTTITITTTTFITTTTTTTIT colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH DETAILS, KEYS, INDEXES] LIMIT 0
 ----
-start_key  end_key  raw_start_key  raw_end_key  range_id  database_name  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  raw_index_start_key  raw_index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  raw_start_key  raw_end_key  range_id  database_name  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  raw_index_start_key  raw_index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 # Show some rows.
 # This also demonstrates how the index information remains NULL if there's no index contained.
@@ -179,10 +179,10 @@ SHOW RANGES WITH KEYS
 ----
 start_key  end_key  raw_start_key  raw_end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until
 
-query TTIFITTTTTTTI colnames
+query TTIFITTTTTTTIT colnames
 SHOW RANGES WITH DETAILS
 ----
-start_key  end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 # Add some tables. This will force at least one range to pop up.
 # also split them to make the test more interesting.
@@ -248,15 +248,15 @@ SELECT * FROM [SHOW RANGES WITH TABLES, KEYS] LIMIT 0
 ----
 start_key  end_key  raw_start_key  raw_end_key  range_id  schema_name  table_name  table_id  table_start_key  table_end_key  raw_table_start_key  raw_table_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until
 
-query TTITTITTFITTTTTTTI colnames
+query TTITTITTFITTTTTTTIT colnames
 SELECT * FROM [SHOW RANGES WITH DETAILS, TABLES] LIMIT 0
 ----
-start_key  end_key  range_id  schema_name  table_name  table_id  table_start_key  table_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  range_id  schema_name  table_name  table_id  table_start_key  table_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
-query TTTTITTITTTTFITTTTTTTI colnames
+query TTTTITTITTTTFITTTTTTTIT colnames
 SELECT * FROM [SHOW RANGES WITH DETAILS, KEYS, TABLES] LIMIT 0
 ----
-start_key  end_key  raw_start_key  raw_end_key  range_id  schema_name  table_name  table_id  table_start_key  table_end_key  raw_table_start_key  raw_table_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  raw_start_key  raw_end_key  range_id  schema_name  table_name  table_id  table_start_key  table_end_key  raw_table_start_key  raw_table_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 # Show the data.
 query TTITTITT colnames
@@ -285,15 +285,15 @@ SELECT * FROM [SHOW RANGES WITH INDEXES, KEYS] LIMIT 0
 ----
 start_key  end_key  raw_start_key  raw_end_key  range_id  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  raw_index_start_key  raw_index_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until
 
-query TTITTITITTFITTTTTTTI colnames
+query TTITTITITTFITTTTTTTIT colnames
 SELECT * FROM [SHOW RANGES WITH DETAILS, INDEXES] LIMIT 0
 ----
-start_key  end_key  range_id  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  range_id  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
-query TTTTITTITITTTTFITTTTTTTI colnames
+query TTTTITTITITTTTFITTTTTTTIT colnames
 SELECT * FROM [SHOW RANGES WITH DETAILS, KEYS, INDEXES] LIMIT 0
 ----
-start_key  end_key  raw_start_key  raw_end_key  range_id  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  raw_index_start_key  raw_index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  raw_start_key  raw_end_key  range_id  schema_name  table_name  table_id  index_name  index_id  index_start_key  index_end_key  raw_index_start_key  raw_index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 # Show some rows.
 # This also demonstrates how the index information remains NULL if there's no index contained.
@@ -325,15 +325,15 @@ SELECT * FROM [SHOW RANGES FROM TABLE t WITH KEYS] LIMIT 0
 ----
 start_key  end_key  raw_start_key  raw_end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until
 
-query TTIFITTTTTTTI colnames
+query TTIFITTTTTTTIT colnames
 SELECT * FROM [SHOW RANGES FROM TABLE t WITH DETAILS] LIMIT 0
 ----
-start_key  end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
-query TTTTIFITTTTTTTI colnames
+query TTTTIFITTTTTTTIT colnames
 SELECT * FROM [SHOW RANGES FROM TABLE t WITH DETAILS,KEYS] LIMIT 0
 ----
-start_key  end_key  raw_start_key  raw_end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  raw_start_key  raw_end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 # Now also look at the output.
 query TTIT colnames
@@ -381,15 +381,15 @@ SELECT * FROM [SHOW RANGES FROM TABLE t WITH INDEXES,KEYS] LIMIT 0
 ----
 start_key  end_key  raw_start_key  raw_end_key  range_id  index_name  index_id  index_start_key  index_end_key  raw_index_start_key  raw_index_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until
 
-query TTITITTFITTTTTTTI colnames
+query TTITITTFITTTTTTTIT colnames
 SELECT * FROM [SHOW RANGES FROM TABLE t WITH INDEXES, DETAILS] LIMIT 0
 ----
-start_key  end_key  range_id  index_name  index_id  index_start_key  index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  range_id  index_name  index_id  index_start_key  index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
-query TTTTITITTTTFITTTTTTTI colnames
+query TTTTITITTTTFITTTTTTTIT colnames
 SELECT * FROM [SHOW RANGES FROM TABLE t WITH INDEXES, KEYS, DETAILS] LIMIT 0
 ----
-start_key  end_key  raw_start_key  raw_end_key  range_id  index_name  index_id  index_start_key  index_end_key  raw_index_start_key  raw_index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  raw_start_key  raw_end_key  range_id  index_name  index_id  index_start_key  index_end_key  raw_index_start_key  raw_index_end_key  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 # Now also look at the output.
 query TTITITT colnames
@@ -418,15 +418,15 @@ SELECT * FROM [SHOW RANGES FROM INDEX t@idx WITH KEYS] LIMIT 0
 ----
 start_key  end_key  raw_start_key  raw_end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until
 
-query TTIFITTTTTTTI colnames
+query TTIFITTTTTTTIT colnames
 SELECT * FROM [SHOW RANGES FROM INDEX t@idx WITH DETAILS] LIMIT 0
 ----
-start_key  end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
-query TTTTIFITTTTTTTI colnames
+query TTTTIFITTTTTTTIT colnames
 SELECT * FROM [SHOW RANGES FROM INDEX t@idx WITH DETAILS, KEYS] LIMIT 0
 ----
-start_key  end_key  raw_start_key  raw_end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size
+start_key  end_key  raw_start_key  raw_end_key  range_id  range_size_mb  lease_holder  lease_holder_locality  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  range_size  span_stats
 
 # Now also look at the output.
 query TTIT colnames

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2384,6 +2384,7 @@ var builtinOidsArray = []string{
 	2411: `to_char(date: date, format: string) -> string`,
 	2412: `crdb_internal.unsafe_lock_replica(range_id: int, lock: bool) -> bool`,
 	2413: `crdb_internal.fingerprint(span: bytes[], start_time: decimal, all_revisions: bool) -> int`,
+	2414: `crdb_internal.tenant_span_stats(spans: tuple[]) -> tuple{bytes AS start_key, bytes AS end_key, jsonb AS stats}`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -576,7 +576,11 @@ The last argument is a JSONB object containing the following optional fields:
 		),
 	),
 	"crdb_internal.tenant_span_stats": makeBuiltin(genProps(),
-		// Tenant overload
+		// This overload defines a built-in that returns the range count,
+		// approximate disk size, live range bytes, total range bytes,
+		// and live range byte percentage for all tables that belong to the
+		// tenant executing the statement. It is invoked without arguments.
+		// e.g. `SELECT * FROM crdb_internal.tenant_span_stats();`
 		makeGeneratorOverload(
 			tree.ParamTypes{},
 			tableSpanStatsGeneratorType,
@@ -584,7 +588,11 @@ The last argument is a JSONB object containing the following optional fields:
 			"Returns statistics (range count, disk size, live range bytes, total range bytes, live range byte percentage) for all of the tenant's tables.",
 			volatility.Stable,
 		),
-		// Database overload
+		// This overload defines a built-in that returns the range count,
+		// approximate disk size, live range bytes, total range bytes,
+		// and live range byte percentage for all tables that belong to the
+		// database specified. The database is specified by its descriptor id.
+		// e.g. `SELECT * FROM crdb_internal.tenant_span_stats(104);`
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "database_id", Typ: types.Int},
@@ -594,7 +602,12 @@ The last argument is a JSONB object containing the following optional fields:
 			"Returns statistics (range count, disk size, live range bytes, total range bytes, live range byte percentage) for tables of the provided database id.",
 			volatility.Stable,
 		),
-		// Table overload
+		// This overload defines a built-in that returns the range count,
+		// approximate disk size, live range bytes, total range bytes,
+		// and live range byte percentage for all tables that belong to the
+		// database and table specified. The database and table are specified
+		// by their descriptor ids.
+		// e.g. `SELECT * FROM crdb_internal.tenant_span_stats(104, 106);`
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "database_id", Typ: types.Int},
@@ -603,6 +616,18 @@ The last argument is a JSONB object containing the following optional fields:
 			tableSpanStatsGeneratorType,
 			makeTableSpanStatsGenerator,
 			"Returns statistics (range count, disk size, live range bytes, total range bytes, live range byte percentage) for the provided table id.",
+			volatility.Stable,
+		),
+		// This overload defines a built-in that returns roachpb.SpanStats for
+		// the spans provided.
+		// e.g. `SELECT * FROM crdb_internal.tenant_span_stats(ARRAY(SELECT('\xfe8a'::bytes, '\xfe8b'::bytes)));`
+		makeGeneratorOverload(
+			tree.ParamTypes{
+				{Name: "spans", Typ: types.AnyTupleArray},
+			},
+			spanStatsGeneratorType,
+			makeSpanStatsGenerator,
+			"Returns SpanStats for the provided spans.",
 			volatility.Stable,
 		),
 	),
@@ -3110,5 +3135,81 @@ func makeTableSpanStatsGenerator(
 	}
 
 	spanBatchLimit := roachpb.SpanStatsBatchLimit.Get(&evalCtx.Settings.SV)
-	return newTableSpanStatsIterator(evalCtx, dbId, tableId, int(spanBatchLimit)), nil
+	return newTableSpanStatsIterator(evalCtx, dbId, tableId,
+		int(spanBatchLimit)), nil
+}
+
+var spanStatsGeneratorType = types.MakeLabeledTuple(
+	[]*types.T{types.Bytes, types.Bytes, types.Json},
+	[]string{"start_key", "end_key", "stats"},
+)
+
+type spanStatsValueGenerator struct {
+	spans     roachpb.Spans // spans are provided as an argument.
+	res       *roachpb.SpanStatsResponse
+	currStats *roachpb.SpanStats
+	currSpan  roachpb.Span
+	idx       int
+	p         eval.Planner
+}
+
+func (s *spanStatsValueGenerator) ResolvedType() *types.T {
+	return spanStatsGeneratorType
+}
+
+func (s *spanStatsValueGenerator) Start(ctx context.Context, txn *kv.Txn) error {
+	res, err := s.p.SpanStats(ctx, s.spans)
+	s.res = res
+	return err
+}
+
+func (s *spanStatsValueGenerator) Next(ctx context.Context) (bool, error) {
+	// We must stop iterating after emitting values for all spans.
+	if s.idx == len(s.spans) {
+		return false, nil
+	}
+	sp := s.spans[s.idx]
+	s.currStats = s.res.SpanToStats[sp.String()]
+	s.currSpan = sp
+	s.idx++
+	return true, nil
+}
+
+func (s *spanStatsValueGenerator) Values() (tree.Datums, error) {
+	jsonStr, err := gojson.Marshal(s.currStats)
+	if err != nil {
+		return nil, err
+	}
+	jsonDatum, err := tree.ParseDJSON(string(jsonStr))
+	if err != nil {
+		return nil, err
+	}
+	return []tree.Datum{
+		tree.NewDBytes(tree.DBytes(s.currSpan.Key)),
+		tree.NewDBytes(tree.DBytes(s.currSpan.EndKey)),
+		jsonDatum,
+	}, nil
+}
+
+func (s *spanStatsValueGenerator) Close(ctx context.Context) {}
+
+func makeSpanStatsGenerator(
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
+	argSpans := tree.MustBeDArray(args[0])
+	spans := make([]roachpb.Span, 0, argSpans.Len())
+	for _, span := range argSpans.Array {
+		s := tree.MustBeDTuple(span)
+		if s.D[0] == tree.DNull || s.D[1] == tree.DNull {
+			continue
+		}
+		startKey := roachpb.Key(tree.MustBeDBytes(s.D[0]))
+		endKey := roachpb.Key(tree.MustBeDBytes(s.D[1]))
+		spans = append(spans, roachpb.Span{
+			Key:    startKey,
+			EndKey: endKey,
+		})
+	}
+
+	return &spanStatsValueGenerator{p: evalCtx.Planner, spans: spans}, nil
 }

--- a/pkg/sql/show_ranges_test.go
+++ b/pkg/sql/show_ranges_test.go
@@ -175,3 +175,94 @@ func TestDeprecatedShowRangesWithClusterSettingChange(t *testing.T) {
 	db.Exec(t, `TABLE crdb_internal.ranges_no_leases`)
 	db.Exec(t, `TABLE crdb_internal.ranges`)
 }
+
+func TestShowRangesWithDetails(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB.Exec(t, "CREATE DATABASE test")
+	sqlDB.Exec(t, "USE test")
+	sqlDB.Exec(t, `
+		CREATE TABLE users (
+		    id INTEGER PRIMARY KEY,
+		    name STRING
+		)
+	`)
+
+	// Assert the required keys are present.
+	res := sqlDB.Query(t, `
+		SELECT
+		    span_stats->'approximate_disk_bytes',
+		    span_stats->'key_count',
+		    span_stats->'key_bytes',
+		    span_stats->'val_count',
+		    span_stats->'val_bytes',
+		    span_stats->'sys_count',
+		    span_stats->'sys_bytes',
+		    span_stats->'live_count',
+		    span_stats->'live_bytes',
+		    span_stats->'intent_count',
+		    span_stats->'intent_bytes'
+		FROM [SHOW RANGES FROM DATABASE test WITH DETAILS]`)
+
+	res.Next()
+	vals := make([]interface{}, 11)
+	for i := range vals {
+		vals[i] = new(interface{})
+	}
+	err := res.Scan(vals...)
+	// Every key should be present, and the scan should be successful.
+	require.NoError(t, err)
+
+	// This invocation of SHOW RANGES should have only returned a single row.
+	require.Equal(t, false, res.NextResultSet())
+
+	// Assert the counterpoint: Scan should return an error for a key that
+	// does not exist.
+	badQuery := sqlDB.Query(t, `
+		SELECT span_stats->'key_does_not_exist'
+		FROM [SHOW RANGES FROM DATABASE test WITH DETAILS]`)
+
+	badQuery.Next()
+	var keyDoesNotExistVal int
+	err = badQuery.Scan(&keyDoesNotExistVal)
+	require.Error(t, err)
+
+	// Now, let's add some users, and query the table's val_bytes.
+	sqlDB.Exec(t, "INSERT INTO test.users (id, name) VALUES (1, 'ab'), (2, 'cd')")
+
+	valBytesPreSplitRes := sqlDB.QueryRow(t, `
+		SELECT span_stats->'val_bytes'
+		FROM [SHOW RANGES FROM DATABASE test WITH DETAILS]`,
+	)
+
+	var valBytesPreSplit int
+	valBytesPreSplitRes.Scan(&valBytesPreSplit)
+
+	// Split the table at the second row, so it occupies a second range.
+	sqlDB.Exec(t, `ALTER TABLE test.users SPLIT AT VALUES (2)`)
+	afterSplit := sqlDB.Query(t, `
+		SELECT span_stats->'val_bytes'
+		FROM [SHOW RANGES FROM TABLE test.users WITH DETAILS]
+	`)
+
+	var valBytesR1 int
+	var valBytesR2 int
+
+	afterSplit.Next()
+	err = afterSplit.Scan(&valBytesR1)
+	require.NoError(t, err)
+
+	afterSplit.Next()
+	err = afterSplit.Scan(&valBytesR2)
+	require.NoError(t, err)
+
+	// Assert that the sum of val_bytes for each range equals the
+	// val_bytes for the whole table.
+	require.Equal(t, valBytesPreSplit, valBytesR1+valBytesR2)
+}


### PR DESCRIPTION
This commit adds object size estimates to `SHOW RANGES WITH DETAILS`.
A new override of `crdb_internal.tenant_span_stats` is introduced
to leverage batched span statistics requests to KV, so only 1 fan-out is
required.

Resolves: https://github.com/cockroachdb/cockroach/issues/97858
Epic: https://cockroachlabs.atlassian.net/browse/CRDB-24928

Release note (sql change): The SHOW RANGES command will now
emit span statistics when the DETAILS option is specified.
The statistics are included in a new column named 'span_stats',
as a JSON object.

The statistics are calculated for the identifier of each row:
`SHOW RANGES WITH DETAILS` will compute span statistics for each range.
`SHOW RANGES WITH TABLES, DETAILS` will compute span statistics
for each table, etc.

The 'span_stats' JSON object has the following keys:
- approximate_disk_bytes
- [key|val|sys|live|intent]_count
- [key|val|sys|live|intent]_bytes

'approximate_disk_bytes' is an approximation of the total on-disk size
of the given object.

'[key|val|sys|live|intent]_count' and '[key|val|sys|live|intent]_bytes'
are defined in enginepb.MVCCStats.