### PR TITLE
rpc: fix display for remoteNode 0

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2135,7 +2135,7 @@ func (rpcCtx *Context) makeDialCtx(
 	dialCtx := rpcCtx.MasterCtx
 	var rnodeID interface{} = remoteNodeID
 	if remoteNodeID == 0 {
-		rnodeID = '?'
+		rnodeID = redact.SafeString("?")
 	}
 	dialCtx = logtags.AddTag(dialCtx, "rnode", rnodeID)
 	dialCtx = logtags.AddTag(dialCtx, "raddr", target)


### PR DESCRIPTION
It was printing byte '?' instead of "?" previously.

Epic: None
Release note: None
