### PR TITLE
ui: no need to refresh page after error

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
@@ -106,7 +106,9 @@ class Layout extends React.Component<LayoutProps & RouteComponentProps> {
               <NavigationBar />
             </div>
             <div ref={this.contentRef} className="layout-panel__content">
-              <ErrorBoundary>{this.props.children}</ErrorBoundary>
+              <ErrorBoundary key={this.props.location.pathname}>
+                {this.props.children}
+              </ErrorBoundary>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Previously, if one page crashes on DB Console, all other pages would show the same error message and the user had to force a refresh on the browser to be able to see the other pages. Now only the broken page shows the error and all the other pages load as expected. The user still needs to force a refresh on the broken page if they want to retry.

Fixes #97533

https://www.loom.com/share/56a6d811d9604b7abe673c1430ee605e

Release note (ui change): If a page crashed, a force refresh is no longer required to be able to see the other pages on DB Console.