### PR TITLE
release-23.1: metric: use cumulative count instead of windowed count in tsdb

### DIFF
--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -432,7 +432,8 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 		// Assert existing calls.
 		require.Equal(t, 1, dialSQLServerCount)
 		require.Equal(t, 1, reportFailureFnCount)
-		require.Equal(t, c.DialTenantLatency.TotalCount(), int64(1))
+		count, _ := c.DialTenantLatency.Total()
+		require.Equal(t, count, int64(1))
 		require.Equal(t, c.DialTenantRetries.Count(), int64(0))
 
 		// Invoke dial tenant with a failure to ReportFailure. Final error
@@ -453,7 +454,8 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 		// Assert existing calls.
 		require.Equal(t, 2, dialSQLServerCount)
 		require.Equal(t, 2, reportFailureFnCount)
-		require.Equal(t, c.DialTenantLatency.TotalCount(), int64(2))
+		count, _ = c.DialTenantLatency.Total()
+		require.Equal(t, count, int64(2))
 		require.Equal(t, c.DialTenantRetries.Count(), int64(0))
 	})
 
@@ -478,8 +480,8 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 		conn, err := c.dialTenantCluster(ctx, nil /* requester */)
 		require.EqualError(t, err, "baz")
 		require.Nil(t, conn)
-
-		require.Equal(t, c.DialTenantLatency.TotalCount(), int64(1))
+		count, _ := c.DialTenantLatency.Total()
+		require.Equal(t, count, int64(1))
 		require.Equal(t, c.DialTenantRetries.Count(), int64(0))
 	})
 
@@ -551,7 +553,8 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 		require.Equal(t, 3, addrLookupFnCount)
 		require.Equal(t, 2, dialSQLServerCount)
 		require.Equal(t, 1, reportFailureFnCount)
-		require.Equal(t, c.DialTenantLatency.TotalCount(), int64(1))
+		count, _ := c.DialTenantLatency.Total()
+		require.Equal(t, count, int64(1))
 		require.Equal(t, c.DialTenantRetries.Count(), int64(2))
 	})
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -434,7 +434,8 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	})
 
 	require.Equal(t, int64(4), s.metrics.SuccessfulConnCount.Count())
-	require.Equal(t, int64(4), s.metrics.ConnectionLatency.TotalCount())
+	count, _ := s.metrics.ConnectionLatency.Total()
+	require.Equal(t, int64(4), count)
 	require.Equal(t, int64(2), s.metrics.AuthFailedCount.Count())
 	require.Equal(t, int64(1), s.metrics.RoutingErrCount.Count())
 }
@@ -575,7 +576,8 @@ func TestProxyTLSClose(t *testing.T) {
 	_ = conn.Close(ctx)
 
 	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
-	require.Equal(t, int64(1), s.metrics.ConnectionLatency.TotalCount())
+	count, _ := s.metrics.ConnectionLatency.Total()
+	require.Equal(t, int64(1), count)
 	require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
 }
 
@@ -682,7 +684,8 @@ func TestInsecureProxy(t *testing.T) {
 	})
 	require.Equal(t, int64(1), s.metrics.AuthFailedCount.Count())
 	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
