### PR TITLE
roachtest: change some cluster settings during mixed-version backups

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -275,6 +275,17 @@ func NewTest(
 	}
 }
 
+// RNG returns the underlying random number generator used by the
+// mixedversion framework to generate a test plan. This rng can be
+// used to make random decisions during test setup.
+//
+// Do NOT use the rng returned by this function in mixedversion hooks
+// (functions passed to `InMixedVersion` and similar). Instead, use
+// the rng instance directly passed as argument to those functions.
+func (t *Test) RNG() *rand.Rand {
+	return t.prng
+}
+
 // InMixedVersion adds a new mixed-version hook to the test. The
 // functionality in the function passed as argument to this function
 // will be tested in arbitrary mixed-version states. If multiple


### PR DESCRIPTION
This commit makes some final (for now) changes to the
`backup-restore/mixed-version` roachtest. Specifically:

* we set some backup/restore related cluster settings. These are
publicly documented settings and should help expose corner cases that
might be harder to come up naturally using the default settings. This
is an area that is known to need more tests, as described in a recent
postmortem [1].

* introduce a background function that executes statements that lead
to rows being inserted into system tables, particularly those that are
generally empty in most tests.

* simplify the workload setup in the test: the `bank` workload is
responsible for testing edge cases, while `tpcc` is a workload that
should better represent customer workloads.

* verify that backups taken in mixed-version can be restored both in
the previous version and in the next version. Previously, we were only
testing the next version.

Note that most of these changes are not specificaly related to the
mixed-version context this test is in. In the future, these features
should be packaged in a format that is easier to consume by other
tests.

[1] https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/3013804060/Postmortem+101963+revision+history+backups

Epic: none

Release note: None

