### PR TITLE
release-23.1: sql: clean up code for pg_description

### DIFF
--- a/pkg/sql/catalog/catalogkeys/commenttype_string.go
+++ b/pkg/sql/catalog/catalogkeys/commenttype_string.go
@@ -14,11 +14,12 @@ func _() {
 	_ = x[IndexCommentType-3]
 	_ = x[SchemaCommentType-4]
 	_ = x[ConstraintCommentType-5]
+	_ = x[FunctionCommentType-6]
 }
 
-const _CommentType_name = "DatabaseCommentTypeTableCommentTypeColumnCommentTypeIndexCommentTypeSchemaCommentTypeConstraintCommentType"
+const _CommentType_name = "DatabaseCommentTypeTableCommentTypeColumnCommentTypeIndexCommentTypeSchemaCommentTypeConstraintCommentTypeFunctionCommentType"
 
-var _CommentType_index = [...]uint8{0, 19, 35, 52, 68, 85, 106}
+var _CommentType_index = [...]uint8{0, 19, 35, 52, 68, 85, 106, 125}
 
 func (i CommentType) String() string {
 	if i < 0 || i >= CommentType(len(_CommentType_index)-1) {

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -58,10 +58,12 @@ const (
 	SchemaCommentType CommentType = 4
 	// ConstraintCommentType comment on a constraint.
 	ConstraintCommentType CommentType = 5
+	// FunctionCommentType comment on a function.
+	FunctionCommentType CommentType = 6
 
 	// MaxCommentTypeValue is the max possible integer of CommentType type.
 	// Update this whenever a new comment type is added.
-	MaxCommentTypeValue = ConstraintCommentType
+	MaxCommentTypeValue = FunctionCommentType
 )
 
 // AllCommentTypes is a slice of all valid schema comment types.
@@ -72,6 +74,7 @@ var AllCommentTypes = []CommentType{
 	IndexCommentType,
 	SchemaCommentType,
 	ConstraintCommentType,
+	FunctionCommentType,
 }
 
 // IsValidCommentType checks if a given comment type is in the valid value

--- a/pkg/sql/catalog/internal/catkv/testdata/testdata
+++ b/pkg/sql/catalog/internal/catkv/testdata/testdata
@@ -127,6 +127,7 @@ trace:
 - Scan /Table/24/1/3/108
 - Scan /Table/24/1/4/108
 - Scan /Table/24/1/5/108
+- Scan /Table/24/1/6/108
 - Get /Table/5/1/108/2/1
 
 # Zone config, but no descriptor should be present.
@@ -143,6 +144,7 @@ trace:
 - Scan /Table/24/1/3/0
 - Scan /Table/24/1/4/0
 - Scan /Table/24/1/5/0
+- Scan /Table/24/1/6/0
 - Get /Table/5/1/0/2/1
 
 get_by_ids id=104 id=105 id=106 id=107
@@ -166,6 +168,7 @@ trace:
 - Scan Range /Table/24/1/3/104 /Table/24/1/3/108
 - Scan Range /Table/24/1/4/104 /Table/24/1/4/108
 - Scan Range /Table/24/1/5/104 /Table/24/1/5/108
+- Scan Range /Table/24/1/6/104 /Table/24/1/6/108
 - Scan Range /Table/5/1/104/2/1 /Table/5/1/108/2/1
 
 is_id_in_cache id=107
@@ -436,6 +439,7 @@ trace:
 - Scan /Table/24/1/3/456
 - Scan /Table/24/1/4/456
 - Scan /Table/24/1/5/456
+- Scan /Table/24/1/6/456
 - Get /Table/5/1/456/2/1
 cached:
 - Get /Table/3/1/456/2/1
@@ -445,6 +449,7 @@ cached:
 - Scan /Table/24/1/3/456
 - Scan /Table/24/1/4/456
 - Scan /Table/24/1/5/456
+- Scan /Table/24/1/6/456
 - Get /Table/5/1/456/2/1
 
 get_by_names name_key=(123,456,foo)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5435,6 +5435,22 @@ CREATE TABLE crdb_internal.kv_catalog_comments (
 				return err
 			}
 		}
+		// Loop over all builtin function comments.
+		// TODO(rafi): This could be moved directly into the catalog, similar to
+		// virtual table comments.
+		for _, name := range builtins.AllBuiltinNames() {
+			_, overloads := builtinsregistry.GetBuiltinProperties(name)
+			for _, builtin := range overloads {
+				if err := addRow(
+					tree.NewDString(catalogkeys.FunctionCommentType.String()),
+					tree.NewDInt(tree.DInt(builtin.Oid)),
+					tree.DZero,
+					tree.NewDString(builtin.Info),
+				); err != nil {
+					return err
+				}
+			}
+		}
 		return nil
 	},
 }

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_catalog
@@ -578,6 +578,7 @@ SELECT
   sub_id,
   to_json(regexp_replace(btrim(comment), 'docs\/v\d+\.\d+\/', 'docs/dev/', 'g'))
 FROM "".crdb_internal.kv_catalog_comments
