### PR TITLE
release-22.2: ui,sqlstats: fix stmt type filter

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -51,7 +51,7 @@ func ExplainTreePlanNodeToJSON(node *roachpb.ExplainTreePlanNode) json.JSON {
 //	  "title": "system.statement_statistics.metadata",
 //	  "type": "object",
 //	  "properties": {
-//	    "stmtTyp":              { "type": "string" },
+//	    "stmtType":             { "type": "string" },
 //	    "query":                { "type": "string" },
 //	    "db":                   { "type": "string" },
 //	    "distsql":              { "type": "boolean" },

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -41,7 +41,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 
 		expectedMetadataStrTemplate := `
 {
-  "stmtTyp":      "{{.String}}",
+  "stmtType":     "{{.String}}",
   "query":        "{{.String}}",
   "querySummary": "{{.String}}",
   "db":           "{{.String}}",
@@ -161,7 +161,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 
 		expectedMetadataStrTemplate := `
 			{
-				"stmtTyp":      "{{.String}}",
+				"stmtType":     "{{.String}}",
 				"query":        "{{.String}}",
 				"querySummary": "{{.String}}",
 				"db":           "{{.String}}",

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -91,7 +91,7 @@ type stmtStatsMetadata roachpb.CollectedStatementStatistics
 
 func (s *stmtStatsMetadata) jsonFields() jsonFields {
 	return jsonFields{
-		{"stmtTyp", (*jsonString)(&s.Stats.SQLType)},
+		{"stmtType", (*jsonString)(&s.Stats.SQLType)},
 		{"query", (*jsonString)(&s.Key.Query)},
 		{"querySummary", (*jsonString)(&s.Key.QuerySummary)},
 		{"db", (*jsonString)(&s.Key.Database)},

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -769,7 +769,7 @@ function FilterBadge(props: FilterBadgeProps): React.ReactElement {
       {value}
       <Cancel
         className={badge.closeArea}
-        onClick={() => removeFilter(filters, name, onRemoveFilter)}
+        onClick={() => removeFilter({ ...filters }, name, onRemoveFilter)}
       />
     </div>
   );


### PR DESCRIPTION
Backport 1/1 commits from #103224.

/cc @cockroachdb/release

---

Previously, the filter badges were not working on CC when trying to update a read-only property.
There was also a typo in some json encoding, making the statement type to mismatch during encoding/decoding, making the stmt filters to also not work.
This commit fixes both issues.

Fixes #102374

Working on CC Console:
https://www.loom.com/share/6b25c7821d1546d585ba6deca10fbf3d

Release note (bug fix): Filter on SQL Activity page are now properly working and a type on the json object from `stmtTyp` to `stmtType` was fixed.

---

Release justification: bug fix
