### PR TITLE
liveness: remove one-time init fields from the mu lock

### DIFF
--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/tenantrate"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -494,6 +495,8 @@ type NodeLivenessTestingKnobs struct {
 	// StorePoolNodeLivenessFn is the function used by the StorePool to determine
 	// whether a node is live or not.
 	StorePoolNodeLivenessFn storepool.NodeLivenessFunc
+	// IsLiveCallback, will be called when a node becomes live.
+	IsLiveCallback liveness.IsLiveCallback
 }
 
 var _ base.ModuleTestingKnobs = NodeLivenessTestingKnobs{}

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -200,6 +200,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		RenewalDuration:         renewal,
 		Settings:                cfg.Settings,
 		HistogramWindowInterval: cfg.HistogramWindowInterval,
+		Engines:                 []storage.Engine{ltc.Eng},
 	})
 	storepool.TimeUntilStoreDead.Override(ctx, &cfg.Settings.SV, storepool.TestTimeUntilStoreDead)
 	cfg.StorePool = storepool.NewStorePool(
@@ -281,16 +282,16 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		t.Fatalf("unable to set node descriptor: %s", err)
 	}
 
-	if !ltc.DisableLivenessHeartbeat {
-		cfg.NodeLiveness.Start(ctx,
-			liveness.NodeLivenessStartOptions{Engines: []storage.Engine{ltc.Eng}})
-	}
-
 	if err := ltc.Store.Start(ctx, ltc.stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
 
 	ltc.Stores.AddStore(ltc.Store)
+
+	if !ltc.DisableLivenessHeartbeat {
+		cfg.NodeLiveness.Start(ctx)
+	}
+
 	ltc.Cfg = cfg
 }
 


### PR DESCRIPTION
Seperate out fields that don't need to be under the mu lock since they are initialized either prior or part of start.
This simplifies later PRs that refactor liveness.