### PR TITLE
build: avoid exiting with code 1 when finding COCKROACH_ vars

### DIFF
--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -15,7 +15,11 @@ BAZEL_IMAGE=$(cat $root/build/.bazelbuilderversion)
 # This can be passed to the `docker` call in run_bazel, allowing
 # engineers to set COCKROACH_* variables via TeamCity and have those
 # set in the environment where `cockroach` runs.
-DOCKER_EXPORT_COCKROACH_VARS=$(env | grep '^COCKROACH_' | cut -d= -f1 | sed -e 's/\(.*\)/-e \1/' | tr '\n' ' ')
+#
+# NB: `|| true` stops the command from returning 1 if there are no
+# COCKROACH_* variables; that would cause builds that use `pipefail`
+# to fail.
+DOCKER_EXPORT_COCKROACH_VARS=$(env | grep '^COCKROACH_' | cut -d= -f1 | sed -e 's/\(.*\)/-e \1/' | tr '\n' ' ') || true
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.


### PR DESCRIPTION
In #103221, we started automatically exporting COCKROACH_* environment variables to the docker process so that setting them on the TeamCity UI would be sufficient for the cockroach process to see them.

However, the command to get all `COCKROACH_*` variables involves `grep`, which will return 1 when no matches are found. Combined with the fact that quite a few build scripts use `set -o pipefail`, this causes builds to fail with a mysterious "exit code 1" if there are no `COCKROACH` env vars.

This appends a `|| true` to the command to avoid an unsuccessful exit code.

Epic: none

Release note: None