### PR TITLE
ccl/sqlproxyccl: add ACL for allowed CIDR ranges

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "access_control.go",
         "allowlist.go",
+        "cidr_ranges.go",
         "denylist.go",
         "file.go",
         "private_endpoints.go",
@@ -31,6 +32,7 @@ go_library(
 go_test(
     name = "acl_test",
     srcs = [
+        "cidr_ranges_test.go",
         "file_test.go",
         "private_endpoints_test.go",
         "watcher_test.go",

--- a/pkg/ccl/sqlproxyccl/acl/cidr_ranges.go
+++ b/pkg/ccl/sqlproxyccl/acl/cidr_ranges.go
@@ -1,0 +1,68 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package acl
+
+import (
+	"context"
+	"net"
+
+	"github.com/cockroachdb/errors"
+)
+
+// CIDRRanges represents the controller used to manage ACL rules for public
+// connections. It rejects connections if:
+//  1. the cluster does not allow public connections, or
+//  2. none of the allowed_cidr_ranges entries match the incoming connection's
+//     IP.
+type CIDRRanges struct {
+	LookupTenantFn lookupTenantFunc
+}
+
+var _ AccessController = &CIDRRanges{}
+
+// CheckConnection implements the AccessController interface.
+func (p *CIDRRanges) CheckConnection(ctx context.Context, conn ConnectionTags) error {
+	tenantObj, err := p.LookupTenantFn(ctx, conn.TenantID)
+	if err != nil {
+		return err
+	}
+
+	// Private connections. This ACL is only responsible for public CIDR ranges.
+	if conn.EndpointID != "" {
+		return nil
+	}
+
+	// Cluster allows public connections, so we'll check allowed CIDR ranges.
+	if tenantObj.AllowPublicConn() {
+		ip := net.ParseIP(conn.IP)
+		if ip == nil {
+			return errors.Newf("could not parse IP address: '%s'", conn.IP)
+		}
+		for _, cidrRange := range tenantObj.AllowedCIDRRanges {
+			// It is assumed that all public CIDR ranges are valid, so the
+			// tenant directory server will have to enforce that.
+			_, ipNetwork, err := net.ParseCIDR(cidrRange)
+			if err != nil {
+				return err
+			}
+			// A matching CIDR range was found.
+			if ipNetwork.Contains(ip) {
+				return nil
+			}
+		}
+	}
+
+	// By default, connections are rejected if the cluster does not allow public
+	// connections, or if no ranges match the connection's IP.
+	return errors.Newf(
+		"connection to '%s' denied: cluster does not allow public connections from IP %s",
+		conn.TenantID.String(),
+		conn.IP,
+	)
+}

--- a/pkg/ccl/sqlproxyccl/acl/cidr_ranges_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/cidr_ranges_test.go
@@ -1,0 +1,140 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package acl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/acl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCIDRRanges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	tenantID := roachpb.MustMakeTenantID(42)
+	makeConn := func(endpoint string) acl.ConnectionTags {
+		return acl.ConnectionTags{
+			IP:         "127.0.0.1",
+			TenantID:   tenantID,
+			EndpointID: endpoint,
+		}
+	}
+
+	t.Run("lookup error", func(t *testing.T) {
+		p := &acl.CIDRRanges{
+			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
+				return nil, errors.New("foo")
+			},
+		}
+		err := p.CheckConnection(ctx, makeConn(""))
+		require.EqualError(t, err, "foo")
+	})
+
+	// Private connection should allow, despite not having any CIDR ranges.
+	t.Run("private connection", func(t *testing.T) {
+		p := &acl.CIDRRanges{
+			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
+				return &tenant.Tenant{
+					ConnectivityType: tenant.ALLOW_PUBLIC_ONLY,
+				}, nil
+			},
+		}
+		err := p.CheckConnection(ctx, makeConn("foo"))
+		require.NoError(t, err)
+	})
+
+	// CIDR ranges do not match.
+	t.Run("bad public connection", func(t *testing.T) {
+		p := &acl.CIDRRanges{
+			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
+				return &tenant.Tenant{
+					ConnectivityType:  tenant.ALLOW_ALL,
+					AllowedCIDRRanges: []string{"127.0.0.0/32", "10.0.0.8/16"},
+				}, nil
+			},
+		}
+		err := p.CheckConnection(ctx, makeConn(""))
+		require.EqualError(t, err, "connection to '42' denied: cluster does not allow public connections from IP 127.0.0.1")
+	})
+
+	t.Run("default behavior if no entries", func(t *testing.T) {
+		p := &acl.CIDRRanges{
+			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
+				return &tenant.Tenant{
+					ConnectivityType:  tenant.ALLOW_ALL,
+					AllowedCIDRRanges: []string{},
+				}, nil
+			},
+		}
+		err := p.CheckConnection(ctx, makeConn(""))
+		require.EqualError(t, err, "connection to '42' denied: cluster does not allow public connections from IP 127.0.0.1")
+	})
+
+	t.Run("good public connection", func(t *testing.T) {
+		p := &acl.CIDRRanges{
+			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
+				return &tenant.Tenant{
+					ConnectivityType:  tenant.ALLOW_ALL,
+					AllowedCIDRRanges: []string{"0.0.0.0/0"},
+				}, nil
+			},
+		}
+		err := p.CheckConnection(ctx, makeConn(""))
+		require.NoError(t, err)
+	})
+
+	t.Run("disallow public connections", func(t *testing.T) {
+		p := &acl.CIDRRanges{
+			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
+				return &tenant.Tenant{
+					ConnectivityType:  tenant.ALLOW_PRIVATE_ONLY,
+					AllowedCIDRRanges: []string{"127.0.0.1/32"},
+				}, nil
+			},
+		}
+		err := p.CheckConnection(ctx, makeConn(""))
+		require.EqualError(t, err, "connection to '42' denied: cluster does not allow public connections from IP 127.0.0.1")
+	})
+
+	t.Run("could not parse connection IP", func(t *testing.T) {
+		p := &acl.CIDRRanges{
+			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
+				return &tenant.Tenant{
+					ConnectivityType:  tenant.ALLOW_ALL,
+					AllowedCIDRRanges: []string{"127.0.0.1/32"},
+				}, nil
+			},
+		}
+		err := p.CheckConnection(ctx, acl.ConnectionTags{
+			IP:       "invalid-value",
+			TenantID: tenantID,
+		})
+		require.EqualError(t, err, "could not parse IP address: 'invalid-value'")
+	})
+
+	t.Run("could not parse CIDR range", func(t *testing.T) {
+		p := &acl.CIDRRanges{
+			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
+				return &tenant.Tenant{
+					ConnectivityType:  tenant.ALLOW_ALL,
+					AllowedCIDRRanges: []string{"127.0.0.1"},
+				}, nil
+			},
+		}
+		err := p.CheckConnection(ctx, makeConn(""))
+		require.EqualError(t, err, "invalid CIDR address: 127.0.0.1")
+	})
+}

