### PR TITLE
roachtest: always unstall on disk-stall failure

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -159,7 +159,15 @@ func runDiskStalledDetection(
 		m.ExpectDeath()
 	}
 	s.Stall(ctx, c.Node(1))
-	defer s.Unstall(ctx, c.Node(1))
+	{
+		// NB: We use a background context in the defer'ed unstall command,
+		// otherwise on test failure our c.Run calls will be ignored. Leaving
+		// the disk stalled will prevent artifact collection, making debugging
+		// difficult.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		defer s.Unstall(ctx, c.Node(1))
+	}
 
 	// Wait twice the maximum sync duration and check if our SQL connection to
 	// node 1 is still alive. It should've been terminated.


### PR DESCRIPTION
Previously, if the disk-stalled/* raochtests failed while the disk was stalled, a defer would attempt to unstall the disk before completing the test. This could fail if the context was cancelled. The stalled disk would then prevent collection of artifacts.

This change updates the defer'd Unstall call to use a background context that will never be cancelled.

Epic: none
Informs #102946
Release note: none