### PR TITLE
log: add buffer format options

### DIFF
--- a/docs/generated/logsinks.md
+++ b/docs/generated/logsinks.md
@@ -402,5 +402,6 @@ set to "NONE" to disable buffering. Example configuration:
 | `max-staleness` | the maximum time a log message will sit in the buffer before a flush is triggered. |
 | `flush-trigger-size` | the number of bytes that will trigger the buffer to flush. |
 | `max-buffer-size` | the limit on the size of the messages that are buffered. If this limit is exceeded, messages are dropped. The limit is expected to be higher than FlushTriggerSize. A buffer is flushed as soon as FlushTriggerSize is reached, and a new buffer is created once the flushing is started. Only one flushing operation is active at a time. |
+| `format` | describes how the buffer output should be formatted. Currently 2 options: newline: default option - separates buffer entries with newline char json-array: separates entries with ',' and wraps buffer contents in square brackets |
 
 

--- a/pkg/cli/log_flags_test.go
+++ b/pkg/cli/log_flags_test.go
@@ -46,7 +46,8 @@ func TestSetupLogging(t *testing.T) {
 		`exit-on-error: false, ` +
 		`buffering: {max-staleness: 5s, ` +
 		`flush-trigger-size: 1.0MiB, ` +
-		`max-buffer-size: 50MiB}}`
+		`max-buffer-size: 50MiB, ` +
+		`format: newline}}`
 	const defaultHTTPConfig = `http-defaults: {` +
 		`method: POST, ` +
 		`unsafe-tls: false, ` +
@@ -58,7 +59,8 @@ func TestSetupLogging(t *testing.T) {
 		`exit-on-error: false, ` +
 		`buffering: {max-staleness: 5s, ` +
 		`flush-trigger-size: 1.0MiB, ` +
-		`max-buffer-size: 50MiB}}`
+		`max-buffer-size: 50MiB, ` +
+		`format: newline}}`
 	stdFileDefaultsRe := regexp.MustCompile(
 		`file-defaults: \{` +
 			`dir: (?P<path>[^,]+), ` +

--- a/pkg/cli/testdata/logflags
+++ b/pkg/cli/testdata/logflags
@@ -383,7 +383,8 @@ redactable: true,
 exit-on-error: false,
 buffering: {max-staleness: 5s,
 flush-trigger-size: 1.0MiB,
-max-buffer-size: 50MiB}}},
+max-buffer-size: 50MiB,
+format: newline}}},
 <stderrDisabled>},
 <stdCaptureFd2(<defaultLogDir>)>}
 

