### PR TITLE
sql: add more udf mutations test coverage

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_update
+++ b/pkg/sql/logictest/testdata/logic_test/udf_update
@@ -71,6 +71,20 @@ SELECT f2(5,32);
 statement error pq: multiple modification subqueries of the same table \"t\" are not supported
 SELECT f2(5,9), f2(7,11);
 
+query T
+SELECT f2(x,y) FROM (VALUES (1,16),(1,17)) v(x,y);
+----
+(1,16)
+(1,17)
+
+query II rowsort
+SELECT * FROM t;
+----
+1 17
+3 4
+5 32
+7 8
+
 statement ok
 CREATE TABLE t2 (a INT, b INT, c INT);
 INSERT INTO t2 VALUES (1,2,3),(4,5,6),(7,8,9);

--- a/pkg/sql/logictest/testdata/logic_test/udf_upsert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_upsert
@@ -32,6 +32,22 @@ NULL
 statement error pq: multiple modification subqueries of the same table \"t_ocdn\" are not supported
 SELECT f_ocdn(1,1,1), f_ocdn(3,2,2), f_ocdn(6,6,2), f_ocdn(2,1,1);
 
+query T
+SELECT f_ocdn(x, y, z) FROM (VALUES (1, 1, 1), (2, 2, 1), (3, 3, 3), (3, 4, 4)) v(x, y, z)
+----
+NULL
+(2,2,1)
+(3,3,3)
+NULL
+
+query III rowsort
+SELECT * FROM t_ocdn
+----
+1 1 1
+2 2 1
+3 3 3
+
+
 statement ok
 CREATE FUNCTION f_ocdn_2vals(i INT, j INT, k INT, m INT, n INT, o INT) RETURNS RECORD AS
 $$
@@ -45,6 +61,8 @@ query III rowsort
 SELECT * FROM t_ocdn;
 ----
 1 1 1
+2 2 1
+3 3 3
 5 5 5
 
 statement error pq: multiple modification subqueries of the same table \"t_ocdn\" are not supported


### PR DESCRIPTION
Adds coverage for queries like `SELECT f(x,y) FROM (VALUES ...) v(x,y)` where `f()` is a function containing a mutation.

Epic: none

Release note: None