### PR TITLE
server: server identity returns nodeID for system tenant

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1070,7 +1070,7 @@ func (s *idProvider) ServerIdentityString(key serverident.ServerIdentificationKe
 	case serverident.IdentifyKVNodeID:
 		// If tenantID is set, this is a SQL-only server and it has no
 		// node ID.
-		if s.tenantID.IsSet() {
+		if s.tenantID.IsSet() && !s.tenantID.IsSystem() {
 			return ""
 		}
 		return s.maybeMemoizeServerID()


### PR DESCRIPTION
Previously, the server identity object would hide the nodeID from identity objects that contained a set tenantID. This was done to create separation of concerns between a secondary tenant and the rest of the cluster. However, this identity is used in populating log payloads with contextual metadata. That led to #103112 due to the fact that the system tenant sets its tenantId to 1 which led to a hidden nodeID.

We now always emit the nodeID when the tenantID is set to the system tenant.

Fixes #103112

Release note (bug fix): 23.1.0 contained a bug where the `node_id` field would be omitted in logs. This fix restores that value.