### PR TITLE
roachtest: disable metamorphic expiration leases in some tests

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -192,6 +192,8 @@ type LeaseType int
 
 func (l LeaseType) String() string {
 	switch l {
+	case DefaultLeases:
+		return "default"
 	case EpochLeases:
 		return "epoch"
 	case ExpirationLeases:

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -102,7 +102,6 @@ func registerDecommission(r registry.Registry) {
 			Name:    "decommission/mixed-versions",
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(numNodes),
-			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() && runtime.GOARCH == "arm64" {
 					t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -102,7 +102,6 @@ func registerFollowerReads(r registry.Registry) {
 			3, /* nodeCount */
 			spec.CPU(2),
 		),
-		Leases: registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -356,7 +356,6 @@ func registerImportMixedVersion(r registry.Registry) {
 		Owner: registry.OwnerSQLQueries,
 		// Mixed-version support was added in 21.1.
 		Cluster: r.MakeClusterSpec(4),
-		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -209,7 +209,6 @@ func registerRebalanceLoad(r registry.Registry) {
 			Name:    `rebalance/by-load/leases/mixed-version`,
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(4), // the last node is just used to generate load
-			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					concurrency = 32
@@ -241,7 +240,6 @@ func registerRebalanceLoad(r registry.Registry) {
 			Name:    `rebalance/by-load/replicas/mixed-version`,
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(7), // the last node is just used to generate load
-			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					concurrency = 32

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -139,7 +139,6 @@ func registerSecondaryIndexesMultiVersionCluster(r registry.Registry) {
 		Name:    "schemachange/secondary-index-multi-version",
 		Owner:   registry.OwnerSQLSchema,
 		Cluster: r.MakeClusterSpec(3),
-		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")


### PR DESCRIPTION
This caused test failures in:

* `decommission/mixed-versions`
* `follower-reads/mixed-version/single-region`
* `import/mixed-versions`
* `kv/splits/nodes=3/quiesce=true`
* `rebalance/by-load/leases/mixed-version`
* `rebalance/by-load/replicas/mixed-version`
* `schemachange/secondary-index-multi-version`

Follows #103190.
Resolves #103271.
Resolves #103272.
Resolves #103275.
Resolves #103268.
Resolves #103287.
Resolves #103303.
Touches #101620.

Epic: none
Release note: None