### PR TITLE
kvserver: annotate queues with profiler labels

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -198,6 +198,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",
         "//pkg/util/mon",
+        "//pkg/util/pprofutil",
         "//pkg/util/protoutil",
         "//pkg/util/quotapool",
         "//pkg/util/retry",

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -14,6 +14,7 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	"runtime/pprof"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -559,6 +560,39 @@ func TestBaseQueueAddRemove(t *testing.T) {
 	if pc := testQueue.getProcessed(); pc > 0 {
 		t.Errorf("expected processed count of 0; got %d", pc)
 	}
+}
+
+// BaseQueueLabel verifies that the queue name tag exists during maybeAdd but
+// does not exist before and after maybeAdd.
+func TestBaseQueueLabel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	tc := testContext{}
+	stopper := stop.NewStopper()
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+	sc := TestStoreConfig(nil)
+	sc.TestingKnobs.BaseQueueInterceptor = func(ctx context.Context, bq *baseQueue) {
+		_, labelDoesExist := pprof.Label(ctx, bq.name)
+		require.True(t, labelDoesExist)
+	}
+	tc.StartWithStoreConfig(ctx, t, stopper, sc)
+	r, err := tc.store.GetReplica(1)
+	require.NoError(t, err)
+
+	testQueue := &testQueueImpl{
+		shouldQueueFn: func(now hlc.ClockTimestamp, r *Replica) (shouldQueue bool, _ float64) {
+			shouldQueue = true
+			return
+		},
+	}
+	bq := makeTestBaseQueue("test", testQueue, tc.store, queueConfig{})
+
+	bq.Start(stopper)
+	bq.maybeAdd(ctx, r, hlc.ClockTimestamp{})
+
+	_, labelDoesExist := pprof.Label(ctx, bq.name)
+	require.False(t, labelDoesExist)
 }
 
 // TestNeedsSystemConfig verifies that queues that don't need the system config

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -466,6 +466,13 @@ type StoreTestingKnobs struct {
 
 	// RangeLeaseAcquireTimeoutOverride overrides RaftConfig.RangeLeaseAcquireTimeout().
 	RangeLeaseAcquireTimeoutOverride time.Duration
+
+	// BaseQueueInterceptor is designed to intercept calls to baseQueue functions
+	// to validate base queue properties. Currently, it only intercepts
+	// baseQueue.MaybeAdd and ensure correct setting of the pprof label. However,
+	// it can be easily extended to validate other properties of baseQueue if
+	// required.
+	BaseQueueInterceptor func(ctx context.Context, bq *baseQueue)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Prior to this commit, the debugging process was complicated because it was
difficult to determine which specific queue invoked a particular function in the
baseQueue while examining the goroutine dump. This lack of clarity is because
different types of queues (consistency, merge, replica, etc.) all utilize the
baseQueue as their base implementation.

To resolve this issue, this commit adds pprof labels to key baseQueue functions
like maybeAdd and processLoop. As a result, when examining the goroutine dump,
the pprof label (queueName, "") now displays the queue name if the queue is
stuck on the function call.

Fixes: https://github.com/cockroachdb/cockroach/issues/102222
Release note: None

<img width="857" alt="Screenshot 2023-05-17 at 11 18 54" src="https://github.com/cockroachdb/cockroach/assets/56973754/3646bf7b-8754-4d5f-b18d-3efcb9f7451d">
