### PR TITLE
ccl/sqlproxyccl: add cluster name validation to LookupTenant

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/access_control.go
+++ b/pkg/ccl/sqlproxyccl/acl/access_control.go
@@ -27,6 +27,10 @@ type ConnectionTags struct {
 	// the public internet. It is assumed that the connection is from a private
 	// network if the PROXY headers include cloud provider endpoint identifiers.
 	EndpointID string
+	// ClusterName represents the name of the cluster (e.g. dim-dog). This is
+	// used to ensure that the incoming connection knows something about the
+	// cluster (in addition to the TenantID) before it is allowed to connect.
+	ClusterName string
 }
 
 type AccessController interface {

--- a/pkg/ccl/sqlproxyccl/acl/file_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/file_test.go
@@ -186,9 +186,9 @@ denylist:
 			),
 			nil,
 			[]denyIOSpec{
-				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(61), ""}, "connection ip '1.2.3.4' denied: over quota"},
-				{ConnectionTags{"1.1.1.1", roachpb.MustMakeTenantID(61), ""}, ""},
-				{ConnectionTags{"1.2.3.5", roachpb.MustMakeTenantID(61), ""}, ""},
+				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(61), "", ""}, "connection ip '1.2.3.4' denied: over quota"},
+				{ConnectionTags{"1.1.1.1", roachpb.MustMakeTenantID(61), "", ""}, ""},
+				{ConnectionTags{"1.2.3.5", roachpb.MustMakeTenantID(61), "", ""}, ""},
 			},
 		},
 		// Blocks both IP address and tenant cluster.
@@ -208,10 +208,10 @@ denylist:
 			),
 			nil,
 			[]denyIOSpec{
-				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(100), ""}, "connection ip '1.2.3.4' denied: over quota"},
-				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(61), ""}, "connection ip '1.2.3.4' denied: over quota"},
-				{ConnectionTags{"1.1.1.1", roachpb.MustMakeTenantID(61), ""}, "connection cluster '61' denied: splunk pipeline"},
-				{ConnectionTags{"1.2.3.5", roachpb.MustMakeTenantID(100), ""}, ""},
+				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(100), "", ""}, "connection ip '1.2.3.4' denied: over quota"},
+				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(61), "", ""}, "connection ip '1.2.3.4' denied: over quota"},
+				{ConnectionTags{"1.1.1.1", roachpb.MustMakeTenantID(61), "", ""}, "connection cluster '61' denied: splunk pipeline"},
+				{ConnectionTags{"1.2.3.5", roachpb.MustMakeTenantID(100), "", ""}, ""},
 			},
 		},
 		// Entry without any expiration.
@@ -224,9 +224,9 @@ denylist:
   reason: over quota`,
 			nil,
 			[]denyIOSpec{
-				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(100), ""}, "connection ip '1.2.3.4' denied: over quota"},
-				{ConnectionTags{"1.1.1.1", roachpb.MustMakeTenantID(61), ""}, ""},
-				{ConnectionTags{"1.2.3.5", roachpb.MustMakeTenantID(100), ""}, ""},
+				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(100), "", ""}, "connection ip '1.2.3.4' denied: over quota"},
+				{ConnectionTags{"1.1.1.1", roachpb.MustMakeTenantID(61), "", ""}, ""},
+				{ConnectionTags{"1.2.3.5", roachpb.MustMakeTenantID(100), "", ""}, ""},
 			},
 		},
 		// Entry that has expired.
@@ -245,9 +245,9 @@ denylist:
 				timeSource.AdvanceTo(startTime.Add(20 * time.Minute))
 			},
 			[]denyIOSpec{
-				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(100), ""}, ""},
-				{ConnectionTags{"1.1.1.1", roachpb.MustMakeTenantID(61), ""}, ""},
-				{ConnectionTags{"1.2.3.5", roachpb.MustMakeTenantID(100), ""}, ""},
+				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(100), "", ""}, ""},
+				{ConnectionTags{"1.1.1.1", roachpb.MustMakeTenantID(61), "", ""}, ""},
+				{ConnectionTags{"1.2.3.5", roachpb.MustMakeTenantID(100), "", ""}, ""},
 			},
 		},
 	}
@@ -459,9 +459,9 @@ allowlist:
     ips: ["1.2.3.4/16"]
 `,
 			[]allowIOSpec{
-				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(100), ""}, ""},
-				{ConnectionTags{"1.1.1.1", roachpb.MustMakeTenantID(61), ""}, "connection ip '1.1.1.1' denied: ip address not allowed"},
-				{ConnectionTags{"1.2.1.1", roachpb.MustMakeTenantID(61), ""}, ""},
+				{ConnectionTags{"1.2.3.4", roachpb.MustMakeTenantID(100), "", ""}, ""},
+				{ConnectionTags{"1.1.1.1", roachpb.MustMakeTenantID(61), "", ""}, "connection ip '1.1.1.1' denied: ip address not allowed"},
+				{ConnectionTags{"1.2.1.1", roachpb.MustMakeTenantID(61), "", ""}, ""},
 			},
 		},
 	}

