### PR TITLE
roachtest: clean up `failover` tests

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -178,8 +178,8 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 9))
 
+	m := c.NewMonitor(ctx, c.Range(1, 9))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Place 5 replicas of all ranges on n3-n9, keeping n1-n2 as SQL gateways.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 5, onlyNodes: []int{3, 4, 5, 6, 7, 8, 9}})
@@ -210,7 +210,6 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 
 	// Start workload on n10 using n1-n2 as gateways.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 9))
 	m.Go(func(ctx context.Context) error {
 		readPercent := 50
 		if readOnly {
@@ -359,8 +358,8 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 7))
 
+	m := c.NewMonitor(ctx, c.Range(1, 7))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Place all ranges on n1-n3 to start with.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -390,7 +389,6 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 
 	// Start workload on n8 using n6-n7 as gateways.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 7))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
@@ -509,7 +507,6 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 3))
 
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Place all ranges on n1-n3 to start with, and wait for upreplication.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -523,6 +520,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 
 	// Now that system ranges are properly placed on n1-n3, start n4-n6.
 	c.Start(ctx, t.L(), opts, settings, c.Range(4, 6))
+	m := c.NewMonitor(ctx, c.Range(1, 6))
 
 	// Create the kv database on n4-n6.
 	t.L().Printf("creating workload database")
@@ -556,7 +554,6 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 
 	// Start workload on n7 using n1-n3 as gateways.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 6))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
@@ -657,8 +654,8 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 7))
 
+	m := c.NewMonitor(ctx, c.Range(1, 7))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Place all ranges on n1-n3, and an extra liveness leaseholder replica on n4.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -686,7 +683,6 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 
 	// Start workload on n8 using n1-n3 as gateways (not partitioned).
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 7))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
@@ -798,8 +794,8 @@ func runFailoverNonSystem(
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 6))
 
+	m := c.NewMonitor(ctx, c.Range(1, 6))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Constrain all existing zone configs to n1-n3.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -825,7 +821,6 @@ func runFailoverNonSystem(
 	// minutes, since we take ~2 minutes to fail and recover each node, and
 	// we do 3 cycles of each of the 3 nodes in order.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 6))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
@@ -933,8 +928,8 @@ func runFailoverLiveness(
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 4))
 
+	m := c.NewMonitor(ctx, c.Range(1, 4))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Constrain all existing zone configs to n1-n3.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -965,7 +960,6 @@ func runFailoverLiveness(
 	// Start workload on n7, using n1-n3 as gateways. Run it for 20 minutes, since
 	// we take ~2 minutes to fail and recover the node, and we do 9 cycles.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 4))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(5), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
@@ -1071,8 +1065,8 @@ func runFailoverSystemNonLiveness(
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 6))
 
+	m := c.NewMonitor(ctx, c.Range(1, 6))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Constrain all existing zone configs to n4-n6, except liveness which is
 	// constrained to n1-n3.
@@ -1103,7 +1097,6 @@ func runFailoverSystemNonLiveness(
 	// we take ~2 minutes to fail and recover each node, and we do 3 cycles of each
 	// of the 3 nodes in order.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 6))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -32,10 +32,9 @@ import (
 )
 
 func registerFailover(r registry.Registry) {
-	for _, expirationLeases := range []bool{false, true} {
-		expirationLeases := expirationLeases // pin loop variable
+	for _, leases := range []registry.LeaseType{registry.EpochLeases, registry.ExpirationLeases} {
 		var suffix string
-		if expirationLeases {
+		if leases == registry.ExpirationLeases {
 			suffix = "/lease=expiration"
 		}
 
@@ -52,10 +51,11 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Benchmark:           true,
 				Timeout:             60 * time.Minute,
-				Cluster:             r.MakeClusterSpec(10, spec.CPU(4), spec.PreferLocalSSD(false)),
+				Cluster:             r.MakeClusterSpec(10, spec.CPU(4), spec.PreferLocalSSD(false)), // uses disk stalls
+				Leases:              leases,
 				SkipPostValidations: registry.PostValidationNoDeadNodes, // cleanup kills nodes
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runFailoverChaos(ctx, t, c, readOnly, expirationLeases)
+					runFailoverChaos(ctx, t, c, readOnly)
 				},
 			})
 		}
