### PR TITLE
ui: enable system tenant to view metrics per tenant

### DIFF
--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -34,6 +34,7 @@ import {
   statementAttr,
   tabAttr,
   tableNameAttr,
+  tenantNameAttr,
   txnFingerprintIdAttr,
   viewAttr,
   idAttr,
@@ -144,7 +145,18 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                       to={`/metrics/:${dashboardNameAttr}/cluster`}
                     />
                     <Route
+                      exact
                       path={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}`}
+                      component={NodeGraphs}
+                    />
+                    <Route
+                      exact
+                      path={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}/tenant/:${tenantNameAttr}`}
+                      component={NodeGraphs}
+                    />
+                    <Route
+                      exact
+                      path={`/metrics/:${dashboardNameAttr}/cluster/tenant/:${tenantNameAttr}`}
                       component={NodeGraphs}
                     />
 

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -525,6 +525,14 @@ const rawTraceReducerObj = new KeyedCachedDataReducer(
 );
 export const refreshRawTrace = rawTraceReducerObj.refresh;
 
+const tenantsListObj = new CachedDataReducer(
+  api.getTenants,
+  "tenants",
+  moment.duration(60, "m"),
+);
+
+export const refreshTenantsList = tenantsListObj.refresh;
+
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
   events: CachedDataReducerState<
