### PR TITLE
cli: exit without error on repeated decommission

### DIFF
--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -796,7 +796,8 @@ func decommissionPreCheckReady(resp *serverpb.DecommissionPreCheckResponse) bool
 		return true
 	}
 	for _, nodeCheckResult := range resp.CheckedNodes {
-		if nodeCheckResult.DecommissionReadiness != serverpb.DecommissionPreCheckResponse_READY {
+		if !(nodeCheckResult.DecommissionReadiness == serverpb.DecommissionPreCheckResponse_READY ||
+			nodeCheckResult.DecommissionReadiness == serverpb.DecommissionPreCheckResponse_ALREADY_DECOMMISSIONED) {
 			return false
 		}
 	}


### PR DESCRIPTION
With the introduction of decommission pre-checks executed by the CLI in #96100, the decommission readiness was used to exit with a non-zero exit code when a node is not ready to be decommissioned. However, as the decommission command is intended to be idempotent, decommissioning an already decommissioned node should not be considered an error, especially since we already print a warning stating as such. This change fixes that check to exit with a code of 0 if a node has already been decommissioned.

Fixes: #98149.

Release note (cli change): Running `cockroch node decommission <nodeID>` for a node that has already been decommissioned will now exit with code 0, as had been the case in CockroachDB versions prior to 23.1.0.