### PR TITLE
builtins: don't panic on placeholders in with_min_timestamp(to_timestamp($1))

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -333,3 +333,6 @@ PREPARE placeholder_min_timestamp_stmt AS SELECT * FROM t AS OF SYSTEM TIME with
 
 statement error expected interval argument for max_staleness
 PREPARE placeholder_bounded_staleness_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_max_staleness($1)
+
+statement error expected float argument for to_timestamp
+PREPARE placeholder_with_min_timestamp_to_timestamp_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(to_timestamp($1))


### PR DESCRIPTION
fixes #102741
fixes #103423

Release note (bug fix): Fixed a crash/panic that could occur if placeholder arguments were used with the with_min_timestamp(to_timestamp($1)) functions.

Release justification: Fix a crash caused by a panic.