@@ -588,6 +596,7 @@ export interface APIReducersState {
   snapshots: KeyedCachedDataReducerState<clusterUiApi.ListTracingSnapshotsResponse>;
   snapshot: KeyedCachedDataReducerState<clusterUiApi.GetTracingSnapshotResponse>;
   rawTrace: KeyedCachedDataReducerState<clusterUiApi.GetTraceResponse>;
+  tenants: CachedDataReducerState<api.ListTenantsResponseMessage>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -642,6 +651,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [rawTraceReducerObj.actionNamespace]: rawTraceReducerObj.reducer,
   [statementFingerprintInsightsReducerObj.actionNamespace]:
     statementFingerprintInsightsReducerObj.reducer,
+  [tenantsListObj.actionNamespace]: tenantsListObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/redux/cookies.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cookies.spec.ts
@@ -1,0 +1,66 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import {
+  getAllCookies,
+  getCookieValue,
+  selectTenantsFromMultitenantSessionCookie,
+  maybeClearTenantCookie,
+  setCookie,
+} from "./cookies";
+
+describe("Cookies", () => {
+  beforeEach(() => {
+    Object.defineProperty(window.document, "cookie", {
+      writable: true,
+      value: "tenant=system;session=abc123,system,def456,demoapp",
+    });
+  });
+  afterEach(() => {
+    Object.defineProperty(window.document, "cookie", {
+      writable: true,
+      value: "",
+    });
+  });
+  it("should return a map of cookie keys mapped to their values", () => {
+    const result = getAllCookies();
+    const expected = new Map();
+    expected.set("tenant", "system");
+    expected.set("session", "abc123,system,def456,demoapp");
+    expect(result).toEqual(expected);
+  });
+  it("should return a cookie value by key or return null", () => {
+    const result = getCookieValue("tenant");
+    const expected = "system";
+    expect(result).toEqual(expected);
+    const result2 = getCookieValue("unknown");
+    expect(result2).toBeNull();
+  });
+  it("should give a string array of tenants from the session cookie or an empty array", () => {
+    const result = selectTenantsFromMultitenantSessionCookie();
+    const expected = ["system", "demoapp"];
+    expect(result).toEqual(expected);
+    Object.defineProperty(window.document, "cookie", {
+      writable: true,
+      value: "",
+    });
+    const result2 = selectTenantsFromMultitenantSessionCookie();
+    expect(result2).toEqual([]);
+  });
+  it("should clear the tenant cookie if in a multitenant cluster", () => {
+    maybeClearTenantCookie();
+    const tenantCookie = getCookieValue("tenant");
+    expect(tenantCookie).toBeNull();
+  });
+  it("should set a cookie given a key and value", () => {
+    setCookie("foo", "bar");
+    const result = getCookieValue("foo");
+    expect(result).toEqual("bar");
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/redux/cookies.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cookies.ts
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 export const MULTITENANT_SESSION_COOKIE_NAME = "session";
+export const SYSTEM_TENANT_NAME = "system";
 
 export const getAllCookies = (): Map<string, string> => {
   const cookieMap: Map<string, string> = new Map();

--- a/pkg/ui/workspaces/db-console/src/redux/tenants.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/tenants.ts
@@ -1,0 +1,32 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { createSelector } from "reselect";
+import { DropdownOption } from "../views/shared/components/dropdown";
+import { AdminUIState } from "./state";
+
+export const tenantsSelector = (state: AdminUIState) =>
+  state.cachedData.tenants?.data?.tenants;
+
+// tenantDropdownOptions makes an array of dropdown options from
+// the tenants found in the redux state. It also adds a synthetic
+// all option which aggregates all metrics.
+export const tenantDropdownOptions = createSelector(
+  tenantsSelector,
+  tenantsList => {
+    const tenantOptions: DropdownOption[] = [{ label: "All", value: "" }];
+    tenantsList?.map(tenant =>
+      tenantOptions.push({
+        label: tenant.tenant_name,
+        value: tenant.tenant_id?.id?.toString(),
+      }),
+    );
+    return tenantOptions;
+  },
+);

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -203,6 +203,11 @@ export type ListTracingSnapshotsRequestMessage =
 export type ListTracingSnapshotsResponseMessage =
   protos.cockroach.server.serverpb.ListTracingSnapshotsResponse;
 
+export type ListTenantsRequestMessage =
+  protos.cockroach.server.serverpb.ListTenantsRequest;
+export type ListTenantsResponseMessage =
+  protos.cockroach.server.serverpb.ListTenantsResponse;
+
 // API constants
 
 export const API_PREFIX = "_admin/v1";
@@ -829,6 +834,18 @@ export function getKeyVisualizerSamples(
   return timeoutFetch(
     serverpb.KeyVisSamplesResponse,
     `${STATUS_PREFIX}/keyvissamples`,
+    req as any,
+    timeout,
+  );
+}
+
+export function getTenants(
+  req: ListTenantsRequestMessage,
+  timeout?: moment.Duration,
+): Promise<ListTenantsResponseMessage> {
+  return timeoutFetch(
+    serverpb.ListTenantsResponse,
+    `${API_PREFIX}/tenants`,
     req as any,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -11,6 +11,7 @@
 import { util } from "@cockroachlabs/cluster-ui";
 
 export const indexNameAttr = "index_name";
+export const tenantNameAttr = "tenant";
 
 export const {
   aggregatedTsAttr,

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
@@ -23,14 +23,20 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import TimeSeriesQueryAggregator = cockroach.ts.tspb.TimeSeriesQueryAggregator;
 
 export default function (props: GraphDashboardProps) {
-  const { storeSources, nodeIDs, nodeDisplayNameByID, storeIDsByNodeID } =
-    props;
+  const {
+    storeSources,
+    nodeIDs,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
+    tenantSource,
+  } = props;
 
   return [
     <LineGraph
       title="Max Changefeed Latency"
       isKvGraph={false}
       sources={storeSources}
+      tenantSource={tenantSource}
     >
       <Axis units={AxisUnits.Duration} label="time">
         <Metric
@@ -46,6 +52,7 @@ export default function (props: GraphDashboardProps) {
       title="Sink Byte Traffic"
       isKvGraph={false}
       sources={storeSources}
+      tenantSource={tenantSource}
     >
       <Axis units={AxisUnits.Bytes} label="bytes">
         <Metric
@@ -56,7 +63,12 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Sink Counts" isKvGraph={false} sources={storeSources}>
+    <LineGraph
+      title="Sink Counts"
+      isKvGraph={false}
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.node.changefeed.emitted_messages"
@@ -71,7 +83,12 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Sink Timings" isKvGraph={false} sources={storeSources}>
+    <LineGraph
+      title="Sink Timings"
+      isKvGraph={false}
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Duration} label="time">
         <Metric
           name="cr.node.changefeed.emit_nanos"
@@ -90,6 +107,7 @@ export default function (props: GraphDashboardProps) {
       title="Changefeed Restarts"
       isKvGraph={false}
       sources={storeSources}
+      tenantSource={tenantSource}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/crossClusterReplication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/crossClusterReplication.tsx
@@ -17,12 +17,13 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 import { GraphDashboardProps } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { storeSources } = props;
+  const { storeSources, tenantSource } = props;
 
   return [
     <LineGraph
       title="Replication Lag"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`The time between the wall clock and replicated time of the replication stream.
           This metric tracks how far behind the replication stream is relative to now. This metric is set to 0 during the initial scan.`}
     >
@@ -36,6 +37,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Logical Bytes"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`Rate at which the logical bytes (sum of keys + values) are ingested by all replication jobs`}
     >
       <Axis units={AxisUnits.Bytes} label="bytes">
@@ -49,6 +51,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="SST Bytes"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`Rate at which the SST bytes (compressed) are sent to KV by all replication jobs`}
     >
       <Axis units={AxisUnits.Bytes} label="bytes">

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils.ts
@@ -42,6 +42,10 @@ export interface GraphDashboardProps {
   storeIDsByNodeID: {
     [key: string]: string[];
   };
+
+  // Tenant ID which should be queried for data. This is empty if all tenants
+  // should be queried.
+  tenantSource?: string;
 }
 
 export function nodeDisplayName(

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -18,10 +18,14 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodeSources, nodeDisplayNameByID } = props;
+  const { nodeIDs, nodeSources, nodeDisplayNameByID, tenantSource } = props;
 
   return [
-    <LineGraph title="Batches" sources={nodeSources}>
+    <LineGraph
+      title="Batches"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="batches">
         <Metric
           name="cr.node.distsender.batches"
@@ -36,7 +40,7 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="RPCs" sources={nodeSources}>
+    <LineGraph title="RPCs" sources={nodeSources} tenantSource={tenantSource}>
       <Axis label="rpcs">
         <Metric
           name="cr.node.distsender.rpc.sent"
@@ -51,7 +55,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="RPC Errors" sources={nodeSources}>
+    <LineGraph
+      title="RPC Errors"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="errors">
         <Metric
           name="cr.node.distsender.rpc.sent.sendnexttimeout"
@@ -71,7 +79,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="KV Transactions" sources={nodeSources}>
+    <LineGraph
+      title="KV Transactions"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="transactions">
         <Metric name="cr.node.txn.commits" title="Committed" nonNegativeRate />
         <Metric
@@ -85,6 +97,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="KV Transaction Durations: 99th percentile"
+      tenantSource={tenantSource}
       tooltip={`The 99th percentile of transaction durations over a 1 minute period.
                               Values are displayed individually for each node.`}
     >
@@ -103,6 +116,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="KV Transaction Durations: 90th percentile"
+      tenantSource={tenantSource}
       tooltip={`The 90th percentile of transaction durations over a 1 minute period.
                               Values are displayed individually for each node.`}
     >
@@ -121,6 +135,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Node Heartbeat Latency: 99th percentile"
+      tenantSource={tenantSource}
       tooltip={`The 99th percentile of latency to heartbeat a node's internal liveness record over a 1 minute period.
                               Values are displayed individually for each node.`}
     >
@@ -139,6 +154,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Node Heartbeat Latency: 90th percentile"
+      tenantSource={tenantSource}
       tooltip={`The 90th percentile of latency to heartbeat a node's internal liveness record over a 1 minute period.
                               Values are displayed individually for each node.`}
     >

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -31,12 +31,14 @@ export default function (props: GraphDashboardProps) {
     nodeSources,
     storeSources,
     tooltipSelection,
+    tenantSource,
   } = props;
 
   return [
     <LineGraph
       title="CPU Percent"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={<div>CPU usage for the CRDB nodes {tooltipSelection}</div>}
     >
       <Axis units={AxisUnits.Percentage} label="CPU">
@@ -53,6 +55,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Host CPU Percent"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={<div>Machine-wide CPU usage {tooltipSelection}</div>}
     >
       <Axis units={AxisUnits.Percentage} label="CPU">
@@ -69,6 +72,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Memory Usage"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={<div>Memory in use {tooltipSelection}</div>}
     >
       <Axis units={AxisUnits.Bytes} label="memory usage">
@@ -82,7 +86,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Disk Read MiB/s" sources={nodeSources}>
+    <LineGraph
+      title="Disk Read MiB/s"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
           <Metric
@@ -95,7 +103,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Disk Write MiB/s" sources={nodeSources}>
+    <LineGraph
+      title="Disk Write MiB/s"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
           <Metric
@@ -108,7 +120,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Disk Read IOPS" sources={nodeSources}>
+    <LineGraph
+      title="Disk Read IOPS"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="IOPS">
         {nodeIDs.map(nid => (
           <Metric
@@ -121,7 +137,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Disk Write IOPS" sources={nodeSources}>
+    <LineGraph
+      title="Disk Write IOPS"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="IOPS">
         {nodeIDs.map(nid => (
           <Metric
@@ -134,7 +154,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Disk Ops In Progress" sources={nodeSources}>
+    <LineGraph
+      title="Disk Ops In Progress"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="Ops">
         {nodeIDs.map(nid => (
           <Metric
@@ -149,6 +173,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Available Disk Capacity"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={<AvailableDiscCapacityGraphTooltip />}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
@@ -162,7 +187,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Network Bytes Received" sources={nodeSources}>
+    <LineGraph
+      title="Network Bytes Received"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
           <Metric
@@ -175,7 +204,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Network Bytes Sent" sources={nodeSources}>
+    <LineGraph
+      title="Network Bytes Sent"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
           <Metric

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -27,10 +27,15 @@ export default function (props: GraphDashboardProps) {
     storeSources,
     nodeDisplayNameByID,
     storeIDsByNodeID,
+    tenantSource,
   } = props;
 
   return [
-    <LineGraph title="CPU Percent" sources={nodeSources}>
+    <LineGraph
+      title="CPU Percent"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Percentage} label="CPU">
         {nodeIDs.map(nid => (
           <Metric
@@ -45,6 +50,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Goroutine Scheduling Latency: 99th percentile"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`P99 scheduling latency for goroutines`}
     >
       <Axis units={AxisUnits.Duration} label="latency">
@@ -65,6 +71,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Runnable Goroutines per CPU"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The number of Goroutines waiting per CPU.`}
     >
       <Axis label="goroutines">
@@ -81,6 +88,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="LSM L0 Health"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`The number of files and sublevels within Level 0.`}
     >
       <Axis label="count">
@@ -105,7 +113,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="KV Admission Slots" sources={nodeSources}>
+    <LineGraph
+      title="KV Admission Slots"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="slots">
         {nodeIDs.map(nid => (
           <>
@@ -129,6 +141,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="KV Admission IO Tokens Exhausted Duration Per Second"
       sources={nodeSources}
+      tenantSource={tenantSource}
     >
       <Axis label="duration (micros/sec)">
         {nodeIDs.map(nid => (
@@ -143,7 +156,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Admission Work Rate" sources={nodeSources}>
+    <LineGraph
+      title="Admission Work Rate"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="work rate">
         {nodeIDs.map(nid => (
           <>
@@ -191,7 +208,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Admission Delay Rate" sources={nodeSources}>
+    <LineGraph
+      title="Admission Delay Rate"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="delay rate (micros/sec)">
         {nodeIDs.map(nid => (
           <>
@@ -232,7 +253,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Admission Delay: 75th percentile" sources={nodeSources}>
+    <LineGraph
+      title="Admission Delay: 75th percentile"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Duration} label="delay for requests that waited">
         {nodeIDs.map(nid => (
           <>

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -30,6 +30,7 @@ export default function (props: GraphDashboardProps) {
     tooltipSelection,
     nodeDisplayNameByID,
     storeIDsByNodeID,
+    tenantSource,
   } = props;
 
   return [
@@ -37,6 +38,7 @@ export default function (props: GraphDashboardProps) {
       title="SQL Statements"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`A moving average of the number of SELECT, INSERT, UPDATE, and DELETE statements
         successfully executed per second ${tooltipSelection}.`}
       preCalcGraphSize={true}
@@ -68,6 +70,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Service Latency: SQL Statements, 99th percentile"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip={
         <div>
           Over the last minute, this node executed 99% of SQL statements within
@@ -96,6 +99,7 @@ export default function (props: GraphDashboardProps) {
       title="SQL Statement Contention"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`A moving average of the number of SQL statements executed per second that experienced contention ${tooltipSelection}.`}
       preCalcGraphSize={true}
     >
@@ -110,6 +114,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Replicas per Node"
+      tenantSource={tenantSource}
       tooltip={
         <div>
           The number of range replicas stored on this node.{" "}
@@ -137,6 +142,7 @@ export default function (props: GraphDashboardProps) {
       title="Capacity"
       isKvGraph={true}
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection} />}
       preCalcGraphSize={true}
     >

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -17,10 +17,20 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodeSources, storeSources, nodeDisplayNameByID } = props;
+  const {
+    nodeIDs,
+    nodeSources,
+    storeSources,
+    nodeDisplayNameByID,
+    tenantSource,
+  } = props;
 
   return [
-    <LineGraph title="Queue Processing Failures" sources={storeSources}>
+    <LineGraph
+      title="Queue Processing Failures"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="failures">
         <Metric
           name="cr.store.queue.gc.process.failure"
@@ -70,7 +80,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Queue Processing Times" sources={storeSources}>
+    <LineGraph
+      title="Queue Processing Times"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Duration} label="processing time">
         <Metric
           name="cr.store.queue.gc.processingnanos"
@@ -123,7 +137,11 @@ export default function (props: GraphDashboardProps) {
     // TODO(mrtracy): The queues below should also have "processing
     // nanos" on the graph, but that has a time unit instead of a count
     // unit, and thus we need support for multi-axis graphs.
-    <LineGraph title="Replica GC Queue" sources={storeSources}>
+    <LineGraph
+      title="Replica GC Queue"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.store.queue.replicagc.process.success"
@@ -143,7 +161,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Replication Queue" sources={storeSources}>
+    <LineGraph
+      title="Replication Queue"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.store.queue.replicate.process.success"
@@ -192,7 +214,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Split Queue" sources={storeSources}>
+    <LineGraph
+      title="Split Queue"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.store.queue.split.process.success"
@@ -207,7 +233,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Merge Queue" sources={storeSources}>
+    <LineGraph
+      title="Merge Queue"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.store.queue.merge.process.success"
@@ -222,7 +252,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Raft Log Queue" sources={storeSources}>
+    <LineGraph
+      title="Raft Log Queue"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.store.queue.raftlog.process.success"
@@ -237,7 +271,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Raft Snapshot Queue" sources={storeSources}>
+    <LineGraph
+      title="Raft Snapshot Queue"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.store.queue.raftsnapshot.process.success"
@@ -252,7 +290,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Consistency Checker Queue" sources={storeSources}>
+    <LineGraph
+      title="Consistency Checker Queue"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.store.queue.consistency.process.success"
@@ -267,7 +309,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Time Series Maintenance Queue" sources={storeSources}>
+    <LineGraph
+      title="Time Series Maintenance Queue"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.store.queue.tsmaintenance.process.success"
@@ -282,7 +328,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="MVCC GC Queue" sources={storeSources}>
+    <LineGraph
+      title="MVCC GC Queue"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.store.queue.gc.process.success"
@@ -300,6 +350,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Protected Timestamp Records"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`Number of protected timestamp records (used by backups, changefeeds, etc. to prevent MVCC GC)`}
     >
       <Axis units={AxisUnits.Count} label="Records">

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -29,11 +29,20 @@ import { cockroach } from "src/js/protos";
 import TimeSeriesQueryAggregator = cockroach.ts.tspb.TimeSeriesQueryAggregator;
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, storeSources, nodeDisplayNameByID, storeIDsByNodeID } =
-    props;
+  const {
+    nodeIDs,
+    storeSources,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
+    tenantSource,
+  } = props;
 
   return [
-    <LineGraph title="Ranges" sources={storeSources}>
+    <LineGraph
+      title="Ranges"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="ranges">
         <Metric name="cr.store.ranges" title="Ranges" />
         <Metric name="cr.store.replicas.leaders" title="Leaders" />
@@ -53,6 +62,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Replicas per Node"
+      tenantSource={tenantSource}
       tooltip={`The number of replicas on each node.`}
     >
       <Axis label="replicas">
@@ -69,6 +79,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Leaseholders per Node"
+      tenantSource={tenantSource}
       tooltip={`The number of leaseholder replicas on each node. A leaseholder replica is the one that
           receives and coordinates all read and write requests for its range.`}
     >
@@ -86,6 +97,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Average Replica Queries per Node"
+      tenantSource={tenantSource}
       tooltip={`Moving average of the number of KV batch requests processed by
          leaseholder replicas on each node per second. Tracks roughly the last
          30 minutes of requests. Used for load-based rebalancing decisions.`}
@@ -104,6 +116,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Average Replica CPU per Node"
+      tenantSource={tenantSource}
       tooltip={`Moving average of all replica CPU usage on each node per second.
          Tracks roughly the last 30 minutes of usage. Used for load-based
          rebalancing decisions.`}
@@ -122,6 +135,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Logical Bytes per Node"
+      tenantSource={tenantSource}
       tooltip={<LogicalBytesGraphTooltip />}
     >
       <Axis units={AxisUnits.Bytes} label="logical store size">
@@ -136,14 +150,22 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Replica Quiescence" sources={storeSources}>
+    <LineGraph
+      title="Replica Quiescence"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="replicas">
         <Metric name="cr.store.replicas" title="Replicas" />
         <Metric name="cr.store.replicas.quiescent" title="Quiescent" />
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Range Operations" sources={storeSources}>
+    <LineGraph
+      title="Range Operations"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="ranges">
         <Metric name="cr.store.range.splits" title="Splits" nonNegativeRate />
         <Metric name="cr.store.range.merges" title="Merges" nonNegativeRate />
@@ -167,7 +189,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Snapshots" sources={storeSources}>
+    <LineGraph
+      title="Snapshots"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="snapshots">
         <Metric
           name="cr.store.range.snapshots.generated"
@@ -197,7 +223,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Snapshot Data Received" sources={storeSources}>
+    <LineGraph
+      title="Snapshot Data Received"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="bytes" units={AxisUnits.Bytes}>
         {nodeIDs.map(nid => (
           <>
@@ -222,6 +252,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Receiver Snapshots Queued"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={ReceiverSnapshotsQueuedTooltip}
     >
       <Axis label="snapshots" units={AxisUnits.Count}>
@@ -238,6 +269,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Circuit Breaker Tripped Replicas"
+      tenantSource={tenantSource}
       tooltip={CircuitBreakerTrippedReplicasTooltip}
     >
       <Axis label="replicas">
@@ -255,6 +287,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Paused Followers"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={PausedFollowersTooltip}
     >
       <Axis label="replicas">
@@ -272,6 +305,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Replicate Queue Actions: Successes"
       sources={storeSources}
+      tenantSource={tenantSource}
     >
       <Axis label="replicas" units={AxisUnits.Count}>
         <Metric
@@ -306,7 +340,11 @@ export default function (props: GraphDashboardProps) {
         />
       </Axis>
     </LineGraph>,
-    <LineGraph title="Replicate Queue Actions: Failures" sources={storeSources}>
+    <LineGraph
+      title="Replicate Queue Actions: Failures"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="replicas" units={AxisUnits.Count}>
         <Metric
           name="cr.store.queue.replicate.addreplica.error"
@@ -340,7 +378,11 @@ export default function (props: GraphDashboardProps) {
         />
       </Axis>
     </LineGraph>,
-    <LineGraph title="Decommissioning Errors" sources={storeSources}>
+    <LineGraph
+      title="Decommissioning Errors"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="replicas" units={AxisUnits.Count}>
         {nodeIDs.map(nid => (
           <Metric

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
@@ -16,10 +16,14 @@ import { Metric, Axis } from "src/views/shared/components/metricQuery";
 import { GraphDashboardProps } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { storeSources } = props;
+  const { storeSources, tenantSource } = props;
 
   return [
-    <LineGraph title="Slow Raft Proposals" sources={storeSources}>
+    <LineGraph
+      title="Slow Raft Proposals"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="proposals">
         <Metric
           name="cr.store.requests.slow.raft"
@@ -29,7 +33,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Slow DistSender RPCs" sources={storeSources}>
+    <LineGraph
+      title="Slow DistSender RPCs"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="proposals">
         <Metric
           name="cr.node.requests.slow.distsender"
@@ -39,7 +47,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Slow Lease Acquisitions" sources={storeSources}>
+    <LineGraph
+      title="Slow Lease Acquisitions"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="lease acquisitions">
         <Metric
           name="cr.store.requests.slow.lease"
@@ -49,7 +61,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Slow Latch Acquisitions" sources={storeSources}>
+    <LineGraph
+      title="Slow Latch Acquisitions"
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="latch acquisitions">
         <Metric
           name="cr.store.requests.slow.latch"

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -18,11 +18,18 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodeSources, tooltipSelection, nodeDisplayNameByID } = props;
+  const {
+    nodeIDs,
+    nodeSources,
+    tooltipSelection,
+    nodeDisplayNameByID,
+    tenantSource,
+  } = props;
 
   return [
     <LineGraph
       title="Live Node Count"
+      tenantSource={tenantSource}
       tooltip="The number of live nodes in the cluster."
     >
       <Axis label="nodes">
@@ -37,6 +44,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Memory Usage"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={
         <div>
           {`Memory in use ${tooltipSelection}:`}
@@ -67,6 +75,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Goroutine Count"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The number of Goroutines ${tooltipSelection}.
            This count should rise and fall based on load.`}
     >
@@ -78,6 +87,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Runnable Goroutines per CPU"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The number of Goroutines waiting for CPU ${tooltipSelection}.
            This count should rise and fall based on load.`}
     >
@@ -97,6 +107,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="GC Runs"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The number of times that Go’s garbage collector was invoked per second ${tooltipSelection}.`}
     >
       <Axis label="runs">
@@ -107,6 +118,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="GC Pause Time"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The amount of processor time used by Go’s garbage collector
            per second ${tooltipSelection}.
            During garbage collection, application code execution is paused.`}
@@ -123,6 +135,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="CPU Time"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The amount of CPU time used by CockroachDB (User)
            and system-level operations (Sys) ${tooltipSelection}.`}
     >
@@ -143,6 +156,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Clock Offset"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`Mean clock offset of each node against the rest of the cluster.`}
     >
       <Axis label="offset" units={AxisUnits.Duration}>

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -24,13 +24,20 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import TimeSeriesQueryAggregator = cockroach.ts.tspb.TimeSeriesQueryAggregator;
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodeSources, tooltipSelection, nodeDisplayNameByID } = props;
+  const {
+    nodeIDs,
+    nodeSources,
+    tooltipSelection,
+    nodeDisplayNameByID,
+    tenantSource,
+  } = props;
 
   return [
     <LineGraph
       title="Open SQL Sessions"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The total number of open SQL Sessions ${tooltipSelection}.`}
     >
       <Axis label="connections">
@@ -70,6 +77,7 @@ export default function (props: GraphDashboardProps) {
       title="Open SQL Transactions"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The total number of open SQL transactions  ${tooltipSelection}.`}
     >
       <Axis label="transactions">
@@ -85,6 +93,7 @@ export default function (props: GraphDashboardProps) {
       title="Active SQL Statements"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The total number of running SQL statements ${tooltipSelection}.`}
     >
       <Axis label="queries">
@@ -100,6 +109,7 @@ export default function (props: GraphDashboardProps) {
       title="SQL Byte Traffic"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`}
     >
       <Axis units={AxisUnits.Bytes} label="byte traffic">
@@ -112,6 +122,7 @@ export default function (props: GraphDashboardProps) {
       title="SQL Statements"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements
         successfully executed per second ${tooltipSelection}.`}
     >
@@ -143,6 +154,7 @@ export default function (props: GraphDashboardProps) {
       title="SQL Statement Errors"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={
         "The number of statements which returned a planning, runtime, or client-side retry error."
       }
@@ -160,6 +172,7 @@ export default function (props: GraphDashboardProps) {
       title="SQL Statement Contention"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The total number of SQL statements that experienced contention ${tooltipSelection}.`}
     >
       <Axis label="queries">
@@ -175,6 +188,7 @@ export default function (props: GraphDashboardProps) {
       title="Full Table/Index Scans"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The total number of full table/index scans ${tooltipSelection}.`}
     >
       <Axis label="full scans">
@@ -193,6 +207,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Active Flows for Distributed SQL Statements"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip="The number of flows on each node contributing to currently running distributed SQL statements."
     >
       <Axis label="flows">
@@ -210,6 +225,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Connection Latency: 99th percentile"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip={`Over the last minute, this node established and authenticated 99% of connections within this time.`}
     >
       <Axis units={AxisUnits.Duration} label="latency">
@@ -228,6 +244,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Connection Latency: 90th percentile"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip={`Over the last minute, this node established and authenticated 90% of connections within this time.`}
     >
       <Axis units={AxisUnits.Duration} label="latency">
@@ -246,6 +263,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Service Latency: SQL Statements, 99.99th percentile"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip={
         <div>
           Over the last minute, this node executed 99.99% of SQL statements
@@ -273,6 +291,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Service Latency: SQL Statements, 99.9th percentile"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip={
         <div>
           Over the last minute, this node executed 99.9% of SQL statements
@@ -300,6 +319,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Service Latency: SQL Statements, 99th percentile"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip={
         <div>
           Over the last minute, this node executed 99% of SQL statements within
@@ -327,6 +347,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Service Latency: SQL Statements, 90th percentile"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip={
         <div>
           Over the last minute, this node executed 90% of SQL statements within
@@ -354,6 +375,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="KV Execution Latency: 99th percentile"
       isKvGraph={true}
+      tenantSource={tenantSource}
       tooltip={`The 99th percentile of latency between query requests and responses over a
           1 minute period. Values are displayed individually for each node.`}
     >
@@ -373,6 +395,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="KV Execution Latency: 90th percentile"
       isKvGraph={true}
+      tenantSource={tenantSource}
       tooltip={`The 90th percentile of latency between query requests and responses over a
            1 minute period. Values are displayed individually for each node.`}
     >
@@ -393,6 +416,7 @@ export default function (props: GraphDashboardProps) {
       title="Transactions"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The total number of transactions initiated, committed, rolled back,
            or aborted per second ${tooltipSelection}.`}
     >
@@ -424,6 +448,7 @@ export default function (props: GraphDashboardProps) {
       title="Transaction Restarts"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={
         <TransactionRestartsToolTip tooltipSelection={tooltipSelection} />
       }
@@ -475,6 +500,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Transaction Latency: 99th percentile"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip={
         <div>
           Over the last minute, this node executed 99% of transactions within
@@ -502,6 +528,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Transaction Latency: 90th percentile"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip={
         <div>
           Over the last minute, this node executed 90% of transactions within
@@ -529,6 +556,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="SQL Memory"
       isKvGraph={false}
+      tenantSource={tenantSource}
       tooltip={`The current amount of allocated SQL memory. This amount is
          compared against the node's --max-sql-memory flag.`}
     >
@@ -549,6 +577,7 @@ export default function (props: GraphDashboardProps) {
       title="Schema Changes"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The total number of DDL statements per second ${tooltipSelection}.`}
     >
       <Axis label="statements">
@@ -564,6 +593,7 @@ export default function (props: GraphDashboardProps) {
       title="Statement Denials: Cluster Settings"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={
         <StatementDenialsClusterSettingsTooltip
           tooltipSelection={tooltipSelection}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -33,6 +33,7 @@ export default function (props: GraphDashboardProps) {
     tooltipSelection,
     storeIDsByNodeID,
     nodeDisplayNameByID,
+    tenantSource,
   } = props;
 
   const getNodeNameById = (id: string) =>
@@ -42,6 +43,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Capacity"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection} />}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
@@ -55,6 +57,7 @@ export default function (props: GraphDashboardProps) {
       title="Live Bytes"
       isKvGraph={false}
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={<LiveBytesGraphTooltip tooltipSelection={tooltipSelection} />}
     >
       <Axis units={AxisUnits.Bytes} label="live bytes">
@@ -66,6 +69,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Log Commit Latency: 99th Percentile"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`The 99th %ile latency for commits to the Raft Log.
         This measures essentially an fdatasync to the storage engine's write-ahead log.`}
     >
@@ -84,6 +88,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Log Commit Latency: 50th Percentile"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`The 50th %ile latency for commits to the Raft Log.
         This measures essentially an fdatasync to the storage engine's write-ahead log.`}
     >
@@ -102,6 +107,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Command Commit Latency: 99th Percentile"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`The 99th %ile latency for commits of Raft commands.
         This measures applying a batch to the storage engine
         (including writes to the write-ahead log), but no fsync.`}
@@ -121,6 +127,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Command Commit Latency: 50th Percentile"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`The 50th %ile latency for commits of Raft commands.
         This measures applying a batch to the storage engine
         (including writes to the write-ahead log), but no fsync.`}
@@ -140,6 +147,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Read Amplification"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`The average number of real read operations executed per logical read operation ${tooltipSelection}.`}
     >
       <Axis label="factor">
@@ -157,6 +165,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="SSTables"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`The number of SSTables in use ${tooltipSelection}.`}
     >
       <Axis label="sstables">
@@ -174,6 +183,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="File Descriptors"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The number of open file descriptors ${tooltipSelection}, compared with the
           file descriptor limit.`}
     >
@@ -186,6 +196,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Flushes"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`Bytes written by memtable flushes ${tooltipSelection}.`}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
@@ -204,6 +215,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Compactions"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`Bytes written by compactions ${tooltipSelection}.`}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
@@ -222,6 +234,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Ingestions"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`Bytes written by sstable ingestions ${tooltipSelection}.`}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
@@ -240,6 +253,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Write Stalls"
       sources={storeSources}
+      tenantSource={tenantSource}
       tooltip={`The number of intentional write stalls per second ${tooltipSelection}. Write stalls
         are used to backpressure incoming writes during periods of heavy write traffic.`}
     >
@@ -255,6 +269,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Time Series Writes"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`The number of successfully written time series samples, and number of errors attempting
         to write time series, per second ${tooltipSelection}.`}
     >
@@ -275,6 +290,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Time Series Bytes Written"
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={
         <div>
           The number of bytes written by the time series system per second{" "}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/ttl.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/ttl.tsx
@@ -18,12 +18,17 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 import { GraphDashboardProps } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeSources } = props;
+  const { nodeSources, tenantSource } = props;
 
   const percentiles = ["p50", "p75", "p90", "p95", "p99"];
 
   return [
-    <LineGraph title="Processing Rate" isKvGraph={false} sources={nodeSources}>
+    <LineGraph
+      title="Processing Rate"
+      isKvGraph={false}
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="rows per second" units={AxisUnits.Count}>
         <Metric
           name="cr.node.jobs.row_level_ttl.rows_selected"
@@ -37,7 +42,12 @@ export default function (props: GraphDashboardProps) {
         />
       </Axis>
     </LineGraph>,
-    <LineGraph title="Estimated Rows" isKvGraph={false} sources={nodeSources}>
+    <LineGraph
+      title="Estimated Rows"
+      isKvGraph={false}
+      sources={nodeSources}
+      tenantSource={tenantSource}
+    >
       <Axis label="row count" units={AxisUnits.Count}>
         <Metric
           name="cr.node.jobs.row_level_ttl.total_rows"
@@ -55,6 +65,7 @@ export default function (props: GraphDashboardProps) {
       title="Job Latency"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`Latency of scanning and deleting within the job.`}
     >
       <Axis label="latency" units={AxisUnits.Duration}>
@@ -78,6 +89,7 @@ export default function (props: GraphDashboardProps) {
       title="Spans in Progress"
       isKvGraph={false}
       sources={nodeSources}
+      tenantSource={tenantSource}
       tooltip={`Number of active spans being processed by TTL.`}
     >
       <Axis label="span count" units={AxisUnits.Count}>

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -16,7 +16,11 @@ import { connect } from "react-redux";
 import { createSelector } from "reselect";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 
-import { nodeIDAttr, dashboardNameAttr } from "src/util/constants";
+import {
+  nodeIDAttr,
+  dashboardNameAttr,
+  tenantNameAttr,
+} from "src/util/constants";
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 import {
   PageConfig,
@@ -29,6 +33,7 @@ import {
   refreshNodes,
   refreshLiveness,
   refreshSettings,
+  refreshTenantsList,
 } from "src/redux/apiReducers";
 import {
   hoverStateSelector,
@@ -85,6 +90,8 @@ import {
   selectCrossClusterReplicationEnabled,
 } from "src/redux/clusterSettings";
 import { getDataFromServer } from "src/util/dataFromServer";
+import { getCookieValue, SYSTEM_TENANT_NAME } from "src/redux/cookies";
+import { tenantDropdownOptions } from "src/redux/tenants";
 
 interface GraphDashboard {
   label: string;
@@ -172,12 +179,15 @@ type MapStateToProps = {
     typeof nodeDisplayNameByIDSelector.resultFunc
   >;
   crossClusterReplicationEnabled: boolean;
+  tenantOptions: ReturnType<() => DropdownOption[]>;
+  currentTenant: string | null;
 };
 
 type MapDispatchToProps = {
   refreshNodes: typeof refreshNodes;
   refreshLiveness: typeof refreshLiveness;
   refreshNodeSettings: typeof refreshSettings;
+  refreshTenantsList: typeof refreshTenantsList;
   hoverOn: typeof hoverOn;
   hoverOff: typeof hoverOff;
   setMetricsFixedWindow: (tw: TimeWindow) => PayloadAction<TimeWindow>;
@@ -214,27 +224,29 @@ export class NodeGraphs extends React.Component<
     this.props.refreshNodeSettings();
   };
 
-  setClusterPath(nodeID: string, dashboardName: string) {
-    const push = this.props.history.push;
-    if (!_.isString(nodeID) || nodeID === "") {
-      push(`/metrics/${dashboardName}/cluster`);
-    } else {
-      push(`/metrics/${dashboardName}/node/${nodeID}`);
+  setClusterPath = (key: string, selected: DropdownOption) => {
+    const { match, history } = this.props;
+    const { value } = selected;
+    const nodeID = getMatchParamByName(match, nodeIDAttr) || "";
+    const dashName = getMatchParamByName(match, dashboardNameAttr) || "";
+    const tenantName = getMatchParamByName(match, tenantNameAttr) || "";
+    const nodeMatchParam = (val: string): string =>
+      val === "" ? "/cluster" : `/node/${val}`;
+    const tenantMatchParam = (val: string): string =>
+      val === "" ? "" : `/tenant/${val}`;
+    let path = "/metrics/";
+    switch (key) {
+      case "dashboard":
+        path += value + nodeMatchParam(nodeID) + tenantMatchParam(tenantName);
+        break;
+      case "node":
+        path += dashName + nodeMatchParam(value) + tenantMatchParam(tenantName);
+        break;
+      default:
+        path += dashName + nodeMatchParam(nodeID) + tenantMatchParam(value);
+        break;
     }
-  }
-
-  nodeChange = (selected: DropdownOption) => {
-    this.setClusterPath(
-      selected.value,
-      getMatchParamByName(this.props.match, dashboardNameAttr),
-    );
-  };
-
-  dashChange = (selected: DropdownOption) => {
-    this.setClusterPath(
-      getMatchParamByName(this.props.match, nodeIDAttr),
-      selected.value,
-    );
+    history.push(path);
   };
 
   componentDidMount() {
@@ -242,6 +254,9 @@ export class NodeGraphs extends React.Component<
     // settings won't change frequently so it's safe to request one
     // when page is loaded.
     this.props.refreshNodeSettings();
+    if (this.props.currentTenant === SYSTEM_TENANT_NAME) {
+      this.props.refreshTenantsList();
+    }
   }
 
   componentDidUpdate() {
@@ -289,6 +304,8 @@ export class NodeGraphs extends React.Component<
       storeIDsByNodeID,
       nodeDisplayNameByID,
       nodeIds,
+      tenantOptions,
+      currentTenant,
     } = this.props;
     const canViewKvGraphs =
       getDataFromServer().FeatureFlags.can_view_kv_metric_dashboards;
@@ -303,7 +320,10 @@ export class NodeGraphs extends React.Component<
 
     const selectedNode = getMatchParamByName(match, nodeIDAttr) || "";
     const nodeSources = selectedNode !== "" ? [selectedNode] : null;
-
+    const selectedTenant =
+      currentTenant === SYSTEM_TENANT_NAME
+        ? getMatchParamByName(match, tenantNameAttr) || ""
+        : "";
     // When "all" is the selected source, some graphs display a line for every
     // node in the cluster using the nodeIDs collection. However, if a specific
     // node is already selected, these per-node graphs should only display data
@@ -332,6 +352,7 @@ export class NodeGraphs extends React.Component<
       tooltipSelection,
       nodeDisplayNameByID,
       storeIDsByNodeID,
+      tenantSource: selectedTenant,
     };
 
     const forwardParams = {
@@ -384,12 +405,22 @@ export class NodeGraphs extends React.Component<
         <Helmet title={"Metrics"} />
         <h3 className="base-heading">Metrics</h3>
         <PageConfig>
+          {currentTenant === SYSTEM_TENANT_NAME && tenantOptions.length > 1 && (
+            <PageConfigItem>
+              <Dropdown
+                title="Tenant"
+                options={tenantOptions}
+                selected={selectedTenant}
+                onChange={selection => this.setClusterPath("tenant", selection)}
+              />
+            </PageConfigItem>
+          )}
           <PageConfigItem>
             <Dropdown
               title="Graph"
               options={nodeDropdownOptions}
               selected={selectedNode}
-              onChange={this.nodeChange}
+              onChange={selection => this.setClusterPath("node", selection)}
             />
           </PageConfigItem>
           <PageConfigItem>
@@ -397,7 +428,9 @@ export class NodeGraphs extends React.Component<
               title="Dashboard"
               options={filteredDropdownOptions}
               selected={dashboard}
-              onChange={this.dashChange}
+              onChange={selection =>
+                this.setClusterPath("dashboard", selection)
+              }
               className="full-size"
             />
           </PageConfigItem>
@@ -458,7 +491,10 @@ export class NodeGraphs extends React.Component<
             <div className="chart-group l-columns__left">{graphComponents}</div>
             <div className="l-columns__right">
               <Alerts />
-              <ClusterSummaryBar nodeSources={nodeSources} />
+              <ClusterSummaryBar
+                nodeSources={nodeSources}
+                tenantSource={selectedTenant}
+              />
             </div>
           </div>
         </section>
@@ -503,12 +539,15 @@ const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
   nodeDropdownOptions: nodeDropdownOptionsSelector(state),
   nodeDisplayNameByID: nodeDisplayNameByIDSelector(state),
   crossClusterReplicationEnabled: selectCrossClusterReplicationEnabled(state),
+  tenantOptions: tenantDropdownOptions(state),
+  currentTenant: getCookieValue("tenant"),
 });
 
 const mapDispatchToProps: MapDispatchToProps = {
   refreshNodes,
   refreshLiveness,
   refreshNodeSettings: refreshSettings,
+  refreshTenantsList,
   hoverOn,
   hoverOff,
   setMetricsFixedWindow: setMetricsFixedWindow,

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -94,6 +94,7 @@ function formatNanosAsMillis(n: number) {
  */
 export interface ClusterSummaryProps {
   nodeSources: string[];
+  tenantSource?: string;
 }
 
 export default function (props: ClusterSummaryProps) {
@@ -151,24 +152,28 @@ export default function (props: ClusterSummaryProps) {
             sources={props.nodeSources}
             name="cr.node.sql.select.count"
             title="Queries/Sec"
+            tenantSource={props.tenantSource}
             nonNegativeRate
           />
           <Metric
             sources={props.nodeSources}
             name="cr.node.sql.insert.count"
             title="Queries/Sec"
+            tenantSource={props.tenantSource}
             nonNegativeRate
           />
           <Metric
             sources={props.nodeSources}
             name="cr.node.sql.update.count"
             title="Queries/Sec"
+            tenantSource={props.tenantSource}
             nonNegativeRate
           />
           <Metric
             sources={props.nodeSources}
             name="cr.node.sql.delete.count"
             title="Queries/Sec"
+            tenantSource={props.tenantSource}
             nonNegativeRate
           />
         </SummaryMetricStat>
@@ -180,6 +185,7 @@ export default function (props: ClusterSummaryProps) {
           <Metric
             sources={props.nodeSources}
             name="cr.node.sql.service.latency-p99"
+            tenantSource={props.tenantSource}
             aggregateMax
             downsampleMax
           />

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/metricQuery/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/metricQuery/index.tsx
@@ -87,6 +87,7 @@ export class Axis extends React.Component<AxisProps, {}> {
 export interface MetricProps {
   name: string;
   sources?: string[];
+  tenantSource?: string;
   title?: string;
   rate?: boolean;
   nonNegativeRate?: boolean;
@@ -138,6 +139,7 @@ export interface MetricsDataComponentProps {
   // convenient syntax for a common use case where all metrics on a graph are
   // are from the same source set.
   sources?: string[];
+  tenantSource?: string;
   setMetricsFixedWindow?: (tw: TimeWindow) => PayloadAction<TimeWindow>;
   setTimeScale?: (ts: TimeScale) => PayloadAction<TimeScale>;
   history?: History;

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
@@ -83,10 +83,12 @@ function queryFromProps(
   } else if (metricProps.aggregateAvg) {
     sourceAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.AVG;
   }
-
+  const tenantSource =
+    metricProps.tenantSource || graphProps.tenantSource || undefined;
   return {
     name: metricProps.name,
     sources: metricProps.sources || graphProps.sources || undefined,
+    tenant_id: tenantSource ? { id: Long.fromString(tenantSource) } : undefined,
     downsampler: downsampler,
     source_aggregator: sourceAggregator,
     derivative: derivative,

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/metricDataProvider.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/metricDataProvider.spec.tsx
@@ -65,7 +65,11 @@ function makeDataProvider(
   );
 }
 
-function makeMetricsRequest(timeInfo: QueryTimeInfo, sources?: string[]) {
+function makeMetricsRequest(
+  timeInfo: QueryTimeInfo,
+  sources?: string[],
+  tenantSource?: string,
+) {
   return new protos.cockroach.ts.tspb.TimeSeriesQueryRequest({
     start_nanos: timeInfo.start,
     end_nanos: timeInfo.end,
@@ -74,6 +78,9 @@ function makeMetricsRequest(timeInfo: QueryTimeInfo, sources?: string[]) {
       {
         name: "test.metric.1",
         sources: sources,
+        tenant_id: tenantSource
+          ? { id: Long.fromString(tenantSource) }
+          : undefined,
         downsampler: protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MAX,
         source_aggregator:
           protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.SUM,
@@ -82,6 +89,9 @@ function makeMetricsRequest(timeInfo: QueryTimeInfo, sources?: string[]) {
       {
         name: "test.metric.2",
         sources: sources,
+        tenant_id: tenantSource
+          ? { id: Long.fromString(tenantSource) }
+          : undefined,
         downsampler: protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MAX,
         source_aggregator:
           protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.SUM,
@@ -90,6 +100,9 @@ function makeMetricsRequest(timeInfo: QueryTimeInfo, sources?: string[]) {
       {
         name: "test.metric.3",
         sources: sources,
+        tenant_id: tenantSource
+          ? { id: Long.fromString(tenantSource) }
+          : undefined,
         downsampler: protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MAX,
         source_aggregator:
           protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.SUM,
@@ -103,8 +116,9 @@ function makeMetricsQuery(
   id: string,
   timeSpan: QueryTimeInfo,
   sources?: string[],
+  tenantSource?: string,
 ): MetricsQuery {
-  const request = makeMetricsRequest(timeSpan, sources);
+  const request = makeMetricsRequest(timeSpan, sources, tenantSource);
   const data = new protos.cockroach.ts.tspb.TimeSeriesQueryResponse({
     results: _.map(request.queries, q => {
       return {


### PR DESCRIPTION
This change adds:
- a new dropdown on the metrics page dashboard which
only shows up when the user is on the system tenant and there
are secondary tenants to allow for viewing the metrics per tenant
- a new redux flow to query `_admin/v1/tenants` to power the dropdown
- a new tenantSource prop to metrics components to allow restriction
of the ts query to a particular tenant

Fixes: https://github.com/cockroachdb/cockroach/issues/101856

Release note (ui change): Added dropdown on the metrics page
dashboard which allows users to view metrics per tenant. The
dropdown is only visible on the system tenant and if there
are secondary tenants.

<img width="1344" alt="Screenshot 2023-05-18 at 4 47 12 PM" src="https://github.com/cockroachdb/cockroach/assets/17861665/e5be454d-11c1-4cdd-bcdc-8c96836f01e7">