### PR TITLE
workload/querybench: add custom query names and separators 

### DIFF
--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -124,7 +124,7 @@ func getNumQueriesInFile(filename, url string) (int, error) {
 		_ = os.Remove(tempFile.Name())
 	}()
 
-	queries, err := querybench.GetQueries(tempFile.Name())
+	queries, err := querybench.GetQueries(tempFile.Name(), "")
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -12,10 +12,11 @@ package querybench
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	gosql "database/sql"
-	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -29,10 +30,11 @@ type queryBench struct {
 	flags           workload.Flags
 	connFlags       *workload.ConnFlags
 	queryFile       string
+	separator       string
 	numRunsPerQuery int
 	verbose         bool
 
-	queries []string
+	stmts []namedStmt
 }
 
 func init() {
@@ -40,18 +42,33 @@ func init() {
 }
 
 var queryBenchMeta = workload.Meta{
-	Name: `querybench`,
-	Description: `QueryBench runs queries from the specified file. The queries are run ` +
-		`sequentially in each concurrent worker.`,
+	Name:        `querybench`,
+	Description: `QueryBench runs queries from the specified file.`,
+	Details: `
+Queries are run sequentially in each concurrent worker.
+
+The file should contain one query per line, or alternatively specify a query
+separator (e.g. ;) via --separator. Comments are specified with # or -- at the
+start of the line (with whitespace). Each query can be prefixed by a name and
+colon. For example:
+
+-- This is a comment.
+name: SELECT foo FROM bar
+
+# Another comment. The query name is optional.
+UPDATE bar SET foo = 'baz'
+`,
 	Version: `1.0.0`,
 	New: func() workload.Generator {
 		g := &queryBench{}
 		g.flags.FlagSet = pflag.NewFlagSet(`querybench`, pflag.ContinueOnError)
 		g.flags.Meta = map[string]workload.FlagMeta{
 			`query-file`: {RuntimeOnly: true},
+			`separator`:  {RuntimeOnly: true},
 			`num-runs`:   {RuntimeOnly: true},
 		}
 		g.flags.StringVar(&g.queryFile, `query-file`, ``, `File of newline separated queries to run`)
+		g.flags.StringVar(&g.separator, `separator`, ``, `String separating queries (defaults to newline)`)
 		g.flags.IntVar(&g.numRunsPerQuery, `num-runs`, 0, `Specifies the number of times each query in the query file to be run `+
 			`(note that --duration and --max-ops take precedence, so if duration or max-ops is reached, querybench will exit without honoring --num-runs)`)
 		g.flags.BoolVar(&g.verbose, `verbose`, true, `Prints out the queries being run as well as histograms`)
@@ -73,14 +90,14 @@ func (g *queryBench) Hooks() workload.Hooks {
 			if g.queryFile == "" {
 				return errors.Errorf("Missing required argument '--query-file'")
 			}
-			queries, err := GetQueries(g.queryFile)
+			stmts, err := GetQueries(g.queryFile, g.separator)
 			if err != nil {
 				return err
 			}
-			if len(queries) < 1 {
+			if len(stmts) < 1 {
 				return errors.New("no queries found in file")
 			}
-			g.queries = queries
+			g.stmts = stmts
 			if g.numRunsPerQuery < 0 {
 				return errors.New("negative --num-runs specified")
 			}
@@ -111,24 +128,16 @@ func (g *queryBench) Ops(
 	db.SetMaxOpenConns(g.connFlags.Concurrency + 1)
 	db.SetMaxIdleConns(g.connFlags.Concurrency + 1)
 
-	stmts := make([]namedStmt, len(g.queries))
-	for i, query := range g.queries {
-		stmts[i] = namedStmt{
-			// TODO(solon): Allow specifying names in the query file rather than using
-			// the entire query as the name.
-			name: fmt.Sprintf("%2d: %s", i+1, query),
+	stmts := g.stmts
+	for i := range stmts {
+		if prep, err := db.Prepare(stmts[i].query); err == nil {
+			stmts[i].preparedStmt = prep
 		}
-		stmt, err := db.Prepare(query)
-		if err != nil {
-			stmts[i].query = query
-			continue
-		}
-		stmts[i].preparedStmt = stmt
 	}
 
 	maxNumStmts := 0
 	if g.numRunsPerQuery > 0 {
-		maxNumStmts = g.numRunsPerQuery * len(g.queries)
+		maxNumStmts = g.numRunsPerQuery * len(stmts)
 	}
 
 	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
@@ -145,29 +154,56 @@ func (g *queryBench) Ops(
 	return ql, nil
 }
 
-// GetQueries returns the lines of a file as a string slice. Ignores lines
-// beginning with '#' or '--'.
-func GetQueries(path string) ([]string, error) {
+// GetQueries returns the queries in a file as a slice of named statements. If
+// no separator is given, splits by newlines.
+func GetQueries(path, separator string) ([]namedStmt, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
 
+	// reComments removes comments at start of line. Don't attempt to parse the
+	// query, just naïvely interpret # and -- as comments.
+	reComments := regexp.MustCompile(`(?m)^\s*(#|--).*`)
+
+	// reNamedQuery handles optional query names, e.g.:
+	// name: SELECT foo FROM bar
+	// If no name is given, the entire query is used as the name.
+	reNamedQuery := regexp.MustCompile(`(?s)^\s*(\S+):\s*(.*)$`)
+
+	// Scan queries up to 1 MB in size with the given separator.
 	scanner := bufio.NewScanner(file)
-	// Read lines up to 1 MB in size.
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	var lines []string
+	if separator := []byte(separator); len(separator) > 0 {
+		scanner.Split(func(data []byte, atEOF bool) (int, []byte, error) {
+			if i := bytes.Index(data, separator); i >= 0 {
+				return i + len(separator), data[0:i], nil
+			} else if atEOF && len(data) > 0 {
+				return len(data), data, nil
+			}
+			return 0, nil, nil
+		})
+	}
+
+	var stmts []namedStmt
 	for scanner.Scan() {
-		line := scanner.Text()
-		if len(line) > 0 && line[0] != '#' && !strings.HasPrefix(line, "--") {
-			lines = append(lines, line)
+		query := scanner.Text()
+		query = reComments.ReplaceAllLiteralString(query, ``)
+		query = strings.TrimSpace(query)
+
+		name := query
+		if m := reNamedQuery.FindStringSubmatch(query); m != nil {
+			name, query = m[1], m[2]
+		}
+		if len(query) > 0 {
+			stmts = append(stmts, namedStmt{
+				name:  name,
+				query: query,
+			})
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return lines, nil
+	return stmts, scanner.Err()
 }
 
 type namedStmt struct {


### PR DESCRIPTION
**workload/querybench: remove `vectorize` option**

This option has been enabled by default since 20.2.

**workload/querybench: add custom query names and separators**

This patch extends the `querybench` workload with support for custom query names and separators. This allows e.g. using multi-line queries separated by `;`, and giving them a terse name instead of outputting the entire query in the workload progress output.

Epic: none
Release note: None