--- a/pkg/ccl/sqlproxyccl/acl/private_endpoints.go
+++ b/pkg/ccl/sqlproxyccl/acl/private_endpoints.go
@@ -49,7 +49,7 @@ func (p *PrivateEndpoints) CheckConnection(ctx context.Context, conn ConnectionT
 
 	// Cluster allows private connections, so we'll check allowed endpoints.
 	if tenantObj.AllowPrivateConn() {
-		for _, endpoints := range tenantObj.PrivateEndpoints {
+		for _, endpoints := range tenantObj.AllowedPrivateEndpoints {
 			// A matching endpointID was found.
 			if endpoints == conn.EndpointID {
 				return nil

--- a/pkg/ccl/sqlproxyccl/acl/private_endpoints.go
+++ b/pkg/ccl/sqlproxyccl/acl/private_endpoints.go
@@ -24,7 +24,11 @@ type lookupTenantFunc func(ctx context.Context, tenantID roachpb.TenantID) (*ten
 
 // PrivateEndpoints represents the controller used to manage ACL rules for
 // private connections. A connection is assumed to be private if it includes
-// the EndpointID field, which gets populated through the PROXY headers.
+// the EndpointID field, which gets populated through the PROXY headers. The
+// controller rejects connections if:
+//  1. the cluster does not allow private connections, or
+//  2. none of the allowed_private_endpoints entries match the incoming
+//     connection's endpoint identifier.
 type PrivateEndpoints struct {
 	LookupTenantFn lookupTenantFunc
 }
@@ -53,11 +57,13 @@ func (p *PrivateEndpoints) CheckConnection(ctx context.Context, conn ConnectionT
 		}
 	}
 
-	// By default, connections are rejected if the cluster does not allow private
-	// connections, or there are no endpoints defined.
+	// By default, connections are rejected if the cluster does not allow
+	// private connections, or if no endpoints match the connection's endpoint
+	// ID.
 	return errors.Newf(
-		"connection to '%s' denied: cluster does not allow this private connection",
+		"connection to '%s' denied: cluster does not allow private connections from endpoint '%s'",
 		conn.TenantID.String(),
+		conn.EndpointID,
 	)
 }
 

--- a/pkg/ccl/sqlproxyccl/acl/private_endpoints_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/private_endpoints_test.go
@@ -63,8 +63,8 @@ func TestPrivateEndpoints(t *testing.T) {
 		p := &acl.PrivateEndpoints{
 			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
 				return &tenant.Tenant{
-					ConnectivityType: tenant.ALLOW_ALL,
-					PrivateEndpoints: []string{"foo", "baz"},
+					ConnectivityType:        tenant.ALLOW_ALL,
+					AllowedPrivateEndpoints: []string{"foo", "baz"},
 				}, nil
 			},
 		}
@@ -76,8 +76,8 @@ func TestPrivateEndpoints(t *testing.T) {
 		p := &acl.PrivateEndpoints{
 			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
 				return &tenant.Tenant{
-					ConnectivityType: tenant.ALLOW_ALL,
-					PrivateEndpoints: []string{},
+					ConnectivityType:        tenant.ALLOW_ALL,
+					AllowedPrivateEndpoints: []string{},
 				}, nil
 			},
 		}
@@ -89,8 +89,8 @@ func TestPrivateEndpoints(t *testing.T) {
 		p := &acl.PrivateEndpoints{
 			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
 				return &tenant.Tenant{
-					ConnectivityType: tenant.ALLOW_ALL,
-					PrivateEndpoints: []string{"foo"},
+					ConnectivityType:        tenant.ALLOW_ALL,
+					AllowedPrivateEndpoints: []string{"foo"},
 				}, nil
 			},
 		}
@@ -102,8 +102,8 @@ func TestPrivateEndpoints(t *testing.T) {
 		p := &acl.PrivateEndpoints{
 			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
 				return &tenant.Tenant{
-					ConnectivityType: tenant.ALLOW_PUBLIC_ONLY,
-					PrivateEndpoints: []string{"foo"},
+					ConnectivityType:        tenant.ALLOW_PUBLIC_ONLY,
+					AllowedPrivateEndpoints: []string{"foo"},
 				}, nil
 			},
 		}

--- a/pkg/ccl/sqlproxyccl/acl/private_endpoints_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/private_endpoints_test.go
@@ -69,7 +69,20 @@ func TestPrivateEndpoints(t *testing.T) {
 			},
 		}
 		err := p.CheckConnection(ctx, makeConn("bar"))
-		require.EqualError(t, err, "connection to '42' denied: cluster does not allow this private connection")
+		require.EqualError(t, err, "connection to '42' denied: cluster does not allow private connections from endpoint 'bar'")
+	})
+
+	t.Run("default behavior if no entries", func(t *testing.T) {
+		p := &acl.PrivateEndpoints{
+			LookupTenantFn: func(ctx context.Context, tenantID roachpb.TenantID) (*tenant.Tenant, error) {
+				return &tenant.Tenant{
+					ConnectivityType: tenant.ALLOW_ALL,
+					PrivateEndpoints: []string{},
+				}, nil
+			},
+		}
+		err := p.CheckConnection(ctx, makeConn("bar"))
+		require.EqualError(t, err, "connection to '42' denied: cluster does not allow private connections from endpoint 'bar'")
 	})
 
 	t.Run("good private connection", func(t *testing.T) {
@@ -95,7 +108,7 @@ func TestPrivateEndpoints(t *testing.T) {
 			},
 		}
 		err := p.CheckConnection(ctx, makeConn("foo"))
-		require.EqualError(t, err, "connection to '42' denied: cluster does not allow this private connection")
+		require.EqualError(t, err, "connection to '42' denied: cluster does not allow private connections from endpoint 'foo'")
 	})
 }
 

