### PR TITLE
ccl/sqlproxyccl: default tenants to both public and private connectivities

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/allowlist.go
+++ b/pkg/ccl/sqlproxyccl/acl/allowlist.go
@@ -44,7 +44,8 @@ func (al *Allowlist) UnmarshalYAML(unmarshal func(interface{}) error) error {
 //
 // TODO(jaylim-crl): Call LookupTenant and return nil if the cluster has no
 // public connectivity. This ACL shouldn't be applied. We would need to do this
-// eventually once we move IP allowlist entries into the tenant object.
+// eventually once we move IP allowlist entries into the tenant object. Don't
+// need to do this now as we don't need anything from the tenant metadata.
 func (al *Allowlist) CheckConnection(ctx context.Context, connection ConnectionTags) error {
 	entry, ok := al.entries[connection.TenantID.String()]
 	if !ok {

--- a/pkg/ccl/sqlproxyccl/acl/private_endpoints.go
+++ b/pkg/ccl/sqlproxyccl/acl/private_endpoints.go
@@ -44,7 +44,7 @@ func (p *PrivateEndpoints) CheckConnection(ctx context.Context, conn ConnectionT
 	}
 
 	// Cluster allows private connections, so we'll check allowed endpoints.
-	if (tenantObj.ConnectivityType & tenant.ALLOW_PRIVATE) != 0 {
+	if tenantObj.AllowPrivateConn() {
 		for _, endpoints := range tenantObj.PrivateEndpoints {
 			// A matching endpointID was found.
 			if endpoints == conn.EndpointID {

--- a/pkg/ccl/sqlproxyccl/acl/private_endpoints_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/private_endpoints_test.go
@@ -50,7 +50,7 @@ func TestPrivateEndpoints(t *testing.T) {
 		p := &acl.PrivateEndpoints{
 			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
 				return &tenant.Tenant{
-					ConnectivityType: tenant.ALLOW_PRIVATE,
+					ConnectivityType: tenant.ALLOW_PRIVATE_ONLY,
 				}, nil
 			},
 		}
@@ -63,7 +63,7 @@ func TestPrivateEndpoints(t *testing.T) {
 		p := &acl.PrivateEndpoints{
 			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
 				return &tenant.Tenant{
-					ConnectivityType: tenant.ALLOW_PUBLIC | tenant.ALLOW_PRIVATE,
+					ConnectivityType: tenant.ALLOW_ALL,
 					PrivateEndpoints: []string{"foo", "baz"},
 				}, nil
 			},
@@ -76,7 +76,7 @@ func TestPrivateEndpoints(t *testing.T) {
 		p := &acl.PrivateEndpoints{
 			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
 				return &tenant.Tenant{
-					ConnectivityType: tenant.ALLOW_PUBLIC | tenant.ALLOW_PRIVATE,
+					ConnectivityType: tenant.ALLOW_ALL,
 					PrivateEndpoints: []string{"foo"},
 				}, nil
 			},
@@ -85,12 +85,11 @@ func TestPrivateEndpoints(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	// Does not have tenant.ALLOW_PRIVATE.
 	t.Run("disallow private connections", func(t *testing.T) {
 		p := &acl.PrivateEndpoints{
 			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
 				return &tenant.Tenant{
-					ConnectivityType: tenant.ALLOW_PUBLIC,
+					ConnectivityType: tenant.ALLOW_PUBLIC_ONLY,
 					PrivateEndpoints: []string{"foo"},
 				}, nil
 			},

--- a/pkg/ccl/sqlproxyccl/acl/watcher_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/watcher_test.go
@@ -75,7 +75,7 @@ func TestACLWatcher(t *testing.T) {
 		Version:          "001",
 		TenantID:         tenantID.ToUint64(),
 		ClusterName:      "my-tenant",
-		ConnectivityType: tenant.ALLOW_PUBLIC | tenant.ALLOW_PRIVATE,
+		ConnectivityType: tenant.ALLOW_ALL,
 		PrivateEndpoints: []string{"foo-bar-baz", "cockroachdb"},
 	})
 
@@ -235,7 +235,7 @@ func TestACLWatcher(t *testing.T) {
 			Version:          "002",
 			TenantID:         tenantID.ToUint64(),
 			ClusterName:      "my-tenant",
-			ConnectivityType: tenant.ALLOW_PUBLIC | tenant.ALLOW_PRIVATE,
+			ConnectivityType: tenant.ALLOW_ALL,
 			PrivateEndpoints: []string{"foo-bar-baz"},
 		})
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -238,21 +238,21 @@ func TestPrivateEndpointsACL(t *testing.T) {
 		Version:          "001",
 		TenantID:         tenant10.ToUint64(),
 		ClusterName:      "my-tenant",
-		ConnectivityType: tenant.ALLOW_PUBLIC | tenant.ALLOW_PRIVATE,
+		ConnectivityType: tenant.ALLOW_ALL,
 		PrivateEndpoints: []string{"vpce-abc123"},
 	})
 	tds.CreateTenant(tenant20, &tenant.Tenant{
 		Version:          "002",
 		TenantID:         tenant20.ToUint64(),
 		ClusterName:      "other-tenant",
-		ConnectivityType: tenant.ALLOW_PUBLIC | tenant.ALLOW_PRIVATE,
+		ConnectivityType: tenant.ALLOW_ALL,
 		PrivateEndpoints: []string{"vpce-some-other-vpc"},
 	})
 	tds.CreateTenant(tenant30, &tenant.Tenant{
 		Version:          "003",
 		TenantID:         tenant30.ToUint64(),
 		ClusterName:      "public-tenant",
-		ConnectivityType: tenant.ALLOW_PUBLIC,
+		ConnectivityType: tenant.ALLOW_PUBLIC_ONLY,
 		PrivateEndpoints: []string{},
 	})
 	// All tenants map to the same pod.
@@ -325,7 +325,7 @@ func TestPrivateEndpointsACL(t *testing.T) {
 					Version:          "010",
 					TenantID:         tenant10.ToUint64(),
 					ClusterName:      "my-tenant",
-					ConnectivityType: tenant.ALLOW_PUBLIC | tenant.ALLOW_PRIVATE,
+					ConnectivityType: tenant.ALLOW_ALL,
 					PrivateEndpoints: []string{},
 				})
 

--- a/pkg/ccl/sqlproxyccl/tenant/directory.proto
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.proto
@@ -96,25 +96,25 @@ message EnsurePodResponse {
 
 // ConnectivityType indicates the extent to which the tenant can be accessed
 // (e.g. private only, public only, or both).
-//
-// NOTE: This is treated as a bitmask, so values should be a factor of 2.
 enum ConnectivityType {
   option (gogoproto.goproto_enum_prefix) = false;
 
-  // ALLOW_NONE indicates that the cluster is entirely inaccessible.
+  // ALLOW_ALL indicates that the cluster allows both public and private
+  // connections. In this case, both IP allowlist and private endpoint rules
+  // will apply.
   //
-  // TODO(jaylim-crl): For now, this is the same as ALLOW_PUBLIC for backwards
-  // compatiblity. Once we updated the directory server to send this field, we
-  // can reject all connections for tenants where type=ALLOW_NONE.
-  ALLOW_NONE = 0;
-  // ALLOW_PUBLIC indicates that the cluster is exposed to the public internet,
-  // and IP allowlist rules will apply. By default, if there are no rules, the
-  // proxy will block all public connections.
-  ALLOW_PUBLIC = 1;
-  // ALLOW_PRIVATE indicates that the cluster allows private endpoints, and
+  // The proxy will block incoming connections if:
+  //   1. the connection is public, and there are no IP allowlist entries, or
+  //   2. the connection is private, and there are no private endpoint entries.
+  ALLOW_ALL = 0;
+  // ALLOW_PUBLIC_ONLY indicates that the cluster is exposed to the public
+  // internet, and IP allowlist rules will apply. By default, if there are no
+  // rules, the proxy will block all public connections.
+  ALLOW_PUBLIC_ONLY = 1;
+  // ALLOW_PRIVATE_ONLY indicates that the cluster allows private endpoints, and
   // private endpoint rules will apply. By default, if there are no rules, the
   // proxy will block all private connections.
-  ALLOW_PRIVATE = 2;
+  ALLOW_PRIVATE_ONLY = 2;
 }
 
 // Tenant contains information about a tenant, such as its name and ID.

--- a/pkg/ccl/sqlproxyccl/tenant/entry.go
+++ b/pkg/ccl/sqlproxyccl/tenant/entry.go
@@ -334,3 +334,15 @@ func hasRunningPod(pods []*Pod) bool {
 	}
 	return false
 }
+
+// AllowPrivateConn returns true if the tenant allows private connections to it,
+// or false otherwise.
+func (t *Tenant) AllowPrivateConn() bool {
+	return t.ConnectivityType == ALLOW_ALL || t.ConnectivityType == ALLOW_PRIVATE_ONLY
+}
+
+// AllowPublicConn returns true if the tenant allows public connections to it,
+// or false otherwise.
+func (t *Tenant) AllowPublicConn() bool {
+	return t.ConnectivityType == ALLOW_ALL || t.ConnectivityType == ALLOW_PUBLIC_ONLY
+}


### PR DESCRIPTION
Previously, we had introduced 3 states (ALLOW_NONE, ALLOW_PUBLIC, and ALLOW_PRIVATE) with the intention that ALLOW_NONE would be useful. Thinking about it further, it does not make sense for a cluster to support ALLOW_NONE (i.e. what would that actually mean?). This commit updates the connectivity types to support ALLOW_ALL, ALLOW_PUBLIC_ONLY, and ALLOW_PRIVATE_ONLY. By default, ConnectivityType=0, which maps to ALLOW_ALL.

Release note: None

Epic: none