-	require.Equal(t, int64(1), s.metrics.ConnectionLatency.TotalCount())
+	count, _ := s.metrics.ConnectionLatency.Total()
+	require.Equal(t, int64(1), count)
 }
 
 func TestErroneousFrontend(t *testing.T) {
@@ -791,7 +794,8 @@ func TestProxyRefuseConn(t *testing.T) {
 	_ = te.TestConnectErr(ctx, t, url, codeProxyRefusedConnection, "too many attempts")
 	require.Equal(t, int64(1), s.metrics.RefusedConnCount.Count())
 	require.Equal(t, int64(0), s.metrics.SuccessfulConnCount.Count())
-	require.Equal(t, int64(0), s.metrics.ConnectionLatency.TotalCount())
+	count, _ := s.metrics.ConnectionLatency.Total()
+	require.Equal(t, int64(0), count)
 	require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
 }
 
@@ -1616,10 +1620,10 @@ func TestConnectionMigration(t *testing.T) {
 			proxy.metrics.ConnMigrationErrorRecoverableCount.Count() +
 			proxy.metrics.ConnMigrationErrorFatalCount.Count()
 		require.Equal(t, totalAttempts, proxy.metrics.ConnMigrationAttemptedCount.Count())
-		require.Equal(t, totalAttempts,
-			proxy.metrics.ConnMigrationAttemptedLatency.TotalCount())
-		require.Equal(t, totalAttempts,
-			proxy.metrics.ConnMigrationTransferResponseMessageSize.TotalCount())
+		count, _ := proxy.metrics.ConnMigrationAttemptedLatency.Total()
+		require.Equal(t, totalAttempts, count)
+		count, _ = proxy.metrics.ConnMigrationTransferResponseMessageSize.Total()
+		require.Equal(t, totalAttempts, count)
 	}
 
 	transferConnWithRetries := func(t *testing.T, f *forwarder) error {
@@ -1939,12 +1943,12 @@ func TestConnectionMigration(t *testing.T) {
 			f.metrics.ConnMigrationErrorRecoverableCount.Count() +
 			f.metrics.ConnMigrationErrorFatalCount.Count()
 		require.Equal(t, totalAttempts, f.metrics.ConnMigrationAttemptedCount.Count())
-		require.Equal(t, totalAttempts,
-			f.metrics.ConnMigrationAttemptedLatency.TotalCount())
+		count, _ := f.metrics.ConnMigrationAttemptedLatency.Total()
+		require.Equal(t, totalAttempts, count)
 		// Here, we get a transfer timeout in response, so the message size
 		// should not be recorded.
-		require.Equal(t, totalAttempts-1,
-			f.metrics.ConnMigrationTransferResponseMessageSize.TotalCount())
+		count, _ = f.metrics.ConnMigrationTransferResponseMessageSize.Total()
+		require.Equal(t, totalAttempts-1, count)
 	})
 
 	// All connections should eventually be terminated.

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1154,6 +1154,8 @@ func checkTxnMetrics(
 func checkTxnMetricsOnce(
 	metrics kvcoord.TxnMetrics, name string, commits, commits1PC, aborts, restarts int64,
 ) error {
+	durationCounts, _ := metrics.Durations.Total()
+	restartsCounts, _ := metrics.Restarts.Total()
 	testcases := []struct {
 		name string
 		a, e int64
@@ -1161,8 +1163,8 @@ func checkTxnMetricsOnce(
 		{"commits", metrics.Commits.Count(), commits},
 		{"commits1PC", metrics.Commits1PC.Count(), commits1PC},
 		{"aborts", metrics.Aborts.Count(), aborts},
-		{"durations", metrics.Durations.TotalCount(), commits + aborts},
-		{"restarts", metrics.Restarts.TotalCount(), restarts},
+		{"durations", durationCounts, commits + aborts},
+		{"restarts", restartsCounts, restarts},
 	}
 
 	for _, tc := range testcases {
@@ -1379,7 +1381,8 @@ func TestTxnDurations(t *testing.T) {
 	// introducing spurious errors or being overly lax.
 	//
 	// TODO(cdo): look into cause of variance.
-	if a, e := hist.TotalCount(), int64(puts); a != e {
+	count, _ := hist.Total()
+	if a, e := count, int64(puts); a != e {
 		t.Fatalf("durations %d != expected %d", a, e)
 	}
 

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -266,7 +266,8 @@ func TestSchedulerLoop(t *testing.T) {
 		return nil
 	})
 
-	require.Equal(t, int64(3), m.RaftSchedulerLatency.TotalCount())
+	count, _ := m.RaftSchedulerLatency.Total()
+	require.Equal(t, int64(3), count)
 }
 
 // Verify that when we enqueue the same range multiple times for the same

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -606,9 +606,12 @@ type registryRecorder struct {
 func extractValue(name string, mtr interface{}, fn func(string, float64)) error {
 	switch mtr := mtr.(type) {
 	case metric.WindowedHistogram:
-		n := float64(mtr.TotalCountWindowed())
-		fn(name+"-count", n)
-		avg := mtr.TotalSumWindowed() / n
+		// Use cumulative stats here
+		count, sum := mtr.Total()
+		fn(name+"-count", float64(count))
+		fn(name+"-sum", sum)
+		// Use windowed stats for avg and quantiles
+		avg := mtr.MeanWindowed()
 		if math.IsNaN(avg) || math.IsInf(avg, +1) || math.IsInf(avg, -1) {
 			avg = 0
 		}

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -442,6 +442,7 @@ func TestMetricsRecorder(t *testing.T) {
 					addExpected(reg.prefix, data.name+q.suffix, reg.source, 100, 10, reg.isNode)
 				}
 				addExpected(reg.prefix, data.name+"-count", reg.source, 100, 1, reg.isNode)
+				addExpected(reg.prefix, data.name+"-sum", reg.source, 100, 9, reg.isNode)
 				addExpected(reg.prefix, data.name+"-avg", reg.source, 100, 9, reg.isNode)
 			default:
 				t.Fatalf("unexpected: %+v", data)

--- a/pkg/util/asciitsdb/asciitsdb.go
+++ b/pkg/util/asciitsdb/asciitsdb.go
@@ -103,12 +103,12 @@ func (t *TSDB) Scrape(ctx context.Context) {
 
 		switch mtr := val.(type) {
 		case metric.WindowedHistogram:
-			n := float64(mtr.TotalCountWindowed())
 			if _, ok := t.mu.points[name]; !ok {
 				return
 			}
-			t.mu.points[name+"-count"] = append(t.mu.points[name+"-count"], n)
-			avg := mtr.TotalSumWindowed() / n
+			count, _ := mtr.Total()
+			t.mu.points[name+"-count"] = append(t.mu.points[name+"-count"], float64(count))
+			avg := mtr.MeanWindowed()
 			if math.IsNaN(avg) || math.IsInf(avg, +1) || math.IsInf(avg, -1) {
 				avg = 0
 			}

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -61,14 +61,24 @@ func (a *AggHistogram) GetMetadata() metric.Metadata { return a.h.GetMetadata() 
 // Inspect is part of the metric.Iterable interface.
 func (a *AggHistogram) Inspect(f func(interface{})) { f(a) }
 
-// TotalCountWindowed is part of the metric.WindowedHistogram interface
-func (a *AggHistogram) TotalCountWindowed() int64 {
-	return a.h.TotalCountWindowed()
+// TotalWindowed is part of the metric.WindowedHistogram interface
+func (a *AggHistogram) TotalWindowed() (int64, float64) {
+	return a.h.TotalWindowed()
 }
 
-// TotalSumWindowed is part of the metric.WindowedHistogram interface
-func (a *AggHistogram) TotalSumWindowed() float64 {
-	return a.h.TotalSumWindowed()
+// Total is part of the metric.WindowedHistogram interface
+func (a *AggHistogram) Total() (int64, float64) {
+	return a.h.Total()
+}
+
+// MeanWindowed is part of the metric.WindowedHistogram interface
+func (a *AggHistogram) MeanWindowed() float64 {
+	return a.h.MeanWindowed()
+}
+
+// Mean is part of the metric.WindowedHistogram interface
+func (a *AggHistogram) Mean() float64 {
+	return a.h.Mean()
 }
 
 // ValueAtQuantileWindowed is part of the metric.WindowedHistogram interface

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -280,15 +280,18 @@ func TestNewHistogramRotate(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		// Windowed histogram is initially empty.
 		h.Inspect(func(interface{}) {}) // triggers ticking
-		require.Zero(t, h.TotalSumWindowed())
+		_, sum := h.TotalWindowed()
+		require.Zero(t, sum)
 		// But cumulative histogram has history (if i > 0).
-		require.EqualValues(t, i, h.TotalCount())
+		count, _ := h.Total()
+		require.EqualValues(t, i, count)
 
 		// Add a measurement and verify it's there.
 		{
 			h.RecordValue(12345)
 			f := float64(12345)
-			require.Equal(t, h.TotalSumWindowed(), f)
+			_, wSum := h.TotalWindowed()
+			require.Equal(t, wSum, f)
 		}
 		// Tick. This rotates the histogram.
 		setNow(time.Duration(i+1) * 10 * time.Second)

--- a/pkg/util/schedulerlatency/histogram.go
+++ b/pkg/util/schedulerlatency/histogram.go
@@ -143,19 +143,31 @@ func (h *runtimeHistogram) GetMetadata() metric.Metadata {
 // Inspect is part of the Iterable interface.
 func (h *runtimeHistogram) Inspect(f func(interface{})) { f(h) }
 
-// TotalCountWindowed implements the WindowedHistogram interface.
-func (h *runtimeHistogram) TotalCountWindowed() int64 {
-	return int64(h.ToPrometheusMetric().Histogram.GetSampleCount())
+// TotalWindowed implements the WindowedHistogram interface.
+func (h *runtimeHistogram) TotalWindowed() (int64, float64) {
+	return h.Total()
 }
 
-// TotalSumWindowed implements the WindowedHistogram interface.
-func (h *runtimeHistogram) TotalSumWindowed() float64 {
-	return h.ToPrometheusMetric().Histogram.GetSampleSum()
+// Total implements the WindowedHistogram interface.
+func (h *runtimeHistogram) Total() (int64, float64) {
+	pHist := h.ToPrometheusMetric().Histogram
+	return int64(pHist.GetSampleCount()), pHist.GetSampleSum()
 }
 
 // ValueAtQuantileWindowed implements the WindowedHistogram interface.
 func (h *runtimeHistogram) ValueAtQuantileWindowed(q float64) float64 {
 	return metric.ValueAtQuantileWindowed(h.ToPrometheusMetric().Histogram, q)
+}
+
+// MeanWindowed implements the WindowedHistogram interface.
+func (h *runtimeHistogram) MeanWindowed() float64 {
+	return h.Mean()
+}
+
+// Mean implements the WindowedHistogram interface.
+func (h *runtimeHistogram) Mean() float64 {
+	pHist := h.ToPrometheusMetric().Histogram
+	return pHist.GetSampleSum() / float64(pHist.GetSampleCount())
 }
 
 // reBucketExpAndTrim takes a list of bucket boundaries (lower bound inclusive)

--- a/pkg/util/schedulerlatency/histogram_test.go
+++ b/pkg/util/schedulerlatency/histogram_test.go
@@ -97,10 +97,8 @@ func TestRuntimeHistogram(t *testing.T) {
 
 			case "print":
 				var buf strings.Builder
-				buf.WriteString(fmt.Sprintf("count=%d sum=%0.2f\n",
-					rh.TotalCountWindowed(),
-					rh.TotalSumWindowed(),
-				))
+				count, sum := rh.Total()
+				buf.WriteString(fmt.Sprintf("count=%d sum=%0.2f\n", count, sum))
 				hist := rh.ToPrometheusMetric().GetHistogram()
 				require.NotNil(t, hist)
 				buf.WriteString("buckets:\n")

--- a/pkg/util/schedulerlatency/scheduler_latency_test.go
+++ b/pkg/util/schedulerlatency/scheduler_latency_test.go
@@ -87,13 +87,12 @@ func TestSchedulerLatencySampler(t *testing.T) {
 		var err error
 		reg.Each(func(name string, mtr interface{}) {
 			wh := mtr.(metric.WindowedHistogram)
-			count := float64(wh.TotalCountWindowed())
-			avg := wh.TotalSumWindowed() / count
+			avg := wh.MeanWindowed()
 			if math.IsNaN(avg) || math.IsInf(avg, +1) || math.IsInf(avg, -1) {
 				avg = 0
 			}
 
-			if wh.ValueAtQuantileWindowed(99) == 0 || count == 0 || avg == 0 {
+			if wh.ValueAtQuantileWindowed(99) == 0 || avg == 0 {
 				err = fmt.Errorf("expected non-zero p99 scheduling latency metrics")
 			}
 		})


### PR DESCRIPTION
Backport 1/1 commits from #101909.

/cc @cockroachdb/release

---

Previously, we were writing the windowed count of a histogram into tsdb.
This meant that on each tick, the count reset. This is useful for
calculating averages and quantiles using windowed histograms, but makes
little sense to record for `count`.

This patch now uses the cumulative count in tsdb.

This patch also adds a `-sum` field to maintain a record of the
cumulative sum along with the cumulative counts.

Fixes https://github.com/cockroachdb/cockroach/issues/98745

Release note (bug fix): Timeseries metric counts will now show
cumulative counts for a histogram rather than the windowed count. A
`-sum` timeseries is also exported to keep track of the cumulative sum
of all samples in the histogram.

Release justification: bug fix
