### PR TITLE
roachprod: add relevant flags for use outside of CRL

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -85,6 +85,8 @@ func initFlags() {
 	rootCmd.PersistentFlags().IntVarP(&config.MaxConcurrency, "max-concurrency", "", 32,
 		"maximum number of operations to execute on nodes concurrently, set to zero for infinite",
 	)
+	rootCmd.PersistentFlags().StringVarP(&config.EmailDomain, "email-domain", "",
+		config.DefaultEmailDomain, "email domain for users")
 
 	createCmd.Flags().DurationVarP(&createVMOpts.Lifetime,
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
@@ -332,6 +334,27 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd} {
 		cmd.Flags().StringVar(&tenantName,
 			"tenant-name", "", "specific tenant to connect to")
+	}
+
+	for _, cmd := range []*cobra.Command{listCmd, createCmd, setupSSHCmd} {
+		cmd.Flags().StringVar(
+			&config.DNSGCloudProject, "dns-gcloud-project",
+			config.DefaultGCloudProject,
+			"google cloud project to use to set up DNS",
+		)
+		cmd.Flags().StringVar(
+			&config.DNSZone, "dns-zone",
+			config.DefaultDNSZone,
+			"zone file in gcloud project to use to set up DNS",
+		)
+	}
+
+	for _, cmd := range []*cobra.Command{createCmd, setupSSHCmd} {
+		cmd.Flags().StringVar(
+			&config.KeysGCloudProject, "keys-gcloud-project",
+			config.DefaultGCloudProject,
+			"google cloud project to use to store and fetch SSH keys",
+		)
 	}
 
 }

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -40,6 +40,15 @@ var (
 	MaxConcurrency = 32
 	// CockroachDevLicense is used by both roachprod and tools that import it.
 	CockroachDevLicense = envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "")
+	// EmailDomain used to form fully qualified usernames for gcloud and slack.
+	EmailDomain string
+	// DNSGCloudProject is the gcloud project to use for DNS records.
+	DNSGCloudProject string
+	// DNSZone is the zone file for the dns entry in the DNSGCloudProject.
+	DNSZone string
+	// KeysGCloudProject is the gcloud project to use to fetch and store SSH
+	// keys for users.
+	KeysGCloudProject string
 )
 
 func init() {
@@ -61,8 +70,8 @@ const (
 	// DefaultDebugDir is used to stash debug information.
 	DefaultDebugDir = "${HOME}/.roachprod/debug"
 
-	// EmailDomain is used to form the full account name for GCE and Slack.
-	EmailDomain = "@cockroachlabs.com"
+	// DefaultEmailDomain is used to form the full account name for GCE and Slack.
+	DefaultEmailDomain = "@cockroachlabs.com"
 
 	// Local is the prefix used to identify local clusters.
 	// It is also used as the zone for local clusters.
@@ -89,6 +98,13 @@ const (
 	// DefaultNumFilesLimit is the default limit on the number of files that can
 	// be opened by the process.
 	DefaultNumFilesLimit = 65 << 13
+
+	// DefaultDNSZone is the default zone file for DNS entries.
+	DefaultDNSZone = "roachprod"
+
+	// DefaultGCloudProject is the default project in gcloud for use with DNS and
+	// SSH key storage.
+	DefaultGCloudProject = "cockroach-ephemeral"
 )
 
 // DefaultEnvVars returns default environment variables used in conjunction with CLI and MakeClusterSettings.

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -35,7 +35,6 @@ import (
 )
 
 const (
-	defaultProject = "cockroach-ephemeral"
 	// ProviderName is gce.
 	ProviderName        = "gce"
 	DefaultImage        = "ubuntu-2004-focal-v20210603"
@@ -49,11 +48,11 @@ var providerInstance = &Provider{}
 
 // DefaultProject returns the default GCE project.
 func DefaultProject() string {
-	return defaultProject
+	return config.DefaultGCloudProject
 }
 
 // projects for which a cron GC job exists.
-var projectsWithGC = []string{defaultProject, "andrei-jepsen"}
+var projectsWithGC = []string{config.DefaultGCloudProject, "andrei-jepsen"}
 
 // Denotes if this provider was successfully initialized.
 var initialized = false
@@ -63,7 +62,7 @@ var initialized = false
 // If the gcloud tool is not available on the local path, the provider is a
 // stub.
 func Init() error {
-	providerInstance.Projects = []string{defaultProject}
+	providerInstance.Projects = []string{config.DefaultGCloudProject}
 	projectFromEnv := os.Getenv("GCE_PROJECT")
 	if projectFromEnv != "" {
 		providerInstance.Projects = []string{projectFromEnv}
@@ -736,7 +735,7 @@ func (p *Provider) Create(
 		"--boot-disk-type", "pd-ssd",
 	}
 
-	if project == defaultProject && p.ServiceAccount == "" {
+	if project == config.DefaultGCloudProject && p.ServiceAccount == "" {
 		p.ServiceAccount = "21965078311-compute@developer.gserviceaccount.com"
 
 	}

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -20,14 +20,10 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
-)
-
-const (
-	dnsProject = "cockroach-shared"
-	dnsZone    = "roachprod"
 )
 
 // Subdomain is the DNS subdomain to in which to maintain cluster node names.
@@ -297,8 +293,8 @@ func SyncDNS(l *logger.Logger, vms vm.List) error {
 	fmt.Fprint(f, zoneBuilder.String())
 	f.Close()
 
-	args := []string{"--project", dnsProject, "dns", "record-sets", "import",
-		f.Name(), "-z", dnsZone, "--delete-all-existing", "--zone-file-format"}
+	args := []string{"--project", config.DNSGCloudProject, "dns", "record-sets", "import",
+		f.Name(), "-z", config.DNSZone, "--delete-all-existing", "--zone-file-format"}
 	cmd := exec.Command("gcloud", args...)
 	output, err := cmd.CombinedOutput()
 
@@ -312,7 +308,7 @@ func GetUserAuthorizedKeys(l *logger.Logger) (authorizedKeys []byte, err error) 
 	var outBuf bytes.Buffer
 	// The below command will return a stream of user:pubkey as text.
 	cmd := exec.Command("gcloud", "compute", "project-info", "describe",
-		"--project=cockroach-ephemeral",
+		"--project="+config.KeysGCloudProject,
 		"--format=value(commonInstanceMetadata.ssh-keys)")
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = &outBuf


### PR DESCRIPTION
Before this PR, roachprod had some hard-coded logic which prevented it from being used with google accounts that weren't @cockroachlabs.com. It also had logic that was not configurable for the name of the gcloud project used for storing keys, and for setting up DNS.

This commit allows for all of these things to be customized with flags on the relevant subcommands. It's not great, but it's better than nothing.

Epic: None

Release note: None