### PR TITLE
kvstreamer: add non-negative float validation to a cluster setting

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/avg_response_estimator.go
+++ b/pkg/kv/kvclient/kvstreamer/avg_response_estimator.go
@@ -36,6 +36,7 @@ var streamerAvgResponseSizeMultiple = settings.RegisterFloatSetting(
 	"sql.distsql.streamer.avg_response_size_multiple",
 	"determines the multiple used when calculating the average response size by the streamer component",
 	defaultAvgResponseSizeMultiple,
+	settings.NonNegativeFloat,
 )
 
 func (e *avgResponseEstimator) init(sv *settings.Values) {


### PR DESCRIPTION
We forgot to add non-negative validation function to private `sql.distsql.streamer.avg_response_size_multiple` cluster setting. If this were set to a negative value, it would result in an undefined behavior of the streamer (we could try setting negative `TargetBytes` limit on `BatchRequest`s). I don't think anyone ever used it though so far.

Epic: None

Release note: None