### PR TITLE
c2c: deflake shutdown test during initial scan or cutover

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -968,6 +968,11 @@ func (rrd *replResilienceDriver) getTargetAndWatcherNodes(ctx context.Context) {
 }
 
 func (rrd *replResilienceDriver) getPhase() c2cPhase {
+	var jobStatus string
+	rrd.setup.dst.sysSQL.QueryRow(rrd.t, `SELECT status FROM [SHOW JOBS] WHERE job_id=$1`,
+		rrd.dstJobID).Scan(&jobStatus)
+	require.Equal(rrd.t, jobs.StatusRunning, jobs.Status(jobStatus))
+
 	progress := getJobProgress(rrd.t, rrd.setup.dst.sysSQL, rrd.dstJobID)
 	streamIngestProgress := progress.GetStreamIngest()
 	highWater := progress.GetHighWater()
@@ -998,11 +1003,11 @@ func (rrd *replResilienceDriver) waitForTargetPhase() error {
 }
 
 func (rrd *replResilienceDriver) sleepBeforeResiliencyEvent() {
-	// Assuming every C2C phase lasts at least 10 seconds, introduce some waiting
+	// Assuming every C2C phase lasts at least 5 seconds, introduce some waiting
 	// before a resiliency event (e.g. a node shutdown) to ensure the event occurs
 	// once we're fully settled into the target phase (e.g. the stream ingestion
 	// processors have observed the cutover signal).
-	randomSleep := time.Duration(5+rrd.rng.Intn(6)) * time.Second
+	randomSleep := time.Duration(1+rrd.rng.Intn(2)) * time.Second
 	rrd.t.L().Printf("Take a %s power nap", randomSleep)
 	time.Sleep(randomSleep)
 }
@@ -1033,7 +1038,7 @@ func registerClusterReplicationResilience(r registry.Registry) {
 			srcNodes:           4,
 			dstNodes:           4,
 			cpus:               8,
-			workload:           replicateKV{readPercent: 0, initRows: 1000000, maxBlockBytes: 1024},
+			workload:           replicateKV{readPercent: 0, initRows: 5000000, maxBlockBytes: 1024},
 			timeout:            20 * time.Minute,
 			additionalDuration: 6 * time.Minute,
 			cutover:            3 * time.Minute,
@@ -1044,6 +1049,7 @@ func registerClusterReplicationResilience(r registry.Registry) {
 			func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 				rrd := makeReplResilienceDriver(t, c, rsp)
+				rrd.t.L().Printf("Planning to shut down node during %s phase", rrd.phase)
 				rrd.setupC2C(ctx, t, c)
 
 				shutdownSetupDone := make(chan struct{})


### PR DESCRIPTION
Previously the c2c shutdown tests that scheduled a node shutdown during an
intitial scan could fail because the initial scan completed too quickly. This
patch 5x's the amount of data ingested during the initial scan to prevent this
failure mode.

This patch also prevents flakes if cutover completes too quickly by lowering
the time the test driver sleeps between when the job enters the cutover phase
and when the node shutdown occurs. The driver also now checks if the ingestion
job has completed before checking the job progress, avoiding a race seen in
issue https://github.com/cockroachdb/cockroach/issues/103248.

Fixes https://github.com/cockroachdb/cockroach/issues/103248

Release note: None