### PR TITLE
concurrency: fix bug in lockStateInfo

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1184,7 +1184,7 @@ func (l *lockState) lockStateInfo(now time.Time) roachpb.LockStateInfo {
 		l.reservation.mu.Lock()
 		lockWaiters = append(lockWaiters, lock.Waiter{
 			WaitingTxn:   l.reservation.txn,
-			ActiveWaiter: true,
+			ActiveWaiter: false,
 			Strength:     lock.Exclusive,
 			WaitDuration: now.Sub(l.reservation.mu.curLockWaitStart),
 		})
@@ -1197,7 +1197,7 @@ func (l *lockState) lockStateInfo(now time.Time) roachpb.LockStateInfo {
 		readerGuard.mu.Lock()
 		lockWaiters = append(lockWaiters, lock.Waiter{
 			WaitingTxn:   readerGuard.txn,
-			ActiveWaiter: false,
+			ActiveWaiter: true, // readers always actively wait at a lock
 			Strength:     lock.None,
 			WaitDuration: now.Sub(readerGuard.mu.curLockWaitStart),
 		})

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -695,18 +695,18 @@ topklocksbywaitduration:
 
 query
 ----
-num locks: 3, bytes returned: 292, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 3, bytes returned: 288, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Replicated duration=2.65s
    waiters:
     waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:true strength:Exclusive wait_duration:2.65s
   range_id=3 key="b" holder=<nil> durability=Unreplicated duration=0s
    waiters:
-    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:true strength:Exclusive wait_duration:2.65s
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:false strength:Exclusive wait_duration:2.65s
     waiting_txn:00000000-0000-0000-0000-000000000001 active_waiter:true strength:Exclusive wait_duration:250ms
   range_id=3 key="c" holder=<nil> durability=Unreplicated duration=0s
    waiters:
-    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:true strength:Exclusive wait_duration:2.65s
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:false strength:Exclusive wait_duration:2.65s
     waiting_txn:00000000-0000-0000-0000-000000000003 active_waiter:true strength:Exclusive wait_duration:0s
 
 # 100ms passes between before releasing a
@@ -860,6 +860,23 @@ topklocksbywaitduration:
   waitingwriters: 0
   waitdurationnanos: 0
   maxwaitdurationnanos: 0
+
+
+query
+----
+num locks: 3, bytes returned: 268, resume reason: RESUME_UNKNOWN, resume span: <nil>
+ locks:
+  range_id=3 key="b" holder=<nil> durability=Unreplicated duration=0s
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:false strength:Exclusive wait_duration:0s
+    waiting_txn:00000000-0000-0000-0000-000000000001 active_waiter:true strength:Exclusive wait_duration:350ms
+  range_id=3 key="c" holder=<nil> durability=Unreplicated duration=0s
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:false strength:Exclusive wait_duration:0s
+    waiting_txn:00000000-0000-0000-0000-000000000003 active_waiter:true strength:Exclusive wait_duration:100ms
+  range_id=3 key="f" holder=00000000-0000-0000-0000-000000000003 durability=Replicated duration=2.75s
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:true strength:None wait_duration:0s
 
 # 500ms passes between before releasing f
 time-tick ms=500


### PR DESCRIPTION
All waiting readers are considered to be actively waiting at a lock;
there's no concept of inactive waiting readers in the lock table.
Previously, when converting a lockState into a roachpb.LockStateInfo,
we would erroneously denote any waiting readers as inactive. This
patch fixes this and adds a test for it.

This patch also fixes how reservations are designated as active or
inactive. Previously, reservations would be marked as active waiters.
This isn't true -- reservation holders do not actively wait at a lock
they hold reservations for. They only wait at other locks or proceed
to evaluation. Now, we mark reservations as inactive waiters as well.
The diff in existing tests is a result of this change.

Epic: none

Release note: None