### PR TITLE
statusccl: backport skip tenant_span_stats test under deadlock

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -132,6 +132,7 @@ func TestTenantStatusAPI(t *testing.T) {
 	})
 
 	t.Run("tenant_span_stats", func(t *testing.T) {
+		skip.UnderDeadlockWithIssue(t, 99770)
 		testTenantSpanStats(ctx, t, testHelper)
 	})
 


### PR DESCRIPTION
Informs: #99770
Epic: none
Release note: None