### PR TITLE
ui: add transaction Insights for Serverless

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -256,7 +256,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
   return (
     <div className={cx("root")}>
       <PageConfig>
-        {!isTenant && <PageConfigItem>{dropDownSelect}</PageConfigItem>}
+        <PageConfigItem>{dropDownSelect}</PageConfigItem>
         <PageConfigItem>
           <Search
             placeholder="Search Statements"


### PR DESCRIPTION
Previously, Transaction Insights was hidden on Serverless, now on 23.1 it can be added back.

Fixes #96372

https://www.loom.com/share/9f79b830005945b1ae8cc5f6e69673d0

Release note (ui change): Add Transaction Insights for Serverless.