### PR TITLE
ccl/sqlproxyccl: validate cluster name before establishing connection

### DIFF
--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -307,7 +307,7 @@ func (c *connector) lookupAddr(ctx context.Context) (string, error) {
 
 	// Lookup tenant in the directory cache. Once we have retrieve the list of
 	// pods, use the Balancer for load balancing.
-	pods, err := c.DirectoryCache.LookupTenantPods(ctx, c.TenantID, c.ClusterName)
+	pods, err := c.DirectoryCache.LookupTenantPods(ctx, c.TenantID)
 	switch {
 	case err == nil:
 		runningPods := make([]*tenant.Pod, 0, len(pods))

--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -585,7 +585,7 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 		tenantID := roachpb.MustMakeTenantID(42)
 		directoryCache := &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(
-				fnCtx context.Context, tenantID roachpb.TenantID, clusterName string,
+				fnCtx context.Context, tenantID roachpb.TenantID,
 			) ([]*tenant.Pod, error) {
 				mu.Lock()
 				defer mu.Unlock()
@@ -677,12 +677,11 @@ func TestConnector_lookupAddr(t *testing.T) {
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(
-				fnCtx context.Context, tenantID roachpb.TenantID, clusterName string,
+				fnCtx context.Context, tenantID roachpb.TenantID,
 			) ([]*tenant.Pod, error) {
 				lookupTenantPodsFnCount++
 				require.Equal(t, ctx, fnCtx)
 				require.Equal(t, c.TenantID, tenantID)
-				require.Equal(t, c.ClusterName, clusterName)
 				return []*tenant.Pod{
 					{TenantID: c.TenantID.ToUint64(), Addr: "127.0.0.10:70", State: tenant.DRAINING},
 					{TenantID: c.TenantID.ToUint64(), Addr: "127.0.0.10:80", State: tenant.RUNNING},
@@ -705,12 +704,11 @@ func TestConnector_lookupAddr(t *testing.T) {
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(
-				fnCtx context.Context, tenantID roachpb.TenantID, clusterName string,
+				fnCtx context.Context, tenantID roachpb.TenantID,
 			) ([]*tenant.Pod, error) {
 				lookupTenantPodsFnCount++
 				require.Equal(t, ctx, fnCtx)
 				require.Equal(t, c.TenantID, tenantID)
-				require.Equal(t, c.ClusterName, clusterName)
 				return nil, status.Errorf(codes.FailedPrecondition, "foo")
 			},
 		}
@@ -730,12 +728,11 @@ func TestConnector_lookupAddr(t *testing.T) {
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(
-				fnCtx context.Context, tenantID roachpb.TenantID, clusterName string,
+				fnCtx context.Context, tenantID roachpb.TenantID,
 			) ([]*tenant.Pod, error) {
 				lookupTenantPodsFnCount++
 				require.Equal(t, ctx, fnCtx)
 				require.Equal(t, c.TenantID, tenantID)
-				require.Equal(t, c.ClusterName, clusterName)
 				return nil, status.Errorf(codes.NotFound, "foo")
 			},
 		}
@@ -755,12 +752,11 @@ func TestConnector_lookupAddr(t *testing.T) {
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(
-				fnCtx context.Context, tenantID roachpb.TenantID, clusterName string,
+				fnCtx context.Context, tenantID roachpb.TenantID,
 			) ([]*tenant.Pod, error) {
 				lookupTenantPodsFnCount++
 				require.Equal(t, ctx, fnCtx)
 				require.Equal(t, c.TenantID, tenantID)
-				require.Equal(t, c.ClusterName, clusterName)
 				return nil, errors.New("foo")
 			},
 		}
@@ -982,7 +978,7 @@ var _ tenant.DirectoryCache = &testTenantDirectoryCache{}
 // cache.
 type testTenantDirectoryCache struct {
 	lookupTenantFn        func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error)
-	lookupTenantPodsFn    func(ctx context.Context, tenantID roachpb.TenantID, clusterName string) ([]*tenant.Pod, error)
+	lookupTenantPodsFn    func(ctx context.Context, tenantID roachpb.TenantID) ([]*tenant.Pod, error)
 	trylookupTenantPodsFn func(ctx context.Context, tenantID roachpb.TenantID) ([]*tenant.Pod, error)
 	reportFailureFn       func(ctx context.Context, tenantID roachpb.TenantID, addr string) error
 }
@@ -996,9 +992,9 @@ func (r *testTenantDirectoryCache) LookupTenant(
 
 // LookupTenantPods implements the tenant.DirectoryCache interface.
 func (r *testTenantDirectoryCache) LookupTenantPods(
-	ctx context.Context, tenantID roachpb.TenantID, clusterName string,
+	ctx context.Context, tenantID roachpb.TenantID,
 ) ([]*tenant.Pod, error) {
-	return r.lookupTenantPodsFn(ctx, tenantID, clusterName)
+	return r.lookupTenantPodsFn(ctx, tenantID)
 }
 
 // TryLookupTenantPods implements the tenant.DirectoryCache interface.

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -42,7 +42,7 @@ func TestDirectoryErrors(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	dir, dirServer := tenantdirsvr.SetupTestDirectory(t, ctx, stopper, nil /* timeSource */)
+	dir, _ := tenantdirsvr.SetupTestDirectory(t, ctx, stopper, nil /* timeSource */)
 
 	// Fail to find a tenant that does not exist.
 	_, err := dir.LookupTenant(ctx, roachpb.MustMakeTenantID(1000))
@@ -57,17 +57,8 @@ func TestDirectoryErrors(t *testing.T) {
 	require.EqualError(t, err, "rpc error: code = NotFound desc = tenant 1002 not in directory cache")
 
 	// Fail to find tenant that does not exist.
-	_, err = dir.LookupTenantPods(ctx, roachpb.MustMakeTenantID(1000), "")
+	_, err = dir.LookupTenantPods(ctx, roachpb.MustMakeTenantID(1000))
 	require.EqualError(t, err, "rpc error: code = NotFound desc = tenant does not exist")
-
-	// Fail to find tenant when cluster name doesn't match.
-	tenantID := roachpb.MustMakeTenantID(10)
-	dirServer.CreateTenant(tenantID, &tenant.Tenant{
-		TenantID:    tenantID.ToUint64(),
-		ClusterName: "tenant-cluster",
-	})
-	_, err = dir.LookupTenantPods(ctx, tenantID, "unknown")
-	require.EqualError(t, err, "rpc error: code = NotFound desc = cluster name unknown doesn't match expected tenant-cluster")
 
 	// No-op when reporting failure for tenant that doesn't exit.
 	require.NoError(t, dir.ReportFailure(ctx, roachpb.MustMakeTenantID(1000), ""))
@@ -347,7 +338,7 @@ func TestWatchPods(t *testing.T) {
 	// that we attempted to call EnsurePod in the test directory server because
 	// the cache has no running pods. In the actual directory server, this
 	// should put the draining pod back to running.
-	pods, err = dir.LookupTenantPods(ctx, tenantID, "my-tenant")
+	pods, err = dir.LookupTenantPods(ctx, tenantID)
 	require.Regexp(t, "tenant has no pods", err)
 	require.Empty(t, pods)
 
@@ -394,7 +385,7 @@ func TestCancelLookups(t *testing.T) {
 	for i := 0; i < lookupCount; i++ {
 		wait.Add(1)
 		go func(i int) {
-			_, backgroundErrors[i] = dir.LookupTenantPods(ctx, tenantID, "")
+			_, backgroundErrors[i] = dir.LookupTenantPods(ctx, tenantID)
 			wait.Done()
 		}(i)
 	}
@@ -432,7 +423,7 @@ func TestResume(t *testing.T) {
 	for i := 0; i < lookupCount; i++ {
 		wait.Add(1)
 		go func(i int) {
-			pods, err := dir.LookupTenantPods(ctx, tenantID, "")
+			pods, err := dir.LookupTenantPods(ctx, tenantID)
 			require.NoError(t, err)
 			addrs[i] = pods[0].Addr
 			wait.Done()
@@ -471,7 +462,7 @@ func TestDeleteTenant(t *testing.T) {
 	require.NoError(t, createTenant(tc, tenantID))
 
 	// Perform lookup to create entry in cache.
-	pods, err := dir.LookupTenantPods(ctx, tenantID, "")
+	pods, err := dir.LookupTenantPods(ctx, tenantID)
 	require.NoError(t, err)
 	require.NotEmpty(t, pods)
 	addr := pods[0].Addr
@@ -483,7 +474,7 @@ func TestDeleteTenant(t *testing.T) {
 
 	// Report failure even though tenant is healthy - refresh should do nothing.
 	require.NoError(t, dir.ReportFailure(ctx, tenantID, addr))
-	pods, err = dir.LookupTenantPods(ctx, tenantID, "")
+	pods, err = dir.LookupTenantPods(ctx, tenantID)
 	require.NoError(t, err)
 	require.NotEmpty(t, pods)
 	addr = pods[0].Addr
@@ -509,7 +500,7 @@ func TestDeleteTenant(t *testing.T) {
 
 	// Now LookupTenantPods should return an error and the directory should no
 	// longer cache the tenant.
-	_, err = dir.LookupTenantPods(ctx, tenantID, "")
+	_, err = dir.LookupTenantPods(ctx, tenantID)
 	require.EqualError(t, err, "rpc error: code = NotFound desc = tenant 50 not found")
 	pods, err = dir.TryLookupTenantPods(ctx, tenantID)
 	require.EqualError(t, err, "rpc error: code = NotFound desc = tenant 50 not in directory cache")
@@ -533,7 +524,7 @@ func TestRefreshThrottling(t *testing.T) {
 	require.NoError(t, createTenant(tc, tenantID))
 
 	// Perform lookup to create entry in cache.
-	pods, err := dir.LookupTenantPods(ctx, tenantID, "")
+	pods, err := dir.LookupTenantPods(ctx, tenantID)
 	require.NoError(t, err)
 	require.NotEmpty(t, pods)
 	addr := pods[0].Addr


### PR DESCRIPTION
Previously, we were only validating cluster names when LookupTenantPods get called within the connector, which happens after the ACL check. The rationale behind that is that we didn't want a malicious actor who's iterating through all tenant IDs spinning up pods for them. The cluster name check ensures that the incoming connection knows something about the tenant.

Now that we have introduced LookupTenant within the ACL logic, it is possible for a malicious actor to iterate through all the tenant IDs, and figure out which tenant IDs are in use (since it returns "connection refused" if the tenant exists). To address that, we will start validating cluster names before running the ACL check (i.e. at the start of the proxy handler) before proceeding. This ensures that we will return a NotFound error if the tenant doesn't exist, or there's a cluster name mismatch. At the same time, the clusterName parameter has been removed from LookupTenantPods since that is no longer needed.

Release note: None

Epic: none