+WHERE type != 'FunctionCommentType'; -- exclude builtin comments since there are so many.
 ----
 DatabaseCommentType    104         0  "this is the test database"
 TableCommentType       111         0  "this is a table"
@@ -915,6 +916,7 @@ SELECT * FROM crdb_internal.kv_catalog_comments WHERE object_id = $kv_id
 TableCommentType       111  0  this is a table
 ConstraintCommentType  111  1  this is a primary key constraint
 ConstraintCommentType  111  2  this is a check constraint
+FunctionCommentType    111  0  Calculates square of the correlation coefficient.
 
 statement ok
 DROP TABLE db.kv CASCADE;
@@ -947,6 +949,7 @@ SELECT * FROM crdb_internal.kv_catalog_comments WHERE object_id = $kv_id
 TableCommentType       111  0  this is a table
 ConstraintCommentType  111  1  this is a primary key constraint
 ConstraintCommentType  111  2  this is a check constraint
+FunctionCommentType    111  0  Calculates square of the correlation coefficient.
 
 query TIIT
 SELECT * FROM system.comments WHERE object_id = $kv_id

--- a/pkg/sql/pg_metadata_test.go
+++ b/pkg/sql/pg_metadata_test.go
@@ -222,11 +222,11 @@ var none = struct{}{}
 var mappedPopulateFunctions = map[string]string{
 	// Currently pg_type cannot be found automatically by this code because it is
 	// not the populate function. Same for pg_proc.
-	"addPGTypeRow":                  "PGCatalogType",
-	"addPgProcUDFRow":               "PGCatalogProc",
-	"addPgProcBuiltinRow":           "PgCatalogProc",
-	"addRowForTimezoneNames":        "PgCatalogTimezoneNames",
-	"populatePgCatalogFromComments": "PGCatalogDescription",
+	"addPGTypeRow":           "PGCatalogType",
+	"addPgProcUDFRow":        "PGCatalogProc",
+	"addPgProcBuiltinRow":    "PgCatalogProc",
+	"addRowForTimezoneNames": "PgCatalogTimezoneNames",
+	"populatePgDescription":  "PGCatalogDescription",
 }
 
 // schemaCodeFixer have specific configurations to fix the files with virtual
@@ -554,7 +554,7 @@ func (scf schemaCodeFixer) fixCatalogGo(t *testing.T, unimplementedTables PGMeta
 			text := reader.Text()
 			trimText := strings.TrimSpace(text)
 			if trimText == scf.textForNewTableInsertion {
-				//VirtualSchemas doesn't have a particular place to start we just print
+				// VirtualSchemas doesn't have a particular place to start we just print
 				// it before virtualTablePosition.
 				output.appendString(scf.printVirtualSchemas(unimplementedTables))
 			}
@@ -589,7 +589,7 @@ func fixPgCatalogGoColumns(pgCode *pgCatalogCode) {
 			if currentPosition < len(positions) && int64(scannedUntil+count) > positions[currentPosition].insertPosition {
 				relativeIndex := int(positions[currentPosition].insertPosition-int64(scannedUntil)) - 1
 				left := text[:relativeIndex]
-				indentation := indentationRE.FindStringSubmatch(text)[1] //The way it is it should at least give ""
+				indentation := indentationRE.FindStringSubmatch(text)[1] // The way it is it should at least give ""
 				if len(strings.TrimSpace(left)) > 0 {
 					// Parenthesis is right after the last variable in this case
 					// indentation is correct.


### PR DESCRIPTION
Backport 1/1 commits from #103257.

/cc @cockroachdb/release

---

By including builtin function comments in
crdb_internal.kv_catalog_comments, we can remove a lot of corner case handling in the pg_description table generation code.

informs #103106
Release note: None
Release justification: refactor needed to backport a performance improvement