### PR TITLE
build: mark some optimizer libraries as `testonly`

### DIFF
--- a/pkg/sql/opt/bench/BUILD.bazel
+++ b/pkg/sql/opt/bench/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "bench",
+    testonly = 1,
     srcs = ["doc.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/bench",
     visibility = ["//visibility:public"],

--- a/pkg/sql/opt/opbench/BUILD.bazel
+++ b/pkg/sql/opt/opbench/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "opbench",
+    testonly = 1,
     srcs = [
         "cat.go",
         "config.go",

--- a/pkg/sql/opt/testutils/testcat/BUILD.bazel
+++ b/pkg/sql/opt/testutils/testcat/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "testcat",
+    testonly = 1,
     srcs = [
         "alter_table.go",
         "create_index.go",

--- a/pkg/sql/opt/testutils/testexpr/BUILD.bazel
+++ b/pkg/sql/opt/testutils/testexpr/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "testexpr",
+    testonly = 1,
     srcs = ["test_expr.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testexpr",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
The `pkg/sql/opt/bench`, `pkg/sql/opt/testutils/testcat`,
`pkg/sql/opt/testutils/testexpr`, and `pkg/sql/opt/opbench` libraries
have been marked `testonly`. This prevents them from being linked into a
`cockroach` binary.

Epic: None

Release note: None
