### PR TITLE
release-23.1: roachtest: enable metamorphic expiration leases in most tests

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -660,6 +660,9 @@ type clusterImpl struct {
 	expiration    time.Time
 	encAtRest     bool // use encryption at rest
 
+	// clusterSettings are additional cluster settings set on cluster startup.
+	clusterSettings map[string]string
+
 	// destroyState contains state related to the cluster's destruction.
 	destroyState destroyState
 }
@@ -1857,6 +1860,7 @@ func (c *clusterImpl) StartE(
 		install.EnvOption(settings.Env),
 		install.NumRacksOption(settings.NumRacks),
 		install.BinaryOption(settings.Binary),
+		install.ClusterSettingsOption(c.clusterSettings),
 		install.ClusterSettingsOption(settings.ClusterSettings),
 	}
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1857,6 +1857,7 @@ func (c *clusterImpl) StartE(
 		install.EnvOption(settings.Env),
 		install.NumRacksOption(settings.NumRacks),
 		install.BinaryOption(settings.Binary),
+		install.ClusterSettingsOption(settings.ClusterSettings),
 	}
 
 	if err := roachprod.Start(ctx, l, c.MakeNodes(opts...), startOpts.RoachprodOpts, clusterSettingsOpts...); err != nil {

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -12,6 +12,7 @@ package registry
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -84,6 +85,10 @@ type TestSpec struct {
 	// cannot be run with encryption enabled.
 	EncryptionSupport EncryptionSupport
 
+	// Leases specifies the kind of leases to use for the cluster. Defaults
+	// to epoch leases.
+	Leases LeaseType
+
 	// SkipPostValidations is a bit-set of post-validations that should be skipped
 	// after the test completes. This is useful for tests that are known to be
 	// incompatible with some validations. By default, tests will run all
@@ -148,3 +153,31 @@ func PromSub(raw string) string {
 	invalidPromRE := regexp.MustCompile("[^a-zA-Z0-9_]")
 	return invalidPromRE.ReplaceAllLiteralString(raw, "_")
 }
+
+// LeaseType specifies the type of leases to use for the cluster.
+type LeaseType int
+
+func (l LeaseType) String() string {
+	switch l {
+	case EpochLeases:
+		return "epoch"
+	case ExpirationLeases:
+		return "expiration"
+	case MetamorphicLeases:
+		return "metamorphic"
+	default:
+		return fmt.Sprintf("leasetype-%d", l)
+	}
+}
+
+const (
+	// DefaultLeases uses the default cluster lease type.
+	DefaultLeases = LeaseType(iota)
+	// EpochLeases uses epoch leases where possible.
+	EpochLeases
+	// ExpirationLeases uses expiration leases for all ranges.
+	ExpirationLeases
+	// MetamorphicLeases randomly chooses epoch or expiration
+	// leases (across the entire cluster)
+	MetamorphicLeases
+)

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -159,6 +159,8 @@ type LeaseType int
 
 func (l LeaseType) String() string {
 	switch l {
+	case DefaultLeases:
+		return "default"
 	case EpochLeases:
 		return "epoch"
 	case ExpirationLeases:

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -27,6 +27,7 @@ func registerAcceptance(r registry.Registry) {
 		numNodes          int
 		timeout           time.Duration
 		encryptionSupport registry.EncryptionSupport
+		defaultLeases     bool
 	}{
 		registry.OwnerKV: {
 			{name: "decommission-self", fn: runDecommissionSelf},
@@ -63,9 +64,10 @@ func registerAcceptance(r registry.Registry) {
 		},
 		registry.OwnerTestEng: {
 			{
-				name:    "version-upgrade",
-				fn:      runVersionUpgrade,
-				timeout: 30 * time.Minute,
+				name:          "version-upgrade",
+				fn:            runVersionUpgrade,
+				timeout:       30 * time.Minute,
+				defaultLeases: true,
 			},
 		},
 		registry.OwnerDisasterRecovery: {
@@ -106,6 +108,9 @@ func registerAcceptance(r registry.Registry) {
 				spec.Timeout = tc.timeout
 			}
 			spec.EncryptionSupport = tc.encryptionSupport
+			if !tc.defaultLeases {
+				spec.Leases = registry.MetamorphicLeases
+			}
 			spec.Run = func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				tc.fn(ctx, t, c)
 			}

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -247,5 +247,6 @@ func registerActiveRecord(r registry.Registry) {
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},
 		Run:        runActiveRecord,
+		Leases:     registry.MetamorphicLeases,
 	})
 }

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_backup.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_backup.go
@@ -41,6 +41,7 @@ func registerElasticControlForBackups(r registry.Registry) {
 		Owner:   registry.OwnerAdmissionControl,
 		Tags:    []string{`weekly`},
 		Cluster: r.MakeClusterSpec(4, spec.CPU(8)),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {
 				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
@@ -35,6 +35,7 @@ func registerElasticControlForCDC(r registry.Registry) {
 		Tags:            []string{`weekly`},
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(8)),
 		RequiresLicense: true,
+		Leases:          registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {
 				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/tests/admission_control_index_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_overload.go
@@ -37,6 +37,7 @@ func registerIndexOverload(r registry.Registry) {
 		Owner:   registry.OwnerAdmissionControl,
 		Tags:    []string{`weekly`},
 		Cluster: r.MakeClusterSpec(4, spec.CPU(8)),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			crdbNodes := c.Spec().NodeCount - 1
 			workloadNode := c.Spec().NodeCount

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
@@ -96,6 +96,7 @@ func registerMultiStoreOverload(r registry.Registry) {
 		Owner:   registry.OwnerAdmissionControl,
 		Tags:    []string{`weekly`},
 		Cluster: r.MakeClusterSpec(2, spec.CPU(8), spec.SSD(2)),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKV(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
@@ -90,6 +90,7 @@ func registerMultiTenantFairness(r registry.Registry) {
 			Name:              fmt.Sprintf("admission-control/multitenant-fairness/%s", s.name),
 			Cluster:           r.MakeClusterSpec(5),
 			Owner:             registry.OwnerAdmissionControl,
+			Leases:            registry.MetamorphicLeases,
 			NonReleaseBlocker: false,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runMultiTenantFairness(ctx, t, c, s)

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
@@ -43,6 +43,7 @@ func registerSnapshotOverload(r registry.Registry) {
 		Owner:   registry.OwnerAdmissionControl,
 		Tags:    []string{`weekly`},
 		Cluster: r.MakeClusterSpec(4, spec.CPU(8)),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {
 				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
@@ -168,6 +168,7 @@ func registerTPCCOverload(r registry.Registry) {
 			Cluster:           r.MakeClusterSpec(s.Nodes+1, spec.CPU(s.CPUs)),
 			Run:               s.run,
 			EncryptionSupport: registry.EncryptionMetamorphic,
+			Leases:            registry.MetamorphicLeases,
 			Timeout:           20 * time.Minute,
 		})
 	}

--- a/pkg/cmd/roachtest/tests/allocator.go
+++ b/pkg/cmd/roachtest/tests/allocator.go
@@ -151,6 +151,7 @@ func registerAllocator(r registry.Registry) {
 		Name:    `replicate/up/1to3`,
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(4),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAllocator(ctx, t, c, 1, 10.0)
 		},
@@ -159,6 +160,7 @@ func registerAllocator(r registry.Registry) {
 		Name:    `replicate/rebalance/3to5`,
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(6),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAllocator(ctx, t, c, 3, 42.0)
 		},
@@ -168,6 +170,7 @@ func registerAllocator(r registry.Registry) {
 		Owner:   registry.OwnerKV,
 		Timeout: 10 * time.Minute,
 		Cluster: r.MakeClusterSpec(9, spec.CPU(1)),
+		Leases:  registry.MetamorphicLeases,
 		Run:     runWideReplication,
 	})
 }

--- a/pkg/cmd/roachtest/tests/alterpk.go
+++ b/pkg/cmd/roachtest/tests/alterpk.go
@@ -183,6 +183,7 @@ func registerAlterPK(r registry.Registry) {
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
 		Cluster: r.MakeClusterSpec(4),
+		Leases:  registry.MetamorphicLeases,
 		Run:     runAlterPKBank,
 	})
 	r.Add(registry.TestSpec{
@@ -191,6 +192,7 @@ func registerAlterPK(r registry.Registry) {
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
 		Cluster: r.MakeClusterSpec(4, spec.CPU(32)),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAlterPKTPCC(ctx, t, c, 250 /* warehouses */, true /* expensiveChecks */)
 		},
@@ -201,6 +203,7 @@ func registerAlterPK(r registry.Registry) {
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
 		Cluster: r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAlterPKTPCC(ctx, t, c, 500 /* warehouses */, false /* expensiveChecks */)
 		},

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -142,6 +142,7 @@ func registerAsyncpg(r registry.Registry) {
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
 		Tags:    []string{`default`, `orm`},
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAsyncpg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -192,6 +192,7 @@ func registerAWSDMS(r registry.Registry) {
 		Owner:   registry.OwnerSQLFoundations, // TODO(otan): add a migrations OWNERS team
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `awsdms`},
+		Leases:  registry.MetamorphicLeases,
 		Run:     runAWSDMS,
 	})
 }

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -199,6 +199,7 @@ func registerBackupNodeShutdown(r registry.Registry) {
 		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           backupNodeRestartSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			gatewayNode := 2
 			nodeToShutdown := 3
@@ -220,6 +221,7 @@ func registerBackupNodeShutdown(r registry.Registry) {
 		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           backupNodeRestartSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			gatewayNode := 2
 			nodeToShutdown := 2
@@ -415,6 +417,7 @@ func registerBackup(r registry.Registry) {
 			Owner:             registry.OwnerDisasterRecovery,
 			Cluster:           r.MakeClusterSpec(3),
 			EncryptionSupport: registry.EncryptionMetamorphic,
+			Leases:            registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.Spec().Cloud != item.machine {
 					t.Skip("backup assumeRole is only configured to run on "+item.machine, "")
@@ -520,6 +523,7 @@ func registerBackup(r registry.Registry) {
 			Owner:             registry.OwnerDisasterRecovery,
 			Cluster:           KMSSpec,
 			EncryptionSupport: registry.EncryptionMetamorphic,
+			Leases:            registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.Spec().Cloud != item.machine {
 					t.Skip("backupKMS roachtest is only configured to run on "+item.machine, "")
@@ -652,6 +656,7 @@ func registerBackup(r registry.Registry) {
 		Name:              `backupTPCC`,
 		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           r.MakeClusterSpec(3),
+		Leases:            registry.MetamorphicLeases,
 		Timeout:           1 * time.Hour,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -858,6 +863,7 @@ func registerBackup(r registry.Registry) {
 		Owner:             registry.OwnerDisasterRecovery,
 		Timeout:           4 * time.Hour,
 		Cluster:           r.MakeClusterSpec(3, spec.CPU(8)),
+		Leases:            registry.MetamorphicLeases,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runBackupMVCCRangeTombstones(ctx, t, c, mvccRangeTombstoneConfig{})

--- a/pkg/cmd/roachtest/tests/cancel.go
+++ b/pkg/cmd/roachtest/tests/cancel.go
@@ -139,6 +139,7 @@ func registerCancel(r registry.Registry) {
 		Name:    fmt.Sprintf("cancel/tpch/distsql/queries=%s,nodes=%d", queries, numNodes),
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCancel(ctx, t, c, tpchQueriesToRun, true /* useDistsql */)
 		},
@@ -148,6 +149,7 @@ func registerCancel(r registry.Registry) {
 		Name:    fmt.Sprintf("cancel/tpch/local/queries=%s,nodes=%d", queries, numNodes),
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCancel(ctx, t, c, tpchQueriesToRun, false /* useDistsql */)
 		},

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -966,6 +966,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/tpcc-1000",
 		Owner:           registry.OwnerCDC,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -989,6 +990,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/tpcc-1000/sink=null",
 		Owner:           registry.OwnerCDC,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		Tags:            []string{"manual"},
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -1013,6 +1015,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/initial-scan",
 		Owner:           registry.OwnerCDC,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1032,6 +1035,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/sink-chaos",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1056,6 +1060,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/crdb-chaos",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1085,6 +1090,7 @@ func registerCDC(r registry.Registry) {
 		// but this cannot be allocated without some sort of configuration outside
 		// of this test. Look into it.
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1116,6 +1122,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/cloud-sink-gcs/rangefeed=true",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1142,6 +1149,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/pubsub-sink",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1177,6 +1185,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/pubsub-sink/assume-role",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1209,6 +1218,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/cloud-sink-gcs/assume-role",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1232,6 +1242,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/webhook-sink",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1264,6 +1275,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/kafka-auth",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(1),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCKafkaAuth(ctx, t, c)
@@ -1273,6 +1285,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/kafka-oauth",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(4),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1307,6 +1320,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/bank",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(4),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Timeout:         30 * time.Minute,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -1317,6 +1331,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/schemareg",
 		Owner:           `cdc`,
 		Cluster:         r.MakeClusterSpec(1),
+		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCSchemaRegistry(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -37,6 +37,7 @@ func registerClearRange(r registry.Registry) {
 				// to <3:30h but it varies.
 				Timeout: 5*time.Hour + 90*time.Minute,
 				Cluster: r.MakeClusterSpec(10, spec.CPU(16)),
+				Leases:  registry.MetamorphicLeases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runClearRange(ctx, t, c, checks, rangeTombstones)
 				},
@@ -54,6 +55,7 @@ func registerClearRange(r registry.Registry) {
 				Timeout:           5*time.Hour + 120*time.Minute,
 				Cluster:           r.MakeClusterSpec(10, spec.CPU(16), spec.SetFileSystem(spec.Zfs)),
 				EncryptionSupport: registry.EncryptionMetamorphic,
+				Leases:            registry.MetamorphicLeases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runClearRange(ctx, t, c, checks, rangeTombstones)
 				},

--- a/pkg/cmd/roachtest/tests/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/tests/clock_jump_crash.go
@@ -139,6 +139,7 @@ func registerClockJumpTests(r registry.Registry) {
 			// These tests muck with NTP, therefore we don't want the cluster reused
 			// by others.
 			Cluster: r.MakeClusterSpec(1, spec.ReuseTagged("offset-injector"), spec.TerminateOnMigration()),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runClockJump(ctx, t, c, tc)
 			},

--- a/pkg/cmd/roachtest/tests/clock_monotonic.go
+++ b/pkg/cmd/roachtest/tests/clock_monotonic.go
@@ -141,6 +141,7 @@ func registerClockMonotonicTests(r registry.Registry) {
 			// These tests muck with NTP, therefor we don't want the cluster reused by
 			// others.
 			Cluster: r.MakeClusterSpec(1, spec.ReuseTagged("offset-injector"), spec.TerminateOnMigration()),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runClockMonotonicity(ctx, t, c, tc)
 			},

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -711,6 +711,7 @@ func c2cRegisterWrapper(
 		Name:            sp.name,
 		Owner:           registry.OwnerDisasterRecovery,
 		Cluster:         r.MakeClusterSpec(sp.dstNodes+sp.srcNodes+1, clusterOps...),
+		Leases:          registry.MetamorphicLeases,
 		Timeout:         sp.timeout,
 		Skip:            sp.skip,
 		RequiresLicense: true,

--- a/pkg/cmd/roachtest/tests/copy.go
+++ b/pkg/cmd/roachtest/tests/copy.go
@@ -182,6 +182,7 @@ func registerCopy(r registry.Registry) {
 			Name:    fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", tc.rows, tc.nodes, tc.txn),
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(tc.nodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runCopy(ctx, t, c, tc.rows, tc.txn)
 			},

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -170,6 +170,7 @@ func registerCopyFrom(r registry.Registry) {
 			Name:    fmt.Sprintf("copyfrom/crdb-atomic/sf=%d/nodes=%d", tc.sf, tc.nodes),
 			Owner:   registry.OwnerSQLQueries,
 			Cluster: r.MakeClusterSpec(tc.nodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runCopyFromCRDB(ctx, t, c, tc.sf, true /*atomic*/)
 			},
@@ -178,6 +179,7 @@ func registerCopyFrom(r registry.Registry) {
 			Name:    fmt.Sprintf("copyfrom/crdb-nonatomic/sf=%d/nodes=%d", tc.sf, tc.nodes),
 			Owner:   registry.OwnerSQLQueries,
 			Cluster: r.MakeClusterSpec(tc.nodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runCopyFromCRDB(ctx, t, c, tc.sf, false /*atomic*/)
 			},
@@ -186,6 +188,7 @@ func registerCopyFrom(r registry.Registry) {
 			Name:    fmt.Sprintf("copyfrom/pg/sf=%d/nodes=%d", tc.sf, tc.nodes),
 			Owner:   registry.OwnerSQLQueries,
 			Cluster: r.MakeClusterSpec(tc.nodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runCopyFromPG(ctx, t, c, tc.sf)
 			},

--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -42,6 +42,7 @@ func registerCostFuzz(r registry.Registry) {
 			RequiresLicense: true,
 			Tags:            nil,
 			Cluster:         clusterSpec,
+			Leases:          registry.MetamorphicLeases,
 			NativeLibs:      registry.LibGEOS,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runQueryComparison(ctx, t, c, &queryComparisonTest{

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -47,6 +47,7 @@ func registerDecommission(r registry.Registry) {
 			Name:    fmt.Sprintf("decommission/nodes=%d/duration=%s", numNodes, duration),
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(numNodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					duration = 5 * time.Minute
@@ -63,6 +64,7 @@ func registerDecommission(r registry.Registry) {
 			Name:    fmt.Sprintf("drain-and-decommission/nodes=%d", numNodes),
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(numNodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDrainAndDecommission(ctx, t, c, numNodes, duration)
 			},
@@ -74,6 +76,7 @@ func registerDecommission(r registry.Registry) {
 			Name:    "decommission/drains",
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(numNodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionDrains(ctx, t, c)
 			},
@@ -86,6 +89,7 @@ func registerDecommission(r registry.Registry) {
 			Owner:   registry.OwnerKV,
 			Timeout: 10 * time.Minute,
 			Cluster: r.MakeClusterSpec(numNodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionRandomized(ctx, t, c)
 			},
@@ -97,6 +101,7 @@ func registerDecommission(r registry.Registry) {
 			Name:    "decommission/mixed-versions",
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(numNodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() && runtime.GOARCH == "arm64" {
 					t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
@@ -111,6 +116,7 @@ func registerDecommission(r registry.Registry) {
 			Name:    "decommission/slow",
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(numNodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionSlow(ctx, t, c)
 			},

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -101,7 +101,6 @@ func registerDecommission(r registry.Registry) {
 			Name:    "decommission/mixed-versions",
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(numNodes),
-			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() && runtime.GOARCH == "arm64" {
 					t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/cmd/roachtest/tests/disk_full.go
+++ b/pkg/cmd/roachtest/tests/disk_full.go
@@ -30,6 +30,7 @@ func registerDiskFull(r registry.Registry) {
 		Name:    "disk-full",
 		Owner:   registry.OwnerStorage,
 		Cluster: r.MakeClusterSpec(5),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() {
 				t.Skip("you probably don't want to fill your local disk")

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -67,6 +67,7 @@ func registerDiskStalledDetection(r registry.Registry) {
 			// the encryption-at-rest implementation that could indefinitely
 			// stall the process during a disk stall.
 			EncryptionSupport: registry.EncryptionMetamorphic,
+			Leases:            registry.MetamorphicLeases,
 		})
 	}
 }

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -217,6 +217,7 @@ func registerDjango(r registry.Registry) {
 		Name:    "django",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runDjango(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/drain.go
+++ b/pkg/cmd/roachtest/tests/drain.go
@@ -40,6 +40,7 @@ func registerDrain(r registry.Registry) {
 			Name:    "drain/early-exit-conn-wait",
 			Owner:   registry.OwnerSQLFoundations,
 			Cluster: r.MakeClusterSpec(1),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runEarlyExitInConnectionWait(ctx, t, c)
 			},
@@ -49,6 +50,7 @@ func registerDrain(r registry.Registry) {
 			Name:    "drain/warn-conn-wait-timeout",
 			Owner:   registry.OwnerSQLFoundations,
 			Cluster: r.MakeClusterSpec(1),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runWarningForConnWait(ctx, t, c)
 			},
@@ -58,6 +60,7 @@ func registerDrain(r registry.Registry) {
 			Name:    "drain/not-at-quorum",
 			Owner:   registry.OwnerSQLFoundations,
 			Cluster: r.MakeClusterSpec(3),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runClusterNotAtQuorum(ctx, t, c)
 			},

--- a/pkg/cmd/roachtest/tests/drop.go
+++ b/pkg/cmd/roachtest/tests/drop.go
@@ -165,6 +165,7 @@ func registerDrop(r registry.Registry) {
 		Name:    fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// NB: this is likely not going to work out in `-local` mode. Edit the
 			// numbers during iteration.

--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -86,6 +86,7 @@ func registerEncryption(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:              fmt.Sprintf("encryption/nodes=%d", n),
 			EncryptionSupport: registry.EncryptionAlwaysEnabled,
+			Leases:            registry.MetamorphicLeases,
 			Owner:             registry.OwnerStorage,
 			Cluster:           r.MakeClusterSpec(n),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/flowable.go
+++ b/pkg/cmd/roachtest/tests/flowable.go
@@ -106,6 +106,7 @@ func registerFlowable(r registry.Registry) {
 		Name:    "flowable",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runFlowable(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -102,7 +102,6 @@ func registerFollowerReads(r registry.Registry) {
 			3, /* nodeCount */
 			spec.CPU(2),
 		),
-		Leases: registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -63,6 +63,7 @@ func registerFollowerReads(r registry.Registry) {
 				spec.Geo(),
 				spec.Zones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b"),
 			),
+			Leases: registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				c.Put(ctx, t.Cockroach(), "./cockroach")
 				c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
@@ -101,6 +102,7 @@ func registerFollowerReads(r registry.Registry) {
 			3, /* nodeCount */
 			spec.CPU(2),
 		),
+		Leases: registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -159,6 +159,7 @@ func registerGopg(r registry.Registry) {
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
 		Tags:    []string{`default`, `orm`},
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runGopg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -136,6 +136,7 @@ func registerGORM(r registry.Registry) {
 		Name:    "gorm",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `orm`},
 		Run:     runGORM,
 	})

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -144,6 +144,7 @@ SELECT node_id
 		Name:    "gossip/chaos/nodes=9",
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(9),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runGossipChaos(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -246,6 +246,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		Name:       opt.testName,
 		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
+		Leases:     registry.MetamorphicLeases,
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/hotspotsplits.go
+++ b/pkg/cmd/roachtest/tests/hotspotsplits.go
@@ -99,6 +99,7 @@ func registerHotSpotSplits(r registry.Registry) {
 		// No problem in 20.1 thanks to:
 		// https://github.com/cockroachdb/cockroach/pull/45323.
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() {
 				concurrency = 32

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -356,7 +356,6 @@ func registerImportMixedVersion(r registry.Registry) {
 		Owner: registry.OwnerSQLQueries,
 		// Mixed-version support was added in 21.1.
 		Cluster: r.MakeClusterSpec(4),
-		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -89,6 +89,7 @@ func registerImportNodeShutdown(r registry.Registry) {
 		Name:    "import/nodeShutdown/worker",
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(4),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
@@ -103,6 +104,7 @@ func registerImportNodeShutdown(r registry.Registry) {
 		Name:    "import/nodeShutdown/coordinator",
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(4),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
@@ -181,6 +183,7 @@ func registerImportTPCC(r registry.Registry) {
 		Cluster:           r.MakeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.Zones(geoZones)),
 		Timeout:           5 * time.Hour,
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runImportTPCC(ctx, t, c, fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
 				5*time.Hour, geoWarehouses)
@@ -213,6 +216,7 @@ func registerImportTPCH(r registry.Registry) {
 			Cluster:           r.MakeClusterSpec(item.nodes),
 			Timeout:           item.timeout,
 			EncryptionSupport: registry.EncryptionMetamorphic,
+			Leases:            registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				tick, perfBuf := initBulkJobPerfArtifacts(t.Name(), item.timeout)
 
@@ -352,6 +356,7 @@ func registerImportMixedVersion(r registry.Registry) {
 		Owner: registry.OwnerSQLQueries,
 		// Mixed-version support was added in 21.1.
 		Cluster: r.MakeClusterSpec(4),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
@@ -398,6 +403,7 @@ func registerImportDecommissioned(r registry.Registry) {
 		Name:    "import/decommissioned",
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(4),
+		Leases:  registry.MetamorphicLeases,
 		Run:     runImportDecommissioned,
 	})
 }

--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -35,6 +35,7 @@ func registerImportCancellation(r registry.Registry) {
 			Owner:   registry.OwnerDisasterRecovery,
 			Timeout: 4 * time.Hour,
 			Cluster: r.MakeClusterSpec(6, spec.CPU(32)),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runImportCancellation(ctx, t, c, rangeTombstones)
 			},

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -27,6 +27,7 @@ func registerInconsistency(r registry.Registry) {
 		Name:    "inconsistency",
 		Owner:   registry.OwnerReplication,
 		Cluster: r.MakeClusterSpec(3),
+		Leases:  registry.MetamorphicLeases,
 		Run:     runInconsistency,
 	})
 }

--- a/pkg/cmd/roachtest/tests/inverted_index.go
+++ b/pkg/cmd/roachtest/tests/inverted_index.go
@@ -28,6 +28,7 @@ func registerSchemaChangeInvertedIndex(r registry.Registry) {
 		Name:    "schemachange/invertedindex",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(5),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSchemaChangeInvertedIndex(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/jasyncsql.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql.go
@@ -143,6 +143,7 @@ func registerJasyncSQL(r registry.Registry) {
 		Name:    "jasync",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runJasyncSQL(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -491,6 +491,7 @@ func registerJepsen(r registry.Registry) {
 				// if they detect that the machines have already been properly
 				// initialized.
 				Cluster: r.MakeClusterSpec(6, spec.ReuseTagged("jepsen")),
+				Leases:  registry.MetamorphicLeases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runJepsen(ctx, t, c, testName, nemesis.config)
 				},

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -130,6 +130,7 @@ func registerKnex(r registry.Registry) {
 		Name:       "knex",
 		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
+		Leases:     registry.MetamorphicLeases,
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -321,6 +321,7 @@ func registerKVContention(r registry.Registry) {
 		Name:    fmt.Sprintf("kv/contention/nodes=%d", nodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(nodes + 1),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
@@ -390,6 +391,7 @@ func registerKVQuiescenceDead(r registry.Registry) {
 		Name:    "kv/quiescence/nodes=3",
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(4),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
@@ -465,6 +467,7 @@ func registerKVGracefulDraining(r registry.Registry) {
 		Owner:   registry.OwnerKV,
 		Skip:    "https://github.com/cockroachdb/cockroach/issues/59094",
 		Cluster: r.MakeClusterSpec(4),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
@@ -692,6 +695,7 @@ func registerKVSplits(r registry.Registry) {
 			Owner:   registry.OwnerKV,
 			Timeout: item.timeout,
 			Cluster: r.MakeClusterSpec(4),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				nodes := c.Spec().NodeCount - 1
 				c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
@@ -759,6 +763,7 @@ func registerKVScalability(r registry.Registry) {
 				Name:    fmt.Sprintf("kv%d/scale/nodes=6", p),
 				Owner:   registry.OwnerKV,
 				Cluster: r.MakeClusterSpec(7, spec.CPU(8)),
+				Leases:  registry.MetamorphicLeases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runScalability(ctx, t, c, p)
 				},
@@ -894,6 +899,7 @@ func registerKVRangeLookups(r registry.Registry) {
 			Name:    fmt.Sprintf("kv50/rangelookups/%s/nodes=%d", workloadName, nodes),
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(nodes+1, spec.CPU(cpus)),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runRangeLookups(ctx, t, c, item.workers, item.workloadType, item.maximumRangeLookupsPerSec)
 			},
@@ -935,6 +941,7 @@ func registerKVRestartImpact(r registry.Registry) {
 		Tags:    []string{`weekly`},
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(13, spec.CPU(8)),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			workloadNode := c.Spec().NodeCount

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -676,26 +676,30 @@ func registerKVSplits(r registry.Registry) {
 	for _, item := range []struct {
 		quiesce bool
 		splits  int
+		leases  registry.LeaseType
 		timeout time.Duration
 	}{
 		// NB: with 500000 splits, this test sometimes fails since it's pushing
 		// far past the number of replicas per node we support, at least if the
 		// ranges start to unquiesce (which can set off a cascade due to resource
 		// exhaustion).
-		{true, 300000, 2 * time.Hour},
+		{true, 300000, registry.EpochLeases, 2 * time.Hour},
 		// This version of the test prevents range quiescence to trigger the
 		// badness described above more reliably for when we wish to improve
 		// the performance. For now, just verify that 30k unquiesced ranges
 		// is tenable.
-		{false, 30000, 2 * time.Hour},
+		{false, 30000, registry.EpochLeases, 2 * time.Hour},
+		// Expiration-based leases prevent quiescence, and are also more expensive
+		// to keep alive. Again, just verify that 30k ranges is ok.
+		{false, 30000, registry.ExpirationLeases, 2 * time.Hour},
 	} {
 		item := item // for use in closure below
 		r.Add(registry.TestSpec{
-			Name:    fmt.Sprintf("kv/splits/nodes=3/quiesce=%t", item.quiesce),
+			Name:    fmt.Sprintf("kv/splits/nodes=3/quiesce=%t/lease=%s", item.quiesce, item.leases),
 			Owner:   registry.OwnerKV,
 			Timeout: item.timeout,
 			Cluster: r.MakeClusterSpec(4),
-			Leases:  registry.MetamorphicLeases,
+			Leases:  item.leases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				nodes := c.Spec().NodeCount - 1
 				c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -138,6 +138,7 @@ func registerLibPQ(r registry.Registry) {
 		Name:    "lib/pq",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `driver`},
 		Run:     runLibPQ,
 	})

--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -134,6 +134,7 @@ func registerLiquibase(r registry.Registry) {
 		Name:    "liquibase",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `tool`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLiquibase(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -73,6 +73,7 @@ func registerLOQRecovery(r registry.Registry) {
 			Owner:               registry.OwnerReplication,
 			Tags:                []string{`default`},
 			Cluster:             spec,
+			Leases:              registry.MetamorphicLeases,
 			SkipPostValidations: registry.PostValidationInvalidDescriptors,
 			NonReleaseBlocker:   true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -84,6 +85,7 @@ func registerLOQRecovery(r registry.Registry) {
 			Owner:               registry.OwnerReplication,
 			Tags:                []string{`default`},
 			Cluster:             spec,
+			Leases:              registry.MetamorphicLeases,
 			SkipPostValidations: registry.PostValidationInvalidDescriptors,
 			NonReleaseBlocker:   true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -40,6 +40,7 @@ func registerMultiTenantDistSQL(r registry.Registry) {
 				Name:    fmt.Sprintf("multitenant/distsql/instances=%d/bundle=%s/timeout=%d", numInstances, b, to),
 				Owner:   registry.OwnerSQLQueries,
 				Cluster: r.MakeClusterSpec(4),
+				Leases:  registry.MetamorphicLeases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runMultiTenantDistSQL(ctx, t, c, numInstances, b == "on", to)
 				},

--- a/pkg/cmd/roachtest/tests/multitenant_shared_process.go
+++ b/pkg/cmd/roachtest/tests/multitenant_shared_process.go
@@ -30,6 +30,7 @@ func registerMultiTenantSharedProcess(r registry.Registry) {
 		Name:    "multitenant/shared-process/basic",
 		Owner:   registry.OwnerMultiTenant,
 		Cluster: r.MakeClusterSpec(crdbNodeCount + 1),
+		Leases:  registry.MetamorphicLeases,
 		Timeout: 1 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			var (

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -120,6 +120,7 @@ func registerMultiTenantTPCH(r registry.Registry) {
 		Name:    "multitenant/tpch",
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(1 /* nodeCount */),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runMultiTenantTPCH(ctx, t, c, false /* enableDirectScans */)
 		},
@@ -128,6 +129,7 @@ func registerMultiTenantTPCH(r registry.Registry) {
 		Name:    "multitenant/tpch_direct_scans",
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(1 /* nodeCount */),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runMultiTenantTPCH(ctx, t, c, true /* enableDirectScans */)
 		},

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -31,7 +31,6 @@ func registerMultiTenantUpgrade(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:              "multitenant-upgrade",
 		Cluster:           r.MakeClusterSpec(2),
-		Leases:            registry.MetamorphicLeases,
 		Owner:             registry.OwnerMultiTenant,
 		NonReleaseBlocker: false,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -31,6 +31,7 @@ func registerMultiTenantUpgrade(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:              "multitenant-upgrade",
 		Cluster:           r.MakeClusterSpec(2),
+		Leases:            registry.MetamorphicLeases,
 		Owner:             registry.OwnerMultiTenant,
 		NonReleaseBlocker: false,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/mvcc_gc.go
+++ b/pkg/cmd/roachtest/tests/mvcc_gc.go
@@ -42,6 +42,7 @@ func registerMVCCGC(r registry.Registry) {
 		Owner:   registry.OwnerKV,
 		Timeout: 30 * time.Minute,
 		Cluster: r.MakeClusterSpec(3),
+		Leases:  registry.MetamorphicLeases,
 		Run:     runMVCCGC,
 	})
 }

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -301,6 +301,7 @@ func registerNetwork(r registry.Registry) {
 		Name:    fmt.Sprintf("network/authentication/nodes=%d", numNodes),
 		Owner:   registry.OwnerKV, // Should be moved to new security team once one exists.
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runNetworkAuthentication(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -170,6 +170,7 @@ PGSSLCERT=$HOME/certs/client.%s.crt PGSSLKEY=$HOME/certs/client.%s.key PGSSLROOT
 		Name:    "node-postgres",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runNodeJSPostgres(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -169,6 +169,7 @@ echo '%s' | git apply --ignore-whitespace -`, npgsqlPatch),
 		Name:    "npgsql",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runNpgsql(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/pebble_write_throughput.go
+++ b/pkg/cmd/roachtest/tests/pebble_write_throughput.go
@@ -36,6 +36,7 @@ func registerPebbleWriteThroughput(r registry.Registry) {
 		Owner:   registry.OwnerStorage,
 		Timeout: 10 * time.Hour,
 		Cluster: r.MakeClusterSpec(5, spec.CPU(16), spec.SSD(16), spec.RAID0(true)),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{"pebble_nightly_write"},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPebbleWriteBenchmark(ctx, t, c, size, pebble)

--- a/pkg/cmd/roachtest/tests/pebble_ycsb.go
+++ b/pkg/cmd/roachtest/tests/pebble_ycsb.go
@@ -69,6 +69,7 @@ func registerPebbleYCSB(r registry.Registry) {
 		Owner:   registry.OwnerStorage,
 		Timeout: 12 * time.Hour,
 		Cluster: r.MakeClusterSpec(5, spec.CPU(16)),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{"pebble_nightly_ycsb_race"},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPebbleYCSB(ctx, t, c, 64, pebble, 30, []string{"A"}, false /* artifacts */)

--- a/pkg/cmd/roachtest/tests/pgjdbc.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc.go
@@ -213,6 +213,7 @@ func registerPgjdbc(r registry.Registry) {
 		Name:    "pgjdbc",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPgjdbc(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -134,6 +134,7 @@ func registerPgx(r registry.Registry) {
 		Name:    "pgx",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPgx(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/pop.go
+++ b/pkg/cmd/roachtest/tests/pop.go
@@ -102,6 +102,7 @@ func registerPop(r registry.Registry) {
 		Name:    "pop",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `orm`},
 		Run:     runPop,
 	})

--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -143,6 +143,7 @@ func registerPsycopg(r registry.Registry) {
 		Name:    "psycopg",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPsycopg(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/queue.go
+++ b/pkg/cmd/roachtest/tests/queue.go
@@ -32,6 +32,7 @@ func registerQueue(r registry.Registry) {
 		Name:    fmt.Sprintf("queue/nodes=%d", numNodes-1),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runQueue(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/quit.go
+++ b/pkg/cmd/roachtest/tests/quit.go
@@ -363,6 +363,7 @@ func registerQuitTransfersLeases(r registry.Registry) {
 			Name:    fmt.Sprintf("transfer-leases/%s", name),
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(3),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runQuitTransfersLeases(ctx, t, c, name, method)
 			},

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -209,7 +209,6 @@ func registerRebalanceLoad(r registry.Registry) {
 			Name:    `rebalance/by-load/leases/mixed-version`,
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(4), // the last node is just used to generate load
-			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					concurrency = 32
@@ -241,7 +240,6 @@ func registerRebalanceLoad(r registry.Registry) {
 			Name:    `rebalance/by-load/replicas/mixed-version`,
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(7), // the last node is just used to generate load
-			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					concurrency = 32

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -191,6 +191,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			Name:    `rebalance/by-load/leases`,
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(4), // the last node is just used to generate load
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() && runtime.GOARCH == "arm64" {
 					t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
@@ -208,6 +209,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			Name:    `rebalance/by-load/leases/mixed-version`,
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(4), // the last node is just used to generate load
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					concurrency = 32
@@ -222,6 +224,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			Name:    `rebalance/by-load/replicas`,
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(7), // the last node is just used to generate load
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					concurrency = 32
@@ -238,6 +241,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			Name:    `rebalance/by-load/replicas/mixed-version`,
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(7), // the last node is just used to generate load
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					concurrency = 32
@@ -260,6 +264,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			Name:    `rebalance/by-load/replicas/ssds=2`,
 			Owner:   registry.OwnerKV,
 			Cluster: cSpec,
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					t.Fatal("cannot run multi-store in local mode")

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -33,6 +33,7 @@ func registerReplicaGC(r registry.Registry) {
 			Name:    fmt.Sprintf("replicagc-changed-peers/restart=%t", restart),
 			Owner:   registry.OwnerReplication,
 			Cluster: r.MakeClusterSpec(6),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runReplicaGCChangedPeers(ctx, t, c, restart)
 			},

--- a/pkg/cmd/roachtest/tests/restart.go
+++ b/pkg/cmd/roachtest/tests/restart.go
@@ -94,6 +94,7 @@ func registerRestart(r registry.Registry) {
 		Name:    "restart/down-for-2m",
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(3),
+		Leases:  registry.MetamorphicLeases,
 		// "cockroach workload is only in 19.1+"
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runRestart(ctx, t, c, 2*time.Minute)

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -66,6 +66,7 @@ func registerRestoreNodeShutdown(r registry.Registry) {
 		Name:    "restore/nodeShutdown/worker",
 		Owner:   registry.OwnerDisasterRecovery,
 		Cluster: sp.hardware.makeClusterSpecs(r, sp.backup.cloud),
+		Leases:  registry.MetamorphicLeases,
 		Timeout: sp.timeout,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			gatewayNode := 2
@@ -83,6 +84,7 @@ func registerRestoreNodeShutdown(r registry.Registry) {
 		Name:    "restore/nodeShutdown/coordinator",
 		Owner:   registry.OwnerDisasterRecovery,
 		Cluster: sp.hardware.makeClusterSpecs(r, sp.backup.cloud),
+		Leases:  registry.MetamorphicLeases,
 		Timeout: sp.timeout,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 

--- a/pkg/cmd/roachtest/tests/roachmart.go
+++ b/pkg/cmd/roachtest/tests/roachmart.go
@@ -75,6 +75,7 @@ func registerRoachmart(r registry.Registry) {
 			Name:    fmt.Sprintf("roachmart/partition=%v", v),
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(9, spec.Geo(), spec.Zones("us-central1-b,us-west1-b,europe-west2-b")),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runRoachmart(ctx, t, c, v)
 			},

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -230,6 +230,7 @@ func registerRubyPG(r registry.Registry) {
 		Name:       "ruby-pg",
 		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
+		Leases:     registry.MetamorphicLeases,
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -168,6 +168,7 @@ func registerRustPostgres(r registry.Registry) {
 		Name:    "rust-postgres",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runRustPostgres(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -32,6 +32,7 @@ func registerSchemaChangeDuringKV(r registry.Registry) {
 		Name:    `schemachange/during/kv`,
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(5),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup?AUTH=implicit`
 
@@ -309,6 +310,7 @@ func makeIndexAddTpccTest(
 		Name:    fmt.Sprintf("schemachange/index/tpcc/w=%d", warehouses),
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: spec,
+		Leases:  registry.MetamorphicLeases,
 		Timeout: length * 3,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
@@ -341,6 +343,7 @@ func makeSchemaChangeBulkIngestTest(
 		Name:    "schemachange/bulkingest",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Timeout: length * 2,
 		// `fixtures import` (with the workload paths) is not supported in 2.1
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -427,6 +430,7 @@ func makeSchemaChangeDuringTPCC(
 		Name:    "schemachange/during/tpcc",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: spec,
+		Leases:  registry.MetamorphicLeases,
 		Timeout: length * 3,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -49,6 +49,7 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 			spec.Geo(),
 			spec.Zones(geoZonesStr),
 		),
+		Leases:     registry.MetamorphicLeases,
 		NativeLibs: registry.LibGEOS,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			maxOps := 5000

--- a/pkg/cmd/roachtest/tests/scrub.go
+++ b/pkg/cmd/roachtest/tests/scrub.go
@@ -57,6 +57,7 @@ func makeScrubTPCCTest(
 		Name:    fmt.Sprintf("scrub/%s/tpcc/w=%d", optionName, warehouses),
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses:   warehouses,

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -139,7 +139,6 @@ func registerSecondaryIndexesMultiVersionCluster(r registry.Registry) {
 		Name:    "schemachange/secondary-index-multi-version",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(3),
-		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -139,6 +139,7 @@ func registerSecondaryIndexesMultiVersionCluster(r registry.Registry) {
 		Name:    "schemachange/secondary-index-multi-version",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(3),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -153,6 +153,7 @@ func registerSequelize(r registry.Registry) {
 		Name:       "sequelize",
 		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
+		Leases:     registry.MetamorphicLeases,
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/slow_drain.go
+++ b/pkg/cmd/roachtest/tests/slow_drain.go
@@ -32,6 +32,7 @@ func registerSlowDrain(r registry.Registry) {
 		Name:    fmt.Sprintf("slow-drain/duration=%s", duration),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSlowDrain(ctx, t, c, duration)
 		},

--- a/pkg/cmd/roachtest/tests/smoketest_secure.go
+++ b/pkg/cmd/roachtest/tests/smoketest_secure.go
@@ -31,6 +31,7 @@ func registerSecure(r registry.Registry) {
 			Tags:    []string{"smoketest", "weekly"},
 			Owner:   registry.OwnerTestEng,
 			Cluster: r.MakeClusterSpec(numNodes),
+			Leases:  registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				c.Put(ctx, t.Cockroach(), "./cockroach")
 				settings := install.MakeClusterSettings(install.SecureOption(true))
@@ -46,6 +47,7 @@ func registerSecure(r registry.Registry) {
 		Name:    "smoketest/secure/multitenant",
 		Owner:   registry.OwnerMultiTenant,
 		Cluster: r.MakeClusterSpec(2),
+		Leases:  registry.MetamorphicLeases,
 		Run:     multitenantSmokeTest,
 	})
 }

--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -150,6 +150,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/load/uniform/nodes=%d", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// This number was determined experimentally. Often, but not always,
 			// more splits will happen.
@@ -195,6 +196,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/load/uniform/nodes=%d/obj=cpu", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:      10 << 30,               // 10 GB
@@ -214,6 +216,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/load/sequential/nodes=%d", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:      10 << 30, // 10 GB
@@ -235,6 +238,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/load/sequential/nodes=%d/obj=cpu", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:      10 << 30,               // 10 GB
@@ -259,6 +263,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/load/spanning/nodes=%d", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:       10 << 30, // 10 GB
@@ -277,6 +282,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/load/spanning/nodes=%d/obj=cpu", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:      10 << 30,               // 10 GB
@@ -301,6 +307,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/load/ycsb/a/nodes=%d/obj=cpu", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:      10 << 30,               // 10 GB
@@ -323,6 +330,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/load/ycsb/b/nodes=%d/obj=cpu", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize: 10 << 30, // 10 GB
@@ -344,6 +352,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/load/ycsb/d/nodes=%d/obj=cpu", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:      10 << 30,               // 10 GB
@@ -366,6 +375,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/load/ycsb/e/nodes=%d/obj=cpu", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:      10 << 30,               // 10 GB
@@ -487,6 +497,7 @@ func registerLargeRange(r registry.Registry) {
 		Name:    fmt.Sprintf("splits/largerange/size=%s,nodes=%d", bytesStr(size), numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Leases:  registry.MetamorphicLeases,
 		Timeout: 5 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLargeRangeSplits(ctx, t, c, size)

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -39,6 +39,7 @@ func registerSQLAlchemy(r registry.Registry) {
 		Name:    "sqlalchemy",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSQLAlchemy(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -296,6 +296,7 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 			Name:            fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
 			Owner:           registry.OwnerSQLQueries,
 			Cluster:         clusterSpec,
+			Leases:          registry.MetamorphicLeases,
 			NativeLibs:      registry.LibGEOS,
 			Timeout:         time.Minute * 20,
 			RequiresLicense: true,

--- a/pkg/cmd/roachtest/tests/sstable_corruption.go
+++ b/pkg/cmd/roachtest/tests/sstable_corruption.go
@@ -182,6 +182,7 @@ func registerSSTableCorruption(r registry.Registry) {
 		Name:    "sstable-corruption/table",
 		Owner:   registry.OwnerStorage,
 		Cluster: r.MakeClusterSpec(3),
+		Leases:  registry.MetamorphicLeases,
 		Timeout: 2 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSSTableCorruption(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/synctest.go
+++ b/pkg/cmd/roachtest/tests/synctest.go
@@ -37,6 +37,7 @@ fi
 		Owner: registry.OwnerStorage,
 		// This test sets up a custom file system; we don't want the cluster reused.
 		Cluster: r.MakeClusterSpec(1, spec.ReuseNone()),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			n := c.Node(1)
 			tmpDir, err := os.MkdirTemp("", "synctest")

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -42,6 +42,7 @@ func registerTLP(r registry.Registry) {
 		RequiresLicense: true,
 		Tags:            nil,
 		Cluster:         r.MakeClusterSpec(1),
+		Leases:          registry.MetamorphicLeases,
 		NativeLibs:      registry.LibGEOS,
 		Run:             runTLP,
 	})

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -494,6 +494,7 @@ func registerTPCC(r registry.Registry) {
 		Tags:              []string{`default`, `release_qualification`},
 		Cluster:           headroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			maxWarehouses := maxSupportedTPCCWarehouses(*t.BuildVersion(), cloud, t.Spec().(*registry.TestSpec).Cluster)
 			headroomWarehouses := int(float64(maxWarehouses) * 0.7)
@@ -519,6 +520,7 @@ func registerTPCC(r registry.Registry) {
 		Tags:              []string{`default`},
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCCMixedHeadroom(ctx, t, c, cloud, 1)
 		},
@@ -530,6 +532,7 @@ func registerTPCC(r registry.Registry) {
 		Tags:              []string{`default`},
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCCMixedHeadroom(ctx, t, c, cloud, 2)
 		},
@@ -539,6 +542,7 @@ func registerTPCC(r registry.Registry) {
 		Owner:             registry.OwnerTestEng,
 		Cluster:           r.MakeClusterSpec(4, spec.CPU(16)),
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses:   1,
@@ -557,6 +561,7 @@ func registerTPCC(r registry.Registry) {
 		// slowly ramp up the load.
 		Timeout:           4*24*time.Hour + 10*time.Hour,
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			warehouses := 1000
 			runTPCC(ctx, t, c, tpccOptions{
@@ -675,6 +680,7 @@ func registerTPCC(r registry.Registry) {
 				// Add an extra node which serves as the workload nodes.
 				Cluster:           r.MakeClusterSpec(len(regions)*nodesPerRegion+1, spec.Geo(), spec.Zones(strings.Join(zs, ","))),
 				EncryptionSupport: registry.EncryptionMetamorphic,
+				Leases:            registry.MetamorphicLeases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					t.Status(tc.desc)
 					duration := 90 * time.Minute
@@ -766,6 +772,7 @@ func registerTPCC(r registry.Registry) {
 		Owner:             registry.OwnerTestEng,
 		Cluster:           r.MakeClusterSpec(4),
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			duration := 30 * time.Minute
 			runTPCC(ctx, t, c, tpccOptions{
@@ -795,6 +802,7 @@ func registerTPCC(r registry.Registry) {
 		Cluster:           r.MakeClusterSpec(4, spec.CPU(16)),
 		Timeout:           6 * time.Hour,
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			skip.WithIssue(t, 53886)
 			runTPCC(ctx, t, c, tpccOptions{

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -520,7 +520,6 @@ func registerTPCC(r registry.Registry) {
 		Tags:              []string{`default`},
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
-		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCCMixedHeadroom(ctx, t, c, cloud, 1)
 		},
@@ -532,7 +531,6 @@ func registerTPCC(r registry.Registry) {
 		Tags:              []string{`default`},
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
-		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCCMixedHeadroom(ctx, t, c, cloud, 2)
 		},

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -182,6 +182,7 @@ func registerTypeORM(r registry.Registry) {
 		Name:    "typeorm",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTypeORM(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -35,6 +35,7 @@ func registerValidateSystemSchemaAfterVersionUpgrade(r registry.Registry) {
 		Name:    "systemschema/validate-after-version-upgrade",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -35,7 +35,6 @@ func registerValidateSystemSchemaAfterVersionUpgrade(r registry.Registry) {
 		Name:    "systemschema/validate-after-version-upgrade",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")

--- a/pkg/sql/colenc/encode.go
+++ b/pkg/sql/colenc/encode.go
@@ -59,6 +59,8 @@ type BatchEncoder struct {
 	// Slice of keys we can reuse across each call to Prepare and between each
 	// column family.
 	keys []roachpb.Key
+	// Slice of keys prefixes so we don't have to re-encode PK for each family.
+	savedPrefixes []roachpb.Key
 	// Slice of value we can reuse across each call to Prepare and between each
 	// column family.
 	values [][]byte
@@ -205,6 +207,8 @@ func (b *BatchEncoder) resetBuffers() {
 		b.extraKeys[row] = b.extraKeys[row][:0]
 		b.lastColIDs[row] = 0
 	}
+
+	b.savedPrefixes = nil
 }
 
 func intMax(a, b int) int {
@@ -389,6 +393,14 @@ func (b *BatchEncoder) encodePK(ctx context.Context, ind catalog.Index) error {
 			}
 		}
 
+		// If we have more than one family we have to copy the keys in order to
+		// re-use their prefixes because the putter routines will sort
+		// and mutate the kys slice.
+		if len(families) > 1 && b.savedPrefixes == nil {
+			b.savedPrefixes = make([]roachpb.Key, len(kys))
+			copy(b.savedPrefixes, kys)
+		}
+
 		// TODO(cucaroach): For updates overwrite makes this a plain put.
 		b.p.CPutTuplesEmpty(kys, values)
 
@@ -537,6 +549,15 @@ func (b *BatchEncoder) encodeSecondaryIndexWithFamilies(
 				continue
 			}
 		}
+
+		// If we have more than one family we have to copy the keys in order to
+		// re-use their prefixes because the putter routines will sort
+		// and mutate the kys slice.
+		if len(familyIDs) > 1 && b.savedPrefixes == nil {
+			b.savedPrefixes = make([]roachpb.Key, len(kys))
+			copy(b.savedPrefixes, kys)
+		}
+
 		// If we are looking at family 0, encode the data as BYTES, as it might
 		// include encoded primary key columns. For other families,
 		// use the tuple encoding for the value.
@@ -651,8 +672,8 @@ func (b *BatchEncoder) initFamily(familyIndex, familyID int) {
 				continue
 			}
 			offset := row * b.keyBufSize
-			// Save old slice.
-			prefix := kys[row][:b.keyPrefixOffsets[row]]
+			// Get a slice pointing to prefix bytes.
+			prefix := b.savedPrefixes[row][:b.keyPrefixOffsets[row]]
 			// Set slice to new space.
 			kys[row] = keyBuf[offset : offset : b.keyBufSize+offset]
 			// Append prefix.

--- a/pkg/sql/colenc/encode_test.go
+++ b/pkg/sql/colenc/encode_test.go
@@ -398,6 +398,27 @@ func TestColFamDropPKNot(t *testing.T) {
 	checkEqual(t, kvs1, kvs2)
 }
 
+func TestColFamilies(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	defer s.Stopper().Stop(ctx)
+	r := sqlutils.MakeSQLRunner(db)
+	r.Exec(t, "CREATE TABLE t (id INT PRIMARY KEY, c1 INT NOT NULL, c2 INT NOT NULL, FAMILY cf1 (id, c1), FAMILY cf2(c2))")
+	sv := &s.ClusterSettings().SV
+	desc := desctestutils.TestingGetTableDescriptor(
+		kvdb, keys.SystemSQLCodec, "defaultdb", "public", "t")
+
+	row1 := []tree.Datum{tree.NewDInt(2), tree.NewDInt(1), tree.NewDInt(2)}
+	row2 := []tree.Datum{tree.NewDInt(1), tree.NewDInt(2), tree.NewDInt(1)}
+	kvs1, err1 := buildRowKVs([]tree.Datums{row1, row2}, desc, desc.PublicColumns(), sv)
+	require.NoError(t, err1)
+	kvs2, err2 := buildVecKVs([]tree.Datums{row1, row2}, desc, desc.PublicColumns(), sv)
+	require.NoError(t, err2)
+	checkEqual(t, kvs1, kvs2)
+}
+
 // TestColIDToRowIndexNull tests case where insert cols is subset of public columns.
 func TestColIDToRowIndexNull(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -19,6 +19,7 @@ import (
 	"math/rand"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -155,16 +156,17 @@ func TestDataDriven(t *testing.T) {
 								}()
 								require.NoError(t, err)
 								vals := make([]driver.Value, 1)
-								var results strings.Builder
+								var results []string
 								for err = nil; err == nil; {
 									err = rows.Next(vals)
 									if err == io.EOF {
 										break
 									}
 									require.NoError(t, err)
-									results.WriteString(fmt.Sprintf("%v\n", vals[0]))
+									results = append(results, fmt.Sprintf("%v", vals[0]))
 								}
-								return results.String()
+								sort.Strings(results)
+								return strings.Join(results, "\n")
 							}
 						case "copy-to", "copy-to-error":
 							var buf bytes.Buffer

--- a/pkg/sql/copy/testdata/copy_from
+++ b/pkg/sql/copy/testdata/copy_from
@@ -660,3 +660,55 @@ COPY tcomp FROM STDIN
 1	(1, 2)
 ----
 CPut /Table/<>/1/1/0 -> /TUPLE/
+
+# Regression test for #103220
+exec-ddl
+CREATE TABLE tfam (id INT PRIMARY KEY, c1 INT NOT NULL, c2 INT NOT NULL, FAMILY cf1 (id, c1), FAMILY cf2(c2))
+----
+
+copy-from-kvtrace
+COPY tfam FROM STDIN QUOTE '"' CSV
+2,1,2
+1,2,1
+----
+CPut /Table/<>/1/1/0 -> /TUPLE/2:2:Int/2
+CPut /Table/<>/1/1/1/1 -> /INT/1
+CPut /Table/<>/1/2/0 -> /TUPLE/2:2:Int/1
+CPut /Table/<>/1/2/1/1 -> /INT/2
+
+query
+SELECT * FROM tfam
+----
+1|2|1
+2|1|2
+
+
+exec-ddl
+CREATE TABLE tfam2 (id INT PRIMARY KEY, c1 INT NOT NULL, c2 INT NOT NULL, c3 INT NOT NULL, FAMILY cf1 (id, c1), FAMILY cf2(c2), FAMILY cf3(c3), INDEX(c2,c1,c3))
+----
+
+copy-from-kvtrace
+COPY tfam2 FROM STDIN QUOTE '"' CSV
+2,1,2,3
+1,2,1,4
+3,5,2,1
+----
+CPut /Table/<>/1/1/0 -> /TUPLE/2:2:Int/2
+CPut /Table/<>/1/1/1/1 -> /INT/1
+CPut /Table/<>/1/1/2/1 -> /INT/4
+CPut /Table/<>/1/2/0 -> /TUPLE/2:2:Int/1
+CPut /Table/<>/1/2/1/1 -> /INT/2
+CPut /Table/<>/1/2/2/1 -> /INT/3
+CPut /Table/<>/1/3/0 -> /TUPLE/2:2:Int/5
+CPut /Table/<>/1/3/1/1 -> /INT/2
+CPut /Table/<>/1/3/2/1 -> /INT/1
+InitPut /Table/<>/2/1/2/4/1/0 -> /BYTES/
+InitPut /Table/<>/2/2/1/3/2/0 -> /BYTES/
+InitPut /Table/<>/2/2/5/1/3/0 -> /BYTES/
+
+query
+SELECT * FROM tfam2
+----
+1|2|1|4
+2|1|2|3
+3|5|2|1

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1326,7 +1326,7 @@ func (t *logicTest) newCluster(
 	if serverArgs.MaxSQLMemoryLimit == 0 {
 		// Specify a fixed memory limit (some test cases verify OOM conditions;
 		// we don't want those to take long on large machines).
-		serverArgs.MaxSQLMemoryLimit = 192 * 1024 * 1024
+		serverArgs.MaxSQLMemoryLimit = 256 * 1024 * 1024
 	}
 	// We have some queries that bump into 100MB default temp storage limit
 	// when run with fakedist-disk config, so we'll use a larger limit here.


### PR DESCRIPTION
Backport 4/4 commits from #103190, 2/2 commits from #103276, 1/1 commits from #103346.

/cc @cockroachdb/release

---

**roachprod: add option for initial cluster settings**

This patch adds a roachprod option `ClusterSettingsOption` that can be used to pass arbitrary initial cluster settings during cluster start.

It also no longer sets `server.remote_debugging.mode = 'any'`, since this setting was removed in 21.2.

  
**roachtest: add option for metamorphic expiration leases**

To increase test coverage of expiration-based leases, this patch adds an opt-in test parameter `Leases` that allows tests to enable them either metamorphically or explicitly.

**roachtest: add TPCC benchmarks with expiration leases**

This patch adds TPCC benchmark variants with expiration leases for a few representative configurations.

**roachtest: enable metamorphic expiration leases in most tests**

This patch uses metamorphic expiration leases in most non-benchmark roachtests. There will likely be some fallout from this, in particular for timing/latency-sensitive tests, but we can deal with that as it happens.

Resolves #103188.
Epic: none
Release note: None
