### PR TITLE
sql: enable deletes in udfs

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2089,6 +2089,13 @@ func TestTenantLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestTenantLogic_udf_delete(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_delete")
+}
+
 func TestTenantLogic_udf_in_column_defaults(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2670,13 +2670,6 @@ statement error pgcode 0A000 unimplemented: DROP TABLE usage inside a function d
 CREATE FUNCTION err() RETURNS VOID LANGUAGE SQL AS 'DROP TABLE t'
 
 
-subtest mutation
-
-# Not all mutations are currently supported in UDF bodies.
-statement error pgcode 0A000 unimplemented: DELETE usage inside a function definition
-CREATE FUNCTION err() RETURNS VOID LANGUAGE SQL AS 'DELETE FROM t WHERE a = 1'
-
-
 subtest prepared_statement
 
 # Prepared statements are not currently supported in UDF bodies.

--- a/pkg/sql/logictest/testdata/logic_test/udf_delete
+++ b/pkg/sql/logictest/testdata/logic_test/udf_delete
@@ -1,0 +1,273 @@
+statement ok
+CREATE TABLE kv (
+  k INT PRIMARY KEY,
+  v INT,
+  UNIQUE INDEX foo (v),
+  INDEX bar (k, v)
+)
+
+statement count 4
+INSERT INTO kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
+
+statement ok
+CREATE VIEW kview AS SELECT k,v FROM kv
+
+statement error pq: "test.public.kview" is not a table
+CREATE FUNCTION f_view() RETURNS RECORD AS
+$$
+  DELETE FROM kview;
+$$ LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION f_kv_predicate() RETURNS SETOF RECORD AS
+$$
+  DELETE FROM kv WHERE k=3 OR v=6 RETURNING k, v;
+$$ LANGUAGE SQL;
+
+query T rowsort
+SELECT f_kv_predicate()
+----
+(3,4)
+(5,6)
+
+query II rowsort
+SELECT * FROM kv
+----
+1 2
+7 8
+
+# Delete non-existent values.
+query T rowsort
+SELECT f_kv_predicate()
+----
+
+statement ok
+CREATE FUNCTION f_kv_all() RETURNS SETOF RECORD AS
+$$
+  DELETE FROM kv RETURNING *;
+$$ LANGUAGE SQL;
+
+query II rowsort
+SELECT * FROM f_kv_all() AS foo(a INT, b INT)
+----
+1 2
+7 8
+
+query II
+SELECT * FROM kv
+----
+
+statement error pq: multiple modification subqueries of the same table "kv" are not supported
+CREATE FUNCTION f_err(i INT, j INT) RETURNS SETOF RECORD AS
+$$
+  DELETE FROM kv WHERE k = i RETURNING k, v;
+  DELETE FROM kv WHERE v = j RETURNING k, v;
+$$ LANGUAGE SQL;
+
+statement error pq: multiple modification subqueries of the same table "kv" are not supported
+CREATE FUNCTION f_err(i INT, j INT) RETURNS SETOF RECORD AS
+$$
+  INSERT INTO kv VALUES (i, j);
+  DELETE FROM kv WHERE k=i AND v=j RETURNING k, v;
+$$ LANGUAGE SQL;
+
+statement ok
+CREATE TABLE unindexed (
+  k INT PRIMARY KEY,
+  v INT
+)
+
+statement count 4
+INSERT INTO unindexed VALUES (1, 2), (3, 4), (5, 6), (7, 8)
+
+statement ok
+CREATE FUNCTION f_unindexed_predicate() RETURNS SETOF RECORD AS
+$$
+  DELETE FROM unindexed WHERE k=3 OR v=6 RETURNING k, v;
+$$ LANGUAGE SQL;
+
+query T rowsort
+SELECT f_unindexed_predicate()
+----
+(3,4)
+(5,6)
+
+query II rowsort
+SELECT * FROM unindexed
+----
+1 2
+7 8
+
+# Delete non-existent values.
+query T rowsort
+SELECT f_unindexed_predicate()
+----
+
+statement ok
+CREATE FUNCTION f_unindexed_all() RETURNS SETOF RECORD AS
+$$
+  DELETE FROM unindexed RETURNING *;
+$$ LANGUAGE SQL;
+
+query II rowsort
+SELECT * FROM f_unindexed_all() AS foo(a INT, b INT);
+----
+1 2
+7 8
+
+query II
+SELECT * FROM unindexed;
+----
+
+statement ok
+INSERT INTO unindexed VALUES (1, 9), (8, 2), (3, 7), (6, 4)
+
+statement ok
+CREATE FUNCTION f_orderby1() RETURNS SETOF RECORD AS
+$$
+  DELETE FROM unindexed WHERE k > 1 AND v < 7 ORDER BY v DESC LIMIT 2 RETURNING v,k;
+$$ LANGUAGE SQL;
+
+query II
+SELECT * FROM f_orderby1() AS foo(a INT, b INT);
+----
+4  6
+2  8
+
+statement ok
+CREATE FUNCTION f_orderby2() RETURNS SETOF RECORD AS
+$$
+  DELETE FROM unindexed ORDER BY v LIMIT 2 RETURNING k,v;
+$$ LANGUAGE SQL;
+
+query II
+SELECT * FROM f_orderby2() AS foo(a INT, b INT);
+----
+3  7
+1  9
+
+statement count 4
+INSERT INTO unindexed VALUES (1, 2), (3, 4), (5, 6), (7, 8)
+
+statement ok
+CREATE FUNCTION f_limit(i INT) RETURNS SETOF RECORD AS
+$$
+  DELETE FROM unindexed LIMIT i RETURNING v
+$$ LANGUAGE SQL;
+
+query I
+SELECT count(*) FROM f_limit(2) AS foo(v INT);
+----
+2
+
+query I
+SELECT count(*) FROM f_limit(1) AS foo(v INT);
+----
+1
+
+query I
+SELECT count(*) FROM f_limit(5) AS foo(v INT);
+----
+1
+
+
+subtest delete_using
+
+statement ok
+CREATE TABLE u_a (
+    a INT NOT NULL PRIMARY KEY,
+    b STRING,
+    c INT
+)
+
+statement ok
+CREATE TABLE u_b (
+  a INT NOT NULL PRIMARY KEY,
+  b STRING
+)
+
+statement ok
+CREATE TABLE u_c (
+  a INT NOT NULL PRIMARY KEY,
+  b STRING,
+  c INT
+)
+
+statement ok
+CREATE TABLE u_d (
+  a INT,
+  b INT
+)
+
+statement ok
+INSERT INTO u_a VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (4, 'd', 40)
+
+statement ok
+INSERT INTO u_b VALUES (10, 'a'), (20, 'b'), (30, 'c'), (40, 'd')
+
+statement ok
+INSERT INTO u_c VALUES (1, 'a', 10), (2, 'b', 50), (3, 'c', 50), (4, 'd', 40)
+
+# Test a join with a filter.
+statement ok
+CREATE FUNCTION f_using_filter(s STRING) RETURNS SETOF RECORD AS
+$$
+  DELETE FROM u_a USING u_b WHERE c = u_b.a AND u_b.b = s RETURNING u_a.a, u_a.b, u_a.c, u_b.*
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_using_filter('d');
+----
+(4,d,40,40,d)
+
+query ITI rowsort
+SELECT * FROM u_a;
+----
+1  a  10
+2  b  20
+3  c  30
+
+# Test a self join.
+statement ok
+INSERT INTO u_a VALUES (5, 'd', 5), (6, 'e', 6)
+
+statement ok
+CREATE FUNCTION f_using_self_join() RETURNS SETOF RECORD AS
+$$
+  DELETE FROM u_a USING u_a u_a2 WHERE u_a.a = u_a2.c RETURNING *
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_using_self_join();
+----
+(5,d,5,5,d,5)
+(6,e,6,6,e,6)
+
+query ITI rowsort
+SELECT * FROM u_a;
+----
+1  a  10
+2  b  20
+3  c  30
+
+# Test when USING uses multiple tables.
+
+statement ok
+INSERT INTO u_c VALUES (30, 'a', 1)
+
+statement ok
+CREATE FUNCTION f_using_multi() RETURNS SETOF RECORD AS
+$$
+DELETE FROM u_a USING u_b, u_c WHERE u_a.c = u_b.a AND u_a.c = u_c.a RETURNING *
+$$ LANGUAGE SQL;
+
+query T rowsort
+SELECT f_using_multi();
+----
+(3,c,30,30,c,30,a,1)
+
+query ITI rowsort
+SELECT * FROM u_a;
+----
+1  a  10
+2  b  20

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2053,6 +2053,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_delete(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_delete")
+}
+
 func TestLogic_udf_in_column_defaults(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2060,6 +2060,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_delete(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_delete")
+}
+
 func TestLogic_udf_in_column_defaults(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2074,6 +2074,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_delete(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_delete")
+}
+
 func TestLogic_udf_in_column_defaults(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2046,6 +2046,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_delete(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_delete")
+}
+
 func TestLogic_udf_in_column_defaults(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -2025,6 +2025,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_delete(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_delete")
+}
+
 func TestLogic_udf_insert(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2074,6 +2074,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_delete(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_delete")
+}
+
 func TestLogic_udf_in_column_defaults(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2270,6 +2270,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_delete(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_delete")
+}
+
 func TestLogic_udf_in_column_defaults(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -314,9 +314,7 @@ func (b *Builder) buildStmt(
 	// An allowlist of statements supported for user defined function.
 	if b.insideFuncDef {
 		switch stmt := stmt.(type) {
-		case *tree.Select, tree.SelectStatement, *tree.Insert, *tree.Update:
-		case *tree.Delete:
-			panic(unimplemented.NewWithIssuef(87289, "%s usage inside a function definition", stmt.StatementTag()))
+		case *tree.Select, tree.SelectStatement, *tree.Insert, *tree.Update, *tree.Delete:
 		default:
 			panic(unimplemented.Newf("user-defined functions", "%s usage inside a function definition", stmt.StatementTag()))
 		}


### PR DESCRIPTION
This PR enables DELETE statements in UDF bodies and adds logic test coverage of them.

Epic: CRDB-19255
Informs: #87289

Release note (sql change): Enables DELETE commands in UDF statement bodies.