### PR TITLE
kvserver: fix expectation order in test assertions

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -399,8 +399,8 @@ func TestRestoreReplicas(t *testing.T) {
 			successes++
 		}
 	}
-	require.Equal(t, failures, 1)
-	require.Equal(t, successes, 1)
+	require.Equal(t, 1, failures, "replica command failed (non leaseholders)")
+	require.Equal(t, 1, successes, "replica command succeeded (leaseholders)")
 
 	testutils.SucceedsSoon(t, func() error {
 		getArgs := getArgs([]byte("a"))


### PR DESCRIPTION
Fix require.Equal argument order in tests to make output more readable.

Previous:
```
        	Error:      	Not equal: 
        	            	expected: 2
        	            	actual  : 1
```
Should be:
```
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
```

Epic: none

Release note: None