### PR TITLE
ci: additionally build `workload` and `dev` for all Unix systems

### DIFF
--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -16,14 +16,14 @@ EXTRA_TARGETS=
 if [ "$CONFIG" == "crosslinux" ]
 then
     DOC_TARGETS=$(grep '^//' docs/generated/bazel_targets.txt)
-    BINARY_TARGETS="@com_github_cockroachdb_go_test_teamcity//:go-test-teamcity //pkg/cmd/dev //pkg/cmd/workload"
+    BINARY_TARGETS="@com_github_cockroachdb_go_test_teamcity//:go-test-teamcity"
     EXTRA_TARGETS="$DOC_TARGETS $BINARY_TARGETS"
 fi
 
 # Extra targets to build on Unix only.
 if [ "$CONFIG" != "crosswindows" ]
 then
-    EXTRA_TARGETS="$EXTRA_TARGETS //pkg/cmd/roachprod"
+    EXTRA_TARGETS="$EXTRA_TARGETS //pkg/cmd/roachprod //pkg/cmd/workload //pkg/cmd/dev"
 fi
 
 bazel build //pkg/cmd/bazci --config=ci


### PR DESCRIPTION
This includes ARM machines and macOS systems.

Epic: none
Release note: None