### PR TITLE
release-23.1: storage: close over disk slow event listener

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -664,7 +664,14 @@ func wrapFilesystemMiddleware(opts *pebble.Options) (vfs.FS, io.Closer) {
 	// wraps the filesystem with a layer that times all write-oriented
 	// operations.
 	fs, closer := vfs.WithDiskHealthChecks(opts.FS, diskHealthCheckInterval,
-		opts.EventListener.DiskSlow)
+		func(info vfs.DiskSlowInfo) {
+			opts.EventListener.DiskSlow(pebble.DiskSlowInfo{
+				Path:      info.Path,
+				OpType:    info.OpType,
+				Duration:  info.Duration,
+				WriteSize: info.WriteSize,
+			})
+		})
 	// If we encounter ENOSPC, exit with an informative exit code.
 	fs = vfs.OnDiskFull(fs, func() {
 		exit.WithCode(exit.DiskFull())


### PR DESCRIPTION
When addressing an interface change in a recent vendor bump (#102882), a closure over the existing event listener (passed in via `opts`) was removed in favor of instantiating Pebble's event listener directly. This had the effect of dropping disk slow events.

Revert to using a function that closed over the `opts`, making use of the existing event listener.

Fixes: #103185
Fixes: #102946
Fixes: #102944
Fixes: #102940

Release note: None.

Release justification: Fixes high-severity issue where disk stalls could go undetected.