### PR TITLE
roachtest: fix drain test to account for jobs_wait

### DIFF
--- a/pkg/cli/rpc_node_shutdown.go
+++ b/pkg/cli/rpc_node_shutdown.go
@@ -68,6 +68,7 @@ func doDrain(
 			Keys: []string{
 				"server.shutdown.drain_wait",
 				"server.shutdown.connection_wait",
+				"server.shutdown.jobs_wait",
 				"server.shutdown.query_wait",
 				"server.shutdown.lease_transfer_wait",
 			},
@@ -76,8 +77,7 @@ func doDrain(
 		if err != nil {
 			return err
 		}
-		// Add an extra buffer of 10 seconds for the timeout.
-		minWait := 10 * time.Second
+		minWait := 0 * time.Second
 		for k, v := range shutdownSettings.KeyValues {
 			wait, err := time.ParseDuration(v.Value)
 			if err != nil {
@@ -90,7 +90,7 @@ func doDrain(
 			}
 		}
 		if minWait > drainCtx.drainWait {
-			fmt.Fprintf(stderr, "warning: --drain-wait is %s, but the server.shutdown.{drain,query,connection,lease_transfer}_wait "+
+			fmt.Fprintf(stderr, "warning: --drain-wait is %s, but the server.shutdown.{drain,query,jobs,connection,lease_transfer}_wait "+
 				"cluster settings require a value of at least %s; using the larger value\n",
 				drainCtx.drainWait, minWait)
 			drainCtx.drainWait = minWait

--- a/pkg/cmd/roachtest/tests/drain.go
+++ b/pkg/cmd/roachtest/tests/drain.go
@@ -364,6 +364,7 @@ func prepareCluster(
 	defer db.Close()
 
 	waitPhasesSettingStmts := []string{
+		"SET CLUSTER SETTING server.shutdown.jobs_wait = '0s';",
 		fmt.Sprintf("SET CLUSTER SETTING server.shutdown.drain_wait = '%fs';", drainWait.Seconds()),
 		fmt.Sprintf("SET CLUSTER SETTING server.shutdown.query_wait = '%fs'", queryWait.Seconds()),
 		fmt.Sprintf("SET CLUSTER SETTING server.shutdown.connection_wait = '%fs'", connectionWait.Seconds()),


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/103396

The change in e8b075b44e6bea78c01c596ce4a2a54f3c057422 made this test start failing. Since we don't need this test to do anything with jobs, we can fix it by turning off the jobs waiting period.

This also fixes the node drain CLI command to be aware of jobs_wait.

Release note: None