### PR TITLE
roachtest/sqlsmith: ignore injected internal error in sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -233,10 +233,12 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 			if err != nil {
 				es := err.Error()
 				if strings.Contains(es, "internal error") {
-					// TODO(yuzefovich): we temporarily ignore internal errors
-					// that are because of #40929.
 					var expectedError bool
 					for _, exp := range []string{
+						// Optimizer panic-injection surfaces as an internal error.
+						"injected panic in optimizer",
+						// TODO(yuzefovich): we temporarily ignore internal errors
+						// that are because of #40929.
 						"could not parse \"0E-2019\" as type decimal",
 					} {
 						expectedError = expectedError || strings.Contains(es, exp)


### PR DESCRIPTION
Panic injection for the optimizer was added to sqlsmith by #99868, but the (expected) internal errors were not ignored, which causes the test to fail. Since the purpose of the panic injection is to find uncaught panics, an internal error indicates all is well. This patch makes sqlsmith ignore errors that include the string: `injected panic in optimizer`.

Fixes #103167

Release note: None