### PR TITLE
kv: add assertion to prevent lock re-acquisition at prior epochs

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1911,6 +1911,31 @@ func (l *lockState) acquireLock(
 		if txn.ID != beforeTxn.ID {
 			return errors.AssertionFailedf("existing lock cannot be acquired by different transaction")
 		}
+		if durability == lock.Unreplicated &&
+			l.holder.holder[lock.Unreplicated].txn != nil &&
+			l.holder.holder[lock.Unreplicated].txn.Epoch > txn.Epoch {
+			// If the lock is being re-acquired as an unreplicated lock, and the
+			// request trying to do so belongs to a prior epoch, we reject the
+			// request. This parallels the logic mvccPutInternal has for intents.
+			return errors.Errorf(
+				"locking request with epoch %d came after lock(unreplicated) had already been acquired at epoch %d in txn %s",
+				txn.Epoch, l.holder.holder[durability].txn.Epoch, txn.ID,
+			)
+		}
+		// TODO(arul): Once we stop storing sequence numbers/transaction protos
+		// associated with replicated locks, the following logic can be deleted.
+		if durability == lock.Replicated &&
+			l.holder.holder[lock.Replicated].txn != nil &&
+			l.holder.holder[lock.Replicated].txn.Epoch > txn.Epoch {
+			// If we're dealing with a replicated lock (intent), and the transaction
+			// acquiring this lock belongs to a prior epoch, we expect mvccPutInternal
+			// to return an error. As such, the request should never call into
+			// AcquireLock and reach this point.
+			return errors.AssertionFailedf(
+				"locking request with epoch %d came after lock(replicated) had already been acquired at epoch %d in txn %s",
+				txn.Epoch, l.holder.holder[durability].txn.Epoch, txn.ID,
+			)
+		}
 		seqs := l.holder.holder[durability].seqs
 		if l.holder.holder[durability].txn != nil && l.holder.holder[durability].txn.Epoch < txn.Epoch {
 			// Clear the sequences for the older epoch.

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -135,7 +135,7 @@ num=1
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
 
-new-txn txn=txn1 ts=14 epoch=1 seq=1
+new-txn txn=txn1 ts=14 epoch=2 seq=1
 ----
 
 new-request r=req6 txn=txn1 ts=14 spans=intent@a
@@ -145,7 +145,7 @@ acquire r=req6 k=a durability=r
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 1, seqs: [1], unrepl epoch: 2, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 2, seqs: [1], unrepl epoch: 2, seqs: [0]
    waiting readers:
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
@@ -158,7 +158,7 @@ acquire r=req6 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 14.000000000,0, info: repl epoch: 1, seqs: [1], unrepl epoch: 1, seqs: [0, 1]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 14.000000000,0, info: repl epoch: 2, seqs: [1], unrepl epoch: 2, seqs: [0, 1]
 
 guard-state r=req5
 ----
@@ -186,7 +186,7 @@ add-discovered r=req7 k=a txn=txn1
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 14.000000000,0, info: repl epoch: 1, seqs: [1], unrepl epoch: 1, seqs: [0, 1]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 14.000000000,0, info: repl epoch: 2, seqs: [1], unrepl epoch: 2, seqs: [0, 1]
    waiting readers:
     req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
@@ -194,3 +194,43 @@ num=1
 guard-state r=req7
 ----
 new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
+
+# ------------------------------------------------------------------------------
+# Try to re-acquire an unreplicated lock that is already held at a higher epoch.
+# This should result in an error, similar to how mvccPutInternal handles this
+# case for intents, as the in-memory lock table is the source of truth for
+# unreplicated locks.
+#
+# We also test the same scenario for replicated locks. The only difference here
+# being that this time, we get an AssertionFailed error -- this is because we
+# expect mvccPutInternal to return an error, and never actually call into the
+# lock table to try and acquire this lock.
+# ------------------------------------------------------------------------------
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 14.000000000,0, info: repl epoch: 2, seqs: [1], unrepl epoch: 2, seqs: [0, 1]
+   waiting readers:
+    req: 3, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 3
+
+new-txn txn=txn1 ts=14 epoch=1 seq=1
+----
+
+new-request r=req8 txn=txn1 ts=14 spans=none@a
+----
+
+scan r=req8
+----
+start-waiting: false
+
+acquire r=req8 k=a durability=u
+----
+locking request with epoch 1 came after lock(unreplicated) had already been acquired at epoch 2 in txn 00000000-0000-0000-0000-000000000001
+
+
+acquire r=req8 k=a durability=r
+----
+locking request with epoch 1 came after lock(replicated) had already been acquired at epoch 2 in txn 00000000-0000-0000-0000-000000000001


### PR DESCRIPTION
Lock re-acquisitions from requests that belong to prior epochs is not allowed. For replicated locks, mvccPutInternal rejects such requests with an error. However, for unreplicated locks where the in-memory lock table is the source of truth, no such check happens. This patch adds one. The comment on `lockHolderInfo.txn` field suggests this was always the intended behavior; it was just never enforced.

While here, we also add an assertion to ensure a replicated lock acquisition never calls into the lock table with a transaction belonging to a prior epoch. We expect this case to be handled in mvccPutInternal, so unlike the unreplicated case, this deserves to be an assertion failure.

This patch also updates a test that unintentionally re-acquired a lock using a txn from an older epoch. We also add a new test.

Informs: #102269

Release note: None