### PR TITLE
kvserver: add expiration lease escape hatch

### DIFF
--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/growstack"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -89,6 +90,12 @@ var ExpirationLeasesOnly = settings.RegisterBoolSetting(
 	!syncutil.DeadlockEnabled &&
 		util.ConstantWithMetamorphicTestBool("kv.expiration_leases_only.enabled", false),
 )
+
+// DisableExpirationLeasesOnly is an escape hatch for ExpirationLeasesOnly,
+// which can be used to hard-disable expiration-based leases e.g. if clusters
+// are unable to start back up due to the lease extension load.
+var DisableExpirationLeasesOnly = envutil.EnvOrDefaultBool(
+	"COCKROACH_DISABLE_EXPIRATION_LEASES_ONLY", false)
 
 // EagerLeaseAcquisitionConcurrency is the number of concurrent, eager lease
 // acquisitions made during Raft ticks, across all stores. Note that this does
@@ -824,7 +831,8 @@ func (r *Replica) requiresExpirationLeaseRLocked() bool {
 // expiration-based lease, either because it requires one or because
 // kv.expiration_leases_only.enabled is enabled.
 func (r *Replica) shouldUseExpirationLeaseRLocked() bool {
-	return ExpirationLeasesOnly.Get(&r.ClusterSettings().SV) || r.requiresExpirationLeaseRLocked()
+	return (ExpirationLeasesOnly.Get(&r.ClusterSettings().SV) && !DisableExpirationLeasesOnly) ||
+		r.requiresExpirationLeaseRLocked()
 }
 
 // requestLeaseLocked executes a request to obtain or extend a lease


### PR DESCRIPTION
This patch adds `COCKROACH_DISABLE_EXPIRATION_LEASES_ONLY`, which can be used to hard-disable expiration-based leases, e.g. in cases where the lease extensions overload the cluster and prevent it from working, and thus prevent operators from disabling the setting.

Epic: none
Release note: None