### PR TITLE
kv: non-blocking write-read conflicts for weak isolation txns

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -243,9 +243,10 @@ func PushTxn(
 		}
 	}
 
+	pusherIso, pusheeIso := args.PusherTxn.IsoLevel, reply.PusheeTxn.IsoLevel
+	pusherPri, pusheePri := args.PusherTxn.Priority, reply.PusheeTxn.Priority
 	var pusherWins bool
 	var reason string
-
 	switch {
 	case txnwait.IsExpired(cArgs.EvalCtx.Clock().Now(), &reply.PusheeTxn):
 		reason = "pushee is expired"
@@ -257,7 +258,7 @@ func PushTxn(
 		// If just attempting to cleanup old or already-committed txns,
 		// pusher always fails.
 		pusherWins = false
-	case txnwait.CanPushWithPriority(args.PusherTxn.Priority, reply.PusheeTxn.Priority):
+	case txnwait.CanPushWithPriority(pushType, pusherIso, pusheeIso, pusherPri, pusheePri):
 		reason = "pusher has priority"
 		pusherWins = true
 	case args.Force:

--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//pkg/kv",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/concurrency/poison",
         "//pkg/kv/kvserver/intentresolver",
@@ -63,6 +64,7 @@ go_test(
         "//pkg/keys",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/batcheval",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/concurrency/poison",
         "//pkg/kv/kvserver/intentresolver",

--- a/pkg/kv/kvserver/concurrency/datadriven_util_test.go
+++ b/pkg/kv/kvserver/concurrency/datadriven_util_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -45,6 +46,26 @@ func scanTimestampWithName(t *testing.T, d *datadriven.TestData, name string) hl
 	return ts
 }
 
+func scanIsoLevel(t *testing.T, d *datadriven.TestData) isolation.Level {
+	const key = "iso"
+	if !d.HasArg(key) {
+		return isolation.Serializable
+	}
+	var isoS string
+	d.ScanArgs(t, key, &isoS)
+	switch isoS {
+	case "serializable":
+		return isolation.Serializable
+	case "snapshot":
+		return isolation.Snapshot
+	case "read-committed":
+		return isolation.ReadCommitted
+	default:
+		d.Fatalf(t, "unknown isolation level: %s", isoS)
+		return 0
+	}
+}
+
 func scanTxnPriority(t *testing.T, d *datadriven.TestData) enginepb.TxnPriority {
 	priority := scanUserPriority(t, d)
 	// NB: don't use roachpb.MakePriority to avoid randomness.
@@ -63,10 +84,11 @@ func scanTxnPriority(t *testing.T, d *datadriven.TestData) enginepb.TxnPriority 
 
 func scanUserPriority(t *testing.T, d *datadriven.TestData) roachpb.UserPriority {
 	const key = "priority"
-	priS := "normal"
-	if d.HasArg(key) {
-		d.ScanArgs(t, key, &priS)
+	if !d.HasArg(key) {
+		return roachpb.NormalUserPriority
 	}
+	var priS string
+	d.ScanArgs(t, key, &priS)
 	switch priS {
 	case "low":
 		return roachpb.MinUserPriority

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
@@ -476,8 +477,7 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 		// under the lock. For write-write conflicts, try to abort the lock
 		// holder entirely so the write request can revoke and replace the lock
 		// with its own lock.
-		switch ws.guardStrength {
-		case lock.None:
+		if ws.guardStrength == lock.None {
 			pushType = kvpb.PUSH_TIMESTAMP
 			beforePushObs = roachpb.ObservedTimestamp{
 				NodeID:    w.nodeDesc.NodeID,
@@ -498,12 +498,9 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 			// adjusting the intent, accepting that the intent would then no longer
 			// round-trip and would lose the local timestamp if rewritten later.
 			log.VEventf(ctx, 2, "pushing timestamp of txn %s above %s", ws.txn.ID.Short(), h.Timestamp)
-
-		case lock.Intent:
+		} else {
 			pushType = kvpb.PUSH_ABORT
 			log.VEventf(ctx, 2, "pushing txn %s to abort", ws.txn.ID.Short())
-		default:
-			log.Fatalf(ctx, "unhandled lock strength %s", ws.guardStrength)
 		}
 
 	case lock.WaitPolicy_Error:
@@ -1243,18 +1240,28 @@ func newWriteIntentErr(req Request, ws waitingState, reason kvpb.WriteIntentErro
 }
 
 func canPushWithPriority(req Request, s waitingState) bool {
-	var pusher, pushee enginepb.TxnPriority
-	if req.Txn != nil {
-		pusher = req.Txn.Priority
-	} else {
-		pusher = roachpb.MakePriority(req.NonTxnPriority)
-	}
 	if s.txn == nil {
 		// Can't push a non-transactional request.
 		return false
 	}
-	pushee = s.txn.Priority
-	return txnwait.CanPushWithPriority(pusher, pushee)
+	var pushType kvpb.PushTxnType
+	if s.guardStrength == lock.None {
+		pushType = kvpb.PUSH_TIMESTAMP
+	} else {
+		pushType = kvpb.PUSH_ABORT
+	}
+	var pusherIso, pusheeIso isolation.Level
+	var pusherPri, pusheePri enginepb.TxnPriority
+	if req.Txn != nil {
+		pusherIso = req.Txn.IsoLevel
+		pusherPri = req.Txn.Priority
+	} else {
+		pusherIso = isolation.Serializable
+		pusherPri = roachpb.MakePriority(req.NonTxnPriority)
+	}
+	pusheeIso = s.txn.IsoLevel
+	pusheePri = s.txn.Priority
+	return txnwait.CanPushWithPriority(pushType, pusherIso, pusheeIso, pusherPri, pusheePri)
 }
 
 func logResolveIntent(ctx context.Context, intent roachpb.LockUpdate) {

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
@@ -1,0 +1,868 @@
+new-txn name=txnSSINormalPushee iso=serializable priority=normal ts=10,1
+----
+
+new-txn name=txnSSIHighPushee iso=serializable priority=high ts=10,1
+----
+
+new-txn name=txnRCNormalPushee iso=read-committed priority=normal ts=10,1
+----
+
+new-txn name=txnRCHighPushee iso=read-committed priority=high ts=10,1
+----
+
+new-txn name=txnSSINormalPusher iso=serializable priority=normal ts=10,1
+----
+
+new-txn name=txnSSIHighPusher iso=serializable priority=high ts=10,1
+----
+
+new-txn name=txnRCNormalPusher iso=read-committed priority=normal ts=10,1
+----
+
+new-txn name=txnRCHighPusher iso=read-committed priority=high ts=10,1
+----
+
+# -------------------------------------------------------------
+# Prep: "Pushee" txns acquire 4 locks each.
+# -------------------------------------------------------------
+
+new-request name=req1 txn=txnSSINormalPushee ts=10,1
+  put key=kSSINormal1  value=v
+  put key=kSSINormal2  value=v
+  put key=kSSINormal3  value=v
+  put key=kSSINormal4  value=v
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+on-lock-acquired req=req1 key=kSSINormal1
+----
+[-] acquire lock: txn 00000001 @ kSSINormal1
+
+on-lock-acquired req=req1 key=kSSINormal2
+----
+[-] acquire lock: txn 00000001 @ kSSINormal2
+
+on-lock-acquired req=req1 key=kSSINormal3
+----
+[-] acquire lock: txn 00000001 @ kSSINormal3
+
+on-lock-acquired req=req1 key=kSSINormal4
+----
+[-] acquire lock: txn 00000001 @ kSSINormal4
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+new-request name=req2 txn=txnSSIHighPushee ts=10,1
+  put key=kSSIHigh1  value=v
+  put key=kSSIHigh2  value=v
+  put key=kSSIHigh3  value=v
+  put key=kSSIHigh4  value=v
+----
+
+sequence req=req2
+----
+[2] sequence req2: sequencing request
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: sequencing complete, returned guard
+
+on-lock-acquired req=req2 key=kSSIHigh1
+----
+[-] acquire lock: txn 00000002 @ kSSIHigh1
+
+on-lock-acquired req=req2 key=kSSIHigh2
+----
+[-] acquire lock: txn 00000002 @ kSSIHigh2
+
+on-lock-acquired req=req2 key=kSSIHigh3
+----
+[-] acquire lock: txn 00000002 @ kSSIHigh3
+
+on-lock-acquired req=req2 key=kSSIHigh4
+----
+[-] acquire lock: txn 00000002 @ kSSIHigh4
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+new-request name=req3 txn=txnRCNormalPushee ts=10,1
+  put key=kRCNormal1  value=v
+  put key=kRCNormal2  value=v
+  put key=kRCNormal3  value=v
+  put key=kRCNormal4  value=v
+----
+
+sequence req=req3
+----
+[3] sequence req3: sequencing request
+[3] sequence req3: acquiring latches
+[3] sequence req3: scanning lock table for conflicting locks
+[3] sequence req3: sequencing complete, returned guard
+
+on-lock-acquired req=req3 key=kRCNormal1
+----
+[-] acquire lock: txn 00000003 @ kRCNormal1
+
+on-lock-acquired req=req3 key=kRCNormal2
+----
+[-] acquire lock: txn 00000003 @ kRCNormal2
+
+on-lock-acquired req=req3 key=kRCNormal3
+----
+[-] acquire lock: txn 00000003 @ kRCNormal3
+
+on-lock-acquired req=req3 key=kRCNormal4
+----
+[-] acquire lock: txn 00000003 @ kRCNormal4
+
+finish req=req3
+----
+[-] finish req3: finishing request
+
+new-request name=req4 txn=txnRCHighPushee ts=10,1
+  put key=kRCHigh1  value=v
+  put key=kRCHigh2  value=v
+  put key=kRCHigh3  value=v
+  put key=kRCHigh4  value=v
+----
+
+sequence req=req4
+----
+[4] sequence req4: sequencing request
+[4] sequence req4: acquiring latches
+[4] sequence req4: scanning lock table for conflicting locks
+[4] sequence req4: sequencing complete, returned guard
+
+on-lock-acquired req=req4 key=kRCHigh1
+----
+[-] acquire lock: txn 00000004 @ kRCHigh1
+
+on-lock-acquired req=req4 key=kRCHigh2
+----
+[-] acquire lock: txn 00000004 @ kRCHigh2
+
+on-lock-acquired req=req4 key=kRCHigh3
+----
+[-] acquire lock: txn 00000004 @ kRCHigh3
+
+on-lock-acquired req=req4 key=kRCHigh4
+----
+[-] acquire lock: txn 00000004 @ kRCHigh4
+
+finish req=req4
+----
+[-] finish req4: finishing request
+
+debug-lock-table
+----
+num=16
+ lock: "kRCHigh1"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh2"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh3"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh4"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal3"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal4"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh2"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh3"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh4"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal2"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal3"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal4"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+
+# -------------------------------------------------------------
+# Pushee: isolation=serializable, priority=normal
+# Pusher: isolation=serializable, priority=normal
+#
+# Explanation: SSI transactions with the same priority can not
+# push each other.
+# -------------------------------------------------------------
+
+new-request name=req5 txn=txnSSINormalPusher ts=10,1
+  get key=kSSINormal1
+----
+
+sequence req=req5
+----
+[5] sequence req5: sequencing request
+[5] sequence req5: acquiring latches
+[5] sequence req5: scanning lock table for conflicting locks
+[5] sequence req5: waiting in lock wait-queues
+[5] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kSSINormal1" (queuedWriters: 0, queuedReaders: 1)
+[5] sequence req5: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
+[5] sequence req5: pushing timestamp of txn 00000001 above 10.000000000,1
+[5] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# -------------------------------------------------------------
+# Pushee: isolation=serializable, priority=normal
+# Pusher: isolation=serializable, priority=high
+#
+# Explanation: SSI transactions with a high priority can push
+# SSI transactions with a normal priority. This also unblocks
+# the previous case.
+# -------------------------------------------------------------
+
+new-request name=req6 txn=txnSSIHighPusher ts=11,1
+  get key=kSSINormal2
+----
+
+sequence req=req6
+----
+[5] sequence req5: resolving intent "kSSINormal1" for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
+[5] sequence req5: lock wait-queue event: done waiting
+[5] sequence req5: conflicted with 00000001-0000-0000-0000-000000000000 on "kSSINormal1" for 0.000s
+[5] sequence req5: acquiring latches
+[5] sequence req5: scanning lock table for conflicting locks
+[5] sequence req5: sequencing complete, returned guard
+[6] sequence req6: sequencing request
+[6] sequence req6: acquiring latches
+[6] sequence req6: scanning lock table for conflicting locks
+[6] sequence req6: waiting in lock wait-queues
+[6] sequence req6: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kSSINormal2" (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req6: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req6: pushing timestamp of txn 00000001 above 11.000000000,1
+[6] sequence req6: pusher pushed pushee to 11.000000000,2
+[6] sequence req6: resolving intent "kSSINormal2" for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
+[6] sequence req6: lock wait-queue event: done waiting
+[6] sequence req6: conflicted with 00000001-0000-0000-0000-000000000000 on "kSSINormal2" for 0.000s
+[6] sequence req6: acquiring latches
+[6] sequence req6: scanning lock table for conflicting locks
+[6] sequence req6: sequencing complete, returned guard
+
+finish req=req5
+----
+[-] finish req5: finishing request
+
+finish req=req6
+----
+[-] finish req6: finishing request
+
+# -------------------------------------------------------------
+# Pushee: isolation=serializable,   priority=normal
+# Pusher: isolation=read-committed, priority=normal
+#
+# Explanation: RC transactions with a normal priority can push
+# SSI transactions with a normal priority.
+# -------------------------------------------------------------
+
+new-request name=req7 txn=txnRCNormalPusher ts=12,1
+  get key=kSSINormal3
+----
+
+sequence req=req7
+----
+[7] sequence req7: sequencing request
+[7] sequence req7: acquiring latches
+[7] sequence req7: scanning lock table for conflicting locks
+[7] sequence req7: waiting in lock wait-queues
+[7] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kSSINormal3" (queuedWriters: 0, queuedReaders: 1)
+[7] sequence req7: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[7] sequence req7: pushing timestamp of txn 00000001 above 12.000000000,1
+[7] sequence req7: pusher pushed pushee to 12.000000000,2
+[7] sequence req7: resolving intent "kSSINormal3" for txn 00000001 with PENDING status and clock observation {1 123.000000000,5}
+[7] sequence req7: lock wait-queue event: done waiting
+[7] sequence req7: conflicted with 00000001-0000-0000-0000-000000000000 on "kSSINormal3" for 0.000s
+[7] sequence req7: acquiring latches
+[7] sequence req7: scanning lock table for conflicting locks
+[7] sequence req7: sequencing complete, returned guard
+
+finish req=req7
+----
+[-] finish req7: finishing request
+
+# -------------------------------------------------------------
+# Pushee: isolation=serializable,   priority=normal
+# Pusher: isolation=read-committed, priority=high
+#
+# Explanation: RC transactions with a high priority can push
+# SSI transactions with a normal priority.
+# -------------------------------------------------------------
+
+new-request name=req8 txn=txnRCHighPusher ts=13,1
+  get key=kSSINormal4
+----
+
+sequence req=req8
+----
+[8] sequence req8: sequencing request
+[8] sequence req8: acquiring latches
+[8] sequence req8: scanning lock table for conflicting locks
+[8] sequence req8: waiting in lock wait-queues
+[8] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kSSINormal4" (queuedWriters: 0, queuedReaders: 1)
+[8] sequence req8: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[8] sequence req8: pushing timestamp of txn 00000001 above 13.000000000,1
+[8] sequence req8: pusher pushed pushee to 13.000000000,2
+[8] sequence req8: resolving intent "kSSINormal4" for txn 00000001 with PENDING status and clock observation {1 123.000000000,7}
+[8] sequence req8: lock wait-queue event: done waiting
+[8] sequence req8: conflicted with 00000001-0000-0000-0000-000000000000 on "kSSINormal4" for 0.000s
+[8] sequence req8: acquiring latches
+[8] sequence req8: scanning lock table for conflicting locks
+[8] sequence req8: sequencing complete, returned guard
+
+finish req=req8
+----
+[-] finish req8: finishing request
+
+debug-lock-table
+----
+num=16
+ lock: "kRCHigh1"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh2"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh3"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh4"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal3"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal4"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh2"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh3"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh4"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal2"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal3"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal4"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+
+# -------------------------------------------------------------
+# Pushee: isolation=serializable, priority=high
+# Pusher: isolation=serializable, priority=normal
+#
+# Explanation: SSI transactions with a normal priority can not
+# push SSI transactions with a high priority.
+# -------------------------------------------------------------
+
+new-request name=req9 txn=txnSSINormalPusher ts=10,1
+  get key=kSSIHigh1
+----
+
+sequence req=req9
+----
+[9] sequence req9: sequencing request
+[9] sequence req9: acquiring latches
+[9] sequence req9: scanning lock table for conflicting locks
+[9] sequence req9: waiting in lock wait-queues
+[9] sequence req9: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kSSIHigh1" (queuedWriters: 0, queuedReaders: 1)
+[9] sequence req9: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
+[9] sequence req9: pushing timestamp of txn 00000002 above 10.000000000,1
+[9] sequence req9: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# -------------------------------------------------------------
+# Pushee: isolation=serializable, priority=high
+# Pusher: isolation=serializable, priority=high
+#
+# Explanation: SSI transactions with the same priority can not
+# push each other.
+# -------------------------------------------------------------
+
+new-request name=req10 txn=txnSSIHighPusher ts=11,1
+  get key=kSSIHigh2
+----
+
+sequence req=req10
+----
+[10] sequence req10: sequencing request
+[10] sequence req10: acquiring latches
+[10] sequence req10: scanning lock table for conflicting locks
+[10] sequence req10: waiting in lock wait-queues
+[10] sequence req10: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kSSIHigh2" (queuedWriters: 0, queuedReaders: 1)
+[10] sequence req10: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
+[10] sequence req10: pushing timestamp of txn 00000002 above 11.000000000,1
+[10] sequence req10: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# -------------------------------------------------------------
+# Pushee: isolation=serializable,   priority=high
+# Pusher: isolation=read-committed, priority=normal
+#
+# Explanation: RC transactions with a normal priority can not
+# push SSI transactions with a high priority.
+# -------------------------------------------------------------
+
+new-request name=req11 txn=txnRCNormalPusher ts=12,1
+  get key=kSSIHigh3
+----
+
+sequence req=req11
+----
+[11] sequence req11: sequencing request
+[11] sequence req11: acquiring latches
+[11] sequence req11: scanning lock table for conflicting locks
+[11] sequence req11: waiting in lock wait-queues
+[11] sequence req11: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kSSIHigh3" (queuedWriters: 0, queuedReaders: 1)
+[11] sequence req11: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
+[11] sequence req11: pushing timestamp of txn 00000002 above 12.000000000,1
+[11] sequence req11: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# -------------------------------------------------------------
+# Pushee: isolation=serializable,   priority=high
+# Pusher: isolation=read-committed, priority=high
+#
+# Explanation: RC transactions with a high priority can push
+# SSI transactions with a high priority. This also unblocks
+# the previous cases.
+# -------------------------------------------------------------
+
+new-request name=req12 txn=txnRCHighPusher ts=13,1
+  get key=kSSIHigh4
+----
+
+sequence req=req12
+----
+[9] sequence req9: resolving intent "kSSIHigh1" for txn 00000002 with PENDING status and clock observation {1 123.000000000,9}
+[9] sequence req9: lock wait-queue event: done waiting
+[9] sequence req9: conflicted with 00000002-0000-0000-0000-000000000000 on "kSSIHigh1" for 0.000s
+[9] sequence req9: acquiring latches
+[9] sequence req9: scanning lock table for conflicting locks
+[9] sequence req9: sequencing complete, returned guard
+[10] sequence req10: resolving intent "kSSIHigh2" for txn 00000002 with PENDING status and clock observation {1 123.000000000,11}
+[10] sequence req10: lock wait-queue event: done waiting
+[10] sequence req10: conflicted with 00000002-0000-0000-0000-000000000000 on "kSSIHigh2" for 0.000s
+[10] sequence req10: acquiring latches
+[10] sequence req10: scanning lock table for conflicting locks
+[10] sequence req10: sequencing complete, returned guard
+[11] sequence req11: resolving intent "kSSIHigh3" for txn 00000002 with PENDING status and clock observation {1 123.000000000,13}
+[11] sequence req11: lock wait-queue event: done waiting
+[11] sequence req11: conflicted with 00000002-0000-0000-0000-000000000000 on "kSSIHigh3" for 0.000s
+[11] sequence req11: acquiring latches
+[11] sequence req11: scanning lock table for conflicting locks
+[11] sequence req11: sequencing complete, returned guard
+[12] sequence req12: sequencing request
+[12] sequence req12: acquiring latches
+[12] sequence req12: scanning lock table for conflicting locks
+[12] sequence req12: waiting in lock wait-queues
+[12] sequence req12: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kSSIHigh4" (queuedWriters: 0, queuedReaders: 1)
+[12] sequence req12: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[12] sequence req12: pushing timestamp of txn 00000002 above 13.000000000,1
+[12] sequence req12: pusher pushed pushee to 13.000000000,2
+[12] sequence req12: resolving intent "kSSIHigh4" for txn 00000002 with PENDING status and clock observation {1 123.000000000,15}
+[12] sequence req12: lock wait-queue event: done waiting
+[12] sequence req12: conflicted with 00000002-0000-0000-0000-000000000000 on "kSSIHigh4" for 0.000s
+[12] sequence req12: acquiring latches
+[12] sequence req12: scanning lock table for conflicting locks
+[12] sequence req12: sequencing complete, returned guard
+
+finish req=req9
+----
+[-] finish req9: finishing request
+
+finish req=req10
+----
+[-] finish req10: finishing request
+
+finish req=req11
+----
+[-] finish req11: finishing request
+
+finish req=req12
+----
+[-] finish req12: finishing request
+
+debug-lock-table
+----
+num=16
+ lock: "kRCHigh1"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh2"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh3"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh4"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal3"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal4"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh2"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh3"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh4"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal2"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal3"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal4"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+
+# -------------------------------------------------------------
+# Pushee: isolation=read-committed, priority=normal
+# Pusher: isolation=serializable,   priority=normal
+#
+# Explanation: RC transactions can always be pushed.
+# -------------------------------------------------------------
+
+new-request name=req13 txn=txnSSINormalPusher ts=10,1
+  get key=kRCNormal1
+----
+
+sequence req=req13
+----
+[13] sequence req13: sequencing request
+[13] sequence req13: acquiring latches
+[13] sequence req13: scanning lock table for conflicting locks
+[13] sequence req13: waiting in lock wait-queues
+[13] sequence req13: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kRCNormal1" (queuedWriters: 0, queuedReaders: 1)
+[13] sequence req13: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[13] sequence req13: pushing timestamp of txn 00000003 above 10.000000000,1
+[13] sequence req13: pusher pushed pushee to 10.000000000,2
+[13] sequence req13: resolving intent "kRCNormal1" for txn 00000003 with PENDING status and clock observation {1 123.000000000,17}
+[13] sequence req13: lock wait-queue event: done waiting
+[13] sequence req13: conflicted with 00000003-0000-0000-0000-000000000000 on "kRCNormal1" for 0.000s
+[13] sequence req13: acquiring latches
+[13] sequence req13: scanning lock table for conflicting locks
+[13] sequence req13: sequencing complete, returned guard
+
+finish req=req13
+----
+[-] finish req13: finishing request
+
+# -------------------------------------------------------------
+# Pushee: isolation=read-committed, priority=normal
+# Pusher: isolation=serializable,   priority=high
+#
+# Explanation: RC transactions can always be pushed.
+# -------------------------------------------------------------
+
+new-request name=req14 txn=txnSSIHighPusher ts=11,1
+  get key=kRCNormal2
+----
+
+sequence req=req14
+----
+[14] sequence req14: sequencing request
+[14] sequence req14: acquiring latches
+[14] sequence req14: scanning lock table for conflicting locks
+[14] sequence req14: waiting in lock wait-queues
+[14] sequence req14: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kRCNormal2" (queuedWriters: 0, queuedReaders: 1)
+[14] sequence req14: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[14] sequence req14: pushing timestamp of txn 00000003 above 11.000000000,1
+[14] sequence req14: pusher pushed pushee to 11.000000000,2
+[14] sequence req14: resolving intent "kRCNormal2" for txn 00000003 with PENDING status and clock observation {1 123.000000000,19}
+[14] sequence req14: lock wait-queue event: done waiting
+[14] sequence req14: conflicted with 00000003-0000-0000-0000-000000000000 on "kRCNormal2" for 0.000s
+[14] sequence req14: acquiring latches
+[14] sequence req14: scanning lock table for conflicting locks
+[14] sequence req14: sequencing complete, returned guard
+
+finish req=req14
+----
+[-] finish req14: finishing request
+
+# -------------------------------------------------------------
+# Pushee: isolation=read-committed, priority=normal
+# Pusher: isolation=read-committed, priority=normal
+#
+# Explanation: RC transactions can always be pushed.
+# -------------------------------------------------------------
+
+new-request name=req15 txn=txnRCNormalPusher ts=12,1
+  get key=kRCNormal3
+----
+
+sequence req=req15
+----
+[15] sequence req15: sequencing request
+[15] sequence req15: acquiring latches
+[15] sequence req15: scanning lock table for conflicting locks
+[15] sequence req15: waiting in lock wait-queues
+[15] sequence req15: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kRCNormal3" (queuedWriters: 0, queuedReaders: 1)
+[15] sequence req15: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[15] sequence req15: pushing timestamp of txn 00000003 above 12.000000000,1
+[15] sequence req15: pusher pushed pushee to 12.000000000,2
+[15] sequence req15: resolving intent "kRCNormal3" for txn 00000003 with PENDING status and clock observation {1 123.000000000,21}
+[15] sequence req15: lock wait-queue event: done waiting
+[15] sequence req15: conflicted with 00000003-0000-0000-0000-000000000000 on "kRCNormal3" for 0.000s
+[15] sequence req15: acquiring latches
+[15] sequence req15: scanning lock table for conflicting locks
+[15] sequence req15: sequencing complete, returned guard
+
+finish req=req15
+----
+[-] finish req15: finishing request
+
+# -------------------------------------------------------------
+# Pushee: isolation=read-committed, priority=normal
+# Pusher: isolation=read-committed, priority=high
+#
+# Explanation: RC transactions can always be pushed.
+# -------------------------------------------------------------
+
+new-request name=req16 txn=txnRCHighPusher ts=13,1
+  get key=kRCNormal4
+----
+
+sequence req=req16
+----
+[16] sequence req16: sequencing request
+[16] sequence req16: acquiring latches
+[16] sequence req16: scanning lock table for conflicting locks
+[16] sequence req16: waiting in lock wait-queues
+[16] sequence req16: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kRCNormal4" (queuedWriters: 0, queuedReaders: 1)
+[16] sequence req16: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[16] sequence req16: pushing timestamp of txn 00000003 above 13.000000000,1
+[16] sequence req16: pusher pushed pushee to 13.000000000,2
+[16] sequence req16: resolving intent "kRCNormal4" for txn 00000003 with PENDING status and clock observation {1 123.000000000,23}
+[16] sequence req16: lock wait-queue event: done waiting
+[16] sequence req16: conflicted with 00000003-0000-0000-0000-000000000000 on "kRCNormal4" for 0.000s
+[16] sequence req16: acquiring latches
+[16] sequence req16: scanning lock table for conflicting locks
+[16] sequence req16: sequencing complete, returned guard
+
+finish req=req16
+----
+[-] finish req16: finishing request
+
+debug-lock-table
+----
+num=16
+ lock: "kRCHigh1"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh2"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh3"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh4"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal3"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal4"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh2"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh3"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh4"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal2"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal3"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal4"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+
+# -------------------------------------------------------------
+# Pushee: isolation=read-committed, priority=high
+# Pusher: isolation=serializable,   priority=normal
+#
+# Explanation: RC transactions can always be pushed.
+# -------------------------------------------------------------
+
+new-request name=req17 txn=txnSSINormalPusher ts=10,1
+  get key=kRCHigh1
+----
+
+sequence req=req17
+----
+[17] sequence req17: sequencing request
+[17] sequence req17: acquiring latches
+[17] sequence req17: scanning lock table for conflicting locks
+[17] sequence req17: waiting in lock wait-queues
+[17] sequence req17: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "kRCHigh1" (queuedWriters: 0, queuedReaders: 1)
+[17] sequence req17: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[17] sequence req17: pushing timestamp of txn 00000004 above 10.000000000,1
+[17] sequence req17: pusher pushed pushee to 10.000000000,2
+[17] sequence req17: resolving intent "kRCHigh1" for txn 00000004 with PENDING status and clock observation {1 123.000000000,25}
+[17] sequence req17: lock wait-queue event: done waiting
+[17] sequence req17: conflicted with 00000004-0000-0000-0000-000000000000 on "kRCHigh1" for 0.000s
+[17] sequence req17: acquiring latches
+[17] sequence req17: scanning lock table for conflicting locks
+[17] sequence req17: sequencing complete, returned guard
+
+finish req=req17
+----
+[-] finish req17: finishing request
+
+# -------------------------------------------------------------
+# Pushee: isolation=read-committed, priority=high
+# Pusher: isolation=serializable,   priority=high
+#
+# Explanation: RC transactions can always be pushed.
+# -------------------------------------------------------------
+
+new-request name=req18 txn=txnSSIHighPusher ts=11,1
+  get key=kRCHigh2
+----
+
+sequence req=req18
+----
+[18] sequence req18: sequencing request
+[18] sequence req18: acquiring latches
+[18] sequence req18: scanning lock table for conflicting locks
+[18] sequence req18: waiting in lock wait-queues
+[18] sequence req18: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "kRCHigh2" (queuedWriters: 0, queuedReaders: 1)
+[18] sequence req18: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[18] sequence req18: pushing timestamp of txn 00000004 above 11.000000000,1
+[18] sequence req18: pusher pushed pushee to 11.000000000,2
+[18] sequence req18: resolving intent "kRCHigh2" for txn 00000004 with PENDING status and clock observation {1 123.000000000,27}
+[18] sequence req18: lock wait-queue event: done waiting
+[18] sequence req18: conflicted with 00000004-0000-0000-0000-000000000000 on "kRCHigh2" for 0.000s
+[18] sequence req18: acquiring latches
+[18] sequence req18: scanning lock table for conflicting locks
+[18] sequence req18: sequencing complete, returned guard
+
+finish req=req18
+----
+[-] finish req18: finishing request
+
+# -------------------------------------------------------------
+# Pushee: isolation=read-committed, priority=high
+# Pusher: isolation=read-committed, priority=normal
+#
+# Explanation: RC transactions can always be pushed.
+# -------------------------------------------------------------
+
+new-request name=req19 txn=txnRCNormalPusher ts=12,1
+  get key=kRCHigh3
+----
+
+sequence req=req19
+----
+[19] sequence req19: sequencing request
+[19] sequence req19: acquiring latches
+[19] sequence req19: scanning lock table for conflicting locks
+[19] sequence req19: waiting in lock wait-queues
+[19] sequence req19: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "kRCHigh3" (queuedWriters: 0, queuedReaders: 1)
+[19] sequence req19: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[19] sequence req19: pushing timestamp of txn 00000004 above 12.000000000,1
+[19] sequence req19: pusher pushed pushee to 12.000000000,2
+[19] sequence req19: resolving intent "kRCHigh3" for txn 00000004 with PENDING status and clock observation {1 123.000000000,29}
+[19] sequence req19: lock wait-queue event: done waiting
+[19] sequence req19: conflicted with 00000004-0000-0000-0000-000000000000 on "kRCHigh3" for 0.000s
+[19] sequence req19: acquiring latches
+[19] sequence req19: scanning lock table for conflicting locks
+[19] sequence req19: sequencing complete, returned guard
+
+finish req=req19
+----
+[-] finish req19: finishing request
+
+# -------------------------------------------------------------
+# Pushee: isolation=read-committed, priority=high
+# Pusher: isolation=read-committed, priority=high
+#
+# Explanation: RC transactions can always be pushed.
+# -------------------------------------------------------------
+
+new-request name=req20 txn=txnRCHighPusher ts=13,1
+  get key=kRCHigh4
+----
+
+sequence req=req20
+----
+[20] sequence req20: sequencing request
+[20] sequence req20: acquiring latches
+[20] sequence req20: scanning lock table for conflicting locks
+[20] sequence req20: waiting in lock wait-queues
+[20] sequence req20: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "kRCHigh4" (queuedWriters: 0, queuedReaders: 1)
+[20] sequence req20: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[20] sequence req20: pushing timestamp of txn 00000004 above 13.000000000,1
+[20] sequence req20: pusher pushed pushee to 13.000000000,2
+[20] sequence req20: resolving intent "kRCHigh4" for txn 00000004 with PENDING status and clock observation {1 123.000000000,31}
+[20] sequence req20: lock wait-queue event: done waiting
+[20] sequence req20: conflicted with 00000004-0000-0000-0000-000000000000 on "kRCHigh4" for 0.000s
+[20] sequence req20: acquiring latches
+[20] sequence req20: scanning lock table for conflicting locks
+[20] sequence req20: sequencing complete, returned guard
+
+finish req=req20
+----
+[-] finish req20: finishing request
+
+debug-lock-table
+----
+num=16
+ lock: "kRCHigh1"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh2"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh3"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCHigh4"
+  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal3"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kRCNormal4"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh2"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh3"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSIHigh4"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal2"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal3"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kSSINormal4"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+
+reset
+----

--- a/pkg/kv/kvserver/txnwait/BUILD.bazel
+++ b/pkg/kv/kvserver/txnwait/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/base",
         "//pkg/kv",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/storage/enginepb",
@@ -37,6 +38,7 @@ go_test(
     deps = [
         "//pkg/kv",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/storage/enginepb",
         "//pkg/util/hlc",

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -73,18 +74,20 @@ func ShouldPushImmediately(req *kvpb.PushTxnRequest) bool {
 	if req.Force {
 		return true
 	}
-	if !(req.PushType == kvpb.PUSH_ABORT || req.PushType == kvpb.PUSH_TIMESTAMP) {
-		return true
-	}
-	if CanPushWithPriority(req.PusherTxn.Priority, req.PusheeTxn.Priority) {
-		return true
-	}
-	return false
+	return CanPushWithPriority(
+		req.PushType,
+		req.PusherTxn.IsoLevel, req.PusheeTxn.IsoLevel,
+		req.PusherTxn.Priority, req.PusheeTxn.Priority,
+	)
 }
 
-// CanPushWithPriority returns true if the given pusher can push the pushee
-// based on its priority.
-func CanPushWithPriority(pusher, pushee enginepb.TxnPriority) bool {
+// CanPushWithPriority returns true if the pusher can perform the specified push
+// type on the pushee, based on the two txns' isolation levels and priorities.
+func CanPushWithPriority(
+	pushType kvpb.PushTxnType,
+	pusherIso, pusheeIso isolation.Level,
+	pusherPri, pusheePri enginepb.TxnPriority,
+) bool {
 	// Normalize the transaction priorities so that normal user priorities are
 	// considered equal for the purposes of pushing.
 	normalize := func(p enginepb.TxnPriority) enginepb.TxnPriority {
@@ -95,8 +98,26 @@ func CanPushWithPriority(pusher, pushee enginepb.TxnPriority) bool {
 			return enginepb.MinTxnPriority + 1
 		}
 	}
-	pusher, pushee = normalize(pusher), normalize(pushee)
-	return pusher > pushee
+	pusherPri, pusheePri = normalize(pusherPri), normalize(pusheePri)
+	switch pushType {
+	case kvpb.PUSH_ABORT:
+		return pusherPri > pusheePri
+	case kvpb.PUSH_TIMESTAMP:
+		// If the pushee transaction tolerates write skew, the PUSH_TIMESTAMP is
+		// harmless, so let it through.
+		return pusheeIso.ToleratesWriteSkew() ||
+			// Else, if the pushee transaction does not tolerate write skew but the
+			// pusher transaction does (and expects other to), let the PUSH_TIMESTAMP
+			// proceed as long as the pusher has at least the same priority.
+			(pusherIso.ToleratesWriteSkew() && pusherPri >= pusheePri) ||
+			// Otherwise, if neither transaction tolerates write skew, let the
+			// PUSH_TIMESTAMP proceed only if the pusher has a higher priority.
+			(pusherPri > pusheePri)
+	case kvpb.PUSH_TOUCH:
+		return true
+	default:
+		panic("unreachable")
+	}
 }
 
 // isPushed returns whether the PushTxn request has already been

--- a/pkg/kv/kvserver/txnwait/queue_test.go
+++ b/pkg/kv/kvserver/txnwait/queue_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -149,10 +150,14 @@ func TestShouldPushImmediately(t *testing.T) {
 				PushType: test.typ,
 				PusherTxn: roachpb.Transaction{
 					TxnMeta: enginepb.TxnMeta{
+						// NOTE: different pusher isolation levels tested below.
+						IsoLevel: isolation.Serializable,
 						Priority: test.pusherPri,
 					},
 				},
 				PusheeTxn: enginepb.TxnMeta{
+					// NOTE: different pushee isolation levels tested below.
+					IsoLevel: isolation.Serializable,
 					Priority: test.pusheePri,
 				},
 			}
@@ -164,15 +169,20 @@ func TestShouldPushImmediately(t *testing.T) {
 
 func TestCanPushWithPriority(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Run(kvpb.PUSH_ABORT.String(), testCanPushWithPriorityPushAbort)
+	t.Run(kvpb.PUSH_TIMESTAMP.String(), testCanPushWithPriorityPushTimestamp)
+	t.Run(kvpb.PUSH_TOUCH.String(), testCanPushWithPriorityPushTouch)
+}
 
+func testCanPushWithPriorityPushAbort(t *testing.T) {
 	min := enginepb.MinTxnPriority
 	max := enginepb.MaxTxnPriority
 	mid1 := enginepb.TxnPriority(1)
 	mid2 := enginepb.TxnPriority(2)
 	testCases := []struct {
-		pusher enginepb.TxnPriority
-		pushee enginepb.TxnPriority
-		exp    bool
+		pusherPri enginepb.TxnPriority
+		pusheePri enginepb.TxnPriority
+		exp       bool
 	}{
 		{min, min, false},
 		{min, mid1, false},
@@ -191,12 +201,221 @@ func TestCanPushWithPriority(t *testing.T) {
 		{max, mid2, true},
 		{max, max, false},
 	}
+	// NOTE: the behavior of PUSH_ABORT pushes is agnostic to isolation levels.
+	for _, pusherIso := range isolation.Levels() {
+		for _, pusheeIso := range isolation.Levels() {
+			for _, test := range testCases {
+				name := fmt.Sprintf("pusherIso=%s/pusheeIso=%s/pusherPri=%d/pusheePri=%d",
+					pusherIso, pusheeIso, test.pusherPri, test.pusheePri)
+				t.Run(name, func(t *testing.T) {
+					canPush := CanPushWithPriority(kvpb.PUSH_ABORT, pusherIso, pusheeIso, test.pusherPri, test.pusheePri)
+					require.Equal(t, test.exp, canPush)
+				})
+			}
+		}
+	}
+}
+
+func testCanPushWithPriorityPushTimestamp(t *testing.T) {
+	SSI := isolation.Serializable
+	SI := isolation.Snapshot
+	RC := isolation.ReadCommitted
+	min := enginepb.MinTxnPriority
+	max := enginepb.MaxTxnPriority
+	mid1 := enginepb.TxnPriority(1)
+	mid2 := enginepb.TxnPriority(2)
+	testCases := []struct {
+		pusherIso isolation.Level
+		pusheeIso isolation.Level
+		pusherPri enginepb.TxnPriority
+		pusheePri enginepb.TxnPriority
+		exp       bool
+	}{
+		// SSI pushing SSI
+		{SSI, SSI, min, min, false},
+		{SSI, SSI, min, mid1, false},
+		{SSI, SSI, min, mid2, false},
+		{SSI, SSI, min, max, false},
+		{SSI, SSI, mid1, min, true},
+		{SSI, SSI, mid1, mid1, false},
+		{SSI, SSI, mid1, mid2, false},
+		{SSI, SSI, mid1, max, false},
+		{SSI, SSI, mid2, min, true},
+		{SSI, SSI, mid2, mid1, false},
+		{SSI, SSI, mid2, mid2, false},
+		{SSI, SSI, mid2, max, false},
+		{SSI, SSI, max, min, true},
+		{SSI, SSI, max, mid1, true},
+		{SSI, SSI, max, mid2, true},
+		{SSI, SSI, max, max, false},
+		// SSI pushing SI
+		{SSI, SI, min, min, true},
+		{SSI, SI, min, mid1, true},
+		{SSI, SI, min, mid2, true},
+		{SSI, SI, min, max, true},
+		{SSI, SI, mid1, min, true},
+		{SSI, SI, mid1, mid1, true},
+		{SSI, SI, mid1, mid2, true},
+		{SSI, SI, mid1, max, true},
+		{SSI, SI, mid2, min, true},
+		{SSI, SI, mid2, mid1, true},
+		{SSI, SI, mid2, mid2, true},
+		{SSI, SI, mid2, max, true},
+		{SSI, SI, max, min, true},
+		{SSI, SI, max, mid1, true},
+		{SSI, SI, max, mid2, true},
+		{SSI, SI, max, max, true},
+		// SSI pushing RC
+		{SSI, RC, min, min, true},
+		{SSI, RC, min, mid1, true},
+		{SSI, RC, min, mid2, true},
+		{SSI, RC, min, max, true},
+		{SSI, RC, mid1, min, true},
+		{SSI, RC, mid1, mid1, true},
+		{SSI, RC, mid1, mid2, true},
+		{SSI, RC, mid1, max, true},
+		{SSI, RC, mid2, min, true},
+		{SSI, RC, mid2, mid1, true},
+		{SSI, RC, mid2, mid2, true},
+		{SSI, RC, mid2, max, true},
+		{SSI, RC, max, min, true},
+		{SSI, RC, max, mid1, true},
+		{SSI, RC, max, mid2, true},
+		{SSI, RC, max, max, true},
+		// SI pushing SSI
+		{SI, SSI, min, min, true},
+		{SI, SSI, min, mid1, false},
+		{SI, SSI, min, mid2, false},
+		{SI, SSI, min, max, false},
+		{SI, SSI, mid1, min, true},
+		{SI, SSI, mid1, mid1, true},
+		{SI, SSI, mid1, mid2, true},
+		{SI, SSI, mid1, max, false},
+		{SI, SSI, mid2, min, true},
+		{SI, SSI, mid2, mid1, true},
+		{SI, SSI, mid2, mid2, true},
+		{SI, SSI, mid2, max, false},
+		{SI, SSI, max, min, true},
+		{SI, SSI, max, mid1, true},
+		{SI, SSI, max, mid2, true},
+		{SI, SSI, max, max, true},
+		// SI pushing SI
+		{SI, SI, min, min, true},
+		{SI, SI, min, mid1, true},
+		{SI, SI, min, mid2, true},
+		{SI, SI, min, max, true},
+		{SI, SI, mid1, min, true},
+		{SI, SI, mid1, mid1, true},
+		{SI, SI, mid1, mid2, true},
+		{SI, SI, mid1, max, true},
+		{SI, SI, mid2, min, true},
+		{SI, SI, mid2, mid1, true},
+		{SI, SI, mid2, mid2, true},
+		{SI, SI, mid2, max, true},
+		{SI, SI, max, min, true},
+		{SI, SI, max, mid1, true},
+		{SI, SI, max, mid2, true},
+		{SI, SI, max, max, true},
+		// SI pushing RC
+		{SI, RC, min, min, true},
+		{SI, RC, min, mid1, true},
+		{SI, RC, min, mid2, true},
+		{SI, RC, min, max, true},
+		{SI, RC, mid1, min, true},
+		{SI, RC, mid1, mid1, true},
+		{SI, RC, mid1, mid2, true},
+		{SI, RC, mid1, max, true},
+		{SI, RC, mid2, min, true},
+		{SI, RC, mid2, mid1, true},
+		{SI, RC, mid2, mid2, true},
+		{SI, RC, mid2, max, true},
+		{SI, RC, max, min, true},
+		{SI, RC, max, mid1, true},
+		{SI, RC, max, mid2, true},
+		{SI, RC, max, max, true},
+		// RC pushing SSI
+		{RC, SSI, min, min, true},
+		{RC, SSI, min, mid1, false},
+		{RC, SSI, min, mid2, false},
+		{RC, SSI, min, max, false},
+		{RC, SSI, mid1, min, true},
+		{RC, SSI, mid1, mid1, true},
+		{RC, SSI, mid1, mid2, true},
+		{RC, SSI, mid1, max, false},
+		{RC, SSI, mid2, min, true},
+		{RC, SSI, mid2, mid1, true},
+		{RC, SSI, mid2, mid2, true},
+		{RC, SSI, mid2, max, false},
+		{RC, SSI, max, min, true},
+		{RC, SSI, max, mid1, true},
+		{RC, SSI, max, mid2, true},
+		{RC, SSI, max, max, true},
+		// RC pushing SI
+		{RC, SI, min, min, true},
+		{RC, SI, min, mid1, true},
+		{RC, SI, min, mid2, true},
+		{RC, SI, min, max, true},
+		{RC, SI, mid1, min, true},
+		{RC, SI, mid1, mid1, true},
+		{RC, SI, mid1, mid2, true},
+		{RC, SI, mid1, max, true},
+		{RC, SI, mid2, min, true},
+		{RC, SI, mid2, mid1, true},
+		{RC, SI, mid2, mid2, true},
+		{RC, SI, mid2, max, true},
+		{RC, SI, max, min, true},
+		{RC, SI, max, mid1, true},
+		{RC, SI, max, mid2, true},
+		{RC, SI, max, max, true},
+		// RC pushing RC
+		{RC, RC, min, min, true},
+		{RC, RC, min, mid1, true},
+		{RC, RC, min, mid2, true},
+		{RC, RC, min, max, true},
+		{RC, RC, mid1, min, true},
+		{RC, RC, mid1, mid1, true},
+		{RC, RC, mid1, mid2, true},
+		{RC, RC, mid1, max, true},
+		{RC, RC, mid2, min, true},
+		{RC, RC, mid2, mid1, true},
+		{RC, RC, mid2, mid2, true},
+		{RC, RC, mid2, max, true},
+		{RC, RC, max, min, true},
+		{RC, RC, max, mid1, true},
+		{RC, RC, max, mid2, true},
+		{RC, RC, max, max, true},
+	}
 	for _, test := range testCases {
-		name := fmt.Sprintf("pusher=%d/pushee=%d", test.pusher, test.pushee)
+		name := fmt.Sprintf("pusherIso=%s/pusheeIso=%s/pusherPri=%d/pusheePri=%d",
+			test.pusherIso, test.pusheeIso, test.pusherPri, test.pusheePri)
 		t.Run(name, func(t *testing.T) {
-			canPush := CanPushWithPriority(test.pusher, test.pushee)
+			canPush := CanPushWithPriority(kvpb.PUSH_TIMESTAMP, test.pusherIso, test.pusheeIso, test.pusherPri, test.pusheePri)
 			require.Equal(t, test.exp, canPush)
 		})
+	}
+}
+
+func testCanPushWithPriorityPushTouch(t *testing.T) {
+	min := enginepb.MinTxnPriority
+	max := enginepb.MaxTxnPriority
+	mid1 := enginepb.TxnPriority(1)
+	mid2 := enginepb.TxnPriority(2)
+	priorities := []enginepb.TxnPriority{min, mid1, mid2, max}
+	// NOTE: the behavior of PUSH_TOUCH pushes is agnostic to isolation levels.
+	for _, pusherIso := range isolation.Levels() {
+		for _, pusheeIso := range isolation.Levels() {
+			// NOTE: the behavior of PUSH_TOUCH pushes is agnostic to txn priorities.
+			for _, pusherPri := range priorities {
+				for _, pusheePri := range priorities {
+					name := fmt.Sprintf("pusherIso=%s/pusheeIso=%s/pusherPri=%d/pusheePri=%d",
+						pusherIso, pusheeIso, pusherPri, pusheePri)
+					t.Run(name, func(t *testing.T) {
+						canPush := CanPushWithPriority(kvpb.PUSH_TOUCH, pusherIso, pusheeIso, pusherPri, pusheePri)
+						require.True(t, canPush)
+					})
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #102014.

This commit updates write-read conflict rules to allow non-blocking behavior for weak isolation transactions. Specifically, PUSH_TIMESTAMP requests are now allowed to succeed when encountering PENDING pushees if any of the following conditions is true:
- the pushee is a weak isolation transaction
- OR the pusher is a weak isolation transaction with an equal priority as the pushee
- OR the pusher has a greater priority than the pushee (previous behavior)

The rationale for this behavior is that weak isolation transactions can tolerate write skew without a refresh or retry. Because of this, they face no consequence from being pushed and also expect others to be pushable (non-blocking).

Longer-term, we would like all write-read conflicts to become non-blocking. For now, these rules ensure that all write-read conflicts between weak isolation transactions are non-blocking, and also that write-read conflicts between a weak isolation transaction and a strong isolation (serializable) transaction has reasonable, tunable behavior.

Release note: None