### PR TITLE
roachtest: add point-tombstone/heterogeneous-value-sizes roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -153,6 +153,7 @@ go_library(
         "synctest.go",
         "sysbench.go",
         "tlp.go",
+        "tombstones.go",
         "tpc_utils.go",
         "tpcc.go",
         "tpcdsvec.go",

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -96,6 +96,7 @@ func RegisterTests(r registry.Registry) {
 	registerPebbleYCSB(r)
 	registerPgjdbc(r)
 	registerPgx(r)
+	registerPointTombstone(r)
 	registerPop(r)
 	registerProcessLock(r)
 	registerPsycopg(r)

--- a/pkg/cmd/roachtest/tests/tombstones.go
+++ b/pkg/cmd/roachtest/tests/tombstones.go
@@ -1,0 +1,202 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/require"
+)
+
+// registerPointTombstone registers the point tombstone test.
+func registerPointTombstone(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Skip: "pebble#2340",
+		SkipDetails: "This roachtest is implemented ahead of implementing and using " +
+			"pebble#2340 within Cockroach. Currently, this roachtest fails through " +
+			"a timeout because the disk space corresponding to the large KVs is " +
+			"never reclaimed. Once pebble#2340 is integrated into Cockroach, we " +
+			"expect this to begin passing, and we can un-skip it.",
+		Name:              "point-tombstone/heterogeneous-value-sizes",
+		Owner:             registry.OwnerStorage,
+		Cluster:           r.MakeClusterSpec(4),
+		EncryptionSupport: registry.EncryptionMetamorphic,
+		Tags: map[string]struct{}{
+			// Set the weekly tag; this roachtest is useful but relatively
+			// specific. Running it weekly should be fine to ensure we don't
+			// regress.
+			"weekly": {},
+		},
+		Timeout: 120 * time.Minute,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			startOpts := option.DefaultStartOpts()
+			startSettings := install.MakeClusterSettings()
+			startSettings.Env = append(startSettings.Env, "COCKROACH_AUTO_BALLAST=false")
+
+			t.Status("starting cluster")
+			c.Put(ctx, t.Cockroach(), "./cockroach")
+			c.Start(ctx, t.L(), startOpts, startSettings, c.Range(1, 3))
+
+			// Wait for upreplication.
+			conn := c.Conn(ctx, t.L(), 2)
+			defer conn.Close()
+			require.NoError(t, conn.PingContext(ctx))
+			require.NoError(t, WaitFor3XReplication(ctx, t, conn))
+
+			execSQLOrFail := func(statement string, args ...interface{}) {
+				if _, err := conn.ExecContext(ctx, statement, args...); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			c.Run(ctx, c.Node(4), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+
+			// Set a low 2m GC ttl.
+			execSQLOrFail("alter database kv configure zone using gc.ttlseconds = $1", 120)
+
+			// Run kv0 with massive 1MB values. This writes about ~30 GB of
+			// logical value data.
+			const numOps1MB = 30720
+			t.Status("starting 1MB-value workload")
+			m := c.NewMonitor(ctx, c.Range(1, 3))
+			m.Go(func(ctx context.Context) error {
+				c.Run(ctx, c.Node(4), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
+					`--concurrency 128 --max-rate 512 --tolerate-errors `+
+					` --min-block-bytes=1048576 --max-block-bytes=1048576 `+
+					` --max-ops %d `+
+					`{pgurl:1-3}`, numOps1MB))
+				return nil
+			})
+			m.Wait()
+
+			// Run kv0 with more typical 4KB values, starting at a later offset
+			// to not overwrite the previously written values. This writes about
+			// ~500MB of logical value data. The additional per-row overhead
+			// will be higher than above, since we're writing more rows.
+			t.Status("starting 4KB-value workload")
+			m = c.NewMonitor(ctx, c.Range(1, 3))
+			m.Go(func(ctx context.Context) error {
+				c.Run(ctx, c.Node(4), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
+					`--concurrency 256 --max-rate 1024 --tolerate-errors `+
+					` --min-block-bytes=4096 --max-block-bytes=4096 `+
+					` --max-ops 122880 --write-seq R%d `+
+					`{pgurl:1-3}`, numOps1MB))
+				return nil
+			})
+			m.Wait()
+
+			// Delete the initially written 1MB values (eg, ~30 GB)
+			t.Status("deleting previously-written 1MB values")
+			var statsAfterDeletes tableSizeInfo
+			m = c.NewMonitor(ctx, c.Range(1, 3))
+			m.Go(func(ctx context.Context) error {
+				n1Conn := c.Conn(ctx, t.L(), 1)
+				defer n1Conn.Close()
+				_, err := n1Conn.ExecContext(ctx, `USE kv;`)
+				require.NoError(t, err)
+
+				var paginationToken int64 = math.MinInt64
+				for done := false; !done; {
+					const deleteQuery = `
+					WITH deleted_keys AS (
+						DELETE FROM kv WHERE k >= $1 AND length(v) = 1048576
+						ORDER BY k ASC LIMIT 1000 RETURNING k
+					)
+					SELECT max(k) FROM deleted_keys;
+					`
+					row := n1Conn.QueryRowContext(ctx, deleteQuery, paginationToken)
+					var nextToken gosql.NullInt64
+					require.NoError(t, row.Scan(&nextToken))
+					done = !nextToken.Valid
+					paginationToken = nextToken.Int64
+				}
+				statsAfterDeletes = queryTableSize(ctx, t, n1Conn, "kv")
+				return nil
+			})
+			m.Wait()
+			fmt.Println(statsAfterDeletes.String())
+			require.LessOrEqual(t, statsAfterDeletes.livePercentage, 0.10)
+
+			// Wait for garbage collection to delete the non-live data.
+			targetSize := uint64(2 << 30) /* 2 GB */
+			t.Status("waiting for garbage collection and compaction to reduce on-disk size to ", humanize.IBytes(targetSize))
+			m = c.NewMonitor(ctx, c.Range(1, 3))
+			m.Go(func(ctx context.Context) error {
+				ticker := time.NewTicker(10 * time.Second)
+				defer ticker.Stop()
+
+				info := queryTableSize(ctx, t, conn, "kv")
+				fmt.Println(info.String())
+				for info.approxDiskBytes > targetSize {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-ticker.C:
+						info = queryTableSize(ctx, t, conn, "kv")
+						fmt.Println(info.String())
+					}
+				}
+				return nil
+			})
+			m.Wait()
+		},
+	})
+}
+
+type tableSizeInfo struct {
+	databaseID      uint64
+	tableID         uint64
+	rangeCount      uint64
+	approxDiskBytes uint64
+	liveBytes       uint64
+	totalBytes      uint64
+	livePercentage  float64
+}
+
+func (info tableSizeInfo) String() string {
+	return fmt.Sprintf("databaseID: %d, tableID: %d, rangeCount: %d, approxDiskBytes: %s, liveBytes: %s, totalBytes: %s, livePercentage: %.1f",
+		info.databaseID,
+		info.tableID,
+		info.rangeCount,
+		humanize.IBytes(info.approxDiskBytes),
+		humanize.IBytes(info.liveBytes),
+		humanize.IBytes(info.totalBytes),
+		info.livePercentage)
+}
+
+func queryTableSize(
+	ctx context.Context, t require.TestingT, conn *gosql.DB, tableName string,
+) (info tableSizeInfo) {
+	require.NoError(t, conn.QueryRowContext(ctx, `
+		SELECT database_id, table_id, range_count, approximate_disk_bytes, live_bytes, total_bytes, live_percentage
+		FROM crdb_internal.tenant_span_stats()
+		JOIN system.namespace ON (database_id, table_id, name) = ("parentID", id, $1)
+	`, tableName).Scan(
+		&info.databaseID,
+		&info.tableID,
+		&info.rangeCount,
+		&info.approxDiskBytes,
+		&info.liveBytes,
+		&info.totalBytes,
+		&info.livePercentage,
+	))
+	return info
+}


