### PR TITLE
release-22.2: sql: fix recently introduced bug around the internal rowsIterator

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -519,7 +519,7 @@ func (r *rowsIterator) Types() colinfo.ResultColumns {
 }
 
 func (r *rowsIterator) HasResults() bool {
-	return r.first.row != nil
+	return r.first != nil && r.first.row != nil
 }
 
 // QueryBuffered executes the supplied SQL statement and returns the resulting
@@ -1020,7 +1020,9 @@ func (ie *InternalExecutor) execInternal(
 
 	// Note that if a context cancellation error has occurred, we still return
 	// the iterator and nil retErr so that the iterator is properly closed by
-	// the caller which will cleanup the connExecutor goroutine.
+	// the caller which will clean up the connExecutor goroutine.
+	// TODO(yuzefovich): reconsider this and return an error explicitly if
+	// r.lastErr is non-nil.
 	return r, nil
 }
 


### PR DESCRIPTION
Backport 2/2 commits from #103514.

/cc @cockroachdb/release

---

This commit fixes a minor bug introduced in https://github.com/cockroachdb/cockroach/commit/c7eb1bfbf667e88945080bcf294a5743f9d2e773
that could lead to a nil pointer panic. In particular, that commit
introduced `HasResults` method to the `rowsIterator`, and it assumed
that `first` field is always non-nil when the iterator was returned on
`QueryIteratorEx` call. However, that is not true - in case an error was
returned from the connExecutor goroutine, then `rowsIterator.lastErr` is
set while `first` is left nil. The expectation is that in such a case
the user of the iterator will receive that error either on `Next` or
`Close` call, properly cleaning up the iterator. We might want to
rethink this and return the error explicitly, but in the spirit of
making the least amount of changes, this commit simply added the non-nil
check for the `first` field.

Fixes: #103508.

Release note (bug fix): CockroachDB could previously encounter a nil
pointer crash when populating data for SQL Activity page in some rare
cases, and this is now fixed. The bug is present in 22.2.9 and 23.1.1
releases.

Release justification: bug fix.