### PR TITLE
release-22.2: sql: fix RowsAffected in internal executor when it encounters a retry error

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -463,8 +463,8 @@ func (w *changefeedResultWriter) AddRow(ctx context.Context, row tree.Datums) er
 		return nil
 	}
 }
-func (w *changefeedResultWriter) IncrementRowsAffected(ctx context.Context, n int) {
-	w.rowsAffected += n
+func (w *changefeedResultWriter) SetRowsAffected(ctx context.Context, n int) {
+	w.rowsAffected = n
 }
 func (w *changefeedResultWriter) SetError(err error) {
 	w.err = err

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -260,7 +260,14 @@ func mustParseOne(s string) parser.Statement {
 // need to read from it.
 func startConnExecutor(
 	ctx context.Context,
-) (*StmtBuf, <-chan []resWithPos, <-chan error, *stop.Stopper, ieResultReader, error) {
+) (
+	*StmtBuf,
+	<-chan []*streamingCommandResult,
+	<-chan error,
+	*stop.Stopper,
+	ieResultReader,
+	error,
+) {
 	// A lot of boilerplate for creating a connExecutor.
 	stopper := stop.NewStopper()
 	clock := hlc.NewClockWithSystemTimeSource(0 /* maxOffset */)
@@ -337,10 +344,10 @@ func startConnExecutor(
 
 	s := NewServer(cfg, pool)
 	buf := NewStmtBuf()
-	syncResults := make(chan []resWithPos, 1)
+	syncResults := make(chan []*streamingCommandResult, 1)
 	resultChannel := newAsyncIEResultChannel()
 	var cc ClientComm = &internalClientComm{
-		sync: func(res []resWithPos) {
+		sync: func(res []*streamingCommandResult) {
 			syncResults <- res
 		},
 		w: resultChannel,
@@ -377,9 +384,9 @@ func TestSessionCloseWithPendingTempTableInTxn(t *testing.T) {
 
 	srv := s.SQLServer().(*Server)
 	stmtBuf := NewStmtBuf()
-	flushed := make(chan []resWithPos)
+	flushed := make(chan []*streamingCommandResult)
 	clientComm := &internalClientComm{
-		sync: func(res []resWithPos) {
+		sync: func(res []*streamingCommandResult) {
 			flushed <- res
 		},
 	}

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -652,7 +652,7 @@ const (
 //
 // ClientComm is implemented by the pgwire connection.
 type ClientComm interface {
-	// createStatementResult creates a StatementResult for stmt.
+	// CreateStatementResult creates a StatementResult for stmt.
 	//
 	// descOpt specifies if result needs to inform the client about row schema. If
 	// it doesn't, a SetColumns call becomes a no-op.
@@ -698,7 +698,7 @@ type ClientComm interface {
 	// CreateDrainResult creates a result for a Drain command.
 	CreateDrainResult(pos CmdPos) DrainResult
 
-	// lockCommunication ensures that no further results are delivered to the
+	// LockCommunication ensures that no further results are delivered to the
 	// client. The returned ClientLock can be queried to see what results have
 	// been already delivered to the client and to discard results that haven't
 	// been delivered.
@@ -912,10 +912,11 @@ type ClientLock interface {
 	// connection.
 	ClientPos() CmdPos
 
-	// RTrim iterates backwards through the results and drops all results with
-	// position >= pos.
-	// It is illegal to call rtrim with a position <= clientPos(). In other words,
-	// results can
+	// RTrim drops all results with position >= pos.
+	//
+	// It is illegal to call RTrim with a position <= ClientPos(). In other
+	// words, results can only be trimmed if they haven't been sent to the
+	// client.
 	RTrim(ctx context.Context, pos CmdPos)
 }
 
@@ -956,6 +957,8 @@ const discarded resCloseType = false
 // streamingCommandResult is a CommandResult that streams rows on the channel
 // and can call a provided callback when closed.
 type streamingCommandResult struct {
+	pos CmdPos
+
 	// All the data (the rows and the metadata) are written into w. The
 	// goroutine writing into this streamingCommandResult might block depending
 	// on the synchronization strategy.
@@ -965,7 +968,7 @@ type streamingCommandResult struct {
 	rowsAffected int
 
 	// closeCallback, if set, is called when Close()/Discard() is called.
-	closeCallback func(*streamingCommandResult, resCloseType)
+	closeCallback func(resCloseType)
 }
 
 var _ RestrictedCommandResult = &streamingCommandResult{}
@@ -1031,7 +1034,7 @@ func (r *streamingCommandResult) SetError(err error) {
 	// in execStmtInOpenState().
 }
 
-// GetEntryFromExtraInfo is part of the sql.RestrictedCommandResult interface.
+// GetBulkJobID is part of the sql.RestrictedCommandResult interface.
 func (r *streamingCommandResult) GetBulkJobID() uint64 {
 	return 0
 }
@@ -1059,14 +1062,14 @@ func (r *streamingCommandResult) RowsAffected() int {
 // Close is part of the CommandResultClose interface.
 func (r *streamingCommandResult) Close(context.Context, TransactionStatusIndicator) {
 	if r.closeCallback != nil {
-		r.closeCallback(r, closed)
+		r.closeCallback(closed)
 	}
 }
 
 // Discard is part of the CommandResult interface.
 func (r *streamingCommandResult) Discard() {
 	if r.closeCallback != nil {
-		r.closeCallback(r, discarded)
+		r.closeCallback(discarded)
 	}
 }
 

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -806,12 +806,13 @@ type RestrictedCommandResult interface {
 	// AddBatch is undefined.
 	SupportsAddBatch() bool
 
-	// IncrementRowsAffected increments a counter by n. This is used for all
+	// SetRowsAffected sets RowsAffected counter to n. This is used for all
 	// result types other than tree.Rows.
-	IncrementRowsAffected(ctx context.Context, n int)
+	SetRowsAffected(ctx context.Context, n int)
 
-	// RowsAffected returns either the number of times AddRow was called, or the
-	// sum of all n passed into IncrementRowsAffected.
+	// RowsAffected returns either the number of times AddRow was called, total
+	// number of rows pushed via AddBatch, or the last value of n passed into
+	// SetRowsAffected.
 	RowsAffected() int
 
 	// DisableBuffering can be called during execution to ensure that
@@ -1001,7 +1002,7 @@ func (r *streamingCommandResult) ResetStmtType(stmt tree.Statement) {
 
 // AddRow is part of the RestrictedCommandResult interface.
 func (r *streamingCommandResult) AddRow(ctx context.Context, row tree.Datums) error {
-	// AddRow() and IncrementRowsAffected() are never called on the same command
+	// AddRow() and SetRowsAffected() are never called on the same command
 	// result, so we will not double count the affected rows by an increment
 	// here.
 	r.rowsAffected++
@@ -1044,13 +1045,13 @@ func (r *streamingCommandResult) Err() error {
 	return r.err
 }
 
-// IncrementRowsAffected is part of the RestrictedCommandResult interface.
-func (r *streamingCommandResult) IncrementRowsAffected(ctx context.Context, n int) {
-	r.rowsAffected += n
+// SetRowsAffected is part of the RestrictedCommandResult interface.
+func (r *streamingCommandResult) SetRowsAffected(ctx context.Context, n int) {
+	r.rowsAffected = n
 	// streamingCommandResult might be used outside of the internal executor
 	// (i.e. not by rowsIterator) in which case the channel is not set.
 	if r.w != nil {
-		_ = r.w.addResult(ctx, ieIteratorResult{rowsAffectedIncrement: &n})
+		_ = r.w.addResult(ctx, ieIteratorResult{rowsAffected: &n})
 	}
 }
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -161,7 +161,7 @@ func (ie *InternalExecutor) runWithEx(
 	sd *sessiondata.SessionData,
 	stmtBuf *StmtBuf,
 	wg *sync.WaitGroup,
-	syncCallback func([]resWithPos),
+	syncCallback func([]*streamingCommandResult),
 	errCallback func(error),
 ) error {
 	ex, err := ie.initConnEx(ctx, txn, w, sd, stmtBuf, syncCallback)
@@ -202,7 +202,7 @@ func (ie *InternalExecutor) initConnEx(
 	w ieResultWriter,
 	sd *sessiondata.SessionData,
 	stmtBuf *StmtBuf,
-	syncCallback func([]resWithPos),
+	syncCallback func([]*streamingCommandResult),
 ) (*connExecutor, error) {
 	clientComm := &internalClientComm{
 		w: w,
@@ -893,7 +893,7 @@ func (ie *InternalExecutor) execInternal(
 	// statement we care about before that command is sent for execution.
 	var resPos CmdPos
 
-	syncCallback := func(results []resWithPos) {
+	syncCallback := func(results []*streamingCommandResult) {
 		// Close the stmtBuf so that the connExecutor exits its run() loop.
 		stmtBuf.Close()
 		for _, res := range results {
@@ -931,7 +931,6 @@ func (ie *InternalExecutor) execInternal(
 	}
 	typeHints := make(tree.PlaceholderTypes, numParams)
 	for i, d := range datums {
-		// Arg numbers start from 1.
 		typeHints[tree.PlaceholderIdx(i)] = d.ResolvedType()
 	}
 	if len(qargs) == 0 {
@@ -1107,7 +1106,7 @@ func (ie *InternalExecutor) checkIfTxnIsConsistent(txn *kv.Txn) error {
 type internalClientComm struct {
 	// results will contain the results of the commands executed by an
 	// InternalExecutor.
-	results []resWithPos
+	results []*streamingCommandResult
 
 	// The results of the query execution will be written into w.
 	w ieResultWriter
@@ -1115,15 +1114,10 @@ type internalClientComm struct {
 	lastDelivered CmdPos
 
 	// sync, if set, is called whenever a Sync is executed.
-	sync func([]resWithPos)
+	sync func([]*streamingCommandResult)
 }
 
 var _ ClientComm = &internalClientComm{}
-
-type resWithPos struct {
-	*streamingCommandResult
-	pos CmdPos
-}
 
 // CreateStatementResult is part of the ClientComm interface.
 func (icc *internalClientComm) CreateStatementResult(
@@ -1143,17 +1137,15 @@ func (icc *internalClientComm) CreateStatementResult(
 // createRes creates a result. onClose, if not nil, is called when the result is
 // closed.
 func (icc *internalClientComm) createRes(pos CmdPos, onClose func()) *streamingCommandResult {
-	res := &streamingCommandResult{
-		w: icc.w,
-		closeCallback: func(res *streamingCommandResult, typ resCloseType) {
-			if typ == discarded {
-				return
-			}
-			icc.results = append(icc.results, resWithPos{streamingCommandResult: res, pos: pos})
-			if onClose != nil {
-				onClose()
-			}
-		},
+	res := &streamingCommandResult{pos: pos, w: icc.w}
+	res.closeCallback = func(typ resCloseType) {
+		if typ == discarded {
+			return
+		}
+		icc.results = append(icc.results, res)
+		if onClose != nil {
+			onClose()
+		}
 	}
 	return res
 }
@@ -1173,7 +1165,7 @@ func (icc *internalClientComm) CreateBindResult(pos CmdPos) BindResult {
 // The returned SyncResult will call the sync callback when its closed.
 func (icc *internalClientComm) CreateSyncResult(pos CmdPos) SyncResult {
 	return icc.createRes(pos, func() {
-		results := make([]resWithPos, len(icc.results))
+		results := make([]*streamingCommandResult, len(icc.results))
 		copy(results, icc.results)
 		icc.results = icc.results[:0]
 		icc.sync(results)
@@ -1241,7 +1233,7 @@ func (ncl *noopClientLock) ClientPos() CmdPos {
 // RTrim is part of the ClientLock interface.
 func (ncl *noopClientLock) RTrim(_ context.Context, pos CmdPos) {
 	var i int
-	var r resWithPos
+	var r *streamingCommandResult
 	for i, r = range ncl.results {
 		if r.pos >= pos {
 			break

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -321,10 +321,10 @@ func (r *commandResult) SetPortalOutput(
 	_ /* err */ = r.conn.writeRowDescription(ctx, cols, formatCodes, &r.conn.writerState.buf)
 }
 
-// IncrementRowsAffected is part of the sql.RestrictedCommandResult interface.
-func (r *commandResult) IncrementRowsAffected(ctx context.Context, n int) {
+// SetRowsAffected is part of the sql.RestrictedCommandResult interface.
+func (r *commandResult) SetRowsAffected(ctx context.Context, n int) {
 	r.assertNotReleased()
-	r.rowsAffected += n
+	r.rowsAffected = n
 }
 
 // RowsAffected is part of the sql.RestrictedCommandResult interface.

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -198,8 +198,8 @@ func (n *recursiveCTENode) AddRow(ctx context.Context, row tree.Datums) error {
 	return n.workingRows.AddRow(ctx, row)
 }
 
-// IncrementRowsAffected is part of the rowResultWriter interface.
-func (n *recursiveCTENode) IncrementRowsAffected(context.Context, int) {
+// SetRowsAffected is part of the rowResultWriter interface.
+func (n *recursiveCTENode) SetRowsAffected(context.Context, int) {
 }
 
 // SetError is part of the rowResultWriter interface.

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -134,8 +134,8 @@ func (d *droppingResultWriter) AddRow(ctx context.Context, row tree.Datums) erro
 	return nil
 }
 
-// IncrementRowsAffected is part of the rowResultWriter interface.
-func (d *droppingResultWriter) IncrementRowsAffected(ctx context.Context, n int) {}
+// SetRowsAffected is part of the rowResultWriter interface.
+func (d *droppingResultWriter) SetRowsAffected(ctx context.Context, n int) {}
 
 // SetError is part of the rowResultWriter interface.
 func (d *droppingResultWriter) SetError(err error) {

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -34,6 +34,19 @@ type InternalExecutorOverride struct {
 	// used as long as that value has a QoSLevel defined
 	// (see QoSLevel.ValidateInternal).
 	QualityOfService *sessiondatapb.QoSLevel
+	// InjectRetryErrorsEnabled, if true, injects a transaction retry error
+	// _after_ the statement has been processed by the execution engine and
+	// _before_ the control flow is returned to the connExecutor state machine.
+	//
+	// The error will be injected (roughly speaking) three times (determined by
+	// the numTxnRetryErrors constant in conn_executor_exec.go).
+	//
+	// For testing only.
+	//
+	// NB: this override applies only to the "top" internal executor, i.e. it
+	// does **not** propagate further to "nested" executors that are spawned up
+	// by the "top" executor.
+	InjectRetryErrorsEnabled bool
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -203,6 +203,9 @@ message LocalOnlySessionData {
   // InjectRetryErrorsEnabled causes statements inside an explicit
   // transaction to return a transaction retry error. It is intended for
   // developers to test their app's retry logic.
+  //
+  // Note that this session variable is **not** propagated to the internal
+  // executors - use InternalExecutorOverride for that.
   bool inject_retry_errors_enabled = 54;
   // NullOrderedLast controls whether NULL is ordered last. We default to
   // NULLS FIRST for ascending order by default, whereas postgres defaults


### PR DESCRIPTION
Backport 3/5 commits from #101477.

/cc @cockroachdb/release

---

This PR contains seemingly-safe fix to one particular manifestation of a long-standing bug in the internal executor that could make it double count some things (rows or metadata) if an internal retry error occurs. In particular, since at least 21.1 (when we introduced the "streaming" internal executor in #59330) if the IE encounters a retry error _after_ it has communicated some results to the client, it would proceed to retry the corresponding command as if the incomplete execution and the retry error never happened. In other words, it was possible for some rows to be double "counted" (either to be directly included multiple times into the result set or indirectly into the "rows affected" number). This PR only fixes double-counting of the "rows affected" by resetting the number of "rows affected" when "rewinding the stmt buffer" in order to retry the error transparently. The original PR contained two more commits which seem a bit risky to backport to 22.2, so we chose to not include them here.

Partially fixes: #98558.

Release justification: bug fix.