@@ -66,9 +66,8 @@ func registerFailover(r registry.Registry) {
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
 			Cluster:   r.MakeClusterSpec(8, spec.CPU(4)),
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runFailoverPartialLeaseGateway(ctx, t, c, expirationLeases)
-			},
+			Leases:    leases,
+			Run:       runFailoverPartialLeaseGateway,
 		})
 
 		r.Add(registry.TestSpec{
@@ -77,9 +76,8 @@ func registerFailover(r registry.Registry) {
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
 			Cluster:   r.MakeClusterSpec(7, spec.CPU(4)),
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runFailoverPartialLeaseLeader(ctx, t, c, expirationLeases)
-			},
+			Leases:    leases,
+			Run:       runFailoverPartialLeaseLeader,
 		})
 
 		r.Add(registry.TestSpec{
@@ -88,9 +86,8 @@ func registerFailover(r registry.Registry) {
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
 			Cluster:   r.MakeClusterSpec(8, spec.CPU(4)),
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runFailoverPartialLeaseLiveness(ctx, t, c, expirationLeases)
-			},
+			Leases:    leases,
+			Run:       runFailoverPartialLeaseLiveness,
 		})
 
 		for _, failureMode := range allFailureModes {
@@ -111,8 +108,9 @@ func registerFailover(r registry.Registry) {
 				Timeout:             30 * time.Minute,
 				SkipPostValidations: postValidation,
 				Cluster:             r.MakeClusterSpec(7, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Leases:              leases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runFailoverNonSystem(ctx, t, c, failureMode, expirationLeases)
+					runFailoverNonSystem(ctx, t, c, failureMode)
 				},
 			})
 			r.Add(registry.TestSpec{
@@ -122,8 +120,9 @@ func registerFailover(r registry.Registry) {
 				Timeout:             30 * time.Minute,
 				SkipPostValidations: postValidation,
 				Cluster:             r.MakeClusterSpec(5, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Leases:              leases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runFailoverLiveness(ctx, t, c, failureMode, expirationLeases)
+					runFailoverLiveness(ctx, t, c, failureMode)
 				},
 			})
 			r.Add(registry.TestSpec{
@@ -133,8 +132,9 @@ func registerFailover(r registry.Registry) {
 				Timeout:             30 * time.Minute,
 				SkipPostValidations: postValidation,
 				Cluster:             r.MakeClusterSpec(7, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Leases:              leases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runFailoverSystemNonLiveness(ctx, t, c, failureMode, expirationLeases)
+					runFailoverSystemNonLiveness(ctx, t, c, failureMode)
 				},
 			})
 		}
@@ -151,9 +151,7 @@ func registerFailover(r registry.Registry) {
 // unavailability for graphing. The read-only workload is useful to test e.g.
 // recovering nodes stealing Raft leadership away, since this requires the
 // replica to still be up-to-date on the log.
-func runFailoverChaos(
-	ctx context.Context, t test.Test, c cluster.Cluster, readOnly, expLeases bool,
-) {
+func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readOnly bool) {
 	require.Equal(t, 10, c.Spec().NodeCount)
 
 	rng, _ := randutil.NewTestRand()
@@ -183,10 +181,6 @@ func runFailoverChaos(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
-	require.NoError(t, err)
-
 	// Place 5 replicas of all ranges on n3-n9, keeping n1-n2 as SQL gateways.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 5, onlyNodes: []int{3, 4, 5, 6, 7, 8, 9}})
 
@@ -200,7 +194,7 @@ func runFailoverChaos(
 		insertCount = 100000
 	}
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	c.Run(ctx, c.Node(10), fmt.Sprintf(
 		`./cockroach workload init kv --splits 1000 --insert-count %d {pgurl:1}`, insertCount))
@@ -347,9 +341,7 @@ func runFailoverChaos(
 // - Skips follower replica in B that's unreachable (n5).
 //
 // We run a kv50 workload on SQL gateways and collect pMax latency for graphing.
-func runFailoverPartialLeaseGateway(
-	ctx context.Context, t test.Test, c cluster.Cluster, expLeases bool,
-) {
+func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 8, c.Spec().NodeCount)
 
 	rng, _ := randutil.NewTestRand()
@@ -370,10 +362,6 @@ func runFailoverPartialLeaseGateway(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
-	require.NoError(t, err)
-
 	// Place all ranges on n1-n3 to start with.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 
@@ -382,7 +370,7 @@ func runFailoverPartialLeaseGateway(
 
 	// Create the kv database with 5 replicas on n2-n6, and leases on n4.
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{
 		replicas: 5, onlyNodes: []int{2, 3, 4, 5, 6}, leaseNode: 4})
@@ -499,9 +487,7 @@ func runFailoverPartialLeaseGateway(
 // and simply create partial partitions between each of n4-n6 in sequence.
 //
 // We run a kv50 workload on SQL gateways and collect pMax latency for graphing.
-func runFailoverPartialLeaseLeader(
-	ctx context.Context, t test.Test, c cluster.Cluster, expLeases bool,
-) {
+func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
 	rng, _ := randutil.NewTestRand()
@@ -525,10 +511,6 @@ func runFailoverPartialLeaseLeader(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
-	require.NoError(t, err)
-
 	// Place all ranges on n1-n3 to start with, and wait for upreplication.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
@@ -536,7 +518,7 @@ func runFailoverPartialLeaseLeader(
 	// Disable the replicate queue. It can otherwise end up with stuck
 	// overreplicated ranges during rebalancing, because downreplication requires
 	// the Raft leader to be colocated with the leaseholder.
-	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.replicate_queue.enabled = false`)
+	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.replicate_queue.enabled = false`)
 	require.NoError(t, err)
 
 	// Now that system ranges are properly placed on n1-n3, start n4-n6.
@@ -657,9 +639,7 @@ func runFailoverPartialLeaseLeader(
 // n5-n7 sequentially, 3 times per node for a total of 9 times. A kv50 workload
 // is running against SQL gateways on n1-n3, and we collect the pMax latency for
 // graphing.
-func runFailoverPartialLeaseLiveness(
-	ctx context.Context, t test.Test, c cluster.Cluster, expLeases bool,
-) {
+func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 8, c.Spec().NodeCount)
 
 	rng, _ := randutil.NewTestRand()
@@ -680,10 +660,6 @@ func runFailoverPartialLeaseLiveness(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
-	require.NoError(t, err)
-
 	// Place all ranges on n1-n3, and an extra liveness leaseholder replica on n4.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 	configureZone(t, ctx, conn, `RANGE liveness`, zoneConfig{
@@ -694,7 +670,7 @@ func runFailoverPartialLeaseLiveness(
 
 	// Create the kv database on n5-n7.
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{5, 6, 7}})
 
@@ -802,7 +778,7 @@ func runFailoverPartialLeaseLiveness(
 // order, with 1 minute between each operation, for 3 cycles totaling 9
 // failures.
 func runFailoverNonSystem(
-	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode, expLeases bool,
+	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode,
 ) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
@@ -828,9 +804,6 @@ func runFailoverNonSystem(
 	// Configure cluster. This test controls the ranges manually.
 	t.L().Printf("configuring cluster")
 	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
 	require.NoError(t, err)
 
 	// Constrain all existing zone configs to n1-n3.
@@ -945,7 +918,7 @@ func runFailoverNonSystem(
 // directed at n1-n3 with a rate of 2048 reqs/s. n4 fails and recovers, with 1
 // minute between each operation, for 9 cycles.
 func runFailoverLiveness(
-	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode, expLeases bool,
+	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode,
 ) {
 	require.Equal(t, 5, c.Spec().NodeCount)
 
@@ -971,9 +944,6 @@ func runFailoverLiveness(
 	// Configure cluster. This test controls the ranges manually.
 	t.L().Printf("configuring cluster")
 	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
 	require.NoError(t, err)
 
 	// Constrain all existing zone configs to n1-n3.
@@ -1092,7 +1062,7 @@ func runFailoverLiveness(
 // order, with 1 minute between each operation, for 3 cycles totaling 9
 // failures.
 func runFailoverSystemNonLiveness(
-	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode, expLeases bool,
+	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode,
 ) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
@@ -1118,9 +1088,6 @@ func runFailoverSystemNonLiveness(
 	// Configure cluster. This test controls the ranges manually.
 	t.L().Printf("configuring cluster")
 	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
 	require.NoError(t, err)
 
 	// Constrain all existing zone configs to n4-n6, except liveness which is

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -37,6 +37,29 @@ var rangeLeaseRenewalDuration = func() time.Duration {
 	return raftCfg.RangeLeaseRenewalDuration()
 }()
 
+// registerFailover registers a set of failover benchmarks. These tests
+// benchmark the maximum unavailability experienced by clients during various
+// node failures, and exports them for roachperf graphing. They do not make any
+// assertions on recovery time, similarly to other performance benchmarks.
+//
+// The tests run a kv workload against a cluster while subjecting individual
+// nodes to various failures. The workload uses dedicated SQL gateway nodes that
+// don't fail, relying on these for error handling and retries. The pMax latency
+// seen by any client is exported and graphed. Since recovery times are
+// probabilistic, each test performs multiple failures (typically 9) in order to
+// find the worst-case recovery time following a failure.
+//
+// Failures last for 60 seconds before the node is recovered. Thus, the maximum
+// measured unavailability is 60 seconds, which in practice means permanent
+// unavailability (for some or all clients).
+//
+// No attempt is made to find the distribution of recovery times (e.g. the
+// minimum and median), since this requires more sophisticated data recording
+// and analysis. Simply taking the median across all requests is not sufficient,
+// since requests are also executed against a healthy cluster between failures,
+// and against healthy replicas during failures, thus the vast majority of
+// requests are successful with nominal latencies. See also:
+// https://github.com/cockroachdb/cockroach/issues/103654
 func registerFailover(r registry.Registry) {
 	for _, leases := range []registry.LeaseType{registry.EpochLeases, registry.ExpirationLeases} {
 		var suffix string
@@ -446,9 +469,9 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	m.Wait()
 }
 
-// runFailoverLeaseLeader tests a partial network partition between leaseholders
-// and Raft leaders. These will prevent the leaseholder from making Raft
-// proposals, but it can still hold onto leases as long as it can heartbeat
+// runFailoverPartialLeaseLeader tests a partial network partition between
+// leaseholders and Raft leaders. This will prevent the leaseholder from making
+// Raft proposals, but it can still hold onto leases as long as it can heartbeat
 // liveness.
 //
 // Cluster topology:
@@ -704,23 +727,14 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 //
 //   - The workload consists of individual point reads and writes.
 //
-// Since the lease unavailability is probabilistic, depending e.g. on the time
-// since the last heartbeat and other variables, we run 9 failures and record
-// the pMax latency to find the upper bound on unavailability. We expect this
-// worst-case latency to be slightly larger than the lease interval (9s), to
-// account for lease acquisition and retry latencies. We do not assert this, but
-// instead export latency histograms for graphing.
-//
 // The cluster layout is as follows:
 //
 // n1-n3: System ranges and SQL gateways.
 // n4-n6: Workload ranges.
 // n7:    Workload runner.
 //
-// The test runs a kv50 workload with batch size 1, using 256 concurrent workers
-// directed at n1-n3 with a rate of 2048 reqs/s. n4-n6 fail and recover in
-// order, with 1 minute between each operation, for 3 cycles totaling 9
-// failures.
+// The test runs a kv50 workload via gateways on n1-n3, measuring the pMax
+// latency for graphing.
 func runFailoverNonSystem(
 	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode,
 ) {
@@ -823,21 +837,14 @@ func runFailoverNonSystem(
 //
 //   - The workload consists of individual point reads and writes.
 //
-// Since the range unavailability is probabilistic, depending e.g. on the time
-// since the last heartbeat and other variables, we run 9 failures and record
-// the number of expired leases on n1-n3 as well as the pMax latency to find the
-// upper bound on unavailability. We do not assert anything, but instead export
-// metrics for graphing.
-//
 // The cluster layout is as follows:
 //
 // n1-n3: All ranges, including liveness.
 // n4:    Liveness range leaseholder.
 // n5:    Workload runner.
 //
-// The test runs a kv50 workload with batch size 1, using 256 concurrent workers
-// directed at n1-n3 with a rate of 2048 reqs/s. n4 fails and recovers, with 1
-// minute between each operation, for 9 cycles.
+// The test runs a kv50 workload via gateways on n1-n3, measuring the pMax
+// latency for graphing.
 func runFailoverLiveness(
 	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode,
 ) {
@@ -944,21 +951,14 @@ func runFailoverLiveness(
 //
 //   - The workload consists of individual point reads and writes.
 //
-// Since the lease unavailability is probabilistic, depending e.g. on the time
-// since the last heartbeat and other variables, we run 9 failures and record
-// the pMax latency to find the upper bound on unavailability. Ideally, losing
-// the lease on these ranges should have no impact on the user traffic.
-//
 // The cluster layout is as follows:
 //
 // n1-n3: Workload ranges, liveness range, and SQL gateways.
 // n4-n6: System ranges excluding liveness.
 // n7:    Workload runner.
 //
-// The test runs a kv50 workload with batch size 1, using 256 concurrent workers
-// directed at n1-n3 with a rate of 2048 reqs/s. n4-n6 fail and recover in
-// order, with 1 minute between each operation, for 3 cycles totaling 9
-// failures.
+// The test runs a kv50 workload via gateways on n1-n3, measuring the pMax
+// latency for graphing.
 func runFailoverSystemNonLiveness(
 	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode,
 ) {
@@ -1592,6 +1592,20 @@ func waitForUpreplication(
 // relocateRanges relocates all ranges matching the given predicate from a set
 // of nodes to a different set of nodes. Moves are attempted sequentially from
 // each source onto each target, and errors are retried indefinitely.
+//
+// TODO(erikgrinaker): It would be really neat if the replicate queue could
+// deal with this for us. For that to happen, we need three things:
+//
+//  1. The replicate queue must do this ~immediately. It should take ~10 seconds
+//     for 1000 ranges, not 10 minutes.
+//
+//  2. We need to know when the replicate queue is done placing both replicas and
+//     leases in accordance with the zone configurations, so that we can wait for
+//     it. SpanConfigConformance should provide this, but current doesn't have a
+//     public API, and doesn't handle lease preferences.
+//
+//  3. The replicate queue must guarantee that replicas and leases won't escape
+//     their constraints after the initial setup. We see them do so currently.
 func relocateRanges(
 	t test.Test, ctx context.Context, conn *gosql.DB, predicate string, from, to []int,
 ) {

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -31,6 +31,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var rangeLeaseRenewalDuration = func() time.Duration {
+	var raftCfg base.RaftConfig
+	raftCfg.SetDefaults()
+	return raftCfg.RangeLeaseRenewalDuration()
+}()
+
 func registerFailover(r registry.Registry) {
 	for _, leases := range []registry.LeaseType{registry.EpochLeases, registry.ExpirationLeases} {
 		var suffix string
@@ -154,6 +160,7 @@ func registerFailover(r registry.Registry) {
 func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readOnly bool) {
 	require.Equal(t, 10, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster, and set up failers for all failure modes.
@@ -208,35 +215,30 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	// Wait for upreplication of the new ranges.
 	require.NoError(t, WaitForReplication(ctx, t, conn, 5 /* replicationFactor */))
 
-	// Start workload on n10 using n1-n2 as gateways.
+	// Run workload on n10 via n1-n2 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
 		readPercent := 50
 		if readOnly {
 			readPercent = 100
 		}
-		c.Run(ctx, c.Node(10), fmt.Sprintf(
+		err := c.RunE(ctx, c.Node(10), fmt.Sprintf(
 			`./cockroach workload run kv --read-percent %d --write-seq R%d `+
-				`--duration 45m --concurrency 256 --max-rate 8192 --timeout 1m --tolerate-errors `+
-				`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-				`{pgurl:1-2}`, readPercent, insertCount))
-		return nil
+				`--concurrency 256 --max-rate 8192 --timeout 1m --tolerate-errors `+
+				`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-2}`,
+			readPercent, insertCount))
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to randomly fail random nodes for 1 minute, with 20 cycles.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 20; i++ {
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			sleepFor(ctx, t, time.Minute)
 
 			// Pick 1 or 2 random nodes and failure modes.
 			nodeFailers := map[int]Failer{}
@@ -263,19 +265,13 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 				nodeFailers[node] = failer
 			}
 
-			randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
-
 			// Ranges may occasionally escape their constraints. Move them to where
 			// they should be.
 			relocateRanges(t, ctx, conn, `true`, []int{1, 2}, []int{3, 4, 5, 6, 7, 8, 9})
 
 			// Randomly sleep up to the lease renewal interval, to vary the time
-			// between the last lease renewal and the failure. We start the timer
-			// before the range relocation above to run them concurrently.
-			select {
-			case <-randTimer:
-			case <-ctx.Done():
-			}
+			// between the last lease renewal and the failure.
+			sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 			for node, failer := range nodeFailers {
 				// If the failer supports partial failures (e.g. partial partitions), do
@@ -294,11 +290,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 				}
 			}
 
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			sleepFor(ctx, t, time.Minute)
 
 			for node, failer := range nodeFailers {
 				t.L().Printf("recovering n%d (%s)", node, failer)
@@ -343,6 +335,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 8, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster.
@@ -387,25 +380,23 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	relocateRanges(t, ctx, conn, `database_name != 'kv'`, []int{4, 5, 6, 7}, []int{1, 2, 3})
 	relocateLeases(t, ctx, conn, `database_name = 'kv'`, 4)
 
-	// Start workload on n8 using n6-n7 as gateways.
+	// Run workload on n8 via n6-n7 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:6-7}`)
-		return nil
+		err := c.RunE(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:6-7}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover partial partitions between n4,n5
 	// (leases) and n6,n7 (gateways), both fully and individually, for 3 cycles.
 	// Leases are only placed on n4.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 3; i++ {
 			testcases := []struct {
@@ -423,15 +414,9 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 				{[]int{7}, []int{4}},
 			}
 			for _, tc := range testcases {
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				failer.Ready(ctx, m)
-
-				randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 				// Ranges and leases may occasionally escape their constraints. Move
 				// them to where they should be.
@@ -440,23 +425,15 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 				relocateLeases(t, ctx, conn, `database_name = 'kv'`, 4)
 
 				// Randomly sleep up to the lease renewal interval, to vary the time
-				// between the last lease renewal and the failure. We start the timer
-				// before the range relocation above to run them concurrently.
-				select {
-				case <-randTimer:
-				case <-ctx.Done():
-				}
+				// between the last lease renewal and the failure.
+				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 				for _, node := range tc.nodes {
 					t.L().Printf("failing n%d to n%v (%s lease/gateway)", node, tc.peers, failer)
 					failer.FailPartial(ctx, node, tc.peers)
 				}
 
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				for _, node := range tc.nodes {
 					t.L().Printf("recovering n%d to n%v (%s lease/gateway)", node, tc.peers, failer)
@@ -488,6 +465,7 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster, disabling leader/leaseholder colocation. We only start
@@ -552,36 +530,28 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 		time.Sleep(time.Second)
 	}
 
-	// Start workload on n7 using n1-n3 as gateways.
+	// Run workload on n7 via n1-n3 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
+		err := c.RunE(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:1-3}`)
-		return nil
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover partial partitions between each pair of
 	// n4-n6 for 3 cycles (9 failures total).
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 3; i++ {
 			for _, node := range []int{4, 5, 6} {
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				failer.Ready(ctx, m)
-
-				randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 				// Ranges may occasionally escape their constraints. Move them to where
 				// they should be.
@@ -589,12 +559,8 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 				relocateRanges(t, ctx, conn, `database_name != 'kv'`, []int{4, 5, 6}, []int{1, 2, 3})
 
 				// Randomly sleep up to the lease renewal interval, to vary the time
-				// between the last lease renewal and the failure. We start the timer
-				// before the range relocation above to run them concurrently.
-				select {
-				case <-randTimer:
-				case <-ctx.Done():
-				}
+				// between the last lease renewal and the failure.
+				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 				peer := node + 1
 				if peer > 6 {
@@ -603,11 +569,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 				t.L().Printf("failing n%d to n%d (%s lease/leader)", node, peer, failer)
 				failer.FailPartial(ctx, node, []int{peer})
 
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				t.L().Printf("recovering n%d to n%d (%s lease/leader)", node, peer, failer)
 				failer.Recover(ctx, node)
@@ -639,6 +601,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 8, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster.
@@ -681,37 +644,30 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 	relocateRanges(t, ctx, conn, `database_name != 'kv'`, []int{5, 6, 7}, []int{1, 2, 3, 4})
 	relocateRanges(t, ctx, conn, `range_id != 2`, []int{4}, []int{1, 2, 3})
 
-	// Start workload on n8 using n1-n3 as gateways (not partitioned).
+	// Run workload on n8 using n1-n3 as gateways (not partitioned) until test
+	// ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:1-3}`)
-		return nil
+		err := c.RunE(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover partial partitions between n4 (liveness)
 	// and workload leaseholders n5-n7 for 1 minute each, 3 times per node for 9
 	// times total.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 3; i++ {
 			for _, node := range []int{5, 6, 7} {
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				failer.Ready(ctx, m)
-
-				randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 				// Ranges and leases may occasionally escape their constraints. Move
 				// them to where they should be.
@@ -721,22 +677,14 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 				relocateLeases(t, ctx, conn, `range_id = 2`, 4)
 
 				// Randomly sleep up to the lease renewal interval, to vary the time
-				// between the last lease renewal and the failure. We start the timer
-				// before the range relocation above to run them concurrently.
-				select {
-				case <-randTimer:
-				case <-ctx.Done():
-				}
+				// between the last lease renewal and the failure.
+				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 				peer := 4
 				t.L().Printf("failing n%d to n%d (%s lease/liveness)", node, peer, failer)
 				failer.FailPartial(ctx, node, []int{peer})
 
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				t.L().Printf("recovering n%d to n%d (%s lease/liveness)", node, peer, failer)
 				failer.Recover(ctx, node)
@@ -778,6 +726,7 @@ func runFailoverNonSystem(
 ) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster.
@@ -817,37 +766,27 @@ func runFailoverNonSystem(
 	// the ranges across all nodes regardless.
 	relocateRanges(t, ctx, conn, `database_name = 'kv'`, []int{1, 2, 3}, []int{4, 5, 6})
 
-	// Start workload on n7, using n1-n3 as gateways. Run it for 20
-	// minutes, since we take ~2 minutes to fail and recover each node, and
-	// we do 3 cycles of each of the 3 nodes in order.
+	// Run workload on n7 via n1-n3 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:1-3}`)
-		return nil
+		err := c.RunE(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover n4-n6 in order.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 3; i++ {
 			for _, node := range []int{4, 5, 6} {
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				failer.Ready(ctx, m)
-
-				randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 				// Ranges may occasionally escape their constraints. Move them
 				// to where they should be.
@@ -855,21 +794,13 @@ func runFailoverNonSystem(
 				relocateRanges(t, ctx, conn, `database_name != 'kv'`, []int{node}, []int{1, 2, 3})
 
 				// Randomly sleep up to the lease renewal interval, to vary the time
-				// between the last lease renewal and the failure. We start the timer
-				// before the range relocation above to run them concurrently.
-				select {
-				case <-randTimer:
-				case <-ctx.Done():
-				}
+				// between the last lease renewal and the failure.
+				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 				t.L().Printf("failing n%d (%s)", node, failer)
 				failer.Fail(ctx, node)
 
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				t.L().Printf("recovering n%d (%s)", node, failer)
 				failer.Recover(ctx, node)
@@ -912,6 +843,7 @@ func runFailoverLiveness(
 ) {
 	require.Equal(t, 5, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster. Don't schedule a backup as this roachtest reports to roachperf.
@@ -957,35 +889,26 @@ func runFailoverLiveness(
 	// We also make sure the lease is located on n4.
 	relocateLeases(t, ctx, conn, `range_id = 2`, 4)
 
-	// Start workload on n7, using n1-n3 as gateways. Run it for 20 minutes, since
-	// we take ~2 minutes to fail and recover the node, and we do 9 cycles.
+	// Run workload on n7 via n1-n3 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(5), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:1-3}`)
-		return nil
+		err := c.RunE(ctx, c.Node(5), `./cockroach workload run kv --read-percent 50 `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover n4.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 9; i++ {
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			sleepFor(ctx, t, time.Minute)
 
 			failer.Ready(ctx, m)
-
-			randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 			// Ranges and leases may occasionally escape their constraints. Move them
 			// to where they should be.
@@ -993,21 +916,13 @@ func runFailoverLiveness(
 			relocateLeases(t, ctx, conn, `range_id = 2`, 4)
 
 			// Randomly sleep up to the lease renewal interval, to vary the time
-			// between the last lease renewal and the failure. We start the timer
-			// before the range relocation above to run them concurrently.
-			select {
-			case <-randTimer:
-			case <-ctx.Done():
-			}
+			// between the last lease renewal and the failure.
+			sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 			t.L().Printf("failing n%d (%s)", 4, failer)
 			failer.Fail(ctx, 4)
 
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			sleepFor(ctx, t, time.Minute)
 
 			t.L().Printf("recovering n%d (%s)", 4, failer)
 			failer.Recover(ctx, 4)
@@ -1049,6 +964,7 @@ func runFailoverSystemNonLiveness(
 ) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster.
@@ -1093,37 +1009,27 @@ func runFailoverSystemNonLiveness(
 	relocateRanges(t, ctx, conn, `database_name != 'kv' AND range_id != 2`,
 		[]int{1, 2, 3}, []int{4, 5, 6})
 
-	// Start workload on n7, using n1-n3 as gateways. Run it for 20 minutes, since
-	// we take ~2 minutes to fail and recover each node, and we do 3 cycles of each
-	// of the 3 nodes in order.
+	// Run workload on n7 via n1-n3 as gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:1-3}`)
-		return nil
+		err := c.RunE(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover n4-n6 in order.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 3; i++ {
 			for _, node := range []int{4, 5, 6} {
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				failer.Ready(ctx, m)
-
-				randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 				// Ranges may occasionally escape their constraints. Move them
 				// to where they should be.
@@ -1133,21 +1039,13 @@ func runFailoverSystemNonLiveness(
 					[]int{4, 5, 6}, []int{1, 2, 3})
 
 				// Randomly sleep up to the lease renewal interval, to vary the time
-				// between the last lease renewal and the failure. We start the timer
-				// before the range relocation above to run them concurrently.
-				select {
-				case <-randTimer:
-				case <-ctx.Done():
-				}
+				// between the last lease renewal and the failure.
+				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 				t.L().Printf("failing n%d (%s)", node, failer)
 				failer.Fail(ctx, node)
 
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				t.L().Printf("recovering n%d (%s)", node, failer)
 				failer.Recover(ctx, node)
@@ -1815,4 +1713,13 @@ func nodeMetric(
 		ctx, `SELECT value FROM crdb_internal.node_metrics WHERE name = $1`, metric).Scan(&value)
 	require.NoError(t, err)
 	return value
+}
+
+// sleepFor sleeps for the given duration. The test fails on context cancellation.
+func sleepFor(ctx context.Context, t test.Test, duration time.Duration) {
+	select {
+	case <-time.After(duration):
+	case <-ctx.Done():
+		t.Fatalf("sleep failed: %s", ctx.Err())
+	}
 }

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -801,11 +801,6 @@ func runFailoverNonSystem(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	// Configure cluster. This test controls the ranges manually.
-	t.L().Printf("configuring cluster")
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-
 	// Constrain all existing zone configs to n1-n3.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 
@@ -815,7 +810,7 @@ func runFailoverNonSystem(
 	// Create the kv database, constrained to n4-n6. Despite the zone config, the
 	// ranges will initially be distributed across all cluster nodes.
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{4, 5, 6}})
 	c.Run(ctx, c.Node(7), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
@@ -941,17 +936,11 @@ func runFailoverLiveness(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	// Configure cluster. This test controls the ranges manually.
-	t.L().Printf("configuring cluster")
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-
 	// Constrain all existing zone configs to n1-n3.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 
 	// Constrain the liveness range to n1-n4, with leaseholder preference on n4.
 	configureZone(t, ctx, conn, `RANGE liveness`, zoneConfig{replicas: 4, leaseNode: 4})
-	require.NoError(t, err)
 
 	// Wait for upreplication.
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
@@ -959,7 +948,7 @@ func runFailoverLiveness(
 	// Create the kv database, constrained to n1-n3. Despite the zone config, the
 	// ranges will initially be distributed across all cluster nodes.
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 	c.Run(ctx, c.Node(5), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
@@ -1085,16 +1074,10 @@ func runFailoverSystemNonLiveness(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	// Configure cluster. This test controls the ranges manually.
-	t.L().Printf("configuring cluster")
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-
 	// Constrain all existing zone configs to n4-n6, except liveness which is
 	// constrained to n1-n3.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{4, 5, 6}})
 	configureZone(t, ctx, conn, `RANGE liveness`, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
-	require.NoError(t, err)
 
 	// Wait for upreplication.
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
@@ -1102,7 +1085,7 @@ func runFailoverSystemNonLiveness(
 	// Create the kv database, constrained to n1-n3. Despite the zone config, the
 	// ranges will initially be distributed across all cluster nodes.
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 	c.Run(ctx, c.Node(7), `./cockroach workload init kv --splits 1000 {pgurl:1}`)

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -1844,11 +1844,9 @@ func configureZone(
 		leaseString += fmt.Sprintf("[+node%d]", cfg.leaseNode)
 	}
 
-	query := fmt.Sprintf(
+	_, err := conn.ExecContext(ctx, fmt.Sprintf(
 		`ALTER %s CONFIGURE ZONE USING num_replicas = %d, constraints = '[%s]', lease_preferences = '[%s]'`,
-		target, cfg.replicas, constraintsString, leaseString)
-	t.L().Printf(query)
-	_, err := conn.ExecContext(ctx, query)
+		target, cfg.replicas, constraintsString, leaseString))
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
**roachtest: use `Logger.Printf()` instead of Test.Status() in `failover`**

**roachtest: don't log zone configs in `failover`**

**roachtest: set `failover` lease type on test spec**

**roachtest: don't disable load-based splits in `failover`**

There's no strong reason to disable load-based splits here, and using default settings makes for more realistic failures.

**roachtest: set up monitor early in `failover`**

This patch sets up the cluster monitor immediately after starting cluster nodes, to make the monitored node set more visible.

**roachtest: improve `failover` workload runner**

This patch changes the `failover` tests to run the workload until the test is done (context is cancelled), instead of using a fixed workload interval and trying to fit the failures/recoveries into that interval. This significantly simplifies the fail/recovery loops.

The workload still outputs performance artifacts when cancelled, which is what's needed for roachperf graphs.

**roachtest: improve failover test descriptions**

Epic: none
Release note: None