### PR TITLE
roachtest: fix cdc test timestamp logging

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -740,7 +740,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 				l.Printf("%d of %d resolved timestamps validated, latest is %s behind realtime",
 					v.NumResolvedWithRows, requestedResolved, timeutil.Since(resolved.GoTime()))
 
-				l.Printf("%s was spent validating this resolved timestamp: %s", timeutil.Since(noteResolvedStartTime))
+				l.Printf("%s was spent validating this resolved timestamp: %s", timeutil.Since(noteResolvedStartTime), resolved)
 				l.Printf("%s was spent validating %d rows", timeSpentValidatingRows, numRowsValidated)
 
 				numRowsValidated = 0


### PR DESCRIPTION
This commit fixes format args of logging message.

Current logging:
```
8.224822939s was spent validating this resolved timestamp: %!s(MISSING)
```

Fixed logging
```
207.587058ms was spent validating this resolved timestamp: 1684170215.036471445,0
```
Epic: none

Release note: None