### PR TITLE
sql: make hashed OIDs identifiable for optimal virtual indexes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -356,12 +356,12 @@ WHERE indrelid = (SELECT oid FROM pg_class WHERE relname = 't')
 ORDER BY 1,2,3
 ----
 indexrelid  indrelid  indkey  indclass  indoption  indcollation
-3428148192  107       5       0         2          0
-3428148194  107       2 3 4   0 0 0     2 2 2      0 0 0
-3428148195  107       6       0         2          0
-3428148196  107       3       0         2          0
-3428148197  107       4       0         2          0
-3428148199  107       1       0         2          0
+3428248192  107       5       0         2          0
+3428248194  107       2 3 4   0 0 0     2 2 2      0 0 0
+3428248195  107       6       0         2          0
+3428248196  107       3       0         2          0
+3428248197  107       4       0         2          0
+3428248199  107       1       0         2          0
 
 query TTB colnames
 SELECT index_name, column_name, implicit FROM crdb_internal.index_columns

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -419,6 +419,7 @@ go_library(
         "//pkg/sql/lexbase",
         "//pkg/sql/memsize",
         "//pkg/sql/mutations",
+        "//pkg/sql/oidext",
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/constraint",

--- a/pkg/sql/logictest/testdata/logic_test/alter_role_set
+++ b/pkg/sql/logictest/testdata/logic_test/alter_role_set
@@ -33,9 +33,9 @@ ORDER BY 1, 2
 ----
 setdatabase  setrole    datname      rolname        setconfig
 0            0          NULL         NULL           {application_name=d}
-0            265380634  NULL         test_set_role  {application_name=a,custom_option.setting=e}
+0            265480634  NULL         test_set_role  {application_name=a,custom_option.setting=e}
 106          0          test_set_db  NULL           {application_name=c}
-106          265380634  test_set_db  test_set_role  {application_name=b}
+106          265480634  test_set_db  test_set_role  {application_name=b}
 
 statement ok
 ALTER ROLE test_set_role SET backslash_quote = 'safe_encoding'

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -431,7 +431,7 @@ oid         nspname             nspowner    nspacl
 4294967205  information_schema  NULL        NULL
 4294967118  pg_catalog          NULL        NULL
 4294966988  pg_extension        NULL        NULL
-105         public              2310524507  NULL
+105         public              2310624507  NULL
 
 # Verify that we can still see the schemas even if we don't have any privilege
 # on the current database.
@@ -450,7 +450,7 @@ oid         nspname             nspowner    nspacl
 4294967205  information_schema  NULL        NULL
 4294967118  pg_catalog          NULL        NULL
 4294966988  pg_extension        NULL        NULL
-105         public              2310524507  NULL
+105         public              2310624507  NULL
 
 user root
 
@@ -465,11 +465,11 @@ FROM pg_catalog.pg_database
 ORDER BY oid
 ----
 oid  datname        datdba      encoding  datcollate  datctype    datistemplate  datallowconn
-1    system         3233629770  6         en_US.utf8  en_US.utf8  false          true
-100  defaultdb      1546506610  6         en_US.utf8  en_US.utf8  false          true
-102  postgres       1546506610  6         en_US.utf8  en_US.utf8  false          true
-104  test           1546506610  6         en_US.utf8  en_US.utf8  false          true
-108  constraint_db  1546506610  6         en_US.utf8  en_US.utf8  false          true
+1    system         3233729770  6         en_US.utf8  en_US.utf8  false          true
+100  defaultdb      1546606610  6         en_US.utf8  en_US.utf8  false          true
+102  postgres       1546606610  6         en_US.utf8  en_US.utf8  false          true
+104  test           1546606610  6         en_US.utf8  en_US.utf8  false          true
+108  constraint_db  1546606610  6         en_US.utf8  en_US.utf8  false          true
 
 query OTIOIIOT colnames
 SELECT oid, datname, datconnlimit, datlastsysoid, datfrozenxid, datminmxid, dattablespace, datacl
@@ -565,31 +565,31 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 oid         relname            relnamespace  reltype  reloftype  relowner    relam       relfilenode  reltablespace
-110         t1                 109           100110   0          1546506610  2631952481  0            0
-3687884466  t1_pkey            109           0        0          1546506610  2631952481  0            0
-3687884465  t1_a_key           109           0        0          1546506610  2631952481  0            0
-3687884464  index_key          109           0        0          1546506610  2631952481  0            0
-111         t1_m_seq           109           100111   0          1546506610  0           0            0
-112         t1_n_seq           109           100112   0          1546506610  0           0            0
-113         t2                 109           100113   0          1546506610  2631952481  0            0
-2955071325  t2_pkey            109           0        0          1546506610  2631952481  0            0
-2955071326  t2_t1_id_idx       109           0        0          1546506610  2631952481  0            0
-114         t3                 109           100114   0          1546506610  2631952481  0            0
-2695335054  t3_pkey            109           0        0          1546506610  2631952481  0            0
-2695335053  t3_a_b_idx         109           0        0          1546506610  2631952481  0            0
-115         v1                 109           100115   0          1546506610  0           0            0
-116         t4                 109           100116   0          1546506610  2631952481  0            0
-3214807592  t4_pkey            109           0        0          1546506610  2631952481  0            0
-117         t5                 109           100117   0          1546506610  2631952481  0            0
-1869730585  t5_pkey            109           0        0          1546506610  2631952481  0            0
-120         t6                 109           100120   0          1546506610  2631952481  0            0
-2129466852  t6_pkey            109           0        0          1546506610  2631952481  0            0
-2129466855  t6_expr_idx        109           0        0          1546506610  2631952481  0            0
-2129466854  t6_expr_expr1_idx  109           0        0          1546506610  2631952481  0            0
-2129466848  t6_expr_key        109           0        0          1546506610  2631952481  0            0
-2129466850  t6_expr_idx1       109           0        0          1546506610  2631952481  0            0
-121         mv1                109           100121   0          1546506610  0           0            0
-784389845   mv1_pkey           109           0        0          1546506610  2631952481  0            0
+110         t1                 109           100110   0          1546606610  2632052481  0            0
+3687984466  t1_pkey            109           0        0          1546606610  2632052481  0            0
+3687984465  t1_a_key           109           0        0          1546606610  2632052481  0            0
+3687984464  index_key          109           0        0          1546606610  2632052481  0            0
+111         t1_m_seq           109           100111   0          1546606610  0           0            0
+112         t1_n_seq           109           100112   0          1546606610  0           0            0
+113         t2                 109           100113   0          1546606610  2632052481  0            0
+2955171325  t2_pkey            109           0        0          1546606610  2632052481  0            0
+2955171326  t2_t1_id_idx       109           0        0          1546606610  2632052481  0            0
+114         t3                 109           100114   0          1546606610  2632052481  0            0
+2695435054  t3_pkey            109           0        0          1546606610  2632052481  0            0
+2695435053  t3_a_b_idx         109           0        0          1546606610  2632052481  0            0
+115         v1                 109           100115   0          1546606610  0           0            0
+116         t4                 109           100116   0          1546606610  2632052481  0            0
+3214907592  t4_pkey            109           0        0          1546606610  2632052481  0            0
+117         t5                 109           100117   0          1546606610  2632052481  0            0
+1869830585  t5_pkey            109           0        0          1546606610  2632052481  0            0
+120         t6                 109           100120   0          1546606610  2632052481  0            0
+2129566852  t6_pkey            109           0        0          1546606610  2632052481  0            0
+2129566855  t6_expr_idx        109           0        0          1546606610  2632052481  0            0
+2129566854  t6_expr_expr1_idx  109           0        0          1546606610  2632052481  0            0
+2129566848  t6_expr_key        109           0        0          1546606610  2632052481  0            0
+2129566850  t6_expr_idx1       109           0        0          1546606610  2632052481  0            0
+121         mv1                109           100121   0          1546606610  0           0            0
+784489845   mv1_pkey           109           0        0          1546606610  2632052481  0            0
 
 query TIRIOBBT colnames
 SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared, relpersistence
@@ -715,24 +715,24 @@ attrelid    relname            attname                   atttypid  attstattarget
 110         t1                 l                         20        0              8       13      0         -1
 110         t1                 m                         20        0              8       14      0         -1
 110         t1                 n                         20        0              8       15      0         -1
-3687884466  t1_pkey            p                         701       0              8       1       0         -1
-3687884465  t1_a_key           a                         20        0              8       1       0         -1
-3687884464  index_key          b                         20        0              8       1       0         -1
-3687884464  index_key          c                         20        0              8       2       0         -1
+3687984466  t1_pkey            p                         701       0              8       1       0         -1
+3687984465  t1_a_key           a                         20        0              8       1       0         -1
+3687984464  index_key          b                         20        0              8       1       0         -1
+3687984464  index_key          c                         20        0              8       2       0         -1
 111         t1_m_seq           value                     20        0              8       1       0         -1
 112         t1_n_seq           value                     20        0              8       1       0         -1
 113         t2                 t1_id                     20        0              8       1       0         -1
 113         t2                 rowid                     20        0              8       2       0         -1
-2955071325  t2_pkey            rowid                     20        0              8       1       0         -1
-2955071326  t2_t1_id_idx       t1_id                     20        0              8       1       0         -1
+2955171325  t2_pkey            rowid                     20        0              8       1       0         -1
+2955171326  t2_t1_id_idx       t1_id                     20        0              8       1       0         -1
 114         t3                 a                         20        0              8       1       0         -1
 114         t3                 b                         20        0              8       2       0         -1
 114         t3                 c                         25        0              -1      3       0         -1
 114         t3                 rowid                     20        0              8       4       0         -1
-2695335054  t3_pkey            rowid                     20        0              8       1       0         -1
-2695335053  t3_a_b_idx         a                         20        0              8       1       0         -1
-2695335053  t3_a_b_idx         b                         20        0              8       2       0         -1
-2695335053  t3_a_b_idx         c                         25        0              -1      3       0         -1
+2695435054  t3_pkey            rowid                     20        0              8       1       0         -1
+2695435053  t3_a_b_idx         a                         20        0              8       1       0         -1
+2695435053  t3_a_b_idx         b                         20        0              8       2       0         -1
+2695435053  t3_a_b_idx         c                         25        0              -1      3       0         -1
 115         v1                 p                         701       0              8       1       0         -1
 115         v1                 a                         20        0              8       2       0         -1
 115         v1                 b                         20        0              8       3       0         -1
@@ -741,26 +741,26 @@ attrelid    relname            attname                   atttypid  attstattarget
 116         t4                 b                         701       0              8       2       0         -1
 116         t4                 c                         25        0              -1      3       0         -1
 116         t4                 rowid                     20        0              8       4       0         -1
-3214807592  t4_pkey            rowid                     20        0              8       1       0         -1
+3214907592  t4_pkey            rowid                     20        0              8       1       0         -1
 117         t5                 a                         20        0              8       1       0         -1
 117         t5                 b                         701       0              8       2       0         -1
 117         t5                 c                         25        0              -1      3       0         -1
 117         t5                 rowid                     20        0              8       4       0         -1
-1869730585  t5_pkey            rowid                     20        0              8       1       0         -1
+1869830585  t5_pkey            rowid                     20        0              8       1       0         -1
 120         t6                 a                         20        0              8       1       0         -1
 120         t6                 b                         20        0              8       2       0         -1
 120         t6                 c                         25        0              -1      3       0         -1
 120         t6                 m                         100118    0              -1      4       0         -1
 120         t6                 rowid                     20        0              8       6       0         -1
-2129466852  t6_pkey            rowid                     20        0              8       1       0         -1
-2129466855  t6_expr_idx        crdb_internal_idx_expr    20        0              8       1       0         -1
-2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr_1  25        0              -1      1       0         -1
-2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr    20        0              8       2       0         -1
-2129466848  t6_expr_key        crdb_internal_idx_expr_1  25        0              -1      1       0         -1
-2129466850  t6_expr_idx1       crdb_internal_idx_expr_2  16        0              1       1       0         -1
+2129566852  t6_pkey            rowid                     20        0              8       1       0         -1
+2129566855  t6_expr_idx        crdb_internal_idx_expr    20        0              8       1       0         -1
+2129566854  t6_expr_expr1_idx  crdb_internal_idx_expr_1  25        0              -1      1       0         -1
+2129566854  t6_expr_expr1_idx  crdb_internal_idx_expr    20        0              8       2       0         -1
+2129566848  t6_expr_key        crdb_internal_idx_expr_1  25        0              -1      1       0         -1
+2129566850  t6_expr_idx1       crdb_internal_idx_expr_2  16        0              1       1       0         -1
 121         mv1                ?column?                  20        0              8       1       0         -1
 121         mv1                rowid                     20        0              8       2       0         -1
-784389845   mv1_pkey           rowid                     20        0              8       1       0         -1
+784489845   mv1_pkey           rowid                     20        0              8       1       0         -1
 
 query TTIBTTBBTT colnames,rowsort
 SELECT c.relname, attname, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated
@@ -956,18 +956,18 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 relname            attname                   typname   attcollation  collname
-t1                 d                         varchar   3403232968    default
-t6_expr_key        crdb_internal_idx_expr_1  text      3403232968    default
-t6_expr_expr1_idx  crdb_internal_idx_expr_1  text      3403232968    default
-t6                 c                         text      3403232968    default
-t5                 c                         text      3403232968    default
-t4                 c                         text      3403232968    default
-t3_a_b_idx         c                         text      3403232968    default
-t3                 c                         text      3403232968    default
-t1                 j                         char      3403232968    default
-t1                 i                         _varchar  3403232968    default
-t1                 h                         _bpchar   3403232968    default
-t1                 k                         varchar   999873346     sv
+t1                 d                         varchar   3403332968    default
+t6_expr_key        crdb_internal_idx_expr_1  text      3403332968    default
+t6_expr_expr1_idx  crdb_internal_idx_expr_1  text      3403332968    default
+t6                 c                         text      3403332968    default
+t5                 c                         text      3403332968    default
+t4                 c                         text      3403332968    default
+t3_a_b_idx         c                         text      3403332968    default
+t3                 c                         text      3403332968    default
+t1                 j                         char      3403332968    default
+t1                 i                         _varchar  3403332968    default
+t1                 h                         _bpchar   3403332968    default
+t1                 k                         varchar   999973346     sv
 
 
 ## pg_catalog.pg_am
@@ -977,8 +977,8 @@ SELECT *
 FROM pg_catalog.pg_am
 ----
 oid         amname    amstrategies  amsupport  amcanorder  amcanorderbyop  amcanbackward  amcanunique  amcanmulticol  amoptionalkey  amsearcharray  amsearchnulls  amstorage  amclusterable  ampredlocks  amkeytype  aminsert  ambeginscan  amgettuple  amgetbitmap  amrescan  amendscan  ammarkpos  amrestrpos  ambuild  ambuildempty  ambulkdelete  amvacuumcleanup  amcanreturn  amcostestimate  amoptions  amhandler  amtype
-2631952481  prefix    0             0          true        false           true           true         true           true           true           true           false      false          false        0          NULL      NULL         0           0            NULL      NULL       NULL       NULL        NULL     NULL          NULL          NULL             NULL         NULL            NULL       NULL       i
-4004609370  inverted  0             0          false       false           false          false        false          false          false          true           false      false          false        0          NULL      NULL         0           0            NULL      NULL       NULL       NULL        NULL     NULL          NULL          NULL             NULL         NULL            NULL       NULL       i
+2632052481  prefix    0             0          true        false           true           true         true           true           true           true           false      false          false        0          NULL      NULL         0           0            NULL      NULL       NULL       NULL        NULL     NULL          NULL          NULL             NULL         NULL            NULL       NULL       i
+4004709370  inverted  0             0          false       false           false          false        false          false          false          true           false      false          false        0          NULL      NULL         0           0            NULL      NULL       NULL       NULL        NULL     NULL          NULL          NULL             NULL         NULL            NULL       NULL       i
 
 ## pg_catalog.pg_attrdef
 
@@ -990,16 +990,16 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 oid         relname  adrelid  adnum  adbin                                 adsrc                                 pg_get_expr
-2306804694  t1       110      4      12                                    12                                    12
-2306804700  t1       110      14     nextval('public.t1_m_seq'::REGCLASS)  nextval('public.t1_m_seq'::REGCLASS)  nextval('public.t1_m_seq'::REGCLASS)
-2306804701  t1       110      15     nextval('public.t1_n_seq'::REGCLASS)  nextval('public.t1_n_seq'::REGCLASS)  nextval('public.t1_n_seq'::REGCLASS)
-4171354239  t2       113      2      unique_rowid()                        unique_rowid()                        unique_rowid()
-1221463949  t3       114      3      'FOO'::STRING                         'FOO'::STRING                         'FOO'::STRING
-1221463946  t3       114      4      unique_rowid()                        unique_rowid()                        unique_rowid()
-1740936492  t4       116      4      unique_rowid()                        unique_rowid()                        unique_rowid()
-3086013501  t5       117      4      unique_rowid()                        unique_rowid()                        unique_rowid()
-655595746   t6       120      6      unique_rowid()                        unique_rowid()                        unique_rowid()
-2000672759  mv1      121      2      unique_rowid()                        unique_rowid()                        unique_rowid()
+2306904694  t1       110      4      12                                    12                                    12
+2306904700  t1       110      14     nextval('public.t1_m_seq'::REGCLASS)  nextval('public.t1_m_seq'::REGCLASS)  nextval('public.t1_m_seq'::REGCLASS)
+2306904701  t1       110      15     nextval('public.t1_n_seq'::REGCLASS)  nextval('public.t1_n_seq'::REGCLASS)  nextval('public.t1_n_seq'::REGCLASS)
+4171454239  t2       113      2      unique_rowid()                        unique_rowid()                        unique_rowid()
+1221563949  t3       114      3      'FOO'::STRING                         'FOO'::STRING                         'FOO'::STRING
+1221563946  t3       114      4      unique_rowid()                        unique_rowid()                        unique_rowid()
+1741036492  t4       116      4      unique_rowid()                        unique_rowid()                        unique_rowid()
+3086113501  t5       117      4      unique_rowid()                        unique_rowid()                        unique_rowid()
+655695746   t6       120      6      unique_rowid()                        unique_rowid()                        unique_rowid()
+2000772759  mv1      121      2      unique_rowid()                        unique_rowid()                        unique_rowid()
 
 ## pg_catalog.pg_indexes
 
@@ -1009,23 +1009,23 @@ FROM pg_catalog.pg_indexes
 WHERE schemaname = 'public'
 ----
 crdb_oid    schemaname  tablename  indexname          tablespace
-3687884466  public      t1         t1_pkey            NULL
-3687884465  public      t1         t1_a_key           NULL
-3687884464  public      t1         index_key          NULL
-2342807459  public      t1_m_seq   primary            NULL
-5181036     public      t1_n_seq   primary            NULL
-2955071325  public      t2         t2_pkey            NULL
-2955071326  public      t2         t2_t1_id_idx       NULL
-2695335054  public      t3         t3_pkey            NULL
-2695335053  public      t3         t3_a_b_idx         NULL
-3214807592  public      t4         t4_pkey            NULL
-1869730585  public      t5         t5_pkey            NULL
-2129466852  public      t6         t6_pkey            NULL
-2129466855  public      t6         t6_expr_idx        NULL
-2129466854  public      t6         t6_expr_expr1_idx  NULL
-2129466848  public      t6         t6_expr_key        NULL
-2129466850  public      t6         t6_expr_idx1       NULL
-784389845   public      mv1        mv1_pkey           NULL
+3687984466  public      t1         t1_pkey            NULL
+3687984465  public      t1         t1_a_key           NULL
+3687984464  public      t1         index_key          NULL
+2342907459  public      t1_m_seq   primary            NULL
+5281036     public      t1_n_seq   primary            NULL
+2955171325  public      t2         t2_pkey            NULL
+2955171326  public      t2         t2_t1_id_idx       NULL
+2695435054  public      t3         t3_pkey            NULL
+2695435053  public      t3         t3_a_b_idx         NULL
+3214907592  public      t4         t4_pkey            NULL
+1869830585  public      t5         t5_pkey            NULL
+2129566852  public      t6         t6_pkey            NULL
+2129566855  public      t6         t6_expr_idx        NULL
+2129566854  public      t6         t6_expr_expr1_idx  NULL
+2129566848  public      t6         t6_expr_key        NULL
+2129566850  public      t6         t6_expr_idx1       NULL
+784489845   public      mv1        mv1_pkey           NULL
 
 query OTTT colnames
 SELECT crdb_oid, tablename, indexname, indexdef
@@ -1033,23 +1033,23 @@ FROM pg_catalog.pg_indexes
 WHERE schemaname = 'public'
 ----
 crdb_oid    tablename  indexname          indexdef
-3687884466  t1         t1_pkey            CREATE UNIQUE INDEX t1_pkey ON constraint_db.public.t1 USING btree (p ASC)
-3687884465  t1         t1_a_key           CREATE UNIQUE INDEX t1_a_key ON constraint_db.public.t1 USING btree (a ASC)
-3687884464  t1         index_key          CREATE UNIQUE INDEX index_key ON constraint_db.public.t1 USING btree (b ASC, c ASC)
-2342807459  t1_m_seq   primary            CREATE INDEX "primary" ON constraint_db.public.t1_m_seq USING btree (value ASC)
-5181036     t1_n_seq   primary            CREATE INDEX "primary" ON constraint_db.public.t1_n_seq USING btree (value ASC)
-2955071325  t2         t2_pkey            CREATE UNIQUE INDEX t2_pkey ON constraint_db.public.t2 USING btree (rowid ASC)
-2955071326  t2         t2_t1_id_idx       CREATE INDEX t2_t1_id_idx ON constraint_db.public.t2 USING btree (t1_id ASC)
-2695335054  t3         t3_pkey            CREATE UNIQUE INDEX t3_pkey ON constraint_db.public.t3 USING btree (rowid ASC)
-2695335053  t3         t3_a_b_idx         CREATE INDEX t3_a_b_idx ON constraint_db.public.t3 USING btree (a ASC, b DESC) STORING (c)
-3214807592  t4         t4_pkey            CREATE UNIQUE INDEX t4_pkey ON constraint_db.public.t4 USING btree (rowid ASC)
-1869730585  t5         t5_pkey            CREATE UNIQUE INDEX t5_pkey ON constraint_db.public.t5 USING btree (rowid ASC)
-2129466852  t6         t6_pkey            CREATE UNIQUE INDEX t6_pkey ON constraint_db.public.t6 USING btree (rowid ASC)
-2129466855  t6         t6_expr_idx        CREATE INDEX t6_expr_idx ON constraint_db.public.t6 USING btree ((a + b) ASC)
-2129466854  t6         t6_expr_expr1_idx  CREATE INDEX t6_expr_expr1_idx ON constraint_db.public.t6 USING btree (lower(c) ASC, (a + b) ASC)
-2129466848  t6         t6_expr_key        CREATE UNIQUE INDEX t6_expr_key ON constraint_db.public.t6 USING btree (lower(c) ASC)
-2129466850  t6         t6_expr_idx1       CREATE INDEX t6_expr_idx1 ON constraint_db.public.t6 USING btree ((m = 'foo'::constraint_db.public.mytype) ASC) WHERE (m = 'foo'::constraint_db.public.mytype)
-784389845   mv1        mv1_pkey           CREATE UNIQUE INDEX mv1_pkey ON constraint_db.public.mv1 USING btree (rowid ASC)
+3687984466  t1         t1_pkey            CREATE UNIQUE INDEX t1_pkey ON constraint_db.public.t1 USING btree (p ASC)
+3687984465  t1         t1_a_key           CREATE UNIQUE INDEX t1_a_key ON constraint_db.public.t1 USING btree (a ASC)
+3687984464  t1         index_key          CREATE UNIQUE INDEX index_key ON constraint_db.public.t1 USING btree (b ASC, c ASC)
+2342907459  t1_m_seq   primary            CREATE INDEX "primary" ON constraint_db.public.t1_m_seq USING btree (value ASC)
+5281036     t1_n_seq   primary            CREATE INDEX "primary" ON constraint_db.public.t1_n_seq USING btree (value ASC)
+2955171325  t2         t2_pkey            CREATE UNIQUE INDEX t2_pkey ON constraint_db.public.t2 USING btree (rowid ASC)
+2955171326  t2         t2_t1_id_idx       CREATE INDEX t2_t1_id_idx ON constraint_db.public.t2 USING btree (t1_id ASC)
+2695435054  t3         t3_pkey            CREATE UNIQUE INDEX t3_pkey ON constraint_db.public.t3 USING btree (rowid ASC)
+2695435053  t3         t3_a_b_idx         CREATE INDEX t3_a_b_idx ON constraint_db.public.t3 USING btree (a ASC, b DESC) STORING (c)
+3214907592  t4         t4_pkey            CREATE UNIQUE INDEX t4_pkey ON constraint_db.public.t4 USING btree (rowid ASC)
+1869830585  t5         t5_pkey            CREATE UNIQUE INDEX t5_pkey ON constraint_db.public.t5 USING btree (rowid ASC)
+2129566852  t6         t6_pkey            CREATE UNIQUE INDEX t6_pkey ON constraint_db.public.t6 USING btree (rowid ASC)
+2129566855  t6         t6_expr_idx        CREATE INDEX t6_expr_idx ON constraint_db.public.t6 USING btree ((a + b) ASC)
+2129566854  t6         t6_expr_expr1_idx  CREATE INDEX t6_expr_expr1_idx ON constraint_db.public.t6 USING btree (lower(c) ASC, (a + b) ASC)
+2129566848  t6         t6_expr_key        CREATE UNIQUE INDEX t6_expr_key ON constraint_db.public.t6 USING btree (lower(c) ASC)
+2129566850  t6         t6_expr_idx1       CREATE INDEX t6_expr_idx1 ON constraint_db.public.t6 USING btree ((m = 'foo'::constraint_db.public.mytype) ASC) WHERE (m = 'foo'::constraint_db.public.mytype)
+784489845   mv1        mv1_pkey           CREATE UNIQUE INDEX mv1_pkey ON constraint_db.public.mv1 USING btree (rowid ASC)
 
 ## pg_catalog.pg_index
 
@@ -1059,9 +1059,9 @@ FROM pg_catalog.pg_index
 WHERE indnkeyatts = 2
 ----
 indexrelid  indrelid  indnatts  indisunique  indnullsnotdistinct  indisprimary  indisexclusion
-3687884464  110       2         true         false                false         false
-2695335053  114       3         false        false                false         false
-2129466854  120       2         false        false                false         false
+3687984464  110       2         true         false                false         false
+2695435053  114       3         false        false                false         false
+2129566854  120       2         false        false                false         false
 
 query OBBBBB colnames
 SELECT indexrelid, indimmediate, indisclustered, indisvalid, indcheckxmin, indisready
@@ -1069,9 +1069,9 @@ FROM pg_catalog.pg_index
 WHERE indnkeyatts = 2
 ----
 indexrelid  indimmediate  indisclustered  indisvalid  indcheckxmin  indisready
-3687884464  true          false           true        false         false
-2695335053  false         false           true        false         false
-2129466854  false         false           true        false         false
+3687984464  true          false           true        false         false
+2695435053  false         false           true        false         false
+2129566854  false         false           true        false         false
 
 query OOBBTTTTTT colnames
 SELECT indexrelid, indrelid, indislive, indisreplident, indkey, indcollation, indclass, indoption, indexprs, indpred
@@ -1079,9 +1079,9 @@ FROM pg_catalog.pg_index
 WHERE indnkeyatts = 2
 ----
 indexrelid  indrelid  indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs                indpred
-3687884464  110       true       false           3 4     0 0           0 0       2 2        NULL                    NULL
-2695335053  114       true       false           1 2 3   0 0           0 0       2 1        NULL                    NULL
-2129466854  120       true       false           0 0     3403232968 0  0 0       2 2        {(lower(c)),"(a + b)"}  NULL
+3687984464  110       true       false           3 4     0 0           0 0       2 2        NULL                    NULL
+2695435053  114       true       false           1 2 3   0 0           0 0       2 1        NULL                    NULL
+2129566854  120       true       false           0 0     3403332968 0  0 0       2 2        {(lower(c)),"(a + b)"}  NULL
 
 # Index expression elements should have an indkey of 0 and be included in
 # indexprs.
@@ -1111,111 +1111,111 @@ FROM pg_catalog.pg_index
 ORDER BY indexrelid
 ----
 indexrelid  indrelid  indnatts  indisunique  indnullsnotdistinct  indisprimary  indisexclusion  indimmediate  indisclustered  indisvalid  indcheckxmin  indisready  indislive  indisreplident  indkey         indcollation               indclass     indoption    indexprs  indpred                                                                                                                       indnkeyatts
-144368028   32        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-190763692   48        1         false        false                true          false           false         false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-404104296   39        2         true         false                true          false           true          false           true        false         false       true       false           3 1            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-450499960   55        1         false        false                false         false           false         false           true        false         false       true       false           2              0                          0            2            NULL      NULL                                                                                                                          1
-450499963   55        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-496895627   7         1         false        false                true          false           false         false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-543291288   23        1         false        false                false         false           false         false           true        false         false       true       false           1              3403232968                 0            2            NULL      NULL                                                                                                                          1
-543291289   23        1         false        false                false         false           false         false           true        false         false       true       false           2              3403232968                 0            2            NULL      NULL                                                                                                                          1
-543291291   23        2         true         false                true          false           true          false           true        false         false       true       false           1 2            3403232968 3403232968      0 0          2 2          NULL      NULL                                                                                                                          2
-543291292   23        2         true         false                false         false           true          false           true        false         false       true       false           4 5            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-543291294   23        1         false        false                false         false           false         false           true        false         false       true       false           4              0                          0            2            NULL      NULL                                                                                                                          1
-543291295   23        1         false        false                false         false           false         false           true        false         false       true       false           5              0                          0            2            NULL      NULL                                                                                                                          1
-663840560   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 17         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-663840561   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 16         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-663840562   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 15         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-663840563   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 14         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-663840564   42        1         false        false                false         false           false         false           true        false         false       true       false           13             0                          0            2            NULL      NULL                                                                                                                          1
-663840565   42        2         false        false                false         false           false         false           true        false         false       true       false           2 3            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-663840566   42        6         true         false                true          false           true          false           true        false         false       true       false           1 2 3 4 5 6    0 0 0 0 3403232968 0       0 0 0 0 0 0  2 2 2 2 2 2  NULL      NULL                                                                                                                          6
-663840574   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 19         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-663840575   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 18         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-710236230   58        1         true         false                true          false           true          false           true        false         false       true       false           1              3403232968                 0            2            NULL      NULL                                                                                                                          1
-803027558   26        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 0 3403232968             0 0 0        2 2 2        NULL      NULL                                                                                                                          3
-923576837   41        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-969972501   57        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-1062763829  25        4         true         false                true          false           true          false           true        false         false       true       false           1 2 3 4        0 0 3403232968 3403232968  0 0 0 0      2 2 2 2      NULL      NULL                                                                                                                          4
-1183313104  44        2         true         false                true          false           true          false           true        false         false       true       false           1 2            0 3403232968               0 0          2 2          NULL      NULL                                                                                                                          2
-1183313107  44        3         true         false                false         false           true          false           true        false         false       true       false           1 4 3          0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-1229708768  60        5         true         false                true          false           true          false           true        false         false       true       false           1 2 3 4 5      0 0 0 0 3403232968         0 0 0 0 0    2 2 2 2 2    NULL      NULL                                                                                                                          5
-1229708770  60        2         false        false                false         false           false         false           true        false         false       true       false           1 11           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-1229708771  60        2         false        false                false         false           false         false           true        false         false       true       false           2 3            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-1229708772  60        2         false        false                false         false           false         false           true        false         false       true       false           1 14           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-1229708773  60        2         false        false                false         false           false         false           true        false         false       true       false           1 12           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-1229708774  60        2         false        false                false         false           false         false           true        false         false       true       false           1 16           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-1229708775  60        2         false        false                false         false           false         false           true        false         false       true       false           1 15           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-1229708777  60        2         false        false                false         false           false         false           true        false         false       true       false           1 17           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-1276104432  12        2         true         false                true          false           true          false           true        false         false       true       false           1 6            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-1322500096  28        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-1489445036  35        6         false        false                false         false           false         false           true        false         false       true       false           2 1 3 6 7 8    0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-1489445039  35        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-1535840700  51        4         true         false                false         false           true          false           true        false         false       true       false           2 5 3 4        3403232968 0               0 0          2 2          NULL      NULL                                                                                                                          2
-1535840701  51        4         true         false                false         false           true          false           true        false         false       true       false           2 1 3 4        3403232968 3403232968      0 0          2 2          NULL      NULL                                                                                                                          2
-1535840703  51        2         true         false                true          false           true          false           true        false         false       true       false           1 2            3403232968 3403232968      0 0          2 2          NULL      NULL                                                                                                                          2
-1582236367  3         1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-1628632026  19        1         false        false                false         false           false         false           true        false         false       true       false           6              0                          0            2            NULL      NULL                                                                                                                          1
-1628632027  19        1         false        false                false         false           false         false           true        false         false       true       false           7              0                          0            2            NULL      NULL                                                                                                                          1
-1628632028  19        1         false        false                false         false           false         false           true        false         false       true       false           5              0                          0            2            NULL      NULL                                                                                                                          1
-1628632029  19        1         false        false                false         false           false         false           true        false         false       true       false           4              0                          0            2            NULL      NULL                                                                                                                          1
-1628632031  19        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-1795576969  54        1         true         false                false         false           true          false           true        false         false       true       false           2              0                          0            2            NULL      NULL                                                                                                                          1
-1795576970  54        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-1841972634  6         1         true         false                true          false           true          false           true        false         false       true       false           1              3403232968                 0            2            NULL      NULL                                                                                                                          1
-2008917577  37        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-2008917578  37        1         false        false                false         false           false         false           true        false         false       true       false           5              0                          0            2            NULL      NULL                                                                                                                          1
-2055313241  53        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 3403232968 0             0 0 0        2 2 1        NULL      NULL                                                                                                                          3
-2101708905  5         1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-2148104569  21        2         true         false                true          false           true          false           true        false         false       true       false           1 2            3403232968 3403232968      0 0          2 2          NULL      NULL                                                                                                                          2
-2268653844  40        4         true         false                true          false           true          false           true        false         false       true       false           1 2 3 4        0 0 0 0                    0 0 0 0      2 2 2 2      NULL      NULL                                                                                                                          4
-2315049508  56        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-2315049511  56        1         true         false                false         false           true          false           true        false         false       true       false           2              0                          0            2            NULL      NULL                                                                                                                          1
-2361445172  8         1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-2361445174  8         1         false        false                false         false           false         false           true        false         false       true       false           6              0                          0            2            NULL      NULL                                                                                                                          1
-2361445175  8         1         true         false                false         false           true          false           true        false         false       true       false           4              3403232968                 0            2            NULL      NULL                                                                                                                          1
-2407840836  24        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 0 0                      0 0 0        2 2 2        NULL      NULL                                                                                                                          3
-2528390115  47        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-2621181440  15        2         false        false                false         false           false         false           true        false         false       true       false           2 3            3403232968 0               0 0          2 2          NULL      NULL                                                                                                                          2
-2621181441  15        3         false        false                false         false           false         false           true        false         false       true       false           6 7 2          3403232968 0               0 0          2 2          NULL      NULL                                                                                                                          2
-2621181443  15        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-2621181446  15        6         false        false                false         false           false         false           true        false         false       true       false           8 2 3 11 10 9  0 3403232968 0             0 0 0        2 2 2        NULL      status IN ('running'::STRING, 'reverting'::STRING, 'pending'::STRING, 'pause-requested'::STRING, 'cancel-requested'::STRING)  3
-2621181447  15        1         false        false                false         false           false         false           true        false         false       true       false           12             3403232968                 0            2            NULL      NULL                                                                                                                          1
-2667577107  31        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-2834522046  34        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-2880917710  50        2         true         false                true          false           true          false           true        false         false       true       false           1 2            0 3403232968               0 0          2 2          NULL      NULL                                                                                                                          2
-3094258317  33        2         true         false                true          false           true          false           true        false         false       true       false           1 2            3403232968 3403232968      0 0          2 2          NULL      NULL                                                                                                                          2
-3094258318  33        1         false        false                false         false           false         false           true        false         false       true       false           4              0                          0            2            NULL      NULL                                                                                                                          1
-3353994584  36        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-3400390248  52        1         true         false                true          false           true          false           true        false         false       true       false           1              3403232968                 0            2            NULL      NULL                                                                                                                          1
-3446785912  4         1         true         false                true          false           true          false           true        false         false       true       false           1              3403232968                 0            2            NULL      NULL                                                                                                                          1
-3446785915  4         1         true         false                false         false           true          false           true        false         false       true       false           4              0                          0            2            NULL      NULL                                                                                                                          1
-3493181576  20        2         true         false                true          false           true          false           true        false         false       true       false           1 2            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-3613730848  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 12         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-3613730849  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 13         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-3613730850  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 10         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-3613730851  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 11         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-3613730852  43        1         false        false                false         false           false         false           true        false         false       true       false           2              0                          0            2            NULL      NULL                                                                                                                          1
-3613730853  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 9          0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-3613730855  43        4         true         false                true          false           true          false           true        false         false       true       false           1 2 3 4        0 0 3403232968 0           0 0 0 0      2 2 2 2      NULL      NULL                                                                                                                          4
-3613730862  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 14         0 3403232968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
-3660126519  59        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 3403232968 0             0 0 0        2 2 2        NULL      NULL                                                                                                                          3
-3706522180  11        5         true         false                true          false           true          false           true        false         false       true       false           5 1 2 4 3      0 0 0 0 0                  0 0 0 0 0    2 2 2 2 2    NULL      NULL                                                                                                                          5
-3752917847  27        2         true         false                true          false           true          false           true        false         false       true       false           1 2            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-3873467121  46        2         true         false                true          false           true          false           true        false         false       true       false           6 1            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-3919862786  62        1         false        false                true          false           false         false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
-3966258450  14        1         true         false                true          false           true          false           true        false         false       true       false           1              3403232968                 0            2            NULL      NULL                                                                                                                          1
-4012654114  30        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 0 3403232968             0 0 0        2 2 2        NULL      NULL                                                                                                                          3
-4133203393  45        2         true         false                true          false           true          false           true        false         false       true       false           1 2            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
-4179599057  61        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 0 3403232968             0 0 0        2 2 2        NULL      NULL                                                                                                                          3
-4179599058  61        1         false        false                false         false           false         false           true        false         false       true       false           2              0                          0            2            NULL      NULL                                                                                                                          1
-4179599059  61        2         false        false                false         false           false         false           true        false         false       true       false           1 8            0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-4179599060  61        2         false        false                false         false           false         false           true        false         false       true       false           1 9            0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-4179599061  61        2         false        false                false         false           false         false           true        false         false       true       false           1 11           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-4179599062  61        2         false        false                false         false           false         false           true        false         false       true       false           1 12           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-4179599063  61        2         false        false                false         false           false         false           true        false         false       true       false           1 13           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-4179599064  61        2         false        false                false         false           false         false           true        false         false       true       false           1 14           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
-4225994721  13        2         true         false                true          false           true          false           true        false         false       true       false           1 7            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+144468028   32        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+190863692   48        1         false        false                true          false           false         false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+404204296   39        2         true         false                true          false           true          false           true        false         false       true       false           3 1            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+450599960   55        1         false        false                false         false           false         false           true        false         false       true       false           2              0                          0            2            NULL      NULL                                                                                                                          1
+450599963   55        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+496995627   7         1         false        false                true          false           false         false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+543391288   23        1         false        false                false         false           false         false           true        false         false       true       false           1              3403332968                 0            2            NULL      NULL                                                                                                                          1
+543391289   23        1         false        false                false         false           false         false           true        false         false       true       false           2              3403332968                 0            2            NULL      NULL                                                                                                                          1
+543391291   23        2         true         false                true          false           true          false           true        false         false       true       false           1 2            3403332968 3403332968      0 0          2 2          NULL      NULL                                                                                                                          2
+543391292   23        2         true         false                false         false           true          false           true        false         false       true       false           4 5            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+543391294   23        1         false        false                false         false           false         false           true        false         false       true       false           4              0                          0            2            NULL      NULL                                                                                                                          1
+543391295   23        1         false        false                false         false           false         false           true        false         false       true       false           5              0                          0            2            NULL      NULL                                                                                                                          1
+663940560   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 17         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+663940561   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 16         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+663940562   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 15         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+663940563   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 14         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+663940564   42        1         false        false                false         false           false         false           true        false         false       true       false           13             0                          0            2            NULL      NULL                                                                                                                          1
+663940565   42        2         false        false                false         false           false         false           true        false         false       true       false           2 3            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+663940566   42        6         true         false                true          false           true          false           true        false         false       true       false           1 2 3 4 5 6    0 0 0 0 3403332968 0       0 0 0 0 0 0  2 2 2 2 2 2  NULL      NULL                                                                                                                          6
+663940574   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 19         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+663940575   42        3         false        false                false         false           false         false           true        false         false       true       false           1 5 18         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+710336230   58        1         true         false                true          false           true          false           true        false         false       true       false           1              3403332968                 0            2            NULL      NULL                                                                                                                          1
+803127558   26        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 0 3403332968             0 0 0        2 2 2        NULL      NULL                                                                                                                          3
+923676837   41        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+970072501   57        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+1062863829  25        4         true         false                true          false           true          false           true        false         false       true       false           1 2 3 4        0 0 3403332968 3403332968  0 0 0 0      2 2 2 2      NULL      NULL                                                                                                                          4
+1183413104  44        2         true         false                true          false           true          false           true        false         false       true       false           1 2            0 3403332968               0 0          2 2          NULL      NULL                                                                                                                          2
+1183413107  44        3         true         false                false         false           true          false           true        false         false       true       false           1 4 3          0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+1229808768  60        5         true         false                true          false           true          false           true        false         false       true       false           1 2 3 4 5      0 0 0 0 3403332968         0 0 0 0 0    2 2 2 2 2    NULL      NULL                                                                                                                          5
+1229808770  60        2         false        false                false         false           false         false           true        false         false       true       false           1 11           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+1229808771  60        2         false        false                false         false           false         false           true        false         false       true       false           2 3            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+1229808772  60        2         false        false                false         false           false         false           true        false         false       true       false           1 14           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+1229808773  60        2         false        false                false         false           false         false           true        false         false       true       false           1 12           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+1229808774  60        2         false        false                false         false           false         false           true        false         false       true       false           1 16           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+1229808775  60        2         false        false                false         false           false         false           true        false         false       true       false           1 15           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+1229808777  60        2         false        false                false         false           false         false           true        false         false       true       false           1 17           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+1276204432  12        2         true         false                true          false           true          false           true        false         false       true       false           1 6            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+1322600096  28        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+1489545036  35        6         false        false                false         false           false         false           true        false         false       true       false           2 1 3 6 7 8    0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+1489545039  35        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+1535940700  51        4         true         false                false         false           true          false           true        false         false       true       false           2 5 3 4        3403332968 0               0 0          2 2          NULL      NULL                                                                                                                          2
+1535940701  51        4         true         false                false         false           true          false           true        false         false       true       false           2 1 3 4        3403332968 3403332968      0 0          2 2          NULL      NULL                                                                                                                          2
+1535940703  51        2         true         false                true          false           true          false           true        false         false       true       false           1 2            3403332968 3403332968      0 0          2 2          NULL      NULL                                                                                                                          2
+1582336367  3         1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+1628732026  19        1         false        false                false         false           false         false           true        false         false       true       false           6              0                          0            2            NULL      NULL                                                                                                                          1
+1628732027  19        1         false        false                false         false           false         false           true        false         false       true       false           7              0                          0            2            NULL      NULL                                                                                                                          1
+1628732028  19        1         false        false                false         false           false         false           true        false         false       true       false           5              0                          0            2            NULL      NULL                                                                                                                          1
+1628732029  19        1         false        false                false         false           false         false           true        false         false       true       false           4              0                          0            2            NULL      NULL                                                                                                                          1
+1628732031  19        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+1795676969  54        1         true         false                false         false           true          false           true        false         false       true       false           2              0                          0            2            NULL      NULL                                                                                                                          1
+1795676970  54        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+1842072634  6         1         true         false                true          false           true          false           true        false         false       true       false           1              3403332968                 0            2            NULL      NULL                                                                                                                          1
+2009017577  37        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+2009017578  37        1         false        false                false         false           false         false           true        false         false       true       false           5              0                          0            2            NULL      NULL                                                                                                                          1
+2055413241  53        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 3403332968 0             0 0 0        2 2 1        NULL      NULL                                                                                                                          3
+2101808905  5         1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+2148204569  21        2         true         false                true          false           true          false           true        false         false       true       false           1 2            3403332968 3403332968      0 0          2 2          NULL      NULL                                                                                                                          2
+2268753844  40        4         true         false                true          false           true          false           true        false         false       true       false           1 2 3 4        0 0 0 0                    0 0 0 0      2 2 2 2      NULL      NULL                                                                                                                          4
+2315149508  56        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+2315149511  56        1         true         false                false         false           true          false           true        false         false       true       false           2              0                          0            2            NULL      NULL                                                                                                                          1
+2361545172  8         1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+2361545174  8         1         false        false                false         false           false         false           true        false         false       true       false           6              0                          0            2            NULL      NULL                                                                                                                          1
+2361545175  8         1         true         false                false         false           true          false           true        false         false       true       false           4              3403332968                 0            2            NULL      NULL                                                                                                                          1
+2407940836  24        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 0 0                      0 0 0        2 2 2        NULL      NULL                                                                                                                          3
+2528490115  47        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+2621281440  15        2         false        false                false         false           false         false           true        false         false       true       false           2 3            3403332968 0               0 0          2 2          NULL      NULL                                                                                                                          2
+2621281441  15        3         false        false                false         false           false         false           true        false         false       true       false           6 7 2          3403332968 0               0 0          2 2          NULL      NULL                                                                                                                          2
+2621281443  15        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+2621281446  15        6         false        false                false         false           false         false           true        false         false       true       false           8 2 3 11 10 9  0 3403332968 0             0 0 0        2 2 2        NULL      status IN ('running'::STRING, 'reverting'::STRING, 'pending'::STRING, 'pause-requested'::STRING, 'cancel-requested'::STRING)  3
+2621281447  15        1         false        false                false         false           false         false           true        false         false       true       false           12             3403332968                 0            2            NULL      NULL                                                                                                                          1
+2667677107  31        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+2834622046  34        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+2881017710  50        2         true         false                true          false           true          false           true        false         false       true       false           1 2            0 3403332968               0 0          2 2          NULL      NULL                                                                                                                          2
+3094358317  33        2         true         false                true          false           true          false           true        false         false       true       false           1 2            3403332968 3403332968      0 0          2 2          NULL      NULL                                                                                                                          2
+3094358318  33        1         false        false                false         false           false         false           true        false         false       true       false           4              0                          0            2            NULL      NULL                                                                                                                          1
+3354094584  36        1         true         false                true          false           true          false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+3400490248  52        1         true         false                true          false           true          false           true        false         false       true       false           1              3403332968                 0            2            NULL      NULL                                                                                                                          1
+3446885912  4         1         true         false                true          false           true          false           true        false         false       true       false           1              3403332968                 0            2            NULL      NULL                                                                                                                          1
+3446885915  4         1         true         false                false         false           true          false           true        false         false       true       false           4              0                          0            2            NULL      NULL                                                                                                                          1
+3493281576  20        2         true         false                true          false           true          false           true        false         false       true       false           1 2            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+3613830848  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 12         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+3613830849  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 13         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+3613830850  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 10         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+3613830851  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 11         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+3613830852  43        1         false        false                false         false           false         false           true        false         false       true       false           2              0                          0            2            NULL      NULL                                                                                                                          1
+3613830853  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 9          0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+3613830855  43        4         true         false                true          false           true          false           true        false         false       true       false           1 2 3 4        0 0 3403332968 0           0 0 0 0      2 2 2 2      NULL      NULL                                                                                                                          4
+3613830862  43        3         false        false                false         false           false         false           true        false         false       true       false           1 3 14         0 3403332968 0             0 0 0        2 2 1        NULL      app_name NOT LIKE '$ internal%'::STRING                                                                                       3
+3660226519  59        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 3403332968 0             0 0 0        2 2 2        NULL      NULL                                                                                                                          3
+3706622180  11        5         true         false                true          false           true          false           true        false         false       true       false           5 1 2 4 3      0 0 0 0 0                  0 0 0 0 0    2 2 2 2 2    NULL      NULL                                                                                                                          5
+3753017847  27        2         true         false                true          false           true          false           true        false         false       true       false           1 2            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+3873567121  46        2         true         false                true          false           true          false           true        false         false       true       false           6 1            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+3919962786  62        1         false        false                true          false           false         false           true        false         false       true       false           1              0                          0            2            NULL      NULL                                                                                                                          1
+3966358450  14        1         true         false                true          false           true          false           true        false         false       true       false           1              3403332968                 0            2            NULL      NULL                                                                                                                          1
+4012754114  30        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 0 3403332968             0 0 0        2 2 2        NULL      NULL                                                                                                                          3
+4133303393  45        2         true         false                true          false           true          false           true        false         false       true       false           1 2            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
+4179699057  61        3         true         false                true          false           true          false           true        false         false       true       false           1 2 3          0 0 3403332968             0 0 0        2 2 2        NULL      NULL                                                                                                                          3
+4179699058  61        1         false        false                false         false           false         false           true        false         false       true       false           2              0                          0            2            NULL      NULL                                                                                                                          1
+4179699059  61        2         false        false                false         false           false         false           true        false         false       true       false           1 8            0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+4179699060  61        2         false        false                false         false           false         false           true        false         false       true       false           1 9            0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+4179699061  61        2         false        false                false         false           false         false           true        false         false       true       false           1 11           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+4179699062  61        2         false        false                false         false           false         false           true        false         false       true       false           1 12           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+4179699063  61        2         false        false                false         false           false         false           true        false         false       true       false           1 13           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+4179699064  61        2         false        false                false         false           false         false           true        false         false       true       false           1 14           0 0                        0 0          2 1          NULL      NULL                                                                                                                          2
+4226094721  13        2         true         false                true          false           true          false           true        false         false       true       false           1 7            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
 
 # From #26504
 skipif config 3node-tenant-default-configs
@@ -1227,205 +1227,205 @@ FROM pg_index
 ORDER BY indexrelid, operator_argument_position
 ----
 indexrelid  operator_argument_type_oid  operator_argument_position
-144368028   0                           1
-190763692   0                           1
-404104296   0                           1
-404104296   0                           2
-450499960   0                           1
-450499963   0                           1
-496895627   0                           1
-543291288   0                           1
-543291289   0                           1
-543291291   0                           1
-543291291   0                           2
-543291292   0                           1
-543291292   0                           2
-543291294   0                           1
-543291295   0                           1
-663840560   0                           1
-663840560   0                           2
-663840560   0                           3
-663840561   0                           1
-663840561   0                           2
-663840561   0                           3
-663840562   0                           1
-663840562   0                           2
-663840562   0                           3
-663840563   0                           1
-663840563   0                           2
-663840563   0                           3
-663840564   0                           1
-663840565   0                           1
-663840565   0                           2
-663840566   0                           1
-663840566   0                           2
-663840566   0                           3
-663840566   0                           4
-663840566   0                           5
-663840566   0                           6
-663840574   0                           1
-663840574   0                           2
-663840574   0                           3
-663840575   0                           1
-663840575   0                           2
-663840575   0                           3
-710236230   0                           1
-803027558   0                           1
-803027558   0                           2
-803027558   0                           3
-923576837   0                           1
-969972501   0                           1
-1062763829  0                           1
-1062763829  0                           2
-1062763829  0                           3
-1062763829  0                           4
-1183313104  0                           1
-1183313104  0                           2
-1183313107  0                           1
-1183313107  0                           2
-1229708768  0                           1
-1229708768  0                           2
-1229708768  0                           3
-1229708768  0                           4
-1229708768  0                           5
-1229708770  0                           1
-1229708770  0                           2
-1229708771  0                           1
-1229708771  0                           2
-1229708772  0                           1
-1229708772  0                           2
-1229708773  0                           1
-1229708773  0                           2
-1229708774  0                           1
-1229708774  0                           2
-1229708775  0                           1
-1229708775  0                           2
-1229708777  0                           1
-1229708777  0                           2
-1276104432  0                           1
-1276104432  0                           2
-1322500096  0                           1
-1489445036  0                           1
-1489445036  0                           2
-1489445039  0                           1
-1535840700  0                           1
-1535840700  0                           2
-1535840701  0                           1
-1535840701  0                           2
-1535840703  0                           1
-1535840703  0                           2
-1582236367  0                           1
-1628632026  0                           1
-1628632027  0                           1
-1628632028  0                           1
-1628632029  0                           1
-1628632031  0                           1
-1795576969  0                           1
-1795576970  0                           1
-1841972634  0                           1
-2008917577  0                           1
-2008917578  0                           1
-2055313241  0                           1
-2055313241  0                           2
-2055313241  0                           3
-2101708905  0                           1
-2148104569  0                           1
-2148104569  0                           2
-2268653844  0                           1
-2268653844  0                           2
-2268653844  0                           3
-2268653844  0                           4
-2315049508  0                           1
-2315049511  0                           1
-2361445172  0                           1
-2361445174  0                           1
-2361445175  0                           1
-2407840836  0                           1
-2407840836  0                           2
-2407840836  0                           3
-2528390115  0                           1
-2621181440  0                           1
-2621181440  0                           2
-2621181441  0                           1
-2621181441  0                           2
-2621181443  0                           1
-2621181446  0                           1
-2621181446  0                           2
-2621181446  0                           3
-2621181447  0                           1
-2667577107  0                           1
-2834522046  0                           1
-2880917710  0                           1
-2880917710  0                           2
-3094258317  0                           1
-3094258317  0                           2
-3094258318  0                           1
-3353994584  0                           1
-3400390248  0                           1
-3446785912  0                           1
-3446785915  0                           1
-3493181576  0                           1
-3493181576  0                           2
-3613730848  0                           1
-3613730848  0                           2
-3613730848  0                           3
-3613730849  0                           1
-3613730849  0                           2
-3613730849  0                           3
-3613730850  0                           1
-3613730850  0                           2
-3613730850  0                           3
-3613730851  0                           1
-3613730851  0                           2
-3613730851  0                           3
-3613730852  0                           1
-3613730853  0                           1
-3613730853  0                           2
-3613730853  0                           3
-3613730855  0                           1
-3613730855  0                           2
-3613730855  0                           3
-3613730855  0                           4
-3613730862  0                           1
-3613730862  0                           2
-3613730862  0                           3
-3660126519  0                           1
-3660126519  0                           2
-3660126519  0                           3
-3706522180  0                           1
-3706522180  0                           2
-3706522180  0                           3
-3706522180  0                           4
-3706522180  0                           5
-3752917847  0                           1
-3752917847  0                           2
-3873467121  0                           1
-3873467121  0                           2
-3919862786  0                           1
-3966258450  0                           1
-4012654114  0                           1
-4012654114  0                           2
-4012654114  0                           3
-4133203393  0                           1
-4133203393  0                           2
-4179599057  0                           1
-4179599057  0                           2
-4179599057  0                           3
-4179599058  0                           1
-4179599059  0                           1
-4179599059  0                           2
-4179599060  0                           1
-4179599060  0                           2
-4179599061  0                           1
-4179599061  0                           2
-4179599062  0                           1
-4179599062  0                           2
-4179599063  0                           1
-4179599063  0                           2
-4179599064  0                           1
-4179599064  0                           2
-4225994721  0                           1
-4225994721  0                           2
+144468028   0                           1
+190863692   0                           1
+404204296   0                           1
+404204296   0                           2
+450599960   0                           1
+450599963   0                           1
+496995627   0                           1
+543391288   0                           1
+543391289   0                           1
+543391291   0                           1
+543391291   0                           2
+543391292   0                           1
+543391292   0                           2
+543391294   0                           1
+543391295   0                           1
+663940560   0                           1
+663940560   0                           2
+663940560   0                           3
+663940561   0                           1
+663940561   0                           2
+663940561   0                           3
+663940562   0                           1
+663940562   0                           2
+663940562   0                           3
+663940563   0                           1
+663940563   0                           2
+663940563   0                           3
+663940564   0                           1
+663940565   0                           1
+663940565   0                           2
+663940566   0                           1
+663940566   0                           2
+663940566   0                           3
+663940566   0                           4
+663940566   0                           5
+663940566   0                           6
+663940574   0                           1
+663940574   0                           2
+663940574   0                           3
+663940575   0                           1
+663940575   0                           2
+663940575   0                           3
+710336230   0                           1
+803127558   0                           1
+803127558   0                           2
+803127558   0                           3
+923676837   0                           1
+970072501   0                           1
+1062863829  0                           1
+1062863829  0                           2
+1062863829  0                           3
+1062863829  0                           4
+1183413104  0                           1
+1183413104  0                           2
+1183413107  0                           1
+1183413107  0                           2
+1229808768  0                           1
+1229808768  0                           2
+1229808768  0                           3
+1229808768  0                           4
+1229808768  0                           5
+1229808770  0                           1
+1229808770  0                           2
+1229808771  0                           1
+1229808771  0                           2
+1229808772  0                           1
+1229808772  0                           2
+1229808773  0                           1
+1229808773  0                           2
+1229808774  0                           1
+1229808774  0                           2
+1229808775  0                           1
+1229808775  0                           2
+1229808777  0                           1
+1229808777  0                           2
+1276204432  0                           1
+1276204432  0                           2
+1322600096  0                           1
+1489545036  0                           1
+1489545036  0                           2
+1489545039  0                           1
+1535940700  0                           1
+1535940700  0                           2
+1535940701  0                           1
+1535940701  0                           2
+1535940703  0                           1
+1535940703  0                           2
+1582336367  0                           1
+1628732026  0                           1
+1628732027  0                           1
+1628732028  0                           1
+1628732029  0                           1
+1628732031  0                           1
+1795676969  0                           1
+1795676970  0                           1
+1842072634  0                           1
+2009017577  0                           1
+2009017578  0                           1
+2055413241  0                           1
+2055413241  0                           2
+2055413241  0                           3
+2101808905  0                           1
+2148204569  0                           1
+2148204569  0                           2
+2268753844  0                           1
+2268753844  0                           2
+2268753844  0                           3
+2268753844  0                           4
+2315149508  0                           1
+2315149511  0                           1
+2361545172  0                           1
+2361545174  0                           1
+2361545175  0                           1
+2407940836  0                           1
+2407940836  0                           2
+2407940836  0                           3
+2528490115  0                           1
+2621281440  0                           1
+2621281440  0                           2
+2621281441  0                           1
+2621281441  0                           2
+2621281443  0                           1
+2621281446  0                           1
+2621281446  0                           2
+2621281446  0                           3
+2621281447  0                           1
+2667677107  0                           1
+2834622046  0                           1
+2881017710  0                           1
+2881017710  0                           2
+3094358317  0                           1
+3094358317  0                           2
+3094358318  0                           1
+3354094584  0                           1
+3400490248  0                           1
+3446885912  0                           1
+3446885915  0                           1
+3493281576  0                           1
+3493281576  0                           2
+3613830848  0                           1
+3613830848  0                           2
+3613830848  0                           3
+3613830849  0                           1
+3613830849  0                           2
+3613830849  0                           3
+3613830850  0                           1
+3613830850  0                           2
+3613830850  0                           3
+3613830851  0                           1
+3613830851  0                           2
+3613830851  0                           3
+3613830852  0                           1
+3613830853  0                           1
+3613830853  0                           2
+3613830853  0                           3
+3613830855  0                           1
+3613830855  0                           2
+3613830855  0                           3
+3613830855  0                           4
+3613830862  0                           1
+3613830862  0                           2
+3613830862  0                           3
+3660226519  0                           1
+3660226519  0                           2
+3660226519  0                           3
+3706622180  0                           1
+3706622180  0                           2
+3706622180  0                           3
+3706622180  0                           4
+3706622180  0                           5
+3753017847  0                           1
+3753017847  0                           2
+3873567121  0                           1
+3873567121  0                           2
+3919962786  0                           1
+3966358450  0                           1
+4012754114  0                           1
+4012754114  0                           2
+4012754114  0                           3
+4133303393  0                           1
+4133303393  0                           2
+4179699057  0                           1
+4179699057  0                           2
+4179699057  0                           3
+4179699058  0                           1
+4179699059  0                           1
+4179699059  0                           2
+4179699060  0                           1
+4179699060  0                           2
+4179699061  0                           1
+4179699061  0                           2
+4179699062  0                           1
+4179699062  0                           2
+4179699063  0                           1
+4179699063  0                           2
+4179699064  0                           1
+4179699064  0                           2
+4226094721  0                           1
+4226094721  0                           2
 
 ## pg_catalog.pg_collation
 
@@ -1437,7 +1437,7 @@ SELECT * FROM pg_collation
 WHERE collname='en-US'
 ----
 oid         collname  collnamespace  collowner  collencoding  collcollate  collctype  collprovider  collversion  collisdeterministic
-3903121477  en-US     4294967118     NULL       6             NULL         NULL       NULL          NULL         NULL
+3903221477  en-US     4294967118     NULL       6             NULL         NULL       NULL          NULL         NULL
 
 user testuser
 
@@ -1447,7 +1447,7 @@ SELECT oid, collname FROM pg_collation
 WHERE collname='en-US'
 ----
 oid         collname
-3903121477  en-US
+3903221477  en-US
 
 user root
 
@@ -1492,27 +1492,27 @@ JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 conname        contype  condeferrable  condeferred  convalidated  conrelid  contypid  conindid
-t1_pkey        p        false          false        true          110       0         3687884466
-t1_a_key       u        false          false        true          110       0         3687884465
-index_key      u        false          false        true          110       0         3687884464
-primary        p        false          false        true          111       0         2342807459
-primary        p        false          false        true          112       0         5181036
-t2_pkey        p        false          false        true          113       0         2955071325
-fk             f        false          false        true          113       0         3687884465
-t3_pkey        p        false          false        true          114       0         2695335054
+t1_pkey        p        false          false        true          110       0         3687984466
+t1_a_key       u        false          false        true          110       0         3687984465
+index_key      u        false          false        true          110       0         3687984464
+primary        p        false          false        true          111       0         2342907459
+primary        p        false          false        true          112       0         5281036
+t2_pkey        p        false          false        true          113       0         2955171325
+fk             f        false          false        true          113       0         3687984465
+t3_pkey        p        false          false        true          114       0         2695435054
 check_b        c        false          false        true          114       0         0
 check_c        c        false          false        true          114       0         0
-fk             f        false          false        true          114       0         3687884464
-t4_pkey        p        false          false        true          116       0         3214807592
+fk             f        false          false        true          114       0         3687984464
+t4_pkey        p        false          false        true          116       0         3214907592
 unique_a       u        false          false        true          116       0         0
 uwi_b_c        u        false          false        true          116       0         0
 uwi_b_partial  u        false          false        true          116       0         0
-t5_pkey        p        false          false        true          117       0         1869730585
+t5_pkey        p        false          false        true          117       0         1869830585
 fk_b_c         f        false          false        true          117       0         0
 t5_a_fkey      f        false          false        true          117       0         0
-t6_pkey        p        false          false        true          120       0         2129466852
-t6_expr_key    u        false          false        true          120       0         2129466848
-mv1_pkey       p        false          false        true          121       0         784389845
+t6_pkey        p        false          false        true          120       0         2129566852
+t6_expr_key    u        false          false        true          120       0         2129566848
+mv1_pkey       p        false          false        true          121       0         784489845
 
 query T
 SELECT conname
@@ -1638,14 +1638,14 @@ ORDER BY objid, refobjid, refobjsubid
 classid     objid       objsubid  refclassid  refobjid    refobjsubid  deptype
 4294967103  111         0         4294967106  110         14           a
 4294967103  112         0         4294967106  110         15           a
-4294967060  842401391   0         4294967106  110         1            n
-4294967060  842401391   0         4294967106  110         2            n
-4294967060  842401391   0         4294967106  110         3            n
-4294967060  842401391   0         4294967106  110         4            n
-4294967103  1179276562  0         4294967106  3687884464  0            n
-4294967103  3935750373  0         4294967106  3687884465  0            n
-4294967103  4072017905  0         4294967106  0           0            n
-4294967103  4170826110  0         4294967106  0           0            n
+4294967060  842501391   0         4294967106  110         1            n
+4294967060  842501391   0         4294967106  110         2            n
+4294967060  842501391   0         4294967106  110         3            n
+4294967060  842501391   0         4294967106  110         4            n
+4294967103  1179376562  0         4294967106  3687984464  0            n
+4294967103  3935850373  0         4294967106  3687984465  0            n
+4294967103  4072117905  0         4294967106  0           0            n
+4294967103  4170926110  0         4294967106  0           0            n
 
 # Some entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table. Other entries are links to pg_class when it is
@@ -1729,8 +1729,8 @@ SELECT * FROM pg_rewrite WHERE ev_class IN (
 ) ORDER BY oid
 ----
 oid         rulename  ev_class  ev_type  ev_enabled  is_instead  ev_qual  ev_action
-554906963   _RETURN   129       1        NULL        true        NULL     NULL
-1899983969  _RETURN   130       1        NULL        true        NULL     NULL
+555006963   _RETURN   129       1        NULL        true        NULL     NULL
+1900083969  _RETURN   130       1        NULL        true        NULL     NULL
 
 ## pg_catalog.pg_enum
 statement ok
@@ -1741,13 +1741,13 @@ query OORT colnames
 SELECT * FROM pg_enum
 ----
 oid         enumtypid  enumsortorder  enumlabel
-3341603527  100118     0              foo
-3341603335  100118     1              bar
-3341603399  100118     2              baz
-2452389720  100131     0              v1
-2452389784  100131     1              v2
-2553055434  100133     0              v3
-2553055242  100133     1              v4
+3341703527  100118     0              foo
+3341703335  100118     1              bar
+3341703399  100118     2              baz
+2452489720  100131     0              v1
+2452489784  100131     1              v2
+2553155434  100133     0              v3
+2553155242  100133     1              v4
 
 ## pg_catalog.pg_type
 
@@ -1840,25 +1840,25 @@ oid     typname                typnamespace  typowner    typlen  typbyval  typty
 90003   _geography             4294967118    NULL        -1      false     b
 90004   box2d                  4294967118    NULL        32      true      b
 90005   _box2d                 4294967118    NULL        -1      false     b
-100110  t1                     109           1546506610  -1      false     c
-100111  t1_m_seq               109           1546506610  -1      false     c
-100112  t1_n_seq               109           1546506610  -1      false     c
-100113  t2                     109           1546506610  -1      false     c
-100114  t3                     109           1546506610  -1      false     c
-100115  v1                     109           1546506610  -1      false     c
-100116  t4                     109           1546506610  -1      false     c
-100117  t5                     109           1546506610  -1      false     c
-100118  mytype                 109           1546506610  -1      false     e
-100119  _mytype                109           1546506610  -1      false     b
-100120  t6                     109           1546506610  -1      false     c
-100121  mv1                    109           1546506610  -1      false     c
-100128  source_table           109           1546506610  -1      false     c
-100129  depend_view            109           1546506610  -1      false     c
-100130  view_dependingon_view  109           1546506610  -1      false     c
-100131  newtype1               109           1546506610  -1      false     e
-100132  _newtype1              109           1546506610  -1      false     b
-100133  newtype2               109           1546506610  -1      false     e
-100134  _newtype2              109           1546506610  -1      false     b
+100110  t1                     109           1546606610  -1      false     c
+100111  t1_m_seq               109           1546606610  -1      false     c
+100112  t1_n_seq               109           1546606610  -1      false     c
+100113  t2                     109           1546606610  -1      false     c
+100114  t3                     109           1546606610  -1      false     c
+100115  v1                     109           1546606610  -1      false     c
+100116  t4                     109           1546606610  -1      false     c
+100117  t5                     109           1546606610  -1      false     c
+100118  mytype                 109           1546606610  -1      false     e
+100119  _mytype                109           1546606610  -1      false     b
+100120  t6                     109           1546606610  -1      false     c
+100121  mv1                    109           1546606610  -1      false     c
+100128  source_table           109           1546606610  -1      false     c
+100129  depend_view            109           1546606610  -1      false     c
+100130  view_dependingon_view  109           1546606610  -1      false     c
+100131  newtype1               109           1546606610  -1      false     e
+100132  _newtype1              109           1546606610  -1      false     b
+100133  newtype2               109           1546606610  -1      false     e
+100134  _newtype2              109           1546606610  -1      false     b
 
 query OTTBBTOOO colnames
 SELECT oid, typname, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray
@@ -2196,14 +2196,14 @@ ORDER BY oid
 oid     typname                typndims  typcollation  typdefaultbin  typdefault  typacl
 16      bool                   0         0             NULL           NULL        NULL
 17      bytea                  0         0             NULL           NULL        NULL
-18      char                   0         3403232968    NULL           NULL        NULL
-19      name                   0         3403232968    NULL           NULL        NULL
+18      char                   0         3403332968    NULL           NULL        NULL
+19      name                   0         3403332968    NULL           NULL        NULL
 20      int8                   0         0             NULL           NULL        NULL
 21      int2                   0         0             NULL           NULL        NULL
 22      int2vector             0         0             NULL           NULL        NULL
 23      int4                   0         0             NULL           NULL        NULL
 24      regproc                0         0             NULL           NULL        NULL
-25      text                   0         3403232968    NULL           NULL        NULL
+25      text                   0         3403332968    NULL           NULL        NULL
 26      oid                    0         0             NULL           NULL        NULL
 30      oidvector              0         0             NULL           NULL        NULL
 700     float4                 0         0             NULL           NULL        NULL
@@ -2212,23 +2212,23 @@ oid     typname                typndims  typcollation  typdefaultbin  typdefault
 869     inet                   0         0             NULL           NULL        NULL
 1000    _bool                  0         0             NULL           NULL        NULL
 1001    _bytea                 0         0             NULL           NULL        NULL
-1002    _char                  0         3403232968    NULL           NULL        NULL
-1003    _name                  0         3403232968    NULL           NULL        NULL
+1002    _char                  0         3403332968    NULL           NULL        NULL
+1003    _name                  0         3403332968    NULL           NULL        NULL
 1005    _int2                  0         0             NULL           NULL        NULL
 1006    _int2vector            0         0             NULL           NULL        NULL
 1007    _int4                  0         0             NULL           NULL        NULL
 1008    _regproc               0         0             NULL           NULL        NULL
-1009    _text                  0         3403232968    NULL           NULL        NULL
+1009    _text                  0         3403332968    NULL           NULL        NULL
 1013    _oidvector             0         0             NULL           NULL        NULL
-1014    _bpchar                0         3403232968    NULL           NULL        NULL
-1015    _varchar               0         3403232968    NULL           NULL        NULL
+1014    _bpchar                0         3403332968    NULL           NULL        NULL
+1015    _varchar               0         3403332968    NULL           NULL        NULL
 1016    _int8                  0         0             NULL           NULL        NULL
 1021    _float4                0         0             NULL           NULL        NULL
 1022    _float8                0         0             NULL           NULL        NULL
 1028    _oid                   0         0             NULL           NULL        NULL
 1041    _inet                  0         0             NULL           NULL        NULL
-1042    bpchar                 0         3403232968    NULL           NULL        NULL
-1043    varchar                0         3403232968    NULL           NULL        NULL
+1042    bpchar                 0         3403332968    NULL           NULL        NULL
+1043    varchar                0         3403332968    NULL           NULL        NULL
 1082    date                   0         0             NULL           NULL        NULL
 1083    time                   0         0             NULL           NULL        NULL
 1114    timestamp              0         0             NULL           NULL        NULL
@@ -2254,7 +2254,7 @@ oid     typname                typndims  typcollation  typdefaultbin  typdefault
 2210    _regclass              0         0             NULL           NULL        NULL
 2211    _regtype               0         0             NULL           NULL        NULL
 2249    record                 0         0             NULL           NULL        NULL
-2277    anyarray               0         3403232968    NULL           NULL        NULL
+2277    anyarray               0         3403332968    NULL           NULL        NULL
 2278    void                   0         0             NULL           NULL        NULL
 2283    anyelement             0         0             NULL           NULL        NULL
 2287    _record                0         0             NULL           NULL        NULL
@@ -2323,7 +2323,7 @@ FROM pg_catalog.pg_type
 WHERE typname = 'newtype1'
 ----
 oid     typname   typnamespace  typowner    typlen  typbyval  typtype
-100131  newtype1  109           1546506610  -1      false     e
+100131  newtype1  109           1546606610  -1      false     e
 
 query OTOOIBT colnames
 SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
@@ -2345,7 +2345,7 @@ FROM pg_catalog.pg_type
 WHERE typname = 'source_table'
 ----
 oid     typname       typnamespace  typowner    typlen  typbyval  typtype
-100128  source_table  109           1546506610  -1      false     c
+100128  source_table  109           1546606610  -1      false     c
 
 let $sourceid
 SELECT oid
@@ -2359,7 +2359,7 @@ FROM pg_catalog.pg_type
 WHERE oid = $sourceid
 ----
 oid     typname       typnamespace  typowner    typlen  typbyval  typtype
-100128  source_table  109           1546506610  -1      false     c
+100128  source_table  109           1546606610  -1      false     c
 
 let $vtableSourceId
 SELECT oid
@@ -2373,7 +2373,7 @@ FROM pg_catalog.pg_type
 WHERE oid = $vtableSourceId
 ----
 oid         typname  typnamespace  typowner    typlen  typbyval  typtype
-4294967068  pg_proc  4294967118    2310524507  -1      false     c
+4294967068  pg_proc  4294967118    2310624507  -1      false     c
 
 ## pg_catalog.pg_proc
 
@@ -2535,10 +2535,10 @@ FROM pg_catalog.pg_roles
 ORDER BY rolname
 ----
 oid         rolname   rolsuper  rolinherit  rolcreaterole  rolcreatedb  rolcatupdate  rolcanlogin  rolreplication
-2310524507  admin     true      true        true           true         false         true         false
-3233629770  node      true      true        true           true         false         false        false
-1546506610  root      true      true        true           true         false         true         false
-2264919399  testuser  false     true        false          false        false         true         false
+2310624507  admin     true      true        true           true         false         true         false
+3233729770  node      true      true        true           true         false         false        false
+1546606610  root      true      true        true           true         false         true         false
+2265019399  testuser  false     true        false          false        false         true         false
 
 query OTITTBT colnames
 SELECT oid, rolname, rolconnlimit, rolpassword, rolvaliduntil, rolbypassrls, rolconfig
@@ -2546,10 +2546,10 @@ FROM pg_catalog.pg_roles
 ORDER BY rolname
 ----
 oid         rolname   rolconnlimit  rolpassword  rolvaliduntil  rolbypassrls  rolconfig
-2310524507  admin     -1            ********     NULL           false         NULL
-3233629770  node      -1            ********     NULL           false         NULL
-1546506610  root      -1            ********     NULL           false         NULL
-2264919399  testuser  -1            ********     NULL           false         NULL
+2310624507  admin     -1            ********     NULL           false         NULL
+3233729770  node      -1            ********     NULL           false         NULL
+1546606610  root      -1            ********     NULL           false         NULL
+2265019399  testuser  -1            ********     NULL           false         NULL
 
 ## pg_catalog.pg_auth_members
 
@@ -2558,7 +2558,7 @@ SELECT roleid, member, grantor, admin_option
 FROM pg_catalog.pg_auth_members
 ----
 roleid      member      grantor  admin_option
-2310524507  1546506610  NULL     true
+2310624507  1546606610  NULL     true
 
 ## pg_catalog.pg_user
 
@@ -2568,9 +2568,9 @@ FROM pg_catalog.pg_user
 ORDER BY usename
 ----
 usename   usesysid    usecreatedb  usesuper  userepl  usebypassrls  passwd    valuntil  useconfig
-node      3233629770  true         true      false    false         ********  NULL      NULL
-root      1546506610  true         true      false    false         ********  NULL      NULL
-testuser  2264919399  false        false     false    false         ********  NULL      NULL
+node      3233729770  true         true      false    false         ********  NULL      NULL
+root      1546606610  true         true      false    false         ********  NULL      NULL
+testuser  2265019399  false        false     false    false         ********  NULL      NULL
 
 ## pg_catalog.pg_description
 
@@ -2596,7 +2596,7 @@ relname       objoid      classoid    objsubid  description
 pg_class      135         4294967106  0         mycomment1
 pg_class      4294966990  4294967106  0         database users
 pg_class      135         4294967106  1         mycomment2
-pg_class      125730312   4294967106  0         mycomment3
+pg_class      125830312   4294967106  0         mycomment3
 pg_namespace  136         4294967077  0         mycomment4
 pg_proc       738         4294967068  0         Calculates the absolute value of `val`.
 pg_proc       739         4294967068  0         Calculates the absolute value of `val`.
@@ -3180,7 +3180,7 @@ query OTOOTBBOOOOOOOO colnames
 SELECT * FROM pg_catalog.pg_operator where oprname='+' and oprleft='float8'::regtype
 ----
 oid       oprname  oprnamespace  oprowner  oprkind  oprcanmerge  oprcanhash  oprleft  oprright  oprresult  oprcom  oprnegate  oprcode  oprrest  oprjoin
-74817020  +        4294967118    NULL      b        false        false       701      701       701        NULL    NULL       NULL     NULL     NULL
+74917020  +        4294967118    NULL      b        false        false       701      701       701        NULL    NULL       NULL     NULL     NULL
 
 # Verify proper functionality of system information functions.
 
@@ -3204,17 +3204,17 @@ JOIN pg_catalog.pg_class c ON def.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-2306804694  t1         12
-2306804700  t1         nextval('public.t1_m_seq'::REGCLASS)
-2306804701  t1         nextval('public.t1_n_seq'::REGCLASS)
-4171354239  t2         unique_rowid()
-1221463949  t3         'FOO'::STRING
-1221463946  t3         unique_rowid()
-1740936492  t4         unique_rowid()
-3086013501  t5         unique_rowid()
-655595746   t6         unique_rowid()
-2000672759  mv1        unique_rowid()
-1249221897  testtable  unique_rowid()
+2306904694  t1         12
+2306904700  t1         nextval('public.t1_m_seq'::REGCLASS)
+2306904701  t1         nextval('public.t1_n_seq'::REGCLASS)
+4171454239  t2         unique_rowid()
+1221563949  t3         'FOO'::STRING
+1221563946  t3         unique_rowid()
+1741036492  t4         unique_rowid()
+3086113501  t5         unique_rowid()
+655695746   t6         unique_rowid()
+2000772759  mv1        unique_rowid()
+1249321897  testtable  unique_rowid()
 
 # Verify that a set database shows tables from that database for a non-root
 # user, when that user has permissions.
@@ -3392,31 +3392,31 @@ JOIN pg_operator c ON c.oprname = '>' AND b.proargtypes[0] = c.oprleft AND b.pro
 WHERE (b.proname = 'max' OR b.proname = 'bool_or') AND c.oid = a.aggsortop;
 ----
 oid         oprname  aggsortop
-3636536082  >        3636536082
-1737252658  >        1737252658
-1737252658  >        1737252658
-1224236426  >        1224236426
-3636536082  >        3636536082
-264553706   >        264553706
-883535762   >        883535762
-1383827510  >        1383827510
-2318307066  >        2318307066
-3234851498  >        3234851498
-256681770   >        256681770
-530358714   >        530358714
-2105536758  >        2105536758
-1928531314  >        1928531314
-1737252658  >        1737252658
-1737252658  >        1737252658
-2948286002  >        2948286002
-2139039570  >        2139039570
-3802002898  >        3802002898
-3457382662  >        3457382662
-3421685890  >        3421685890
-1064453514  >        1064453514
-1778355034  >        1778355034
-3944320082  >        3944320082
-1385359122  >        1385359122
+3636636082  >        3636636082
+1737352658  >        1737352658
+1737352658  >        1737352658
+1224336426  >        1224336426
+3636636082  >        3636636082
+264653706   >        264653706
+883635762   >        883635762
+1383927510  >        1383927510
+2318407066  >        2318407066
+3234951498  >        3234951498
+256781770   >        256781770
+530458714   >        530458714
+2105636758  >        2105636758
+1928631314  >        1928631314
+1737352658  >        1737352658
+1737352658  >        1737352658
+2948386002  >        2948386002
+2139139570  >        2139139570
+3802102898  >        3802102898
+3457482662  >        3457482662
+3421785890  >        3421785890
+1064553514  >        1064553514
+1778455034  >        1778455034
+3944420082  >        3944420082
+1385459122  >        1385459122
 
 # Check whether correct operator's oid is set for min, bool_and and every.
 query OTO colnames,rowsort
@@ -3426,32 +3426,32 @@ JOIN pg_operator c ON c.oprname = '<' AND b.proargtypes[0] = c.oprleft AND b.pro
 WHERE (b.proname = 'min' OR b.proname = 'bool_and' OR b.proname = 'every') AND c.oid = a.aggsortop;
 ----
 oid         oprname  aggsortop
-2134593616  <        2134593616
-2134593616  <        2134593616
-235310192   <        235310192
-235310192   <        235310192
-3859576864  <        3859576864
-2134593616  <        2134593616
-3269496816  <        3269496816
-3676560592  <        3676560592
-2011297100  <        2011297100
-2790955336  <        2790955336
-2457977576  <        2457977576
-426663592   <        426663592
-1494969736  <        1494969736
-2104629996  <        2104629996
-3942776496  <        3942776496
-235310192   <        235310192
-235310192   <        235310192
-1446343536  <        1446343536
-2699108304  <        2699108304
-3842027408  <        3842027408
-2897050084  <        2897050084
-4132205728  <        4132205728
-2300570720  <        2300570720
-3675947880  <        3675947880
-3575809104  <        3575809104
-1579888144  <        1579888144
+2134693616  <        2134693616
+2134693616  <        2134693616
+235410192   <        235410192
+235410192   <        235410192
+3859676864  <        3859676864
+2134693616  <        2134693616
+3269596816  <        3269596816
+3676660592  <        3676660592
+2011397100  <        2011397100
+2791055336  <        2791055336
+2458077576  <        2458077576
+426763592   <        426763592
+1495069736  <        1495069736
+2104729996  <        2104729996
+3942876496  <        3942876496
+235410192   <        235410192
+235410192   <        235410192
+1446443536  <        1446443536
+2699208304  <        2699208304
+3842127408  <        3842127408
+2897150084  <        2897150084
+4132305728  <        4132305728
+2300670720  <        2300670720
+3676047880  <        3676047880
+3575909104  <        3575909104
+1579988144  <        1579988144
 
 subtest collated_string_type
 
@@ -4393,21 +4393,21 @@ query TOBBBBTTT colnames
 SELECT * FROM pg_shadow ORDER BY usename;
 ----
 usename                       usesysid    usecreatedb  usesuper  userepl  usebypassrls  passwd    valuntil                       useconfig
-admin                         2310524507  true         true      false    false         ********  NULL                           NULL
-anyuser                       2525089181  false        false     false    false         ********  NULL                           NULL
-regression_70180              2066478618  false        false     false    false         ********  NULL                           NULL
-regular_user                  3044356792  false        false     false    false         ********  NULL                           NULL
-role_test_login               2531829827  false        false     false    false         ********  NULL                           NULL
-role_test_nodate              1492950893  false        false     false    false         ********  NULL                           NULL
-role_test_with_date           1212615927  false        false     false    false         ********  2021-01-01 00:00:00 +0000 UTC  NULL
-role_test_with_date_timezone  1682504215  false        false     false    false         ********  2020-12-31 22:00:00 +0000 UTC  NULL
-root                          1546506610  true         true      false    false         ********  NULL                           NULL
-sh_owner                      2488412215  false        false     false    false         ********  NULL                           NULL
-sh_user                       2387559583  false        false     false    false         ********  NULL                           NULL
-super_user                    2430969455  false        true      false    false         ********  NULL                           NULL
-testuser                      2264919399  false        false     false    false         ********  NULL                           NULL
-testuser1                     3957504276  true         false     false    false         ********  NULL                           {timezone=America/Los_Angeles,application_name=a}
-testuser2                     3957504279  false        false     false    false         ********  3022-01-01 00:00:00 +0000 UTC  NULL
+admin                         2310624507  true         true      false    false         ********  NULL                           NULL
+anyuser                       2525189181  false        false     false    false         ********  NULL                           NULL
+regression_70180              2066578618  false        false     false    false         ********  NULL                           NULL
+regular_user                  3044456792  false        false     false    false         ********  NULL                           NULL
+role_test_login               2531929827  false        false     false    false         ********  NULL                           NULL
+role_test_nodate              1493050893  false        false     false    false         ********  NULL                           NULL
+role_test_with_date           1212715927  false        false     false    false         ********  2021-01-01 00:00:00 +0000 UTC  NULL
+role_test_with_date_timezone  1682604215  false        false     false    false         ********  2020-12-31 22:00:00 +0000 UTC  NULL
+root                          1546606610  true         true      false    false         ********  NULL                           NULL
+sh_owner                      2488512215  false        false     false    false         ********  NULL                           NULL
+sh_user                       2387659583  false        false     false    false         ********  NULL                           NULL
+super_user                    2431069455  false        true      false    false         ********  NULL                           NULL
+testuser                      2265019399  false        false     false    false         ********  NULL                           NULL
+testuser1                     3957604276  true         false     false    false         ********  NULL                           {timezone=America/Los_Angeles,application_name=a}
+testuser2                     3957604279  false        false     false    false         ********  3022-01-01 00:00:00 +0000 UTC  NULL
 
 # Testing oids references the same roles in pg_shadow and pg_authid
 query B colnames
@@ -4439,165 +4439,165 @@ SELECT * FROM pg_cast
 ORDER BY oid
 ----
 oid         castsource  casttarget  castfunc  castcontext  castmethod
-140679991   1042        25          2205      i            NULL
-140679996   1042        18          2142      a            NULL
-140679997   1042        19          2282      i            NULL
-186882866   869         1042        2342      a            NULL
-186882867   869         1043        2224      a            NULL
-207790440   1042        1042        2347      i            NULL
-207790441   1042        1043        2229      i            NULL
-253993333   869         25          881       a            NULL
-398529196   90002       90002       2362      i            NULL
-398529198   90002       90000       2162      e            NULL
-486164264   1266        1266        2083      i            NULL
-486164449   1266        1083        2287      a            NULL
-519779712   25          25          2205      i            NULL
-519779722   25          19          2282      i            NULL
-519779723   25          18          2142      a            NULL
-586890230   25          1043        2229      i            NULL
-586890231   25          1042        2347      i            NULL
-637806108   700         1700        2355      a            NULL
-641069276   1700        700         2167      i            NULL
-641069277   1700        701         2106      i            NULL
-654000812   25          2205        2237      i            NULL
-674624401   1700        23          2150      a            NULL
-674624402   1700        20          2087      a            NULL
-674624403   1700        21          2300      a            NULL
-704916921   700         701         2112      i            NULL
-705151184   3802        16          2292      e            NULL
-705151188   3802        20          2095      e            NULL
-705151189   3802        21          2308      e            NULL
-705151191   3802        23          2157      e            NULL
-708179464   1700        1700        2349      i            NULL
-718142737   1186        1083        2283      a            NULL
-718142856   1186        1186        2310      i            NULL
-738471997   700         23          2156      a            NULL
-738471998   700         20          2094      a            NULL
-738471999   700         21          2307      a            NULL
-738706266   3802        700         2173      e            NULL
-738706267   3802        701         2113      e            NULL
-805816982   3802        1700        2356      e            NULL
-939073229   25          90000       2165      i            NULL
-1019153911  90002       17          2145      i            NULL
-1039252266  19          25          2205      i            NULL
-1106362732  19          1043        2229      a            NULL
-1106362733  19          1042        2347      a            NULL
-1298988567  16          23          2153      e            NULL
-1298988569  16          25          2193      a            NULL
-1366099038  16          1042        2335      a            NULL
-1366099039  16          1043        2217      a            NULL
-1418646496  1043        1043        2229      i            NULL
-1418646497  1043        1042        2347      i            NULL
-1485756966  1043        25          2205      i            NULL
-1485756972  1043        19          2282      i            NULL
-1485756973  1043        18          2142      a            NULL
-1619977802  1043        2205        2237      i            NULL
-1646747850  26          4089        2232      i            NULL
-1730635912  26          2202        2176      i            NULL
-1730635916  26          2206        2179      i            NULL
-1730635919  26          2205        2235      i            NULL
-1864856754  26          24          2316      i            NULL
-1864856765  26          23          2152      a            NULL
-1864856766  26          20          2089      a            NULL
-1940039391  23          4089        2233      i            NULL
-1984069072  1560        1560        2102      i            NULL
-1984069074  1560        1562        2242      i            NULL
-1990371905  23          2206        2180      i            NULL
-1990371906  23          2205        2236      i            NULL
-1990371909  23          2202        2177      i            NULL
-2083548972  701         23          2156      a            NULL
-2083548974  701         21          2307      a            NULL
-2083548975  701         20          2094      a            NULL
-2084734765  1560        23          2148      e            NULL
-2084734766  1560        20          2085      e            NULL
-2091037769  23          1560        2103      e            NULL
-2091037941  23          1700        2352      i            NULL
-2117104349  701         700         2175      a            NULL
-2124592994  23          21          2304      a            NULL
-2124592995  23          20          2091      i            NULL
-2124592997  23          18          2131      e            NULL
-2124592999  23          16          2290      e            NULL
-2124593005  23          26          2256      i            NULL
-2124593007  23          24          2317      i            NULL
-2133298650  26          4096        2249      i            NULL
-2146493458  1114        1184        2246      i            NULL
-2146493576  1114        1082        2320      a            NULL
-2146493577  1114        1083        2285      a            NULL
-2146493672  1114        1114        2099      i            NULL
-2158148128  23          701         2109      i            NULL
-2158148129  23          700         2170      i            NULL
-2173360273  2205        20          2089      a            NULL
-2173360274  2205        23          2152      a            NULL
-2173360287  2205        26          2258      i            NULL
-2184214537  701         1700        2355      a            NULL
-2188735018  1184        1114        2100      a            NULL
-2188735050  1184        1082        2321      a            NULL
-2188735051  1184        1083        2286      a            NULL
-2188735106  1184        1266        2082      a            NULL
-2188735184  1184        1184        2247      i            NULL
-2233330912  20          4089        2233      i            NULL
-2250108209  20          2205        2236      i            NULL
-2250108210  20          2206        2180      i            NULL
-2250108214  20          2202        2177      i            NULL
-2350774022  20          1560        2103      e            NULL
-2350774202  20          1700        2352      i            NULL
-2384329297  20          21          2304      a            NULL
-2384329299  20          23          2159      a            NULL
-2384329308  20          24          2317      i            NULL
-2384329310  20          26          2256      i            NULL
-2393034919  23          4096        2250      i            NULL
-2417884630  20          700         2170      i            NULL
-2417884631  20          701         2109      i            NULL
-2424867656  1082        1114        2097      i            NULL
-2424867762  1082        1184        2244      i            NULL
-2433096517  2202        23          2152      a            NULL
-2433096518  2202        20          2089      a            NULL
-2433096520  2202        26          2258      i            NULL
-2433096522  2202        24          2316      i            NULL
-2456191196  90000       3802        2252      e            NULL
-2493265536  4089        20          2089      a            NULL
-2493265539  4089        23          2152      a            NULL
-2493265550  4089        26          2258      i            NULL
-2623967189  90000       17          2144      i            NULL
-2623967197  90000       25          2190      i            NULL
-2652771188  20          4096        2250      i            NULL
-2794916917  17          90000       2163      i            NULL
-2794916919  17          90002       2363      i            NULL
-3132647220  90004       90000       2160      i            NULL
-3335448938  24          2202        2176      i            NULL
-3460964389  21          4096        2250      i            NULL
-3469670034  24          26          2258      i            NULL
-3469670044  24          20          2089      a            NULL
-3469670047  24          23          2152      a            NULL
-3518437249  2206        23          2152      a            NULL
-3518437250  2206        20          2089      a            NULL
-3518437260  2206        26          2258      i            NULL
-3628740423  21          1700        2352      i            NULL
-3635723561  1083        1186        2312      i            NULL
-3635723641  1083        1266        2081      i            NULL
-3635723696  1083        1083        2284      i            NULL
-3695851154  21          701         2109      i            NULL
-3695851155  21          700         2170      i            NULL
-3729406273  21          20          2091      i            NULL
-3729406274  21          23          2159      i            NULL
-3729406285  21          24          2317      i            NULL
-3729406287  21          26          2256      i            NULL
-3746183697  21          4089        2233      i            NULL
-3790213776  1562        1562        2242      i            NULL
-3790213778  1562        1560        2102      i            NULL
-3815325360  90000       90000       2161      i            NULL
-3815325362  90000       90002       2361      i            NULL
-3815325364  90000       90004       2358      i            NULL
-3854332660  4096        20          2089      a            NULL
-3854332663  4096        23          2152      a            NULL
-3854332666  4096        26          2258      i            NULL
-3863627120  21          2205        2236      i            NULL
-3863627123  21          2206        2180      i            NULL
-3863627127  21          2202        2177      i            NULL
-3922032068  18          1042        2347      a            NULL
-3922032069  18          1043        2229      a            NULL
-3989142581  18          23          2158      e            NULL
-3989142587  18          25          2205      i            NULL
+140779991   1042        25          2205      i            NULL
+140779996   1042        18          2142      a            NULL
+140779997   1042        19          2282      i            NULL
+186982866   869         1042        2342      a            NULL
+186982867   869         1043        2224      a            NULL
+207890440   1042        1042        2347      i            NULL
+207890441   1042        1043        2229      i            NULL
+254093333   869         25          881       a            NULL
+398629196   90002       90002       2362      i            NULL
+398629198   90002       90000       2162      e            NULL
+486264264   1266        1266        2083      i            NULL
+486264449   1266        1083        2287      a            NULL
+519879712   25          25          2205      i            NULL
+519879722   25          19          2282      i            NULL
+519879723   25          18          2142      a            NULL
+586990230   25          1043        2229      i            NULL
+586990231   25          1042        2347      i            NULL
+637906108   700         1700        2355      a            NULL
+641169276   1700        700         2167      i            NULL
+641169277   1700        701         2106      i            NULL
+654100812   25          2205        2237      i            NULL
+674724401   1700        23          2150      a            NULL
+674724402   1700        20          2087      a            NULL
+674724403   1700        21          2300      a            NULL
+705016921   700         701         2112      i            NULL
+705251184   3802        16          2292      e            NULL
+705251188   3802        20          2095      e            NULL
+705251189   3802        21          2308      e            NULL
+705251191   3802        23          2157      e            NULL
+708279464   1700        1700        2349      i            NULL
+718242737   1186        1083        2283      a            NULL
+718242856   1186        1186        2310      i            NULL
+738571997   700         23          2156      a            NULL
+738571998   700         20          2094      a            NULL
+738571999   700         21          2307      a            NULL
+738806266   3802        700         2173      e            NULL
+738806267   3802        701         2113      e            NULL
+805916982   3802        1700        2356      e            NULL
+939173229   25          90000       2165      i            NULL
+1019253911  90002       17          2145      i            NULL
+1039352266  19          25          2205      i            NULL
+1106462732  19          1043        2229      a            NULL
+1106462733  19          1042        2347      a            NULL
+1299088567  16          23          2153      e            NULL
+1299088569  16          25          2193      a            NULL
+1366199038  16          1042        2335      a            NULL
+1366199039  16          1043        2217      a            NULL
+1418746496  1043        1043        2229      i            NULL
+1418746497  1043        1042        2347      i            NULL
+1485856966  1043        25          2205      i            NULL
+1485856972  1043        19          2282      i            NULL
+1485856973  1043        18          2142      a            NULL
+1620077802  1043        2205        2237      i            NULL
+1646847850  26          4089        2232      i            NULL
+1730735912  26          2202        2176      i            NULL
+1730735916  26          2206        2179      i            NULL
+1730735919  26          2205        2235      i            NULL
+1864956754  26          24          2316      i            NULL
+1864956765  26          23          2152      a            NULL
+1864956766  26          20          2089      a            NULL
+1940139391  23          4089        2233      i            NULL
+1984169072  1560        1560        2102      i            NULL
+1984169074  1560        1562        2242      i            NULL
+1990471905  23          2206        2180      i            NULL
+1990471906  23          2205        2236      i            NULL
+1990471909  23          2202        2177      i            NULL
+2083648972  701         23          2156      a            NULL
+2083648974  701         21          2307      a            NULL
+2083648975  701         20          2094      a            NULL
+2084834765  1560        23          2148      e            NULL
+2084834766  1560        20          2085      e            NULL
+2091137769  23          1560        2103      e            NULL
+2091137941  23          1700        2352      i            NULL
+2117204349  701         700         2175      a            NULL
+2124692994  23          21          2304      a            NULL
+2124692995  23          20          2091      i            NULL
+2124692997  23          18          2131      e            NULL
+2124692999  23          16          2290      e            NULL
+2124693005  23          26          2256      i            NULL
+2124693007  23          24          2317      i            NULL
+2133398650  26          4096        2249      i            NULL
+2146593458  1114        1184        2246      i            NULL
+2146593576  1114        1082        2320      a            NULL
+2146593577  1114        1083        2285      a            NULL
+2146593672  1114        1114        2099      i            NULL
+2158248128  23          701         2109      i            NULL
+2158248129  23          700         2170      i            NULL
+2173460273  2205        20          2089      a            NULL
+2173460274  2205        23          2152      a            NULL
+2173460287  2205        26          2258      i            NULL
+2184314537  701         1700        2355      a            NULL
+2188835018  1184        1114        2100      a            NULL
+2188835050  1184        1082        2321      a            NULL
+2188835051  1184        1083        2286      a            NULL
+2188835106  1184        1266        2082      a            NULL
+2188835184  1184        1184        2247      i            NULL
+2233430912  20          4089        2233      i            NULL
+2250208209  20          2205        2236      i            NULL
+2250208210  20          2206        2180      i            NULL
+2250208214  20          2202        2177      i            NULL
+2350874022  20          1560        2103      e            NULL
+2350874202  20          1700        2352      i            NULL
+2384429297  20          21          2304      a            NULL
+2384429299  20          23          2159      a            NULL
+2384429308  20          24          2317      i            NULL
+2384429310  20          26          2256      i            NULL
+2393134919  23          4096        2250      i            NULL
+2417984630  20          700         2170      i            NULL
+2417984631  20          701         2109      i            NULL
+2424967656  1082        1114        2097      i            NULL
+2424967762  1082        1184        2244      i            NULL
+2433196517  2202        23          2152      a            NULL
+2433196518  2202        20          2089      a            NULL
+2433196520  2202        26          2258      i            NULL
+2433196522  2202        24          2316      i            NULL
+2456291196  90000       3802        2252      e            NULL
+2493365536  4089        20          2089      a            NULL
+2493365539  4089        23          2152      a            NULL
+2493365550  4089        26          2258      i            NULL
+2624067189  90000       17          2144      i            NULL
+2624067197  90000       25          2190      i            NULL
+2652871188  20          4096        2250      i            NULL
+2795016917  17          90000       2163      i            NULL
+2795016919  17          90002       2363      i            NULL
+3132747220  90004       90000       2160      i            NULL
+3335548938  24          2202        2176      i            NULL
+3461064389  21          4096        2250      i            NULL
+3469770034  24          26          2258      i            NULL
+3469770044  24          20          2089      a            NULL
+3469770047  24          23          2152      a            NULL
+3518537249  2206        23          2152      a            NULL
+3518537250  2206        20          2089      a            NULL
+3518537260  2206        26          2258      i            NULL
+3628840423  21          1700        2352      i            NULL
+3635823561  1083        1186        2312      i            NULL
+3635823641  1083        1266        2081      i            NULL
+3635823696  1083        1083        2284      i            NULL
+3695951154  21          701         2109      i            NULL
+3695951155  21          700         2170      i            NULL
+3729506273  21          20          2091      i            NULL
+3729506274  21          23          2159      i            NULL
+3729506285  21          24          2317      i            NULL
+3729506287  21          26          2256      i            NULL
+3746283697  21          4089        2233      i            NULL
+3790313776  1562        1562        2242      i            NULL
+3790313778  1562        1560        2102      i            NULL
+3815425360  90000       90000       2161      i            NULL
+3815425362  90000       90002       2361      i            NULL
+3815425364  90000       90004       2358      i            NULL
+3854432660  4096        20          2089      a            NULL
+3854432663  4096        23          2152      a            NULL
+3854432666  4096        26          2258      i            NULL
+3863727120  21          2205        2236      i            NULL
+3863727123  21          2206        2180      i            NULL
+3863727127  21          2202        2177      i            NULL
+3922132068  18          1042        2347      a            NULL
+3922132069  18          1043        2229      a            NULL
+3989242581  18          23          2158      e            NULL
+3989242587  18          25          2205      i            NULL
 
 subtest seq_bound_should_consistent_with_session_var
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
@@ -9,10 +9,10 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {=r/}
-1451375629  1546506610  0                S              {=r/}
-1451375629  1546506610  0                n              {=U/}
-1451375629  1546506610  0                f              {=X/}
+1451475629  1546606610  0                r              {=r/}
+1451475629  1546606610  0                S              {=r/}
+1451475629  1546606610  0                n              {=U/}
+1451475629  1546606610  0                f              {=X/}
 
 statement ok
 CREATE USER foo
@@ -31,11 +31,11 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
-1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
-1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
-1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
+1451475629  1546606610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451475629  1546606610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451475629  1546606610  0                T              {bar=U*/,foo=U*/}
+1451475629  1546606610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
+1451475629  1546606610  0                f              {bar=X*/,foo=X*/,=X/}
 
 statement ok
 GRANT foo, bar TO root;
@@ -52,21 +52,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,foo=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/,foo=C*U*/}
-97389596    1791217281  0                f              {bar=X*/,foo=X*/}
-3755498903  2026795574  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
-3755498903  2026795574  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {bar=U*/,foo=U*/,=U/}
-3755498903  2026795574  0                n              {bar=C*U*/,foo=C*U*/}
-3755498903  2026795574  0                f              {bar=X*/,foo=X*/}
-1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
-1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
-1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
-1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,foo=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/,foo=C*U*/}
+97489596    1791317281  0                f              {bar=X*/,foo=X*/}
+3755598903  2026895574  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
+3755598903  2026895574  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {bar=U*/,foo=U*/,=U/}
+3755598903  2026895574  0                n              {bar=C*U*/,foo=C*U*/}
+3755598903  2026895574  0                f              {bar=X*/,foo=X*/}
+1451475629  1546606610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451475629  1546606610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451475629  1546606610  0                T              {bar=U*/,foo=U*/}
+1451475629  1546606610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
+1451475629  1546606610  0                f              {bar=X*/,foo=X*/,=X/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -81,21 +81,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {}
-97389596    1791217281  0                S              {}
-97389596    1791217281  0                T              {=U/}
-97389596    1791217281  0                n              {}
-97389596    1791217281  0                f              {}
-3755498903  2026795574  0                r              {}
-3755498903  2026795574  0                S              {}
-3755498903  2026795574  0                T              {=U/}
-3755498903  2026795574  0                n              {}
-3755498903  2026795574  0                f              {}
-1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
-1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
-1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
-1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
+97489596    1791317281  0                r              {}
+97489596    1791317281  0                S              {}
+97489596    1791317281  0                T              {=U/}
+97489596    1791317281  0                n              {}
+97489596    1791317281  0                f              {}
+3755598903  2026895574  0                r              {}
+3755598903  2026895574  0                S              {}
+3755598903  2026895574  0                T              {=U/}
+3755598903  2026895574  0                n              {}
+3755598903  2026895574  0                f              {}
+1451475629  1546606610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451475629  1546606610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451475629  1546606610  0                T              {bar=U*/,foo=U*/}
+1451475629  1546606610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
+1451475629  1546606610  0                f              {bar=X*/,foo=X*/,=X/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT ALL ON TABLES TO foo WITH GRANT OPTION;
@@ -115,21 +115,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*r*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
-1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
-1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
-1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
-1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*r*w*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
+1451475629  1546606610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451475629  1546606610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451475629  1546606610  0                T              {bar=U*/,foo=U*/}
+1451475629  1546606610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
+1451475629  1546606610  0                f              {bar=X*/,foo=X*/,=X/}
 
 # Revoke SELECT from foo and GRANT it back with foo being the creator role.
 # Ensure revoking a single privilege reflects correctly.
@@ -140,21 +140,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
-1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
-1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
-1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
-1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*w*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
+1451475629  1546606610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451475629  1546606610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451475629  1546606610  0                T              {bar=U*/,foo=U*/}
+1451475629  1546606610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
+1451475629  1546606610  0                f              {bar=X*/,foo=X*/,=X/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT SELECT ON TABLES TO foo;
@@ -163,21 +163,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
-1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
-1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
-1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
-1451375629  1546506610  0                f              {bar=X*/,foo=X*/,=X/}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*rw*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
+1451475629  1546606610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451475629  1546606610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451475629  1546606610  0                T              {bar=U*/,foo=U*/}
+1451475629  1546606610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
+1451475629  1546606610  0                f              {bar=X*/,foo=X*/,=X/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;
@@ -192,17 +192,17 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
-1451375629  1546506610  0                r              {bar=C*a*d*w*/,foo=C*a*d*w*/}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*rw*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
+1451475629  1546606610  0                r              {bar=C*a*d*w*/,foo=C*a*d*w*/}
 
 # GRANT, DROP and ZONECONFIG should not show up in defaclacl.
 statement ok
@@ -213,17 +213,17 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
-1451375629  1546506610  0                r              {foo=/}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*rw*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
+1451475629  1546606610  0                r              {foo=/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE DROP, ZONECONFIG ON TABLES FROM foo;
@@ -241,21 +241,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
-880552153   0           0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
-880552153   0           0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
-880552153   0           0                T              {bar=U*/,foo=U*/}
-880552153   0           0                n              {bar=C*U*/,foo=C*U*/}
-880552153   0           0                f              {bar=X*/,foo=X*/}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*rw*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
+880652153   0           0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
+880652153   0           0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
+880652153   0           0                T              {bar=U*/,foo=U*/}
+880652153   0           0                n              {bar=C*U*/,foo=C*U*/}
+880652153   0           0                f              {bar=X*/,foo=X*/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE ALL ON TABLES FROM foo, bar;
@@ -268,16 +268,16 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*rw*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
 
 user testuser
 
@@ -294,21 +294,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
-2709666228  2264919399  0                r              {}
-2709666228  2264919399  0                S              {}
-2709666228  2264919399  0                T              {=U/}
-2709666228  2264919399  0                n              {}
-2709666228  2264919399  0                f              {}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*rw*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
+2709766228  2265019399  0                r              {}
+2709766228  2265019399  0                S              {}
+2709766228  2265019399  0                T              {=U/}
+2709766228  2265019399  0                n              {}
+2709766228  2265019399  0                f              {}
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM public;
@@ -318,21 +318,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
-2709666228  2264919399  0                r              {}
-2709666228  2264919399  0                S              {}
-2709666228  2264919399  0                T              {}
-2709666228  2264919399  0                n              {}
-2709666228  2264919399  0                f              {}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*rw*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
+2709766228  2265019399  0                r              {}
+2709766228  2265019399  0                S              {}
+2709766228  2265019399  0                T              {}
+2709766228  2265019399  0                n              {}
+2709766228  2265019399  0                f              {}
 
 
 statement ok
@@ -344,21 +344,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
-2709666228  2264919399  0                r              {}
-2709666228  2264919399  0                S              {}
-2709666228  2264919399  0                T              {testuser=U*/}
-2709666228  2264919399  0                n              {}
-2709666228  2264919399  0                f              {}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*rw*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
+2709766228  2265019399  0                r              {}
+2709766228  2265019399  0                S              {}
+2709766228  2265019399  0                T              {testuser=U*/}
+2709766228  2265019399  0                n              {}
+2709766228  2265019399  0                f              {}
 
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO foo WITH GRANT OPTION;
@@ -373,18 +373,18 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/}
-97389596    1791217281  0                f              {bar=X*/}
-3755498903  2026795574  0                r              {foo=C*a*d*rw*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-3755498903  2026795574  0                n              {foo=C*U*/}
-3755498903  2026795574  0                f              {foo=X*/}
-2709666228  2264919399  0                r              {foo=C*a*d*r*w*/}
-2709666228  2264919399  0                S              {foo=C*U*a*d*r*w*/}
-2709666228  2264919399  0                T              {foo=U*/,testuser=U*/}
-2709666228  2264919399  0                n              {foo=C*U*/}
-2709666228  2264919399  0                f              {foo=X*/}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/}
+97489596    1791317281  0                f              {bar=X*/}
+3755598903  2026895574  0                r              {foo=C*a*d*rw*/}
+3755598903  2026895574  0                S              {foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+3755598903  2026895574  0                n              {foo=C*U*/}
+3755598903  2026895574  0                f              {foo=X*/}
+2709766228  2265019399  0                r              {foo=C*a*d*r*w*/}
+2709766228  2265019399  0                S              {foo=C*U*a*d*r*w*/}
+2709766228  2265019399  0                T              {foo=U*/,testuser=U*/}
+2709766228  2265019399  0                n              {foo=C*U*/}
+2709766228  2265019399  0                f              {foo=X*/}

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl_with_grant_option
@@ -17,9 +17,9 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {=r/}
-1451375629  1546506610  0                S              {=r/}
-1451375629  1546506610  0                n              {=U/}
+1451475629  1546606610  0                r              {=r/}
+1451475629  1546606610  0                S              {=r/}
+1451475629  1546606610  0                n              {=U/}
 
 statement ok
 CREATE USER foo
@@ -38,11 +38,11 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
-1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
-1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
-1451375629  1546506610  0                f              {bar=X*/,foo=X*/}
+1451475629  1546606610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+1451475629  1546606610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451475629  1546606610  0                T              {bar=U*/,foo=U*/}
+1451475629  1546606610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
+1451475629  1546606610  0                f              {bar=X*/,foo=X*/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR SELECT, DELETE ON TABLES FROM foo, bar;
@@ -55,11 +55,11 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=C*a*drw*/,foo=C*a*drw*/,=r/}
-1451375629  1546506610  0                S              {bar=CU*a*d*r*w/,foo=CU*a*d*r*w/,=r/}
-1451375629  1546506610  0                T              {bar=U/,foo=U/}
-1451375629  1546506610  0                n              {bar=CU*/,foo=CU*/,=U/}
-1451375629  1546506610  0                f              {bar=X/,foo=X/}
+1451475629  1546606610  0                r              {bar=C*a*drw*/,foo=C*a*drw*/,=r/}
+1451475629  1546606610  0                S              {bar=CU*a*d*r*w/,foo=CU*a*d*r*w/,=r/}
+1451475629  1546606610  0                T              {bar=U/,foo=U/}
+1451475629  1546606610  0                n              {bar=CU*/,foo=CU*/,=U/}
+1451475629  1546606610  0                f              {bar=X/,foo=X/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR ALL ON TABLES FROM foo, bar;
@@ -72,11 +72,11 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
-1451375629  1546506610  0                T              {bar=U/,foo=U/}
-1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
-1451375629  1546506610  0                f              {bar=X/,foo=X/}
+1451475629  1546606610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451475629  1546606610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451475629  1546606610  0                T              {bar=U/,foo=U/}
+1451475629  1546606610  0                n              {bar=CU/,foo=CU/,=U/}
+1451475629  1546606610  0                f              {bar=X/,foo=X/}
 
 statement ok
 GRANT foo, bar TO root;
@@ -93,21 +93,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
-97389596    1791217281  0                T              {bar=U*/,foo=U*/,=U/}
-97389596    1791217281  0                n              {bar=C*U*/,foo=C*U*/}
-97389596    1791217281  0                f              {bar=X*/,foo=X*/}
-3755498903  2026795574  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
-3755498903  2026795574  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
-3755498903  2026795574  0                T              {bar=U*/,foo=U*/,=U/}
-3755498903  2026795574  0                n              {bar=C*U*/,foo=C*U*/}
-3755498903  2026795574  0                f              {bar=X*/,foo=X*/}
-1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
-1451375629  1546506610  0                T              {bar=U/,foo=U/}
-1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
-1451375629  1546506610  0                f              {bar=X/,foo=X/}
+97489596    1791317281  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
+97489596    1791317281  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
+97489596    1791317281  0                T              {bar=U*/,foo=U*/,=U/}
+97489596    1791317281  0                n              {bar=C*U*/,foo=C*U*/}
+97489596    1791317281  0                f              {bar=X*/,foo=X*/}
+3755598903  2026895574  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
+3755598903  2026895574  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
+3755598903  2026895574  0                T              {bar=U*/,foo=U*/,=U/}
+3755598903  2026895574  0                n              {bar=C*U*/,foo=C*U*/}
+3755598903  2026895574  0                f              {bar=X*/,foo=X*/}
+1451475629  1546606610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451475629  1546606610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451475629  1546606610  0                T              {bar=U/,foo=U/}
+1451475629  1546606610  0                n              {bar=CU/,foo=CU/,=U/}
+1451475629  1546606610  0                f              {bar=X/,foo=X/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -122,21 +122,21 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {}
-97389596    1791217281  0                S              {}
-97389596    1791217281  0                T              {=U/}
-97389596    1791217281  0                n              {}
-97389596    1791217281  0                f              {}
-3755498903  2026795574  0                r              {}
-3755498903  2026795574  0                S              {}
-3755498903  2026795574  0                T              {=U/}
-3755498903  2026795574  0                n              {}
-3755498903  2026795574  0                f              {}
-1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
-1451375629  1546506610  0                T              {bar=U/,foo=U/}
-1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
-1451375629  1546506610  0                f              {bar=X/,foo=X/}
+97489596    1791317281  0                r              {}
+97489596    1791317281  0                S              {}
+97489596    1791317281  0                T              {=U/}
+97489596    1791317281  0                n              {}
+97489596    1791317281  0                f              {}
+3755598903  2026895574  0                r              {}
+3755598903  2026895574  0                S              {}
+3755598903  2026895574  0                T              {=U/}
+3755598903  2026895574  0                n              {}
+3755598903  2026895574  0                f              {}
+1451475629  1546606610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451475629  1546606610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451475629  1546606610  0                T              {bar=U/,foo=U/}
+1451475629  1546606610  0                n              {bar=CU/,foo=CU/,=U/}
+1451475629  1546606610  0                f              {bar=X/,foo=X/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT ALL ON TABLES TO foo;
@@ -169,11 +169,11 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
-1451375629  1546506610  0                T              {bar=U/,foo=U/}
-1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
-1451375629  1546506610  0                f              {bar=X/,foo=X/}
+1451475629  1546606610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451475629  1546606610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451475629  1546606610  0                T              {bar=U/,foo=U/}
+1451475629  1546606610  0                n              {bar=CU/,foo=CU/,=U/}
+1451475629  1546606610  0                f              {bar=X/,foo=X/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT USAGE ON TYPES TO foo WITH GRANT OPTION
@@ -183,12 +183,12 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-3755498903  2026795574  0                T              {foo=U*/,=U/}
-1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
-1451375629  1546506610  0                T              {bar=U/,foo=U/}
-1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
-1451375629  1546506610  0                f              {bar=X/,foo=X/}
+3755598903  2026895574  0                T              {foo=U*/,=U/}
+1451475629  1546606610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451475629  1546606610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451475629  1546606610  0                T              {bar=U/,foo=U/}
+1451475629  1546606610  0                n              {bar=CU/,foo=CU/,=U/}
+1451475629  1546606610  0                f              {bar=X/,foo=X/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo REVOKE GRANT OPTION FOR USAGE ON TYPES FROM foo
@@ -198,8 +198,8 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
-1451375629  1546506610  0                T              {bar=U/,foo=U/}
-1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
-1451375629  1546506610  0                f              {bar=X/,foo=X/}
+1451475629  1546606610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+1451475629  1546606610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451475629  1546606610  0                T              {bar=U/,foo=U/}
+1451475629  1546606610  0                n              {bar=CU/,foo=CU/,=U/}
+1451475629  1546606610  0                f              {bar=X/,foo=X/}

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -141,7 +141,7 @@ public  105
 query OO
 SELECT 'root'::REGROLE, 'root'::REGROLE::OID
 ----
-root  1546506610
+root  1546606610
 
 query OO
 SELECT 'bool'::REGTYPE, 'bool'::REGTYPE::OID

--- a/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
@@ -83,7 +83,7 @@ ALTER DATABASE d OWNER TO testuser
 query TT
 SELECT datname, datdba FROM pg_database WHERE datname='d'
 ----
-d  2264919399
+d  2265019399
 
 # Switch to database d so it can reassign from current db
 statement ok
@@ -96,7 +96,7 @@ REASSIGN OWNED BY testuser TO testuser2
 query TT
 SELECT datname, datdba FROM pg_database WHERE datname='d'
 ----
-d  3957504279
+d  3957604279
 
 user testuser2
 
@@ -132,8 +132,8 @@ CREATE SCHEMA s2
 query TT
 SELECT nspname, nspowner FROM pg_namespace WHERE nspname='s1' OR nspname='s2'
 ----
-s1  2264919399
-s2  1546506610
+s1  2265019399
+s2  1546606610
 
 # root / superusers can always perform REASSIGN OWNED BY.
 user root
@@ -147,8 +147,8 @@ user testuser2
 query TT
 SELECT nspname, nspowner FROM pg_namespace WHERE nspname='s1' OR nspname='s2'
 ----
-s1  3957504279
-s2  3957504279
+s1  3957604279
+s2  3957604279
 
 # Ensure testuser2 is new owner by dropping.
 statement ok
@@ -196,7 +196,7 @@ ALTER TYPE s.typ OWNER to testuser
 query TT
 SELECT nspname, nspowner FROM pg_namespace WHERE nspname='s'
 ----
-s  2264919399
+s  2265019399
 
 query TT
 SELECT tablename, tableowner FROM pg_tables WHERE tablename='t'
@@ -206,8 +206,8 @@ t  testuser
 query TT
 SELECT typname, typowner FROM pg_type WHERE typname='_typ' OR typname='typ'
 ----
-typ   2264919399
-_typ  2264919399
+typ   2265019399
+_typ  2265019399
 
 statement ok
 REASSIGN OWNED BY testuser TO testuser2
@@ -216,7 +216,7 @@ REASSIGN OWNED BY testuser TO testuser2
 query TT
 SELECT nspname, nspowner FROM pg_namespace WHERE nspname='s'
 ----
-s  3957504279
+s  3957604279
 
 query TT
 SELECT tablename, tableowner FROM pg_tables WHERE tablename='t'
@@ -226,8 +226,8 @@ t  testuser2
 query TT
 SELECT typname, typowner FROM pg_type WHERE typname='_typ' OR typname='typ'
 ----
-typ   3957504279
-_typ  3957504279
+typ   3957604279
+_typ  3957604279
 
 # Ensure testuser2 is owner by dropping as member of testuser2.
 user testuser2
@@ -272,8 +272,8 @@ ALTER TABLE d.t2 OWNER TO testuser
 query TT
 SELECT datname, datdba FROM pg_database WHERE datname='d' OR datname='test'
 ----
-d     2264919399
-test  1546506610
+d     2265019399
+test  1546606610
 
 query TT
 SELECT tablename, tableowner FROM pg_tables WHERE tablename='t1'
@@ -303,8 +303,8 @@ REASSIGN OWNED BY testuser TO testuser2
 query TT
 SELECT datname, datdba FROM pg_database WHERE datname='d' OR datname='test'
 ----
-d     2264919399
-test  1546506610
+d     2265019399
+test  1546606610
 
 query TT
 SELECT tablename, tableowner FROM pg_tables WHERE tablename='t1'

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -174,9 +174,9 @@ query TTTTTBBBTITTTTTT
 SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict, proretset, provolatile, pronargs, prorettype, proargtypes, proargmodes, proargnames, prokind, prosrc
 FROM pg_catalog.pg_proc WHERE proname IN ('proc_f', 'proc_f_2');
 ----
-100118  proc_f    105  1546506610  14  false  false  false  v  1  20  20     {i}    NULL    f  SELECT 1;
-100119  proc_f    105  1546506610  14  true   true   false  i  2  25  25 20  {i,i}  {"",b}  f  SELECT 'hello';
-100121  proc_f_2  120  1546506610  14  false  false  false  v  1  25  25     {i}    NULL    f  SELECT 'hello';
+100118  proc_f    105  1546606610  14  false  false  false  v  1  20  20     {i}    NULL    f  SELECT 1;
+100119  proc_f    105  1546606610  14  true   true   false  i  2  25  25 20  {i,i}  {"",b}  f  SELECT 'hello';
+100121  proc_f_2  120  1546606610  14  false  false  false  v  1  25  25     {i}    NULL    f  SELECT 'hello';
 
 # Ensure that the pg_proc virtual index works properly.
 
@@ -3094,10 +3094,10 @@ SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict,
 FROM pg_catalog.pg_proc WHERE proname IN ('f_93314', 'f_93314_alias', 'f_93314_comp', 'f_93314_comp_t')
 ORDER BY oid;
 ----
-100272  f_93314         105  1546506610  14  false  false  false  v  0  100271  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
-100274  f_93314_alias   105  1546506610  14  false  false  false  v  0  100273  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
-100278  f_93314_comp    105  1546506610  14  false  false  false  v  0  100275  ·  {}  NULL  SELECT (1, 2);
-100279  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100277  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
+100272  f_93314         105  1546606610  14  false  false  false  v  0  100271  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
+100274  f_93314_alias   105  1546606610  14  false  false  false  v  0  100273  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
+100278  f_93314_comp    105  1546606610  14  false  false  false  v  0  100275  ·  {}  NULL  SELECT (1, 2);
+100279  f_93314_comp_t  105  1546606610  14  false  false  false  v  0  100277  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
 
 # Regression test for #95240. Strict UDFs that are inlined should result in NULL
 # when presented with NULL arguments.

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
+	"math"
 	"strings"
 	"time"
 	"unicode"
@@ -36,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -1128,11 +1130,11 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 					if err != nil {
 						if errors.Is(err, catalog.ErrDescriptorNotFound) ||
 							catalog.HasInactiveDescriptorError(err) {
-							// No table found, so no rows. In this case, we'll fall back to the
-							// full table scan if the index isn't complete - see the
-							// indexContainsNonTableDescriptorIDs parameter.
+							// No table found, so no rows. If know this value is
+							// not a hashed OID we can safely say the table was populated
+							// and skip an expensive step populating the full tables.
 							//nolint:returnerrcheck
-							return false, nil
+							return !IsMaybeHashedOid(oid.Oid(id)), nil
 						}
 						return false, err
 					}
@@ -4675,6 +4677,11 @@ type oidHasher struct {
 	h hash.Hash32
 }
 
+// IsMaybeHashedOid returns if the OID value is possibly a hashed value.
+func IsMaybeHashedOid(o oid.Oid) bool {
+	return o > oidext.CockroachPredefinedOIDMax
+}
+
 func makeOidHasher() oidHasher {
 	return oidHasher{h: fnv.New32()}
 }
@@ -4740,6 +4747,10 @@ func (h oidHasher) writeTypeTag(tag oidTypeTag) {
 
 func (h oidHasher) getOid() *tree.DOid {
 	i := h.h.Sum32()
+	// Ensure generated OID hashes are above the pre-defined max limit,
+	// this gives us a cheap filter.
+	i = i%(math.MaxUint32-oidext.CockroachPredefinedOIDMax) +
+		oidext.CockroachPredefinedOIDMax
 	h.h.Reset()
 	return tree.NewDOid(oid.Oid(i))
 }


### PR DESCRIPTION
Due to the recent increase in table sizes for builtins, certain tables like pg_class are now joining on hundreds of rows. While these tables contain virtual indexes, these virtual indexes will return to full table scan if an OID is not found. That's because they have no way of knowing if the OID is a hashed index or a descriptor ID. To address this, these changes are going to alter OID hashing, so that OID hashes are generated at values greater than CockroachPredefinedOIDMax. This then allows virtual indexes to avoid full table scans if the value matched is not found (i.e. if its a builtin function reference).

Fixes: #102851

Release note (sql change): OID generation for pg_catalog has changed. For example column, index and constraint OID's will have different values. Relation, type and function OID's are unchanged.


Benchmark difference after this change:
````
Before:
BenchmarkORMQueries/introspection_description_join-16                          1        43943592221 ns/op              134.0 roundtrips

After:
BenchmarkORMQueries/introspection_description_join-16                          1        8972831474 ns/op               134.0 roundtrips
````

```
goarch: arm64
                                             │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BxbnSBiT4e/bench.ae796e15493 │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BxbnSBiT4e/bench.a5ad91451a4 │
                                             │                                      sec/op                                       │                          sec/op                            vs base                │
ORMQueries/introspection_description_join-10                                                                         26.639 ± 3%                                                  4.874 ± 3%  -81.70% (p=0.000 n=10)

                                             │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BxbnSBiT4e/bench.ae796e15493 │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BxbnSBiT4e/bench.a5ad91451a4 │
                                             │                                    roundtrips                                     │                          roundtrips                            vs base            │
ORMQueries/introspection_description_join-10                                                                          134.0 ± 0%                                                      134.0 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                                             │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BxbnSBiT4e/bench.ae796e15493 │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BxbnSBiT4e/bench.a5ad91451a4 │
                                             │                                       B/op                                        │                           B/op                             vs base                │
ORMQueries/introspection_description_join-10                                                                       13.033Gi ± 0%                                                3.704Gi ± 0%  -71.58% (p=0.000 n=10)

                                             │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BxbnSBiT4e/bench.ae796e15493 │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BxbnSBiT4e/bench.a5ad91451a4 │
                                             │                                     allocs/op                                     │                         allocs/op                          vs base                │
ORMQueries/introspection_description_join-10                                                                        189.16M ± 0%                                                 39.85M ± 0%  -78.93% (p=0.000 n=10)
```