### PR TITLE
ui,sqlstats: fix stmt type filter

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -50,7 +50,7 @@ func ExplainTreePlanNodeToJSON(node *appstatspb.ExplainTreePlanNode) json.JSON {
 //	  "title": "system.statement_statistics.metadata",
 //	  "type": "object",
 //	  "properties": {
-//	    "stmtTyp":              { "type": "string" },
+//	    "stmtType":             { "type": "string" },
 //	    "query":                { "type": "string" },
 //	    "db":                   { "type": "string" },
 //	    "distsql":              { "type": "boolean" },

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -41,7 +41,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 
 		expectedMetadataStrTemplate := `
 {
-  "stmtTyp":      "{{.String}}",
+  "stmtType":     "{{.String}}",
   "query":        "{{.String}}",
   "querySummary": "{{.String}}",
   "db":           "{{.String}}",
@@ -233,7 +233,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 
 		expectedMetadataStrTemplate := `
 			{
-				"stmtTyp":      "{{.String}}",
+				"stmtType":     "{{.String}}",
 				"query":        "{{.String}}",
 				"querySummary": "{{.String}}",
 				"db":           "{{.String}}",

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -92,7 +92,7 @@ type stmtStatsMetadata appstatspb.CollectedStatementStatistics
 
 func (s *stmtStatsMetadata) jsonFields() jsonFields {
 	return jsonFields{
-		{"stmtTyp", (*jsonString)(&s.Stats.SQLType)},
+		{"stmtType", (*jsonString)(&s.Stats.SQLType)},
 		{"query", (*jsonString)(&s.Key.Query)},
 		{"querySummary", (*jsonString)(&s.Key.QuerySummary)},
 		{"db", (*jsonString)(&s.Key.Database)},

--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -143,7 +143,7 @@ export type StatementMetadata = {
   implicitTxn: boolean;
   query: string;
   querySummary: string;
-  stmtTyp: string;
+  stmtType: string;
   vec: boolean;
 };
 
@@ -240,7 +240,7 @@ export function convertStatementRawFormatToAggregatedStatistics(
       rows_written: s.statistics.statistics.rowsWritten,
       run_lat: s.statistics.statistics.runLat,
       service_lat: s.statistics.statistics.svcLat,
-      sql_type: s.metadata.stmtTyp,
+      sql_type: s.metadata.stmtType,
     },
   };
 }

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -845,7 +845,7 @@ function FilterBadge(props: FilterBadgeProps): React.ReactElement {
       {value}
       <Cancel
         className={badge.closeArea}
-        onClick={() => removeFilter(filters, name, onRemoveFilter)}
+        onClick={() => removeFilter({ ...filters }, name, onRemoveFilter)}
       />
     </div>
   );


### PR DESCRIPTION
Previously, the filter badges were not working on CC when trying to update a read-only property.
There was also a typo in some json encoding, making the statement type to mismatch during encoding/decoding, making the stmt filters to also not work.
This commit fixes both issues.

Fixes #102374

Working on CC Console:
https://www.loom.com/share/6b25c7821d1546d585ba6deca10fbf3d

Release note (bug fix): Filter on SQL Activity page are now properly working and a type on the json object from `stmtTyp` to `stmtType` was fixed.