### PR TITLE
admission: defend against severe elastic cpu token debt

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1580,13 +1580,13 @@ func (r *Registry) stepThroughStateMachine(
 	payload := job.Payload()
 	jobType := payload.Type()
 	if jobErr != nil {
-		log.Infof(ctx, "%s job %d: stepping through state %s with error: %+v", jobType, job.ID(), status, jobErr)
+		log.Errorf(ctx, "%s job %d: stepping through state %s with error: %+v", jobType, job.ID(), status, jobErr)
 	} else {
 		log.Infof(ctx, "%s job %d: stepping through state %s", jobType, job.ID(), status)
 	}
 	jm := r.metrics.JobMetrics[jobType]
 	onExecutionFailed := func(cause error) error {
-		log.InfofDepth(
+		log.ErrorfDepth(
 			ctx, 1,
 			"job %d: %s execution encountered retriable error: %+v",
 			job.ID(), status, cause,

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -6441,6 +6441,16 @@ func mvccExportToWriter(
 	}
 
 	elasticCPUHandle := admission.ElasticCPUWorkHandleFromContext(ctx)
+	// NB: StartTimer is used to denote that we're just starting to do
+	// the actual on-CPU work we acquired CPU tokens for. We've seen that before
+	// hitting his code path, we may have already used up our allotted CPU slice
+	// resolving intents or doing conflict resolution. The effect was that
+	// OverLimit() below is immediately true, and we exported just a single key
+	// for the entire request, making for extremely inefficient backups. By
+	// starting the timer here we guarantee that our allotted CPU slice is spent
+	// actually doing the backup work.
+	elasticCPUHandle.StartTimer()
+
 	iter := NewMVCCIncrementalIterator(reader, MVCCIncrementalIterOptions{
 		KeyTypes:             IterKeyTypePointsAndRanges,
 		StartKey:             opts.StartKey.Key,

--- a/pkg/util/admission/elastic_cpu_granter.go
+++ b/pkg/util/admission/elastic_cpu_granter.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -108,6 +109,8 @@ type elasticCPUGranter struct {
 		// requester.granted() is called while holding GrantCoordinator.mu.
 		syncutil.Mutex
 		tb               *quotapool.TokenBucket
+		tbLastReset      time.Time
+		tbReset          *util.EveryN
 		utilizationLimit float64
 	}
 	requester requester
@@ -210,6 +213,17 @@ func (e *elasticCPUGranter) setUtilizationLimit(utilizationLimit float64) {
 	rate := utilizationLimit * float64(int64(runtime.GOMAXPROCS(0))*time.Second.Nanoseconds())
 	e.mu.utilizationLimit = utilizationLimit
 	e.mu.tb.UpdateConfig(quotapool.TokensPerSecond(rate), quotapool.Tokens(rate))
+	if now := timeutil.Now(); now.Sub(e.mu.tbLastReset) > 15*time.Second { // TODO(irfansharif): make this is a cluster setting?
+		// Periodically reset the token bucket. This is just defense-in-depth
+		// and at worst, over-admits. We've seen production clusters where the
+		// token bucket was severely in debt and caused wait queue times of
+		// minutes, which can be long enough to fail backups completely
+		// (#102817).
+		e.mu.tb.Reset()
+		e.mu.tbLastReset = now
+	}
+	e.metrics.NanosExhaustedDuration.Update(e.mu.tb.Exhausted().Microseconds())
+	e.metrics.AvailableNanos.Update(int64(e.mu.tb.Available()))
 
 	e.metrics.UtilizationLimit.Update(utilizationLimit)
 	if log.V(1) {
@@ -236,8 +250,13 @@ func (e *elasticCPUGranter) computeUtilizationMetric() {
 		return // nothing to do
 	}
 
-	currentCumAcquiredNanos := e.metrics.AcquiredNanos.Count()
+	// NB: Read the returned-nanos atomic before the acquired-nanos one, to
+	// avoid spurious negative values given these we don't read these two under
+	// a mutex. It's still possible for returned-nanos > acquired-nanos,
+	// resulting in a negative utilization -- it needs to be investigated
+	// (#103359).
 	currentCumReturnedNanos := e.metrics.ReturnedNanos.Count()
+	currentCumAcquiredNanos := e.metrics.AcquiredNanos.Count()
 	currentCumUsedNanos := currentCumAcquiredNanos - currentCumReturnedNanos
 
 	if e.metrics.lastCumUsedNanos != 0 {
@@ -269,11 +288,39 @@ var ( // granter-side metrics (some of these have parallels on the requester sid
 		Unit:        metric.Unit_NANOSECONDS,
 	}
 
+	elasticCPUPreWorkNanos = metric.Metadata{
+		Name:        "admission.elastic_cpu.pre_work_nanos",
+		Help:        "Total CPU nanoseconds spent doing pre-work, before doing elastic work",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+
 	// elasticCPUMaxAvailableNanos is a static metric, useful for computing the
 	// % utilization: (acquired - returned)/max available.
 	elasticCPUMaxAvailableNanos = metric.Metadata{
 		Name:        "admission.elastic_cpu.max_available_nanos",
 		Help:        "Maximum available CPU nanoseconds per second ignoring utilization limit",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+
+	elasticCPUNanosExhaustedDuration = metric.Metadata{
+		Name:        "admission.elastic_cpu.nanos_exhausted_duration",
+		Help:        "Total duration when elastic CPU nanoseconds were exhausted, in micros",
+		Measurement: "Microseconds",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	elasticCPUOverLimitDurations = metric.Metadata{
+		Name:        "admission.elastic_cpu.over_limit_durations",
+		Help:        "Measurement of how much over the prescribed limit elastic requests ran (not recorded if requests don't run over)",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+
+	elasticCPUAvailableNanos = metric.Metadata{
+		Name:        "admission.elastic_cpu.available_nanos",
+		Help:        "Instantaneous available CPU nanoseconds per second ignoring utilization limit",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
@@ -297,10 +344,14 @@ var ( // granter-side metrics (some of these have parallels on the requester sid
 // elasticCPUGranterMetrics are the metrics associated with an instance of the
 // ElasticCPUGranter.
 type elasticCPUGranterMetrics struct {
-	AcquiredNanos     *metric.Counter
-	ReturnedNanos     *metric.Counter
-	MaxAvailableNanos *metric.Counter
-	UtilizationLimit  *metric.GaugeFloat64
+	AcquiredNanos          *metric.Counter
+	ReturnedNanos          *metric.Counter
+	PreWorkNanos           *metric.Counter
+	MaxAvailableNanos      *metric.Counter
+	AvailableNanos         *metric.Gauge
+	UtilizationLimit       *metric.GaugeFloat64
+	NanosExhaustedDuration *metric.Gauge
+	OverLimitDuration      metric.IHistogram
 
 	Utilization      *metric.GaugeFloat64 // updated every elasticCPUUtilizationMetricInterval, using fields below
 	everyInterval    util.EveryN
@@ -311,12 +362,21 @@ const elasticCPUUtilizationMetricInterval = 10 * time.Second
 
 func makeElasticCPUGranterMetrics() *elasticCPUGranterMetrics {
 	metrics := &elasticCPUGranterMetrics{
-		AcquiredNanos:     metric.NewCounter(elasticCPUAcquiredNanos),
-		ReturnedNanos:     metric.NewCounter(elasticCPUReturnedNanos),
-		MaxAvailableNanos: metric.NewCounter(elasticCPUMaxAvailableNanos),
-		Utilization:       metric.NewGaugeFloat64(elasticCPUGranterUtilization),
-		UtilizationLimit:  metric.NewGaugeFloat64(elasticCPUGranterUtilizationLimit),
-		everyInterval:     util.Every(elasticCPUUtilizationMetricInterval),
+		AcquiredNanos:          metric.NewCounter(elasticCPUAcquiredNanos),
+		ReturnedNanos:          metric.NewCounter(elasticCPUReturnedNanos),
+		PreWorkNanos:           metric.NewCounter(elasticCPUPreWorkNanos),
+		MaxAvailableNanos:      metric.NewCounter(elasticCPUMaxAvailableNanos),
+		AvailableNanos:         metric.NewGauge(elasticCPUAvailableNanos),
+		NanosExhaustedDuration: metric.NewGauge(elasticCPUNanosExhaustedDuration),
+		OverLimitDuration: metric.NewHistogram(metric.HistogramOptions{
+			Mode:     metric.HistogramModePrometheus,
+			Metadata: elasticCPUOverLimitDurations,
+			Duration: base.DefaultHistogramWindowInterval(),
+			Buckets:  metric.IOLatencyBuckets,
+		}),
+		Utilization:      metric.NewGaugeFloat64(elasticCPUGranterUtilization),
+		UtilizationLimit: metric.NewGaugeFloat64(elasticCPUGranterUtilizationLimit),
+		everyInterval:    util.Every(elasticCPUUtilizationMetricInterval),
 	}
 
 	metrics.MaxAvailableNanos.Inc(int64(runtime.GOMAXPROCS(0)) * time.Second.Nanoseconds())

--- a/pkg/util/admission/elastic_cpu_work_handle.go
+++ b/pkg/util/admission/elastic_cpu_work_handle.go
@@ -28,6 +28,11 @@ type ElasticCPUWorkHandle struct {
 	// before indicating that it's over limit. It measures the duration since
 	// cpuStart.
 	allotted time.Duration
+	// preWork measures how much on-CPU running time this request accrued before
+	// starting doing the actual work it intended to. We don't want the preWork
+	// duration to count against what it was allotted, but we still want to
+	// track to deduct an appropriate number of granter tokens.
+	preWork time.Duration
 
 	// This handle is used in tight loops that are sensitive to per-iteration
 	// overhead (checking against the running time too can have an effect). To
@@ -42,17 +47,35 @@ type ElasticCPUWorkHandle struct {
 	// between that running time and what this handle was allotted.
 	runningTimeAtLastCheck, differenceWithAllottedAtLastCheck time.Duration
 
-	testingOverrideRunningTime func() time.Duration
-
-	testingOverrideOverLimit func() (bool, time.Duration)
+	testingOverrideRunningTime func() time.Duration // overrides the time since cpuStart
+	testingOverrideOverLimit   func() (bool, time.Duration)
 }
 
 func newElasticCPUWorkHandle(allotted time.Duration) *ElasticCPUWorkHandle {
 	h := &ElasticCPUWorkHandle{allotted: allotted}
-	h.cpuStart = h.runningTime()
+	h.cpuStart = grunning.Time()
 	return h
 }
 
+// StartTimer is used to denote that we're just starting to do the actual on-CPU
+// work we acquired CPU tokens for. It's possible for requests to do
+// semi-unrelated pre-work up until this point, time spent that we don't want to
+// count against our allotted CPU time. But we still want to deduct granter
+// tokens for that time to avoid over-admission. StartTimer makes note of how
+// much pre-work was done and starts counting any subsequent on-CPU time against
+// what was allotted. If StartTimer is never invoked, all on-CPU time is counted
+// against what was allotted. It can only be called once.
+func (h *ElasticCPUWorkHandle) StartTimer() {
+	if h == nil {
+		return
+	}
+	h.preWork = h.runningTime()
+	h.cpuStart = grunning.Time()
+}
+
+// runningTime returns the time spent since cpuStart. cpuStart is captured when
+// the handle is first constructed, and optionally reset if callers make use of
+// StartTimer.
 func (h *ElasticCPUWorkHandle) runningTime() time.Duration {
 	if h == nil {
 		return time.Duration(0)
@@ -64,10 +87,19 @@ func (h *ElasticCPUWorkHandle) runningTime() time.Duration {
 }
 
 // OverLimit is used to check whether we're over the allotted elastic CPU
-// tokens. It also returns the absolute time difference between how long we ran
-// for and what was allotted. Integrated callers are expected to invoke this in
-// tight loops (we assume most callers are CPU-intensive and thus have tight
-// loops somewhere) and bail once done.
+// tokens. If StartTimer was invoked, we start measuring on-CPU time only after
+// the invocation. It also returns the total time difference between how long we
+// ran for and what was allotted. The difference includes pre-work, if any. If
+// the difference is positive we've exceeded what was allotted, and vice versa.
+// It's possible to not be OverLimit but still have exceeded the allotment
+// (because of excessive pre-work).
+//
+// Integrated callers are expected to invoke this in tight loops (we assume most
+// callers are CPU-intensive and thus have tight loops somewhere) and bail once
+// done.
+//
+// TODO(irfansharif): Non-test callers use one or the other return value, not
+// both. Split this API?
 func (h *ElasticCPUWorkHandle) OverLimit() (overLimit bool, difference time.Duration) {
 	if h == nil { // not applicable
 		return false, time.Duration(0)
@@ -76,7 +108,7 @@ func (h *ElasticCPUWorkHandle) OverLimit() (overLimit bool, difference time.Dura
 	// What we're effectively doing is just:
 	//
 	// 		runningTime := h.runningTime()
-	// 		return runningTime > h.allotted, grunning.Difference(runningTime, h.allotted)
+	// 		return runningTime > h.allotted, runningTime - h.allotted
 	//
 	// But since this is invoked in tight loops where we're sensitive to
 	// per-iteration overhead (the naive form described above causes a 5%
@@ -88,7 +120,7 @@ func (h *ElasticCPUWorkHandle) OverLimit() (overLimit bool, difference time.Dura
 	// adjust for it elsewhere by penalizing subsequent waiters.
 	h.itersSinceLastCheck++
 	if h.itersSinceLastCheck < h.itersUntilCheck {
-		return false, h.differenceWithAllottedAtLastCheck
+		return false, h.preWork + h.differenceWithAllottedAtLastCheck
 	}
 	return h.overLimitInner()
 }
@@ -100,7 +132,7 @@ func (h *ElasticCPUWorkHandle) overLimitInner() (overLimit bool, difference time
 
 	runningTime := h.runningTime()
 	if runningTime >= h.allotted {
-		return true, grunning.Difference(runningTime, h.allotted)
+		return true, h.preWork + (runningTime - h.allotted)
 	}
 
 	if h.itersUntilCheck == 0 {
@@ -112,9 +144,9 @@ func (h *ElasticCPUWorkHandle) overLimitInner() (overLimit bool, difference time
 		}
 	}
 
-	h.runningTimeAtLastCheck, h.differenceWithAllottedAtLastCheck = runningTime, grunning.Difference(runningTime, h.allotted)
+	h.runningTimeAtLastCheck, h.differenceWithAllottedAtLastCheck = runningTime, runningTime-h.allotted
 	h.itersSinceLastCheck = 0
-	return false, h.differenceWithAllottedAtLastCheck
+	return false, h.differenceWithAllottedAtLastCheck + h.preWork
 }
 
 // TestingOverrideOverLimit allows tests to override the behaviour of
@@ -151,9 +183,8 @@ func TestingNewElasticCPUHandle() *ElasticCPUWorkHandle {
 	return newElasticCPUWorkHandle(420 * time.Hour) // use a very high allotment
 }
 
-// TestingNewElasticCPUWithCallback constructs an
-// ElascticCPUWorkHandle with a testing override for the behaviour of
-// OverLimit().
+// TestingNewElasticCPUHandleWithCallback constructs an ElasticCPUWorkHandle
+// with a testing override for the behaviour of OverLimit().
 func TestingNewElasticCPUHandleWithCallback(cb func() (bool, time.Duration)) *ElasticCPUWorkHandle {
 	h := TestingNewElasticCPUHandle()
 	h.testingOverrideOverLimit = cb

--- a/pkg/util/admission/elastic_cpu_work_handle_test.go
+++ b/pkg/util/admission/elastic_cpu_work_handle_test.go
@@ -50,17 +50,18 @@ func TestElasticCPUWorkHandle(t *testing.T) {
 
 	{ // Invoke once; we should see internal state primed for future iterations.
 		overLimit, difference := handle.OverLimit()
+		expDifference := -allotment // we've not used anything, so we're at the difference is 0-allotment
 		require.False(t, overLimit)
-		require.Equal(t, allotment, difference)
+		require.Equal(t, expDifference, difference)
 		require.Equal(t, 0, handle.itersSinceLastCheck)
 		require.Equal(t, 1, handle.itersUntilCheck)
 		require.Equal(t, zero, handle.runningTimeAtLastCheck)
-		require.Equal(t, allotment, handle.differenceWithAllottedAtLastCheck)
+		require.Equal(t, expDifference, handle.differenceWithAllottedAtLastCheck)
 	}
 
 	{ // Invoke while under the 1ms running duration. We should start doubling our itersUntilCheck count.
 		setRunning(100 * time.Microsecond)
-		expDifference := 99*time.Millisecond + 900*time.Microsecond
+		expDifference := -(99*time.Millisecond + 900*time.Microsecond) // difference is negative, since we're under our allotment
 
 		overLimit, difference := handle.OverLimit()
 		require.False(t, overLimit)
@@ -84,8 +85,8 @@ func TestElasticCPUWorkHandle(t *testing.T) {
 	}
 
 	{ // Cross the 1ms running mark. Loop until we observe as much.
-		setRunning(time.Millisecond + 100*time.Microsecond) // set to 1.1 ms to estimate 4 iters since last check (at 100us)
-		expDifference := 98*time.Millisecond + 900*time.Microsecond
+		setRunning(time.Millisecond + 100*time.Microsecond)            // set to 1.1 ms to estimate 4 iters since last check (at 100us)
+		expDifference := -(98*time.Millisecond + 900*time.Microsecond) // difference is negative, since we're under our allotment
 
 		internalIters := 0
 		for {
@@ -147,6 +148,7 @@ func TestElasticCPUWorkHandle(t *testing.T) {
 
 	{
 		setRunning(allotment + 50*time.Microsecond)
+		expDifference := 50 * time.Microsecond // difference is finally positive, since we're over our allotment
 		for i := 0; i < 7; i++ {
 			overLimit, _ := handle.OverLimit()
 			require.False(t, overLimit)
@@ -154,6 +156,59 @@ func TestElasticCPUWorkHandle(t *testing.T) {
 
 		overLimit, difference := handle.OverLimit()
 		require.True(t, overLimit)
-		require.Equal(t, 50*time.Microsecond, difference)
+		require.Equal(t, expDifference, difference)
 	}
+}
+
+func TestElasticCPUWorkHandlePreWork(t *testing.T) {
+	overrideMu := struct {
+		syncutil.Mutex
+		running time.Duration
+	}{}
+	setRunning := func(running time.Duration) {
+		overrideMu.Lock()
+		defer overrideMu.Unlock()
+		overrideMu.running = running
+	}
+
+	const allotment = 100 * time.Millisecond
+	const zero = time.Duration(0)
+
+	setRunning(zero)
+
+	handle := newElasticCPUWorkHandle(allotment)
+	handle.testingOverrideRunningTime = func() time.Duration {
+		overrideMu.Lock()
+		defer overrideMu.Unlock()
+		return overrideMu.running
+	}
+
+	// Start the timer after already run for 450ms.
+	setRunning(450 * time.Millisecond)
+	handle.StartTimer()
+	// All of it should count towards "pre-work" now.
+	require.Equal(t, handle.preWork, 450*time.Millisecond)
+
+	// Set the running time (effectively duration since the timer started, or
+	// when the handle was initialized) to 70ms.
+	setRunning(70 * time.Millisecond)
+
+	// OverLimit() only considers time spent after doing pre-work in its boolean
+	// return. Since our allotment was 100ms, of which we've used 70ms, we're
+	// not over limit.
+	overLimit, difference := handle.OverLimit()
+	require.False(t, overLimit)
+	// That said, the difference it returns does include all pre-work. So +450ms
+	// doing pre-work, and -30ms from the unused allotment after the timer
+	// started.
+	require.Equal(t, difference, (450-30)*time.Millisecond)
+
+	// Blow past the 100ms allotment after the timer started.
+	setRunning(150 * time.Millisecond)
+	// Since 150ms > 100ms, we're now over limit.
+	overLimit, difference = handle.OverLimit()
+	require.True(t, overLimit)
+	// Pre-work is still counted in the difference we return. Also included is
+	// how much over the allotment we ran (+50ms).
+	require.Equal(t, difference, (450+50)*time.Millisecond)
 }

--- a/pkg/util/quotapool/token_bucket.go
+++ b/pkg/util/quotapool/token_bucket.go
@@ -36,6 +36,9 @@ type TokenBucket struct {
 
 	current     Tokens
 	lastUpdated time.Time
+
+	exhaustedStart  time.Time
+	exhaustedMicros int64
 }
 
 // Init the token bucket.
@@ -60,6 +63,7 @@ func (tb *TokenBucket) Update() {
 			tb.current = tb.burst
 		}
 		tb.lastUpdated = now
+		tb.updateExhaustedMicros()
 	}
 }
 
@@ -77,6 +81,13 @@ func (tb *TokenBucket) UpdateConfig(rate TokensPerSecond, burst Tokens) {
 	tb.burst = burst
 
 	tb.current += burstDelta
+	tb.updateExhaustedMicros()
+}
+
+// Reset resets the current tokens to whatever the burst is.
+func (tb *TokenBucket) Reset() {
+	tb.current = tb.burst
+	tb.updateExhaustedMicros()
 }
 
 // Adjust returns tokens to the bucket (positive delta) or accounts for a debt
@@ -87,6 +98,7 @@ func (tb *TokenBucket) Adjust(delta Tokens) {
 	if tb.current > tb.burst {
 		tb.current = tb.burst
 	}
+	tb.updateExhaustedMicros()
 }
 
 // TryToFulfill either removes the given amount if is available, or returns a
@@ -112,7 +124,35 @@ func (tb *TokenBucket) TryToFulfill(amount Tokens) (fulfilled bool, tryAgainAfte
 	}
 
 	tb.current -= amount
+	tb.updateExhaustedMicros()
 	return true, 0
+}
+
+// Exhausted returns the cumulative duration over which this token bucket was
+// exhausted. Exported only for metrics.
+func (tb *TokenBucket) Exhausted() time.Duration {
+	var ongoingExhaustionMicros int64
+	if !tb.exhaustedStart.IsZero() {
+		ongoingExhaustionMicros = tb.timeSource.Now().Sub(tb.exhaustedStart).Microseconds()
+	}
+	return time.Duration(tb.exhaustedMicros+ongoingExhaustionMicros) * time.Microsecond
+}
+
+// Available returns the currently available tokens (can be -ve). Exported only
+// for metrics.
+func (tb *TokenBucket) Available() Tokens {
+	return tb.current
+}
+
+func (tb *TokenBucket) updateExhaustedMicros() {
+	now := tb.timeSource.Now()
+	if tb.current <= 0 && tb.exhaustedStart.IsZero() {
+		tb.exhaustedStart = now
+	}
+	if tb.current > 0 && !tb.exhaustedStart.IsZero() {
+		tb.exhaustedMicros += now.Sub(tb.exhaustedStart).Microseconds()
+		tb.exhaustedStart = time.Time{}
+	}
 }
 
 // TestingInternalParameters returns the refill rate (configured), burst tokens


### PR DESCRIPTION
Speculative fix for #102817.
Speculative fix for #103359.

In experiments and in production clusters, we observed elastic CPU wait queue durations in the order of minutes, which can be long enough to fail entire backups. Separately, we saw that with the elastic CPU limiter enabled, backups can sometimes be extremely inefficient, likely exporting a single key per ExportRequest (#103365 will improve this observability). We suspect that happened because by the time we actually got to the mvccExportToSST loop, we'd already expended the 100ms CPU-time grant we were given resolving intents or doing conflict resolution. Now we instead start the CPU timer per request once actually in the mvccExportToSST loop, not counting all the "pre-work" CPU time against our allotted budget. We still deduct CPU tokens for that work to avoid risking over-admission, and export a metric for how much pre-work we're doing. As a defense-in-depth thing, we also periodically reset the elastic CPU token bucket periodically (every 30s), again permitting some amount of over-admission.

While here, we export a few other metrics in the elastic CPU limiter stack to better diagnose issues:
- admission.elastic_cpu.nanos_exhausted_duration, which is the total duration when elastic CPU tokens were exhausted, in micros. We have equivalents for {IO token, CPU slot} exhaustion.
- admission.elastic_cpu.over_limit_durations, a latency histogram that surfaces exactly how much over the 100ms grants we go. This was quite high before this patch when ExportRequests could spend time resolving intents, pushing txns, doing conflict resolution.
- admission.elastic_cpu.pre_work_nanos, the elastic CPU time spent doing pre-work. See commentary above.
- admission.elastic_cpu.available_nanos, an instantaneous metric that surfaces exactly how many tokens are available. Useful to understand how much debt we're in.

Release note (bug fix): In earlier patch releases of v23.1, it was possible for backups to be excessively slow, slower than they were in earlier releases. It was also possible for them to fail with errors of the following form: 'operation "Export Request for span ..." timed out after 5m0.001s'. At least one of the reasons for this behavior is now addressed. This problem also affected v22.2 clusters if using a hidden-by-default, default-as-disabled cluster setting, 'admission.elastic_cpu.enabled'.