### PR TITLE
sql: check schema privileges when dropping role

### DIFF
--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -214,6 +214,22 @@ func (n *DropRoleNode) startExec(params runParams) error {
 			return err
 		}
 
+		for _, u := range schemaDesc.GetPrivileges().Users {
+			if _, ok := userNames[u.User()]; ok {
+				if privilegeObjectFormatter.Len() > 0 {
+					privilegeObjectFormatter.WriteString(", ")
+				}
+				sn := tree.ObjectNamePrefix{
+					ExplicitCatalog: true,
+					CatalogName:     tree.Name(dbDesc.GetName()),
+					ExplicitSchema:  true,
+					SchemaName:      tree.Name(schemaDesc.GetName()),
+				}
+				privilegeObjectFormatter.FormatNode(&sn)
+				break
+			}
+		}
+
 		if err := accumulateDependentDefaultPrivileges(schemaDesc.GetDefaultPrivilegeDescriptor(), userNames, dbDesc.GetName(), schemaDesc.GetName()); err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -172,3 +172,26 @@ test           owner_grant_option  admin                     ALL             tru
 test           owner_grant_option  other_owner               ALL             true
 test           owner_grant_option  owner_grant_option_child  USAGE           false
 test           owner_grant_option  root                      ALL             true
+
+# Regression test to cover checking schema-level privileges at role drop time
+subtest regression_102962
+
+statement ok
+CREATE SCHEMA sc102962
+
+statement ok
+CREATE ROLE r102962
+
+statement ok
+GRANT USAGE ON SCHEMA sc102962 TO r102962
+
+query TTTTB colnames
+SHOW GRANTS ON SCHEMA sc102962
+----
+database_name  schema_name  grantee  privilege_type  is_grantable
+test           sc102962     admin    ALL             true
+test           sc102962     r102962  USAGE           false
+test           sc102962     root     ALL             true
+
+statement error pgcode 2BP01 pq: cannot drop role/user r102962: grants still exist on test.sc102962
+DROP ROLE r102962


### PR DESCRIPTION
Previously, dropping a role which has privileges on a schema did not result in a error. This patch fixes this bug by adding the missing logic which performs this check.

Fixes #102962.

Release note (bug fix): DROP ROLE now correctly returns an 2BP01 error when the given role has been granted privileges on a schema.