--- a/pkg/util/log/buffered_sink_test.go
+++ b/pkg/util/log/buffered_sink_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -31,11 +32,15 @@ const noSizeTrigger = 0
 const noMaxBufferSize = 0
 
 func getMockBufferedSync(
-	t *testing.T, maxStaleness time.Duration, sizeTrigger uint64, maxBufferSize uint64,
+	t *testing.T,
+	maxStaleness time.Duration,
+	sizeTrigger uint64,
+	maxBufferSize uint64,
+	fmtType *logconfig.BufferFormat,
 ) (sink *bufferedSink, mock *MockLogSink, cleanup func()) {
 	ctrl := gomock.NewController(t)
 	mock = NewMockLogSink(ctrl)
-	sink = newBufferedSink(mock, maxStaleness, sizeTrigger, maxBufferSize, false /* crashOnAsyncFlushErr */)
+	sink = newBufferedSink(mock, maxStaleness, sizeTrigger, maxBufferSize, false /* crashOnAsyncFlushErr */, fmtType)
 	closer := newBufferedSinkCloser()
 	sink.Start(closer)
 	cleanup = func() {
@@ -55,7 +60,7 @@ func addArgs(f func()) func([]byte, sinkOutputOptions) {
 
 func TestBufferOneLine(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, noSizeTrigger, noMaxBufferSize)
+	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, noSizeTrigger, noMaxBufferSize, nil)
 	defer cleanup()
 
 	var wg sync.WaitGroup
@@ -72,7 +77,7 @@ func TestBufferOneLine(t *testing.T) {
 
 func TestBufferSinkBuffers(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, noSizeTrigger, noMaxBufferSize)
+	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, noSizeTrigger, noMaxBufferSize, nil)
 	defer cleanup()
 
 	flushC := make(chan struct{})
@@ -99,7 +104,7 @@ func TestBufferSinkBuffers(t *testing.T) {
 
 func TestBufferMaxStaleness(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sink, mock, cleanup := getMockBufferedSync(t, time.Second /* maxStaleness*/, noSizeTrigger, noMaxBufferSize)
+	sink, mock, cleanup := getMockBufferedSync(t, time.Second /* maxStaleness*/, noSizeTrigger, noMaxBufferSize, nil)
 	defer cleanup()
 
 	var wg sync.WaitGroup
@@ -116,7 +121,7 @@ func TestBufferMaxStaleness(t *testing.T) {
 
 func TestBufferSizeTrigger(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, 2 /* sizeTrigger */, noMaxBufferSize)
+	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, 2 /* sizeTrigger */, noMaxBufferSize, nil)
 	defer cleanup()
 
 	var wg sync.WaitGroup
@@ -133,7 +138,7 @@ func TestBufferSizeTrigger(t *testing.T) {
 
 func TestBufferSizeTriggerMultipleFlush(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, 8 /* sizeTrigger */, noMaxBufferSize)
+	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, 8 /* sizeTrigger */, noMaxBufferSize, nil)
 	defer cleanup()
 
 	flush1C := make(chan struct{})
@@ -174,7 +179,7 @@ func TestBufferedSinkCrashOnAsyncFlushErr(t *testing.T) {
 	bufferMaxSize := uint64(20)
 	triggerSize := uint64(10)
 	// Configure a sink to crash on flush errors.
-	sink := newBufferedSink(mock, noMaxStaleness, triggerSize, bufferMaxSize, true /* crashOnAsyncFlushErr */)
+	sink := newBufferedSink(mock, noMaxStaleness, triggerSize, bufferMaxSize, true /* crashOnAsyncFlushErr */, nil)
 	sink.Start(closer)
 
 	crashC := make(chan struct{})
@@ -201,7 +206,7 @@ func TestBufferedSinkCrashOnAsyncFlushErr(t *testing.T) {
 // the flush is done.
 func TestBufferedSinkForceSync(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, noSizeTrigger, noMaxBufferSize)
+	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, noSizeTrigger, noMaxBufferSize, nil)
 	defer cleanup()
 
 	ch := make(chan struct{})
@@ -237,7 +242,7 @@ func TestBufferedSinkBlockedFlush(t *testing.T) {
 	mock := NewMockLogSink(ctrl)
 	bufferMaxSize := uint64(20)
 	triggerSize := uint64(10)
-	sink := newBufferedSink(mock, noMaxStaleness, triggerSize, bufferMaxSize, false /* crashOnAsyncFlushErr */)
+	sink := newBufferedSink(mock, noMaxStaleness, triggerSize, bufferMaxSize, false /* crashOnAsyncFlushErr */, nil)
 	sink.Start(closer)
 
 	// firstFlushSem will be signaled when the bufferedSink flushes for the first
@@ -315,7 +320,7 @@ func TestBufferedSinkSyncFlush(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mock := NewMockLogSink(ctrl)
-	sink := newBufferedSink(mock, noMaxStaleness, noSizeTrigger, noMaxBufferSize, false /* crashOnAsyncFlushErr */)
+	sink := newBufferedSink(mock, noMaxStaleness, noSizeTrigger, noMaxBufferSize, false /* crashOnAsyncFlushErr */, nil)
 	sink.Start(closer)
 
 	mock.EXPECT().output(gomock.Eq([]byte("a")), gomock.Any())
@@ -329,7 +334,7 @@ func TestBufferCtxDoneFlushesRemainingMsgs(t *testing.T) {
 	closer := newBufferedSinkCloser()
 	ctrl := gomock.NewController(t)
 	mock := NewMockLogSink(ctrl)
-	sink := newBufferedSink(mock, noMaxStaleness, noSizeTrigger, noMaxBufferSize, false /* crashOnAsyncFlushErr */)
+	sink := newBufferedSink(mock, noMaxStaleness, noSizeTrigger, noMaxBufferSize, false /* crashOnAsyncFlushErr */, nil)
 	sink.Start(closer)
 	defer ctrl.Finish()
 
@@ -346,6 +351,100 @@ func TestBufferCtxDoneFlushesRemainingMsgs(t *testing.T) {
 	require.NoError(t, sink.output([]byte("test2"), sinkOutputOptions{}))
 	require.NoError(t, sink.output([]byte("test3"), sinkOutputOptions{}))
 	require.NoError(t, closer.Close(defaultCloserTimeout))
+}
+
+func TestBufferFormatJsonArray(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	fmtType := logconfig.BufferFormat("json-array")
+	sink, mock, cleanup := getMockBufferedSync(t, noMaxStaleness, 8 /* sizeTrigger */, noMaxBufferSize, &fmtType)
+	defer cleanup()
+
+	// Test that the following occurs:
+	// json-array format should prepend '[' and append ']' to the buffer output.
+	// Entries are separated with ",".
+	// It does not modify log entries themselves.
+
+	flush1C := make(chan struct{})
+	flush2C := make(chan struct{})
+
+	gomock.InOrder(
+		mock.EXPECT().
+			output(gomock.Eq([]byte("[test1,test2]")), sinkOutputOptionsMatcher{extraFlush: gomock.Eq(true)}).
+			Do(addArgs(func() { close(flush1C) })),
+		mock.EXPECT().
+			output(gomock.Eq([]byte("[test3]")), sinkOutputOptionsMatcher{extraFlush: gomock.Eq(true)}).
+			Do(addArgs(func() { close(flush2C) })),
+	)
+
+	require.NoError(t, sink.output([]byte("test1"), sinkOutputOptions{}))
+	require.NoError(t, sink.output([]byte("test2"), sinkOutputOptions{}))
+	select {
+	case <-flush1C:
+	case <-time.After(10 * time.Second):
+		t.Fatal("first flush didn't happen")
+	}
+	require.NoError(t, sink.output([]byte("test3"), sinkOutputOptions{extraFlush: true}))
+	select {
+	case <-flush2C:
+	case <-time.After(10 * time.Second):
+		t.Fatal("second flush didn't happen")
+	}
+
+}
+
+func TestMsgBufFlushFormat(t *testing.T) {
+	testCases := []struct {
+		bufferContents []string
+		prefix         string
+		suffix         string
+		delimiter      string
+		expected       string
+	}{
+		{
+			bufferContents: []string{"hello", "world"},
+			prefix:         "",
+			suffix:         "",
+			delimiter:      "\n",
+			expected:       "hello\nworld",
+		},
+		{
+			bufferContents: []string{"a", "b", "cde", "efg", "hijklmn", "o", "pqrst"},
+			prefix:         "MyPrefix ",
+			suffix:         " MySuffix",
+			delimiter:      " , ",
+			expected:       "MyPrefix a , b , cde , efg , hijklmn , o , pqrst MySuffix",
+		},
+		{
+			bufferContents: []string{"onetwo", "three", "fourfive", "sixseven", "eightnineten"},
+			prefix:         "\n",
+			suffix:         "\n",
+			delimiter:      "",
+			expected:       "\nonetwothreefourfivesixseveneightnineten\n",
+		},
+		{
+			bufferContents: []string{"onetwo", "three", "fourfive", "sixseven", "eightnineten"},
+			prefix:         "",
+			suffix:         "",
+			delimiter:      "",
+			expected:       "onetwothreefourfivesixseveneightnineten",
+		},
+	}
+
+	for _, tc := range testCases {
+		// Set up the contents of the msgBuf.
+		buf := msgBuf{}
+		for _, strMsg := range tc.bufferContents {
+			msg := getBuffer()
+			msg.WriteString(strMsg)
+			require.NoError(t, buf.appendMsg(msg, nil))
+		}
+
+		// Flush.
+		resBuf, _ := buf.flush(tc.prefix, tc.suffix, tc.delimiter)
+
+		// Check output.
+		require.Equal(t, tc.expected, resBuf.String())
+	}
 }
 
 type sinkOutputOptionsMatcher struct {

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -415,12 +415,15 @@ func attachBufferWrapper(
 	if bufConfig.IsNone() {
 		return
 	}
+
 	bs := newBufferedSink(
 		s.sink,
 		*bufConfig.MaxStaleness,
 		uint64(*bufConfig.FlushTriggerSize),
 		uint64(*bufConfig.MaxBufferSize),
-		s.criticality /* crashOnAsyncFlushErr */)
+		s.criticality, /* crashOnAsyncFlushErr */
+		bufConfig.Format,
+	)
 	bs.Start(closer)
 	s.sink = bs
 }
@@ -452,9 +455,11 @@ func (l *sinkInfo) describeAppliedConfig() (c logconfig.CommonSinkConfig) {
 	c.Format = &f
 	bufferedSink, ok := l.sink.(*bufferedSink)
 	if ok {
+
 		c.Buffering.MaxStaleness = &bufferedSink.maxStaleness
 		triggerSize := logconfig.ByteSize(bufferedSink.triggerSize)
 		c.Buffering.FlushTriggerSize = &triggerSize
+		c.Buffering.Format = &bufferedSink.format.fmtType
 		bufferedSink.mu.Lock()
 		maxBufferSize := logconfig.ByteSize(bufferedSink.mu.buf.maxSizeBytes)
 		c.Buffering.MaxBufferSize = &maxBufferSize

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -103,6 +103,7 @@ sinks:
         max-staleness: 5s
         flush-trigger-size: 1.0MiB
         max-buffer-size: 50MiB
+        format: newline
   stderr:
     filter: NONE
 capture-stray-errors:
@@ -178,6 +179,7 @@ sinks:
         max-staleness: 5s
         flush-trigger-size: 1.0MiB
         max-buffer-size: 50MiB
+        format: newline
   stderr:
     filter: NONE
 capture-stray-errors:
@@ -453,6 +455,7 @@ fluent-defaults:
     max-staleness: 15s
     flush-trigger-size: 10KiB
     max-buffer-size: 2MiB
+    format: json-array
 sinks:
   fluent-servers:
     a:
@@ -460,6 +463,7 @@ sinks:
       channels: STORAGE
       buffering:
         max-staleness: 10s
+        format: newline
     b:
       address: b
       channels: OPS
@@ -494,6 +498,7 @@ sinks:
         max-staleness: 10s
         flush-trigger-size: 10KiB
         max-buffer-size: 2.0MiB
+        format: newline
     b:
       channels: {INFO: [OPS]}
       net: tcp
@@ -507,6 +512,7 @@ sinks:
         max-staleness: 15s
         flush-trigger-size: 5.0KiB
         max-buffer-size: 2.0MiB
+        format: json-array
     c:
       channels: {INFO: [HEALTH]}
       net: tcp
@@ -520,6 +526,7 @@ sinks:
         max-staleness: 15s
         flush-trigger-size: 10KiB
         max-buffer-size: 3.0MiB
+        format: json-array
     d:
       channels: {INFO: [SESSIONS]}
       net: tcp

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -42,6 +42,7 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 	defaultBufferedStaleness := 5 * time.Second
 	defaultFlushTriggerSize := ByteSize(1024 * 1024)   // 1mib
 	defaultMaxBufferSize := ByteSize(50 * 1024 * 1024) // 50mib
+	bufferFmt := BufferFmtNewline
 
 	baseCommonSinkConfig := CommonSinkConfig{
 		Filter:      logpb.Severity_INFO,
@@ -56,6 +57,7 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 				MaxStaleness:     &zeroDuration,
 				FlushTriggerSize: &zeroByteSize,
 				MaxBufferSize:    &zeroByteSize,
+				Format:           &bufferFmt,
 			},
 		},
 	}
@@ -76,6 +78,7 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 					MaxStaleness:     &zeroDuration,
 					FlushTriggerSize: &zeroByteSize,
 					MaxBufferSize:    &zeroByteSize,
+					Format:           &bufferFmt,
 				},
 			},
 		},
@@ -88,6 +91,7 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 					MaxStaleness:     &defaultBufferedStaleness,
 					FlushTriggerSize: &defaultFlushTriggerSize,
 					MaxBufferSize:    &defaultMaxBufferSize,
+					Format:           &bufferFmt,
 				},
 			},
 		},
@@ -100,6 +104,7 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 					MaxStaleness:     &defaultBufferedStaleness,
 					FlushTriggerSize: &defaultFlushTriggerSize,
 					MaxBufferSize:    &defaultMaxBufferSize,
+					Format:           &bufferFmt,
 				},
 			},
 		},

