### PR TITLE
dev: fix ^ handling in --files arg for testlogic command

### DIFF
--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -310,5 +310,6 @@ func munge(s string) string {
 	s = strings.ReplaceAll(s, "-", "_")
 	s = strings.ReplaceAll(s, ".", "_")
 	s = strings.ReplaceAll(s, "/", "")
+	s = strings.ReplaceAll(s, "^", "^Test[a-zA-Z0-9]+_")
 	return s
 }


### PR DESCRIPTION
Presently, trying to filter logic tests by prefix is broken, because a --files regexp including ^ gets passed to bazel's --test_filter as-is thereby never matching any test name. Logic test names are generated as TestLogic_.* for base logic tests, TestCCLLogic_* for CCL logic tests, etc.

This patch replaces '^' with '^Test[a-zA-Z0-9]+_' for this purpose.

Fixes #103468.

Release note: None