### PR DESCRIPTION
Introduce a new roachtest that exercises a current gap in Pebble's point tombstone heuristics. Rows with a heterogeneous size distribution can be problematic, because Pebble's existing heuristics rely on average value sizes in order to encourage disk-space reclaiming compactions. With heterogeneous value sizes, these heuristics can dramatically over-or-under estimate the amount of disk space reclaimed.

This new roachtest runs a kv0 workload for a fixed number of rows, all with 1MiB values. It then runs another a kv0 workload for 4x the number of rows, all with 4KiB values. Then it deletes all the 1MiB-valued rows, with a reduced TTL, and expects that a reasonable amount of disk space is reclaimed. Currently, this roachtest is skipped. With a recent nightly build of Cockroach, the test times out, stalled with the approximate disk-bytes size of the `kv` table stagnant at 92 GiB, despite the MVCC logical size of the table totalling just 1.4 GiB.

```
databaseID: 104, tableID: 106, rangeCount: 3003, approxDiskBytes: 92 GiB, liveBytes: 1.4 GiB, totalBytes: 1.4 GiB, livePercentage: 1.0
```

Examining one store's sstable properties reveals the point tombstones remain uncompacted in levels L3, L4 and L5.

```
                       L0     L1     L2     L3         L4         L5         L6         TOTAL
count                  0      0      0      23         122        545        1192       1882
seq num
  smallest             0      0      0      2973624    2291108    460760     145525     145525
  largest              0      0      0      6014495    4886656    4063619    2833606    6014495
size
  data                 0 B    0 B    0 B    62 M       480 M      3.6 G      26 G       31 G
    blocks             0      0      0      2513       7859       8292       29255      47919
  index                0 B    0 B    0 B    123 K      344 K      356 K      1.2 M      2.0 M
    blocks             0      0      0      23         122        545        1192       1882
    top-level          0 B    0 B    0 B    0 B        0 B        0 B        0 B        0 B
  filter               0 B    0 B    0 B    116 K      104 K      123 K      164 K      508 K
  raw-key              0 B    0 B    0 B    5.1 M      2.6 M      2.5 M      3.2 M      13 M
  raw-value            0 B    0 B    0 B    74 M       485 M      3.6 G      26 G       31 G
  pinned-key           0 B    0 B    0 B    0 B        0 B        0 B        0 B        0 B
  pinned-value         0 B    0 B    0 B    0 B        0 B        0 B        0 B        0 B
records
  set                  0      0      0      33 K       67 K       51 K       91 K       243 K
  delete               0      0      0      119 K      8.2 K      9.1 K      0          136 K
  range-delete         0      0      0      0          0          0          0          0
  range-key-sets       0      0      0      0          0          0          0          0
  range-key-unsets     0      0      0      0          0          0          0          0
  range-key-deletes    0      0      0      0          0          0          0          0
  merge                0      0      0      6.8 K      6.8 K      14 K       6.7 K      34 K
  pinned               0      0      0      0          0          0          0          0
```

<img width="729" alt="Screenshot 2023-05-17 at 4 27 17 PM" src="https://github.com/cockroachdb/cockroach/assets/867352/d8e3188a-75fb-4670-9c61-e5ff8b369894">
<img width="719" alt="Screenshot 2023-05-17 at 4 27 08 PM" src="https://github.com/cockroachdb/cockroach/assets/867352/cd787935-9ea0-4515-a314-2a279243ac0f">


Informs cockroachdb/pebble#2340.
Epic: CRDB-25405
Release note: none