--- a/pkg/util/log/testdata/config
+++ b/pkg/util/log/testdata/config
@@ -83,6 +83,7 @@ sinks:
         max-staleness: 5s
         flush-trigger-size: 1.0MiB
         max-buffer-size: 50MiB
+        format: newline
   stderr:
     format: crdb-v2-tty
     redact: false
@@ -128,6 +129,7 @@ sinks:
         max-staleness: 5s
         flush-trigger-size: 1.0MiB
         max-buffer-size: 50MiB
+        format: newline
   stderr:
     format: crdb-v2-tty
     redact: false


### PR DESCRIPTION
This commit adds an option to format the logging sink
buffers on flush.

New option (under `buffering` in the config file):
- format: string that is either 'json-array' or 'newline',
defaulting to 'newline'.

Format options:
- json-array: adds '[' at the start of the buffer output and ']'
at the end. Separates entries in the buffer with ",".
- newline (default): separates entries in the buffer with "\n".

This change was motivated by the desire to be able to send batched logs
to the Datadog API, which expects them to be in a JSON array when multiple
logs are present. Note that If buffering is off, it is still valid to
send a single JSON log to the Datadog logs API.

Part of: https://github.com/cockroachdb/cockroach/issues/103477

Release note (cli change): New log config option for the
`buffering` field to allow buffer output to formatted  as
JSON arrays. This can be useful for APIs requring json array
format, such as the Datadog logs API.
New fields:
- format: 'json-array' or 'newline'.
Descriptions:
- json-array: adds '[' at the start of the buffer output and ']'
at the end. Separates entries in the buffer with ",".
- newline (default): separates entries in the buffer with "\n".