### PR TITLE
release-23.1: kvserver: include more non-redactable info in logs

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -260,6 +260,7 @@ go_test(
         "closed_timestamp_test.go",
         "consistency_queue_test.go",
         "debug_print_test.go",
+        "errors_test.go",
         "gossip_test.go",
         "helpers_test.go",
         "intent_resolver_integration_test.go",

--- a/pkg/kv/kvserver/errors_test.go
+++ b/pkg/kv/kvserver/errors_test.go
@@ -1,0 +1,29 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorFormatting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var e error = decommissionPurgatoryError{errors.New("hello")}
+	require.Equal(t, "hello", redact.Sprint(e).Redact().StripMarkers())
+	e = rangeMergePurgatoryError{errors.New("hello")}
+	require.Equal(t, "hello", redact.Sprint(e).Redact().StripMarkers())
+}

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -181,6 +181,13 @@ func (mq *mergeQueue) shouldQueue(
 // indicate that the error should send the range to purgatory.
 type rangeMergePurgatoryError struct{ error }
 
+var _ errors.SafeFormatter = decommissionPurgatoryError{}
+
+func (e rangeMergePurgatoryError) SafeFormatError(p errors.Printer) (next error) {
+	p.Print(e.error)
+	return nil
+}
+
 func (rangeMergePurgatoryError) PurgatoryErrorMarker() {}
 
 var _ PurgatoryError = rangeMergePurgatoryError{}

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -36,7 +36,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
-	"go.etcd.io/raft/v3"
+	"github.com/cockroachdb/redact"
+	raft "go.etcd.io/raft/v3"
 )
 
 const (
@@ -771,6 +772,13 @@ func (rq *replicateQueue) process(
 // that the error should send the range to purgatory.
 type decommissionPurgatoryError struct{ error }
 
+var _ errors.SafeFormatter = decommissionPurgatoryError{}
+
+func (e decommissionPurgatoryError) SafeFormatError(p errors.Printer) (next error) {
+	p.Print(e.error)
+	return nil
+}
+
 func (decommissionPurgatoryError) PurgatoryErrorMarker() {}
 
 var _ PurgatoryError = decommissionPurgatoryError{}
@@ -823,7 +831,7 @@ func (rq *replicateQueue) processOneChangeWithTracing(
 		loggingThreshold := rq.logTracesThresholdFunc(rq.store.cfg.Settings, repl)
 		exceededDuration := loggingThreshold > time.Duration(0) && processDuration > loggingThreshold
 
-		var traceOutput string
+		var traceOutput redact.RedactableString
 		traceLoggingNeeded := (err != nil || exceededDuration) && log.ExpensiveLogEnabled(ctx, 1)
 		if traceLoggingNeeded {
 			// If we have tracing spans from execChangeReplicasTxn, filter it from
@@ -832,7 +840,7 @@ func (rq *replicateQueue) processOneChangeWithTracing(
 			rec = filterTracingSpans(sp.GetConfiguredRecording(),
 				replicaChangeTxnGetDescOpName, replicaChangeTxnUpdateDescOpName,
 			)
-			traceOutput = fmt.Sprintf("\ntrace:\n%s", rec)
+			traceOutput = redact.Sprintf("\ntrace:\n%s", rec)
 		}
 
 		if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #103127.

/cc @cockroachdb/release

---

This patch ensures that the trace copy in replication errors includes non-redactable bits. It also ensures that the purgatory errors are properly included.

Release note: None
Epic: None

----

Release justification: improves observability
