### PR TITLE
c2c: configure PartitionedStreamClient with 15 second KeepAlive policy

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -196,6 +196,11 @@ func makePlan(
 			execinfrapb.ProcessorCoreUnion{StreamIngestionFrontier: streamIngestionFrontierSpec},
 			execinfrapb.PostProcessSpec{}, streamIngestionResultTypes)
 
+		for src, dst := range streamIngestionFrontierSpec.SubscribingSQLInstances {
+			log.Infof(ctx, "physical replication src-dst pair: %s:%d",
+				src, dst)
+		}
+
 		p.PlanToStreamColMap = []int{0}
 		sql.FinalizePlan(ctx, planCtx, p)
 		return p, planCtx, nil

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -79,6 +80,8 @@ type c2cSetup struct {
 	gatewayNodes option.NodeListOption
 	promCfg      *prometheus.Config
 }
+
+const maxExpectedLatencyDefault = 2 * time.Minute
 
 var c2cPromMetrics = map[string]clusterstats.ClusterStat{
 	"LogicalMegabytes": {
@@ -320,6 +323,9 @@ type replicationSpec struct {
 
 	expectedNodeDeaths int32
 
+	// maxLatency override the maxAcceptedLatencyDefault.
+	maxAcceptedLatency time.Duration
+
 	// If non-empty, the test will be skipped with the supplied reason.
 	skip string
 
@@ -344,10 +350,10 @@ type replicationDriver struct {
 	rng     *rand.Rand
 }
 
-func makeReplicationDriver(t test.Test, c cluster.Cluster, rs replicationSpec) replicationDriver {
+func makeReplicationDriver(t test.Test, c cluster.Cluster, rs replicationSpec) *replicationDriver {
 	rng, seed := randutil.NewTestRand()
 	t.L().Printf(`Random Seed is %d`, seed)
-	return replicationDriver{
+	return &replicationDriver{
 		t:   t,
 		c:   c,
 		rs:  rs,
@@ -647,7 +653,11 @@ func (rd *replicationDriver) main(ctx context.Context) {
 
 	// latency verifier queries may error during a node shutdown event; therefore
 	// tolerate errors if we anticipate node deaths.
-	lv := makeLatencyVerifier("stream-ingestion", 0, 2*time.Minute, rd.t.L(),
+	maxExpectedLatency := maxExpectedLatencyDefault
+	if rd.rs.maxAcceptedLatency != 0 {
+		maxExpectedLatency = rd.rs.maxAcceptedLatency
+	}
+	lv := makeLatencyVerifier("stream-ingestion", 0, maxExpectedLatency, rd.t.L(),
 		getStreamIngestionJobInfo, rd.t.Status, rd.rs.expectedNodeDeaths > 0)
 	defer lv.maybeLogLatencyHist()
 
@@ -851,17 +861,17 @@ func (c c2cPhase) String() string {
 	}
 }
 
-// replResilienceSpec defines inputs to the replication resilience tests, set
+// replShutdownSpec defines inputs to the replication node shutdown tests, set
 // during roachtest registration. This can not be modified during roachtest
 // execution.
-type replResilienceSpec struct {
+type replShutdownSpec struct {
 	replicationSpec
 
 	onSrc         bool
 	onCoordinator bool
 }
 
-func (rsp *replResilienceSpec) name() string {
+func (rsp *replShutdownSpec) name() string {
 	var builder strings.Builder
 	builder.WriteString("c2c/shutdown")
 	if rsp.onSrc {
@@ -877,10 +887,10 @@ func (rsp *replResilienceSpec) name() string {
 	return builder.String()
 }
 
-// replResilienceDriver manages the execution of the replication resilience tests.
-type replResilienceDriver struct {
-	replicationDriver
-	rsp replResilienceSpec
+// replShutdownDriver manages the execution of the replication node shutdown tests.
+type replShutdownDriver struct {
+	*replicationDriver
+	rsp replShutdownSpec
 
 	// phase indicates the c2c phase a node shutdown will occur.
 	phase c2cPhase
@@ -892,18 +902,18 @@ type replResilienceDriver struct {
 	watcherNode  int
 }
 
-func makeReplResilienceDriver(
-	t test.Test, c cluster.Cluster, rsp replResilienceSpec,
-) replResilienceDriver {
+func makeReplShutdownDriver(
+	t test.Test, c cluster.Cluster, rsp replShutdownSpec,
+) replShutdownDriver {
 	rd := makeReplicationDriver(t, c, rsp.replicationSpec)
-	return replResilienceDriver{
+	return replShutdownDriver{
 		replicationDriver: rd,
 		phase:             c2cPhase(rd.rng.Intn(int(phaseCutover) + 1)),
 		rsp:               rsp,
 	}
 }
 
-func (rrd *replResilienceDriver) getJobIDs(ctx context.Context) {
+func (rrd *replShutdownDriver) getJobIDs(ctx context.Context) {
 	jobIDQuery := `SELECT job_id FROM [SHOW JOBS] WHERE job_type = '%s'`
 	testutils.SucceedsWithin(rrd.t, func() error {
 		if err := rrd.setup.dst.db.QueryRowContext(ctx, fmt.Sprintf(jobIDQuery,
@@ -918,18 +928,14 @@ func (rrd *replResilienceDriver) getJobIDs(ctx context.Context) {
 	}, time.Minute)
 }
 
-func (rrd *replResilienceDriver) getTargetInfo() (
-	*clusterInfo,
-	jobspb.JobID,
-	option.NodeListOption,
-) {
+func (rrd *replShutdownDriver) getTargetInfo() (*clusterInfo, jobspb.JobID, option.NodeListOption) {
 	if rrd.rsp.onSrc {
 		return rrd.setup.src, rrd.srcJobID, rrd.setup.src.nodes
 	}
 	return rrd.setup.dst, rrd.dstJobID, rrd.setup.dst.nodes
 }
 
-func (rrd *replResilienceDriver) getTargetAndWatcherNodes(ctx context.Context) {
+func (rrd *replShutdownDriver) getTargetAndWatcherNodes(ctx context.Context) {
 	var coordinatorNode int
 	info, jobID, nodes := rrd.getTargetInfo()
 
@@ -968,13 +974,13 @@ func (rrd *replResilienceDriver) getTargetAndWatcherNodes(ctx context.Context) {
 	rrd.watcherNode = findAnotherNode(targetNode)
 }
 
-func (rrd *replResilienceDriver) getPhase() c2cPhase {
+func getPhase(rd *replicationDriver, dstJobID jobspb.JobID) c2cPhase {
 	var jobStatus string
-	rrd.setup.dst.sysSQL.QueryRow(rrd.t, `SELECT status FROM [SHOW JOBS] WHERE job_id=$1`,
-		rrd.dstJobID).Scan(&jobStatus)
-	require.Equal(rrd.t, jobs.StatusRunning, jobs.Status(jobStatus))
+	rd.setup.dst.sysSQL.QueryRow(rd.t, `SELECT status FROM [SHOW JOBS] WHERE job_id=$1`,
+		dstJobID).Scan(&jobStatus)
+	require.Equal(rd.t, jobs.StatusRunning, jobs.Status(jobStatus))
 
-	streamIngestProgress := getJobProgress(rrd.t, rrd.setup.dst.sysSQL, rrd.dstJobID).GetStreamIngest()
+	streamIngestProgress := getJobProgress(rd.t, rd.setup.dst.sysSQL, dstJobID).GetStreamIngest()
 	if streamIngestProgress.ReplicatedTime.IsEmpty() {
 		return phaseInitialScan
 	}
@@ -984,15 +990,15 @@ func (rrd *replResilienceDriver) getPhase() c2cPhase {
 	return phaseCutover
 }
 
-func (rrd *replResilienceDriver) waitForTargetPhase() error {
+func waitForTargetPhase(rd *replicationDriver, dstJobID jobspb.JobID, targetPhase c2cPhase) error {
 	for {
-		currentPhase := rrd.getPhase()
-		rrd.t.L().Printf("Current Phase %s", currentPhase.String())
+		currentPhase := getPhase(rd, dstJobID)
+		rd.t.L().Printf("Current Phase %s", currentPhase.String())
 		switch {
-		case currentPhase < rrd.phase:
+		case currentPhase < targetPhase:
 			time.Sleep(5 * time.Second)
-		case currentPhase == rrd.phase:
-			rrd.t.L().Printf("In target phase %s", currentPhase.String())
+		case currentPhase == targetPhase:
+			rd.t.L().Printf("In target phase %s", currentPhase.String())
 			return nil
 		default:
 			return errors.New("c2c job past target phase")
@@ -1000,18 +1006,35 @@ func (rrd *replResilienceDriver) waitForTargetPhase() error {
 	}
 }
 
-func (rrd *replResilienceDriver) sleepBeforeResiliencyEvent() {
-	// Assuming every C2C phase lasts at least 5 seconds, introduce some waiting
+func sleepBeforeResiliencyEvent(rd *replicationDriver) {
+	// Assuming every C2C phase lasts at least 10 seconds, introduce some waiting
 	// before a resiliency event (e.g. a node shutdown) to ensure the event occurs
 	// once we're fully settled into the target phase (e.g. the stream ingestion
 	// processors have observed the cutover signal).
-	randomSleep := time.Duration(1+rrd.rng.Intn(2)) * time.Second
-	rrd.t.L().Printf("Take a %s power nap", randomSleep)
+	randomSleep := time.Duration(1+rd.rng.Intn(2)) * time.Second
+	rd.t.L().Printf("Take a %s power nap", randomSleep)
 	time.Sleep(randomSleep)
 }
 
+// getSrcDestNodePairs return list of src-dest node pairs that are directly connected to each
+// other for the replication stream.
+func getSrcDestNodePairs(rd *replicationDriver, progress *jobspb.StreamIngestionProgress) [][]int {
+	nodePairs := make([][]int, 0)
+	for srcID, progress := range progress.PartitionProgress {
+		srcNode, err := strconv.Atoi(srcID)
+		require.NoError(rd.t, err)
+
+		// The destination cluster indexes nodes starting at 1,
+		// but we need to record the roachprod node.
+		dstNode := int(progress.DestSQLInstanceID) + rd.rs.srcNodes
+		rd.t.L().Printf("Node Pair: Src %d; Dst %d ", srcNode, dstNode)
+		nodePairs = append(nodePairs, []int{srcNode, dstNode})
+	}
+	return nodePairs
+}
+
 func registerClusterReplicationResilience(r registry.Registry) {
-	for _, rsp := range []replResilienceSpec{
+	for _, rsp := range []replShutdownSpec{
 		{
 			onSrc:         true,
 			onCoordinator: true,
@@ -1046,7 +1069,7 @@ func registerClusterReplicationResilience(r registry.Registry) {
 		c2cRegisterWrapper(r, rsp.replicationSpec,
 			func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
-				rrd := makeReplResilienceDriver(t, c, rsp)
+				rrd := makeReplShutdownDriver(t, c, rsp)
 				rrd.t.L().Printf("Planning to shut down node during %s phase", rrd.phase)
 				rrd.setupC2C(ctx, t, c)
 
@@ -1102,8 +1125,8 @@ func registerClusterReplicationResilience(r registry.Registry) {
 				// successful c2c replication execution.
 				shutdownStarter := func() jobStarter {
 					return func(c cluster.Cluster, t test.Test) (string, error) {
-						require.NoError(t, rrd.waitForTargetPhase())
-						rrd.sleepBeforeResiliencyEvent()
+						require.NoError(t, waitForTargetPhase(rrd.replicationDriver, rrd.dstJobID, rrd.phase))
+						sleepBeforeResiliencyEvent(rrd.replicationDriver)
 						return fmt.Sprintf("%d", rrd.dstJobID), nil
 					}
 				}
@@ -1121,6 +1144,76 @@ func registerClusterReplicationResilience(r registry.Registry) {
 			},
 		)
 	}
+}
+
+// registerClusterReplicationDisconnect tests that a physical replication stream
+// succeeds if a source and destination node pair disconnects. When the pair
+// disconnects, we expect its pg connection to time out, causing the job to
+// retry. The job will recreate a topology, potentially with different src-node
+// pairings. If the disconnected nodes no longer match in the new topology, the
+// physical replication stream will make progress in the face of network
+// partition. In the unlikely event that the two disconnected nodes continue to
+// get paired together, the stream should catch up once the test driver
+// reconnects the nodes.
+func registerClusterReplicationDisconnect(r registry.Registry) {
+	sp := replicationSpec{
+		name:               "c2c/disconnect",
+		srcNodes:           3,
+		dstNodes:           3,
+		cpus:               4,
+		workload:           replicateKV{readPercent: 0, initRows: 1000000, maxBlockBytes: 1024},
+		timeout:            20 * time.Minute,
+		additionalDuration: 10 * time.Minute,
+		cutover:            2 * time.Minute,
+		maxAcceptedLatency: 12 * time.Minute,
+	}
+	c2cRegisterWrapper(r, sp, func(ctx context.Context, t test.Test, c cluster.Cluster) {
+		rd := makeReplicationDriver(t, c, sp)
+		rd.setupC2C(ctx, t, c)
+
+		shutdownSetupDone := make(chan struct{})
+
+		rd.replicationStartHook = func(ctx context.Context, rd *replicationDriver) {
+			defer close(shutdownSetupDone)
+		}
+		m := rd.newMonitor(ctx)
+		m.Go(func(ctx context.Context) error {
+			rd.main(ctx)
+			return nil
+		})
+
+		// Dont begin node disconnecion until c2c job is setup.
+		<-shutdownSetupDone
+		dstJobID := jobspb.JobID(getIngestionJobID(t, rd.setup.dst.sysSQL, rd.setup.dst.name))
+
+		// TODO(msbutler): disconnect nodes during a random phase
+		require.NoError(t, waitForTargetPhase(rd, dstJobID, phaseSteadyState))
+		sleepBeforeResiliencyEvent(rd)
+		ingestionProgress := getJobProgress(t, rd.setup.dst.sysSQL, dstJobID).GetStreamIngest()
+
+		srcDestConnections := getSrcDestNodePairs(rd, ingestionProgress)
+		randomNodePair := srcDestConnections[rand.Intn(len(srcDestConnections))]
+		disconnectDuration := sp.additionalDuration
+		rd.t.L().Printf("Disconnecting Src %d, Dest %d for %.2f minutes", randomNodePair[0],
+			randomNodePair[1], disconnectDuration.Minutes())
+
+		// Normally, the blackholeFailer is accessed through the failer interface,
+		// at least in the failover tests. Because this test shouldn't use all the
+		// failer interface calls (e.g. Setup(), and Ready()), we use the
+		// blakholeFailer struct directly. In other words, in this test, we
+		// shouldn't treat the blackholeFailer as an abstracted api.
+		blackholeFailer := &blackholeFailer{t: rd.t, c: rd.c, input: true, output: true}
+		blackholeFailer.FailPartial(ctx, randomNodePair[0], []int{randomNodePair[1]})
+
+		time.Sleep(disconnectDuration)
+		ingestionProgressUpdate := getJobProgress(t, rd.setup.dst.sysSQL, dstJobID).GetStreamIngest()
+
+		// Calling this will log the latest topology.
+		getSrcDestNodePairs(rd, ingestionProgressUpdate)
+		blackholeFailer.Cleanup(ctx)
+		rd.t.L().Printf("Nodes reconnected. C2C Job should eventually complete")
+		m.Wait()
+	})
 }
 
 func getIngestionJobID(t test.Test, dstSQL *sqlutils.SQLRunner, dstTenantName string) int {

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -35,6 +35,7 @@ func RegisterTests(r registry.Registry) {
 	registerClockMonotonicTests(r)
 	registerClusterToCluster(r)
 	registerClusterReplicationResilience(r)
+	registerClusterReplicationDisconnect(r)
 	registerConnectionLatencyTest(r)
 	registerCopy(r)
 	registerCopyFrom(r)


### PR DESCRIPTION
This patch configures the PartitionedStreamClient with a 15 second tcp
keepAlive, causing the job to more eagerly retry if a source-destination node
pairing disconnect for a significant amount of time. After replanning, the job
is likely to make progress because:
 - dsp.ParitionedSpans will likely exclude a totally partitioned source node
 - dsp.PartitionedSpans returns nodes in a non-deterministic order (I think),
   so when the destination job round robins node pairings, it is likely that
the src-dest matches will be different. This prevents two disconnected nodes
from getting matched again.

To test the keepAlive policy, this patch introduces the c2c/Disconnect
roachtest. The test disconnects a random pair of src-destination nodes
participating in the cross-cluster replication stream, for ten minutes, and
tests if the replication job is still able to complete.

This patch only introduces a disconnection during the steady state phase of the
job. A future PR will randomize when the disconnection will occur.

Lastly, while adding this test, I refactored the c2c resilience roachtest
driver to be a c2c node shutdown driver. I did this to prevent API bloat:
c2c/disconnect does not need all the state required for the node shutdown
tests.

Informs https://github.com/cockroachdb/cockroach/issues/89487

Release note: None