### PR TITLE
ui: add missing latency info

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -147,13 +147,23 @@ export type StatementMetadata = {
   vec: boolean;
 };
 
+type LatencyInfo = {
+  max: number;
+  min: number;
+  p50: number;
+  p90: number;
+  p99: number;
+};
+
 type Statistics = {
   bytesRead: NumericStat;
   cnt: Long;
   firstAttemptCnt: Long;
   idleLat: NumericStat;
   indexes: string[];
+  lastErrorCode: string;
   lastExecAt: string;
+  latencyInfo: LatencyInfo;
   maxRetries: Long;
   nodes: Long[];
   numRows: NumericStat;
@@ -226,9 +236,17 @@ export function convertStatementRawFormatToAggregatedStatistics(
       idle_lat: s.statistics.statistics.idleLat,
       index_recommendations: s.statistics.index_recommendations,
       indexes: s.statistics.statistics.indexes,
+      last_error_code: s.statistics.statistics.lastErrorCode,
       last_exec_timestamp: stringToTimestamp(
         s.statistics.statistics.lastExecAt,
       ),
+      latency_info: {
+        max: s.statistics.statistics.latencyInfo.max,
+        min: s.statistics.statistics.latencyInfo.min,
+        p50: s.statistics.statistics.latencyInfo.p50,
+        p90: s.statistics.statistics.latencyInfo.p90,
+        p99: s.statistics.statistics.latencyInfo.p99,
+      },
       max_retries: s.statistics.statistics.maxRetries,
       nodes: s.statistics.statistics.nodes,
       num_rows: s.statistics.statistics.numRows,


### PR DESCRIPTION
The convert statement raw to aggregated function was missing some parameters, making some places on the UI show as NaN.
This commit adds the missing information.
Tests that would have caught this are being added as part of another PR with cypress tests.

Epic: none

Before
<img width="1330" alt="Screenshot 2023-05-12 at 2 35 11 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/d6869749-0c5e-4683-a813-28bb373e0148">


After
<img width="1148" alt="Screenshot 2023-05-12 at 2 34 45 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/98fc548c-1e5e-4ec9-9198-86757719c8a3">


Release note (bug fix): Add missing information on the index details page about latency information of most used fingerprints.