### PR TITLE
dev: have `--count` use `--runs_per_test` instead of `-test.count`

### DIFF
--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -64,7 +64,7 @@ type formatter func(context.Context, failure) (issues.IssueFormatter, issues.Pos
 
 func defaultFormatter(ctx context.Context, f failure) (issues.IssueFormatter, issues.PostRequest) {
 	teams := getOwner(ctx, f.packageName, f.testName)
-	repro := fmt.Sprintf("./dev test ./pkg/%s --race --stress -f %s TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1",
+	repro := fmt.Sprintf("./dev test ./pkg/%s --race --count 250 -f %s",
 		trimPkg(f.packageName), f.testName)
 
 	var projColID int

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -66,17 +66,17 @@ pkg/kv/kvserver:kvserver_test) instead.`,
     dev test pkg/spanconfig/... pkg/ccl/spanconfigccl/...
         Test multiple packages recursively
 
-    dev test --race --stress ...
-        Run a test under race and stress
+    dev test --stress --timeout=1m --test-args='-test.timeout 5s'
+        Stress for 1m until a test runs longer than 5s
+
+    dev test --race --count 250 ...
+        Run a test under race, 250 times in parallel
 
     dev test pkg/spanconfig/... --test-args '-test.trace=trace.out'
         Pass arguments to go test (see 'go help testflag'; prefix args with '-test.{arg}')
 
-    dev test pkg/spanconfig --stress --stress-args '-maxruns 1000 -p 4'
-        Pass arguments to github.com/cockroachdb/stress
-
-    dev test --stress --timeout=1m --test-args='-test.timeout 5s'
-        Stress for 1m until a test runs longer than 5s
+    dev test pkg/spanconfig --stress --stress-args '-maxruns 1000 -p 4' --timeout=10m
+        Pass arguments to github.com/cockroachdb/stress, run for 10 min
 
     dev test pkg/server -f=TestSpanStatsResponse -v --count=5 --vmodule='raft=1'
 `,
@@ -338,7 +338,7 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, "--test_arg", "-show-logs")
 	}
 	if count != 1 {
-		args = append(args, "--test_arg", fmt.Sprintf("-test.count=%d", count))
+		args = append(args, fmt.Sprintf("--runs_per_test=%d", count))
 	}
 	if vModule != "" {
 		args = append(args, "--test_arg", fmt.Sprintf("-vmodule=%s", vModule))

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -56,7 +56,7 @@ bazel test pkg/testutils:all pkg/util/limit:all --test_env=GOTRACEBACK=all --tes
 exec
 dev test pkg/spanconfig --count 5 --race
 ----
-bazel test --config=race pkg/spanconfig:all --test_env=GOTRACEBACK=all --test_arg -test.count=5 --test_output errors --build_event_binary_file=/tmp/path
+bazel test --config=race pkg/spanconfig:all --test_env=GOTRACEBACK=all --runs_per_test=5 --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/cmd/dev -f TestDataDriven/test --rewrite -v
@@ -67,7 +67,7 @@ bazel test pkg/cmd/dev:all --nocache_test_results --test_env=GOTRACEBACK=all --t
 exec
 dev test pkg/server -f=TestSpanStatsResponse -v --count=5 --vmodule=raft=1
 ----
-bazel test pkg/server:all --test_env=GOTRACEBACK=all --test_filter=TestSpanStatsResponse --test_arg -test.v --test_arg -test.count=5 --test_arg -vmodule=raft=1 --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
+bazel test pkg/server:all --test_env=GOTRACEBACK=all --test_filter=TestSpanStatsResponse --test_arg -test.v --runs_per_test=5 --test_arg -vmodule=raft=1 --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
 
 exec
 dev test --short


### PR DESCRIPTION
Since this uses parallelism, it's an appropriate replacement for
`stress` in many cases. Also update references to `--stress` elsewhere
to suggest just using this.

If you literally want to use `-test.count`, you can do
`--test_arg -test.count`.

Epic: none
Release note: None