### PR TITLE
roachtest: add `failover` chaos tests

### DIFF
--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -179,15 +179,15 @@ func (p clusterReusePolicyOption) apply(spec *ClusterSpec) {
 	spec.ReusePolicy = p.p
 }
 
-type preferSSDOption struct{}
+type preferLocalSSDOption bool
 
-func (*preferSSDOption) apply(spec *ClusterSpec) {
-	spec.PreferLocalSSD = true
+func (o preferLocalSSDOption) apply(spec *ClusterSpec) {
+	spec.PreferLocalSSD = bool(o)
 }
 
-// PreferSSD prefers using local SSD, when possible.
-func PreferSSD() Option {
-	return &preferSSDOption{}
+// PreferLocalSSD specifies whether to prefer using local SSD, when possible.
+func PreferLocalSSD(prefer bool) Option {
+	return preferLocalSSDOption(prefer)
 }
 
 type terminateOnMigrationOption struct{}

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -77,7 +77,7 @@ func (r *testRegistryImpl) MakeClusterSpec(nodeCount int, opts ...spec.Option) s
 	// overrides the SSD and zones settings from the registry.
 	var finalOpts []spec.Option
 	if r.preferSSD {
-		finalOpts = append(finalOpts, spec.PreferSSD())
+		finalOpts = append(finalOpts, spec.PreferLocalSSD(true))
 	}
 	if r.zones != "" {
 		finalOpts = append(finalOpts, spec.Zones(r.zones))

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -28,7 +28,8 @@ func TestMakeTestRegistry(t *testing.T) {
 		require.Equal(t, "foo", r.instanceType)
 		require.Equal(t, spec.AWS, r.cloud)
 
-		s := r.MakeClusterSpec(100, spec.Geo(), spec.Zones("zone99"), spec.CPU(12), spec.PreferSSD())
+		s := r.MakeClusterSpec(100, spec.Geo(), spec.Zones("zone99"), spec.CPU(12),
+			spec.PreferLocalSSD(true))
 		require.EqualValues(t, 100, s.NodeCount)
 		require.Equal(t, "foo", s.InstanceType)
 		require.True(t, s.Geo)

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -165,7 +165,7 @@ func runFailoverPartialLeaseGateway(
 	opts := option.DefaultStartOpts()
 	settings := install.MakeClusterSettings()
 
-	failer := makeFailer(t, c, failureModeBlackhole, opts, settings).(partialFailer)
+	failer := makeFailer(t, c, failureModeBlackhole, opts, settings).(PartialFailer)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
@@ -317,7 +317,7 @@ func runFailoverPartialLeaseLeader(
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_DISABLE_LEADER_FOLLOWS_LEASEHOLDER=true")
 
-	failer := makeFailer(t, c, failureModeBlackhole, opts, settings).(partialFailer)
+	failer := makeFailer(t, c, failureModeBlackhole, opts, settings).(PartialFailer)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
@@ -469,7 +469,7 @@ func runFailoverPartialLeaseLiveness(
 	opts := option.DefaultStartOpts()
 	settings := install.MakeClusterSettings()
 
-	failer := makeFailer(t, c, failureModeBlackhole, opts, settings).(partialFailer)
+	failer := makeFailer(t, c, failureModeBlackhole, opts, settings).(PartialFailer)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
@@ -1026,7 +1026,7 @@ func makeFailer(
 	failureMode failureMode,
 	opts option.StartOpts,
 	settings install.ClusterSettings,
-) failer {
+) Failer {
 	f := makeFailerWithoutLocalNoop(t, c, failureMode, opts, settings)
 	if c.IsLocal() && !f.CanUseLocal() {
 		t.Status(fmt.Sprintf(
@@ -1043,7 +1043,7 @@ func makeFailerWithoutLocalNoop(
 	failureMode failureMode,
 	opts option.StartOpts,
 	settings install.ClusterSettings,
-) failer {
+) Failer {
 	switch failureMode {
 	case failureModeBlackhole:
 		return &blackholeFailer{
@@ -1101,8 +1101,8 @@ func makeFailerWithoutLocalNoop(
 	}
 }
 
-// failer fails and recovers a given node in some particular way.
-type failer interface {
+// Failer fails and recovers a given node in some particular way.
+type Failer interface {
 	fmt.Stringer
 
 	// CanUseLocal returns true if the failer can be run with a local cluster.
@@ -1125,9 +1125,9 @@ type failer interface {
 	Recover(ctx context.Context, nodeID int)
 }
 
-// partialFailer supports partial failures between specific node pairs.
-type partialFailer interface {
-	failer
+// PartialFailer supports partial failures between specific node pairs.
+type PartialFailer interface {
+	Failer
 
 	// FailPartial fails the node for the given peers.
 	FailPartial(ctx context.Context, nodeID int, peerIDs []int)

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -77,17 +77,13 @@ func registerFailover(r registry.Registry) {
 			failureModePause,
 		} {
 			failureMode := failureMode // pin loop variable
-			makeSpec := func(nNodes, nCPU int) spec.ClusterSpec {
-				s := r.MakeClusterSpec(nNodes, spec.CPU(nCPU))
-				if failureMode == failureModeDiskStall {
-					// Use PDs in an attempt to work around flakes encountered when using
-					// SSDs. See #97968.
-					s.PreferLocalSSD = false
-				}
-				return s
-			}
-			var postValidation registry.PostValidation = 0
+
+			var usePD bool
+			var postValidation registry.PostValidation
 			if failureMode == failureModeDiskStall {
+				// Use PDs in an attempt to work around flakes encountered when using
+				// SSDs. See #97968.
+				usePD = true
 				postValidation = registry.PostValidationNoDeadNodes
 			}
 			r.Add(registry.TestSpec{
@@ -95,7 +91,7 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Timeout:             30 * time.Minute,
 				SkipPostValidations: postValidation,
-				Cluster:             makeSpec(7 /* nodes */, 4 /* cpus */),
+				Cluster:             r.MakeClusterSpec(7, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runFailoverNonSystem(ctx, t, c, failureMode, expirationLeases)
 				},
@@ -105,7 +101,7 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Timeout:             30 * time.Minute,
 				SkipPostValidations: postValidation,
-				Cluster:             makeSpec(5 /* nodes */, 4 /* cpus */),
+				Cluster:             r.MakeClusterSpec(5, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runFailoverLiveness(ctx, t, c, failureMode, expirationLeases)
 				},
@@ -115,7 +111,7 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Timeout:             30 * time.Minute,
 				SkipPostValidations: postValidation,
-				Cluster:             makeSpec(7 /* nodes */, 4 /* cpus */),
+				Cluster:             r.MakeClusterSpec(7, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runFailoverSystemNonLiveness(ctx, t, c, failureMode, expirationLeases)
 				},

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -1105,6 +1105,9 @@ func makeFailerWithoutLocalNoop(
 type Failer interface {
 	fmt.Stringer
 
+	// Mode returns the failure mode of the failer.
+	Mode() failureMode
+
 	// CanUseLocal returns true if the failer can be run with a local cluster.
 	CanUseLocal() bool
 
@@ -1136,7 +1139,8 @@ type PartialFailer interface {
 // noopFailer doesn't do anything.
 type noopFailer struct{}
 
-func (f *noopFailer) String() string                          { return string(failureModeNoop) }
+func (f *noopFailer) Mode() failureMode                       { return failureModeNoop }
+func (f *noopFailer) String() string                          { return string(f.Mode()) }
 func (f *noopFailer) CanUseLocal() bool                       { return true }
 func (f *noopFailer) Setup(context.Context)                   {}
 func (f *noopFailer) Ready(context.Context, cluster.Monitor)  {}
@@ -1158,15 +1162,16 @@ type blackholeFailer struct {
 	output bool
 }
 
-func (f *blackholeFailer) String() string {
+func (f *blackholeFailer) Mode() failureMode {
 	if f.input && !f.output {
-		return string(failureModeBlackholeRecv)
+		return failureModeBlackholeRecv
 	} else if f.output && !f.input {
-		return string(failureModeBlackholeSend)
+		return failureModeBlackholeSend
 	}
-	return string(failureModeBlackhole)
+	return failureModeBlackhole
 }
 
+func (f *blackholeFailer) String() string                         { return string(f.Mode()) }
 func (f *blackholeFailer) CanUseLocal() bool                      { return false } // needs iptables
 func (f *blackholeFailer) Setup(context.Context)                  {}
 func (f *blackholeFailer) Ready(context.Context, cluster.Monitor) {}
@@ -1250,7 +1255,8 @@ type crashFailer struct {
 	startSettings install.ClusterSettings
 }
 
-func (f *crashFailer) String() string                             { return string(failureModeCrash) }
+func (f *crashFailer) Mode() failureMode                          { return failureModeCrash }
+func (f *crashFailer) String() string                             { return string(f.Mode()) }
 func (f *crashFailer) CanUseLocal() bool                          { return true }
 func (f *crashFailer) Setup(_ context.Context)                    {}
 func (f *crashFailer) Ready(_ context.Context, m cluster.Monitor) { f.m = m }
@@ -1279,7 +1285,8 @@ type deadlockFailer struct {
 	locks            map[int][]roachpb.RangeID // track locks by node
 }
 
-func (f *deadlockFailer) String() string                             { return string(failureModeDeadlock) }
+func (f *deadlockFailer) Mode() failureMode                          { return failureModeDeadlock }
+func (f *deadlockFailer) String() string                             { return string(f.Mode()) }
 func (f *deadlockFailer) CanUseLocal() bool                          { return true }
 func (f *deadlockFailer) Setup(context.Context)                      {}
 func (f *deadlockFailer) Ready(_ context.Context, m cluster.Monitor) { f.m = m }
@@ -1368,7 +1375,8 @@ type diskStallFailer struct {
 	staller       diskStaller
 }
 
-func (f *diskStallFailer) String() string    { return string(failureModeDiskStall) }
+func (f *diskStallFailer) Mode() failureMode { return failureModeDiskStall }
+func (f *diskStallFailer) String() string    { return string(f.Mode()) }
 func (f *diskStallFailer) CanUseLocal() bool { return false } // needs dmsetup
 
 func (f *diskStallFailer) Setup(ctx context.Context) {
@@ -1408,10 +1416,11 @@ type pauseFailer struct {
 	c cluster.Cluster
 }
 
-func (f *pauseFailer) String() string              { return string(failureModePause) }
-func (f *pauseFailer) CanUseLocal() bool           { return true }
-func (f *pauseFailer) Setup(ctx context.Context)   {}
-func (f *pauseFailer) Cleanup(ctx context.Context) {}
+func (f *pauseFailer) Mode() failureMode       { return failureModePause }
+func (f *pauseFailer) String() string          { return string(f.Mode()) }
+func (f *pauseFailer) CanUseLocal() bool       { return true }
+func (f *pauseFailer) Setup(context.Context)   {}
+func (f *pauseFailer) Cleanup(context.Context) {}
 
 func (f *pauseFailer) Ready(ctx context.Context, m cluster.Monitor) {
 	// The process pause can trip the disk stall detector, so we disable it.

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -37,6 +37,25 @@ func registerFailover(r registry.Registry) {
 			suffix = "/lease=expiration"
 		}
 
+		for _, readOnly := range []bool{false, true} {
+			readOnly := readOnly // pin loop variable
+			suffix := suffix
+			if readOnly {
+				suffix = "/read-only" + suffix
+			} else {
+				suffix = "/read-write" + suffix
+			}
+			r.Add(registry.TestSpec{
+				Name:    "failover/chaos" + suffix,
+				Owner:   registry.OwnerKV,
+				Timeout: 60 * time.Minute,
+				Cluster: r.MakeClusterSpec(10, spec.CPU(4), spec.PreferLocalSSD(false)), // uses disk stalls
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runFailoverChaos(ctx, t, c, readOnly, expirationLeases)
+				},
+			})
+		}
+
 		r.Add(registry.TestSpec{
 			Name:    "failover/partial/lease-gateway" + suffix,
 			Owner:   registry.OwnerKV,
@@ -67,15 +86,7 @@ func registerFailover(r registry.Registry) {
 			},
 		})
 
-		for _, failureMode := range []failureMode{
-			failureModeBlackhole,
-			failureModeBlackholeRecv,
-			failureModeBlackholeSend,
-			failureModeCrash,
-			failureModeDeadlock,
-			failureModeDiskStall,
-			failureModePause,
-		} {
+		for _, failureMode := range allFailureModes {
 			failureMode := failureMode // pin loop variable
 
 			var usePD bool
@@ -118,6 +129,181 @@ func registerFailover(r registry.Registry) {
 			})
 		}
 	}
+}
+
+// runFailoverChaos sets up a 9-node cluster with RF=5 and randomly scattered
+// ranges and replicas, and then runs a random failure on one or two random
+// nodes for 1 minute with 1 minute recovery, for 20 cycles total. Nodes n1-n2
+// are used as SQL gateways, and are not failed to avoid disconnecting the
+// client workload.
+//
+// It runs with either a read-write or read-only KV workload, measuring the pMax
+// unavailability for graphing. The read-only workload is useful to test e.g.
+// recovering nodes stealing Raft leadership away, since this requires the
+// replica to still be up-to-date on the log.
+func runFailoverChaos(
+	ctx context.Context, t test.Test, c cluster.Cluster, readOnly, expLeases bool,
+) {
+	require.Equal(t, 10, c.Spec().NodeCount)
+
+	rng, _ := randutil.NewTestRand()
+
+	// Create cluster, and set up failers for all failure modes.
+	opts := option.DefaultStartOpts()
+	settings := install.MakeClusterSettings()
+	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
+	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
+
+	failers := []Failer{}
+	for _, failureMode := range allFailureModes {
+		failer := makeFailerWithoutLocalNoop(t, c, failureMode, opts, settings)
+		if c.IsLocal() && !failer.CanUseLocal() {
+			t.Status(fmt.Sprintf("skipping failure mode %q on local cluster", failureMode))
+			continue
+		}
+		failer.Setup(ctx)
+		defer failer.Cleanup(ctx)
+		failers = append(failers, failer)
+	}
+
+	c.Put(ctx, t.Cockroach(), "./cockroach")
+	c.Start(ctx, t.L(), opts, settings, c.Range(1, 9))
+
+	conn := c.Conn(ctx, t.L(), 1)
+	defer conn.Close()
+
+	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
+		expLeases)
+	require.NoError(t, err)
+
+	// Place 5 replicas of all ranges on n3-n9, keeping n1-n2 as SQL gateways.
+	configureAllZones(t, ctx, conn, zoneConfig{replicas: 5, onlyNodes: []int{3, 4, 5, 6, 7, 8, 9}})
+
+	// Wait for upreplication.
+	require.NoError(t, WaitForReplication(ctx, t, conn, 5 /* replicationFactor */))
+
+	// Create the kv database. If this is a read-only workload, populate it with
+	// 100.000 keys.
+	var insertCount int
+	if readOnly {
+		insertCount = 100000
+	}
+	t.Status("creating workload database")
+	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	require.NoError(t, err)
+	c.Run(ctx, c.Node(10), fmt.Sprintf(
+		`./cockroach workload init kv --splits 1000 --insert-count %d {pgurl:1}`, insertCount))
+
+	// Scatter the ranges, then relocate them off of the SQL gateways n1-n2.
+	t.Status("scattering table")
+	_, err = conn.ExecContext(ctx, `ALTER TABLE kv.kv SCATTER`)
+	require.NoError(t, err)
+	relocateRanges(t, ctx, conn, `true`, []int{1, 2}, []int{3, 4, 5, 6, 7, 8, 9})
+
+	// Wait for upreplication of the new ranges.
+	require.NoError(t, WaitForReplication(ctx, t, conn, 5 /* replicationFactor */))
+
+	// Start workload on n10 using n1-n2 as gateways.
+	t.Status("running workload")
+	m := c.NewMonitor(ctx, c.Range(1, 9))
+	m.Go(func(ctx context.Context) error {
+		readPercent := 50
+		if readOnly {
+			readPercent = 100
+		}
+		c.Run(ctx, c.Node(10), fmt.Sprintf(
+			`./cockroach workload run kv --read-percent %d --write-seq R%d `+
+				`--duration 45m --concurrency 256 --max-rate 8192 --timeout 1m --tolerate-errors `+
+				`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
+				`{pgurl:1-2}`, readPercent, insertCount))
+		return nil
+	})
+
+	// Start a worker to randomly fail random nodes for 1 minute, with 20 cycles.
+	m.Go(func(ctx context.Context) error {
+		var raftCfg base.RaftConfig
+		raftCfg.SetDefaults()
+
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+
+		for i := 0; i < 20; i++ {
+			select {
+			case <-ticker.C:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			// Pick 1 or 2 random nodes and failure modes.
+			nodeFailers := map[int]Failer{}
+			for numNodes := 1 + rng.Intn(2); len(nodeFailers) < numNodes; {
+				var node int
+				for node == 0 || nodeFailers[node] != nil {
+					node = 3 + rng.Intn(7) // n1-n2 are SQL gateways, n10 is workload runner
+				}
+				var failer Failer
+				for failer == nil {
+					failer = failers[rng.Intn(len(failers))]
+					for _, other := range nodeFailers {
+						if !other.CanRunWith(failer.Mode()) || !failer.CanRunWith(other.Mode()) {
+							failer = nil // failers aren't compatible, pick a different one
+							break
+						}
+					}
+				}
+				if d, ok := failer.(*deadlockFailer); ok { // randomize deadlockFailer
+					d.numReplicas = 1 + rng.Intn(10)
+					d.onlyLeaseholders = rng.Float64() < 0.5
+				}
+				failer.Ready(ctx, m)
+				nodeFailers[node] = failer
+			}
+
+			randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
+
+			// Ranges may occasionally escape their constraints. Move them to where
+			// they should be.
+			relocateRanges(t, ctx, conn, `true`, []int{1, 2}, []int{3, 4, 5, 6, 7, 8, 9})
+
+			// Randomly sleep up to the lease renewal interval, to vary the time
+			// between the last lease renewal and the failure. We start the timer
+			// before the range relocation above to run them concurrently.
+			select {
+			case <-randTimer:
+			case <-ctx.Done():
+			}
+
+			for node, failer := range nodeFailers {
+				// If the failer supports partial failures (e.g. partial partitions), do
+				// one with 50% probability against a random node (including SQL
+				// gateways).
+				if partialFailer, ok := failer.(PartialFailer); ok && rng.Float64() < 0.5 {
+					var partialPeer int
+					for partialPeer == 0 || partialPeer == node {
+						partialPeer = 1 + rng.Intn(9)
+					}
+					t.Status(fmt.Sprintf("failing n%d to n%d (%s)", node, partialPeer, failer))
+					partialFailer.FailPartial(ctx, node, []int{partialPeer})
+				} else {
+					t.Status(fmt.Sprintf("failing n%d (%s)", node, failer))
+					failer.Fail(ctx, node)
+				}
+			}
+
+			select {
+			case <-ticker.C:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			for node, failer := range nodeFailers {
+				t.Status(fmt.Sprintf("recovering n%d (%s)", node, failer))
+				failer.Recover(ctx, node)
+			}
+		}
+		return nil
+	})
+	m.Wait()
 }
 
 // runFailoverPartialLeaseGateway tests a partial network partition between a
@@ -1020,6 +1206,17 @@ const (
 	failureModeNoop          failureMode = "noop"
 )
 
+var allFailureModes = []failureMode{
+	failureModeBlackhole,
+	failureModeBlackholeRecv,
+	failureModeBlackholeSend,
+	failureModeCrash,
+	failureModeDeadlock,
+	failureModeDiskStall,
+	failureModePause,
+	// failureModeNoop intentionally omitted
+}
+
 // makeFailer creates a new failer for the given failureMode. It may return a
 // noopFailer on local clusters.
 func makeFailer(
@@ -1113,6 +1310,11 @@ type Failer interface {
 	// CanUseLocal returns true if the failer can be run with a local cluster.
 	CanUseLocal() bool
 
+	// CanRunWith returns true if the failer can run concurrently with another
+	// given failure mode on a different cluster node. It is not required to
+	// commute, i.e. A may not be able to run with B even though B can run with A.
+	CanRunWith(other failureMode) bool
+
 	// Setup prepares the failer. It is called before the cluster is started.
 	Setup(ctx context.Context)
 
@@ -1145,6 +1347,7 @@ type noopFailer struct{}
 func (f *noopFailer) Mode() failureMode                       { return failureModeNoop }
 func (f *noopFailer) String() string                          { return string(f.Mode()) }
 func (f *noopFailer) CanUseLocal() bool                       { return true }
+func (f *noopFailer) CanRunWith(failureMode) bool             { return true }
 func (f *noopFailer) Setup(context.Context)                   {}
 func (f *noopFailer) Ready(context.Context, cluster.Monitor)  {}
 func (f *noopFailer) Cleanup(context.Context)                 {}
@@ -1176,6 +1379,7 @@ func (f *blackholeFailer) Mode() failureMode {
 
 func (f *blackholeFailer) String() string                         { return string(f.Mode()) }
 func (f *blackholeFailer) CanUseLocal() bool                      { return false } // needs iptables
+func (f *blackholeFailer) CanRunWith(failureMode) bool            { return true }
 func (f *blackholeFailer) Setup(context.Context)                  {}
 func (f *blackholeFailer) Ready(context.Context, cluster.Monitor) {}
 
@@ -1261,6 +1465,7 @@ type crashFailer struct {
 func (f *crashFailer) Mode() failureMode                          { return failureModeCrash }
 func (f *crashFailer) String() string                             { return string(f.Mode()) }
 func (f *crashFailer) CanUseLocal() bool                          { return true }
+func (f *crashFailer) CanRunWith(failureMode) bool                { return true }
 func (f *crashFailer) Setup(_ context.Context)                    {}
 func (f *crashFailer) Ready(_ context.Context, m cluster.Monitor) { f.m = m }
 func (f *crashFailer) Cleanup(_ context.Context)                  {}
@@ -1291,6 +1496,7 @@ type deadlockFailer struct {
 func (f *deadlockFailer) Mode() failureMode                          { return failureModeDeadlock }
 func (f *deadlockFailer) String() string                             { return string(f.Mode()) }
 func (f *deadlockFailer) CanUseLocal() bool                          { return true }
+func (f *deadlockFailer) CanRunWith(m failureMode) bool              { return true }
 func (f *deadlockFailer) Setup(context.Context)                      {}
 func (f *deadlockFailer) Ready(_ context.Context, m cluster.Monitor) { f.m = m }
 func (f *deadlockFailer) Cleanup(context.Context)                    {}
@@ -1378,9 +1584,10 @@ type diskStallFailer struct {
 	staller       diskStaller
 }
 
-func (f *diskStallFailer) Mode() failureMode { return failureModeDiskStall }
-func (f *diskStallFailer) String() string    { return string(f.Mode()) }
-func (f *diskStallFailer) CanUseLocal() bool { return false } // needs dmsetup
+func (f *diskStallFailer) Mode() failureMode           { return failureModeDiskStall }
+func (f *diskStallFailer) String() string              { return string(f.Mode()) }
+func (f *diskStallFailer) CanUseLocal() bool           { return false } // needs dmsetup
+func (f *diskStallFailer) CanRunWith(failureMode) bool { return true }
 
 func (f *diskStallFailer) Setup(ctx context.Context) {
 	f.staller.Setup(ctx)
@@ -1424,6 +1631,12 @@ func (f *pauseFailer) String() string          { return string(f.Mode()) }
 func (f *pauseFailer) CanUseLocal() bool       { return true }
 func (f *pauseFailer) Setup(context.Context)   {}
 func (f *pauseFailer) Cleanup(context.Context) {}
+
+func (f *pauseFailer) CanRunWith(other failureMode) bool {
+	// Since we disable the disk stall detector, we can't run concurrently with
+	// a disk stall on a different node.
+	return other != failureModeDiskStall
+}
 
 func (f *pauseFailer) Ready(ctx context.Context, _ cluster.Monitor) {
 	// The process pause can trip the disk stall detector, so we disable it. We


### PR DESCRIPTION
**roachtest: export `Failer` in failover tests**

This avoids linters complaining about a `failer` local shadowing the `failer` interface.

**roachtest: add `Failer.Mode()` for failover tests**

**roachtest: reset disk stall detector in `failover/pause`**

The pause failure mode needs to re-enable the disk stall detector after a failure, for use in chaos tests.

**roachtest: allow disabling local SSD via `PreferLocalSSD()`**

**roachtest: add `failover` chaos tests**

This patch adds chaos tests to the `failover` suite. It sets up a 9-node cluster with RF=5 and runs both read-only and read-write workloads against it while failing 1 or 2 random nodes using random failure modes for 1 minute each. As with the other `failover` tests, the pMax unavailability is measured for graphing.

Resolves #103260.
Epic: none
Release note: None