--- a/pkg/ccl/sqlproxyccl/acl/watcher_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/watcher_test.go
@@ -76,12 +76,12 @@ func TestACLWatcher(t *testing.T) {
 	dir, tds := tenantdirsvr.SetupTestDirectory(t, ctx, stopper, nil /* timeSource */)
 	tenantID := roachpb.MustMakeTenantID(10)
 	tds.CreateTenant(tenantID, &tenant.Tenant{
-		Version:           "001",
-		TenantID:          tenantID.ToUint64(),
-		ClusterName:       "my-tenant",
-		ConnectivityType:  tenant.ALLOW_ALL,
-		AllowedCIDRRanges: []string{"1.1.0.0/16"},
-		PrivateEndpoints:  []string{"foo-bar-baz", "cockroachdb"},
+		Version:                 "001",
+		TenantID:                tenantID.ToUint64(),
+		ClusterName:             "my-tenant",
+		ConnectivityType:        tenant.ALLOW_ALL,
+		AllowedCIDRRanges:       []string{"1.1.0.0/16"},
+		AllowedPrivateEndpoints: []string{"foo-bar-baz", "cockroachdb"},
 	})
 
 	t.Run("connection is allowed", func(t *testing.T) {
@@ -254,12 +254,12 @@ func TestACLWatcher(t *testing.T) {
 
 		// Update the tenant.
 		tds.UpdateTenant(tenantID, &tenant.Tenant{
-			Version:           "002",
-			TenantID:          tenantID.ToUint64(),
-			ClusterName:       "my-tenant",
-			ConnectivityType:  tenant.ALLOW_ALL,
-			AllowedCIDRRanges: []string{"1.1.0.0/16"},
-			PrivateEndpoints:  []string{"foo-bar-baz"},
+			Version:                 "002",
+			TenantID:                tenantID.ToUint64(),
+			ClusterName:             "my-tenant",
+			ConnectivityType:        tenant.ALLOW_ALL,
+			AllowedCIDRRanges:       []string{"1.1.0.0/16"},
+			AllowedPrivateEndpoints: []string{"foo-bar-baz"},
 		})
 
 		// Wait until watcher has received the updated event.

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -445,6 +445,127 @@ func TestPrivateEndpointsACL(t *testing.T) {
 	})
 }
 
+func TestAllowedCIDRRangesACL(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Insecure: false,
+		// Need to disable the test tenant here because it appears as though
+		// we're not able to establish the necessary connections from within
+		// it. More investigation required (tracked with #76378).
+		DefaultTestTenant: base.TestTenantDisabled,
+	})
+	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	defer sql.Stopper().Stop(ctx)
+
+	// Create a default user.
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
+
+	// Create the directory server.
+	tds := tenantdirsvr.NewTestStaticDirectoryServer(sql.Stopper(), nil /* timeSource */)
+	tenant10 := roachpb.MustMakeTenantID(10)
+	tenant20 := roachpb.MustMakeTenantID(20)
+	tenant30 := roachpb.MustMakeTenantID(30)
+	tds.CreateTenant(tenant10, &tenant.Tenant{
+		Version:           "001",
+		TenantID:          tenant10.ToUint64(),
+		ClusterName:       "my-tenant",
+		ConnectivityType:  tenant.ALLOW_ALL,
+		AllowedCIDRRanges: []string{"127.0.0.1/32"},
+	})
+	tds.CreateTenant(tenant20, &tenant.Tenant{
+		Version:           "002",
+		TenantID:          tenant20.ToUint64(),
+		ClusterName:       "other-tenant",
+		ConnectivityType:  tenant.ALLOW_ALL,
+		AllowedCIDRRanges: []string{"10.0.0.8/32"},
+	})
+	tds.CreateTenant(tenant30, &tenant.Tenant{
+		Version:           "003",
+		TenantID:          tenant30.ToUint64(),
+		ClusterName:       "private-tenant",
+		ConnectivityType:  tenant.ALLOW_PRIVATE_ONLY,
+		AllowedCIDRRanges: []string{"0.0.0.0/0"},
+	})
+	// All tenants map to the same pod.
+	for _, tenID := range []roachpb.TenantID{tenant10, tenant20, tenant30} {
+		tds.AddPod(tenID, &tenant.Pod{
+			TenantID:       tenID.ToUint64(),
+			Addr:           sql.ServingSQLAddr(),
+			State:          tenant.RUNNING,
+			StateTimestamp: timeutil.Now(),
+		})
+	}
+	require.NoError(t, tds.Start(ctx))
+
+	options := &ProxyOptions{
+		SkipVerify:         true,
+		PollConfigInterval: 10 * time.Millisecond,
+	}
+	options.testingKnobs.directoryServer = tds
+	s, sqlAddr, _ := newSecureProxyServer(ctx, t, sql.Stopper(), options)
+
+	t.Run("public connection allowed", func(t *testing.T) {
+		url := fmt.Sprintf("postgres://bob:builder@%s/my-tenant-10.defaultdb?sslmode=require", sqlAddr)
+		te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+			// Initial connection.
+			require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
+			require.NoError(t, runTestQuery(ctx, conn))
+
+			// Remove ranges and connection should be disconnected.
+			tds.UpdateTenant(tenant10, &tenant.Tenant{
+				Version:           "010",
+				TenantID:          tenant10.ToUint64(),
+				ClusterName:       "my-tenant",
+				ConnectivityType:  tenant.ALLOW_ALL,
+				AllowedCIDRRanges: []string{},
+			})
+
+			// Wait until watcher has received the updated event.
+			testutils.SucceedsSoon(t, func() error {
+				ten, err := s.handler.directoryCache.LookupTenant(ctx, tenant10)
+				if err != nil {
+					return err
+				}
+				if ten.Version != "010" {
+					return errors.New("tenant is not up-to-date")
+				}
+				return nil
+			})
+
+			// Subsequent Exec calls will eventually fail.
+			var err error
+			require.Eventually(
+				t,
+				func() bool {
+					_, err = conn.Exec(ctx, "SELECT 1")
+					return err != nil
+				},
+				time.Second, 5*time.Millisecond,
+				"Expected the connection to eventually fail",
+			)
+			require.Regexp(t, "connection reset by peer|unexpected EOF", err.Error())
+			require.Equal(t, int64(1), s.metrics.ExpiredClientConnCount.Count())
+		})
+	})
+
+	t.Run("public connection disallowed on another tenant", func(t *testing.T) {
+		url := fmt.Sprintf("postgres://bob:builder@%s/other-tenant-20.defaultdb?sslmode=require", sqlAddr)
+		_ = te.TestConnectErr(ctx, t, url, codeProxyRefusedConnection, "connection refused")
+	})
+
+	t.Run("public connection disallowed on private tenant", func(t *testing.T) {
+		url := fmt.Sprintf("postgres://bob:builder@%s/private-tenant-30.defaultdb?sslmode=require", sqlAddr)
+		_ = te.TestConnectErr(ctx, t, url, codeProxyRefusedConnection, "connection refused")
+	})
+}
+
 func TestLongDBName(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1139,8 +1260,9 @@ func TestDenylistUpdate(t *testing.T) {
 	tenantID := serverutils.TestTenantID()
 	tds := tenantdirsvr.NewTestStaticDirectoryServer(sql.Stopper(), nil /* timeSource */)
 	tds.CreateTenant(tenantID, &tenant.Tenant{
-		TenantID:    tenantID.ToUint64(),
-		ClusterName: "tenant-cluster",
+		TenantID:          tenantID.ToUint64(),
+		ClusterName:       "tenant-cluster",
+		AllowedCIDRRanges: []string{"0.0.0.0/0"},
 	})
 	tds.AddPod(tenantID, &tenant.Pod{
 		TenantID:       tenantID.ToUint64(),
@@ -1228,8 +1350,9 @@ func TestDirectoryConnect(t *testing.T) {
 	tenants := startTestTenantPodsWithStopper(ctx, t, s, tenantID, 1, base.TestingKnobs{}, tenantStopper)
 	tds := tenantdirsvr.NewTestStaticDirectoryServer(s.Stopper(), nil /* timeSource */)
 	tds.CreateTenant(tenantID, &tenant.Tenant{
-		TenantID:    tenantID.ToUint64(),
-		ClusterName: "tenant-cluster",
+		TenantID:          tenantID.ToUint64(),
+		ClusterName:       "tenant-cluster",
+		AllowedCIDRRanges: []string{"0.0.0.0/0"},
 	})
 	tds.AddPod(tenantID, &tenant.Pod{
 		TenantID:       tenantID.ToUint64(),
@@ -1341,8 +1464,9 @@ func TestConnectionRebalancingDisabled(t *testing.T) {
 	// Register one SQL pod in the directory server.
 	tds := tenantdirsvr.NewTestStaticDirectoryServer(s.Stopper(), nil /* timeSource */)
 	tds.CreateTenant(tenantID, &tenant.Tenant{
-		TenantID:    tenantID.ToUint64(),
-		ClusterName: "tenant-cluster",
+		TenantID:          tenantID.ToUint64(),
+		ClusterName:       "tenant-cluster",
+		AllowedCIDRRanges: []string{"0.0.0.0/0"},
 	})
 	tds.AddPod(tenantID, &tenant.Pod{
 		TenantID:       tenantID.ToUint64(),
@@ -1440,8 +1564,9 @@ func TestCancelQuery(t *testing.T) {
 	// Register one SQL pod in the directory server.
 	tds := tenantdirsvr.NewTestStaticDirectoryServer(s.Stopper(), timeSource)
 	tds.CreateTenant(tenantID, &tenant.Tenant{
-		TenantID:    tenantID.ToUint64(),
-		ClusterName: "tenant-cluster",
+		TenantID:          tenantID.ToUint64(),
+		ClusterName:       "tenant-cluster",
+		AllowedCIDRRanges: []string{"0.0.0.0/0"},
 	})
 	tds.AddPod(tenantID, &tenant.Pod{
 		TenantID:       tenantID.ToUint64(),
@@ -1773,8 +1898,9 @@ func TestPodWatcher(t *testing.T) {
 	// once the watcher has been established.
 	tds := tenantdirsvr.NewTestStaticDirectoryServer(s.Stopper(), nil /* timeSource */)
 	tds.CreateTenant(tenantID, &tenant.Tenant{
-		TenantID:    tenantID.ToUint64(),
-		ClusterName: "tenant-cluster",
+		TenantID:          tenantID.ToUint64(),
+		ClusterName:       "tenant-cluster",
+		AllowedCIDRRanges: []string{"0.0.0.0/0"},
 	})
 	for i := 0; i < 3; i++ {
 		tds.AddPod(tenantID, &tenant.Pod{
@@ -2259,8 +2385,9 @@ func TestAcceptedConnCountMetric(t *testing.T) {
 	// Register the SQL pod in the directory server.
 	tds := tenantdirsvr.NewTestStaticDirectoryServer(s.Stopper(), nil /* timeSource */)
 	tds.CreateTenant(tenantID, &tenant.Tenant{
-		TenantID:    tenantID.ToUint64(),
-		ClusterName: "tenant-cluster",
+		TenantID:          tenantID.ToUint64(),
+		ClusterName:       "tenant-cluster",
+		AllowedCIDRRanges: []string{"0.0.0.0/0"},
 	})
 	tds.AddPod(tenantID, &tenant.Pod{
 		TenantID:       tenantID.ToUint64(),
@@ -2348,8 +2475,9 @@ func TestCurConnCountMetric(t *testing.T) {
 	// Register the SQL pod in the directory server.
 	tds := tenantdirsvr.NewTestStaticDirectoryServer(s.Stopper(), nil /* timeSource */)
 	tds.CreateTenant(tenantID, &tenant.Tenant{
-		TenantID:    tenantID.ToUint64(),
-		ClusterName: "tenant-cluster",
+		TenantID:          tenantID.ToUint64(),
+		ClusterName:       "tenant-cluster",
+		AllowedCIDRRanges: []string{"0.0.0.0/0"},
 	})
 	tds.AddPod(tenantID, &tenant.Pod{
 		TenantID:       tenantID.ToUint64(),

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -297,25 +297,25 @@ func TestPrivateEndpointsACL(t *testing.T) {
 	tenant20 := roachpb.MustMakeTenantID(20)
 	tenant30 := roachpb.MustMakeTenantID(30)
 	tds.CreateTenant(tenant10, &tenant.Tenant{
-		Version:          "001",
-		TenantID:         tenant10.ToUint64(),
-		ClusterName:      "my-tenant",
-		ConnectivityType: tenant.ALLOW_ALL,
-		PrivateEndpoints: []string{"vpce-abc123"},
+		Version:                 "001",
+		TenantID:                tenant10.ToUint64(),
+		ClusterName:             "my-tenant",
+		ConnectivityType:        tenant.ALLOW_ALL,
+		AllowedPrivateEndpoints: []string{"vpce-abc123"},
 	})
 	tds.CreateTenant(tenant20, &tenant.Tenant{
-		Version:          "002",
-		TenantID:         tenant20.ToUint64(),
-		ClusterName:      "other-tenant",
-		ConnectivityType: tenant.ALLOW_ALL,
-		PrivateEndpoints: []string{"vpce-some-other-vpc"},
+		Version:                 "002",
+		TenantID:                tenant20.ToUint64(),
+		ClusterName:             "other-tenant",
+		ConnectivityType:        tenant.ALLOW_ALL,
+		AllowedPrivateEndpoints: []string{"vpce-some-other-vpc"},
 	})
 	tds.CreateTenant(tenant30, &tenant.Tenant{
-		Version:          "003",
-		TenantID:         tenant30.ToUint64(),
-		ClusterName:      "public-tenant",
-		ConnectivityType: tenant.ALLOW_PUBLIC_ONLY,
-		PrivateEndpoints: []string{},
+		Version:                 "003",
+		TenantID:                tenant30.ToUint64(),
+		ClusterName:             "public-tenant",
+		ConnectivityType:        tenant.ALLOW_PUBLIC_ONLY,
+		AllowedPrivateEndpoints: []string{},
 	})
 	// All tenants map to the same pod.
 	for _, tenID := range []roachpb.TenantID{tenant10, tenant20, tenant30} {
@@ -384,11 +384,11 @@ func TestPrivateEndpointsACL(t *testing.T) {
 
 				// Remove endpoints and connection should be disconnected.
 				tds.UpdateTenant(tenant10, &tenant.Tenant{
-					Version:          "010",
-					TenantID:         tenant10.ToUint64(),
-					ClusterName:      "my-tenant",
-					ConnectivityType: tenant.ALLOW_ALL,
-					PrivateEndpoints: []string{},
+					Version:                 "010",
+					TenantID:                tenant10.ToUint64(),
+					ClusterName:             "my-tenant",
+					ConnectivityType:        tenant.ALLOW_ALL,
+					AllowedPrivateEndpoints: []string{},
 				})
 
 				// Wait until watcher has received the updated event.

--- a/pkg/ccl/sqlproxyccl/tenant/directory.proto
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.proto
@@ -133,10 +133,10 @@ message Tenant {
   // allowed to access the tenant. This will only apply if the tenant allows
   // public connections.
   repeated string allowed_cidr_ranges = 5 [(gogoproto.customname) = "AllowedCIDRRanges"];
-  // PrivateEndpoints corresponds to the list of available endpoint identifiers
-  // that could access the tenant. This will only apply if the tenant allows
-  // private connections.
-  repeated string private_endpoints = 6;
+  // AllowedPrivateEndpoints corresponds to the list of endpoint identifiers
+  // that are allowed to access the tenant. This will only apply if the tenant
+  // allows private connections.
+  repeated string allowed_private_endpoints = 6;
 }
 
 // GetTenantRequest is used by a client to request from the sever metadata

--- a/pkg/ccl/sqlproxyccl/tenant/directory.proto
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.proto
@@ -129,10 +129,14 @@ message Tenant {
   string cluster_name = 3;
   // ConnectivityType indicates the extent to which the tenant can be accessed.
   ConnectivityType connectivity_type = 4;
+  // AllowedCIDRRanges corresponds to the list of source CIDR ranges that are
+  // allowed to access the tenant. This will only apply if the tenant allows
+  // public connections.
+  repeated string allowed_cidr_ranges = 5 [(gogoproto.customname) = "AllowedCIDRRanges"];
   // PrivateEndpoints corresponds to the list of available endpoint identifiers
   // that could access the tenant. This will only apply if the tenant allows
   // private connections.
-  repeated string private_endpoints = 5;
+  repeated string private_endpoints = 6;
 }
 
 // GetTenantRequest is used by a client to request from the sever metadata

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -90,21 +90,21 @@ func TestWatchTenants(t *testing.T) {
 	// it before.
 	tenantID := roachpb.MustMakeTenantID(20)
 	baseTenant := &tenant.Tenant{
-		Version:           "010",
-		TenantID:          tenantID.ToUint64(),
-		ClusterName:       "my-tenant",
-		AllowedCIDRRanges: []string{"127.0.0.1/16"},
-		PrivateEndpoints:  []string{"a"},
+		Version:                 "010",
+		TenantID:                tenantID.ToUint64(),
+		ClusterName:             "my-tenant",
+		AllowedCIDRRanges:       []string{"127.0.0.1/16"},
+		AllowedPrivateEndpoints: []string{"a"},
 	}
 	tds.CreateTenant(tenantID, baseTenant)
 	resp := <-tenantWatcher
 	require.Equal(t, tenant.EVENT_ADDED, resp.Type)
 	require.Equal(t, &tenant.Tenant{
-		Version:           "010",
-		TenantID:          20,
-		ClusterName:       "my-tenant",
-		AllowedCIDRRanges: []string{"127.0.0.1/16"},
-		PrivateEndpoints:  []string{"a"},
+		Version:                 "010",
+		TenantID:                20,
+		ClusterName:             "my-tenant",
+		AllowedCIDRRanges:       []string{"127.0.0.1/16"},
+		AllowedPrivateEndpoints: []string{"a"},
 	}, resp.Tenant)
 	_, err := dir.TryLookupTenantPods(ctx, tenantID)
 	require.EqualError(t, err, "rpc error: code = NotFound desc = tenant 20 not in directory cache")
@@ -113,20 +113,20 @@ func TestWatchTenants(t *testing.T) {
 	tenantObj, err := dir.LookupTenant(ctx, tenantID)
 	require.NoError(t, err)
 	require.Equal(t, &tenant.Tenant{
-		Version:           "010",
-		TenantID:          20,
-		ClusterName:       "my-tenant",
-		AllowedCIDRRanges: []string{"127.0.0.1/16"},
-		PrivateEndpoints:  []string{"a"},
+		Version:                 "010",
+		TenantID:                20,
+		ClusterName:             "my-tenant",
+		AllowedCIDRRanges:       []string{"127.0.0.1/16"},
+		AllowedPrivateEndpoints: []string{"a"},
 	}, tenantObj)
 
 	// Update the tenant object.
 	updatedTenant := &tenant.Tenant{
-		Version:           "011",
-		TenantID:          20,
-		ClusterName:       "foo-bar",
-		AllowedCIDRRanges: []string{"127.0.0.1/16", "0.0.0.0/0"},
-		PrivateEndpoints:  []string{"a", "b"},
+		Version:                 "011",
+		TenantID:                20,
+		ClusterName:             "foo-bar",
+		AllowedCIDRRanges:       []string{"127.0.0.1/16", "0.0.0.0/0"},
+		AllowedPrivateEndpoints: []string{"a", "b"},
 	}
 	tds.UpdateTenant(tenantID, updatedTenant)
 	resp = <-tenantWatcher
@@ -137,11 +137,11 @@ func TestWatchTenants(t *testing.T) {
 	tenantObj, err = dir.LookupTenant(ctx, tenantID)
 	require.NoError(t, err)
 	require.Equal(t, &tenant.Tenant{
-		Version:           "011",
-		TenantID:          20,
-		ClusterName:       "foo-bar",
-		AllowedCIDRRanges: []string{"127.0.0.1/16", "0.0.0.0/0"},
-		PrivateEndpoints:  []string{"a", "b"},
+		Version:                 "011",
+		TenantID:                20,
+		ClusterName:             "foo-bar",
+		AllowedCIDRRanges:       []string{"127.0.0.1/16", "0.0.0.0/0"},
+		AllowedPrivateEndpoints: []string{"a", "b"},
 	}, tenantObj)
 
 	// Update the tenant object with an old version.
@@ -159,11 +159,11 @@ func TestWatchTenants(t *testing.T) {
 	tenantObj, err = dir.LookupTenant(ctx, tenantID)
 	require.NoError(t, err)
 	require.Equal(t, &tenant.Tenant{
-		Version:           "011",
-		TenantID:          20,
-		ClusterName:       "foo-bar",
-		AllowedCIDRRanges: []string{"127.0.0.1/16", "0.0.0.0/0"},
-		PrivateEndpoints:  []string{"a", "b"},
+		Version:                 "011",
+		TenantID:                20,
+		ClusterName:             "foo-bar",
+		AllowedCIDRRanges:       []string{"127.0.0.1/16", "0.0.0.0/0"},
+		AllowedPrivateEndpoints: []string{"a", "b"},
 	}, tenantObj)
 
 	// Finally, delete the tenant.

--- a/pkg/ccl/sqlproxyccl/tenant/entry_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/entry_test.go
@@ -81,8 +81,9 @@ func TestTenantMetadataUpdate(t *testing.T) {
 
 	// Use an old version.
 	ten := &Tenant{
-		Version:          "002",
-		PrivateEndpoints: []string{"a", "b"},
+		Version:           "002",
+		AllowedCIDRRanges: []string{"0.0.0.0/0"},
+		PrivateEndpoints:  []string{"a", "b"},
 	}
 	e.UpdateTenant(ten)
 	require.True(t, e.IsValid())

--- a/pkg/ccl/sqlproxyccl/tenant/entry_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/entry_test.go
@@ -81,9 +81,9 @@ func TestTenantMetadataUpdate(t *testing.T) {
 
 	// Use an old version.
 	ten := &Tenant{
-		Version:           "002",
-		AllowedCIDRRanges: []string{"0.0.0.0/0"},
-		PrivateEndpoints:  []string{"a", "b"},
+		Version:                 "002",
+		AllowedCIDRRanges:       []string{"0.0.0.0/0"},
+		AllowedPrivateEndpoints: []string{"a", "b"},
 	}
 	e.UpdateTenant(ten)
 	require.True(t, e.IsValid())

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
@@ -169,8 +169,9 @@ func (s *TestDirectoryServer) GetTenant(
 ) (*tenant.GetTenantResponse, error) {
 	return &tenant.GetTenantResponse{
 		Tenant: &tenant.Tenant{
-			TenantID:    req.TenantID,
-			ClusterName: "tenant-cluster",
+			TenantID:          req.TenantID,
+			ClusterName:       "tenant-cluster",
+			AllowedCIDRRanges: []string{"0.0.0.0/0"},
 		},
 	}, nil
 }

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
@@ -119,13 +119,21 @@ func (d *TestSimpleDirectoryServer) GetTenant(
 	if _, ok := d.mu.deleted[roachpb.MustMakeTenantID(req.TenantID)]; ok {
 		return nil, status.Errorf(codes.NotFound, "tenant has been deleted")
 	}
-	// Note that we do not return a ClusterName field here. Doing this skips
-	// the clusterName validation in the directory cache which makes testing
-	// easier. If we hardcoded a cluster name here, all connection strings will
-	// need to be updated to use that cluster name, including the one used by
-	// the ORM tests, which is currently hardcoded to "prancing-pony":
-	// https://github.com/cockroachdb/cockroach-go/blob/e1659d1d/testserver/tenant.go#L244.
-	return &tenant.GetTenantResponse{}, nil
+	return &tenant.GetTenantResponse{
+		Tenant: &tenant.Tenant{
+			TenantID: req.TenantID,
+			// Note that we do not return a ClusterName field here. Doing this
+			// skips the clusterName validation in the directory cache which
+			// makes testing easier.
+			//
+			// If we hardcoded a cluster name here, all connection strings will
+			// need to be updated to use that cluster name, including the one
+			// used by the ORM tests, which is currently hardcoded to
+			// "prancing-pony": https://github.com/cockroachdb/cockroach-go/blob/e1659d1d/testserver/tenant.go#L244
+			ClusterName:       "",
+			AllowedCIDRRanges: []string{"0.0.0.0/0"},
+		},
+	}, nil
 }
 
 // WatchTenants is a no-op for the simple directory.

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
@@ -546,8 +546,8 @@ func (d *TestStaticDirectoryServer) notifyTenantUpdateLocked(
 	copyTenant := *t
 	copyTenant.AllowedCIDRRanges = make([]string, len(t.AllowedCIDRRanges))
 	copy(copyTenant.AllowedCIDRRanges, t.AllowedCIDRRanges)
-	copyTenant.PrivateEndpoints = make([]string, len(t.PrivateEndpoints))
-	copy(copyTenant.PrivateEndpoints, t.PrivateEndpoints)
+	copyTenant.AllowedPrivateEndpoints = make([]string, len(t.AllowedPrivateEndpoints))
+	copy(copyTenant.AllowedPrivateEndpoints, t.AllowedPrivateEndpoints)
 	res := &tenant.WatchTenantsResponse{Type: typ, Tenant: &copyTenant}
 
 	for e := d.mu.tenantEventListeners.Front(); e != nil; {

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
@@ -544,6 +544,8 @@ func (d *TestStaticDirectoryServer) notifyTenantUpdateLocked(
 ) {
 	// Make a copy of the tenant to prevent race issues.
 	copyTenant := *t
+	copyTenant.AllowedCIDRRanges = make([]string, len(t.AllowedCIDRRanges))
+	copy(copyTenant.AllowedCIDRRanges, t.AllowedCIDRRanges)
 	copyTenant.PrivateEndpoints = make([]string, len(t.PrivateEndpoints))
 	copy(copyTenant.PrivateEndpoints, t.PrivateEndpoints)
 	res := &tenant.WatchTenantsResponse{Type: typ, Tenant: &copyTenant}


### PR DESCRIPTION
#### ccl/sqlproxyccl: add ACL for allowed CIDR ranges

Previously, the proxy only supported file based IP allowlist entries. This
commit adds a new ACL for allowed CIDR ranges, and will only apply if the
allowlist file isn't supplied to the proxy. Unlike the file-based ACL, this
makes use of the per-tenant metadata to store allowed CIDR ranges (i.e. in
the new AllowedCIDRRanges field). By default, if there are no CIDR ranges, it
is expected to block all incoming connections.

#### ccl/sqlproxyccl: rename PrivateEndpoints to AllowedPrivateEndpoints

This commit renames PrivateEndpoints to AllowedPrivateEndpoints in the tenant
proto message to be consistent with AllowedCIDRRanges. In theory, we could have
done AllowedEndpoints, but we'll leave "Private" in to be more explicit.

Release note: None

Epic: none