### PR TITLE
release-22.2: ui: fix errors from undefined usage

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -244,7 +244,9 @@ export class SessionsPage extends React.Component<
   onChangePage = (current: number): void => {
     const { pagination } = this.state;
     this.setState({ pagination: { ...pagination, current } });
-    this.props.onPageChanged(current);
+    if (this.props.onPageChanged) {
+      this.props.onPageChanged(current);
+    }
   };
 
   onSubmitFilters = (filters: Filters): void => {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -427,7 +427,9 @@ export class StatementsPage extends React.Component<
       ...prevState,
       pagination: { ...pagination, current },
     }));
-    this.props.onPageChanged(current);
+    if (this.props.onPageChanged) {
+      this.props.onPageChanged(current);
+    }
   };
 
   onSubmitSearchField = (search: string): void => {

--- a/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
@@ -9,7 +9,10 @@
 // licenses/APL.txt.
 
 import { createSelector } from "reselect";
-import { LocalStorageKeys } from "../localStorage";
+import {
+  LocalStorageKeys,
+  LocalStorageState,
+} from "src/store/localStorage/localStorage.reducer";
 import { AppState } from "../reducers";
 
 export const adminUISelector = createSelector(
@@ -19,7 +22,12 @@ export const adminUISelector = createSelector(
 
 export const localStorageSelector = createSelector(
   adminUISelector,
-  adminUiState => adminUiState?.localStorage,
+  adminUiState => {
+    if (adminUiState) {
+      return adminUiState.localStorage;
+    }
+    return {} as LocalStorageState;
+  },
 );
 
 export const selectTimeScale = createSelector(


### PR DESCRIPTION
Backport 1/1 commits from #103484.

/cc @cockroachdb/release

---

The fix done on #98177 was reverted on #98815, so this commit is adding the check back, which is necessary to not cause an undefined error.

Example of error saw on Datadog:

<img width="998" alt="Screenshot 2023-05-16 at 6 36 07 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/0e979df8-e66e-4b3c-9cb6-24ace5dd26fd">


The value for AdminUI could take some time to be initialized, making calls using localStorage fail. This commit adds a check and return an empty object instead of undefined for localStorage.

Examples of this error saw on Datadog:
<img width="1092" alt="Screenshot 2023-05-16 at 3 59 27 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/2553fdfc-54f5-4ec1-addf-1af597180e7a">

<img width="1180" alt="Screenshot 2023-05-16 at 4 00 59 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/f93e7c12-5fdd-490a-b072-298b7b2158ae">

Epic: None

Release note (bug fix): Fixes calls to undefined objects.

---

Release justification: bug fix
