### PR TITLE
sql: more redactable details about traces in logs

### DIFF
--- a/pkg/base/node_id.go
+++ b/pkg/base/node_id.go
@@ -184,6 +184,9 @@ func (s SQLInstanceID) String() string {
 	return strconv.Itoa(int(s))
 }
 
+// SafeValue implements the redact.SafeValue interface.
+func (s SQLInstanceID) SafeValue() {}
+
 // SQLIDContainer is a variant of NodeIDContainer that contains SQL instance IDs.
 type SQLIDContainer NodeIDContainer
 

--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -175,7 +175,7 @@ func (t *descriptorState) upsertLeaseLocked(
 	return nil, toRelease, nil
 }
 
-var _ redact.SafeMessager = (*descriptorVersionState)(nil)
+var _ redact.SafeFormatter = (*descriptorVersionState)(nil)
 
 func newDescriptorVersionState(
 	t *descriptorState,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -968,17 +968,18 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	if stmtThresholdSpan != nil {
 		stmtDur := timeutil.Since(ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionQueryReceived))
-		needRecording := stmtTraceThreshold < stmtDur
-		if needRecording {
+		if needRecording := stmtDur >= stmtTraceThreshold; needRecording {
 			rec := stmtThresholdSpan.FinishAndGetRecording(tracingpb.RecordingVerbose)
 			// NB: This recording does not include the commit for implicit
 			// transactions if the statement didn't auto-commit.
+			redactableStmt := p.FormatAstAsRedactableString(stmt.AST, &p.semaCtx.Annotations)
 			logTraceAboveThreshold(
 				ctx,
-				rec,
-				fmt.Sprintf("SQL stmt %s", stmt.AST.String()),
-				stmtTraceThreshold,
-				stmtDur,
+				rec,                /* recording */
+				"SQL statement",    /* opName */
+				redactableStmt,     /* detail */
+				stmtTraceThreshold, /* threshold */
+				stmtDur,            /* elapsed */
 			)
 		} else {
 			stmtThresholdSpan.Finish()
@@ -2938,26 +2939,20 @@ func (ex *connExecutor) recordTransactionFinish(
 	)
 }
 
-// logTraceAboveThreshold logs a span's recording if the duration is above a
-// given threshold. It is used when txn or stmt threshold tracing is enabled.
+// logTraceAboveThreshold logs a span's recording. It is used when txn or stmt threshold tracing is enabled.
 // This function assumes that sp is non-nil and threshold tracing was enabled.
+// The caller is responsible for only calling the function when elapsed >= threshold.
 func logTraceAboveThreshold(
-	ctx context.Context, r tracingpb.Recording, opName string, threshold, elapsed time.Duration,
+	ctx context.Context,
+	r tracingpb.Recording,
+	opName redact.RedactableString,
+	detail redact.RedactableString,
+	threshold, elapsed time.Duration,
 ) {
-	if elapsed < threshold {
-		return
-	}
 	if r == nil {
 		log.Warning(ctx, "missing trace when threshold tracing was enabled")
-		return
 	}
-	dump := r.String()
-	if len(dump) == 0 {
-		return
-	}
-	// Note that log lines larger than 65k are truncated in the debug zip (see
-	// #50166).
-	log.Infof(ctx, "%s took %s, exceeding threshold of %s:\n%s", opName, elapsed, threshold, dump)
+	log.SqlExec.Infof(ctx, "%s took %s, exceeding threshold of %s:\n%s\n%s", opName, elapsed, threshold, detail, r)
 }
 
 func (ex *connExecutor) execWithProfiling(

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2554,7 +2554,7 @@ func (st *SessionTracing) TraceRetryInformation(ctx context.Context, retries int
 
 // TraceExecStart conditionally emits a trace message at the moment
 // plan execution starts.
-func (st *SessionTracing) TraceExecStart(ctx context.Context, engine string) {
+func (st *SessionTracing) TraceExecStart(ctx context.Context, engine redact.SafeString) {
 	log.VEventfDepth(ctx, 2, 1, "execution starts: %s engine", engine)
 }
 

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_gogo_protobuf//types",
         "@org_golang_google_grpc//:go_default_library",

--- a/pkg/sql/execinfrapb/component_stats.go
+++ b/pkg/sql/execinfrapb/component_stats.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/optional"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+	"github.com/cockroachdb/redact"
 	"github.com/dustin/go-humanize"
 	"github.com/gogo/protobuf/types"
 )
@@ -76,6 +77,25 @@ func (s *ComponentStats) StatsForQueryPlan() []string {
 		result = append(result, fmt.Sprintf("%s: %v", key, value))
 	})
 	return result
+}
+
+// String implements fmt.Stringer and protoutil.Message.
+func (s *ComponentStats) String() string {
+	return redact.StringWithoutMarkers(s)
+}
+
+var _ redact.SafeFormatter = (*ComponentStats)(nil)
+
+// SafeValue implements redact.SafeValue.
+func (ComponentID_Type) SafeValue() {}
+
+// SafeFormat implements redact.SafeFormatter.
+func (s *ComponentStats) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("ComponentStats{ID: %v", s.Component)
+	s.formatStats(func(key string, value interface{}) {
+		w.Printf(", %s: %v", redact.SafeString(key), value)
+	})
+	w.SafeRune('}')
 }
 
 // formatStats calls fn for each statistic that is set.

--- a/pkg/sql/execinfrapb/component_stats.proto
+++ b/pkg/sql/execinfrapb/component_stats.proto
@@ -63,6 +63,8 @@ message ComponentID {
 // Depending on the component, not all statistics apply. For all fields, the zero
 // value indicates that the particular stat is not available.
 message ComponentStats {
+  option (gogoproto.goproto_stringer) = false;
+
   optional ComponentID component = 1 [(gogoproto.nullable) = false];
 
   optional NetworkRxStats net_rx = 2 [(gogoproto.nullable) = false];

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -58,6 +58,7 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"NodeIDContainer":  {},
 						"SQLIDContainer":   {},
 						"StoreIDContainer": {},
+						"SQLInstanceID":    {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/cli/exit": {
 						"Code": {},
@@ -133,6 +134,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"DescriptorVersion":            {},
 						"IndexDescriptorVersion":       {},
 						"MutationID":                   {},
+					},
+					"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb": {
+						"ComponentID_Type": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase": {
 						"FormatCode": {},

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -230,7 +230,7 @@ func (sp *Span) String() string {
 	return sp.OperationName()
 }
 
-// Redactable returns true if this Span's tracer is marked redactable
+// Redactable returns true if this Span's tracer is marked redactable.
 func (sp *Span) Redactable() bool {
 	if sp == nil || sp.i.isNoop() {
 		return false

--- a/pkg/util/tracing/tracingpb/recording.go
+++ b/pkg/util/tracing/tracingpb/recording.go
@@ -291,7 +291,7 @@ func (r Recording) visitSpan(sp RecordedSpan, depth int) []traceLogData {
 	})
 	for _, c := range childrenMetadata {
 		var sb redact.StringBuilder
-		sb.Printf("[%s: %s]", redact.SafeString(c.Operation), c.Metadata.String())
+		sb.Printf("[%s: %s]", redact.SafeString(c.Operation), c.Metadata)
 		ownLogs = append(ownLogs, conv(sb.RedactableString(), sp.StartTime, time.Time{}))
 	}
 

--- a/pkg/util/tracing/tracingpb/recording.go
+++ b/pkg/util/tracing/tracingpb/recording.go
@@ -265,12 +265,12 @@ func (r Recording) visitSpan(sp RecordedSpan, depth int) []traceLogData {
 	sb.SafeString(redact.SafeString(sp.Operation))
 
 	for _, tg := range sp.TagGroups {
-		var prefix string
+		var prefix redact.RedactableString
 		if tg.Name != AnonymousTagGroupName {
-			prefix = fmt.Sprintf("%s-", tg.Name)
+			prefix = redact.Sprint("%s-", redact.SafeString(tg.Name))
 		}
 		for _, tag := range tg.Tags {
-			sb.Printf(" %s%s:%s", redact.SafeString(prefix), redact.SafeString(tag.Key), tag.Value)
+			sb.Printf(" %s%s:%s", prefix, redact.SafeString(tag.Key), tag.Value)
 		}
 	}
 


### PR DESCRIPTION
Followup to #103034.
Fixes #103319.

Prior to this patch, the logging output for SQL statements / txns that exceeded the tracing threshold would mark the entire SQL statement syntax and the entire trace as redactable.

This commit improves the situation by making the statement syntax and the trace more finely redactable, ensuring that more details are included after redaction.

Note: the redaction is still pretty strong by default, as long as `trace.redactable.enabled` defaults to `false`. See #103884.

Release note (sql change): The logging output emitted when `sql.trace.stmt.enable_threshold` or `sql.trace.txn.enable_threshold` are set is now emited on the SQL_EXEC channel instead of DEV as previously.

Epic: CRDB-27642