### PR TITLE
jobs: mark migration jobs as "automatic"

### DIFF
--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -158,6 +158,7 @@ var AutomaticJobTypes = [...]Type{
 	TypeAutoConfigEnvRunner,
 	TypeAutoConfigTask,
 	TypeKeyVisualizer,
+	TypeMigration,
 	TypeAutoUpdateSQLActivity,
 }
 


### PR DESCRIPTION
We create one-off jobs for every intermediate cluster version during upgrades, and it can spam the output of SHOW JOBS. For example:
```
  root@localhost:26257/defaultdb> SHOW JOBS;
          job_id       | job_type  |                description
  ---------------------+-----------+-----------------------------------------
    864558611492405249 | IMPORT    | IMPORT INTO testing2.public.logs(name, m
    864554910592598017 | MIGRATION | Upgrade to 22.2-102: "create sql activiy
    864554910267506689 | MIGRATION | Upgrade to 22.2-98: "change TTL for SQLS
    864554909978984449 | MIGRATION | Upgrade to 22.2-90: "create auto configr
    864554909707894785 | MIGRATION | Upgrade to 22.2-38: "create jobs metric
    864554909422551041 | MIGRATION | Upgrade to 22.2-32: "add tables and job
    864554909179969537 | MIGRATION | Upgrade to 22.1-42: "add default SQL sce
    864554908912189441 | MIGRATION | Upgrade to 0.0-12: "create default dataa
    864554908649947137 | MIGRATION | Upgrade to 0.0-10: "update system.locato
    864554908419293185 | MIGRATION | Upgrade to 0.0-8: "initialize the clustr
    864554908146270209 | MIGRATION | Upgrade to 0.0-6: "populate initial veri
    864554907898314753 | MIGRATION | Upgrade to 0.0-4: "enable diagnostics rp
    864554907587837953 | MIGRATION | Upgrade to 0.0-2: "add users and roles"
  (14 rows)
```
Release note: None