--- a/pkg/ccl/sqlproxyccl/acl/private_endpoints.go
+++ b/pkg/ccl/sqlproxyccl/acl/private_endpoints.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pires/go-proxyproto/tlvparse"
 )
 
-type lookupTenantFunc func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error)
+type lookupTenantFunc func(ctx context.Context, tenantID roachpb.TenantID, clusterName string) (*tenant.Tenant, error)
 
 // PrivateEndpoints represents the controller used to manage ACL rules for
 // private connections. A connection is assumed to be private if it includes
@@ -33,7 +33,7 @@ var _ AccessController = &PrivateEndpoints{}
 
 // CheckConnection implements the AccessController interface.
 func (p *PrivateEndpoints) CheckConnection(ctx context.Context, conn ConnectionTags) error {
-	tenantObj, err := p.LookupTenantFn(ctx, conn.TenantID)
+	tenantObj, err := p.LookupTenantFn(ctx, conn.TenantID, conn.ClusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/sqlproxyccl/acl/watcher_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/watcher_test.go
@@ -241,7 +241,7 @@ func TestACLWatcher(t *testing.T) {
 
 		// Wait until watcher has received the updated event.
 		testutils.SucceedsSoon(t, func() error {
-			ten, err := dir.LookupTenant(ctx, tenantID)
+			ten, err := dir.LookupTenant(ctx, tenantID, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -981,7 +981,7 @@ var _ tenant.DirectoryCache = &testTenantDirectoryCache{}
 // testTenantDirectoryCache is a test implementation of the tenant directory
 // cache.
 type testTenantDirectoryCache struct {
-	lookupTenantFn        func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error)
+	lookupTenantFn        func(ctx context.Context, tenantID roachpb.TenantID, clusterName string) (*tenant.Tenant, error)
 	lookupTenantPodsFn    func(ctx context.Context, tenantID roachpb.TenantID, clusterName string) ([]*tenant.Pod, error)
 	trylookupTenantPodsFn func(ctx context.Context, tenantID roachpb.TenantID) ([]*tenant.Pod, error)
 	reportFailureFn       func(ctx context.Context, tenantID roachpb.TenantID, addr string) error
@@ -989,9 +989,9 @@ type testTenantDirectoryCache struct {
 
 // LookupTenant implements the tenant.DirectoryCache interface.
 func (r *testTenantDirectoryCache) LookupTenant(
-	ctx context.Context, tenantID roachpb.TenantID,
+	ctx context.Context, tenantID roachpb.TenantID, clusterName string,
 ) (*tenant.Tenant, error) {
-	return r.lookupTenantFn(ctx, tenantID)
+	return r.lookupTenantFn(ctx, tenantID, clusterName)
 }
 
 // LookupTenantPods implements the tenant.DirectoryCache interface.

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -392,9 +392,10 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn net.Conn) 
 	removeListener, err := handler.aclWatcher.ListenForDenied(
 		ctx,
 		acl.ConnectionTags{
-			IP:         ipAddr,
-			TenantID:   tenID,
-			EndpointID: endpointID,
+			IP:          ipAddr,
+			TenantID:    tenID,
+			ClusterName: clusterName,
+			EndpointID:  endpointID,
 		},
 		func(err error) {
 			err = withCode(

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -331,7 +331,7 @@ func TestPrivateEndpointsACL(t *testing.T) {
 
 				// Wait until watcher has received the updated event.
 				testutils.SucceedsSoon(t, func() error {
-					ten, err := s.handler.directoryCache.LookupTenant(ctx, tenant10)
+					ten, err := s.handler.directoryCache.LookupTenant(ctx, tenant10, "my-tenant")
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Prior to this patch, there's a possibility where the proxy returns a connection refused error for tenants which exist, but the cluster names and ACL entries do not match. This would indicate that the tenant is active, and ideally we should mask that for security purposes. This commit addresses that by validating cluster name in LookupTenant, and returning a NotFound error whenever the tenant name does not match the incoming connection's cluster name. This mimics the same behavor as LookupTenantPods.

Release note: None

Epic: none