### PR TITLE
roachtest: add `failover` variants for replica deadlocks

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -22,8 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,6 +72,7 @@ func registerFailover(r registry.Registry) {
 			failureModeBlackholeRecv,
 			failureModeBlackholeSend,
 			failureModeCrash,
+			failureModeDeadlock,
 			failureModeDiskStall,
 			failureModePause,
 		} {
@@ -606,6 +609,7 @@ func runFailoverNonSystem(
 	// Create cluster.
 	opts := option.DefaultStartOpts()
 	settings := install.MakeClusterSettings()
+	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 
 	failer := makeFailer(t, c, failureMode, opts, settings)
 	failer.Setup(ctx)
@@ -745,6 +749,7 @@ func runFailoverLiveness(
 	// Create cluster. Don't schedule a backup as this roachtest reports to roachperf.
 	opts := option.DefaultStartOptsNoBackups()
 	settings := install.MakeClusterSettings()
+	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 
 	failer := makeFailer(t, c, failureMode, opts, settings)
 	failer.Setup(ctx)
@@ -888,6 +893,7 @@ func runFailoverSystemNonLiveness(
 	// Create cluster.
 	opts := option.DefaultStartOpts()
 	settings := install.MakeClusterSettings()
+	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 
 	failer := makeFailer(t, c, failureMode, opts, settings)
 	failer.Setup(ctx)
@@ -1006,6 +1012,7 @@ const (
 	failureModeBlackholeRecv failureMode = "blackhole-recv"
 	failureModeBlackholeSend failureMode = "blackhole-send"
 	failureModeCrash         failureMode = "crash"
+	failureModeDeadlock      failureMode = "deadlock"
 	failureModeDiskStall     failureMode = "disk-stall"
 	failureModePause         failureMode = "pause"
 	failureModeNoop          failureMode = "noop"
@@ -1063,6 +1070,15 @@ func makeFailerWithoutLocalNoop(
 			c:             c,
 			startOpts:     opts,
 			startSettings: settings,
+		}
+	case failureModeDeadlock:
+		return &deadlockFailer{
+			t:                t,
+			c:                c,
+			startOpts:        opts,
+			startSettings:    settings,
+			onlyLeaseholders: true,
+			numReplicas:      5,
 		}
 	case failureModeDiskStall:
 		return &diskStallFailer{
@@ -1247,6 +1263,98 @@ func (f *crashFailer) Fail(ctx context.Context, nodeID int) {
 
 func (f *crashFailer) Recover(ctx context.Context, nodeID int) {
 	f.c.Start(ctx, f.t.L(), f.startOpts, f.startSettings, f.c.Node(nodeID))
+}
+
+// deadlockFailer deadlocks replicas. In addition to deadlocks, this failure
+// mode is representative of all failure modes that leave a replica unresponsive
+// while the node is otherwise still functional.
+type deadlockFailer struct {
+	t                test.Test
+	c                cluster.Cluster
+	m                cluster.Monitor
+	startOpts        option.StartOpts
+	startSettings    install.ClusterSettings
+	onlyLeaseholders bool
+	numReplicas      int
+	locks            map[int][]roachpb.RangeID // track locks by node
+}
+
+func (f *deadlockFailer) String() string                             { return string(failureModeDeadlock) }
+func (f *deadlockFailer) CanUseLocal() bool                          { return true }
+func (f *deadlockFailer) Setup(context.Context)                      {}
+func (f *deadlockFailer) Ready(_ context.Context, m cluster.Monitor) { f.m = m }
+func (f *deadlockFailer) Cleanup(context.Context)                    {}
+
+func (f *deadlockFailer) Fail(ctx context.Context, nodeID int) {
+	require.NotZero(f.t, f.numReplicas)
+	if f.locks == nil {
+		f.locks = map[int][]roachpb.RangeID{}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second) // can take a while to lock
+	defer cancel()
+
+	predicate := `$1 = ANY(replicas)`
+	if f.onlyLeaseholders {
+		predicate += ` AND lease_holder = $1`
+	}
+
+	conn := f.c.Conn(ctx, f.t.L(), nodeID)
+	rows, err := conn.QueryContext(ctx, fmt.Sprintf(
+		`SELECT range_id, crdb_internal.unsafe_lock_replica(range_id, true) FROM [
+			SELECT range_id FROM [SHOW CLUSTER RANGES WITH DETAILS]
+			WHERE %s
+			ORDER BY random()
+			LIMIT $2
+		]`, predicate), nodeID, f.numReplicas)
+	require.NoError(f.t, err)
+	for rows.Next() {
+		var rangeID roachpb.RangeID
+		var locked bool
+		require.NoError(f.t, rows.Scan(&rangeID, &locked))
+		require.True(f.t, locked)
+		f.t.Status(fmt.Sprintf("locked r%d on n%d", rangeID, nodeID))
+		f.locks[nodeID] = append(f.locks[nodeID], rangeID)
+	}
+	require.NoError(f.t, rows.Err())
+}
+
+func (f *deadlockFailer) Recover(ctx context.Context, nodeID int) {
+	if f.locks == nil || len(f.locks[nodeID]) == 0 {
+		return
+	}
+
+	err := func() error {
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		conn, err := f.c.ConnE(ctx, f.t.L(), nodeID)
+		if err != nil {
+			return err
+		}
+		for _, rangeID := range f.locks[nodeID] {
+			var unlocked bool
+			err := conn.QueryRowContext(ctx,
+				`SELECT crdb_internal.unsafe_lock_replica($1, false)`, rangeID).Scan(&unlocked)
+			if err != nil {
+				return err
+			} else if !unlocked {
+				return errors.Errorf("r%d was not unlocked", rangeID)
+			} else {
+				f.t.Status(fmt.Sprintf("unlocked r%d on n%d", rangeID, nodeID))
+			}
+		}
+		return nil
+	}()
+	// We may have locked replicas that prevent us from connecting to the node
+	// again, so we fall back to restarting the node.
+	if err != nil {
+		f.t.Status(fmt.Sprintf("failed to unlock replicas on n%d, restarting node: %s", nodeID, err))
+		f.m.ExpectDeath()
+		f.c.Stop(ctx, f.t.L(), option.DefaultStopOpts(), f.c.Node(nodeID))
+		f.c.Start(ctx, f.t.L(), f.startOpts, f.startSettings, f.c.Node(nodeID))
+	}
+	delete(f.locks, nodeID)
 }
 
 // diskStallFailer stalls the disk indefinitely. This should cause the node to

--- a/pkg/kv/kvserver/kvserverbase/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverbase/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/quotapool",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvserver/kvserverbase/stores.go
+++ b/pkg/kv/kvserver/kvserverbase/stores.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 )
 
@@ -38,6 +39,10 @@ type Store interface {
 
 	// SetQueueActive disables/enables the named queue.
 	SetQueueActive(active bool, queue string) error
+
+	// GetReplicaMutexForTesting returns the mutex of the replica with the given
+	// range ID, or nil if no replica was found. This is used for testing.
+	GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.RWMutex
 }
 
 // UnsupportedStoresIterator is a StoresIterator that only returns "unsupported"

--- a/pkg/kv/kvserver/stores_base.go
+++ b/pkg/kv/kvserver/stores_base.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 )
@@ -91,5 +92,14 @@ func (s *baseStore) SetQueueActive(active bool, queue string) error {
 	}
 
 	kvQueue.SetDisabled(!active)
+	return nil
+}
+
+// GetReplicaMutexForTesting is part of kvserverbase.Store.
+func (s *baseStore) GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.RWMutex {
+	store := (*Store)(s)
+	if repl := store.GetReplicaIfExists(rangeID); repl != nil {
+		return &repl.mu.RWMutex
+	}
 	return nil
 }

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -104,6 +104,7 @@ go_library(
         "//pkg/util/bitarray",
         "//pkg/util/duration",
         "//pkg/util/encoding",
+        "//pkg/util/envutil",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/fuzzystrmatch",
         "//pkg/util/hlc",

--- a/pkg/sql/sem/builtins/builtinconstants/constants.go
+++ b/pkg/sql/sem/builtins/builtinconstants/constants.go
@@ -57,6 +57,7 @@ const (
 	CategorySystemInfo          = "System info"
 	CategorySystemRepair        = "System repair"
 	CategoryStreamIngestion     = "Stream Ingestion"
+	CategoryTesting             = "Testing"
 )
 
 const (

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2382,6 +2382,7 @@ var builtinOidsArray = []string{
 	2409: `st_bdpolyfromtext(str: string, srid: int) -> geometry`,
 	2410: `crdb_internal.pretty_value(raw_value: bytes) -> string`,
 	2411: `to_char(date: date, format: string) -> string`,
+	2412: `crdb_internal.unsafe_lock_replica(range_id: int, lock: bool) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
**builtins: add `crdb_internal.unsafe_lock_replica()`**

This patch adds `crdb_internal.unsafe_lock_replica()` which can be used to (un)lock a given replica mutex on the gateway node. It requires the env var `COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true`. This is useful to test replica deadlocks or stalls in end-to-end resiliency tests.
  
**roachtest: add `failover` variants for replica deadlocks**

This patch adds `failover` variants that benchmark the pMax unavailability when 5 random leaseholder replicas are deadlocked on a node. The node remains alive, and continues to heartbeat both via liveness and RPC, as do other replicas on the node. The deadlocked replicas will be entirely unresponsive however, and depending on the timing this can also cause deadlocks on other mutexes.

This failure mode is representative of all failure modes that leave a replica unresponsive. This includes disk stalls, which will also hold replica locks during the stall, but disk stalls have specialized handling in e.g. Pebble and during node heartbeats that eventually resolve them while deadlocks don't.

We currently don't handle this failure mode at all, and expect permanent unavailability.

Resolves #103192.
Epic: none
Release note: None