### PR TITLE
kv: deflake TestRefresh

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
@@ -152,6 +152,9 @@ func TestRefresh(t *testing.T) {
 	}
 	s, _, _ := serverutils.StartServer(t,
 		base.TestServerArgs{
+			// Disable span configs to avoid measuring protected timestamp lookups
+			// performed by the AUTO SPAN CONFIG RECONCILIATION job.
+			DisableSpanConfigs: true,
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
 					TestingRequestFilter: st.requestFilter,


### PR DESCRIPTION
Fixes #74613.
Fixes #100418.
Fixes #101298.

This commit deflakes `TestRefresh` by disabling the  span configs to avoid measuring protected timestamp lookups by the AUTO SPAN CONFIG RECONCILIATION job.

Release note: None