### PR TITLE
roachprod: fix regression in propagateDiskLabels

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -886,15 +886,16 @@ func propagateDiskLabels(
 	argsPrefix = append(argsPrefix, "--project", project)
 
 	for zone, zoneHosts := range zoneToHostNames {
-		argsPrefix = append(argsPrefix, "--zone", zone)
+		zoneArg := []string{"--zone", zone}
 
 		for _, host := range zoneHosts {
-			host := host
+			hostName := host
 
 			g.Go(func() error {
-				args := append([]string(nil), argsPrefix...)
+				bootDiskArgs := append([]string(nil), argsPrefix...)
+				bootDiskArgs = append(bootDiskArgs, zoneArg...)
 				// N.B. boot disk has the same name as the host.
-				bootDiskArgs := append(args, host)
+				bootDiskArgs = append(bootDiskArgs, hostName)
 				cmd := exec.Command("gcloud", bootDiskArgs...)
 
 				output, err := cmd.CombinedOutput()
@@ -906,9 +907,10 @@ func propagateDiskLabels(
 
 			if !opts.SSDOpts.UseLocalSSD {
 				g.Go(func() error {
-					args := append([]string(nil), argsPrefix...)
+					persistentDiskArgs := append([]string(nil), argsPrefix...)
+					persistentDiskArgs = append(persistentDiskArgs, zoneArg...)
 					// N.B. additional persistent disks are suffixed with the offset, starting at 1.
-					persistentDiskArgs := append(args, fmt.Sprintf("%s-1", host))
+					persistentDiskArgs = append(persistentDiskArgs, fmt.Sprintf("%s-1", hostName))
 					cmd := exec.Command("gcloud", persistentDiskArgs...)
 
 					output, err := cmd.CombinedOutput()


### PR DESCRIPTION
Previous PR [1] fixed data races, and as a result of refactoring, introduced another bug.
When multiple zones are used, the `--zone` arg. is duplicated across all hosts.

Epic: none
Release note: None

[1] https://github.com/cockroachdb/cockroach/pull/103087