### PR TITLE
ui: add load endpoint to advanced debug

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -555,6 +555,7 @@ export default function Debug() {
         <DebugTableRow title="Metrics">
           <DebugTableLink name="Variables" url="debug/metrics" />
           <DebugTableLink name="Prometheus" url="_status/vars" />
+          <DebugTableLink name="Load" url="_status/load" />
           <DebugTableLink name="Rules" url="api/v2/rules/" />
         </DebugTableRow>
         <DebugTableRow


### PR DESCRIPTION
The endpoint `_status/load` was missing from the
list of raw endpoints on the Advanced Debug page.
This commit adds to the list.

Fixes #83716

<img width="1244" alt="Screenshot 2023-05-12 at 1 11 02 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/e742201c-46af-4a29-a662-004fb5a733b4">


Release note (ui change): Add `_status/load` to the list of Raw Status Endpoints on the Advanced Debug page.