### PR TITLE
allocator2: add cand to replace for rebalance

### DIFF
--- a/pkg/kv/kvserver/allocator/allocator2/testdata/range_analyzed_constraints
+++ b/pkg/kv/kvserver/allocator/allocator2/testdata/range_analyzed_constraints
@@ -79,6 +79,27 @@ voter-constraints:
     non-voters:
 diversity: voter 0.000000, all 0.000000
 
+candidates 
+----
+nonVoterToVoter
+addingVoter
+	add: (+region=a,-zone=a1)
+voterToNonVoter
+addingNonVoter
+	add: (+region=d,+zone=d2) (+region=c,+zone=c2) ()
+roleSwap
+	err: expected enough voters and non-voters but have 2/3 voters and 0/2 non-voters
+toRemove
+	err: expected enough voters and non-voters but have 2/3 voters and 0/2 non-voters
+voterUnsatisfied
+	err: expected enough voters and non-voters but have 2/3 voters and 0/2 non-voters
+nonVoterUnsatisfied
+	err: expected enough voters and non-voters but have 2/3 voters and 0/2 non-voters
+replaceVoterRebalance replace=2
+	err: expected enough voters and non-voters but have 2/3 voters and 0/2 non-voters
+replaceVoterRebalance replace=3
+	err: expected enough voters and non-voters but have 2/3 voters and 0/2 non-voters
+
 store store-id=5 attrs=ssd locality-tiers=region=d,zone=d2 node-id=2
 ----
 
@@ -120,6 +141,35 @@ voter-constraints:
     voters: 3
     non-voters: 5 6
 diversity: voter 0.000000, all 0.833333
+
+# There are not enough voters (2/3) but enough non-voters (2/2). There are no
+# non-voters satisfying the unsatisfied voter constraint
+# (+region=a,-zone=a1:1). Expect no promotions.
+candidates 
+----
+nonVoterToVoter
+addingVoter
+	add: (+region=a,-zone=a1)
+voterToNonVoter
+	err: expected enough=false non-voters but have 2/2
+addingNonVoter
+	err: expected enough=false non-voters but have 2/2
+roleSwap
+	err: expected enough voters and non-voters but have 2/3 voters and 2/2 non-voters
+toRemove
+	err: expected enough voters and non-voters but have 2/3 voters and 2/2 non-voters
+voterUnsatisfied
+	err: expected enough voters and non-voters but have 2/3 voters and 2/2 non-voters
+nonVoterUnsatisfied
+	err: expected enough voters and non-voters but have 2/3 voters and 2/2 non-voters
+replaceVoterRebalance replace=2
+	err: expected enough voters and non-voters but have 2/3 voters and 2/2 non-voters
+replaceVoterRebalance replace=3
+	err: expected enough voters and non-voters but have 2/3 voters and 2/2 non-voters
+replaceNonVoterRebalance replace=5
+	err: expected enough voters and non-voters but have 2/3 voters and 2/2 non-voters
+replaceNonVoterRebalance replace=6
+	err: expected enough voters and non-voters but have 2/3 voters and 2/2 non-voters
 
 store store-id=8 attrs=tape locality-tiers=region=d,zone=d2 node-id=5
 ----
@@ -165,3 +215,342 @@ voter-constraints:
     voters: 3 9
     non-voters: 5 6 8
 diversity: voter 0.833333, all 0.857143
