### PR TITLE
util/parquet: add crdb metadata to parquet files

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1278,8 +1278,7 @@ func waitForJobStatus(
 }
 
 // TestingSetIncludeParquetMetadata adds the option to turn on adding metadata
-// (primary key column names) to the parquet file which is used to convert parquet
-// data to JSON format
+// to the parquet file which is used in testing.
 func TestingSetIncludeParquetMetadata() func() {
 	includeParquetTestMetadata = true
 	return func() {

--- a/pkg/ccl/changefeedccl/parquet.go
+++ b/pkg/ccl/changefeedccl/parquet.go
@@ -25,7 +25,7 @@ type parquetWriter struct {
 // newParquetWriterFromRow constructs a new parquet writer which outputs to
 // the given sink. This function interprets the schema from the supplied row.
 func newParquetWriterFromRow(
-	row cdcevent.Row, sink io.Writer, maxRowGroupSize int64,
+	row cdcevent.Row, sink io.Writer, opts ...parquet.Option,
 ) (*parquetWriter, error) {
 	columnNames := make([]string, len(row.ResultColumns())+1)
 	columnTypes := make([]*types.T, len(row.ResultColumns())+1)
@@ -48,7 +48,12 @@ func newParquetWriterFromRow(
 		return nil, err
 	}
 
-	writer, err := parquet.NewWriter(schemaDef, sink, parquet.WithMaxRowGroupLength(maxRowGroupSize))
+	writerConstructor := parquet.NewWriter
+	if includeParquetTestMetadata {
+		writerConstructor = parquet.NewWriterWithReaderMeta
+	}
+
+	writer, err := writerConstructor(schemaDef, sink, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/parquet_test.go
+++ b/pkg/ccl/changefeedccl/parquet_test.go
@@ -38,6 +38,8 @@ func TestParquetRows(t *testing.T) {
 	// Rangefeed reader can time out under stress.
 	skip.UnderStress(t)
 
+	defer TestingSetIncludeParquetMetadata()()
+
 	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 		// TODO(#98816): cdctest.GetHydratedTableDescriptor does not work with tenant dbs.
@@ -110,7 +112,7 @@ func TestParquetRows(t *testing.T) {
 				require.NoError(t, err)
 
 				if writer == nil {
-					writer, err = newParquetWriterFromRow(updatedRow, f, maxRowGroupSize)
+					writer, err = newParquetWriterFromRow(updatedRow, f, parquet.WithMaxRowGroupLength(maxRowGroupSize))
 					if err != nil {
 						t.Fatalf(err.Error())
 					}

--- a/pkg/util/parquet/BUILD.bazel
+++ b/pkg/util/parquet/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "@com_github_apache_arrow_go_v11//parquet",
         "@com_github_apache_arrow_go_v11//parquet/compress",
         "@com_github_apache_arrow_go_v11//parquet/file",
+        "@com_github_apache_arrow_go_v11//parquet/metadata",
         "@com_github_apache_arrow_go_v11//parquet/schema",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_lib_pq//oid",

--- a/pkg/util/parquet/BUILD.bazel
+++ b/pkg/util/parquet/BUILD.bazel
@@ -33,7 +33,6 @@ go_library(
         "@com_github_apache_arrow_go_v11//parquet/schema",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_lib_pq//oid",
-        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/parquet/testutils.go
+++ b/pkg/util/parquet/testutils.go
@@ -11,24 +11,37 @@
 package parquet
 
 import (
+	"fmt"
+	"io"
 	"math"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/apache/arrow/go/v11/parquet"
 	"github.com/apache/arrow/go/v11/parquet/file"
+	"github.com/apache/arrow/go/v11/parquet/metadata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/errors"
-	"github.com/stretchr/testify/assert"
+	"github.com/lib/pq/oid"
 	"github.com/stretchr/testify/require"
 )
 
-// ReadFileAndVerifyDatums reads the parquetFile and first asserts its metadata
-// matches the metadata from the writer. Then, it reads the file and asserts
-// that it's data matches writtenDatums.
+// NewWriterWithReaderMeta constructs a Writer that writes additional metadata
+// required to use the reader utility functions below.
+func NewWriterWithReaderMeta(
+	sch *SchemaDefinition, sink io.Writer, opts ...Option,
+) (*Writer, error) {
+	opts = append(opts, WithMetadata(MakeReaderMetadata(sch)))
+	return NewWriter(sch, sink, opts...)
+}
+
+// ReadFileAndVerifyDatums asserts that a parquet file's metadata matches the
+// metadata from the writer and its data matches writtenDatums.
 func ReadFileAndVerifyDatums(
 	t *testing.T,
 	parquetFile string,
@@ -37,34 +50,91 @@ func ReadFileAndVerifyDatums(
 	writer *Writer,
 	writtenDatums [][]tree.Datum,
 ) {
-	f, err := os.Open(parquetFile)
-	require.NoError(t, err)
+	meta, readDatums, closeReader, err := ReadFile(parquetFile)
+	defer func() {
+		require.NoError(t, closeReader())
+	}()
 
-	reader, err := file.NewParquetReader(f)
 	require.NoError(t, err)
-
-	assert.Equal(t, reader.NumRows(), int64(numRows))
-	assert.Equal(t, reader.MetaData().Schema.NumColumns(), numCols)
+	require.Equal(t, int64(numRows), meta.GetNumRows())
+	require.Equal(t, numCols, meta.Schema.NumColumns())
 
 	numRowGroups := int(math.Ceil(float64(numRows) / float64(writer.cfg.maxRowGroupLength)))
-	assert.EqualValues(t, numRowGroups, reader.NumRowGroups())
+	require.EqualValues(t, numRowGroups, len(meta.GetRowGroups()))
 
-	readDatums := make([][]tree.Datum, numRows)
 	for i := 0; i < numRows; i++ {
-		readDatums[i] = make([]tree.Datum, numCols)
+		for j := 0; j < numCols; j++ {
+			ValidateDatum(t, writtenDatums[i][j], readDatums[i][j])
+		}
+	}
+}
+
+// ReadFile reads a parquet file and returns the contained metadata and datums.
+//
+// To use this function, the Writer must be configured to write CRDB-specific
+// metadata for the reader. See NewWriterWithReaderMeta.
+//
+// close() should be called to release the underlying reader once the returned
+// metadata is not required anymore. The returned metadata should not be used
+// after close() is called.
+//
+// NB: The returned datums may not be hydrated or identical to the ones
+// which were written. See comment on ValidateDatum for more info.
+func ReadFile(
+	parquetFile string,
+) (meta *metadata.FileMetaData, datums [][]tree.Datum, close func() error, err error) {
+	f, err := os.Open(parquetFile)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	reader, err := file.NewParquetReader(f)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var readDatums [][]tree.Datum
+
+	typFamiliesMeta := reader.MetaData().KeyValueMetadata().FindValue(typeFamilyMetaKey)
+	if typFamiliesMeta == nil {
+		return nil, nil, nil,
+			errors.AssertionFailedf("missing type family metadata. ensure the writer is configured" +
+				" to write reader metadata. see NewWriterWithReaderMeta()")
+	}
+	typFamilies, err := deserializeIntArray(*typFamiliesMeta)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	typOidsMeta := reader.MetaData().KeyValueMetadata().FindValue(typeOidMetaKey)
+	if typOidsMeta == nil {
+		return nil, nil, nil,
+			errors.AssertionFailedf("missing type oid metadata. ensure the writer is configured" +
+				" to write reader metadata. see NewWriterWithReaderMeta()")
+	}
+	typOids, err := deserializeIntArray(*typOidsMeta)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	startingRowIdx := 0
 	for rg := 0; rg < reader.NumRowGroups(); rg++ {
 		rgr := reader.RowGroup(rg)
 		rowsInRowGroup := rgr.NumRows()
+		for i := int64(0); i < rowsInRowGroup; i++ {
+			readDatums = append(readDatums, make([]tree.Datum, rgr.NumColumns()))
+		}
 
-		for colIdx := 0; colIdx < numCols; colIdx++ {
+		for colIdx := 0; colIdx < rgr.NumColumns(); colIdx++ {
 			col, err := rgr.Column(colIdx)
-			require.NoError(t, err)
+			if err != nil {
+				return nil, nil, nil, err
+			}
 
-			dec := writer.sch.cols[colIdx].decoder
-			typ := writer.sch.cols[colIdx].typ
+			dec, err := decoderFromFamilyAndType(oid.Oid(typOids[colIdx]), types.Family(typFamilies[colIdx]))
+			if err != nil {
+				return nil, nil, nil, err
+			}
 
 			// Based on how we define schemas, we can detect an array by seeing if the
 			// primitive col reader has a max repetition level of 1. See comments above
@@ -73,53 +143,85 @@ func ReadFileAndVerifyDatums(
 
 			switch col.Type() {
 			case parquet.Types.Boolean:
-				colDatums, read, err := readBatch(col, make([]bool, 1), dec, typ, isArray)
-				require.NoError(t, err)
-				require.Equal(t, rowsInRowGroup, read)
+				colDatums, read, err := readBatch(col, make([]bool, 1), dec, isArray)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				if read != rowsInRowGroup {
+					return nil, nil, nil,
+						errors.AssertionFailedf("expected to read %d values but found %d", rowsInRowGroup, read)
+				}
 				decodeValuesIntoDatumsHelper(colDatums, readDatums, colIdx, startingRowIdx)
 			case parquet.Types.Int32:
-				colDatums, read, err := readBatch(col, make([]int32, 1), dec, typ, isArray)
-				require.NoError(t, err)
-				require.Equal(t, rowsInRowGroup, read)
+				colDatums, read, err := readBatch(col, make([]int32, 1), dec, isArray)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				if read != rowsInRowGroup {
+					return nil, nil, nil,
+						errors.AssertionFailedf("expected to read %d values but found %d", rowsInRowGroup, read)
+				}
 				decodeValuesIntoDatumsHelper(colDatums, readDatums, colIdx, startingRowIdx)
 			case parquet.Types.Int64:
-				colDatums, read, err := readBatch(col, make([]int64, 1), dec, typ, isArray)
-				require.NoError(t, err)
-				require.Equal(t, rowsInRowGroup, read)
+				colDatums, read, err := readBatch(col, make([]int64, 1), dec, isArray)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				if read != rowsInRowGroup {
+					return nil, nil, nil,
+						errors.AssertionFailedf("expected to read %d values but found %d", rowsInRowGroup, read)
+				}
 				decodeValuesIntoDatumsHelper(colDatums, readDatums, colIdx, startingRowIdx)
 			case parquet.Types.Int96:
 				panic("unimplemented")
 			case parquet.Types.Float:
-				arrs, read, err := readBatch(col, make([]float32, 1), dec, typ, isArray)
-				require.NoError(t, err)
-				require.Equal(t, rowsInRowGroup, read)
+				arrs, read, err := readBatch(col, make([]float32, 1), dec, isArray)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				if read != rowsInRowGroup {
+					return nil, nil, nil,
+						errors.AssertionFailedf("expected to read %d values but found %d", rowsInRowGroup, read)
+				}
 				decodeValuesIntoDatumsHelper(arrs, readDatums, colIdx, startingRowIdx)
 			case parquet.Types.Double:
-				arrs, read, err := readBatch(col, make([]float64, 1), dec, typ, isArray)
-				require.NoError(t, err)
-				require.Equal(t, rowsInRowGroup, read)
+				arrs, read, err := readBatch(col, make([]float64, 1), dec, isArray)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				if read != rowsInRowGroup {
+					return nil, nil, nil,
+						errors.AssertionFailedf("expected to read %d values but found %d", rowsInRowGroup, read)
+				}
 				decodeValuesIntoDatumsHelper(arrs, readDatums, colIdx, startingRowIdx)
 			case parquet.Types.ByteArray:
-				colDatums, read, err := readBatch(col, make([]parquet.ByteArray, 1), dec, typ, isArray)
-				require.NoError(t, err)
-				require.Equal(t, rowsInRowGroup, read)
+				colDatums, read, err := readBatch(col, make([]parquet.ByteArray, 1), dec, isArray)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				if read != rowsInRowGroup {
+					return nil, nil, nil,
+						errors.AssertionFailedf("expected to read %d values but found %d", rowsInRowGroup, read)
+				}
 				decodeValuesIntoDatumsHelper(colDatums, readDatums, colIdx, startingRowIdx)
 			case parquet.Types.FixedLenByteArray:
-				colDatums, read, err := readBatch(col, make([]parquet.FixedLenByteArray, 1), dec, typ, isArray)
-				require.NoError(t, err)
-				require.Equal(t, rowsInRowGroup, read)
+				colDatums, read, err := readBatch(col, make([]parquet.FixedLenByteArray, 1), dec, isArray)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				if read != rowsInRowGroup {
+					return nil, nil, nil,
+						errors.AssertionFailedf("expected to read %d values but found %d", rowsInRowGroup, read)
+				}
 				decodeValuesIntoDatumsHelper(colDatums, readDatums, colIdx, startingRowIdx)
 			}
 		}
 		startingRowIdx += int(rowsInRowGroup)
 	}
-	require.NoError(t, reader.Close())
-
-	for i := 0; i < numRows; i++ {
-		for j := 0; j < numCols; j++ {
-			validateDatum(t, writtenDatums[i][j], readDatums[i][j])
-		}
-	}
+	// Since reader.MetaData() is being returned, we do not close the reader.
+	// This is defensive - we should not assume any method or data on the reader
+	// is safe to read once it is closed.
+	return reader.MetaData(), readDatums, reader.Close, nil
 }
 
 type batchReader[T parquetDatatypes] interface {
@@ -128,7 +230,7 @@ type batchReader[T parquetDatatypes] interface {
 
 // readBatch reads all the datums in a row group for a column.
 func readBatch[T parquetDatatypes](
-	r file.ColumnChunkReader, valueAlloc []T, dec decoder, typ *types.T, isArray bool,
+	r file.ColumnChunkReader, valueAlloc []T, dec decoder, isArray bool,
 ) (tree.Datums, int64, error) {
 	br, ok := r.(batchReader[T])
 	if !ok {
@@ -156,7 +258,7 @@ func readBatch[T parquetDatatypes](
 					result = append(result, tree.DNull)
 					continue
 				}
-				arrDatum := tree.NewDArray(typ)
+				arrDatum := &tree.DArray{}
 				result = append(result, arrDatum)
 				// Replevel 0, Deflevel 1 represents an array which is empty.
 				if defLevels[0] == 1 {
@@ -209,15 +311,16 @@ func unwrapDatum(d tree.Datum) tree.Datum {
 	}
 }
 
-// validateDatum validates that the "contents" of the expected datum matches the
+// ValidateDatum validates that the "contents" of the expected datum matches the
 // contents of the actual datum. For example, when validating two arrays, we
 // only compare the datums in the arrays. We do not compare CRDB-specific
 // metadata fields such as (tree.DArray).HasNulls or (tree.DArray).HasNonNulls.
 //
 // The reason for this special comparison that the parquet format is presently
 // used in an export use case, so we only need to test roundtripability with
-// data end users see. We do not need to check roundtripability of internal CRDB data.
-func validateDatum(t *testing.T, expected tree.Datum, actual tree.Datum) {
+// data end users see. We do not need to check roundtripability of internal CRDB
+// data.
+func ValidateDatum(t *testing.T, expected tree.Datum, actual tree.Datum) {
 	// The randgen library may generate datums wrapped in a *tree.DOidWrapper, so
 	// we should unwrap them. We unwrap at this stage as opposed to when
 	// generating datums to test that the writer can handle wrapped datums.
@@ -246,7 +349,7 @@ func validateDatum(t *testing.T, expected tree.Datum, actual tree.Datum) {
 		arr2 := actual.(*tree.DArray).Array
 		require.Equal(t, len(arr1), len(arr2))
 		for i := 0; i < len(arr1); i++ {
-			validateDatum(t, arr1[i], arr2[i])
+			ValidateDatum(t, arr1[i], arr2[i])
 		}
 	case types.EnumFamily:
 		require.Equal(t, expected.(*tree.DEnum).LogicalRep, actual.(*tree.DEnum).LogicalRep)
@@ -275,4 +378,43 @@ func makeTestingEnumType() *types.T {
 		},
 	}
 	return enumType
+}
+
+const typeOidMetaKey = `crdbTypeOIDs`
+const typeFamilyMetaKey = `crdbTypeFamilies`
+
+// MakeReaderMetadata returns column type metadata that will be written to all
+// parquet files. This metadata is useful for roundtrip tests where we construct
+// CRDB datums from the raw data in written to parquet files.
+func MakeReaderMetadata(sch *SchemaDefinition) map[string]string {
+	meta := map[string]string{}
+	typOids := make([]uint32, 0, len(sch.cols))
+	typFamilies := make([]int32, 0, len(sch.cols))
+	for _, col := range sch.cols {
+		typOids = append(typOids, uint32(col.typ.Oid()))
+		typFamilies = append(typFamilies, int32(col.typ.Family()))
+	}
+	meta[typeOidMetaKey] = serializeIntArray(typOids)
+	meta[typeFamilyMetaKey] = serializeIntArray(typFamilies)
+	return meta
+}
+
+// serializeIntArray serializes an int array to a string "23 2 32 43 32".
+func serializeIntArray[I int32 | uint32](ints []I) string {
+	return strings.Trim(fmt.Sprint(ints), "[]")
+}
+
+// deserializeIntArray deserializes an integer sting in the format "23 2 32 43
+// 32" to an array of ints.
+func deserializeIntArray(s string) ([]uint32, error) {
+	vals := strings.Split(s, " ")
+	result := make([]uint32, 0, len(vals))
+	for _, val := range vals {
+		intVal, err := strconv.Atoi(val)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, uint32(intVal))
+	}
+	return result, nil
 }

--- a/pkg/util/parquet/writer_test.go
+++ b/pkg/util/parquet/writer_test.go
@@ -121,7 +121,7 @@ func TestRandomDatums(t *testing.T) {
 	schemaDef, err := NewSchema(sch.columnNames, sch.columnTypes)
 	require.NoError(t, err)
 
-	writer, err := NewWriter(schemaDef, f, WithMaxRowGroupLength(maxRowGroupSize))
+	writer, err := NewWriterWithReaderMeta(schemaDef, f, WithMaxRowGroupLength(maxRowGroupSize))
 	require.NoError(t, err)
 
 	for _, row := range datums {
@@ -135,6 +135,8 @@ func TestRandomDatums(t *testing.T) {
 	ReadFileAndVerifyDatums(t, f.Name(), numRows, numCols, writer, datums)
 }
 
+// TestBasicDatums tests roundtripability for all supported scalar data types
+// and one simple array type.
 func TestBasicDatums(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
@@ -468,7 +470,7 @@ func TestBasicDatums(t *testing.T) {
 			schemaDef, err := NewSchema(tc.sch.columnNames, tc.sch.columnTypes)
 			require.NoError(t, err)
 
-			writer, err := NewWriter(schemaDef, f, WithMaxRowGroupLength(maxRowGroupSize))
+			writer, err := NewWriterWithReaderMeta(schemaDef, f, WithMaxRowGroupLength(maxRowGroupSize))
 			require.NoError(t, err)
 
 			for _, row := range datums {

--- a/pkg/util/parquet/writer_test.go
+++ b/pkg/util/parquet/writer_test.go
@@ -516,67 +516,77 @@ func TestInvalidWriterUsage(t *testing.T) {
 }
 
 func TestVersions(t *testing.T) {
-	schemaDef, err := NewSchema([]string{}, []*types.T{})
-	require.NoError(t, err)
-
 	for version := range allowedVersions {
-		fileName := "TestVersions.parquet"
-		f, err := os.CreateTemp("", fileName)
-		require.NoError(t, err)
-
-		writer, err := NewWriter(schemaDef, f, WithVersion(version))
-		require.NoError(t, err)
-
-		err = writer.Close()
-		require.NoError(t, err)
-
-		f, err = os.Open(f.Name())
-		require.NoError(t, err)
-
-		reader, err := file.NewParquetReader(f)
-		require.NoError(t, err)
-
-		require.Equal(t, reader.MetaData().Version(), writer.cfg.version)
-
-		err = reader.Close()
-		require.NoError(t, err)
+		opt := WithVersion(version)
+		optionsTest(t, opt, func(t *testing.T, reader *file.Reader) {
+			require.Equal(t, reader.MetaData().Version(), allowedVersions[version])
+		})
 	}
 
+	schemaDef, err := NewSchema([]string{}, []*types.T{})
+	require.NoError(t, err)
 	buf := bytes.Buffer{}
 	_, err = NewWriter(schemaDef, &buf, WithVersion("invalid"))
 	require.Error(t, err)
 }
 
 func TestCompressionCodecs(t *testing.T) {
+	for compression := range compressionCodecToParquet {
+		opt := WithCompressionCodec(compression)
+		optionsTest(t, opt, func(t *testing.T, reader *file.Reader) {
+			colChunk, err := reader.MetaData().RowGroup(0).ColumnChunk(0)
+			require.NoError(t, err)
+			require.Equal(t, colChunk.Compression(), compressionCodecToParquet[compression])
+		})
+	}
+}
+
+// TestMetadata tests writing arbitrary kv metadata to parquet files.
+func TestMetadata(t *testing.T) {
+	meta := map[string]string{}
+	meta["testKey1"] = "testValue1"
+	meta["testKey2"] = "testValue2"
+	opt := WithMetadata(meta)
+	optionsTest(t, opt, func(t *testing.T, reader *file.Reader) {
+		val := reader.MetaData().KeyValueMetadata().FindValue("testKey1")
+		require.NotNil(t, reader.MetaData().KeyValueMetadata().FindValue("testKey1"))
+		require.Equal(t, *val, "testValue1")
+
+		val = reader.MetaData().KeyValueMetadata().FindValue("testKey2")
+		require.NotNil(t, reader.MetaData().KeyValueMetadata().FindValue("testKey2"))
+		require.Equal(t, *val, "testValue2")
+	})
+}
+
+// optionsTest can be used to assert the behavior of an Option. It creates a
+// writer using the supplied Option and writes a parquet file with sample data.
+// Then it calls the provided test function with the reader and subsequently
+// closes it.
+func optionsTest(t *testing.T, opt Option, testFn func(t *testing.T, reader *file.Reader)) {
 	schemaDef, err := NewSchema([]string{"a"}, []*types.T{types.Int})
 	require.NoError(t, err)
 
-	for compression := range compressionCodecToParquet {
-		fileName := "TestCompressionCodecs.parquet"
-		f, err := os.CreateTemp("", fileName)
-		require.NoError(t, err)
+	fileName := "OptionsTest.parquet"
+	f, err := os.CreateTemp("", fileName)
+	require.NoError(t, err)
 
-		writer, err := NewWriter(schemaDef, f, WithCompressionCodec(compression))
-		require.NoError(t, err)
+	writer, err := NewWriter(schemaDef, f, opt)
+	require.NoError(t, err)
 
-		err = writer.AddRow([]tree.Datum{tree.NewDInt(0)})
-		require.NoError(t, err)
+	err = writer.AddRow([]tree.Datum{tree.NewDInt(0)})
+	require.NoError(t, err)
 
-		err = writer.Close()
-		require.NoError(t, err)
+	err = writer.Close()
+	require.NoError(t, err)
 
-		f, err = os.Open(f.Name())
-		require.NoError(t, err)
+	f, err = os.Open(f.Name())
+	require.NoError(t, err)
 
-		reader, err := file.NewParquetReader(f)
-		require.NoError(t, err)
+	reader, err := file.NewParquetReader(f)
+	require.NoError(t, err)
 
-		colChunk, err := reader.MetaData().RowGroup(0).ColumnChunk(0)
-		require.NoError(t, err)
+	testFn(t, reader)
 
-		require.Equal(t, colChunk.Compression(), compressionCodecToParquet[compression])
-
-		err = reader.Close()
-		require.NoError(t, err)
-	}
+	err = reader.Close()
+	require.NoError(t, err)
 }


### PR DESCRIPTION
util/parquet: add option to write kv metadata to files

This change adds an option to the writer which allows the caller
to write arbitrary kv metadata to parquet files. This is useful
for testing purposes.

Informs: https://github.com/cockroachdb/cockroach/issues/99028
Epic: https://cockroachlabs.atlassian.net/browse/CRDB-15071
Release note: None

---

util/parquet: remove dependency on writer to read parquet files

Previously, the test utils used to read parquet files
would require the writer as an argument. The main reason
the writer was required is that the writer contained
crdb-specific type information which could be used to
decode raw data until crdb datums.

With this change, the writer is updated to write this
crdb-specific type information to the parquet file in
its metadata. The reader is updated to the read type
information from the file metadata. There is a new
test utility function `ReadFile(parquetFile string)`
which can be used to read all datums from a parquet
file without providing any additional type information.
The function also returns metadata since it is possible
for users of the `Writer` to write arbitrary metadata
and such users may need this metadata in testing.

Informs: https://github.com/cockroachdb/cockroach/issues/99028
Epic: https://cockroachlabs.atlassian.net/browse/CRDB-15071
Release note: None