### PR TITLE
logictest: disable DistSQL while updating DistSQL span resolver

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1313,6 +1313,15 @@ func (t *logicTest) newCluster(
 		// disable stats collection on system tables in order to have
 		// deterministic tests.
 		stats.AutomaticStatisticsOnSystemTables.Override(context.Background(), &st.SV, false)
+		if t.cfg.UseFakeSpanResolver {
+			// We will need to update the DistSQL span resolver with the fake
+			// resolver, but this can only be done while DistSQL is disabled.
+			// Note that this is needed since the internal queries could use
+			// DistSQL if it's not disabled, and we have to disable it before
+			// the cluster started (so that we don't have any internal queries
+			// using DistSQL concurrently with updating the span resolver).
+			sql.DistSQLClusterExecMode.Override(context.Background(), &st.SV, int64(sessiondatapb.DistSQLOff))
+		}
 		return st
 	}
 	var corpusCollectionCallback func(p scplan.Plan, stageIdx int) error
@@ -1451,8 +1460,14 @@ func (t *logicTest) newCluster(
 
 	t.cluster = serverutils.StartNewTestCluster(t.rootT, cfg.NumNodes, params)
 	if cfg.UseFakeSpanResolver {
-		fakeResolver := physicalplanutils.FakeResolverForTestCluster(t.cluster)
-		t.cluster.Server(t.nodeIdx).SetDistSQLSpanResolver(fakeResolver)
+		// We need to update the DistSQL span resolver with the fake resolver.
+		// Note that DistSQL was disabled in makeClusterSetting above, so we
+		// will reset the setting after updating the span resolver.
+		for nodeIdx := 0; nodeIdx < cfg.NumNodes; nodeIdx++ {
+			fakeResolver := physicalplanutils.FakeResolverForTestCluster(t.cluster)
+			t.cluster.Server(nodeIdx).SetDistSQLSpanResolver(fakeResolver)
+		}
+		serverutils.SetClusterSetting(t.rootT, t.cluster, "sql.defaults.distsql", "auto")
 	}
 
 	connsForClusterSettingChanges := []*gosql.DB{t.cluster.ServerConn(0)}

--- a/pkg/sql/physicalplan/fake_span_resolver.go
+++ b/pkg/sql/physicalplan/fake_span_resolver.go
@@ -167,15 +167,11 @@ func (fit *fakeSpanResolverIterator) Seek(
 	// Build ranges corresponding to the fake splits and assign them random
 	// replicas.
 	fit.ranges = make([]fakeRange, len(splits)-1)
-	// TODO(michae2): Condense this logic when #100051 is fixed.
-	nodes := fit.fsr.nodes
-	n := len(nodes)
 	for i := range fit.ranges {
-		j := fit.rng.Intn(n)
 		fit.ranges[i] = fakeRange{
 			startKey: splits[i],
 			endKey:   splits[i+1],
-			replica:  nodes[j],
+			replica:  fit.fsr.nodes[fit.rng.Intn(len(fit.fsr.nodes))],
 		}
 	}
 


### PR DESCRIPTION
Over the last half a year we made a couple of changes that changed which session data internal queries are using, and as a result internal queries can now use DistSQL in most places. This can now lead to rare flakes in `fakedist-*` logic test configurations where we're updating the DistSQL span resolver after having started the cluster, meaning that internal queries that are using DistSQL might be running concurrently with the span resolver update. This is not allowed by the interface, so this commit should fix these rare flakes by explicitly disabling DistSQL before the cluster is started in `fakedist-*` configs until after the span resolver is updated, at which point the DistSQL setting is reset.

I believe this violation of the interface is the root cause for segfault we saw in #100108, so this commit reverts the debugging introduced in response to that ticket.

Additionally, previously we updated the span resolver only on a single node in the cluster, and this commit updates it on all nodes in the cluster, which seems more reasonable.

Fixes: #99107.

Release note: None