### PR TITLE
split: [DNM] only retain safe split keys

### DIFF
--- a/pkg/kv/kvserver/split/weighted_finder_test.go
+++ b/pkg/kv/kvserver/split/weighted_finder_test.go
@@ -46,6 +46,17 @@ func (r WFLargestRandSource) Intn(int) int {
 	return 0
 }
 
+func colKey(prefix roachpb.Key) roachpb.Key {
+	return keys.MakeFamilyKey(prefix, 9)
+}
+
+func colFamSpan(span roachpb.Span) roachpb.Span {
+	return roachpb.Span{
+		Key:    colKey(span.Key),
+		EndKey: colKey(span.EndKey),
+	}
+}
+
 // TestSplitWeightedFinderKey verifies the Key() method correctly
 // finds an appropriate split point for the range.
 func TestSplitWeightedFinderKey(t *testing.T) {
@@ -190,17 +201,6 @@ func TestSplitWeightedFinderRecorder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
-
-	colKey := func(prefix roachpb.Key) roachpb.Key {
-		return keys.MakeFamilyKey(prefix, 9)
-	}
-
-	colFamSpan := func(span roachpb.Span) roachpb.Span {
-		return roachpb.Span{
-			Key:    colKey(span.Key),
-			EndKey: colKey(span.EndKey),
-		}
-	}
 
 	const ReservoirKeyOffset = 1000
 


### PR DESCRIPTION
Previously, the load based range splitter could suggest split keys which were in-between SQL rows. This violated assumptions made in SQL code, which require that rows are never split across ranges.

This patch updates the unweighted split finder to only retain safe sample keys. The weighted split finder already does this (e4f003b). Note that the weighted split finder is used by default (>=23.1), whilst the unweighted split finder is used when
`kv.allocator.load_based_rebalancing.objective` is set to `qps` (default `cpu`).

Informs: #43094
Fixes: #103483

Release note: None