### PR TITLE
coldata: make Vec a struct rather than an interface

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -646,7 +646,7 @@ func (b *Bytes) Deserialize(data []byte, offsets []int32) {
 
 // ProportionalSize calls the method of the same name on bytes-like vectors,
 // panicking if not bytes-like.
-func ProportionalSize(v Vec, length int64) int64 {
+func ProportionalSize(v *Vec, length int64) int64 {
 	family := v.CanonicalTypeFamily()
 	switch family {
 	case types.BytesFamily:
@@ -660,7 +660,7 @@ func ProportionalSize(v Vec, length int64) int64 {
 }
 
 // ResetIfBytesLike calls Reset on v if it is bytes-like, noop otherwise.
-func ResetIfBytesLike(v Vec) {
+func ResetIfBytesLike(v *Vec) {
 	switch v.CanonicalTypeFamily() {
 	case types.BytesFamily:
 		v.Bytes().Reset()

--- a/pkg/col/coldata/native_types.go
+++ b/pkg/col/coldata/native_types.go
@@ -215,7 +215,7 @@ func (c Float64s) CopySlice(src Float64s, destIdx, srcStartIdx, srcEndIdx int) {
 // destIdx.
 //
 // Note that this method is usually inlined, but it isn't in case of the
-// memColumn.Copy generated code (probably because of the size of that
+// Vec.Copy generated code (probably because of the size of that
 // function), so we don't assert the inlining with the GCAssert linter.
 func (c Decimals) CopySlice(src Decimals, destIdx, srcStartIdx, srcEndIdx int) {
 	srcSlice := src[srcStartIdx:srcEndIdx]

--- a/pkg/col/coldata/nulls_test.go
+++ b/pkg/col/coldata/nulls_test.go
@@ -157,7 +157,7 @@ func TestSetAndUnsetNulls(t *testing.T) {
 func TestNullsSet(t *testing.T) {
 	args := SliceArgs{
 		// Neither type nor the length here matter.
-		Src: NewMemColumn(types.Bool, 0, StandardColumnFactory),
+		Src: NewVec(types.Bool, 0, StandardColumnFactory),
 	}
 	for _, withSel := range []bool{false, true} {
 		t.Run(fmt.Sprintf("WithSel=%t", withSel), func(t *testing.T) {

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -27,7 +27,7 @@ type Column interface {
 // SliceArgs represents the arguments passed in to Vec.Append and Nulls.set.
 type SliceArgs struct {
 	// Src is the data being appended.
-	Src Vec
+	Src *Vec
 	// Sel is an optional slice specifying indices to append to the destination
 	// slice. Note that Src{Start,End}Idx apply to Sel.
 	Sel []int
@@ -42,103 +42,10 @@ type SliceArgs struct {
 	SrcEndIdx int
 }
 
-// Vec is an interface that represents a column vector that's accessible by
-// Go native types.
-type Vec interface {
-	// Type returns the type of data stored in this Vec. Consider whether
-	// CanonicalTypeFamily() should be used instead.
-	Type() *types.T
-	// CanonicalTypeFamily returns the canonical type family of data stored in
-	// this Vec.
-	CanonicalTypeFamily() types.Family
-
-	// Bool returns a bool list.
-	Bool() Bools
-	// Int16 returns an int16 slice.
-	Int16() Int16s
-	// Int32 returns an int32 slice.
-	Int32() Int32s
-	// Int64 returns an int64 slice.
-	Int64() Int64s
-	// Float64 returns a float64 slice.
-	Float64() Float64s
-	// Bytes returns a flat Bytes representation.
-	Bytes() *Bytes
-	// Decimal returns an apd.Decimal slice.
-	Decimal() Decimals
-	// Timestamp returns a time.Time slice.
-	Timestamp() Times
-	// Interval returns a duration.Duration slice.
-	Interval() Durations
-	// JSON returns a vector of JSONs.
-	JSON() *JSONs
-	// Datum returns a vector of Datums.
-	Datum() DatumVec
-
-	// Col returns the raw, typeless backing storage for this Vec.
-	Col() Column
-
-	// SetCol sets the member column (in the case of mutable columns).
-	SetCol(Column)
-
-	// TemplateType returns an []interface{} and is used for operator templates.
-	// Do not call this from normal code - it'll always panic.
-	TemplateType() []interface{}
-
-	// Append uses SliceArgs to append elements of a source Vec into this Vec.
-	// It is logically equivalent to:
-	// destVec = append(destVec[:args.DestIdx], args.Src[args.SrcStartIdx:args.SrcEndIdx])
-	// An optional Sel slice can also be provided to apply a filter on the source
-	// Vec.
-	// Refer to the SliceArgs comment for specifics and TestAppend for examples.
-	//
-	// Note: Append()'ing from a Vector into itself is not supported.
-	Append(SliceArgs)
-
-	// Copy uses SliceArgs to copy elements of a source Vec into this Vec. It is
-	// logically equivalent to:
-	// copy(destVec[args.DestIdx:], args.Src[args.SrcStartIdx:args.SrcEndIdx])
-	// An optional Sel slice can also be provided to apply a filter on the source
-	// Vec.
-	// Refer to the SliceArgs comment for specifics and TestCopy for examples.
-	Copy(SliceArgs)
-
-	// CopyWithReorderedSource copies a value at position order[sel[i]] in src
-	// into the receiver at position sel[i]. len(sel) elements are copied.
-	// Resulting values of elements not mentioned in sel are undefined after
-	// this function.
-	CopyWithReorderedSource(src Vec, sel, order []int)
-
-	// Window returns a "window" into the Vec. A "window" is similar to Golang's
-	// slice of the current Vec from [start, end), but the returned object is NOT
-	// allowed to be modified (the modification might result in an undefined
-	// behavior).
-	Window(start int, end int) Vec
-
-	// MaybeHasNulls returns true if the column possibly has any null values, and
-	// returns false if the column definitely has no null values.
-	MaybeHasNulls() bool
-
-	// Nulls returns the nulls vector for the column.
-	Nulls() *Nulls
-
-	// SetNulls sets the nulls vector for this column.
-	SetNulls(Nulls)
-
-	// Length returns the length of the slice that is underlying this Vec.
-	Length() int
-
-	// Capacity returns the capacity of the Golang's slice that is underlying
-	// this Vec. Note that if there is no "slice" (like in case of flat bytes),
-	// then "capacity" of such object is equal to the number of elements.
-	Capacity() int
-}
-
-var _ Vec = &memColumn{}
-
-// memColumn is a simple pass-through implementation of Vec that just casts
-// a generic interface{} to the proper type when requested.
-type memColumn struct {
+// Vec is a column vector that's accessible by Go native types.
+// TODO(yuzefovich): consider storing / passing vectors by value rather than
+// pointer.
+type Vec struct {
 	t                   *types.T
 	canonicalTypeFamily types.Family
 	col                 Column
@@ -269,10 +176,10 @@ func (cf *defaultColumnFactory) MakeColumns(columns []Column, t *types.T, length
 	}
 }
 
-// NewMemColumn returns a new memColumn, initialized with a length using the
-// given column factory.
-func NewMemColumn(t *types.T, length int, factory ColumnFactory) Vec {
-	return &memColumn{
+// NewVec returns a new Vec, initialized with a length using the given column
+// factory.
+func NewVec(t *types.T, length int, factory ColumnFactory) *Vec {
+	return &Vec{
 		t:                   t,
 		canonicalTypeFamily: typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()),
 		col:                 factory.MakeColumn(t, length),
@@ -280,116 +187,143 @@ func NewMemColumn(t *types.T, length int, factory ColumnFactory) Vec {
 	}
 }
 
-func (m *memColumn) Type() *types.T {
-	return m.t
+// Type returns the type of data stored in this Vec. Consider whether
+// CanonicalTypeFamily() should be used instead.
+func (v *Vec) Type() *types.T {
+	return v.t
 }
 
-func (m *memColumn) CanonicalTypeFamily() types.Family {
-	return m.canonicalTypeFamily
+// CanonicalTypeFamily returns the canonical type family of data stored in this
+// Vec.
+func (v *Vec) CanonicalTypeFamily() types.Family {
+	return v.canonicalTypeFamily
 }
 
-func (m *memColumn) SetCol(col Column) {
-	m.col = col
+// SetCol sets the member column (in the case of mutable columns).
+func (v *Vec) SetCol(col Column) {
+	v.col = col
 }
 
-func (m *memColumn) Bool() Bools {
-	return m.col.(Bools)
+// Bool returns a bool list.
+func (v *Vec) Bool() Bools {
+	return v.col.(Bools)
 }
 
-func (m *memColumn) Int16() Int16s {
-	return m.col.(Int16s)
+// Int16 returns an int16 slice.
+func (v *Vec) Int16() Int16s {
+	return v.col.(Int16s)
 }
 
-func (m *memColumn) Int32() Int32s {
-	return m.col.(Int32s)
+// Int32 returns an int32 slice.
+func (v *Vec) Int32() Int32s {
+	return v.col.(Int32s)
 }
 
-func (m *memColumn) Int64() Int64s {
-	return m.col.(Int64s)
+// Int64 returns an int64 slice.
+func (v *Vec) Int64() Int64s {
+	return v.col.(Int64s)
 }
 
-func (m *memColumn) Float64() Float64s {
-	return m.col.(Float64s)
+// Float64 returns a float64 slice.
+func (v *Vec) Float64() Float64s {
+	return v.col.(Float64s)
 }
 
-func (m *memColumn) Bytes() *Bytes {
-	return m.col.(*Bytes)
+// Bytes returns a flat Bytes representation.
+func (v *Vec) Bytes() *Bytes {
+	return v.col.(*Bytes)
 }
 
-func (m *memColumn) Decimal() Decimals {
-	return m.col.(Decimals)
+// Decimal returns an apd.Decimal slice.
+func (v *Vec) Decimal() Decimals {
+	return v.col.(Decimals)
 }
 
-func (m *memColumn) Timestamp() Times {
-	return m.col.(Times)
+// Timestamp returns a time.Time slice.
+func (v *Vec) Timestamp() Times {
+	return v.col.(Times)
 }
 
-func (m *memColumn) Interval() Durations {
-	return m.col.(Durations)
+// Interval returns a duration.Duration slice.
+func (v *Vec) Interval() Durations {
+	return v.col.(Durations)
 }
 
-func (m *memColumn) JSON() *JSONs {
-	return m.col.(*JSONs)
+// JSON returns a vector of JSONs.
+func (v *Vec) JSON() *JSONs {
+	return v.col.(*JSONs)
 }
 
-func (m *memColumn) Datum() DatumVec {
-	return m.col.(DatumVec)
+// Datum returns a vector of Datums.
+func (v *Vec) Datum() DatumVec {
+	return v.col.(DatumVec)
 }
 
-func (m *memColumn) Col() Column {
-	return m.col
+// Col returns the raw, typeless backing storage for this Vec.
+func (v *Vec) Col() Column {
+	return v.col
 }
 
-func (m *memColumn) TemplateType() []interface{} {
+// TemplateType returns an []interface{} and is used for operator templates.
+// Do not call this from normal code - it'll always panic.
+func (v *Vec) TemplateType() []interface{} {
 	panic("don't call this from non template code")
 }
 
-func (m *memColumn) MaybeHasNulls() bool {
-	return m.nulls.maybeHasNulls
+// MaybeHasNulls returns true if the column possibly has any null values, and
+// returns false if the column definitely has no null values.
+func (v *Vec) MaybeHasNulls() bool {
+	return v.nulls.maybeHasNulls
 }
 
-func (m *memColumn) Nulls() *Nulls {
-	return &m.nulls
+// Nulls returns the nulls vector for the column.
+func (v *Vec) Nulls() *Nulls {
+	return &v.nulls
 }
 
-func (m *memColumn) SetNulls(n Nulls) {
-	m.nulls = n
+// SetNulls sets the nulls vector for this column.
+func (v *Vec) SetNulls(n Nulls) {
+	v.nulls = n
 }
 
-func (m *memColumn) Length() int {
-	return m.col.Len()
+// Length returns the length of the slice that is underlying this Vec.
+func (v *Vec) Length() int {
+	return v.col.Len()
 }
 
-func (m *memColumn) Capacity() int {
-	switch m.CanonicalTypeFamily() {
+// Capacity returns the capacity of the Golang's slice that is underlying
+// this Vec. Note that if there is no "slice" (like in case of flat bytes),
+// then "capacity" of such object is equal to the number of elements.
+func (v *Vec) Capacity() int {
+	switch v.CanonicalTypeFamily() {
 	case types.BoolFamily:
-		return cap(m.col.(Bools))
+		return cap(v.col.(Bools))
 	case types.BytesFamily:
-		return m.Bytes().Len()
+		return v.Bytes().Len()
 	case types.IntFamily:
-		switch m.t.Width() {
+		switch v.t.Width() {
 		case 16:
-			return cap(m.col.(Int16s))
+			return cap(v.col.(Int16s))
 		case 32:
-			return cap(m.col.(Int32s))
+			return cap(v.col.(Int32s))
 		case 0, 64:
-			return cap(m.col.(Int64s))
+			return cap(v.col.(Int64s))
 		default:
-			panic(fmt.Sprintf("unexpected int width: %d", m.t.Width()))
+			panic(fmt.Sprintf("unexpected int width: %d", v.t.Width()))
 		}
 	case types.FloatFamily:
-		return cap(m.col.(Float64s))
+		return cap(v.col.(Float64s))
 	case types.DecimalFamily:
-		return cap(m.col.(Decimals))
+		return cap(v.col.(Decimals))
 	case types.TimestampTZFamily:
-		return cap(m.col.(Times))
+		return cap(v.col.(Times))
 	case types.IntervalFamily:
-		return cap(m.col.(Durations))
+		return cap(v.col.(Durations))
 	case types.JsonFamily:
-		return m.JSON().Len()
+		return v.JSON().Len()
 	case typeconv.DatumVecCanonicalTypeFamily:
-		return m.col.(DatumVec).Cap()
+		return v.col.(DatumVec).Cap()
 	default:
-		panic(fmt.Sprintf("unhandled type %s", m.t))
+		panic(fmt.Sprintf("unhandled type %s", v.t))
 	}
 }

--- a/pkg/col/coldata/vec_test.go
+++ b/pkg/col/coldata/vec_test.go
@@ -22,12 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMemColumnWindow(t *testing.T) {
+func TestVecWindow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	rng, _ := randutil.NewTestRand()
 
-	c := coldata.NewMemColumn(types.Int, coldata.BatchSize(), coldata.StandardColumnFactory)
+	c := coldata.NewVec(types.Int, coldata.BatchSize(), coldata.StandardColumnFactory)
 
 	ints := c.Int64()
 	for i := 0; i < coldata.BatchSize(); i++ {
@@ -115,7 +115,7 @@ func TestNullRanges(t *testing.T) {
 		},
 	}
 
-	c := coldata.NewMemColumn(types.Int, coldata.BatchSize(), coldata.StandardColumnFactory)
+	c := coldata.NewVec(types.Int, coldata.BatchSize(), coldata.StandardColumnFactory)
 	for _, tc := range tcs {
 		if tc.end > coldata.BatchSize() {
 			continue
@@ -141,7 +141,7 @@ func TestAppend(t *testing.T) {
 	// TODO(asubiotto): Test nulls.
 	var typ = types.Int
 
-	src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+	src := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 	sel := make([]int, len(src.Int64()))
 	for i := range sel {
 		sel[i] = i
@@ -217,7 +217,7 @@ func TestAppend(t *testing.T) {
 			tc.args.SrcEndIdx = coldata.BatchSize()
 		}
 		t.Run(tc.name, func(t *testing.T) {
-			dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+			dest := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 			dest.Append(tc.args)
 			require.Equal(t, tc.expectedLength, len(dest.Int64()))
 		})
@@ -228,7 +228,7 @@ func TestCopy(t *testing.T) {
 	// TODO(asubiotto): Test nulls.
 	var typ = types.Int
 
-	src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+	src := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 	srcInts := src.Int64()
 	for i := range srcInts {
 		srcInts[i] = int64(i + 1)
@@ -285,7 +285,7 @@ func TestCopy(t *testing.T) {
 		}
 		tc.args.Src = src
 		t.Run(tc.name, func(t *testing.T) {
-			dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+			dest := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 			dest.Copy(tc.args)
 			destInts := dest.Int64()
 			firstNonZero := 0
@@ -309,7 +309,7 @@ func TestCopyNulls(t *testing.T) {
 	var typ = types.Int
 
 	// Set up the destination vector.
-	dst := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+	dst := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 	dstInts := dst.Int64()
 	for i := range dstInts {
 		dstInts[i] = int64(1)
@@ -320,7 +320,7 @@ func TestCopyNulls(t *testing.T) {
 	}
 
 	// Set up the source vector.
-	src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+	src := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 	srcInts := src.Int64()
 	for i := range srcInts {
 		srcInts[i] = 2
@@ -363,7 +363,7 @@ func TestCopyWithReorderedSource(t *testing.T) {
 	var typ = types.Int
 
 	for _, hasNulls := range []bool{false, true} {
-		src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+		src := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 		srcInts := src.Int64()
 		sel := make([]int, 0, coldata.BatchSize())
 		for i := range srcInts {
@@ -381,7 +381,7 @@ func TestCopyWithReorderedSource(t *testing.T) {
 			order[sel[i]] = o
 		}
 
-		dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+		dest := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 		dest.CopyWithReorderedSource(src, sel, order)
 		destInts := dest.Int64()
 
@@ -435,7 +435,7 @@ func BenchmarkAppend(b *testing.B) {
 				if !typ.Identical(types.Bytes) && bc.bytesLen == longBytesLen {
 					continue
 				}
-				src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+				src := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 				coldatatestutils.RandomVec(coldatatestutils.RandomVecArgs{
 					Rand:             rng,
 					Vec:              src,
@@ -448,7 +448,7 @@ func BenchmarkAppend(b *testing.B) {
 				b.Run(fmt.Sprintf("%s/%s/NullProbability=%.1f", typ, bc.name, nullProbability), func(b *testing.B) {
 					b.SetBytes(int64(bc.bytesLen * coldata.BatchSize()))
 					bc.args.DestIdx = 0
-					dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+					dest := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 					for i := 0; i < b.N; i++ {
 						dest.Append(bc.args)
 						bc.args.DestIdx += coldata.BatchSize()
@@ -481,7 +481,7 @@ func BenchmarkCopy(b *testing.B) {
 
 	for _, typ := range []*types.T{types.Bytes, types.Decimal, types.Int} {
 		for _, nullProbability := range []float64{0, 0.2} {
-			src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+			src := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 			coldatatestutils.RandomVec(coldatatestutils.RandomVecArgs{
 				Rand:             rng,
 				Vec:              src,
@@ -492,7 +492,7 @@ func BenchmarkCopy(b *testing.B) {
 			for _, bc := range benchCases {
 				bc.args.Src = src
 				bc.args.SrcEndIdx = coldata.BatchSize()
-				dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+				dest := coldata.NewVec(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 				b.Run(fmt.Sprintf("%s/%s/NullProbability=%.1f", typ, bc.name, nullProbability), func(b *testing.B) {
 					b.SetBytes(8 * int64(coldata.BatchSize()))
 					for i := 0; i < b.N; i++ {

--- a/pkg/col/coldataext/vec_handler.go
+++ b/pkg/col/coldataext/vec_handler.go
@@ -27,7 +27,7 @@ import (
 )
 
 // MakeVecHandler makes a tree.ValueHandler that stores values to a coldata.Vec.
-func MakeVecHandler(vec coldata.Vec) tree.ValueHandler {
+func MakeVecHandler(vec *coldata.Vec) tree.ValueHandler {
 	v := vecHandler{nulls: vec.Nulls()}
 	switch vec.CanonicalTypeFamily() {
 	case types.BoolFamily:

--- a/pkg/col/coldatatestutils/random_testutils.go
+++ b/pkg/col/coldatatestutils/random_testutils.go
@@ -58,7 +58,7 @@ type RandomVecArgs struct {
 	// Rand is the provided RNG.
 	Rand *rand.Rand
 	// Vec is the vector to be filled with random values.
-	Vec coldata.Vec
+	Vec *coldata.Vec
 	// N is the number of values to be generated.
 	N int
 	// NullProbability determines the probability of a single value being NULL.
@@ -222,7 +222,7 @@ func RandomVec(args RandomVecArgs) {
 
 // setNull sets ith element in vec to null and might set the actual value (which
 // should be ignored) to some garbage.
-func setNull(rng *rand.Rand, vec coldata.Vec, i int) {
+func setNull(rng *rand.Rand, vec *coldata.Vec, i int) {
 	vec.Nulls().SetNull(i)
 	switch vec.CanonicalTypeFamily() {
 	case types.DecimalFamily:

--- a/pkg/sql/colconv/batch.go
+++ b/pkg/sql/colconv/batch.go
@@ -23,7 +23,7 @@ func init() {
 
 // vecsToStringWithRowPrefix returns a pretty representation of the vectors with
 // each row being in a separate string.
-func vecsToStringWithRowPrefix(vecs []coldata.Vec, length int, sel []int, prefix string) []string {
+func vecsToStringWithRowPrefix(vecs []*coldata.Vec, length int, sel []int, prefix string) []string {
 	var builder strings.Builder
 	converter := NewAllVecToDatumConverter(len(vecs))
 	defer converter.Release()

--- a/pkg/sql/colconv/batch_test.go
+++ b/pkg/sql/colconv/batch_test.go
@@ -22,7 +22,7 @@ import (
 func TestVecsToStringWithRowPrefix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	vec := coldata.NewMemColumn(types.String, coldata.BatchSize(), coldata.StandardColumnFactory)
+	vec := coldata.NewVec(types.String, coldata.BatchSize(), coldata.StandardColumnFactory)
 	input := []string{"one", "two", "three"}
 	for i := range input {
 		vec.Bytes().Set(i, []byte(input[i]))
@@ -48,6 +48,6 @@ func TestVecsToStringWithRowPrefix(t *testing.T) {
 		{length: 3, prefix: "row: "},
 		{length: 2, sel: []int{0, 2}, prefix: "row: "},
 	} {
-		require.Equal(t, getExpected(tc.length, tc.sel, tc.prefix), vecsToStringWithRowPrefix([]coldata.Vec{vec}, tc.length, tc.sel, tc.prefix))
+		require.Equal(t, getExpected(tc.length, tc.sel, tc.prefix), vecsToStringWithRowPrefix([]*coldata.Vec{vec}, tc.length, tc.sel, tc.prefix))
 	}
 }

--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -204,7 +204,7 @@ func (c *VecToDatumConverter) ConvertBatch(batch coldata.Batch) {
 // Note that this method is equivalent to ConvertBatch with the only difference
 // being the fact that it takes in a "disassembled" batch and not coldata.Batch.
 // Consider whether you should be using ConvertBatch instead.
-func (c *VecToDatumConverter) ConvertVecs(vecs []coldata.Vec, inputLen int, sel []int) {
+func (c *VecToDatumConverter) ConvertVecs(vecs []*coldata.Vec, inputLen int, sel []int) {
 	if len(c.vecIdxsToConvert) == 0 || inputLen == 0 {
 		// No vectors were selected for conversion or there are no tuples to
 		// convert, so there is nothing to do.
@@ -249,7 +249,7 @@ func (c *VecToDatumConverter) GetDatumColumn(colIdx int) tree.Datums {
 // selection vector. It doesn't account for the memory used by the newly
 // created tree.Datums, so it is up to the caller to do the memory accounting.
 func ColVecToDatumAndDeselect(
-	converted []tree.Datum, col coldata.Vec, length int, sel []int, da *tree.DatumAlloc,
+	converted []tree.Datum, col *coldata.Vec, length int, sel []int, da *tree.DatumAlloc,
 ) {
 	if length == 0 {
 		return
@@ -1125,7 +1125,7 @@ func ColVecToDatumAndDeselect(
 // doesn't account for the memory used by the newly created tree.Datums, so it
 // is up to the caller to do the memory accounting.
 func ColVecToDatum(
-	converted []tree.Datum, col coldata.Vec, length int, sel []int, da *tree.DatumAlloc,
+	converted []tree.Datum, col *coldata.Vec, length int, sel []int, da *tree.DatumAlloc,
 ) {
 	if length == 0 {
 		return

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -214,7 +214,7 @@ func (c *VecToDatumConverter) ConvertBatch(batch coldata.Batch) {
 // Note that this method is equivalent to ConvertBatch with the only difference
 // being the fact that it takes in a "disassembled" batch and not coldata.Batch.
 // Consider whether you should be using ConvertBatch instead.
-func (c *VecToDatumConverter) ConvertVecs(vecs []coldata.Vec, inputLen int, sel []int) {
+func (c *VecToDatumConverter) ConvertVecs(vecs []*coldata.Vec, inputLen int, sel []int) {
 	if len(c.vecIdxsToConvert) == 0 || inputLen == 0 {
 		// No vectors were selected for conversion or there are no tuples to
 		// convert, so there is nothing to do.
@@ -259,7 +259,7 @@ func (c *VecToDatumConverter) GetDatumColumn(colIdx int) tree.Datums {
 // selection vector. It doesn't account for the memory used by the newly
 // created tree.Datums, so it is up to the caller to do the memory accounting.
 func ColVecToDatumAndDeselect(
-	converted []tree.Datum, col coldata.Vec, length int, sel []int, da *tree.DatumAlloc,
+	converted []tree.Datum, col *coldata.Vec, length int, sel []int, da *tree.DatumAlloc,
 ) {
 	if length == 0 {
 		return
@@ -281,7 +281,7 @@ func ColVecToDatumAndDeselect(
 // doesn't account for the memory used by the newly created tree.Datums, so it
 // is up to the caller to do the memory accounting.
 func ColVecToDatum(
-	converted []tree.Datum, col coldata.Vec, length int, sel []int, da *tree.DatumAlloc,
+	converted []tree.Datum, col *coldata.Vec, length int, sel []int, da *tree.DatumAlloc,
 ) {
 	if length == 0 {
 		return
@@ -338,7 +338,7 @@ func setSrcIdx(srcIdx int, idx int, sel []int, hasSel bool) {
 // execgen:template<hasNulls, hasSel, deselect>
 func vecToDatum(
 	converted []tree.Datum,
-	col coldata.Vec,
+	col *coldata.Vec,
 	length int,
 	sel []int,
 	da *tree.DatumAlloc,

--- a/pkg/sql/colenc/encode.go
+++ b/pkg/sql/colenc/encode.go
@@ -616,12 +616,12 @@ func encodeColumns[T []byte | roachpb.Key](
 	directions rowenc.Directions,
 	colMap catalog.TableColMap,
 	start, end int,
-	vecs []coldata.Vec,
+	vecs []*coldata.Vec,
 	keys []T,
 ) error {
 	var err error
 	for colIdx, id := range columnIDs {
-		var vec coldata.Vec
+		var vec *coldata.Vec
 		i, ok := colMap.Get(id)
 		if ok {
 			vec = vecs[i]
@@ -703,7 +703,7 @@ func (b *BatchEncoder) checkMemory() error {
 }
 
 func (b *BatchEncoder) skipColumnNotInPrimaryIndexValue(
-	colID catid.ColumnID, vec coldata.Vec, row int,
+	colID catid.ColumnID, vec *coldata.Vec, row int,
 ) bool {
 	// Reuse this function but fake out the value and handle composites here.
 	if skip := b.rh.SkipColumnNotInPrimaryIndexValue(colID, tree.DNull); skip {
@@ -715,7 +715,7 @@ func (b *BatchEncoder) skipColumnNotInPrimaryIndexValue(
 	return false
 }
 
-func isComposite(vec coldata.Vec, row int) bool {
+func isComposite(vec *coldata.Vec, row int) bool {
 	switch vec.CanonicalTypeFamily() {
 	case types.FloatFamily:
 		f := tree.DFloat(vec.Float64()[row])

--- a/pkg/sql/colenc/inverted.go
+++ b/pkg/sql/colenc/inverted.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func invertedColToDatum(vec coldata.Vec, row int) tree.Datum {
+func invertedColToDatum(vec *coldata.Vec, row int) tree.Datum {
 	if vec.Nulls().NullAt(row) {
 		return tree.DNull
 	}
@@ -52,7 +52,7 @@ func (b *BatchEncoder) encodeInvertedSecondaryIndex(
 	if kys, err = b.encodeInvertedIndexPrefixKeys(kys, index); err != nil {
 		return err
 	}
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	if i, ok := b.colMap.Get(index.InvertedColumnID()); ok {
 		vec = b.b.ColVecs()[i]
 	}
@@ -127,7 +127,7 @@ func (b *BatchEncoder) encodeInvertedIndexPrefixKeys(
 func writeColumnValueOneRow(
 	value []byte,
 	colMap catalog.TableColMap,
-	vecs []coldata.Vec,
+	vecs []*coldata.Vec,
 	cols []rowenc.ValueEncodedColumn,
 	row int,
 ) ([]byte, error) {

--- a/pkg/sql/colenc/key.go
+++ b/pkg/sql/colenc/key.go
@@ -48,7 +48,7 @@ func partialIndexAndNullCheck[T []byte | roachpb.Key](
 //
 // vec=nil indicates that all values are NULL.
 func encodeKeys[T []byte | roachpb.Key](
-	kys []T, dir encoding.Direction, vec coldata.Vec, start, end int,
+	kys []T, dir encoding.Direction, vec *coldata.Vec, start, end int,
 ) error {
 	count := end - start
 	if vec == nil {
@@ -234,7 +234,7 @@ func (b *BatchEncoder) encodeIndexKey(
 			return err
 		}
 		col, ok := b.colMap.Get(k.ColumnID)
-		var vec coldata.Vec
+		var vec *coldata.Vec
 		if ok {
 			vec = b.b.ColVec(col)
 		} else {

--- a/pkg/sql/colenc/legacy.go
+++ b/pkg/sql/colenc/legacy.go
@@ -23,7 +23,7 @@ import (
 
 // MarshalLegacy is the vectorized version of the row based valueside.MarshalLegacy.
 // It plucks off the vectorized types for special handling and delegates the rest.
-func MarshalLegacy(colType *types.T, vec coldata.Vec, row int) (roachpb.Value, error) {
+func MarshalLegacy(colType *types.T, vec *coldata.Vec, row int) (roachpb.Value, error) {
 	var r roachpb.Value
 
 	if vec.Nulls().NullAt(row) {

--- a/pkg/sql/colenc/value.go
+++ b/pkg/sql/colenc/value.go
@@ -22,7 +22,7 @@ import (
 
 // valuesideEncodeCol is the vector version of valueside.Encode.
 func valuesideEncodeCol(
-	appendTo []byte, colID valueside.ColumnIDDelta, vec coldata.Vec, row int,
+	appendTo []byte, colID valueside.ColumnIDDelta, vec *coldata.Vec, row int,
 ) ([]byte, error) {
 	if vec.Nulls().NullAt(row) {
 		return encoding.EncodeNullValue(appendTo, uint32(colID)), nil

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -864,13 +864,13 @@ func TestAggregatorRandom(t *testing.T) {
 					log.Infof(context.Background(), "%s/groupSize=%d/numInputBatches=%d/hasNulls=%t", agg.name, groupSize, numInputBatches, hasNulls)
 					nTuples := coldata.BatchSize() * numInputBatches
 					typs := []*types.T{types.Int, types.Float}
-					cols := []coldata.Vec{
-						testAllocator.NewMemColumn(typs[0], nTuples),
-						testAllocator.NewMemColumn(typs[1], nTuples),
+					cols := []*coldata.Vec{
+						testAllocator.NewVec(typs[0], nTuples),
+						testAllocator.NewVec(typs[1], nTuples),
 					}
 					if agg.order == partial {
 						typs = append(typs, types.Int)
-						cols = append(cols, testAllocator.NewMemColumn(typs[2], nTuples))
+						cols = append(cols, testAllocator.NewVec(typs[2], nTuples))
 					}
 					groups, aggCol, aggColNulls := cols[0].Int64(), cols[1].Float64(), cols[1].Nulls()
 					expectedTuples := colexectestutils.Tuples{}
@@ -1042,9 +1042,9 @@ func benchmarkAggregateFunction(
 		groupCols = append(groupCols, uint32(g))
 	}
 	typs = append(typs, aggInputTypes...)
-	cols := make([]coldata.Vec, len(typs))
+	cols := make([]*coldata.Vec, len(typs))
 	for i := range typs {
-		cols[i] = testAllocator.NewMemColumn(typs[i], numInputRows)
+		cols[i] = testAllocator.NewVec(typs[i], numInputRows)
 	}
 	groups := cols[0].Int64()
 	if agg.order == ordered {

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -44,7 +44,7 @@ type aggregatorHelper interface {
 	// start of the new aggregation group (when groups is nil, then all tuples
 	// belong to the same group).
 	// Note: inputLen is assumed to be greater than zero.
-	performAggregation(ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *aggBucket, groups []bool)
+	performAggregation(ctx context.Context, vecs []*coldata.Vec, inputLen int, sel []int, bucket *aggBucket, groups []bool)
 }
 
 // newAggregatorHelper creates a new aggregatorHelper based on the provided
@@ -105,7 +105,7 @@ func (h *defaultAggregatorHelper) makeSeenMaps() []map[string]struct{} {
 }
 
 func (h *defaultAggregatorHelper) performAggregation(
-	_ context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *aggBucket, _ []bool,
+	_ context.Context, vecs []*coldata.Vec, inputLen int, sel []int, bucket *aggBucket, _ []bool,
 ) {
 	for fnIdx, fn := range bucket.fns {
 		fn.Compute(vecs, h.spec.Aggregations[fnIdx].ColIdx, 0 /* startIdx */, inputLen, sel)
@@ -118,7 +118,7 @@ func (h *defaultAggregatorHelper) performAggregation(
 type aggregatorHelperBase struct {
 	spec *execinfrapb.AggregatorSpec
 
-	vecs    []coldata.Vec
+	vecs    []*coldata.Vec
 	usesSel bool
 	origSel []int
 	origLen int
@@ -132,7 +132,7 @@ func newAggregatorHelperBase(
 	return b
 }
 
-func (b *aggregatorHelperBase) saveState(vecs []coldata.Vec, origLen int, origSel []int) {
+func (b *aggregatorHelperBase) saveState(vecs []*coldata.Vec, origLen int, origSel []int) {
 	b.vecs = vecs
 	b.origLen = origLen
 	b.usesSel = origSel != nil
@@ -141,7 +141,7 @@ func (b *aggregatorHelperBase) saveState(vecs []coldata.Vec, origLen int, origSe
 	}
 }
 
-func (b *aggregatorHelperBase) restoreState() ([]coldata.Vec, int, []int) {
+func (b *aggregatorHelperBase) restoreState() ([]*coldata.Vec, int, []int) {
 	sel := b.origSel
 	if !b.usesSel {
 		sel = nil
@@ -180,8 +180,8 @@ func newFilteringHashAggHelper(
 // for which filtering column has 'true' value set. It also returns whether
 // state might have been modified.
 func (h *filteringSingleFunctionHashHelper) applyFilter(
-	ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int,
-) (_ []coldata.Vec, _ int, _ []int, maybeModified bool) {
+	ctx context.Context, vecs []*coldata.Vec, inputLen int, sel []int,
+) (_ []*coldata.Vec, _ int, _ []int, maybeModified bool) {
 	if h.filter == nil {
 		return vecs, inputLen, sel, false
 	}
@@ -219,7 +219,7 @@ func (h *filteringHashAggregatorHelper) makeSeenMaps() []map[string]struct{} {
 }
 
 func (h *filteringHashAggregatorHelper) performAggregation(
-	ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *aggBucket, _ []bool,
+	ctx context.Context, vecs []*coldata.Vec, inputLen int, sel []int, bucket *aggBucket, _ []bool,
 ) {
 	h.saveState(vecs, inputLen, sel)
 	for fnIdx, fn := range bucket.fns {
@@ -422,7 +422,7 @@ func newFilteringDistinctHashAggregatorHelper(
 //  4. Restore the state to the original state (if it might have been
 //     modified).
 func (h *filteringDistinctHashAggregatorHelper) performAggregation(
-	ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *aggBucket, _ []bool,
+	ctx context.Context, vecs []*coldata.Vec, inputLen int, sel []int, bucket *aggBucket, _ []bool,
 ) {
 	h.saveState(vecs, inputLen, sel)
 	h.aggColsConverter.ConvertVecs(vecs, inputLen, sel)
@@ -467,7 +467,7 @@ func newDistinctOrderedAggregatorHelper(
 // DISTINCT aggregation
 func (h *distinctOrderedAggregatorHelper) performAggregation(
 	ctx context.Context,
-	vecs []coldata.Vec,
+	vecs []*coldata.Vec,
 	inputLen int,
 	sel []int,
 	bucket *aggBucket,
@@ -524,7 +524,7 @@ func (o *singleBatchOperator) Next() coldata.Batch {
 	return o.batch
 }
 
-func (o *singleBatchOperator) reset(vecs []coldata.Vec, inputLen int, sel []int) {
+func (o *singleBatchOperator) reset(vecs []*coldata.Vec, inputLen int, sel []int) {
 	o.nexted = false
 	for i, vec := range vecs {
 		o.batch.ReplaceCol(vec, i)

--- a/pkg/sql/colexec/and_or_projection.eg.go
+++ b/pkg/sql/colexec/and_or_projection.eg.go
@@ -216,7 +216,7 @@ func (o *andProjOp) Next() coldata.Batch {
 	// fully determines the result of the logical operation.
 	var (
 		knownResult                   bool
-		leftVec, rightVec             coldata.Vec
+		leftVec, rightVec             *coldata.Vec
 		leftValIsNull, rightValIsNull bool
 		leftVal, rightVal             bool
 	)
@@ -651,7 +651,7 @@ func (o *andRightNullProjOp) Next() coldata.Batch {
 	// fully determines the result of the logical operation.
 	var (
 		knownResult                   bool
-		leftVec, rightVec             coldata.Vec
+		leftVec, rightVec             *coldata.Vec
 		leftValIsNull, rightValIsNull bool
 		leftVal, rightVal             bool
 	)
@@ -1053,7 +1053,7 @@ func (o *andLeftNullProjOp) Next() coldata.Batch {
 	// fully determines the result of the logical operation.
 	var (
 		knownResult                   bool
-		leftVec, rightVec             coldata.Vec
+		leftVec, rightVec             *coldata.Vec
 		leftValIsNull, rightValIsNull bool
 		leftVal, rightVal             bool
 	)
@@ -1436,7 +1436,7 @@ func (o *orProjOp) Next() coldata.Batch {
 	// fully determines the result of the logical operation.
 	var (
 		knownResult                   bool
-		leftVec, rightVec             coldata.Vec
+		leftVec, rightVec             *coldata.Vec
 		leftValIsNull, rightValIsNull bool
 		leftVal, rightVal             bool
 	)
@@ -1872,7 +1872,7 @@ func (o *orRightNullProjOp) Next() coldata.Batch {
 	// fully determines the result of the logical operation.
 	var (
 		knownResult                   bool
-		leftVec, rightVec             coldata.Vec
+		leftVec, rightVec             *coldata.Vec
 		leftValIsNull, rightValIsNull bool
 		leftVal, rightVal             bool
 	)
@@ -2275,7 +2275,7 @@ func (o *orLeftNullProjOp) Next() coldata.Batch {
 	// fully determines the result of the logical operation.
 	var (
 		knownResult                   bool
-		leftVec, rightVec             coldata.Vec
+		leftVec, rightVec             *coldata.Vec
 		leftValIsNull, rightValIsNull bool
 		leftVal, rightVal             bool
 	)

--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -202,7 +202,7 @@ func (o *_OP_LOWERProjOp) Next() coldata.Batch {
 	// fully determines the result of the logical operation.
 	var (
 		knownResult                   bool
-		leftVec, rightVec             coldata.Vec
+		leftVec, rightVec             *coldata.Vec
 		leftValIsNull, rightValIsNull bool
 		leftVal, rightVal             bool
 	)

--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -52,7 +52,7 @@ func (b *defaultBuiltinFuncOperator) Next() coldata.Batch {
 	sel := batch.Selection()
 	output := batch.ColVec(b.outputIdx)
 	b.allocator.PerformOperation(
-		[]coldata.Vec{output},
+		[]*coldata.Vec{output},
 		func() {
 			b.toDatumConverter.ConvertBatchAndDeselect(batch)
 			for i := 0; i < n; i++ {

--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -89,7 +89,7 @@ type AggregateFunc interface {
 	// SetOutput sets the output vector to write the results of aggregation
 	// into. If the output vector changes, it is up to the caller to make sure
 	// that results already written to the old vector are propagated further.
-	SetOutput(vec coldata.Vec)
+	SetOutput(vec *coldata.Vec)
 
 	// CurrentOutputIndex returns the current index in the output vector that
 	// the aggregate function is writing to. All indices < the index returned
@@ -103,7 +103,7 @@ type AggregateFunc interface {
 	// Note: the implementations should be careful to account for their memory
 	// usage.
 	// Note: endIdx is assumed to be greater than zero.
-	Compute(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int)
+	Compute(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int)
 
 	// Flush flushes the result of aggregation on the last group. It should be
 	// called once after input batches have been Compute()'d. outputIdx is only
@@ -129,7 +129,7 @@ type orderedAggregateFuncBase struct {
 	curIdx    int
 	allocator *colmem.Allocator
 	// vec is the output vector of this function.
-	vec coldata.Vec
+	vec *coldata.Vec
 	// nulls is the nulls vector of the output vector of this function.
 	nulls *coldata.Nulls
 	// isFirstGroup tracks whether the new group (indicated by 'true' in
@@ -142,7 +142,7 @@ func (o *orderedAggregateFuncBase) Init(groups []bool) {
 	o.Reset()
 }
 
-func (o *orderedAggregateFuncBase) SetOutput(vec coldata.Vec) {
+func (o *orderedAggregateFuncBase) SetOutput(vec *coldata.Vec) {
 	o.vec = vec
 	o.nulls = vec.Nulls()
 }
@@ -170,14 +170,14 @@ func (o *orderedAggregateFuncBase) Reset() {
 type unorderedAggregateFuncBase struct {
 	allocator *colmem.Allocator
 	// vec is the output vector of this function.
-	vec coldata.Vec
+	vec *coldata.Vec
 	// nulls is the nulls vector of the output vector of this function.
 	nulls *coldata.Nulls
 }
 
 func (h *unorderedAggregateFuncBase) Init(_ []bool) {}
 
-func (h *unorderedAggregateFuncBase) SetOutput(vec coldata.Vec) {
+func (h *unorderedAggregateFuncBase) SetOutput(vec *coldata.Vec) {
 	h.vec = vec
 	h.nulls = vec.Nulls()
 }

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -111,7 +111,7 @@ type anyNotNull_TYPE_AGGKINDAgg struct {
 var _ AggregateFunc = &anyNotNull_TYPE_AGGKINDAgg{}
 
 // {{if eq "_AGGKIND" "Ordered"}}
-func (a *anyNotNull_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNull_TYPE_AGGKINDAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.TemplateType()
 }
@@ -119,7 +119,7 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 // {{end}}
 
 func (a *anyNotNull_TYPE_AGGKINDAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	// {{if eq "_AGGKIND" "Hash"}}
 	if a.foundNonNullForCurrentGroup {
@@ -133,7 +133,7 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) Compute(
 	execgen.SETVARIABLESIZE(oldCurAggSize, a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.TemplateType(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// {{if eq "_AGGKIND" "Ordered"}}
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756

--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -125,7 +125,7 @@ type avg_TYPE_AGGKINDAgg struct {
 var _ AggregateFunc = &avg_TYPE_AGGKINDAgg{}
 
 // {{if eq "_AGGKIND" "Ordered"}}
-func (a *avg_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
+func (a *avg_TYPE_AGGKINDAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec._RET_TYPE()
 }
@@ -133,13 +133,13 @@ func (a *avg_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 // {{end}}
 
 func (a *avg_TYPE_AGGKINDAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	execgen.SETVARIABLESIZE(oldCurSumSize, a.curSum)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.TemplateType(), vec.Nulls()
 	// {{if not (eq "_AGGKIND" "Window")}}
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// {{if eq "_AGGKIND" "Ordered"}}
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
@@ -252,7 +252,9 @@ func (a *avg_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
-func (a *avg_TYPE_AGGKINDAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (a *avg_TYPE_AGGKINDAgg) Remove(
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+) {
 	execgen.SETVARIABLESIZE(oldCurSumSize, a.curSum)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.TemplateType(), vec.Nulls()

--- a/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
@@ -72,7 +72,7 @@ type bool_OP_TYPE_AGGKINDAgg struct {
 var _ AggregateFunc = &bool_OP_TYPE_AGGKINDAgg{}
 
 // {{if eq "_AGGKIND" "Ordered"}}
-func (a *bool_OP_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
+func (a *bool_OP_TYPE_AGGKINDAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bool()
 }
@@ -80,13 +80,13 @@ func (a *bool_OP_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 // {{end}}
 
 func (a *bool_OP_TYPE_AGGKINDAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	execgen.SETVARIABLESIZE(oldCurAggSize, a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
 	// {{if not (eq "_AGGKIND" "Window")}}
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// {{if eq "_AGGKIND" "Ordered"}}
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
@@ -205,7 +205,7 @@ func (a *bool_OP_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 // used when the window frame only grows. For the case when the window frame can
 // shrink, the default quadratic-scaling implementation is necessary.
 func (*bool_OP_TYPE_AGGKINDAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	colexecerror.InternalError(
 		errors.AssertionFailedf("Remove called on bool_OP_TYPE_AGGKINDAgg"),

--- a/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
@@ -52,7 +52,7 @@ type concat_AGGKINDAgg struct {
 }
 
 // {{if eq "_AGGKIND" "Ordered"}}
-func (a *concat_AGGKINDAgg) SetOutput(vec coldata.Vec) {
+func (a *concat_AGGKINDAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bytes()
 }
@@ -60,13 +60,13 @@ func (a *concat_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 // {{end}}
 
 func (a *concat_AGGKINDAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	execgen.SETVARIABLESIZE(oldCurAggSize, a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
 	// {{if not (eq "_AGGKIND" "Window")}}
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// {{if eq "_AGGKIND" "Ordered"}}
 		// Capture groups to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756

--- a/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
@@ -53,7 +53,7 @@ type count_COUNTKIND_AGGKINDAgg struct {
 var _ AggregateFunc = &count_COUNTKIND_AGGKINDAgg{}
 
 // {{if eq "_AGGKIND" "Ordered"}}
-func (a *count_COUNTKIND_AGGKINDAgg) SetOutput(vec coldata.Vec) {
+func (a *count_COUNTKIND_AGGKINDAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int64()
 }
@@ -61,7 +61,7 @@ func (a *count_COUNTKIND_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 // {{end}}
 
 func (a *count_COUNTKIND_AGGKINDAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	// {{if not (eq .CountKind "Rows")}}
 	// If this is a COUNT(col) aggregator and there are nulls in this batch,
@@ -70,7 +70,7 @@ func (a *count_COUNTKIND_AGGKINDAgg) Compute(
 	nulls := vecs[inputIdxs[0]].Nulls()
 	// {{end}}
 	// {{if not (eq "_AGGKIND" "Window")}}
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// {{if eq "_AGGKIND" "Ordered"}}
 		// Capture groups to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
@@ -173,7 +173,7 @@ func (a *count_COUNTKIND_AGGKINDAgg) Reset() {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *count_COUNTKIND_AGGKINDAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	nulls := vecs[inputIdxs[0]].Nulls()
 	if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
@@ -58,12 +58,12 @@ type default_AGGKINDAgg struct {
 var _ AggregateFunc = &default_AGGKINDAgg{}
 
 func (a *default_AGGKINDAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	// Note that we only need to account for the memory of the output vector
 	// and not for the intermediate results of aggregation since the aggregate
 	// function itself does the latter.
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// {{if eq "_AGGKIND" "Ordered"}}
 		// Capture groups to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756

--- a/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
@@ -115,7 +115,7 @@ type anyNotNullBoolHashAgg struct {
 var _ AggregateFunc = &anyNotNullBoolHashAgg{}
 
 func (a *anyNotNullBoolHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -127,7 +127,7 @@ func (a *anyNotNullBoolHashAgg) Compute(
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -223,7 +223,7 @@ type anyNotNullBytesHashAgg struct {
 var _ AggregateFunc = &anyNotNullBytesHashAgg{}
 
 func (a *anyNotNullBytesHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -235,7 +235,7 @@ func (a *anyNotNullBytesHashAgg) Compute(
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -335,7 +335,7 @@ type anyNotNullDecimalHashAgg struct {
 var _ AggregateFunc = &anyNotNullDecimalHashAgg{}
 
 func (a *anyNotNullDecimalHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -347,7 +347,7 @@ func (a *anyNotNullDecimalHashAgg) Compute(
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -443,7 +443,7 @@ type anyNotNullInt16HashAgg struct {
 var _ AggregateFunc = &anyNotNullInt16HashAgg{}
 
 func (a *anyNotNullInt16HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -455,7 +455,7 @@ func (a *anyNotNullInt16HashAgg) Compute(
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -551,7 +551,7 @@ type anyNotNullInt32HashAgg struct {
 var _ AggregateFunc = &anyNotNullInt32HashAgg{}
 
 func (a *anyNotNullInt32HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -563,7 +563,7 @@ func (a *anyNotNullInt32HashAgg) Compute(
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -659,7 +659,7 @@ type anyNotNullInt64HashAgg struct {
 var _ AggregateFunc = &anyNotNullInt64HashAgg{}
 
 func (a *anyNotNullInt64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -671,7 +671,7 @@ func (a *anyNotNullInt64HashAgg) Compute(
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -767,7 +767,7 @@ type anyNotNullFloat64HashAgg struct {
 var _ AggregateFunc = &anyNotNullFloat64HashAgg{}
 
 func (a *anyNotNullFloat64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -779,7 +779,7 @@ func (a *anyNotNullFloat64HashAgg) Compute(
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -875,7 +875,7 @@ type anyNotNullTimestampHashAgg struct {
 var _ AggregateFunc = &anyNotNullTimestampHashAgg{}
 
 func (a *anyNotNullTimestampHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -887,7 +887,7 @@ func (a *anyNotNullTimestampHashAgg) Compute(
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -983,7 +983,7 @@ type anyNotNullIntervalHashAgg struct {
 var _ AggregateFunc = &anyNotNullIntervalHashAgg{}
 
 func (a *anyNotNullIntervalHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -995,7 +995,7 @@ func (a *anyNotNullIntervalHashAgg) Compute(
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -1091,7 +1091,7 @@ type anyNotNullJSONHashAgg struct {
 var _ AggregateFunc = &anyNotNullJSONHashAgg{}
 
 func (a *anyNotNullJSONHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -1106,7 +1106,7 @@ func (a *anyNotNullJSONHashAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.JSON(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -1234,7 +1234,7 @@ type anyNotNullDatumHashAgg struct {
 var _ AggregateFunc = &anyNotNullDatumHashAgg{}
 
 func (a *anyNotNullDatumHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	if a.foundNonNullForCurrentGroup {
 		// We have already seen non-null for the current group, and since there
@@ -1249,7 +1249,7 @@ func (a *anyNotNullDatumHashAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -85,12 +85,12 @@ type avgInt16HashAgg struct {
 var _ AggregateFunc = &avgInt16HashAgg{}
 
 func (a *avgInt16HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -199,12 +199,12 @@ type avgInt32HashAgg struct {
 var _ AggregateFunc = &avgInt32HashAgg{}
 
 func (a *avgInt32HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -313,12 +313,12 @@ type avgInt64HashAgg struct {
 var _ AggregateFunc = &avgInt64HashAgg{}
 
 func (a *avgInt64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -427,12 +427,12 @@ type avgDecimalHashAgg struct {
 var _ AggregateFunc = &avgDecimalHashAgg{}
 
 func (a *avgDecimalHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -541,12 +541,12 @@ type avgFloat64HashAgg struct {
 var _ AggregateFunc = &avgFloat64HashAgg{}
 
 func (a *avgFloat64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurSumSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -643,12 +643,12 @@ type avgIntervalHashAgg struct {
 var _ AggregateFunc = &avgIntervalHashAgg{}
 
 func (a *avgIntervalHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurSumSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
@@ -42,12 +42,12 @@ type boolAndHashAgg struct {
 var _ AggregateFunc = &boolAndHashAgg{}
 
 func (a *boolAndHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -138,12 +138,12 @@ type boolOrHashAgg struct {
 var _ AggregateFunc = &boolOrHashAgg{}
 
 func (a *boolOrHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
@@ -35,12 +35,12 @@ type concatHashAgg struct {
 }
 
 func (a *concatHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
@@ -36,9 +36,9 @@ type countRowsHashAgg struct {
 var _ AggregateFunc = &countRowsHashAgg{}
 
 func (a *countRowsHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			{
 				// We don't need to pay attention to nulls (either because it's a
@@ -100,13 +100,13 @@ type countHashAgg struct {
 var _ AggregateFunc = &countHashAgg{}
 
 func (a *countHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	// If this is a COUNT(col) aggregator and there are nulls in this batch,
 	// we must check each value for nullity. Note that it is only legal to do a
 	// COUNT aggregate on a single column.
 	nulls := vecs[inputIdxs[0]].Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			if nulls.MaybeHasNulls() {
 				for _, i := range sel[startIdx:endIdx] {

--- a/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
@@ -44,12 +44,12 @@ type defaultHashAgg struct {
 var _ AggregateFunc = &defaultHashAgg{}
 
 func (a *defaultHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	// Note that we only need to account for the memory of the output vector
 	// and not for the intermediate results of aggregation since the aggregate
 	// function itself does the latter.
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			// We don't need to check whether sel is non-nil in case of the
 			// hash aggregator because it always uses non-nil sel to specify

--- a/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
@@ -126,12 +126,12 @@ type minBoolHashAgg struct {
 var _ AggregateFunc = &minBoolHashAgg{}
 
 func (a *minBoolHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -263,12 +263,12 @@ type minBytesHashAgg struct {
 var _ AggregateFunc = &minBytesHashAgg{}
 
 func (a *minBytesHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -393,12 +393,12 @@ type minDecimalHashAgg struct {
 var _ AggregateFunc = &minDecimalHashAgg{}
 
 func (a *minDecimalHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -514,12 +514,12 @@ type minInt16HashAgg struct {
 var _ AggregateFunc = &minInt16HashAgg{}
 
 func (a *minInt16HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -657,12 +657,12 @@ type minInt32HashAgg struct {
 var _ AggregateFunc = &minInt32HashAgg{}
 
 func (a *minInt32HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -800,12 +800,12 @@ type minInt64HashAgg struct {
 var _ AggregateFunc = &minInt64HashAgg{}
 
 func (a *minInt64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -943,12 +943,12 @@ type minFloat64HashAgg struct {
 var _ AggregateFunc = &minFloat64HashAgg{}
 
 func (a *minFloat64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -1102,12 +1102,12 @@ type minTimestampHashAgg struct {
 var _ AggregateFunc = &minTimestampHashAgg{}
 
 func (a *minTimestampHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -1237,12 +1237,12 @@ type minIntervalHashAgg struct {
 var _ AggregateFunc = &minIntervalHashAgg{}
 
 func (a *minIntervalHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -1358,7 +1358,7 @@ type minJSONHashAgg struct {
 var _ AggregateFunc = &minJSONHashAgg{}
 
 func (a *minJSONHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
@@ -1366,7 +1366,7 @@ func (a *minJSONHashAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.JSON(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -1556,7 +1556,7 @@ type minDatumHashAgg struct {
 var _ AggregateFunc = &minDatumHashAgg{}
 
 func (a *minDatumHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
@@ -1565,7 +1565,7 @@ func (a *minDatumHashAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -1775,12 +1775,12 @@ type maxBoolHashAgg struct {
 var _ AggregateFunc = &maxBoolHashAgg{}
 
 func (a *maxBoolHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -1912,12 +1912,12 @@ type maxBytesHashAgg struct {
 var _ AggregateFunc = &maxBytesHashAgg{}
 
 func (a *maxBytesHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -2042,12 +2042,12 @@ type maxDecimalHashAgg struct {
 var _ AggregateFunc = &maxDecimalHashAgg{}
 
 func (a *maxDecimalHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -2163,12 +2163,12 @@ type maxInt16HashAgg struct {
 var _ AggregateFunc = &maxInt16HashAgg{}
 
 func (a *maxInt16HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -2306,12 +2306,12 @@ type maxInt32HashAgg struct {
 var _ AggregateFunc = &maxInt32HashAgg{}
 
 func (a *maxInt32HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -2449,12 +2449,12 @@ type maxInt64HashAgg struct {
 var _ AggregateFunc = &maxInt64HashAgg{}
 
 func (a *maxInt64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -2592,12 +2592,12 @@ type maxFloat64HashAgg struct {
 var _ AggregateFunc = &maxFloat64HashAgg{}
 
 func (a *maxFloat64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -2751,12 +2751,12 @@ type maxTimestampHashAgg struct {
 var _ AggregateFunc = &maxTimestampHashAgg{}
 
 func (a *maxTimestampHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -2886,12 +2886,12 @@ type maxIntervalHashAgg struct {
 var _ AggregateFunc = &maxIntervalHashAgg{}
 
 func (a *maxIntervalHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -3007,7 +3007,7 @@ type maxJSONHashAgg struct {
 var _ AggregateFunc = &maxJSONHashAgg{}
 
 func (a *maxJSONHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
@@ -3015,7 +3015,7 @@ func (a *maxJSONHashAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.JSON(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -3205,7 +3205,7 @@ type maxDatumHashAgg struct {
 var _ AggregateFunc = &maxDatumHashAgg{}
 
 func (a *maxDatumHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
@@ -3214,7 +3214,7 @@ func (a *maxDatumHashAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -84,12 +84,12 @@ type sumInt16HashAgg struct {
 var _ AggregateFunc = &sumInt16HashAgg{}
 
 func (a *sumInt16HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -193,12 +193,12 @@ type sumInt32HashAgg struct {
 var _ AggregateFunc = &sumInt32HashAgg{}
 
 func (a *sumInt32HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -302,12 +302,12 @@ type sumInt64HashAgg struct {
 var _ AggregateFunc = &sumInt64HashAgg{}
 
 func (a *sumInt64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -411,12 +411,12 @@ type sumDecimalHashAgg struct {
 var _ AggregateFunc = &sumDecimalHashAgg{}
 
 func (a *sumDecimalHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -520,12 +520,12 @@ type sumFloat64HashAgg struct {
 var _ AggregateFunc = &sumFloat64HashAgg{}
 
 func (a *sumFloat64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -621,12 +621,12 @@ type sumIntervalHashAgg struct {
 var _ AggregateFunc = &sumIntervalHashAgg{}
 
 func (a *sumIntervalHashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -66,12 +66,12 @@ type sumIntInt16HashAgg struct {
 var _ AggregateFunc = &sumIntInt16HashAgg{}
 
 func (a *sumIntInt16HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -173,12 +173,12 @@ type sumIntInt32HashAgg struct {
 var _ AggregateFunc = &sumIntInt32HashAgg{}
 
 func (a *sumIntInt32HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {
@@ -280,12 +280,12 @@ type sumIntInt64HashAgg struct {
 var _ AggregateFunc = &sumIntInt64HashAgg{}
 
 func (a *sumIntInt64HashAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		{
 			sel = sel[startIdx:endIdx]
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -135,7 +135,7 @@ type _AGG_TYPE_AGGKINDAgg struct {
 var _ AggregateFunc = &_AGG_TYPE_AGGKINDAgg{}
 
 // {{if eq "_AGGKIND" "Ordered"}}
-func (a *_AGG_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
+func (a *_AGG_TYPE_AGGKINDAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec._TYPE()
 }
@@ -143,13 +143,13 @@ func (a *_AGG_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 // {{end}}
 
 func (a *_AGG_TYPE_AGGKINDAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	execgen.SETVARIABLESIZE(oldCurAggSize, a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec._TYPE(), vec.Nulls()
 	// {{if not (eq "_AGGKIND" "Window")}}
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// {{if eq "_AGGKIND" "Ordered"}}
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
@@ -276,7 +276,7 @@ func (a *_AGG_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*_AGG_TYPE_AGGKINDAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*_AGG_TYPE_AGGKINDAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on _AGG_TYPE_AGGKINDAgg"))
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -191,19 +191,19 @@ type anyNotNullBoolOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullBoolOrderedAgg{}
 
-func (a *anyNotNullBoolOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullBoolOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bool()
 }
 
 func (a *anyNotNullBoolOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -390,19 +390,19 @@ type anyNotNullBytesOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullBytesOrderedAgg{}
 
-func (a *anyNotNullBytesOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullBytesOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bytes()
 }
 
 func (a *anyNotNullBytesOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -593,19 +593,19 @@ type anyNotNullDecimalOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullDecimalOrderedAgg{}
 
-func (a *anyNotNullDecimalOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullDecimalOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *anyNotNullDecimalOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -792,19 +792,19 @@ type anyNotNullInt16OrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullInt16OrderedAgg{}
 
-func (a *anyNotNullInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullInt16OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int16()
 }
 
 func (a *anyNotNullInt16OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -991,19 +991,19 @@ type anyNotNullInt32OrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullInt32OrderedAgg{}
 
-func (a *anyNotNullInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullInt32OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int32()
 }
 
 func (a *anyNotNullInt32OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1190,19 +1190,19 @@ type anyNotNullInt64OrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullInt64OrderedAgg{}
 
-func (a *anyNotNullInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullInt64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int64()
 }
 
 func (a *anyNotNullInt64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1389,19 +1389,19 @@ type anyNotNullFloat64OrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullFloat64OrderedAgg{}
 
-func (a *anyNotNullFloat64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullFloat64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Float64()
 }
 
 func (a *anyNotNullFloat64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1588,19 +1588,19 @@ type anyNotNullTimestampOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullTimestampOrderedAgg{}
 
-func (a *anyNotNullTimestampOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullTimestampOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Timestamp()
 }
 
 func (a *anyNotNullTimestampOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1787,19 +1787,19 @@ type anyNotNullIntervalOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullIntervalOrderedAgg{}
 
-func (a *anyNotNullIntervalOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullIntervalOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Interval()
 }
 
 func (a *anyNotNullIntervalOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1986,13 +1986,13 @@ type anyNotNullJSONOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullJSONOrderedAgg{}
 
-func (a *anyNotNullJSONOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullJSONOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.JSON()
 }
 
 func (a *anyNotNullJSONOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
@@ -2001,7 +2001,7 @@ func (a *anyNotNullJSONOrderedAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.JSON(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -2242,13 +2242,13 @@ type anyNotNullDatumOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullDatumOrderedAgg{}
 
-func (a *anyNotNullDatumOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *anyNotNullDatumOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Datum()
 }
 
 func (a *anyNotNullDatumOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
@@ -2257,7 +2257,7 @@ func (a *anyNotNullDatumOrderedAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -137,18 +137,18 @@ type avgInt16OrderedAgg struct {
 
 var _ AggregateFunc = &avgInt16OrderedAgg{}
 
-func (a *avgInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *avgInt16OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *avgInt16OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -395,18 +395,18 @@ type avgInt32OrderedAgg struct {
 
 var _ AggregateFunc = &avgInt32OrderedAgg{}
 
-func (a *avgInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *avgInt32OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *avgInt32OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -653,18 +653,18 @@ type avgInt64OrderedAgg struct {
 
 var _ AggregateFunc = &avgInt64OrderedAgg{}
 
-func (a *avgInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *avgInt64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *avgInt64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -911,18 +911,18 @@ type avgDecimalOrderedAgg struct {
 
 var _ AggregateFunc = &avgDecimalOrderedAgg{}
 
-func (a *avgDecimalOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *avgDecimalOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *avgDecimalOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1169,18 +1169,18 @@ type avgFloat64OrderedAgg struct {
 
 var _ AggregateFunc = &avgFloat64OrderedAgg{}
 
-func (a *avgFloat64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *avgFloat64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Float64()
 }
 
 func (a *avgFloat64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurSumSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1391,18 +1391,18 @@ type avgIntervalOrderedAgg struct {
 
 var _ AggregateFunc = &avgIntervalOrderedAgg{}
 
-func (a *avgIntervalOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *avgIntervalOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Interval()
 }
 
 func (a *avgIntervalOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurSumSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups

--- a/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
@@ -42,18 +42,18 @@ type boolAndOrderedAgg struct {
 
 var _ AggregateFunc = &boolAndOrderedAgg{}
 
-func (a *boolAndOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *boolAndOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bool()
 }
 
 func (a *boolAndOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -235,18 +235,18 @@ type boolOrOrderedAgg struct {
 
 var _ AggregateFunc = &boolOrOrderedAgg{}
 
-func (a *boolOrOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *boolOrOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bool()
 }
 
 func (a *boolOrOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups

--- a/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
@@ -36,18 +36,18 @@ type concatOrderedAgg struct {
 	foundNonNullForCurrentGroup bool
 }
 
-func (a *concatOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *concatOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bytes()
 }
 
 func (a *concatOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups

--- a/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
@@ -36,15 +36,15 @@ type countRowsOrderedAgg struct {
 
 var _ AggregateFunc = &countRowsOrderedAgg{}
 
-func (a *countRowsOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *countRowsOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int64()
 }
 
 func (a *countRowsOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -148,19 +148,19 @@ type countOrderedAgg struct {
 
 var _ AggregateFunc = &countOrderedAgg{}
 
-func (a *countOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *countOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int64()
 }
 
 func (a *countOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	// If this is a COUNT(col) aggregator and there are nulls in this batch,
 	// we must check each value for nullity. Note that it is only legal to do a
 	// COUNT aggregate on a single column.
 	nulls := vecs[inputIdxs[0]].Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups

--- a/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
@@ -44,12 +44,12 @@ type defaultOrderedAgg struct {
 var _ AggregateFunc = &defaultOrderedAgg{}
 
 func (a *defaultOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	// Note that we only need to account for the memory of the output vector
 	// and not for the intermediate results of aggregation since the aggregate
 	// function itself does the latter.
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups

--- a/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
@@ -203,18 +203,18 @@ type minBoolOrderedAgg struct {
 
 var _ AggregateFunc = &minBoolOrderedAgg{}
 
-func (a *minBoolOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minBoolOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bool()
 }
 
 func (a *minBoolOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -490,18 +490,18 @@ type minBytesOrderedAgg struct {
 
 var _ AggregateFunc = &minBytesOrderedAgg{}
 
-func (a *minBytesOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minBytesOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bytes()
 }
 
 func (a *minBytesOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -754,18 +754,18 @@ type minDecimalOrderedAgg struct {
 
 var _ AggregateFunc = &minDecimalOrderedAgg{}
 
-func (a *minDecimalOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minDecimalOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *minDecimalOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1009,18 +1009,18 @@ type minInt16OrderedAgg struct {
 
 var _ AggregateFunc = &minInt16OrderedAgg{}
 
-func (a *minInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minInt16OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int16()
 }
 
 func (a *minInt16OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1308,18 +1308,18 @@ type minInt32OrderedAgg struct {
 
 var _ AggregateFunc = &minInt32OrderedAgg{}
 
-func (a *minInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minInt32OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int32()
 }
 
 func (a *minInt32OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1607,18 +1607,18 @@ type minInt64OrderedAgg struct {
 
 var _ AggregateFunc = &minInt64OrderedAgg{}
 
-func (a *minInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minInt64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int64()
 }
 
 func (a *minInt64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1906,18 +1906,18 @@ type minFloat64OrderedAgg struct {
 
 var _ AggregateFunc = &minFloat64OrderedAgg{}
 
-func (a *minFloat64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minFloat64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Float64()
 }
 
 func (a *minFloat64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -2237,18 +2237,18 @@ type minTimestampOrderedAgg struct {
 
 var _ AggregateFunc = &minTimestampOrderedAgg{}
 
-func (a *minTimestampOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minTimestampOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Timestamp()
 }
 
 func (a *minTimestampOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -2520,18 +2520,18 @@ type minIntervalOrderedAgg struct {
 
 var _ AggregateFunc = &minIntervalOrderedAgg{}
 
-func (a *minIntervalOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minIntervalOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Interval()
 }
 
 func (a *minIntervalOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -2775,13 +2775,13 @@ type minJSONOrderedAgg struct {
 
 var _ AggregateFunc = &minJSONOrderedAgg{}
 
-func (a *minJSONOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minJSONOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.JSON()
 }
 
 func (a *minJSONOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
@@ -2789,7 +2789,7 @@ func (a *minJSONOrderedAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.JSON(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -3163,13 +3163,13 @@ type minDatumOrderedAgg struct {
 
 var _ AggregateFunc = &minDatumOrderedAgg{}
 
-func (a *minDatumOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *minDatumOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Datum()
 }
 
 func (a *minDatumOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
@@ -3178,7 +3178,7 @@ func (a *minDatumOrderedAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -3520,18 +3520,18 @@ type maxBoolOrderedAgg struct {
 
 var _ AggregateFunc = &maxBoolOrderedAgg{}
 
-func (a *maxBoolOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxBoolOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bool()
 }
 
 func (a *maxBoolOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -3807,18 +3807,18 @@ type maxBytesOrderedAgg struct {
 
 var _ AggregateFunc = &maxBytesOrderedAgg{}
 
-func (a *maxBytesOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxBytesOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Bytes()
 }
 
 func (a *maxBytesOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -4071,18 +4071,18 @@ type maxDecimalOrderedAgg struct {
 
 var _ AggregateFunc = &maxDecimalOrderedAgg{}
 
-func (a *maxDecimalOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxDecimalOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *maxDecimalOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -4326,18 +4326,18 @@ type maxInt16OrderedAgg struct {
 
 var _ AggregateFunc = &maxInt16OrderedAgg{}
 
-func (a *maxInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxInt16OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int16()
 }
 
 func (a *maxInt16OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -4625,18 +4625,18 @@ type maxInt32OrderedAgg struct {
 
 var _ AggregateFunc = &maxInt32OrderedAgg{}
 
-func (a *maxInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxInt32OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int32()
 }
 
 func (a *maxInt32OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -4924,18 +4924,18 @@ type maxInt64OrderedAgg struct {
 
 var _ AggregateFunc = &maxInt64OrderedAgg{}
 
-func (a *maxInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxInt64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int64()
 }
 
 func (a *maxInt64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -5223,18 +5223,18 @@ type maxFloat64OrderedAgg struct {
 
 var _ AggregateFunc = &maxFloat64OrderedAgg{}
 
-func (a *maxFloat64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxFloat64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Float64()
 }
 
 func (a *maxFloat64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -5554,18 +5554,18 @@ type maxTimestampOrderedAgg struct {
 
 var _ AggregateFunc = &maxTimestampOrderedAgg{}
 
-func (a *maxTimestampOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxTimestampOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Timestamp()
 }
 
 func (a *maxTimestampOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -5837,18 +5837,18 @@ type maxIntervalOrderedAgg struct {
 
 var _ AggregateFunc = &maxIntervalOrderedAgg{}
 
-func (a *maxIntervalOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxIntervalOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Interval()
 }
 
 func (a *maxIntervalOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -6092,13 +6092,13 @@ type maxJSONOrderedAgg struct {
 
 var _ AggregateFunc = &maxJSONOrderedAgg{}
 
-func (a *maxJSONOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxJSONOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.JSON()
 }
 
 func (a *maxJSONOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
@@ -6106,7 +6106,7 @@ func (a *maxJSONOrderedAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.JSON(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -6480,13 +6480,13 @@ type maxDatumOrderedAgg struct {
 
 var _ AggregateFunc = &maxDatumOrderedAgg{}
 
-func (a *maxDatumOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *maxDatumOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Datum()
 }
 
 func (a *maxDatumOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
@@ -6495,7 +6495,7 @@ func (a *maxDatumOrderedAgg) Compute(
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -136,18 +136,18 @@ type sumInt16OrderedAgg struct {
 
 var _ AggregateFunc = &sumInt16OrderedAgg{}
 
-func (a *sumInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *sumInt16OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *sumInt16OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -375,18 +375,18 @@ type sumInt32OrderedAgg struct {
 
 var _ AggregateFunc = &sumInt32OrderedAgg{}
 
-func (a *sumInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *sumInt32OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *sumInt32OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -614,18 +614,18 @@ type sumInt64OrderedAgg struct {
 
 var _ AggregateFunc = &sumInt64OrderedAgg{}
 
-func (a *sumInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *sumInt64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *sumInt64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -853,18 +853,18 @@ type sumDecimalOrderedAgg struct {
 
 var _ AggregateFunc = &sumDecimalOrderedAgg{}
 
-func (a *sumDecimalOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *sumDecimalOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Decimal()
 }
 
 func (a *sumDecimalOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1092,18 +1092,18 @@ type sumFloat64OrderedAgg struct {
 
 var _ AggregateFunc = &sumFloat64OrderedAgg{}
 
-func (a *sumFloat64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *sumFloat64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Float64()
 }
 
 func (a *sumFloat64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -1315,18 +1315,18 @@ type sumIntervalOrderedAgg struct {
 
 var _ AggregateFunc = &sumIntervalOrderedAgg{}
 
-func (a *sumIntervalOrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *sumIntervalOrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Interval()
 }
 
 func (a *sumIntervalOrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -103,18 +103,18 @@ type sumIntInt16OrderedAgg struct {
 
 var _ AggregateFunc = &sumIntInt16OrderedAgg{}
 
-func (a *sumIntInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *sumIntInt16OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int64()
 }
 
 func (a *sumIntInt16OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -338,18 +338,18 @@ type sumIntInt32OrderedAgg struct {
 
 var _ AggregateFunc = &sumIntInt32OrderedAgg{}
 
-func (a *sumIntInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *sumIntInt32OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int64()
 }
 
 func (a *sumIntInt32OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups
@@ -573,18 +573,18 @@ type sumIntInt64OrderedAgg struct {
 
 var _ AggregateFunc = &sumIntInt64OrderedAgg{}
 
-func (a *sumIntInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+func (a *sumIntInt64OrderedAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec.Int64()
 }
 
 func (a *sumIntInt64OrderedAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		groups := a.groups

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -125,7 +125,7 @@ type sum_SUMKIND_TYPE_AGGKINDAgg struct {
 var _ AggregateFunc = &sum_SUMKIND_TYPE_AGGKINDAgg{}
 
 // {{if eq "_AGGKIND" "Ordered"}}
-func (a *sum_SUMKIND_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
+func (a *sum_SUMKIND_TYPE_AGGKINDAgg) SetOutput(vec *coldata.Vec) {
 	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.col = vec._RET_TYPE()
 }
@@ -133,13 +133,13 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 // {{end}}
 
 func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	execgen.SETVARIABLESIZE(oldCurAggSize, a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.TemplateType(), vec.Nulls()
 	// {{if not (eq "_AGGKIND" "Window")}}
-	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{a.vec}, func() {
 		// {{if eq "_AGGKIND" "Ordered"}}
 		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
@@ -253,7 +253,7 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	execgen.SETVARIABLESIZE(oldCurAggSize, a.curAgg)
 	vec := vecs[inputIdxs[0]]

--- a/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
@@ -85,7 +85,7 @@ type avgInt16WindowAgg struct {
 var _ AggregateFunc = &avgInt16WindowAgg{}
 
 func (a *avgInt16WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
@@ -187,7 +187,9 @@ func (a *avgInt16WindowAggAlloc) newAggFunc() AggregateFunc {
 
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
-func (a *avgInt16WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (a *avgInt16WindowAgg) Remove(
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
@@ -255,7 +257,7 @@ type avgInt32WindowAgg struct {
 var _ AggregateFunc = &avgInt32WindowAgg{}
 
 func (a *avgInt32WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
@@ -357,7 +359,9 @@ func (a *avgInt32WindowAggAlloc) newAggFunc() AggregateFunc {
 
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
-func (a *avgInt32WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (a *avgInt32WindowAgg) Remove(
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
@@ -425,7 +429,7 @@ type avgInt64WindowAgg struct {
 var _ AggregateFunc = &avgInt64WindowAgg{}
 
 func (a *avgInt64WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
@@ -527,7 +531,9 @@ func (a *avgInt64WindowAggAlloc) newAggFunc() AggregateFunc {
 
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
-func (a *avgInt64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (a *avgInt64WindowAgg) Remove(
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
@@ -595,7 +601,7 @@ type avgDecimalWindowAgg struct {
 var _ AggregateFunc = &avgDecimalWindowAgg{}
 
 func (a *avgDecimalWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
@@ -697,7 +703,9 @@ func (a *avgDecimalWindowAggAlloc) newAggFunc() AggregateFunc {
 
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
-func (a *avgDecimalWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (a *avgDecimalWindowAgg) Remove(
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+) {
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
@@ -765,7 +773,7 @@ type avgFloat64WindowAgg struct {
 var _ AggregateFunc = &avgFloat64WindowAgg{}
 
 func (a *avgFloat64WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurSumSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -855,7 +863,9 @@ func (a *avgFloat64WindowAggAlloc) newAggFunc() AggregateFunc {
 
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
-func (a *avgFloat64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (a *avgFloat64WindowAgg) Remove(
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+) {
 	var oldCurSumSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
@@ -915,7 +925,7 @@ type avgIntervalWindowAgg struct {
 var _ AggregateFunc = &avgIntervalWindowAgg{}
 
 func (a *avgIntervalWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurSumSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -995,7 +1005,9 @@ func (a *avgIntervalWindowAggAlloc) newAggFunc() AggregateFunc {
 
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
-func (a *avgIntervalWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (a *avgIntervalWindowAgg) Remove(
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+) {
 	var oldCurSumSize uintptr
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()

--- a/pkg/sql/colexec/colexecagg/window_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_bool_and_or_agg.eg.go
@@ -43,7 +43,7 @@ type boolAndWindowAgg struct {
 var _ AggregateFunc = &boolAndWindowAgg{}
 
 func (a *boolAndWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -124,7 +124,7 @@ func (a *boolAndWindowAggAlloc) newAggFunc() AggregateFunc {
 // used when the window frame only grows. For the case when the window frame can
 // shrink, the default quadratic-scaling implementation is necessary.
 func (*boolAndWindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	colexecerror.InternalError(
 		errors.AssertionFailedf("Remove called on boolAndWindowAgg"),
@@ -151,7 +151,7 @@ type boolOrWindowAgg struct {
 var _ AggregateFunc = &boolOrWindowAgg{}
 
 func (a *boolOrWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -232,7 +232,7 @@ func (a *boolOrWindowAggAlloc) newAggFunc() AggregateFunc {
 // used when the window frame only grows. For the case when the window frame can
 // shrink, the default quadratic-scaling implementation is necessary.
 func (*boolOrWindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	colexecerror.InternalError(
 		errors.AssertionFailedf("Remove called on boolOrWindowAgg"),

--- a/pkg/sql/colexec/colexecagg/window_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_concat_agg.eg.go
@@ -35,7 +35,7 @@ type concatWindowAgg struct {
 }
 
 func (a *concatWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]

--- a/pkg/sql/colexec/colexecagg/window_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_count_agg.eg.go
@@ -36,7 +36,7 @@ type countRowsWindowAgg struct {
 var _ AggregateFunc = &countRowsWindowAgg{}
 
 func (a *countRowsWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	// Unnecessary memory accounting can have significant overhead for window
 	// aggregate functions because Compute is called at least once for every row.
@@ -99,7 +99,7 @@ type countWindowAgg struct {
 var _ AggregateFunc = &countWindowAgg{}
 
 func (a *countWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	// If this is a COUNT(col) aggregator and there are nulls in this batch,
 	// we must check each value for nullity. Note that it is only legal to do a
@@ -140,7 +140,7 @@ func (a *countWindowAgg) Reset() {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *countWindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	nulls := vecs[inputIdxs[0]].Nulls()
 	if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/window_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_min_max_agg.eg.go
@@ -126,7 +126,7 @@ type minBoolWindowAgg struct {
 var _ AggregateFunc = &minBoolWindowAgg{}
 
 func (a *minBoolWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -251,7 +251,7 @@ func (a *minBoolWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minBoolWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minBoolWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minBoolWindowAgg"))
 }
 
@@ -269,7 +269,7 @@ type minBytesWindowAgg struct {
 var _ AggregateFunc = &minBytesWindowAgg{}
 
 func (a *minBytesWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
@@ -382,7 +382,7 @@ func (a *minBytesWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minBytesWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minBytesWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minBytesWindowAgg"))
 }
 
@@ -400,7 +400,7 @@ type minDecimalWindowAgg struct {
 var _ AggregateFunc = &minDecimalWindowAgg{}
 
 func (a *minDecimalWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
@@ -509,7 +509,7 @@ func (a *minDecimalWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minDecimalWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minDecimalWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minDecimalWindowAgg"))
 }
 
@@ -527,7 +527,7 @@ type minInt16WindowAgg struct {
 var _ AggregateFunc = &minInt16WindowAgg{}
 
 func (a *minInt16WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -658,7 +658,7 @@ func (a *minInt16WindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minInt16WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minInt16WindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minInt16WindowAgg"))
 }
 
@@ -676,7 +676,7 @@ type minInt32WindowAgg struct {
 var _ AggregateFunc = &minInt32WindowAgg{}
 
 func (a *minInt32WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -807,7 +807,7 @@ func (a *minInt32WindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minInt32WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minInt32WindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minInt32WindowAgg"))
 }
 
@@ -825,7 +825,7 @@ type minInt64WindowAgg struct {
 var _ AggregateFunc = &minInt64WindowAgg{}
 
 func (a *minInt64WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -956,7 +956,7 @@ func (a *minInt64WindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minInt64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minInt64WindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minInt64WindowAgg"))
 }
 
@@ -974,7 +974,7 @@ type minFloat64WindowAgg struct {
 var _ AggregateFunc = &minFloat64WindowAgg{}
 
 func (a *minFloat64WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -1121,7 +1121,7 @@ func (a *minFloat64WindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minFloat64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minFloat64WindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minFloat64WindowAgg"))
 }
 
@@ -1139,7 +1139,7 @@ type minTimestampWindowAgg struct {
 var _ AggregateFunc = &minTimestampWindowAgg{}
 
 func (a *minTimestampWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -1262,7 +1262,7 @@ func (a *minTimestampWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minTimestampWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minTimestampWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minTimestampWindowAgg"))
 }
 
@@ -1280,7 +1280,7 @@ type minIntervalWindowAgg struct {
 var _ AggregateFunc = &minIntervalWindowAgg{}
 
 func (a *minIntervalWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -1389,7 +1389,7 @@ func (a *minIntervalWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minIntervalWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minIntervalWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minIntervalWindowAgg"))
 }
 
@@ -1407,7 +1407,7 @@ type minJSONWindowAgg struct {
 var _ AggregateFunc = &minJSONWindowAgg{}
 
 func (a *minJSONWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
@@ -1585,7 +1585,7 @@ func (a *minJSONWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minJSONWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minJSONWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minJSONWindowAgg"))
 }
 
@@ -1603,7 +1603,7 @@ type minDatumWindowAgg struct {
 var _ AggregateFunc = &minDatumWindowAgg{}
 
 func (a *minDatumWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
@@ -1732,7 +1732,7 @@ func (a *minDatumWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*minDatumWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*minDatumWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on minDatumWindowAgg"))
 }
 
@@ -1819,7 +1819,7 @@ type maxBoolWindowAgg struct {
 var _ AggregateFunc = &maxBoolWindowAgg{}
 
 func (a *maxBoolWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -1944,7 +1944,7 @@ func (a *maxBoolWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxBoolWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxBoolWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxBoolWindowAgg"))
 }
 
@@ -1962,7 +1962,7 @@ type maxBytesWindowAgg struct {
 var _ AggregateFunc = &maxBytesWindowAgg{}
 
 func (a *maxBytesWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
@@ -2075,7 +2075,7 @@ func (a *maxBytesWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxBytesWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxBytesWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxBytesWindowAgg"))
 }
 
@@ -2093,7 +2093,7 @@ type maxDecimalWindowAgg struct {
 var _ AggregateFunc = &maxDecimalWindowAgg{}
 
 func (a *maxDecimalWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
@@ -2202,7 +2202,7 @@ func (a *maxDecimalWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxDecimalWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxDecimalWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxDecimalWindowAgg"))
 }
 
@@ -2220,7 +2220,7 @@ type maxInt16WindowAgg struct {
 var _ AggregateFunc = &maxInt16WindowAgg{}
 
 func (a *maxInt16WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -2351,7 +2351,7 @@ func (a *maxInt16WindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxInt16WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxInt16WindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxInt16WindowAgg"))
 }
 
@@ -2369,7 +2369,7 @@ type maxInt32WindowAgg struct {
 var _ AggregateFunc = &maxInt32WindowAgg{}
 
 func (a *maxInt32WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -2500,7 +2500,7 @@ func (a *maxInt32WindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxInt32WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxInt32WindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxInt32WindowAgg"))
 }
 
@@ -2518,7 +2518,7 @@ type maxInt64WindowAgg struct {
 var _ AggregateFunc = &maxInt64WindowAgg{}
 
 func (a *maxInt64WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -2649,7 +2649,7 @@ func (a *maxInt64WindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxInt64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxInt64WindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxInt64WindowAgg"))
 }
 
@@ -2667,7 +2667,7 @@ type maxFloat64WindowAgg struct {
 var _ AggregateFunc = &maxFloat64WindowAgg{}
 
 func (a *maxFloat64WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -2814,7 +2814,7 @@ func (a *maxFloat64WindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxFloat64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxFloat64WindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxFloat64WindowAgg"))
 }
 
@@ -2832,7 +2832,7 @@ type maxTimestampWindowAgg struct {
 var _ AggregateFunc = &maxTimestampWindowAgg{}
 
 func (a *maxTimestampWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -2955,7 +2955,7 @@ func (a *maxTimestampWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxTimestampWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxTimestampWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxTimestampWindowAgg"))
 }
 
@@ -2973,7 +2973,7 @@ type maxIntervalWindowAgg struct {
 var _ AggregateFunc = &maxIntervalWindowAgg{}
 
 func (a *maxIntervalWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -3082,7 +3082,7 @@ func (a *maxIntervalWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxIntervalWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxIntervalWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxIntervalWindowAgg"))
 }
 
@@ -3100,7 +3100,7 @@ type maxJSONWindowAgg struct {
 var _ AggregateFunc = &maxJSONWindowAgg{}
 
 func (a *maxJSONWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
@@ -3278,7 +3278,7 @@ func (a *maxJSONWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxJSONWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxJSONWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxJSONWindowAgg"))
 }
 
@@ -3296,7 +3296,7 @@ type maxDatumWindowAgg struct {
 var _ AggregateFunc = &maxDatumWindowAgg{}
 
 func (a *maxDatumWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 
 	var oldCurAggSize uintptr
@@ -3425,6 +3425,6 @@ func (a *maxDatumWindowAggAlloc) newAggFunc() AggregateFunc {
 // window_aggregator_tmpl.go). This allows min and max operators to be used when
 // the window frame only grows. For the case when the window frame can shrink,
 // a specialized implementation is needed (see min_max_removable_agg_tmpl.go).
-func (*maxDatumWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
+func (*maxDatumWindowAgg) Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
 	colexecerror.InternalError(errors.AssertionFailedf("Remove called on maxDatumWindowAgg"))
 }

--- a/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
@@ -84,7 +84,7 @@ type sumInt16WindowAgg struct {
 var _ AggregateFunc = &sumInt16WindowAgg{}
 
 func (a *sumInt16WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
@@ -183,7 +183,7 @@ func (a *sumInt16WindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *sumInt16WindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
@@ -251,7 +251,7 @@ type sumInt32WindowAgg struct {
 var _ AggregateFunc = &sumInt32WindowAgg{}
 
 func (a *sumInt32WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
@@ -350,7 +350,7 @@ func (a *sumInt32WindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *sumInt32WindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
@@ -418,7 +418,7 @@ type sumInt64WindowAgg struct {
 var _ AggregateFunc = &sumInt64WindowAgg{}
 
 func (a *sumInt64WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
@@ -517,7 +517,7 @@ func (a *sumInt64WindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *sumInt64WindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
@@ -585,7 +585,7 @@ type sumDecimalWindowAgg struct {
 var _ AggregateFunc = &sumDecimalWindowAgg{}
 
 func (a *sumDecimalWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
@@ -684,7 +684,7 @@ func (a *sumDecimalWindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *sumDecimalWindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
@@ -752,7 +752,7 @@ type sumFloat64WindowAgg struct {
 var _ AggregateFunc = &sumFloat64WindowAgg{}
 
 func (a *sumFloat64WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -843,7 +843,7 @@ func (a *sumFloat64WindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *sumFloat64WindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -903,7 +903,7 @@ type sumIntervalWindowAgg struct {
 var _ AggregateFunc = &sumIntervalWindowAgg{}
 
 func (a *sumIntervalWindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -984,7 +984,7 @@ func (a *sumIntervalWindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *sumIntervalWindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]

--- a/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
@@ -66,7 +66,7 @@ type sumIntInt16WindowAgg struct {
 var _ AggregateFunc = &sumIntInt16WindowAgg{}
 
 func (a *sumIntInt16WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -163,7 +163,7 @@ func (a *sumIntInt16WindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *sumIntInt16WindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -229,7 +229,7 @@ type sumIntInt32WindowAgg struct {
 var _ AggregateFunc = &sumIntInt32WindowAgg{}
 
 func (a *sumIntInt32WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -326,7 +326,7 @@ func (a *sumIntInt32WindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *sumIntInt32WindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -392,7 +392,7 @@ type sumIntInt64WindowAgg struct {
 var _ AggregateFunc = &sumIntInt64WindowAgg{}
 
 func (a *sumIntInt64WindowAgg) Compute(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]
@@ -489,7 +489,7 @@ func (a *sumIntInt64WindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *sumIntInt64WindowAgg) Remove(
-	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+	vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
 	var oldCurAggSize uintptr
 	vec := vecs[inputIdxs[0]]

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -1263,7 +1263,7 @@ func (c *castIdentityOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(c.outputIdx)
-	c.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	c.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		srcVec := batch.ColVec(c.colIdx)
 		if sel := batch.Selection(); sel != nil {
 			// We don't want to perform the deselection during copying, so we
@@ -1303,7 +1303,7 @@ func (c *castBPCharIdentityOp) Next() coldata.Batch {
 	outputNulls := outputVec.Nulls()
 	// Note that the loops below are not as optimized as in other cast operators
 	// since this operator should only be planned in tests.
-	c.allocator.PerformOperation([]coldata.Vec{outputVec}, func() {
+	c.allocator.PerformOperation([]*coldata.Vec{outputVec}, func() {
 		if sel := batch.Selection(); sel != nil {
 			for _, i := range sel[:n] {
 				if inputNulls.NullAt(i) {
@@ -1345,7 +1345,7 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 	outputCol := outputVec.Datum()
 	outputNulls := outputVec.Nulls()
 	toType := outputVec.Type()
-	c.allocator.PerformOperation([]coldata.Vec{outputVec}, func() {
+	c.allocator.PerformOperation([]*coldata.Vec{outputVec}, func() {
 		if n > c.da.AllocSize {
 			c.da.AllocSize = n
 		}
@@ -1475,7 +1475,7 @@ func (c *castBoolFloatOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bool()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Float64()
@@ -1623,7 +1623,7 @@ func (c *castBoolInt2Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bool()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int16()
@@ -1771,7 +1771,7 @@ func (c *castBoolInt4Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bool()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int32()
@@ -1919,7 +1919,7 @@ func (c *castBoolIntOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bool()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int64()
@@ -2067,7 +2067,7 @@ func (c *castBoolStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bool()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -2283,7 +2283,7 @@ func (c *castBytesStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -2503,7 +2503,7 @@ func (c *castBytesUuidOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -2647,7 +2647,7 @@ func (c *castDateDecimalOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Decimal()
@@ -2799,7 +2799,7 @@ func (c *castDateFloatOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Float64()
@@ -2935,7 +2935,7 @@ func (c *castDateInt2Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int16()
@@ -3087,7 +3087,7 @@ func (c *castDateInt4Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int32()
@@ -3239,7 +3239,7 @@ func (c *castDateIntOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int64()
@@ -3367,7 +3367,7 @@ func (c *castDateStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -3599,7 +3599,7 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Decimal()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bool()
@@ -3727,7 +3727,7 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Decimal()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Decimal()
@@ -3875,7 +3875,7 @@ func (c *castDecimalFloatOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Decimal()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Float64()
@@ -4035,7 +4035,7 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Decimal()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int16()
@@ -4239,7 +4239,7 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Decimal()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int32()
@@ -4443,7 +4443,7 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Decimal()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int64()
@@ -4623,7 +4623,7 @@ func (c *castDecimalStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Decimal()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -4840,7 +4840,7 @@ func (c *castEnumStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -5072,7 +5072,7 @@ func (c *castFloatBoolOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Float64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bool()
@@ -5208,7 +5208,7 @@ func (c *castFloatDecimalOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Float64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Decimal()
@@ -5368,7 +5368,7 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Float64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int16()
@@ -5516,7 +5516,7 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Float64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int32()
@@ -5664,7 +5664,7 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Float64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int64()
@@ -5812,7 +5812,7 @@ func (c *castFloatStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Float64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -6036,7 +6036,7 @@ func (c *castInt2BoolOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int16()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bool()
@@ -6172,7 +6172,7 @@ func (c *castInt2DecimalOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int16()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Decimal()
@@ -6324,7 +6324,7 @@ func (c *castInt2FloatOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int16()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Float64()
@@ -6460,7 +6460,7 @@ func (c *castInt2Int4Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int16()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int32()
@@ -6588,7 +6588,7 @@ func (c *castInt2IntOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int16()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int64()
@@ -6716,7 +6716,7 @@ func (c *castInt2StringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int16()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -6984,7 +6984,7 @@ func (c *castInt4BoolOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int32()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bool()
@@ -7120,7 +7120,7 @@ func (c *castInt4DecimalOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int32()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Decimal()
@@ -7272,7 +7272,7 @@ func (c *castInt4FloatOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int32()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Float64()
@@ -7408,7 +7408,7 @@ func (c *castInt4Int2Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int32()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int16()
@@ -7560,7 +7560,7 @@ func (c *castInt4IntOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int32()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int64()
@@ -7688,7 +7688,7 @@ func (c *castInt4StringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int32()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -7956,7 +7956,7 @@ func (c *castIntBoolOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bool()
@@ -8092,7 +8092,7 @@ func (c *castIntDecimalOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Decimal()
@@ -8244,7 +8244,7 @@ func (c *castIntFloatOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Float64()
@@ -8380,7 +8380,7 @@ func (c *castIntInt2Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int16()
@@ -8532,7 +8532,7 @@ func (c *castIntInt4Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int32()
@@ -8684,7 +8684,7 @@ func (c *castIntStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Int64()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -8952,7 +8952,7 @@ func (c *castIntervalStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Interval()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -9184,7 +9184,7 @@ func (c *castJsonbStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.JSON()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -9396,7 +9396,7 @@ func (c *castStringBoolOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bool()
@@ -9544,7 +9544,7 @@ func (c *castStringBytesOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -9688,7 +9688,7 @@ func (c *castStringDateOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int64()
@@ -9848,7 +9848,7 @@ func (c *castStringDecimalOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Decimal()
@@ -10056,7 +10056,7 @@ func (c *castStringEnumOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -10204,7 +10204,7 @@ func (c *castStringFloatOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Float64()
@@ -10356,7 +10356,7 @@ func (c *castStringInt2Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int16()
@@ -10540,7 +10540,7 @@ func (c *castStringInt4Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int32()
@@ -10724,7 +10724,7 @@ func (c *castStringIntOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int64()
@@ -10884,7 +10884,7 @@ func (c *castStringIntervalOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Interval()
@@ -11048,7 +11048,7 @@ func (c *castStringJsonbOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.JSON()
@@ -11192,7 +11192,7 @@ func (c *castStringStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -11404,7 +11404,7 @@ func (c *castStringTimestampOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Timestamp()
@@ -11580,7 +11580,7 @@ func (c *castStringTimestamptzOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Timestamp()
@@ -11756,7 +11756,7 @@ func (c *castStringUuidOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -11900,7 +11900,7 @@ func (c *castTimestampStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Timestamp()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -12116,7 +12116,7 @@ func (c *castTimestamptzStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Timestamp()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -12368,7 +12368,7 @@ func (c *castUuidStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Bytes()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -12600,7 +12600,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bool()
@@ -12757,7 +12757,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int16()
@@ -12914,7 +12914,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int32()
@@ -13071,7 +13071,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int64()
@@ -13228,7 +13228,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Float64()
@@ -13385,7 +13385,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Decimal()
@@ -13542,7 +13542,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Int64()
@@ -13699,7 +13699,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Timestamp()
@@ -13856,7 +13856,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Interval()
@@ -14013,7 +14013,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -14166,7 +14166,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -14319,7 +14319,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Timestamp()
@@ -14476,7 +14476,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Bytes()
@@ -14629,7 +14629,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.JSON()
@@ -14782,7 +14782,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec.Datum()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec.Datum()

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -331,7 +331,7 @@ func (c *castIdentityOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(c.outputIdx)
-	c.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	c.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		srcVec := batch.ColVec(c.colIdx)
 		if sel := batch.Selection(); sel != nil {
 			// We don't want to perform the deselection during copying, so we
@@ -371,7 +371,7 @@ func (c *castBPCharIdentityOp) Next() coldata.Batch {
 	outputNulls := outputVec.Nulls()
 	// Note that the loops below are not as optimized as in other cast operators
 	// since this operator should only be planned in tests.
-	c.allocator.PerformOperation([]coldata.Vec{outputVec}, func() {
+	c.allocator.PerformOperation([]*coldata.Vec{outputVec}, func() {
 		if sel := batch.Selection(); sel != nil {
 			for _, i := range sel[:n] {
 				if inputNulls.NullAt(i) {
@@ -413,7 +413,7 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 	outputCol := outputVec.Datum()
 	outputNulls := outputVec.Nulls()
 	toType := outputVec.Type()
-	c.allocator.PerformOperation([]coldata.Vec{outputVec}, func() {
+	c.allocator.PerformOperation([]*coldata.Vec{outputVec}, func() {
 		if n > c.da.AllocSize {
 			c.da.AllocSize = n
 		}
@@ -518,7 +518,7 @@ func (c *cast_NAMEOp) Next() coldata.Batch {
 	// Remove unused warnings.
 	_ = toType
 	c.allocator.PerformOperation(
-		[]coldata.Vec{outputVec}, func() {
+		[]*coldata.Vec{outputVec}, func() {
 			inputCol := inputVec._FROM_TYPE()
 			inputNulls := inputVec.Nulls()
 			outputCol := outputVec._TO_TYPE()

--- a/pkg/sql/colexec/colexecbase/const.eg.go
+++ b/pkg/sql/colexec/colexecbase/const.eg.go
@@ -179,7 +179,7 @@ func (c constBoolOp) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Bool()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check
@@ -218,7 +218,7 @@ func (c constBytesOp) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Bytes()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check
@@ -256,7 +256,7 @@ func (c constDecimalOp) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Decimal()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check
@@ -295,7 +295,7 @@ func (c constInt16Op) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Int16()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check
@@ -334,7 +334,7 @@ func (c constInt32Op) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Int32()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check
@@ -373,7 +373,7 @@ func (c constInt64Op) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Int64()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check
@@ -412,7 +412,7 @@ func (c constFloat64Op) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Float64()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check
@@ -451,7 +451,7 @@ func (c constTimestampOp) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Timestamp()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check
@@ -490,7 +490,7 @@ func (c constIntervalOp) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Interval()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check
@@ -529,7 +529,7 @@ func (c constJSONOp) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.JSON()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check
@@ -567,7 +567,7 @@ func (c constDatumOp) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Datum()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check

--- a/pkg/sql/colexec/colexecbase/const_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/const_tmpl.go
@@ -106,7 +106,7 @@ func (c const_TYPEOp) Next() coldata.Batch {
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.TemplateType()
 	c.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]*coldata.Vec{vec},
 		func() {
 			// Shallow copy col to work around Go issue
 			// https://github.com/golang/go/issues/39756 which prevents bound check

--- a/pkg/sql/colexec/colexecbase/distinct_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/distinct_tmpl.go
@@ -101,7 +101,7 @@ func newSingleDistinct(
 type partitioner interface {
 	// partition partitions the input colVec of size n, writing true to the
 	// outputCol for every value that differs from the previous one.
-	partition(colVec coldata.Vec, outputCol []bool, n int)
+	partition(colVec *coldata.Vec, outputCol []bool, n int)
 
 	// partitionWithOrder is like partition, except it performs the partitioning
 	// on the input Vec as if it were ordered via the input order vector, which is
@@ -110,7 +110,7 @@ type partitioner interface {
 	// implies a reordered input vector [b,b,a], the resultant outputCol would be
 	// [true, false, true], indicating a distinct value at the 0th and 2nd
 	// elements.
-	partitionWithOrder(colVec coldata.Vec, order []int, outputCol []bool, n int)
+	partitionWithOrder(colVec *coldata.Vec, order []int, outputCol []bool, n int)
 }
 
 // newPartitioner returns a new partitioner on type t.
@@ -255,7 +255,7 @@ type partitioner_TYPE struct {
 }
 
 func (p partitioner_TYPE) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal _GOTYPE
 	var lastValNull bool
@@ -284,7 +284,7 @@ func (p partitioner_TYPE) partitionWithOrder(
 	}
 }
 
-func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitioner_TYPE) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     _GOTYPE
 		lastValNull bool

--- a/pkg/sql/colexec/colexecbase/simple_project.go
+++ b/pkg/sql/colexec/colexecbase/simple_project.go
@@ -44,7 +44,7 @@ type projectingBatch struct {
 	projection []uint32
 	// colVecs is a lazily populated slice of coldata.Vecs to support returning
 	// these in ColVecs().
-	colVecs []coldata.Vec
+	colVecs []*coldata.Vec
 }
 
 func newProjectionBatch(projection []uint32) *projectingBatch {
@@ -56,16 +56,16 @@ func newProjectionBatch(projection []uint32) *projectingBatch {
 	return p
 }
 
-func (b *projectingBatch) ColVec(i int) coldata.Vec {
+func (b *projectingBatch) ColVec(i int) *coldata.Vec {
 	return b.Batch.ColVec(int(b.projection[i]))
 }
 
-func (b *projectingBatch) ColVecs() []coldata.Vec {
+func (b *projectingBatch) ColVecs() []*coldata.Vec {
 	if b.Batch == coldata.ZeroBatch {
 		return nil
 	}
 	if b.colVecs == nil || len(b.colVecs) != len(b.projection) {
-		b.colVecs = make([]coldata.Vec, len(b.projection))
+		b.colVecs = make([]*coldata.Vec, len(b.projection))
 	}
 	for i := range b.colVecs {
 		b.colVecs[i] = b.Batch.ColVec(int(b.projection[i]))
@@ -77,12 +77,12 @@ func (b *projectingBatch) Width() int {
 	return len(b.projection)
 }
 
-func (b *projectingBatch) AppendCol(col coldata.Vec) {
+func (b *projectingBatch) AppendCol(col *coldata.Vec) {
 	b.Batch.AppendCol(col)
 	b.projection = append(b.projection, uint32(b.Batch.Width())-1)
 }
 
-func (b *projectingBatch) ReplaceCol(col coldata.Vec, idx int) {
+func (b *projectingBatch) ReplaceCol(col *coldata.Vec, idx int) {
 	b.Batch.ReplaceCol(col, int(b.projection[idx]))
 }
 

--- a/pkg/sql/colexec/colexechash/hash_utils.eg.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.eg.go
@@ -43,7 +43,7 @@ var (
 // transformation to the existing hash.
 func rehash(
 	buckets []uint32,
-	col coldata.Vec,
+	col *coldata.Vec,
 	nKeys int,
 	sel []int,
 	cancelChecker colexecutils.CancelChecker,
@@ -1103,7 +1103,7 @@ func rehash(
 // then we should remove the code duplication here.
 func rehash64(
 	buckets []uint64,
-	col coldata.Vec,
+	col *coldata.Vec,
 	nKeys int,
 	sel []int,
 	cancelChecker colexecutils.CancelChecker,

--- a/pkg/sql/colexec/colexechash/hash_utils.eg.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.eg.go
@@ -41,8 +41,8 @@ var (
 // rehash takes an element of a key (tuple representing a row of equality
 // column values) at a given column and computes a new hash by applying a
 // transformation to the existing hash.
-func rehash(
-	buckets []uint32,
+func rehash[T uint32 | uint64](
+	buckets []T,
 	col *coldata.Vec,
 	nKeys int,
 	sel []int,
@@ -78,7 +78,7 @@ func rehash(
 						p = p*31 + uintptr(x)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -102,7 +102,7 @@ func rehash(
 						p = p*31 + uintptr(x)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -125,7 +125,7 @@ func rehash(
 						p = p*31 + uintptr(x)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -146,7 +146,7 @@ func rehash(
 						p = p*31 + uintptr(x)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			}
@@ -176,7 +176,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -195,7 +195,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -215,7 +215,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -231,7 +231,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			}
@@ -266,7 +266,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -292,7 +292,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -317,7 +317,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -340,7 +340,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			}
@@ -370,7 +370,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -392,7 +392,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -413,7 +413,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -432,7 +432,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			}
@@ -459,7 +459,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -481,7 +481,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -502,7 +502,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -521,7 +521,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			}
@@ -549,7 +549,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -571,7 +571,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -592,7 +592,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -611,7 +611,7 @@ func rehash(
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			}
@@ -644,7 +644,7 @@ func rehash(
 						p = f64hash(noescape(unsafe.Pointer(&f)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -668,7 +668,7 @@ func rehash(
 						p = f64hash(noescape(unsafe.Pointer(&f)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -691,7 +691,7 @@ func rehash(
 						p = f64hash(noescape(unsafe.Pointer(&f)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -712,7 +712,7 @@ func rehash(
 						p = f64hash(noescape(unsafe.Pointer(&f)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			}
@@ -742,7 +742,7 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&s)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -763,7 +763,7 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&s)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -783,7 +783,7 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&s)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -801,7 +801,7 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&s)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			}
@@ -833,7 +833,7 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -856,7 +856,7 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -878,7 +878,7 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -898,7 +898,7 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			}
@@ -931,7 +931,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -953,7 +953,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -976,7 +976,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -995,7 +995,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				}
 			}
@@ -1025,7 +1025,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -1044,1067 +1044,7 @@ func rehash(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
 						//gcassert:bce
-						buckets[i] = uint32(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
-
-						//gcassert:bce
-						buckets[i] = uint32(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
-
-						//gcassert:bce
-						buckets[i] = uint32(p)
-					}
-				}
-			}
-		}
-	default:
-		colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", col.Type()))
-	}
-	cancelChecker.CheckEveryCall()
-}
-
-// rehash64 takes an element of a key (tuple representing a row of equality
-// column values) at a given column and computes a new hash by applying a
-// transformation to the existing hash.
-//
-// Note that this function is a duplicate of rehash except that it works on
-// uint64s instead of uint32s. The function could be made generic, but that
-// incurs a small performance penalty because one of the arguments is an
-// interface.
-// TODO(yuzefovich): if / when we make coldata.Vec to no longer be an interface,
-// then we should remove the code duplication here.
-func rehash64(
-	buckets []uint64,
-	col *coldata.Vec,
-	nKeys int,
-	sel []int,
-	cancelChecker colexecutils.CancelChecker,
-	datumAlloc *tree.DatumAlloc,
-) {
-	switch col.CanonicalTypeFamily() {
-	case types.BoolFamily:
-		switch col.Type().Width() {
-		case -1:
-		default:
-			keys, nulls := col.Bool(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						x := 0
-						if v {
-							x = 1
-						}
-						p = p*31 + uintptr(x)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						x := 0
-						if v {
-							x = 1
-						}
-						p = p*31 + uintptr(x)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						x := 0
-						if v {
-							x = 1
-						}
-						p = p*31 + uintptr(x)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						x := 0
-						if v {
-							x = 1
-						}
-						p = p*31 + uintptr(x)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			}
-		}
-	case types.BytesFamily:
-		switch col.Type().Width() {
-		case -1:
-		default:
-			keys, nulls := col.Bytes(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			}
-		}
-	case types.DecimalFamily:
-		switch col.Type().Width() {
-		case -1:
-		default:
-			keys, nulls := col.Decimal(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for equal decimals to hash to the same value we need to
-						// remove the trailing zeroes if there are any.
-						var tmpDec apd.Decimal //gcassert:noescape
-						tmpDec.Reduce(&v)
-						b := []byte(tmpDec.String())
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for equal decimals to hash to the same value we need to
-						// remove the trailing zeroes if there are any.
-						var tmpDec apd.Decimal //gcassert:noescape
-						tmpDec.Reduce(&v)
-						b := []byte(tmpDec.String())
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for equal decimals to hash to the same value we need to
-						// remove the trailing zeroes if there are any.
-						var tmpDec apd.Decimal //gcassert:noescape
-						tmpDec.Reduce(&v)
-						b := []byte(tmpDec.String())
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for equal decimals to hash to the same value we need to
-						// remove the trailing zeroes if there are any.
-						var tmpDec apd.Decimal //gcassert:noescape
-						tmpDec.Reduce(&v)
-						b := []byte(tmpDec.String())
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			}
-		}
-	case types.IntFamily:
-		switch col.Type().Width() {
-		case 16:
-			keys, nulls := col.Int16(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			}
-		case 32:
-			keys, nulls := col.Int32(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			}
-		case -1:
-		default:
-			keys, nulls := col.Int64(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// In order for integers with different widths but of the same value to
-						// to hash to the same value, we upcast all of them to int64.
-						asInt64 := int64(v)
-						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			}
-		}
-	case types.FloatFamily:
-		switch col.Type().Width() {
-		case -1:
-		default:
-			keys, nulls := col.Float64(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						f := v
-						if math.IsNaN(float64(f)) {
-							f = 0
-						}
-						p = f64hash(noescape(unsafe.Pointer(&f)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						f := v
-						if math.IsNaN(float64(f)) {
-							f = 0
-						}
-						p = f64hash(noescape(unsafe.Pointer(&f)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						f := v
-						if math.IsNaN(float64(f)) {
-							f = 0
-						}
-						p = f64hash(noescape(unsafe.Pointer(&f)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						f := v
-						if math.IsNaN(float64(f)) {
-							f = 0
-						}
-						p = f64hash(noescape(unsafe.Pointer(&f)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			}
-		}
-	case types.TimestampTZFamily:
-		switch col.Type().Width() {
-		case -1:
-		default:
-			keys, nulls := col.Timestamp(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						s := v.UnixNano()
-						p = memhash64(noescape(unsafe.Pointer(&s)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						s := v.UnixNano()
-						p = memhash64(noescape(unsafe.Pointer(&s)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						s := v.UnixNano()
-						p = memhash64(noescape(unsafe.Pointer(&s)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						s := v.UnixNano()
-						p = memhash64(noescape(unsafe.Pointer(&s)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			}
-		}
-	case types.IntervalFamily:
-		switch col.Type().Width() {
-		case -1:
-		default:
-			keys, nulls := col.Interval(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						months, days, nanos := v.Months, v.Days, v.Nanos()
-						p = memhash64(noescape(unsafe.Pointer(&months)), p)
-						p = memhash64(noescape(unsafe.Pointer(&days)), p)
-						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						months, days, nanos := v.Months, v.Days, v.Nanos()
-						p = memhash64(noescape(unsafe.Pointer(&months)), p)
-						p = memhash64(noescape(unsafe.Pointer(&days)), p)
-						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						months, days, nanos := v.Months, v.Days, v.Nanos()
-						p = memhash64(noescape(unsafe.Pointer(&months)), p)
-						p = memhash64(noescape(unsafe.Pointer(&days)), p)
-						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						//gcassert:bce
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						months, days, nanos := v.Months, v.Days, v.Nanos()
-						p = memhash64(noescape(unsafe.Pointer(&months)), p)
-						p = memhash64(noescape(unsafe.Pointer(&days)), p)
-						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			}
-		}
-	case types.JsonFamily:
-		switch col.Type().Width() {
-		case -1:
-		default:
-			keys, nulls := col.JSON(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// Access the underlying []byte directly which allows us to skip
-						// decoding-encoding of the JSON object.
-						_b := keys.Bytes.Get(selIdx)
-
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// Access the underlying []byte directly which allows us to skip
-						// decoding-encoding of the JSON object.
-						_b := keys.Bytes.Get(selIdx)
-
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			} else {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// Access the underlying []byte directly which allows us to skip
-						// decoding-encoding of the JSON object.
-						_b := keys.Bytes.Get(selIdx)
-
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						//gcassert:bce
-						p := uintptr(buckets[i])
-
-						// Access the underlying []byte directly which allows us to skip
-						// decoding-encoding of the JSON object.
-						_b := keys.Bytes.Get(selIdx)
-
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				}
-			}
-		}
-	case typeconv.DatumVecCanonicalTypeFamily:
-		switch col.Type().Width() {
-		case -1:
-		default:
-			keys, nulls := col.Datum(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					_ = sel[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						//gcassert:bce
-						selIdx = sel[i]
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
-					}
-				} else {
-					// Early bounds checks.
-					_ = buckets[nKeys-1]
-					var selIdx int
-					for i := 0; i < nKeys; i++ {
-						selIdx = i
-						if nulls.NullAt(selIdx) {
-							continue
-						}
-						v := keys.Get(selIdx)
-						//gcassert:bce
-						p := uintptr(buckets[i])
-						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
-						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
-
-						//gcassert:bce
-						buckets[i] = uint64(p)
+						buckets[i] = T(p)
 					}
 				}
 			} else {
@@ -2124,7 +1064,7 @@ func rehash64(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
 						//gcassert:bce
-						buckets[i] = uint64(p)
+						buckets[i] = T(p)
 					}
 				} else {
 					// Early bounds checks.
@@ -2140,7 +1080,7 @@ func rehash64(
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
 						//gcassert:bce
-						buckets[i] = uint64(p)
+						buckets[i] = T(p)
 					}
 				}
 			}

--- a/pkg/sql/colexec/colexechash/hash_utils.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.go
@@ -181,7 +181,7 @@ func (d *TupleHashDistributor) Distribute(b coldata.Batch, hashCols []uint32) []
 	}
 
 	for _, i := range hashCols {
-		rehash64(d.buckets, b.ColVec(int(i)), n, b.Selection(), d.cancelChecker, &d.datumAlloc)
+		rehash(d.buckets, b.ColVec(int(i)), n, b.Selection(), d.cancelChecker, &d.datumAlloc)
 	}
 
 	finalizeHash(d.buckets, n, uint64(len(d.selections)))

--- a/pkg/sql/colexec/colexechash/hash_utils_test.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_test.go
@@ -33,7 +33,7 @@ func TestHashFunctionFamily(t *testing.T) {
 	bucketsA, bucketsB := make([]uint32, coldata.BatchSize()), make([]uint32, coldata.BatchSize())
 	nKeys := coldata.BatchSize()
 	keyTypes := []*types.T{types.Int}
-	keys := []coldata.Vec{testAllocator.NewMemColumn(keyTypes[0], coldata.BatchSize())}
+	keys := []*coldata.Vec{testAllocator.NewVec(keyTypes[0], coldata.BatchSize())}
 	for i := int64(0); i < int64(coldata.BatchSize()); i++ {
 		keys[0].Int64()[i] = i
 	}

--- a/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
@@ -72,7 +72,6 @@ func _REHASH_BODY(
 	sel []int,
 	_HAS_SEL bool,
 	_HAS_NULLS bool,
-	_UINT64 bool,
 ) { // */}}
 	// {{define "rehashBody" -}}
 	// Early bounds checks.
@@ -109,11 +108,7 @@ func _REHASH_BODY(
 		p := uintptr(buckets[i])
 		_ASSIGN_HASH(p, v, keys, selIdx)
 		//gcassert:bce
-		// {{if .Uint64}}
-		buckets[i] = uint64(p)
-		// {{else}}
-		buckets[i] = uint32(p)
-		// {{end}}
+		buckets[i] = T(p)
 	}
 	// {{end}}
 
@@ -125,8 +120,8 @@ func _REHASH_BODY(
 // rehash takes an element of a key (tuple representing a row of equality
 // column values) at a given column and computes a new hash by applying a
 // transformation to the existing hash.
-func rehash(
-	buckets []uint32,
+func rehash[T uint32 | uint64](
+	buckets []T,
 	col *coldata.Vec,
 	nKeys int,
 	sel []int,
@@ -142,62 +137,15 @@ func rehash(
 			keys, nulls := col.TemplateType(), col.Nulls()
 			if col.MaybeHasNulls() {
 				if sel != nil {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, true, false)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, true)
 				} else {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, true, false)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, true)
 				}
 			} else {
 				if sel != nil {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, false, false)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, false)
 				} else {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, false, false)
-				}
-			}
-			// {{end}}
-		}
-		// {{end}}
-	default:
-		colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", col.Type()))
-	}
-	cancelChecker.CheckEveryCall()
-}
-
-// rehash64 takes an element of a key (tuple representing a row of equality
-// column values) at a given column and computes a new hash by applying a
-// transformation to the existing hash.
-//
-// Note that this function is a duplicate of rehash except that it works on
-// uint64s instead of uint32s. The function could be made generic, but that
-// incurs a small performance penalty because one of the arguments is an
-// interface.
-// TODO(yuzefovich): if / when we make coldata.Vec to no longer be an interface,
-// then we should remove the code duplication here.
-func rehash64(
-	buckets []uint64,
-	col *coldata.Vec,
-	nKeys int,
-	sel []int,
-	cancelChecker colexecutils.CancelChecker,
-	datumAlloc *tree.DatumAlloc,
-) {
-	switch col.CanonicalTypeFamily() {
-	// {{range .}}
-	case _CANONICAL_TYPE_FAMILY:
-		switch col.Type().Width() {
-		// {{range .WidthOverloads}}
-		case _TYPE_WIDTH:
-			keys, nulls := col.TemplateType(), col.Nulls()
-			if col.MaybeHasNulls() {
-				if sel != nil {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, true, true)
-				} else {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, true, true)
-				}
-			} else {
-				if sel != nil {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, false, true)
-				} else {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, false, true)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, false)
 				}
 			}
 			// {{end}}

--- a/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
@@ -127,7 +127,7 @@ func _REHASH_BODY(
 // transformation to the existing hash.
 func rehash(
 	buckets []uint32,
-	col coldata.Vec,
+	col *coldata.Vec,
 	nKeys int,
 	sel []int,
 	cancelChecker colexecutils.CancelChecker,
@@ -174,7 +174,7 @@ func rehash(
 // then we should remove the code duplication here.
 func rehash64(
 	buckets []uint64,
-	col coldata.Vec,
+	col *coldata.Vec,
 	nKeys int,
 	sel []int,
 	cancelChecker colexecutils.CancelChecker,

--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -235,7 +235,7 @@ type HashTable struct {
 
 	// Keys is a scratch space that stores the equality columns of the tuples
 	// currently being probed.
-	Keys []coldata.Vec
+	Keys []*coldata.Vec
 
 	// Same is a densely-packed list that stores the keyID of the next key in
 	// the hash table that has the same value as the current key. The HeadID of
@@ -359,7 +359,7 @@ func NewHashTable(
 		BuildScratch: hashChains{
 			First: make([]keyID, initialNumHashBuckets),
 		},
-		Keys:              make([]coldata.Vec, len(keyCols)),
+		Keys:              make([]*coldata.Vec, len(keyCols)),
 		Vals:              colexecutils.NewAppendOnlyBufferedBatch(allocator, sourceTypes, colsToStore),
 		keyCols:           keyCols,
 		numBuckets:        initialNumHashBuckets,
@@ -686,9 +686,9 @@ func (ht *HashTable) ComputeHashAndBuildChains(batch coldata.Batch) {
 // NOTE: *first* and *next* vectors should be properly populated.
 func (ht *HashTable) RemoveDuplicates(
 	batch coldata.Batch,
-	keyCols []coldata.Vec,
+	keyCols []*coldata.Vec,
 	first, next []keyID,
-	duplicatesChecker func([]coldata.Vec, uint32, []int) uint32,
+	duplicatesChecker func([]*coldata.Vec, uint32, []int) uint32,
 	probingAgainstItself bool,
 ) {
 	ht.FindBuckets(
@@ -727,7 +727,7 @@ func (ht *HashTable) RepairAfterDistinctBuild() {
 }
 
 // checkCols performs a column by column checkCol on the key columns.
-func (ht *HashTable) checkCols(probeVecs []coldata.Vec, nToCheck uint32, probeSel []int) {
+func (ht *HashTable) checkCols(probeVecs []*coldata.Vec, nToCheck uint32, probeSel []int) {
 	switch ht.probeMode {
 	case HashTableDefaultProbeMode:
 		for i, keyCol := range ht.keyCols {
@@ -746,7 +746,7 @@ func (ht *HashTable) checkCols(probeVecs []coldata.Vec, nToCheck uint32, probeSe
 // tuples in the probe table that are not present in the build table.
 // NOTE: It assumes that probeSel has already been populated and it is not nil.
 func (ht *HashTable) checkColsForDistinctTuples(
-	probeVecs []coldata.Vec, nToCheck uint32, probeSel []int,
+	probeVecs []*coldata.Vec, nToCheck uint32, probeSel []int,
 ) {
 	buildVecs := ht.Vals.ColVecs()
 	for i := range ht.keyCols {
@@ -759,7 +759,7 @@ func (ht *HashTable) checkColsForDistinctTuples(
 
 // ComputeBuckets computes the hash value of each key and stores the result in
 // buckets.
-func (ht *HashTable) ComputeBuckets(buckets []uint32, keys []coldata.Vec, nKeys int, sel []int) {
+func (ht *HashTable) ComputeBuckets(buckets []uint32, keys []*coldata.Vec, nKeys int, sel []int) {
 	if nKeys == 0 {
 		// No work to do - avoid doing the loops below.
 		return
@@ -842,7 +842,7 @@ func (p *hashTableProbeBuffer) SetupLimitedSlices(length int) {
 // NOTE: It assumes that probeSel has already been populated and it is not nil.
 // NOTE: It assumes that nToCheck is positive.
 func (ht *HashTable) CheckBuildForDistinct(
-	probeVecs []coldata.Vec, nToCheck uint32, probeSel []int,
+	probeVecs []*coldata.Vec, nToCheck uint32, probeSel []int,
 ) uint32 {
 	if probeSel == nil {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid selection vector"))
@@ -879,7 +879,7 @@ func (ht *HashTable) CheckBuildForDistinct(
 // NOTE: It assumes that probeSel has already been populated and it is not nil.
 // NOTE: It assumes that nToCheck is positive.
 func (ht *HashTable) CheckBuildForAggregation(
-	probeVecs []coldata.Vec, nToCheck uint32, probeSel []int,
+	probeVecs []*coldata.Vec, nToCheck uint32, probeSel []int,
 ) uint32 {
 	if probeSel == nil {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid selection vector"))

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -35,7 +35,9 @@ var (
 // checkColAgainstItselfForDistinct is similar to checkCol, but it probes the
 // vector against itself for the purposes of finding matches to unordered
 // distinct columns.
-func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck uint32, sel []int) {
+func (ht *HashTable) checkColAgainstItselfForDistinct(
+	vec *coldata.Vec, nToCheck uint32, sel []int,
+) {
 	probeVec, buildVec, probeSel := vec, vec, sel
 	switch probeVec.CanonicalTypeFamily() {
 	case types.BoolFamily:
@@ -3569,7 +3571,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 }
 
 func (ht *HashTable) checkColForDistinctTuples(
-	probeVec, buildVec coldata.Vec, nToCheck uint32, probeSel []int,
+	probeVec, buildVec *coldata.Vec, nToCheck uint32, probeSel []int,
 ) {
 	switch probeVec.CanonicalTypeFamily() {
 	case types.BoolFamily:
@@ -5426,7 +5428,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 // CheckProbeForDistinct performs a column by column check for duplicated tuples
 // in the probe table.
-func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint32, sel []int) uint32 {
+func (ht *HashTable) CheckProbeForDistinct(vecs []*coldata.Vec, nToCheck uint32, sel []int) uint32 {
 	for i := range ht.keyCols {
 		ht.checkColAgainstItselfForDistinct(vecs[i], nToCheck, sel)
 	}
@@ -5556,9 +5558,9 @@ func (ht *HashTable) updateSel(b coldata.Batch) {
 // NOTE: batch is assumed to be non-zero length.
 func (ht *HashTable) FindBuckets(
 	batch coldata.Batch,
-	keyCols []coldata.Vec,
+	keyCols []*coldata.Vec,
 	first, next []keyID,
-	duplicatesChecker func([]coldata.Vec, uint32, []int) uint32,
+	duplicatesChecker func([]*coldata.Vec, uint32, []int) uint32,
 	zeroHeadIDForDistinctTuple bool,
 	probingAgainstItself bool,
 ) {

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -37,7 +37,7 @@ var (
 // the HashTable disallows null equality, then if any element in the key is
 // null, there is no match.
 func (ht *HashTable) checkCol(
-	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint32, probeSel []int,
+	probeVec, buildVec *coldata.Vec, keyColIdx int, nToCheck uint32, probeSel []int,
 ) {
 	switch probeVec.CanonicalTypeFamily() {
 	case types.BoolFamily:

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -38,7 +38,7 @@ var (
 // bucket has reached the end, the key is rejected. If the HashTable disallows
 // null equality, then if any element in the key is null, there is no match.
 func (ht *HashTable) checkColDeleting(
-	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint32, probeSel []int,
+	probeVec, buildVec *coldata.Vec, keyColIdx int, nToCheck uint32, probeSel []int,
 ) {
 	switch probeVec.CanonicalTypeFamily() {
 	case types.BoolFamily:

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -327,7 +327,7 @@ func _CHECK_COL_FUNCTION_TEMPLATE(
 // the HashTable disallows null equality, then if any element in the key is
 // null, there is no match.
 func (ht *HashTable) checkCol(
-	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint32, probeSel []int,
+	probeVec, buildVec *coldata.Vec, keyColIdx int, nToCheck uint32, probeSel []int,
 ) {
 	// {{with .Overloads}}
 	_CHECK_COL_FUNCTION_TEMPLATE(false, false, false)
@@ -341,7 +341,9 @@ func (ht *HashTable) checkCol(
 // checkColAgainstItselfForDistinct is similar to checkCol, but it probes the
 // vector against itself for the purposes of finding matches to unordered
 // distinct columns.
-func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck uint32, sel []int) {
+func (ht *HashTable) checkColAgainstItselfForDistinct(
+	vec *coldata.Vec, nToCheck uint32, sel []int,
+) {
 	// {{/*
 	// In order to reuse the same template function as checkCol uses, we use
 	// the same variable names.
@@ -362,7 +364,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 // bucket has reached the end, the key is rejected. If the HashTable disallows
 // null equality, then if any element in the key is null, there is no match.
 func (ht *HashTable) checkColDeleting(
-	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint32, probeSel []int,
+	probeVec, buildVec *coldata.Vec, keyColIdx int, nToCheck uint32, probeSel []int,
 ) {
 	// {{with .Overloads}}
 	_CHECK_COL_FUNCTION_TEMPLATE(false, false, true)
@@ -375,7 +377,7 @@ func (ht *HashTable) checkColDeleting(
 // {{with .Overloads}}
 
 func (ht *HashTable) checkColForDistinctTuples(
-	probeVec, buildVec coldata.Vec, nToCheck uint32, probeSel []int,
+	probeVec, buildVec *coldata.Vec, nToCheck uint32, probeSel []int,
 ) {
 	switch probeVec.CanonicalTypeFamily() {
 	// {{range .LeftFamilies}}
@@ -765,7 +767,7 @@ func (ht *HashTable) Check(nToCheck uint32, probeSel []int) uint32 {
 
 // CheckProbeForDistinct performs a column by column check for duplicated tuples
 // in the probe table.
-func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint32, sel []int) uint32 {
+func (ht *HashTable) CheckProbeForDistinct(vecs []*coldata.Vec, nToCheck uint32, sel []int) uint32 {
 	for i := range ht.keyCols {
 		ht.checkColAgainstItselfForDistinct(vecs[i], nToCheck, sel)
 	}
@@ -859,9 +861,9 @@ func (ht *HashTable) updateSel(b coldata.Batch) {
 // NOTE: batch is assumed to be non-zero length.
 func (ht *HashTable) FindBuckets(
 	batch coldata.Batch,
-	keyCols []coldata.Vec,
+	keyCols []*coldata.Vec,
 	first, next []keyID,
-	duplicatesChecker func([]coldata.Vec, uint32, []int) uint32,
+	duplicatesChecker func([]*coldata.Vec, uint32, []int) uint32,
 	zeroHeadIDForDistinctTuple bool,
 	probingAgainstItself bool,
 ) {
@@ -886,10 +888,10 @@ func (ht *HashTable) FindBuckets(
 func findBuckets(
 	ht *HashTable,
 	batch coldata.Batch,
-	keyCols []coldata.Vec,
+	keyCols []*coldata.Vec,
 	first []keyID,
 	next []keyID,
-	duplicatesChecker func([]coldata.Vec, uint32, []int) uint32,
+	duplicatesChecker func([]*coldata.Vec, uint32, []int) uint32,
 	zeroHeadIDForDistinctTuple bool,
 	probingAgainstItself bool,
 ) {

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -304,7 +304,7 @@ func (c *crossJoiner) willEmit() int {
 
 // setAllNulls sets all tuples in vecs with indices in [0, length) range to
 // null.
-func setAllNulls(vecs []coldata.Vec, length int) {
+func setAllNulls(vecs []*coldata.Vec, length int) {
 	for i := range vecs {
 		vecs[i].Nulls().SetNullRange(0 /* startIdx */, length)
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoinbase.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoinbase.eg.go
@@ -35,7 +35,7 @@ var (
 // isBufferedGroupFinished checks to see whether or not the buffered group
 // corresponding to the first tuple continues in batch.
 func (o *mergeJoinBase) isBufferedGroupFinished(
-	input *mergeJoinInput, firstTuple []coldata.Vec, batch coldata.Batch, rowIdx int,
+	input *mergeJoinInput, firstTuple []*coldata.Vec, batch coldata.Batch, rowIdx int,
 ) bool {
 	if batch.Length() == 0 {
 		return true

--- a/pkg/sql/colexec/colexecjoin/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoinbase_tmpl.go
@@ -59,7 +59,7 @@ func _ASSIGN_EQ(_, _, _, _, _, _ interface{}) int {
 // isBufferedGroupFinished checks to see whether or not the buffered group
 // corresponding to the first tuple continues in batch.
 func (o *mergeJoinBase) isBufferedGroupFinished(
-	input *mergeJoinInput, firstTuple []coldata.Vec, batch coldata.Batch, rowIdx int,
+	input *mergeJoinInput, firstTuple []*coldata.Vec, batch coldata.Batch, rowIdx int,
 ) bool {
 	if batch.Length() == 0 {
 		return true

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -233,7 +233,7 @@ type mjBuilderCrossProductState struct {
 type mjBufferedGroupState struct {
 	// leftFirstTuple is the first tuple of the left buffered group. It is set
 	// only in case the left buffered group spans more than one input batch.
-	leftFirstTuple []coldata.Vec
+	leftFirstTuple []*coldata.Vec
 	// leftGroupStartIdx is the position within the current left batch where the
 	// left buffered group starts. If the group spans multiple batches, this
 	// will be set to 0 on all consecutive batches.
@@ -246,7 +246,7 @@ type mjBufferedGroupState struct {
 	leftBatchDone bool
 	// rightFirstTuple is the first tuple of the right buffered group. It is set
 	// only in case the right buffered group spans more than one input batch.
-	rightFirstTuple []coldata.Vec
+	rightFirstTuple []*coldata.Vec
 	// scratchSel is a scratch selection vector initialized only when needed.
 	scratchSel []int
 

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -10934,7 +10934,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -12527,7 +12527,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -12070,7 +12070,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -13641,7 +13641,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -7730,7 +7730,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -9257,7 +9257,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -8434,7 +8434,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -9961,7 +9961,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -9878,7 +9878,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -11471,7 +11471,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -9922,7 +9922,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -11449,7 +11449,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -7686,7 +7686,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -9213,7 +9213,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -9834,7 +9834,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -11405,7 +11405,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -9878,7 +9878,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -11449,7 +11449,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -7642,7 +7642,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -9169,7 +9169,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
@@ -62,11 +62,11 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 	defer cleanup()
 	rng, _ := randutil.NewTestRand()
 	typs := []*types.T{types.Int, types.Bytes, types.Decimal}
-	colsLeft := make([]coldata.Vec, len(typs))
-	colsRight := make([]coldata.Vec, len(typs))
+	colsLeft := make([]*coldata.Vec, len(typs))
+	colsRight := make([]*coldata.Vec, len(typs))
 	for i, typ := range typs {
-		colsLeft[i] = testAllocator.NewMemColumn(typ, nTuples)
-		colsRight[i] = testAllocator.NewMemColumn(typ, nTuples)
+		colsLeft[i] = testAllocator.NewVec(typ, nTuples)
+		colsRight[i] = testAllocator.NewVec(typ, nTuples)
 	}
 	groupsLeft := colsLeft[0].Int64()
 	groupsRight := colsRight[0].Int64()
@@ -82,7 +82,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 		groupsRight[i] = int64(rightGroupIdx)
 	}
 	for i := range typs[1:] {
-		for _, vecs := range [][]coldata.Vec{colsLeft, colsRight} {
+		for _, vecs := range [][]*coldata.Vec{colsLeft, colsRight} {
 			coldatatestutils.RandomVec(coldatatestutils.RandomVecArgs{
 				Rand:            rng,
 				Vec:             vecs[i+1],

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -842,7 +842,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildLeftGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}
@@ -1003,7 +1003,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildRightGroupsFromBatch(
 				lastSrcCol := colIdx == len(input.sourceTypes)-1
 				outStartIdx := destStartIdx
 				out := o.output.ColVec(colIdx + colOffset)
-				var src coldata.Vec
+				var src *coldata.Vec
 				if batch.Length() > 0 {
 					src = batch.ColVec(colIdx)
 				}

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_op.eg.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_op.eg.go
@@ -41,7 +41,7 @@ func (d *defaultCmpProjOp) Next() coldata.Batch {
 	}
 	sel := batch.Selection()
 	output := batch.ColVec(d.outputIdx)
-	d.allocator.PerformOperation([]coldata.Vec{output}, func() {
+	d.allocator.PerformOperation([]*coldata.Vec{output}, func() {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		leftColumn := d.toDatumConverter.GetDatumColumn(d.col1Idx)
 		rightColumn := d.toDatumConverter.GetDatumColumn(d.col2Idx)

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
@@ -58,7 +58,7 @@ func (d *defaultCmp_KINDProjOp) Next() coldata.Batch {
 	}
 	sel := batch.Selection()
 	output := batch.ColVec(d.outputIdx)
-	d.allocator.PerformOperation([]coldata.Vec{output}, func() {
+	d.allocator.PerformOperation([]*coldata.Vec{output}, func() {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		// {{if .IsRightConst}}
 		nonConstColumn := d.toDatumConverter.GetDatumColumn(d.colIdx)

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -70,7 +70,7 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -152,7 +152,7 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -234,7 +234,7 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -316,7 +316,7 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -398,7 +398,7 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -480,7 +480,7 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -562,7 +562,7 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -644,7 +644,7 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -726,7 +726,7 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -811,7 +811,7 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -931,7 +931,7 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1013,7 +1013,7 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1095,7 +1095,7 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1177,7 +1177,7 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1259,7 +1259,7 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1341,7 +1341,7 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1423,7 +1423,7 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1505,7 +1505,7 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1587,7 +1587,7 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1672,7 +1672,7 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1792,7 +1792,7 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1874,7 +1874,7 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -1956,7 +1956,7 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2038,7 +2038,7 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2120,7 +2120,7 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2202,7 +2202,7 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2284,7 +2284,7 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2366,7 +2366,7 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2448,7 +2448,7 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2533,7 +2533,7 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2653,7 +2653,7 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2763,7 +2763,7 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2873,7 +2873,7 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -2983,7 +2983,7 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -3093,7 +3093,7 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -3199,7 +3199,7 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -3305,7 +3305,7 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -3411,7 +3411,7 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -3532,7 +3532,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -3656,7 +3656,7 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -3762,7 +3762,7 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -3868,7 +3868,7 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -3974,7 +3974,7 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -4095,7 +4095,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -4219,7 +4219,7 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -4325,7 +4325,7 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -4431,7 +4431,7 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -4537,7 +4537,7 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -4658,7 +4658,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -4782,7 +4782,7 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Float64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -4876,7 +4876,7 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Timestamp()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -4970,7 +4970,7 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Timestamp()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -5064,7 +5064,7 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -5141,7 +5141,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -5268,7 +5268,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -5395,7 +5395,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -5522,7 +5522,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -5649,7 +5649,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -5773,7 +5773,7 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -5883,7 +5883,7 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -5993,7 +5993,7 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -6103,7 +6103,7 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -6213,7 +6213,7 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -6319,7 +6319,7 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -6425,7 +6425,7 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -6531,7 +6531,7 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -6652,7 +6652,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -6776,7 +6776,7 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -6882,7 +6882,7 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -6988,7 +6988,7 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -7094,7 +7094,7 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -7215,7 +7215,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -7339,7 +7339,7 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -7445,7 +7445,7 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -7551,7 +7551,7 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -7657,7 +7657,7 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -7778,7 +7778,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -7902,7 +7902,7 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Float64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -7996,7 +7996,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -8082,7 +8082,7 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Timestamp()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -8176,7 +8176,7 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -8253,7 +8253,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -8377,7 +8377,7 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.JSON()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -8483,7 +8483,7 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.JSON()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -8575,7 +8575,7 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.JSON()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -8667,7 +8667,7 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.JSON()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -8762,7 +8762,7 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -8885,7 +8885,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -9012,7 +9012,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -9137,7 +9137,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -9264,7 +9264,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -9391,7 +9391,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -9515,7 +9515,7 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -9625,7 +9625,7 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -9735,7 +9735,7 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -9845,7 +9845,7 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -9955,7 +9955,7 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -10049,7 +10049,7 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -10187,7 +10187,7 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -10325,7 +10325,7 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -10463,7 +10463,7 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -10581,7 +10581,7 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -10655,7 +10655,7 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -10793,7 +10793,7 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -10931,7 +10931,7 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -11069,7 +11069,7 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -11187,7 +11187,7 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -11261,7 +11261,7 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -11399,7 +11399,7 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -11537,7 +11537,7 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -11675,7 +11675,7 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -11793,7 +11793,7 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -11867,7 +11867,7 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Float64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -11961,7 +11961,7 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -12035,7 +12035,7 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -12109,7 +12109,7 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -12183,7 +12183,7 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -12257,7 +12257,7 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -12331,7 +12331,7 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -12425,7 +12425,7 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -12551,7 +12551,7 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -12677,7 +12677,7 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -12803,7 +12803,7 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -12945,7 +12945,7 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -13067,7 +13067,7 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -13189,7 +13189,7 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -13311,7 +13311,7 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -13461,7 +13461,7 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -13583,7 +13583,7 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -13705,7 +13705,7 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -13827,7 +13827,7 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -13977,7 +13977,7 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -14099,7 +14099,7 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -14221,7 +14221,7 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -14343,7 +14343,7 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -14493,7 +14493,7 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Float64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -14603,7 +14603,7 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -14693,7 +14693,7 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -14783,7 +14783,7 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -14873,7 +14873,7 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Interval()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -14963,7 +14963,7 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -15089,7 +15089,7 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -15215,7 +15215,7 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -15341,7 +15341,7 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -15483,7 +15483,7 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -15585,7 +15585,7 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -15687,7 +15687,7 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -15789,7 +15789,7 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -15939,7 +15939,7 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -16041,7 +16041,7 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -16143,7 +16143,7 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -16245,7 +16245,7 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -16395,7 +16395,7 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -16497,7 +16497,7 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -16599,7 +16599,7 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -16701,7 +16701,7 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -16851,7 +16851,7 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Float64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -16961,7 +16961,7 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -17087,7 +17087,7 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -17213,7 +17213,7 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -17339,7 +17339,7 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -17465,7 +17465,7 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -17567,7 +17567,7 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -17669,7 +17669,7 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -17771,7 +17771,7 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -17905,7 +17905,7 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -18007,7 +18007,7 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -18109,7 +18109,7 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -18211,7 +18211,7 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -18345,7 +18345,7 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -18447,7 +18447,7 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -18549,7 +18549,7 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -18651,7 +18651,7 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -18785,7 +18785,7 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Float64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -18895,7 +18895,7 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -19005,7 +19005,7 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -19115,7 +19115,7 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -19225,7 +19225,7 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -19335,7 +19335,7 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -19465,7 +19465,7 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -19595,7 +19595,7 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -19725,7 +19725,7 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -19843,7 +19843,7 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -19973,7 +19973,7 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -20103,7 +20103,7 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -20233,7 +20233,7 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -20351,7 +20351,7 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -20481,7 +20481,7 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -20611,7 +20611,7 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -20741,7 +20741,7 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Decimal()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -20859,7 +20859,7 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Float64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -20953,7 +20953,7 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bytes()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -21051,7 +21051,7 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.JSON()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -21148,7 +21148,7 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -21268,7 +21268,7 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -21374,7 +21374,7 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -21480,7 +21480,7 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -21586,7 +21586,7 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -21692,7 +21692,7 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -21798,7 +21798,7 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -21904,7 +21904,7 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -22010,7 +22010,7 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -22116,7 +22116,7 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -22225,7 +22225,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -22352,7 +22352,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -22479,7 +22479,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -22603,7 +22603,7 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -22709,7 +22709,7 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -22815,7 +22815,7 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -22921,7 +22921,7 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -23027,7 +23027,7 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -23133,7 +23133,7 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -23239,7 +23239,7 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -23345,7 +23345,7 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -23451,7 +23451,7 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Int64()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -23560,7 +23560,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -23687,7 +23687,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -23814,7 +23814,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Datum()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -23938,7 +23938,7 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.JSON()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -24056,7 +24056,7 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.JSON()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -24164,7 +24164,7 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.JSON()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -24272,7 +24272,7 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.JSON()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -24380,7 +24380,7 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bytes()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -24534,7 +24534,7 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bytes()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -24678,7 +24678,7 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bytes()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -24822,7 +24822,7 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bytes()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -24966,7 +24966,7 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.JSON()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -25072,7 +25072,7 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bytes()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -25218,7 +25218,7 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -25348,7 +25348,7 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -25442,7 +25442,7 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -25564,7 +25564,7 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -25686,7 +25686,7 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -25808,7 +25808,7 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -25938,7 +25938,7 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -26036,7 +26036,7 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -26178,7 +26178,7 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -26320,7 +26320,7 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -26462,7 +26462,7 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -26636,7 +26636,7 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -26758,7 +26758,7 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -26900,7 +26900,7 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -27042,7 +27042,7 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -27184,7 +27184,7 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -27358,7 +27358,7 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -27480,7 +27480,7 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -27622,7 +27622,7 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -27764,7 +27764,7 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -27906,7 +27906,7 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -28080,7 +28080,7 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -28202,7 +28202,7 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -28376,7 +28376,7 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -28550,7 +28550,7 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -28724,7 +28724,7 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -28898,7 +28898,7 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -29028,7 +29028,7 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -29154,7 +29154,7 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -29252,7 +29252,7 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -29370,7 +29370,7 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -29486,7 +29486,7 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -29616,7 +29616,7 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -29710,7 +29710,7 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -29832,7 +29832,7 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -29954,7 +29954,7 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -30076,7 +30076,7 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -30206,7 +30206,7 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -30304,7 +30304,7 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -30446,7 +30446,7 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -30588,7 +30588,7 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -30730,7 +30730,7 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -30904,7 +30904,7 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -31026,7 +31026,7 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -31168,7 +31168,7 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -31310,7 +31310,7 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -31452,7 +31452,7 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -31626,7 +31626,7 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -31748,7 +31748,7 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -31890,7 +31890,7 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -32032,7 +32032,7 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -32174,7 +32174,7 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -32348,7 +32348,7 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -32470,7 +32470,7 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -32644,7 +32644,7 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -32818,7 +32818,7 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -32992,7 +32992,7 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -33166,7 +33166,7 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -33296,7 +33296,7 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -33422,7 +33422,7 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -33520,7 +33520,7 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -33638,7 +33638,7 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -33754,7 +33754,7 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -33884,7 +33884,7 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -33978,7 +33978,7 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -34100,7 +34100,7 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -34222,7 +34222,7 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -34344,7 +34344,7 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -34474,7 +34474,7 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -34572,7 +34572,7 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -34714,7 +34714,7 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -34856,7 +34856,7 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -34998,7 +34998,7 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -35172,7 +35172,7 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -35294,7 +35294,7 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -35436,7 +35436,7 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -35578,7 +35578,7 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -35720,7 +35720,7 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -35894,7 +35894,7 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -36016,7 +36016,7 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -36158,7 +36158,7 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -36300,7 +36300,7 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -36442,7 +36442,7 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -36616,7 +36616,7 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -36738,7 +36738,7 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -36912,7 +36912,7 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -37086,7 +37086,7 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -37260,7 +37260,7 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -37434,7 +37434,7 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -37564,7 +37564,7 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -37690,7 +37690,7 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -37788,7 +37788,7 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -37906,7 +37906,7 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -38022,7 +38022,7 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -38152,7 +38152,7 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -38246,7 +38246,7 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -38368,7 +38368,7 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -38490,7 +38490,7 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -38612,7 +38612,7 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -38742,7 +38742,7 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -38840,7 +38840,7 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -38982,7 +38982,7 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -39124,7 +39124,7 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -39266,7 +39266,7 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -39440,7 +39440,7 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -39562,7 +39562,7 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -39704,7 +39704,7 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -39846,7 +39846,7 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -39988,7 +39988,7 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -40162,7 +40162,7 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -40284,7 +40284,7 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -40426,7 +40426,7 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -40568,7 +40568,7 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -40710,7 +40710,7 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -40884,7 +40884,7 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -41006,7 +41006,7 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -41180,7 +41180,7 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -41354,7 +41354,7 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -41528,7 +41528,7 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -41702,7 +41702,7 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -41832,7 +41832,7 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -41958,7 +41958,7 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -42056,7 +42056,7 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -42174,7 +42174,7 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -42290,7 +42290,7 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -42420,7 +42420,7 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -42514,7 +42514,7 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -42636,7 +42636,7 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -42758,7 +42758,7 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -42880,7 +42880,7 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -43010,7 +43010,7 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -43108,7 +43108,7 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -43250,7 +43250,7 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -43392,7 +43392,7 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -43534,7 +43534,7 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -43708,7 +43708,7 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -43830,7 +43830,7 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -43972,7 +43972,7 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -44114,7 +44114,7 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -44256,7 +44256,7 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -44430,7 +44430,7 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -44552,7 +44552,7 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -44694,7 +44694,7 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -44836,7 +44836,7 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -44978,7 +44978,7 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -45152,7 +45152,7 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -45274,7 +45274,7 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -45448,7 +45448,7 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -45622,7 +45622,7 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -45796,7 +45796,7 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -45970,7 +45970,7 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -46100,7 +46100,7 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -46226,7 +46226,7 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -46324,7 +46324,7 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -46442,7 +46442,7 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -46558,7 +46558,7 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -46688,7 +46688,7 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -46782,7 +46782,7 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -46904,7 +46904,7 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -47026,7 +47026,7 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -47148,7 +47148,7 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -47278,7 +47278,7 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -47376,7 +47376,7 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -47518,7 +47518,7 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -47660,7 +47660,7 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -47802,7 +47802,7 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -47976,7 +47976,7 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -48098,7 +48098,7 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -48240,7 +48240,7 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -48382,7 +48382,7 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -48524,7 +48524,7 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -48698,7 +48698,7 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -48820,7 +48820,7 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -48962,7 +48962,7 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -49104,7 +49104,7 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -49246,7 +49246,7 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -49420,7 +49420,7 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -49542,7 +49542,7 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -49716,7 +49716,7 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -49890,7 +49890,7 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -50064,7 +50064,7 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -50238,7 +50238,7 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -50368,7 +50368,7 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -50494,7 +50494,7 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -50592,7 +50592,7 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
@@ -50710,7 +50710,7 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec.Bool()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -112,7 +112,7 @@ func (p _OP_NAME) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		projCol := projVec._RET_TYP()
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)

--- a/pkg/sql/colexec/colexecproj/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecproj/projection_ops_test.go
@@ -148,7 +148,7 @@ func TestRandomComparisons(t *testing.T) {
 		lVec := b.ColVec(0)
 		rVec := b.ColVec(1)
 		ret := b.ColVec(2)
-		for _, vec := range []coldata.Vec{lVec, rVec} {
+		for _, vec := range []*coldata.Vec{lVec, rVec} {
 			coldatatestutils.RandomVec(
 				coldatatestutils.RandomVecArgs{
 					Rand:             rng,
@@ -186,7 +186,7 @@ func TestRandomComparisons(t *testing.T) {
 				expected[i] = b
 			}
 			cmpOp := treecmp.MakeComparisonOperator(cmpOpSymbol)
-			input := colexectestutils.NewChunkingBatchSource(testAllocator, typs, []coldata.Vec{lVec, rVec, ret}, numTuples)
+			input := colexectestutils.NewChunkingBatchSource(testAllocator, typs, []*coldata.Vec{lVec, rVec, ret}, numTuples)
 			op, err := colexectestutils.CreateTestProjectingOperator(
 				ctx, flowCtx, input, []*types.T{typ, typ},
 				fmt.Sprintf("@1 %s @2", cmpOp), testMemAcc,

--- a/pkg/sql/colexec/colexecprojconst/default_cmp_proj_const_op.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/default_cmp_proj_const_op.eg.go
@@ -42,7 +42,7 @@ func (d *defaultCmpRConstProjOp) Next() coldata.Batch {
 	}
 	sel := batch.Selection()
 	output := batch.ColVec(d.outputIdx)
-	d.allocator.PerformOperation([]coldata.Vec{output}, func() {
+	d.allocator.PerformOperation([]*coldata.Vec{output}, func() {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		nonConstColumn := d.toDatumConverter.GetDatumColumn(d.colIdx)
 		_ = nonConstColumn[n-1]

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -63,7 +63,7 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -137,7 +137,7 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -211,7 +211,7 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -285,7 +285,7 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -359,7 +359,7 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -433,7 +433,7 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -507,7 +507,7 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -581,7 +581,7 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -655,7 +655,7 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -732,7 +732,7 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -840,7 +840,7 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -914,7 +914,7 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -988,7 +988,7 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1062,7 +1062,7 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1136,7 +1136,7 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1210,7 +1210,7 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1284,7 +1284,7 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1358,7 +1358,7 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1432,7 +1432,7 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1509,7 +1509,7 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1617,7 +1617,7 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1691,7 +1691,7 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1765,7 +1765,7 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1839,7 +1839,7 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1913,7 +1913,7 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1987,7 +1987,7 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2061,7 +2061,7 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2135,7 +2135,7 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2209,7 +2209,7 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2286,7 +2286,7 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2394,7 +2394,7 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2496,7 +2496,7 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2598,7 +2598,7 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2700,7 +2700,7 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2802,7 +2802,7 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2900,7 +2900,7 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2998,7 +2998,7 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3096,7 +3096,7 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3209,7 +3209,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3327,7 +3327,7 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3425,7 +3425,7 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3523,7 +3523,7 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3621,7 +3621,7 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3734,7 +3734,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3852,7 +3852,7 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3950,7 +3950,7 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4048,7 +4048,7 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4146,7 +4146,7 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4259,7 +4259,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4377,7 +4377,7 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4463,7 +4463,7 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4549,7 +4549,7 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4635,7 +4635,7 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4704,7 +4704,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4825,7 +4825,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4944,7 +4944,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5063,7 +5063,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5182,7 +5182,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5298,7 +5298,7 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5400,7 +5400,7 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5502,7 +5502,7 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5604,7 +5604,7 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5706,7 +5706,7 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5804,7 +5804,7 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5902,7 +5902,7 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6000,7 +6000,7 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6113,7 +6113,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6231,7 +6231,7 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6329,7 +6329,7 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6427,7 +6427,7 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6525,7 +6525,7 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6638,7 +6638,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6756,7 +6756,7 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6854,7 +6854,7 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6952,7 +6952,7 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7050,7 +7050,7 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7163,7 +7163,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7281,7 +7281,7 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7367,7 +7367,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7445,7 +7445,7 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7531,7 +7531,7 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7600,7 +7600,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7718,7 +7718,7 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7818,7 +7818,7 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7902,7 +7902,7 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7986,7 +7986,7 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8073,7 +8073,7 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8184,7 +8184,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8303,7 +8303,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8422,7 +8422,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8541,7 +8541,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8660,7 +8660,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8776,7 +8776,7 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8878,7 +8878,7 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8980,7 +8980,7 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9082,7 +9082,7 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9184,7 +9184,7 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9270,7 +9270,7 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9400,7 +9400,7 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9530,7 +9530,7 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9660,7 +9660,7 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9770,7 +9770,7 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9836,7 +9836,7 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9966,7 +9966,7 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10096,7 +10096,7 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10226,7 +10226,7 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10336,7 +10336,7 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10402,7 +10402,7 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10532,7 +10532,7 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10662,7 +10662,7 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10792,7 +10792,7 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10902,7 +10902,7 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10968,7 +10968,7 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11054,7 +11054,7 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11120,7 +11120,7 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11186,7 +11186,7 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11252,7 +11252,7 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11318,7 +11318,7 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11384,7 +11384,7 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11470,7 +11470,7 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11588,7 +11588,7 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11706,7 +11706,7 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11824,7 +11824,7 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11958,7 +11958,7 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12072,7 +12072,7 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12186,7 +12186,7 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12300,7 +12300,7 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12442,7 +12442,7 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12556,7 +12556,7 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12670,7 +12670,7 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12784,7 +12784,7 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12926,7 +12926,7 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13040,7 +13040,7 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13154,7 +13154,7 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13268,7 +13268,7 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13410,7 +13410,7 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13512,7 +13512,7 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13594,7 +13594,7 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13676,7 +13676,7 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13758,7 +13758,7 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13840,7 +13840,7 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13958,7 +13958,7 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14076,7 +14076,7 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14194,7 +14194,7 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14328,7 +14328,7 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14422,7 +14422,7 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14516,7 +14516,7 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14610,7 +14610,7 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14752,7 +14752,7 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14846,7 +14846,7 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14940,7 +14940,7 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15034,7 +15034,7 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15176,7 +15176,7 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15270,7 +15270,7 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15364,7 +15364,7 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15458,7 +15458,7 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15600,7 +15600,7 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15702,7 +15702,7 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15820,7 +15820,7 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15938,7 +15938,7 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16056,7 +16056,7 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16174,7 +16174,7 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16268,7 +16268,7 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16362,7 +16362,7 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16456,7 +16456,7 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16582,7 +16582,7 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16676,7 +16676,7 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16770,7 +16770,7 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16864,7 +16864,7 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16990,7 +16990,7 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17084,7 +17084,7 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17178,7 +17178,7 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17272,7 +17272,7 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17398,7 +17398,7 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17500,7 +17500,7 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17602,7 +17602,7 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17704,7 +17704,7 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17806,7 +17806,7 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17908,7 +17908,7 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18030,7 +18030,7 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18152,7 +18152,7 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18274,7 +18274,7 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18384,7 +18384,7 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18506,7 +18506,7 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18628,7 +18628,7 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18750,7 +18750,7 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18860,7 +18860,7 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18982,7 +18982,7 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19104,7 +19104,7 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19226,7 +19226,7 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19336,7 +19336,7 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19422,7 +19422,7 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19514,7 +19514,7 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19605,7 +19605,7 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19713,7 +19713,7 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19811,7 +19811,7 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19909,7 +19909,7 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20007,7 +20007,7 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20105,7 +20105,7 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20203,7 +20203,7 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20301,7 +20301,7 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20399,7 +20399,7 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20497,7 +20497,7 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20598,7 +20598,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20717,7 +20717,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20836,7 +20836,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20952,7 +20952,7 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21050,7 +21050,7 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21148,7 +21148,7 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21246,7 +21246,7 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21344,7 +21344,7 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21442,7 +21442,7 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21540,7 +21540,7 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21638,7 +21638,7 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21736,7 +21736,7 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21837,7 +21837,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21956,7 +21956,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22075,7 +22075,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22191,7 +22191,7 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22303,7 +22303,7 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22403,7 +22403,7 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22503,7 +22503,7 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22603,7 +22603,7 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22751,7 +22751,7 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22887,7 +22887,7 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23023,7 +23023,7 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23159,7 +23159,7 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23259,7 +23259,7 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col

--- a/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
@@ -141,7 +141,7 @@ func (p _OP_CONST_NAME) Next() coldata.Batch {
 	col = vec._L_TYP()
 	// {{end}}
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -66,7 +66,7 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -140,7 +140,7 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -214,7 +214,7 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -288,7 +288,7 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -362,7 +362,7 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -436,7 +436,7 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -510,7 +510,7 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -584,7 +584,7 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -658,7 +658,7 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -735,7 +735,7 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -843,7 +843,7 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -917,7 +917,7 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -991,7 +991,7 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1065,7 +1065,7 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1139,7 +1139,7 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1213,7 +1213,7 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1287,7 +1287,7 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1361,7 +1361,7 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1435,7 +1435,7 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1512,7 +1512,7 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1620,7 +1620,7 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1694,7 +1694,7 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1768,7 +1768,7 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1842,7 +1842,7 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1916,7 +1916,7 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -1990,7 +1990,7 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2064,7 +2064,7 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2138,7 +2138,7 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2212,7 +2212,7 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2289,7 +2289,7 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2397,7 +2397,7 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2499,7 +2499,7 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2601,7 +2601,7 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2703,7 +2703,7 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2805,7 +2805,7 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -2903,7 +2903,7 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3001,7 +3001,7 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3099,7 +3099,7 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3212,7 +3212,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3328,7 +3328,7 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3426,7 +3426,7 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3524,7 +3524,7 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3622,7 +3622,7 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3735,7 +3735,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3851,7 +3851,7 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -3949,7 +3949,7 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4047,7 +4047,7 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4145,7 +4145,7 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4258,7 +4258,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4374,7 +4374,7 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4460,7 +4460,7 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4546,7 +4546,7 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4632,7 +4632,7 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4701,7 +4701,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4820,7 +4820,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -4941,7 +4941,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5062,7 +5062,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5183,7 +5183,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5301,7 +5301,7 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5403,7 +5403,7 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5505,7 +5505,7 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5607,7 +5607,7 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5709,7 +5709,7 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5807,7 +5807,7 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -5905,7 +5905,7 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6003,7 +6003,7 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6116,7 +6116,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6232,7 +6232,7 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6330,7 +6330,7 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6428,7 +6428,7 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6526,7 +6526,7 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6639,7 +6639,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6755,7 +6755,7 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6853,7 +6853,7 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -6951,7 +6951,7 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7049,7 +7049,7 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7162,7 +7162,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7278,7 +7278,7 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7364,7 +7364,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7442,7 +7442,7 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7528,7 +7528,7 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7597,7 +7597,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7713,7 +7713,7 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7813,7 +7813,7 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7899,7 +7899,7 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -7985,7 +7985,7 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8074,7 +8074,7 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8185,7 +8185,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8306,7 +8306,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8425,7 +8425,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8546,7 +8546,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8667,7 +8667,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8785,7 +8785,7 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8887,7 +8887,7 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -8989,7 +8989,7 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9091,7 +9091,7 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9193,7 +9193,7 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9279,7 +9279,7 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9409,7 +9409,7 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9539,7 +9539,7 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9669,7 +9669,7 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9779,7 +9779,7 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9845,7 +9845,7 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -9975,7 +9975,7 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10105,7 +10105,7 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10235,7 +10235,7 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10345,7 +10345,7 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10411,7 +10411,7 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10541,7 +10541,7 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10671,7 +10671,7 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10801,7 +10801,7 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10911,7 +10911,7 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -10977,7 +10977,7 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11063,7 +11063,7 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11129,7 +11129,7 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11195,7 +11195,7 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11261,7 +11261,7 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11327,7 +11327,7 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11393,7 +11393,7 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11479,7 +11479,7 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11597,7 +11597,7 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11715,7 +11715,7 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11833,7 +11833,7 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -11967,7 +11967,7 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12081,7 +12081,7 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12195,7 +12195,7 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12309,7 +12309,7 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12451,7 +12451,7 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12565,7 +12565,7 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12679,7 +12679,7 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12793,7 +12793,7 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -12935,7 +12935,7 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13049,7 +13049,7 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13163,7 +13163,7 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13277,7 +13277,7 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13419,7 +13419,7 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13521,7 +13521,7 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13603,7 +13603,7 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13685,7 +13685,7 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13767,7 +13767,7 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13849,7 +13849,7 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -13967,7 +13967,7 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14085,7 +14085,7 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14203,7 +14203,7 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14337,7 +14337,7 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14431,7 +14431,7 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14525,7 +14525,7 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14619,7 +14619,7 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14761,7 +14761,7 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14855,7 +14855,7 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -14949,7 +14949,7 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15043,7 +15043,7 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15185,7 +15185,7 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15279,7 +15279,7 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15373,7 +15373,7 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15467,7 +15467,7 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15609,7 +15609,7 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15711,7 +15711,7 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15829,7 +15829,7 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -15947,7 +15947,7 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16065,7 +16065,7 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16183,7 +16183,7 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16277,7 +16277,7 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16371,7 +16371,7 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16465,7 +16465,7 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16591,7 +16591,7 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16685,7 +16685,7 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16779,7 +16779,7 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16873,7 +16873,7 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -16999,7 +16999,7 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17093,7 +17093,7 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17187,7 +17187,7 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17281,7 +17281,7 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17407,7 +17407,7 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17509,7 +17509,7 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17611,7 +17611,7 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17713,7 +17713,7 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17815,7 +17815,7 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -17917,7 +17917,7 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18039,7 +18039,7 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18161,7 +18161,7 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18283,7 +18283,7 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18393,7 +18393,7 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18515,7 +18515,7 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18637,7 +18637,7 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18759,7 +18759,7 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18869,7 +18869,7 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -18991,7 +18991,7 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19113,7 +19113,7 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19235,7 +19235,7 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19345,7 +19345,7 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19431,7 +19431,7 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19523,7 +19523,7 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19614,7 +19614,7 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19722,7 +19722,7 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19820,7 +19820,7 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -19918,7 +19918,7 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20016,7 +20016,7 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20114,7 +20114,7 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20212,7 +20212,7 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20310,7 +20310,7 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20408,7 +20408,7 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20506,7 +20506,7 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20607,7 +20607,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20728,7 +20728,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20849,7 +20849,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -20967,7 +20967,7 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21065,7 +21065,7 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21163,7 +21163,7 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21261,7 +21261,7 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21359,7 +21359,7 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21457,7 +21457,7 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21555,7 +21555,7 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21653,7 +21653,7 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21751,7 +21751,7 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21852,7 +21852,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -21973,7 +21973,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22094,7 +22094,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22212,7 +22212,7 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22324,7 +22324,7 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22426,7 +22426,7 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22528,7 +22528,7 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22630,7 +22630,7 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22778,7 +22778,7 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -22916,7 +22916,7 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23054,7 +23054,7 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23192,7 +23192,7 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23292,7 +23292,7 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23432,7 +23432,7 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23554,7 +23554,7 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23642,7 +23642,7 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23756,7 +23756,7 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23870,7 +23870,7 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -23984,7 +23984,7 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -24106,7 +24106,7 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -24196,7 +24196,7 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -24330,7 +24330,7 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -24464,7 +24464,7 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -24598,7 +24598,7 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -24764,7 +24764,7 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -24878,7 +24878,7 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -25012,7 +25012,7 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -25146,7 +25146,7 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -25280,7 +25280,7 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -25446,7 +25446,7 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -25560,7 +25560,7 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -25694,7 +25694,7 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -25828,7 +25828,7 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -25962,7 +25962,7 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -26128,7 +26128,7 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -26242,7 +26242,7 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -26408,7 +26408,7 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -26574,7 +26574,7 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -26740,7 +26740,7 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -26906,7 +26906,7 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -27028,7 +27028,7 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -27146,7 +27146,7 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -27236,7 +27236,7 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -27348,7 +27348,7 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -27452,7 +27452,7 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -27574,7 +27574,7 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -27662,7 +27662,7 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -27776,7 +27776,7 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -27890,7 +27890,7 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -28004,7 +28004,7 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -28126,7 +28126,7 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -28216,7 +28216,7 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -28350,7 +28350,7 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -28484,7 +28484,7 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -28618,7 +28618,7 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -28784,7 +28784,7 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -28898,7 +28898,7 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -29032,7 +29032,7 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -29166,7 +29166,7 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -29300,7 +29300,7 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -29466,7 +29466,7 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -29580,7 +29580,7 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -29714,7 +29714,7 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -29848,7 +29848,7 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -29982,7 +29982,7 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -30148,7 +30148,7 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -30262,7 +30262,7 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -30428,7 +30428,7 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -30594,7 +30594,7 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -30760,7 +30760,7 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -30926,7 +30926,7 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -31048,7 +31048,7 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -31166,7 +31166,7 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -31256,7 +31256,7 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -31368,7 +31368,7 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -31472,7 +31472,7 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -31594,7 +31594,7 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -31682,7 +31682,7 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -31796,7 +31796,7 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -31910,7 +31910,7 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -32024,7 +32024,7 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -32146,7 +32146,7 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -32236,7 +32236,7 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -32370,7 +32370,7 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -32504,7 +32504,7 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -32638,7 +32638,7 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -32804,7 +32804,7 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -32918,7 +32918,7 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -33052,7 +33052,7 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -33186,7 +33186,7 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -33320,7 +33320,7 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -33486,7 +33486,7 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -33600,7 +33600,7 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -33734,7 +33734,7 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -33868,7 +33868,7 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -34002,7 +34002,7 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -34168,7 +34168,7 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -34282,7 +34282,7 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -34448,7 +34448,7 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -34614,7 +34614,7 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -34780,7 +34780,7 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -34946,7 +34946,7 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -35068,7 +35068,7 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -35186,7 +35186,7 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -35276,7 +35276,7 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -35388,7 +35388,7 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -35492,7 +35492,7 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -35614,7 +35614,7 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -35702,7 +35702,7 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -35816,7 +35816,7 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -35930,7 +35930,7 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -36044,7 +36044,7 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -36166,7 +36166,7 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -36256,7 +36256,7 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -36390,7 +36390,7 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -36524,7 +36524,7 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -36658,7 +36658,7 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -36824,7 +36824,7 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -36938,7 +36938,7 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -37072,7 +37072,7 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -37206,7 +37206,7 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -37340,7 +37340,7 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -37506,7 +37506,7 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -37620,7 +37620,7 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -37754,7 +37754,7 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -37888,7 +37888,7 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -38022,7 +38022,7 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -38188,7 +38188,7 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -38302,7 +38302,7 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -38468,7 +38468,7 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -38634,7 +38634,7 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -38800,7 +38800,7 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -38966,7 +38966,7 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -39088,7 +39088,7 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -39206,7 +39206,7 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -39296,7 +39296,7 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -39408,7 +39408,7 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -39512,7 +39512,7 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -39634,7 +39634,7 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -39722,7 +39722,7 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -39836,7 +39836,7 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -39950,7 +39950,7 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -40064,7 +40064,7 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -40186,7 +40186,7 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -40276,7 +40276,7 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -40410,7 +40410,7 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -40544,7 +40544,7 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -40678,7 +40678,7 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -40844,7 +40844,7 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -40958,7 +40958,7 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -41092,7 +41092,7 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -41226,7 +41226,7 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -41360,7 +41360,7 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -41526,7 +41526,7 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -41640,7 +41640,7 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -41774,7 +41774,7 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -41908,7 +41908,7 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -42042,7 +42042,7 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -42208,7 +42208,7 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -42322,7 +42322,7 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -42488,7 +42488,7 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -42654,7 +42654,7 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -42820,7 +42820,7 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -42986,7 +42986,7 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -43108,7 +43108,7 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -43226,7 +43226,7 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -43316,7 +43316,7 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -43428,7 +43428,7 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -43532,7 +43532,7 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -43654,7 +43654,7 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -43742,7 +43742,7 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -43856,7 +43856,7 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -43970,7 +43970,7 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -44084,7 +44084,7 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -44206,7 +44206,7 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -44296,7 +44296,7 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -44430,7 +44430,7 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -44564,7 +44564,7 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -44698,7 +44698,7 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -44864,7 +44864,7 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -44978,7 +44978,7 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -45112,7 +45112,7 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -45246,7 +45246,7 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -45380,7 +45380,7 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -45546,7 +45546,7 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -45660,7 +45660,7 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -45794,7 +45794,7 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -45928,7 +45928,7 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -46062,7 +46062,7 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -46228,7 +46228,7 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -46342,7 +46342,7 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -46508,7 +46508,7 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -46674,7 +46674,7 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -46840,7 +46840,7 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -47006,7 +47006,7 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -47128,7 +47128,7 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -47246,7 +47246,7 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -47336,7 +47336,7 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 	var col *coldata.JSONs
 	col = vec.JSON()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -47448,7 +47448,7 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 	var col coldata.DatumVec
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col

--- a/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
@@ -38,7 +38,7 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -118,7 +118,7 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -198,7 +198,7 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -278,7 +278,7 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col
@@ -404,7 +404,7 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 	var col *coldata.Bytes
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Capture col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
 		col := col

--- a/pkg/sql/colexec/colexecspan/span_assembler_test.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_test.go
@@ -95,9 +95,9 @@ func TestSpanAssembler(t *testing.T) {
 									}
 									neededColumns := intsets.MakeFast(1, 2, 3, 4)
 
-									cols := make([]coldata.Vec, len(typs))
+									cols := make([]*coldata.Vec, len(typs))
 									for i, typ := range typs {
-										cols[i] = testAllocator.NewMemColumn(typ, nTuples)
+										cols[i] = testAllocator.NewVec(typ, nTuples)
 									}
 									for i := range typs {
 										coldatatestutils.RandomVec(coldatatestutils.RandomVecArgs{

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -754,7 +754,7 @@ func stringToDatum(val string, typ *types.T, evalCtx *eval.Context) tree.Datum {
 
 // setColVal is a test helper function to set the given value at the equivalent
 // col[idx]. This function is slow due to reflection.
-func setColVal(vec coldata.Vec, idx int, val interface{}, evalCtx *eval.Context) {
+func setColVal(vec *coldata.Vec, idx int, val interface{}, evalCtx *eval.Context) {
 	switch vec.CanonicalTypeFamily() {
 	case types.BytesFamily:
 		var (
@@ -1651,7 +1651,7 @@ type chunkingBatchSource struct {
 	colexecop.ZeroInputNode
 	allocator *colmem.Allocator
 	typs      []*types.T
-	cols      []coldata.Vec
+	cols      []*coldata.Vec
 	len       int
 
 	curIdx int
@@ -1663,7 +1663,7 @@ var _ colexecop.ResettableOperator = &chunkingBatchSource{}
 // NewChunkingBatchSource returns a new chunkingBatchSource with the given
 // column types, columns, and length.
 func NewChunkingBatchSource(
-	allocator *colmem.Allocator, typs []*types.T, cols []coldata.Vec, len int,
+	allocator *colmem.Allocator, typs []*types.T, cols []*coldata.Vec, len int,
 ) colexecop.ResettableOperator {
 	return &chunkingBatchSource{
 		allocator: allocator,

--- a/pkg/sql/colexec/colexecutils/spilling_buffer.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer.go
@@ -226,7 +226,7 @@ func (b *SpillingBuffer) AppendTuples(
 // made.
 func (b *SpillingBuffer) GetVecWithTuple(
 	ctx context.Context, colIdx, idx int,
-) (_ coldata.Vec, rowIdx int, length int) {
+) (_ *coldata.Vec, rowIdx int, length int) {
 	var err error
 	if idx < 0 || idx >= b.Length() {
 		colexecerror.InternalError(

--- a/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
@@ -131,7 +131,7 @@ func TestSpillingBuffer(t *testing.T) {
 		testBatch := coldata.NewMemBatchNoCols(typesToStore, 0 /* capacity */)
 		oracleBatch := coldata.NewMemBatchNoCols(typesToStore, 0 /* capacity */)
 		checkWindowAtIndex := func(startIdx int) (nextIdx int) {
-			var vec coldata.Vec
+			var vec *coldata.Vec
 			var idx, length int
 			for i, colIdx := range colsToStore {
 				vec, idx, length = buf.GetVecWithTuple(ctx, i, startIdx)

--- a/pkg/sql/colexec/colexecutils/utils.go
+++ b/pkg/sql/colexec/colexecutils/utils.go
@@ -104,7 +104,7 @@ type AppendOnlyBufferedBatch struct {
 
 	allocator   *colmem.Allocator
 	length      int
-	colVecs     []coldata.Vec
+	colVecs     []*coldata.Vec
 	colsToStore []int
 	// sel is the selection vector on this batch. Note that it is stored
 	// separately from embedded coldata.Batch because we need to be able to
@@ -139,12 +139,12 @@ func (b *AppendOnlyBufferedBatch) Width() int {
 }
 
 // ColVec implements the coldata.Batch interface.
-func (b *AppendOnlyBufferedBatch) ColVec(i int) coldata.Vec {
+func (b *AppendOnlyBufferedBatch) ColVec(i int) *coldata.Vec {
 	return b.colVecs[i]
 }
 
 // ColVecs implements the coldata.Batch interface.
-func (b *AppendOnlyBufferedBatch) ColVecs() []coldata.Vec {
+func (b *AppendOnlyBufferedBatch) ColVecs() []*coldata.Vec {
 	return b.colVecs
 }
 
@@ -170,12 +170,12 @@ func (b *AppendOnlyBufferedBatch) SetSelection(useSel bool) {
 }
 
 // AppendCol implements the coldata.Batch interface.
-func (b *AppendOnlyBufferedBatch) AppendCol(coldata.Vec) {
+func (b *AppendOnlyBufferedBatch) AppendCol(*coldata.Vec) {
 	colexecerror.InternalError(errors.AssertionFailedf("AppendCol is prohibited on AppendOnlyBufferedBatch"))
 }
 
 // ReplaceCol implements the coldata.Batch interface.
-func (b *AppendOnlyBufferedBatch) ReplaceCol(coldata.Vec, int) {
+func (b *AppendOnlyBufferedBatch) ReplaceCol(*coldata.Vec, int) {
 	colexecerror.InternalError(errors.AssertionFailedf("ReplaceCol is prohibited on AppendOnlyBufferedBatch"))
 }
 

--- a/pkg/sql/colexec/colexecwindow/count_rows_aggregator.go
+++ b/pkg/sql/colexec/colexecwindow/count_rows_aggregator.go
@@ -92,7 +92,7 @@ func (a *countRowsWindowAggregator) processBatch(batch coldata.Batch, startIdx, 
 		return
 	}
 	outVec := batch.ColVec(a.outputColIdx)
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		outCol := outVec.Int64()
 		_, _ = outCol[startIdx], outCol[endIdx-1]
 		for i := startIdx; i < endIdx; i++ {

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
@@ -198,7 +198,7 @@ func (a *minBoolAggregator) processBatch(batch coldata.Batch, startIdx, endIdx i
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Bool()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -370,7 +370,7 @@ func (a *minBytesAggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Bytes()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -524,7 +524,7 @@ func (a *minDecimalAggregator) processBatch(batch coldata.Batch, startIdx, endId
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Decimal()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -680,7 +680,7 @@ func (a *minInt16Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int16()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -858,7 +858,7 @@ func (a *minInt32Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int32()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -1036,7 +1036,7 @@ func (a *minInt64Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int64()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -1214,7 +1214,7 @@ func (a *minFloat64Aggregator) processBatch(batch coldata.Batch, startIdx, endId
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Float64()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -1408,7 +1408,7 @@ func (a *minTimestampAggregator) processBatch(batch coldata.Batch, startIdx, end
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Timestamp()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -1578,7 +1578,7 @@ func (a *minIntervalAggregator) processBatch(batch coldata.Batch, startIdx, endI
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Interval()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -1734,7 +1734,7 @@ func (a *minJSONAggregator) processBatch(batch coldata.Batch, startIdx, endIdx i
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.JSON()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -1933,7 +1933,7 @@ func (a *minDatumAggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Datum()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -2176,7 +2176,7 @@ func (a *maxBoolAggregator) processBatch(batch coldata.Batch, startIdx, endIdx i
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Bool()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -2348,7 +2348,7 @@ func (a *maxBytesAggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Bytes()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -2502,7 +2502,7 @@ func (a *maxDecimalAggregator) processBatch(batch coldata.Batch, startIdx, endId
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Decimal()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -2658,7 +2658,7 @@ func (a *maxInt16Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int16()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -2836,7 +2836,7 @@ func (a *maxInt32Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int32()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -3014,7 +3014,7 @@ func (a *maxInt64Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int64()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -3192,7 +3192,7 @@ func (a *maxFloat64Aggregator) processBatch(batch coldata.Batch, startIdx, endId
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Float64()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -3386,7 +3386,7 @@ func (a *maxTimestampAggregator) processBatch(batch coldata.Batch, startIdx, end
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Timestamp()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -3556,7 +3556,7 @@ func (a *maxIntervalAggregator) processBatch(batch coldata.Batch, startIdx, endI
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Interval()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
@@ -3712,7 +3712,7 @@ func (a *maxJSONAggregator) processBatch(batch coldata.Batch, startIdx, endIdx i
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.JSON()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -3911,7 +3911,7 @@ func (a *maxDatumAggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Datum()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
@@ -175,7 +175,7 @@ func (a *_AGG_TYPEAggregator) processBatch(batch coldata.Batch, startIdx, endIdx
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.TemplateType()
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		// {{if not .IsBytesLike}}
 		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		// {{end}}

--- a/pkg/sql/colexec/colexecwindow/range_offset_handler.eg.go
+++ b/pkg/sql/colexec/colexecwindow/range_offset_handler.eg.go
@@ -765,7 +765,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInt16) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -836,7 +836,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInt16) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -912,7 +912,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInt32) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -983,7 +983,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInt32) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -1059,7 +1059,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInt64) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -1130,7 +1130,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInt64) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -1206,7 +1206,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDecimal) getIdx(ctx context.Context,
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -1278,7 +1278,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDecimal) getIdx(ctx context.Context,
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -1343,7 +1343,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscFloat64) getIdx(ctx context.Context,
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -1411,7 +1411,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscFloat64) getIdx(ctx context.Context,
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -1495,7 +1495,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInterval) getIdx(ctx context.Context
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -1559,7 +1559,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInterval) getIdx(ctx context.Context
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -1624,7 +1624,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDate) getIdx(ctx context.Context, cu
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -1702,7 +1702,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDate) getIdx(ctx context.Context, cu
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -1783,7 +1783,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscTimestamp) getIdx(ctx context.Contex
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -1852,7 +1852,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscTimestamp) getIdx(ctx context.Contex
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -1927,7 +1927,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDatum) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -1996,7 +1996,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDatum) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -2063,7 +2063,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInt16) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -2102,7 +2102,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInt16) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -2183,7 +2183,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInt32) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -2222,7 +2222,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInt32) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -2303,7 +2303,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInt64) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -2342,7 +2342,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInt64) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -2423,7 +2423,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDecimal) getIdx(ctx context.Context
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -2463,7 +2463,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDecimal) getIdx(ctx context.Context
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -2533,7 +2533,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescFloat64) getIdx(ctx context.Context
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -2569,7 +2569,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescFloat64) getIdx(ctx context.Context
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -2658,7 +2658,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInterval) getIdx(ctx context.Contex
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -2690,7 +2690,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInterval) getIdx(ctx context.Contex
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -2760,7 +2760,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDate) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -2806,7 +2806,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDate) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -2892,7 +2892,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescTimestamp) getIdx(ctx context.Conte
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -2929,7 +2929,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescTimestamp) getIdx(ctx context.Conte
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -3009,7 +3009,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDatum) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -3046,7 +3046,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDatum) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -3118,7 +3118,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInt16) getIdx(ctx context.Context, cur
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -3206,7 +3206,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInt16) getIdx(ctx context.Context, cur
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -3282,7 +3282,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInt32) getIdx(ctx context.Context, cur
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -3370,7 +3370,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInt32) getIdx(ctx context.Context, cur
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -3446,7 +3446,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInt64) getIdx(ctx context.Context, cur
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -3534,7 +3534,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInt64) getIdx(ctx context.Context, cur
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -3610,7 +3610,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDecimal) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -3699,7 +3699,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDecimal) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -3764,7 +3764,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscFloat64) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -3849,7 +3849,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscFloat64) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -3933,7 +3933,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInterval) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -4014,7 +4014,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInterval) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -4079,7 +4079,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDate) getIdx(ctx context.Context, curr
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -4174,7 +4174,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDate) getIdx(ctx context.Context, curr
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -4255,7 +4255,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscTimestamp) getIdx(ctx context.Context,
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -4341,7 +4341,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscTimestamp) getIdx(ctx context.Context,
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -4416,7 +4416,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDatum) getIdx(ctx context.Context, cur
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -4502,7 +4502,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDatum) getIdx(ctx context.Context, cur
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -4569,7 +4569,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInt16) getIdx(ctx context.Context, cu
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -4625,7 +4625,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInt16) getIdx(ctx context.Context, cu
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -4706,7 +4706,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInt32) getIdx(ctx context.Context, cu
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -4762,7 +4762,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInt32) getIdx(ctx context.Context, cu
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -4843,7 +4843,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInt64) getIdx(ctx context.Context, cu
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -4899,7 +4899,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInt64) getIdx(ctx context.Context, cu
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -4980,7 +4980,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDecimal) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -5037,7 +5037,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDecimal) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -5107,7 +5107,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescFloat64) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -5160,7 +5160,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescFloat64) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -5249,7 +5249,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInterval) getIdx(ctx context.Context,
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -5298,7 +5298,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInterval) getIdx(ctx context.Context,
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -5368,7 +5368,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDate) getIdx(ctx context.Context, cur
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -5431,7 +5431,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDate) getIdx(ctx context.Context, cur
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -5517,7 +5517,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescTimestamp) getIdx(ctx context.Context
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -5571,7 +5571,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescTimestamp) getIdx(ctx context.Context
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -5651,7 +5651,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDatum) getIdx(ctx context.Context, cu
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -5705,7 +5705,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDatum) getIdx(ctx context.Context, cu
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -5777,7 +5777,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInt16) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -5848,7 +5848,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInt16) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -5924,7 +5924,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInt32) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -5995,7 +5995,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInt32) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -6071,7 +6071,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInt64) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -6142,7 +6142,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInt64) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -6218,7 +6218,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDecimal) getIdx(ctx context.Context,
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -6290,7 +6290,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDecimal) getIdx(ctx context.Context,
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -6355,7 +6355,7 @@ func (h *rangeHandlerOffsetFollowingStartAscFloat64) getIdx(ctx context.Context,
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -6423,7 +6423,7 @@ func (h *rangeHandlerOffsetFollowingStartAscFloat64) getIdx(ctx context.Context,
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -6507,7 +6507,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInterval) getIdx(ctx context.Context
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -6571,7 +6571,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInterval) getIdx(ctx context.Context
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -6636,7 +6636,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDate) getIdx(ctx context.Context, cu
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -6714,7 +6714,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDate) getIdx(ctx context.Context, cu
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -6795,7 +6795,7 @@ func (h *rangeHandlerOffsetFollowingStartAscTimestamp) getIdx(ctx context.Contex
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -6864,7 +6864,7 @@ func (h *rangeHandlerOffsetFollowingStartAscTimestamp) getIdx(ctx context.Contex
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -6939,7 +6939,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDatum) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -7008,7 +7008,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDatum) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -7075,7 +7075,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInt16) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -7114,7 +7114,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInt16) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -7195,7 +7195,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInt32) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -7234,7 +7234,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInt32) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -7315,7 +7315,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInt64) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -7354,7 +7354,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInt64) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -7435,7 +7435,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDecimal) getIdx(ctx context.Context
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -7475,7 +7475,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDecimal) getIdx(ctx context.Context
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -7545,7 +7545,7 @@ func (h *rangeHandlerOffsetFollowingStartDescFloat64) getIdx(ctx context.Context
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -7581,7 +7581,7 @@ func (h *rangeHandlerOffsetFollowingStartDescFloat64) getIdx(ctx context.Context
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -7670,7 +7670,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInterval) getIdx(ctx context.Contex
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -7702,7 +7702,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInterval) getIdx(ctx context.Contex
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -7772,7 +7772,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDate) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -7818,7 +7818,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDate) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -7904,7 +7904,7 @@ func (h *rangeHandlerOffsetFollowingStartDescTimestamp) getIdx(ctx context.Conte
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -7941,7 +7941,7 @@ func (h *rangeHandlerOffsetFollowingStartDescTimestamp) getIdx(ctx context.Conte
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -8021,7 +8021,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDatum) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -8058,7 +8058,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDatum) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -8130,7 +8130,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInt16) getIdx(ctx context.Context, cur
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -8218,7 +8218,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInt16) getIdx(ctx context.Context, cur
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -8294,7 +8294,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInt32) getIdx(ctx context.Context, cur
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -8382,7 +8382,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInt32) getIdx(ctx context.Context, cur
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -8458,7 +8458,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInt64) getIdx(ctx context.Context, cur
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -8546,7 +8546,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInt64) getIdx(ctx context.Context, cur
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -8622,7 +8622,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDecimal) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -8711,7 +8711,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDecimal) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -8776,7 +8776,7 @@ func (h *rangeHandlerOffsetFollowingEndAscFloat64) getIdx(ctx context.Context, c
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -8861,7 +8861,7 @@ func (h *rangeHandlerOffsetFollowingEndAscFloat64) getIdx(ctx context.Context, c
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -8945,7 +8945,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInterval) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -9026,7 +9026,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInterval) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -9091,7 +9091,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDate) getIdx(ctx context.Context, curr
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -9186,7 +9186,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDate) getIdx(ctx context.Context, curr
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -9267,7 +9267,7 @@ func (h *rangeHandlerOffsetFollowingEndAscTimestamp) getIdx(ctx context.Context,
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -9353,7 +9353,7 @@ func (h *rangeHandlerOffsetFollowingEndAscTimestamp) getIdx(ctx context.Context,
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -9428,7 +9428,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDatum) getIdx(ctx context.Context, cur
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -9514,7 +9514,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDatum) getIdx(ctx context.Context, cur
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -9581,7 +9581,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInt16) getIdx(ctx context.Context, cu
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -9637,7 +9637,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInt16) getIdx(ctx context.Context, cu
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -9718,7 +9718,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInt32) getIdx(ctx context.Context, cu
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -9774,7 +9774,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInt32) getIdx(ctx context.Context, cu
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -9855,7 +9855,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInt64) getIdx(ctx context.Context, cu
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -9911,7 +9911,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInt64) getIdx(ctx context.Context, cu
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -9992,7 +9992,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDecimal) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -10049,7 +10049,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDecimal) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -10119,7 +10119,7 @@ func (h *rangeHandlerOffsetFollowingEndDescFloat64) getIdx(ctx context.Context, 
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -10172,7 +10172,7 @@ func (h *rangeHandlerOffsetFollowingEndDescFloat64) getIdx(ctx context.Context, 
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -10261,7 +10261,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInterval) getIdx(ctx context.Context,
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -10310,7 +10310,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInterval) getIdx(ctx context.Context,
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -10380,7 +10380,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDate) getIdx(ctx context.Context, cur
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -10443,7 +10443,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDate) getIdx(ctx context.Context, cur
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -10529,7 +10529,7 @@ func (h *rangeHandlerOffsetFollowingEndDescTimestamp) getIdx(ctx context.Context
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -10583,7 +10583,7 @@ func (h *rangeHandlerOffsetFollowingEndDescTimestamp) getIdx(ctx context.Context
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break
@@ -10663,7 +10663,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDatum) getIdx(ctx context.Context, cu
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -10717,7 +10717,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDatum) getIdx(ctx context.Context, cu
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break

--- a/pkg/sql/colexec/colexecwindow/range_offset_handler_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/range_offset_handler_tmpl.go
@@ -207,7 +207,7 @@ func (h *_OP_STRING) getIdx(ctx context.Context, currRow, lastIdx int) (idx int)
 		return lastIdx
 	}
 
-	var vec coldata.Vec
+	var vec *coldata.Vec
 	var vecIdx, n int
 	vec, vecIdx, _ = h.storedCols.GetVecWithTuple(ctx, h.ordColIdx, currRow)
 
@@ -293,7 +293,7 @@ func (h *_OP_STRING) getIdx(ctx context.Context, currRow, lastIdx int) (idx int)
 	// Scan to the next peer group and then compare to the value indicated by
 	// the offset. If the comparison fails, scan again to the next peer group
 	// and repeat.
-	var peersVec coldata.Vec
+	var peersVec *coldata.Vec
 	for {
 		if idx >= h.storedCols.Length() {
 			break

--- a/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
@@ -40,7 +40,7 @@ type slidingWindowAggregateFunc interface {
 	// Note: the implementations should be careful to account for their memory
 	// usage.
 	// Note: endIdx is assumed to be greater than zero.
-	Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int)
+	Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int)
 }
 
 // NewWindowAggregatorOperator creates a new Operator that computes aggregate
@@ -81,7 +81,7 @@ func NewWindowAggregatorOperator(
 		outputColIdx: args.OutputColIdx,
 		inputIdxs:    inputIdxs,
 		framer:       framer,
-		vecs:         make([]coldata.Vec, len(inputIdxs)),
+		vecs:         make([]*coldata.Vec, len(inputIdxs)),
 	}
 	var agg colexecagg.AggregateFunc
 	if aggAlloc != nil {
@@ -146,7 +146,7 @@ type windowAggregatorBase struct {
 
 	outputColIdx int
 	inputIdxs    []uint32
-	vecs         []coldata.Vec
+	vecs         []*coldata.Vec
 	framer       windowFramer
 }
 
@@ -213,7 +213,7 @@ func (a *windowAggregator) Close(ctx context.Context) {
 func (a *windowAggregator) processBatch(batch coldata.Batch, startIdx, endIdx int) {
 	outVec := batch.ColVec(a.outputColIdx)
 	a.agg.SetOutput(outVec)
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			{
@@ -260,7 +260,7 @@ func (a *slidingWindowAggregator) Close(ctx context.Context) {
 func (a *slidingWindowAggregator) processBatch(batch coldata.Batch, startIdx, endIdx int) {
 	outVec := batch.ColVec(a.outputColIdx)
 	a.agg.SetOutput(outVec)
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()

--- a/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
@@ -42,7 +42,7 @@ type slidingWindowAggregateFunc interface {
 	// Note: the implementations should be careful to account for their memory
 	// usage.
 	// Note: endIdx is assumed to be greater than zero.
-	Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int)
+	Remove(vecs []*coldata.Vec, inputIdxs []uint32, startIdx, endIdx int)
 }
 
 // NewWindowAggregatorOperator creates a new Operator that computes aggregate
@@ -83,7 +83,7 @@ func NewWindowAggregatorOperator(
 		outputColIdx: args.OutputColIdx,
 		inputIdxs:    inputIdxs,
 		framer:       framer,
-		vecs:         make([]coldata.Vec, len(inputIdxs)),
+		vecs:         make([]*coldata.Vec, len(inputIdxs)),
 	}
 	var agg colexecagg.AggregateFunc
 	if aggAlloc != nil {
@@ -148,7 +148,7 @@ type windowAggregatorBase struct {
 
 	outputColIdx int
 	inputIdxs    []uint32
-	vecs         []coldata.Vec
+	vecs         []*coldata.Vec
 	framer       windowFramer
 }
 
@@ -215,7 +215,7 @@ func (a *windowAggregator) Close(ctx context.Context) {
 func (a *windowAggregator) processBatch(batch coldata.Batch, startIdx, endIdx int) {
 	outVec := batch.ColVec(a.outputColIdx)
 	a.agg.SetOutput(outVec)
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			aggregateOverIntervals(a.framer.frameIntervals(), false /* removeRows */)
@@ -240,7 +240,7 @@ func (a *slidingWindowAggregator) Close(ctx context.Context) {
 func (a *slidingWindowAggregator) processBatch(batch coldata.Batch, startIdx, endIdx int) {
 	outVec := batch.ColVec(a.outputColIdx)
 	a.agg.SetOutput(outVec)
-	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+	a.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()

--- a/pkg/sql/colexec/colexecwindow/window_functions_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_test.go
@@ -1244,11 +1244,11 @@ func BenchmarkWindowFunctions(b *testing.B) {
 		return op
 	}
 
-	inputCreator := func(length int) []coldata.Vec {
+	inputCreator := func(length int) []*coldata.Vec {
 		const arg1Offset, arg1Range = 5, 10
-		vecs := make([]coldata.Vec, len(sourceTypes))
+		vecs := make([]*coldata.Vec, len(sourceTypes))
 		for i := range vecs {
-			vecs[i] = testAllocator.NewMemColumn(sourceTypes[i], length)
+			vecs[i] = testAllocator.NewVec(sourceTypes[i], length)
 		}
 		argCol1 := vecs[arg1ColIdx].Int64()
 		argCol2 := vecs[arg2ColIdx].Int64()

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -490,7 +490,7 @@ func runDistinctBenchmarks(
 		nRowsOptions = []int{coldata.BatchSize()}
 	}
 	bytesValueScratch := make([]byte, bytesValueLength)
-	setFirstValue := func(vec coldata.Vec) {
+	setFirstValue := func(vec *coldata.Vec) {
 		if typ := vec.Type(); typ.Identical(types.Int) {
 			vec.Int64()[0] = 0
 		} else if typ.Identical(types.Bytes) {
@@ -499,7 +499,7 @@ func runDistinctBenchmarks(
 			colexecerror.InternalError(errors.AssertionFailedf("unsupported type %s", typ))
 		}
 	}
-	setIthValue := func(vec coldata.Vec, i int, newValueProbability float64) {
+	setIthValue := func(vec *coldata.Vec, i int, newValueProbability float64) {
 		if i == 0 {
 			colexecerror.InternalError(errors.New("setIthValue called with i == 0"))
 		}
@@ -540,10 +540,10 @@ func runDistinctBenchmarks(
 				}
 				for _, typ := range []*types.T{types.Int, types.Bytes} {
 					typs := make([]*types.T, nCols)
-					cols := make([]coldata.Vec, nCols)
+					cols := make([]*coldata.Vec, nCols)
 					for i := range typs {
 						typs[i] = typ
-						cols[i] = testAllocator.NewMemColumn(typs[i], nRows)
+						cols[i] = testAllocator.NewVec(typs[i], nRows)
 					}
 					numOrderedCols := getNumOrderedCols(nCols)
 					newValueProbability := getNewValueProbabilityForDistinct(newTupleProbability, nCols)
@@ -568,7 +568,7 @@ func runDistinctBenchmarks(
 							order[i], order[j] = order[j], order[i]
 						})
 						for colIdx, oldCol := range cols {
-							cols[colIdx] = testAllocator.NewMemColumn(typs[colIdx], nRows)
+							cols[colIdx] = testAllocator.NewVec(typs[colIdx], nRows)
 							if typs[colIdx].Identical(types.Int) {
 								oldInt64s := oldCol.Int64()
 								newInt64s := cols[colIdx].Int64()

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
@@ -25,14 +25,18 @@ func genHashUtils(inputFileContents string, wr io.Writer) error {
 		"_TYPE_WIDTH", typeWidthReplacement,
 		"_TYPE", "{{.VecMethod}}",
 		"TemplateType", "{{.VecMethod}}",
+		// Currently, github.com/dave/dst library used by execgen doesn't
+		// support the generics well, so we need to put the generic type clause
+		// manually.
+		"func rehash(", "func rehash[T uint32 | uint64](",
 	)
 	s := r.Replace(inputFileContents)
 
 	assignHash := makeFunctionRegex("_ASSIGN_HASH", 4)
 	s = assignHash.ReplaceAllString(s, makeTemplateFunctionCall("Global.AssignHash", 4))
 
-	rehash := makeFunctionRegex("_REHASH_BODY", 8)
-	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "HasSel" $6 "HasNulls" $7 "Uint64" $8}}`)
+	rehash := makeFunctionRegex("_REHASH_BODY", 7)
+	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "HasSel" $6 "HasNulls" $7}}`)
 
 	s = replaceManipulationFuncsAmbiguous(".Global", s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -855,8 +855,8 @@ var supportedWidthsByCanonicalTypeFamily = map[types.Family][]int32{
 
 var numericCanonicalTypeFamilies = []types.Family{types.IntFamily, types.FloatFamily, types.DecimalFamily}
 
-// toVecMethod returns the method name from coldata.Vec interface that can be
-// used to get the well-typed underlying memory from a vector.
+// toVecMethod returns the method name from coldata.Vec struct that can be used
+// to get the well-typed underlying memory from a vector.
 func toVecMethod(canonicalTypeFamily types.Family, width int32) string {
 	switch canonicalTypeFamily {
 	case types.BoolFamily:

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -176,10 +176,10 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 // newIntColumns returns nCols columns of types.Int with non-decreasing values
 // starting at 0. dupCount controls the number of duplicates for each row
 // (including the row itself), use dupCount=1 for distinct tuples.
-func newIntColumns(nCols int, length int, dupCount int) []coldata.Vec {
-	cols := make([]coldata.Vec, nCols)
+func newIntColumns(nCols int, length int, dupCount int) []*coldata.Vec {
+	cols := make([]*coldata.Vec, nCols)
 	for colIdx := 0; colIdx < nCols; colIdx++ {
-		cols[colIdx] = testAllocator.NewMemColumn(types.Int, length)
+		cols[colIdx] = testAllocator.NewVec(types.Int, length)
 		col := cols[colIdx].Int64()
 		for i := 0; i < length; i++ {
 			col[i] = int64(i / dupCount)
@@ -192,10 +192,10 @@ func newIntColumns(nCols int, length int, dupCount int) []coldata.Vec {
 // values of 8 byte size, starting at '00000000'. dupCount controls the number
 // of duplicates for each row (including the row itself), use dupCount=1 for
 // distinct tuples.
-func newBytesColumns(nCols int, length int, dupCount int) []coldata.Vec {
-	cols := make([]coldata.Vec, nCols)
+func newBytesColumns(nCols int, length int, dupCount int) []*coldata.Vec {
+	cols := make([]*coldata.Vec, nCols)
 	for colIdx := 0; colIdx < nCols; colIdx++ {
-		cols[colIdx] = testAllocator.NewMemColumn(types.Bytes, length)
+		cols[colIdx] = testAllocator.NewVec(types.Bytes, length)
 		col := cols[colIdx].Bytes()
 		for i := 0; i < length; i++ {
 			col.Set(i, []byte(fmt.Sprintf("%08d", i/dupCount)))
@@ -238,7 +238,7 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 					// provide a meaningful signal, so we skip such config.
 					continue
 				}
-				var cols []coldata.Vec
+				var cols []*coldata.Vec
 				if typ.Identical(types.Int) {
 					cols = newIntColumns(nCols, nRows, 1 /* dupCount */)
 				} else {

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1054,8 +1054,8 @@ func BenchmarkHashJoiner(b *testing.B) {
 	// right input.
 	const leftRowsMultiple = 2
 
-	getCols := func(typ *types.T, length int, distinct bool, nullProb float64) []coldata.Vec {
-		var cols []coldata.Vec
+	getCols := func(typ *types.T, length int, distinct bool, nullProb float64) []*coldata.Vec {
+		var cols []*coldata.Vec
 		dupCount := 1
 		if distinct {
 			// When the source contains non-distinct tuples, then each tuple

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1740,8 +1740,8 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 	typs := []*types.T{types.Int}
-	colsLeft := []coldata.Vec{testAllocator.NewMemColumn(typs[0], nTuples)}
-	colsRight := []coldata.Vec{testAllocator.NewMemColumn(typs[0], nTuples)}
+	colsLeft := []*coldata.Vec{testAllocator.NewVec(typs[0], nTuples)}
+	colsRight := []*coldata.Vec{testAllocator.NewVec(typs[0], nTuples)}
 	groupsLeft := colsLeft[0].Int64()
 	groupsRight := colsRight[0].Int64()
 	for i := range groupsLeft {
@@ -1813,7 +1813,7 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 			func(t *testing.T) {
 				nTuples := coldata.BatchSize() * numInputBatches
 				typs := []*types.T{types.Int}
-				cols := []coldata.Vec{testAllocator.NewMemColumn(typs[0], nTuples)}
+				cols := []*coldata.Vec{testAllocator.NewVec(typs[0], nTuples)}
 				groups := cols[0].Int64()
 				for i := range groups {
 					groups[i] = int64(i)
@@ -1885,9 +1885,9 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 					lastGroupSize := nTuples % groupSize
 					expCount := nTuples/groupSize*(groupSize*groupSize) + lastGroupSize*lastGroupSize
 					typs := []*types.T{types.Int, types.Int}
-					cols := []coldata.Vec{
-						testAllocator.NewMemColumn(typs[0], nTuples),
-						testAllocator.NewMemColumn(typs[1], nTuples),
+					cols := []*coldata.Vec{
+						testAllocator.NewVec(typs[0], nTuples),
+						testAllocator.NewVec(typs[1], nTuples),
 					}
 					for i := range cols[0].Int64() {
 						cols[0].Int64()[i] = int64(i / groupSize)
@@ -1939,11 +1939,11 @@ type expectedGroup struct {
 
 func newBatchesOfRandIntRows(
 	nTuples int, maxRunLength int64, skipValues bool, randomIncrement int64,
-) ([]coldata.Vec, []coldata.Vec, []expectedGroup) {
+) ([]*coldata.Vec, []*coldata.Vec, []expectedGroup) {
 	rng, _ := randutil.NewTestRand()
-	lCols := []coldata.Vec{testAllocator.NewMemColumn(types.Int, nTuples)}
+	lCols := []*coldata.Vec{testAllocator.NewVec(types.Int, nTuples)}
 	lCol := lCols[0].Int64()
-	rCols := []coldata.Vec{testAllocator.NewMemColumn(types.Int, nTuples)}
+	rCols := []*coldata.Vec{testAllocator.NewVec(types.Int, nTuples)}
 	rCol := rCols[0].Int64()
 	exp := make([]expectedGroup, nTuples)
 	val := int64(0)

--- a/pkg/sql/colexec/range_stats.go
+++ b/pkg/sql/colexec/range_stats.go
@@ -89,7 +89,7 @@ func (r *rangeStatsOperator) Next() coldata.Batch {
 	output := batch.ColVec(r.outputIdx)
 	jsonOutput := output.JSON()
 	r.allocator.PerformOperation(
-		[]coldata.Vec{output},
+		[]*coldata.Vec{output},
 		func() {
 			// TODO(yuzefovich): consider reusing these slices across
 			// iterations.

--- a/pkg/sql/colexec/sort.eg.go
+++ b/pkg/sql/colexec/sort.eg.go
@@ -305,7 +305,7 @@ type sortBoolAscWithNullsOp struct {
 }
 
 func (s *sortBoolAscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
@@ -392,7 +392,7 @@ type sortBytesAscWithNullsOp struct {
 }
 
 func (s *sortBytesAscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Bytes()
 	s.allocator = allocator
@@ -484,7 +484,7 @@ type sortDecimalAscWithNullsOp struct {
 }
 
 func (s *sortDecimalAscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
@@ -561,7 +561,7 @@ type sortInt16AscWithNullsOp struct {
 }
 
 func (s *sortInt16AscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
@@ -649,7 +649,7 @@ type sortInt32AscWithNullsOp struct {
 }
 
 func (s *sortInt32AscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
@@ -737,7 +737,7 @@ type sortInt64AscWithNullsOp struct {
 }
 
 func (s *sortInt64AscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
@@ -825,7 +825,7 @@ type sortFloat64AscWithNullsOp struct {
 }
 
 func (s *sortFloat64AscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
@@ -921,7 +921,7 @@ type sortTimestampAscWithNullsOp struct {
 }
 
 func (s *sortTimestampAscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
@@ -1005,7 +1005,7 @@ type sortIntervalAscWithNullsOp struct {
 }
 
 func (s *sortIntervalAscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
@@ -1082,7 +1082,7 @@ type sortJSONAscWithNullsOp struct {
 }
 
 func (s *sortJSONAscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
@@ -1165,7 +1165,7 @@ type sortDatumAscWithNullsOp struct {
 }
 
 func (s *sortDatumAscWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
@@ -1244,7 +1244,7 @@ type sortBoolDescWithNullsOp struct {
 }
 
 func (s *sortBoolDescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
@@ -1331,7 +1331,7 @@ type sortBytesDescWithNullsOp struct {
 }
 
 func (s *sortBytesDescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Bytes()
 	s.allocator = allocator
@@ -1423,7 +1423,7 @@ type sortDecimalDescWithNullsOp struct {
 }
 
 func (s *sortDecimalDescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
@@ -1500,7 +1500,7 @@ type sortInt16DescWithNullsOp struct {
 }
 
 func (s *sortInt16DescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
@@ -1588,7 +1588,7 @@ type sortInt32DescWithNullsOp struct {
 }
 
 func (s *sortInt32DescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
@@ -1676,7 +1676,7 @@ type sortInt64DescWithNullsOp struct {
 }
 
 func (s *sortInt64DescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
@@ -1764,7 +1764,7 @@ type sortFloat64DescWithNullsOp struct {
 }
 
 func (s *sortFloat64DescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
@@ -1860,7 +1860,7 @@ type sortTimestampDescWithNullsOp struct {
 }
 
 func (s *sortTimestampDescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
@@ -1944,7 +1944,7 @@ type sortIntervalDescWithNullsOp struct {
 }
 
 func (s *sortIntervalDescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
@@ -2021,7 +2021,7 @@ type sortJSONDescWithNullsOp struct {
 }
 
 func (s *sortJSONDescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
@@ -2104,7 +2104,7 @@ type sortDatumDescWithNullsOp struct {
 }
 
 func (s *sortDatumDescWithNullsOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
@@ -2183,7 +2183,7 @@ type sortBoolAscOp struct {
 }
 
 func (s *sortBoolAscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
@@ -2260,7 +2260,7 @@ type sortBytesAscOp struct {
 }
 
 func (s *sortBytesAscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Bytes()
 	s.allocator = allocator
@@ -2342,7 +2342,7 @@ type sortDecimalAscOp struct {
 }
 
 func (s *sortDecimalAscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
@@ -2409,7 +2409,7 @@ type sortInt16AscOp struct {
 }
 
 func (s *sortInt16AscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
@@ -2488,7 +2488,7 @@ type sortInt32AscOp struct {
 }
 
 func (s *sortInt32AscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
@@ -2567,7 +2567,7 @@ type sortInt64AscOp struct {
 }
 
 func (s *sortInt64AscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
@@ -2646,7 +2646,7 @@ type sortFloat64AscOp struct {
 }
 
 func (s *sortFloat64AscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
@@ -2732,7 +2732,7 @@ type sortTimestampAscOp struct {
 }
 
 func (s *sortTimestampAscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
@@ -2806,7 +2806,7 @@ type sortIntervalAscOp struct {
 }
 
 func (s *sortIntervalAscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
@@ -2873,7 +2873,7 @@ type sortJSONAscOp struct {
 }
 
 func (s *sortJSONAscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
@@ -2946,7 +2946,7 @@ type sortDatumAscOp struct {
 }
 
 func (s *sortDatumAscOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
@@ -3015,7 +3015,7 @@ type sortBoolDescOp struct {
 }
 
 func (s *sortBoolDescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
@@ -3092,7 +3092,7 @@ type sortBytesDescOp struct {
 }
 
 func (s *sortBytesDescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Bytes()
 	s.allocator = allocator
@@ -3174,7 +3174,7 @@ type sortDecimalDescOp struct {
 }
 
 func (s *sortDecimalDescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
@@ -3241,7 +3241,7 @@ type sortInt16DescOp struct {
 }
 
 func (s *sortInt16DescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
@@ -3320,7 +3320,7 @@ type sortInt32DescOp struct {
 }
 
 func (s *sortInt32DescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
@@ -3399,7 +3399,7 @@ type sortInt64DescOp struct {
 }
 
 func (s *sortInt64DescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
@@ -3478,7 +3478,7 @@ type sortFloat64DescOp struct {
 }
 
 func (s *sortFloat64DescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
@@ -3564,7 +3564,7 @@ type sortTimestampDescOp struct {
 }
 
 func (s *sortTimestampDescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
@@ -3638,7 +3638,7 @@ type sortIntervalDescOp struct {
 }
 
 func (s *sortIntervalDescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
@@ -3705,7 +3705,7 @@ type sortJSONDescOp struct {
 }
 
 func (s *sortJSONDescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
@@ -3778,7 +3778,7 @@ type sortDatumDescOp struct {
 }
 
 func (s *sortDatumDescOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -74,7 +74,7 @@ type spooler interface {
 	// spool performs the actual spooling.
 	spool()
 	// getValues returns ith Vec of the already spooled data.
-	getValues(i int) coldata.Vec
+	getValues(i int) *coldata.Vec
 	// getNumTuples returns the number of spooled tuples.
 	getNumTuples() int
 	// getPartitionsCol returns a partitions column vector in which every true
@@ -138,7 +138,7 @@ func (p *allSpooler) spool() {
 	}
 }
 
-func (p *allSpooler) getValues(i int) coldata.Vec {
+func (p *allSpooler) getValues(i int) *coldata.Vec {
 	if !p.spooled {
 		colexecerror.InternalError(errors.AssertionFailedf("getValues() is called before spool()"))
 	}
@@ -237,7 +237,7 @@ type colSorter interface {
 	// init prepares this sorter, given a particular Vec and an order vector,
 	// which must be the same size as the input Vec and will be permuted with
 	// the same swaps as the column.
-	init(ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int)
+	init(ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int)
 	// reset releases memory allocated by the colSorter. It should be called
 	// when the colSorter is no longer needed.
 	reset()

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -432,7 +432,7 @@ func (s *chunker) spool() {
 	s.readFrom = s.prepareNextChunks()
 }
 
-func (s *chunker) getValues(i int) coldata.Vec {
+func (s *chunker) getValues(i int) *coldata.Vec {
 	switch s.readFrom {
 	case chunkerReadFromBuffer:
 		return s.bufferedTuples.ColVec(i).Window(0 /* start */, s.bufferedTuples.Length())

--- a/pkg/sql/colexec/sort_partitioner.eg.go
+++ b/pkg/sql/colexec/sort_partitioner.eg.go
@@ -34,7 +34,7 @@ import (
 type partitioner interface {
 	// partition partitions the input colVec of size n, writing true to the
 	// outputCol for every value that differs from the previous one.
-	partition(colVec coldata.Vec, outputCol []bool, n int)
+	partition(colVec *coldata.Vec, outputCol []bool, n int)
 
 	// partitionWithOrder is like partition, except it performs the partitioning
 	// on the input Vec as if it were ordered via the input order vector, which is
@@ -43,7 +43,7 @@ type partitioner interface {
 	// implies a reordered input vector [b,b,a], the resultant outputCol would be
 	// [true, false, true], indicating a distinct value at the 0th and 2nd
 	// elements.
-	partitionWithOrder(colVec coldata.Vec, order []int, outputCol []bool, n int)
+	partitionWithOrder(colVec *coldata.Vec, order []int, outputCol []bool, n int)
 }
 
 // newPartitioner returns a new partitioner on type t.
@@ -122,7 +122,7 @@ type partitionerBool struct {
 }
 
 func (p partitionerBool) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal bool
 	var lastValNull bool
@@ -231,7 +231,7 @@ func (p partitionerBool) partitionWithOrder(
 	}
 }
 
-func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerBool) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     bool
 		lastValNull bool
@@ -355,7 +355,7 @@ type partitionerBytes struct {
 }
 
 func (p partitionerBytes) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal []byte
 	var lastValNull bool
@@ -448,7 +448,7 @@ func (p partitionerBytes) partitionWithOrder(
 	}
 }
 
-func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerBytes) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     []byte
 		lastValNull bool
@@ -553,7 +553,7 @@ type partitionerDecimal struct {
 }
 
 func (p partitionerDecimal) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal apd.Decimal
 	var lastValNull bool
@@ -646,7 +646,7 @@ func (p partitionerDecimal) partitionWithOrder(
 	}
 }
 
-func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerDecimal) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     apd.Decimal
 		lastValNull bool
@@ -754,7 +754,7 @@ type partitionerInt16 struct {
 }
 
 func (p partitionerInt16) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal int16
 	var lastValNull bool
@@ -869,7 +869,7 @@ func (p partitionerInt16) partitionWithOrder(
 	}
 }
 
-func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerInt16) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     int16
 		lastValNull bool
@@ -999,7 +999,7 @@ type partitionerInt32 struct {
 }
 
 func (p partitionerInt32) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal int32
 	var lastValNull bool
@@ -1114,7 +1114,7 @@ func (p partitionerInt32) partitionWithOrder(
 	}
 }
 
-func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerInt32) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     int32
 		lastValNull bool
@@ -1244,7 +1244,7 @@ type partitionerInt64 struct {
 }
 
 func (p partitionerInt64) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal int64
 	var lastValNull bool
@@ -1359,7 +1359,7 @@ func (p partitionerInt64) partitionWithOrder(
 	}
 }
 
-func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerInt64) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     int64
 		lastValNull bool
@@ -1489,7 +1489,7 @@ type partitionerFloat64 struct {
 }
 
 func (p partitionerFloat64) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal float64
 	var lastValNull bool
@@ -1620,7 +1620,7 @@ func (p partitionerFloat64) partitionWithOrder(
 	}
 }
 
-func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerFloat64) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     float64
 		lastValNull bool
@@ -1766,7 +1766,7 @@ type partitionerTimestamp struct {
 }
 
 func (p partitionerTimestamp) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal time.Time
 	var lastValNull bool
@@ -1873,7 +1873,7 @@ func (p partitionerTimestamp) partitionWithOrder(
 	}
 }
 
-func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerTimestamp) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     time.Time
 		lastValNull bool
@@ -1995,7 +1995,7 @@ type partitionerInterval struct {
 }
 
 func (p partitionerInterval) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal duration.Duration
 	var lastValNull bool
@@ -2088,7 +2088,7 @@ func (p partitionerInterval) partitionWithOrder(
 	}
 }
 
-func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerInterval) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     duration.Duration
 		lastValNull bool
@@ -2196,7 +2196,7 @@ type partitionerJSON struct {
 }
 
 func (p partitionerJSON) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal json.JSON
 	var lastValNull bool
@@ -2301,7 +2301,7 @@ func (p partitionerJSON) partitionWithOrder(
 	}
 }
 
-func (p partitionerJSON) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerJSON) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     json.JSON
 		lastValNull bool
@@ -2418,7 +2418,7 @@ type partitionerDatum struct {
 }
 
 func (p partitionerDatum) partitionWithOrder(
-	colVec coldata.Vec, order []int, outputCol []bool, n int,
+	colVec *coldata.Vec, order []int, outputCol []bool, n int,
 ) {
 	var lastVal interface{}
 	var lastValNull bool
@@ -2515,7 +2515,7 @@ func (p partitionerDatum) partitionWithOrder(
 	}
 }
 
-func (p partitionerDatum) partition(colVec coldata.Vec, outputCol []bool, n int) {
+func (p partitionerDatum) partition(colVec *coldata.Vec, outputCol []bool, n int) {
 	var (
 		lastVal     interface{}
 		lastValNull bool

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -115,7 +115,7 @@ type sort_TYPE_DIR_HANDLES_NULLSOp struct {
 }
 
 func (s *sort_TYPE_DIR_HANDLES_NULLSOp) init(
-	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+	ctx context.Context, allocator *colmem.Allocator, col *coldata.Vec, order []int,
 ) {
 	s.sortCol = col.TemplateType()
 	// {{if .CanAbbreviate}}

--- a/pkg/sql/colexec/substring.eg.go
+++ b/pkg/sql/colexec/substring.eg.go
@@ -115,7 +115,7 @@ func (s *substringInt64Int16Operator) Next() coldata.Batch {
 	outputCol := outputVec.Bytes()
 	outputNulls := outputVec.Nulls()
 	s.allocator.PerformOperation(
-		[]coldata.Vec{outputVec},
+		[]*coldata.Vec{outputVec},
 		func() {
 			argsMaybeHaveNulls := bytesNulls.MaybeHasNulls() || startNulls.MaybeHasNulls() || lengthNulls.MaybeHasNulls()
 			for i := 0; i < n; i++ {
@@ -216,7 +216,7 @@ func (s *substringInt64Int32Operator) Next() coldata.Batch {
 	outputCol := outputVec.Bytes()
 	outputNulls := outputVec.Nulls()
 	s.allocator.PerformOperation(
-		[]coldata.Vec{outputVec},
+		[]*coldata.Vec{outputVec},
 		func() {
 			argsMaybeHaveNulls := bytesNulls.MaybeHasNulls() || startNulls.MaybeHasNulls() || lengthNulls.MaybeHasNulls()
 			for i := 0; i < n; i++ {
@@ -317,7 +317,7 @@ func (s *substringInt64Int64Operator) Next() coldata.Batch {
 	outputCol := outputVec.Bytes()
 	outputNulls := outputVec.Nulls()
 	s.allocator.PerformOperation(
-		[]coldata.Vec{outputVec},
+		[]*coldata.Vec{outputVec},
 		func() {
 			argsMaybeHaveNulls := bytesNulls.MaybeHasNulls() || startNulls.MaybeHasNulls() || lengthNulls.MaybeHasNulls()
 			for i := 0; i < n; i++ {
@@ -418,7 +418,7 @@ func (s *substringInt16Int16Operator) Next() coldata.Batch {
 	outputCol := outputVec.Bytes()
 	outputNulls := outputVec.Nulls()
 	s.allocator.PerformOperation(
-		[]coldata.Vec{outputVec},
+		[]*coldata.Vec{outputVec},
 		func() {
 			argsMaybeHaveNulls := bytesNulls.MaybeHasNulls() || startNulls.MaybeHasNulls() || lengthNulls.MaybeHasNulls()
 			for i := 0; i < n; i++ {
@@ -519,7 +519,7 @@ func (s *substringInt16Int32Operator) Next() coldata.Batch {
 	outputCol := outputVec.Bytes()
 	outputNulls := outputVec.Nulls()
 	s.allocator.PerformOperation(
-		[]coldata.Vec{outputVec},
+		[]*coldata.Vec{outputVec},
 		func() {
 			argsMaybeHaveNulls := bytesNulls.MaybeHasNulls() || startNulls.MaybeHasNulls() || lengthNulls.MaybeHasNulls()
 			for i := 0; i < n; i++ {
@@ -620,7 +620,7 @@ func (s *substringInt16Int64Operator) Next() coldata.Batch {
 	outputCol := outputVec.Bytes()
 	outputNulls := outputVec.Nulls()
 	s.allocator.PerformOperation(
-		[]coldata.Vec{outputVec},
+		[]*coldata.Vec{outputVec},
 		func() {
 			argsMaybeHaveNulls := bytesNulls.MaybeHasNulls() || startNulls.MaybeHasNulls() || lengthNulls.MaybeHasNulls()
 			for i := 0; i < n; i++ {
@@ -721,7 +721,7 @@ func (s *substringInt32Int16Operator) Next() coldata.Batch {
 	outputCol := outputVec.Bytes()
 	outputNulls := outputVec.Nulls()
 	s.allocator.PerformOperation(
-		[]coldata.Vec{outputVec},
+		[]*coldata.Vec{outputVec},
 		func() {
 			argsMaybeHaveNulls := bytesNulls.MaybeHasNulls() || startNulls.MaybeHasNulls() || lengthNulls.MaybeHasNulls()
 			for i := 0; i < n; i++ {
@@ -822,7 +822,7 @@ func (s *substringInt32Int32Operator) Next() coldata.Batch {
 	outputCol := outputVec.Bytes()
 	outputNulls := outputVec.Nulls()
 	s.allocator.PerformOperation(
-		[]coldata.Vec{outputVec},
+		[]*coldata.Vec{outputVec},
 		func() {
 			argsMaybeHaveNulls := bytesNulls.MaybeHasNulls() || startNulls.MaybeHasNulls() || lengthNulls.MaybeHasNulls()
 			for i := 0; i < n; i++ {
@@ -923,7 +923,7 @@ func (s *substringInt32Int64Operator) Next() coldata.Batch {
 	outputCol := outputVec.Bytes()
 	outputNulls := outputVec.Nulls()
 	s.allocator.PerformOperation(
-		[]coldata.Vec{outputVec},
+		[]*coldata.Vec{outputVec},
 		func() {
 			argsMaybeHaveNulls := bytesNulls.MaybeHasNulls() || startNulls.MaybeHasNulls() || lengthNulls.MaybeHasNulls()
 			for i := 0; i < n; i++ {

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -116,7 +116,7 @@ func (s *substring_StartType_LengthTypeOperator) Next() coldata.Batch {
 	outputCol := outputVec.Bytes()
 	outputNulls := outputVec.Nulls()
 	s.allocator.PerformOperation(
-		[]coldata.Vec{outputVec},
+		[]*coldata.Vec{outputVec},
 		func() {
 			argsMaybeHaveNulls := bytesNulls.MaybeHasNulls() || startNulls.MaybeHasNulls() || lengthNulls.MaybeHasNulls()
 			for i := 0; i < n; i++ {

--- a/pkg/sql/colexec/tuple_proj_op.go
+++ b/pkg/sql/colexec/tuple_proj_op.go
@@ -64,7 +64,7 @@ func (t *tupleProjOp) Next() coldata.Batch {
 	t.converter.ConvertBatchAndDeselect(batch)
 	projVec := batch.ColVec(t.outputIdx)
 
-	t.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+	t.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
 		// Preallocate the tuples and their underlying datums in a contiguous
 		// slice to reduce allocations.
 		tuples := make([]tree.DTuple, n)

--- a/pkg/sql/colexec/values_differ.eg.go
+++ b/pkg/sql/colexec/values_differ.eg.go
@@ -35,7 +35,7 @@ var (
 // valuesDiffer takes in two ColVecs as well as values indices to check whether
 // the values differ. This function pays attention to NULLs.
 func valuesDiffer(
-	aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValueIdx int, nullsAreDistinct bool,
+	aColVec *coldata.Vec, aValueIdx int, bColVec *coldata.Vec, bValueIdx int, nullsAreDistinct bool,
 ) bool {
 	switch aColVec.CanonicalTypeFamily() {
 	case types.BoolFamily:

--- a/pkg/sql/colexec/values_differ_tmpl.go
+++ b/pkg/sql/colexec/values_differ_tmpl.go
@@ -63,7 +63,7 @@ func _ASSIGN_NE(_, _, _, _, _, _ string) bool {
 // valuesDiffer takes in two ColVecs as well as values indices to check whether
 // the values differ. This function pays attention to NULLs.
 func valuesDiffer(
-	aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValueIdx int, nullsAreDistinct bool,
+	aColVec *coldata.Vec, aValueIdx int, bColVec *coldata.Vec, bValueIdx int, nullsAreDistinct bool,
 ) bool {
 	switch aColVec.CanonicalTypeFamily() {
 	// {{range .}}

--- a/pkg/sql/colexec/vec_comparators.eg.go
+++ b/pkg/sql/colexec/vec_comparators.eg.go
@@ -47,7 +47,7 @@ type vecComparator interface {
 	set(srcVecIdx, dstVecIdx int, srcValIdx, dstValIdx int)
 
 	// setVec updates the vector at idx.
-	setVec(idx int, vec coldata.Vec)
+	setVec(idx int, vec *coldata.Vec)
 }
 
 type BoolVecComparator struct {
@@ -80,7 +80,7 @@ func (c *BoolVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int) 
 	return cmp
 }
 
-func (c *BoolVecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *BoolVecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.Bool()
 	c.nulls[idx] = vec.Nulls()
 }
@@ -117,7 +117,7 @@ func (c *BytesVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	return cmp
 }
 
-func (c *BytesVecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *BytesVecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.Bytes()
 	c.nulls[idx] = vec.Nulls()
 }
@@ -153,7 +153,7 @@ func (c *DecimalVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 in
 	return cmp
 }
 
-func (c *DecimalVecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *DecimalVecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.Decimal()
 	c.nulls[idx] = vec.Nulls()
 }
@@ -201,7 +201,7 @@ func (c *Int16VecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	return cmp
 }
 
-func (c *Int16VecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *Int16VecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.Int16()
 	c.nulls[idx] = vec.Nulls()
 }
@@ -249,7 +249,7 @@ func (c *Int32VecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	return cmp
 }
 
-func (c *Int32VecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *Int32VecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.Int32()
 	c.nulls[idx] = vec.Nulls()
 }
@@ -297,7 +297,7 @@ func (c *Int64VecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	return cmp
 }
 
-func (c *Int64VecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *Int64VecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.Int64()
 	c.nulls[idx] = vec.Nulls()
 }
@@ -353,7 +353,7 @@ func (c *Float64VecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 in
 	return cmp
 }
 
-func (c *Float64VecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *Float64VecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.Float64()
 	c.nulls[idx] = vec.Nulls()
 }
@@ -397,7 +397,7 @@ func (c *TimestampVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 
 	return cmp
 }
 
-func (c *TimestampVecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *TimestampVecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.Timestamp()
 	c.nulls[idx] = vec.Nulls()
 }
@@ -434,7 +434,7 @@ func (c *IntervalVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 i
 	return cmp
 }
 
-func (c *IntervalVecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *IntervalVecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.Interval()
 	c.nulls[idx] = vec.Nulls()
 }
@@ -477,7 +477,7 @@ func (c *JSONVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int) 
 	return cmp
 }
 
-func (c *JSONVecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *JSONVecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.JSON()
 	c.nulls[idx] = vec.Nulls()
 }
@@ -515,7 +515,7 @@ func (c *DatumVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	return cmp
 }
 
-func (c *DatumVecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *DatumVecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec.Datum()
 	c.nulls[idx] = vec.Nulls()
 }

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -75,7 +75,7 @@ type vecComparator interface {
 	set(srcVecIdx, dstVecIdx int, srcValIdx, dstValIdx int)
 
 	// setVec updates the vector at idx.
-	setVec(idx int, vec coldata.Vec)
+	setVec(idx int, vec *coldata.Vec)
 }
 
 // {{range .}}
@@ -102,7 +102,7 @@ func (c *_TYPEVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	return cmp
 }
 
-func (c *_TYPEVecComparator) setVec(idx int, vec coldata.Vec) {
+func (c *_TYPEVecComparator) setVec(idx int, vec *coldata.Vec) {
 	c.vecs[idx] = vec._TYPE()
 	c.nulls[idx] = vec.Nulls()
 }

--- a/pkg/sql/colexecop/testutils.go
+++ b/pkg/sql/colexecop/testutils.go
@@ -55,7 +55,7 @@ func (b *BatchBuffer) Next() coldata.Batch {
 type RepeatableBatchSource struct {
 	ZeroInputNode
 
-	colVecs  []coldata.Vec
+	colVecs  []*coldata.Vec
 	typs     []*types.T
 	sel      []int
 	batchLen int

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -82,7 +82,7 @@ func TestMaybeAppendColumn(t *testing.T) {
 
 		// We expect that the old vector is reallocated because the present one
 		// is made to be of insufficient capacity.
-		b.ReplaceCol(testAllocator.NewMemColumn(types.Int, 1 /* capacity */), colIdx)
+		b.ReplaceCol(testAllocator.NewVec(types.Int, 1 /* capacity */), colIdx)
 		testAllocator.MaybeAppendColumn(b, types.Int, colIdx)
 		require.Equal(t, coldata.BatchSize(), b.ColVec(colIdx).Capacity())
 

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -70,7 +70,7 @@ func makeDatumFromColOffset(
 	hint *types.T,
 	evalCtx *eval.Context,
 	semaCtx *tree.SemaContext,
-	col coldata.Vec,
+	col *coldata.Vec,
 	rowIdx int,
 ) (tree.Datum, error) {
 	if col.Nulls().NullAt(rowIdx) {

--- a/pkg/sql/sem/tree/parse_string_test.go
+++ b/pkg/sql/sem/tree/parse_string_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func vecRow(v coldata.Vec, i int) any {
+func vecRow(v *coldata.Vec, i int) any {
 	switch v.CanonicalTypeFamily() {
 	case types.BoolFamily:
 		return v.Bool()[i]

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2098,10 +2098,10 @@ func TestLint(t *testing.T) {
 			// We prohibit usage of:
 			// - coldata.NewMemBatch
 			// - coldata.NewMemBatchWithCapacity
-			// - coldata.NewMemColumn
+			// - coldata.NewVec
 			// - coldata.Batch.AppendCol
 			// TODO(yuzefovich): prohibit call to coldata.NewMemBatchNoCols.
-			`(coldata\.NewMem(Batch|BatchWithCapacity|Column)|\.AppendCol)\(`,
+			`(coldata\.New(MemBatch|MemBatchWithCapacity|Vec)|\.AppendCol)\(`,
 			"--",
 			// TODO(yuzefovich): prohibit calling coldata.* methods from other
 			// sql/col* packages.
@@ -2229,7 +2229,7 @@ func TestLint(t *testing.T) {
 		}
 
 		if err := stream.ForEach(filter, func(s string) {
-			t.Errorf("\n%s <- forbidden; use coldata.Vec.Copy or colexecutils.AppendOnlyBufferedGroup", s)
+			t.Errorf("\n%s <- forbidden; use coldata.Vec.Copy or colexecutils.AppendOnlyBufferedBatch", s)
 		}); err != nil {
 			t.Error(err)
 		}

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload/tpch"
 )
 
-func columnByteSize(col coldata.Vec) int64 {
+func columnByteSize(col *coldata.Vec) int64 {
 	switch t := col.Type(); col.CanonicalTypeFamily() {
 	case types.IntFamily:
 		switch t.Width() {

--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -74,7 +74,7 @@ func WriteCSVRows(
 	return rowBatchIdx, csvW.Error()
 }
 
-func colDatumToCSVString(col coldata.Vec, rowIdx int) string {
+func colDatumToCSVString(col *coldata.Vec, rowIdx int) string {
 	if col.Nulls().NullAt(rowIdx) {
 		return `NULL`
 	}


### PR DESCRIPTION
**coldata: make Vec a struct rather than an interface**

This commit makes it so that `Vec` interface that only has a single `memColumn` implementation becomes that implementation itself. It is mostly a mechanical change of `coldata.Vec` into `*coldata.Vec` (and the same for slices) as well of `coldata.NewMemColumn` into `coldata.NewVec`.

This allows us to remove the interface boxing as well as the interface dispatch.
```
name                                           old alloc/op   new alloc/op   delta
NewMemBatchWithCapacity/oneInt/len=1-24            208B ± 0%      200B ± 0%   -3.85%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/threeInts/len=1-24         480B ± 0%      456B ± 0%   -5.00%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allOnce/len=1-24         2.27kB ± 0%    2.19kB ± 0%   -3.52%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allThrice/len=1-24       6.68kB ± 0%    6.39kB ± 0%   -4.31%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/oneInt/len=32-24           700B ± 0%      692B ± 0%   -1.14%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/threeInts/len=32-24      1.48kB ± 0%    1.46kB ± 0%   -1.62%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allOnce/len=32-24        8.48kB ± 0%    8.40kB ± 0%   -0.94%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allThrice/len=32-24      24.8kB ± 0%    24.5kB ± 0%   -1.16%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/oneInt/len=1024-24       16.7kB ± 0%    16.7kB ± 0%   -0.05%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/threeInts/len=1024-24    33.6kB ± 0%    33.6kB ± 0%   -0.07%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allOnce/len=1024-24       204kB ± 0%     204kB ± 0%   -0.04%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allThrice/len=1024-24     581kB ± 0%     581kB ± 0%   -0.05%  (p=0.000 n=10+10)
```

**colexechash: remove some duplication by using generics**

We recently introduced some code duplication for `rehash` function to be able to handle both `uint32` and `uint64` out of performance considerations - we couldn't use generics because one argument to the function was an interface, which introduces another virtualization layer to the generic function. However, that argument was made concrete in the previous commit, so we can now utilize the generics to remove the code duplication without any performance hit.

Epic: None

Release note: None