### PR TITLE
tracing: fix a bug in the previous commit

### DIFF
--- a/pkg/util/tracing/tracingpb/recorded_span.go
+++ b/pkg/util/tracing/tracingpb/recorded_span.go
@@ -199,7 +199,7 @@ func (m OperationMetadata) SafeFormat(s redact.SafePrinter, _ rune) {
 	if m.ContainsUnfinished {
 		s.Printf(", unfinished")
 	}
-	s.Print("}")
+	s.SafeRune('}')
 }
 
 func (c CapturedStack) String() string {


### PR DESCRIPTION
This was a shortcoming in  #103034.

The closing '}' in the representation of OperationMetadata is an unredactable safe string.

I will send a separate PR with a unit test.

Release note: None
Epic: CRDB-27642