+
+# There are too many voters (4/3) and non-voters (3/2). +region=d,+zone=d2d is
+# oversatisfied (2/1) by s5 and s8, s6 satisfies no non-voter constraints.
+# Expect all of these as candidates. We prefer removing non-voters before
+# removing voting replicas.
+candidates
+----
+nonVoterToVoter
+	err: expected enough=false voters but have 4/3
+addingVoter
+	err: expected enough=false voters but have 4/3
+voterToNonVoter
+	err: expected enough=false non-voters but have 3/2
+addingNonVoter
+	err: expected enough=false non-voters but have 3/2
+roleSwap
+toRemove
+	remove: 5 8 6
+voterUnsatisfied
+nonVoterUnsatisfied
+	remove: 5 8 6
+	add: (+region=c,+zone=c2)
+replaceVoterRebalance replace=2
+	err: expected only matched constraints but found under=1 match=0 over=2
+replaceVoterRebalance replace=3
+	err: expected only matched constraints but found under=1 match=0 over=2
+replaceVoterRebalance replace=9
+	err: expected only matched constraints but found under=1 match=0 over=2
+replaceVoterRebalance replace=10
+	err: expected only matched constraints but found under=1 match=0 over=2
+replaceNonVoterRebalance replace=5
+	err: expected only matched constraints but found under=1 match=0 over=2
+replaceNonVoterRebalance replace=6
+	err: expected only matched constraints but found under=1 match=0 over=2
+replaceNonVoterRebalance replace=8
+	err: expected only matched constraints but found under=1 match=0 over=2
+
+store store-id=11 attrs=flash locality-tiers=region=c,zone=c2 node-id=8
+----
+
+# The constraints are all matched and there is the correct number of voters and
+# non-voters. Check the rebalance candidates.
+analyze-constraints config-name=multi-region1
+store-id=5 type=NON_VOTER   
+store-id=11 type=NON_VOTER
+store-id=2 type=VOTER_FULL  
+store-id=10 type=VOTER_FULL 
+store-id=3 type=VOTER_FULL  
+----
+needed: voters 3 non-voters 2
+voters: 2(=b,=b1,=1) 10(=a,=a3,=7) 3(=b,=b1,=1)
+non-voters: 5(=d,=d2,=2) 11(=c,=c2,=8)
+constraints:
+  +region=d,+zone=d2:1
+    voters:
+    non-voters: 5
+  +region=c,+zone=c2:1
+    voters:
+    non-voters: 11
+  :3
+    voters: 2 10 3
+    non-voters:
+voter-constraints:
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  +region=a,-zone=a1:1
+    voters: 10
+    non-voters:
+  :1
+    voters: 3
+    non-voters: 5 11
+diversity: voter 0.666667, all 0.900000
+
+candidates 
+----
+nonVoterToVoter
+	err: expected enough=false voters but have 3/3
+addingVoter
+	err: expected enough=false voters but have 3/3
+voterToNonVoter
+	err: expected enough=false non-voters but have 2/2
+addingNonVoter
+	err: expected enough=false non-voters but have 2/2
+roleSwap
+toRemove
+voterUnsatisfied
+nonVoterUnsatisfied
+replaceVoterRebalance replace=2
+	add: (+ssd,+region=b,+zone=b1)
+replaceVoterRebalance replace=10
+	add: (+region=a,-zone=a1)
+replaceVoterRebalance replace=3
+	add: ()
+replaceNonVoterRebalance replace=5
+	add: (+region=d,+zone=d2)
+replaceNonVoterRebalance replace=11
+	add: (+region=c,+zone=c2)
+
+# Missing a voter to satisfy +region=a,-zone=a1:1, have a non-voter (s10) which
+# satisfies this constraint. Expect nonVoterToVoter suggests removing s10.
+analyze-constraints config-name=multi-region1
+store-id=2 type=VOTER_FULL  
+store-id=3 type=VOTER_FULL  
+store-id=5 type=NON_VOTER   
+store-id=10 type=NON_VOTER 
+store-id=11 type=NON_VOTER
+----
+needed: voters 3 non-voters 2
+voters: 2(=b,=b1,=1) 3(=b,=b1,=1)
+non-voters: 5(=d,=d2,=2) 10(=a,=a3,=7) 11(=c,=c2,=8)
+constraints:
+  +region=d,+zone=d2:1
+    voters:
+    non-voters: 5
+  +region=c,+zone=c2:1
+    voters:
+    non-voters: 11
+  :3
+    voters: 2 3
+    non-voters: 10
+voter-constraints:
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  +region=a,-zone=a1:1
+    voters:
+    non-voters: 10
+  :1
+    voters: 3
+    non-voters: 5 11
+diversity: voter 0.000000, all 0.900000
+
+candidates
+----
+nonVoterToVoter
+	remove: 10
+addingVoter
+	add: (+region=a,-zone=a1)
+voterToNonVoter
+	err: expected enough=false non-voters but have 3/2
+addingNonVoter
+	err: expected enough=false non-voters but have 3/2
+roleSwap
+	err: expected enough voters and non-voters but have 2/3 voters and 3/2 non-voters
+toRemove
+	err: expected enough voters and non-voters but have 2/3 voters and 3/2 non-voters
+voterUnsatisfied
+	err: expected enough voters and non-voters but have 2/3 voters and 3/2 non-voters
+nonVoterUnsatisfied
+	err: expected enough voters and non-voters but have 2/3 voters and 3/2 non-voters
+replaceVoterRebalance replace=2
+	err: expected enough voters and non-voters but have 2/3 voters and 3/2 non-voters
+replaceVoterRebalance replace=3
+	err: expected enough voters and non-voters but have 2/3 voters and 3/2 non-voters
+replaceNonVoterRebalance replace=5
+	err: expected enough voters and non-voters but have 2/3 voters and 3/2 non-voters
+replaceNonVoterRebalance replace=10
+	err: expected enough voters and non-voters but have 2/3 voters and 3/2 non-voters
+replaceNonVoterRebalance replace=11
+	err: expected enough voters and non-voters but have 2/3 voters and 3/2 non-voters
+
+# Missing voter constraint (+region=a,-zone=a1), expect a role swap and
+# voter unsatisfied constraint disjunction.
+analyze-constraints config-name=multi-region1
+store-id=2 type=VOTER_FULL  
+store-id=3 type=VOTER_FULL  
+store-id=5 type=VOTER_FULL   
+store-id=10 type=NON_VOTER 
+store-id=11 type=NON_VOTER
+----
+needed: voters 3 non-voters 2
+voters: 2(=b,=b1,=1) 3(=b,=b1,=1) 5(=d,=d2,=2)
+non-voters: 10(=a,=a3,=7) 11(=c,=c2,=8)
+constraints:
+  +region=d,+zone=d2:1
+    voters: 5
+    non-voters:
+  +region=c,+zone=c2:1
+    voters:
+    non-voters: 11
+  :3
+    voters: 2 3
+    non-voters: 10
+voter-constraints:
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  +region=a,-zone=a1:1
+    voters:
+    non-voters: 10
+  :1
+    voters: 3 5
+    non-voters: 11
+diversity: voter 0.666667, all 0.900000
+
+candidates
+----
+nonVoterToVoter
+	err: expected enough=false voters but have 3/3
+addingVoter
+	err: expected enough=false voters but have 3/3
+voterToNonVoter
+	err: expected enough=false non-voters but have 2/2
+addingNonVoter
+	err: expected enough=false non-voters but have 2/2
+roleSwap
+	remove: 3 5 10
+toRemove
+voterUnsatisfied
+	remove: 3 5
+	add: (+region=a,-zone=a1)
+nonVoterUnsatisfied
+replaceVoterRebalance replace=2
+	err: expected only matched voter constraints but found under=1 match=1 over=1
+replaceVoterRebalance replace=3
+	err: expected only matched voter constraints but found under=1 match=1 over=1
+replaceVoterRebalance replace=5
+	err: expected only matched voter constraints but found under=1 match=1 over=1
+replaceNonVoterRebalance replace=10
+	err: expected only matched voter constraints but found under=1 match=1 over=1
+replaceNonVoterRebalance replace=11
+	err: expected only matched voter constraints but found under=1 match=1 over=1
+
+# Too many voters (4/3) and not enough non-voters (1/2). Voter store 3 and 11
+# satisfy an all replica constraint but no non-empty voter 
+analyze-constraints config-name=multi-region1
+store-id=5 type=NON_VOTER   
+store-id=11 type=VOTER_FULL
+store-id=2 type=VOTER_FULL  
+store-id=10 type=VOTER_FULL 
+store-id=3 type=VOTER_FULL 
+----
+needed: voters 3 non-voters 2
+voters: 11(=c,=c2,=8) 2(=b,=b1,=1) 10(=a,=a3,=7) 3(=b,=b1,=1)
+non-voters: 5(=d,=d2,=2)
+constraints:
+  +region=d,+zone=d2:1
+    voters:
+    non-voters: 5
+  +region=c,+zone=c2:1
+    voters: 11
+    non-voters:
+  :3
+    voters: 2 10 3
+    non-voters:
+voter-constraints:
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  +region=a,-zone=a1:1
+    voters: 10
+    non-voters:
+  :1
+    voters: 11 3
+    non-voters: 5
+diversity: voter 0.833333, all 0.900000
+
+candidates
+----
+nonVoterToVoter
+	err: expected enough=false voters but have 4/3
+addingVoter
+	err: expected enough=false voters but have 4/3
+voterToNonVoter
+	remove: 3 11
+addingNonVoter
+	err: could not find unsatisfied constraint
+roleSwap
+	err: expected enough voters and non-voters but have 4/3 voters and 1/2 non-voters
+toRemove
+	err: expected enough voters and non-voters but have 4/3 voters and 1/2 non-voters
+voterUnsatisfied
+	err: expected enough voters and non-voters but have 4/3 voters and 1/2 non-voters
+nonVoterUnsatisfied
+	err: expected enough voters and non-voters but have 4/3 voters and 1/2 non-voters
+replaceVoterRebalance replace=11
+	err: expected enough voters and non-voters but have 4/3 voters and 1/2 non-voters
+replaceVoterRebalance replace=2
+	err: expected enough voters and non-voters but have 4/3 voters and 1/2 non-voters
+replaceVoterRebalance replace=10
+	err: expected enough voters and non-voters but have 4/3 voters and 1/2 non-voters
+replaceVoterRebalance replace=3
+	err: expected enough voters and non-voters but have 4/3 voters and 1/2 non-voters
+replaceNonVoterRebalance replace=5
+	err: expected enough voters and non-voters but have 4/3 voters and 1/2 non-voters
+
+span-config name=no-constraint num-replicas=5 num-voters=3
+----
+ num-replicas=5 num-voters=3
+ constraints:
+   :5
+
+analyze-constraints config-name=no-constraint
+store-id=2 type=VOTER_FULL   
+store-id=3 type=VOTER_FULL
+store-id=5 type=VOTER_FULL  
+store-id=6 type=NON_VOTER 
+store-id=7 type=NON_VOTER 
+----
+needed: voters 3 non-voters 2
+voters: 2(=b,=b1,=1) 3(=b,=b1,=1) 5(=d,=d2,=2)
+non-voters: 6(=a,=a1,=3) 7(=a,=a1,=4)
+constraints:
+  :5
+    voters: 2 3 5
+    non-voters: 6 7
+diversity: voter 0.666667, all 0.833333
+
+candidates
+----
+nonVoterToVoter
+	err: expected enough=false voters but have 3/3
+addingVoter
+	err: expected enough=false voters but have 3/3
+voterToNonVoter
+	err: expected enough=false non-voters but have 2/2
+addingNonVoter
+	err: expected enough=false non-voters but have 2/2
+roleSwap
+toRemove
+voterUnsatisfied
+nonVoterUnsatisfied
+replaceVoterRebalance replace=2
+	add: ()
+replaceVoterRebalance replace=3
+	add: ()
+replaceVoterRebalance replace=5
+	add: ()
+replaceNonVoterRebalance replace=6
+	add: ()
+replaceNonVoterRebalance replace=7
+	add: ()
+
+# TODO(kvoli): Test additional configurations
+# - Single conjunction without num_replicas specified for either/both
+#   constraints and voter constraints.
+# - Only prohibiting constraints.
+# - Common configurations not already included such as REGION survival.


### PR DESCRIPTION
Fill in these range analyzed constraint functions:

```
candidatesNonVoterConstraintsUnsatisfied
candidatesToReplaceVoterForRebalance
candidatesToReplaceNonVoterForRebalance
```

Also add assertions which return an error when
`rangeAnalyzedConstraints` method preconditions are
not met.

Epic: CRDB-25222
Informs:  https://github.com/cockroachdb/cockroach/issues/103320

Release note: None