### PR TITLE
backupccl: allow more restore workers for large nodes

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -278,10 +278,20 @@ func registerRestore(r registry.Registry) {
 			backup:   makeBackupSpecs(backupSpecs{cloud: spec.GCE}),
 			timeout:  1 * time.Hour,
 		},
+		// Benchmarks using a low memory per core ratio - we don't expect ideal
+		// performance but nodes should not OOM.
 		{
-			// Benchmarks using a low memory per core ratio - we don't expect ideal
-			// performance but nodes should not OOM.
 			hardware: makeHardwareSpecs(hardwareSpecs{mem: spec.Low}),
+			backup:   makeBackupSpecs(backupSpecs{cloud: spec.GCE}),
+			timeout:  1 * time.Hour,
+		},
+		{
+			hardware: makeHardwareSpecs(hardwareSpecs{cpus: 16, mem: spec.Low}),
+			backup:   makeBackupSpecs(backupSpecs{cloud: spec.GCE}),
+			timeout:  1 * time.Hour,
+		},
+		{
+			hardware: makeHardwareSpecs(hardwareSpecs{cpus: 32, mem: spec.Low}),
 			backup:   makeBackupSpecs(backupSpecs{cloud: spec.GCE}),
 			timeout:  1 * time.Hour,
 		},
@@ -675,7 +685,7 @@ func (rd *restoreDriver) prepareCluster(ctx context.Context) {
 
 	if rd.c.Spec().Cloud != rd.sp.backup.cloud {
 		// For now, only run the test on the cloud provider that also stores the backup.
-		rd.t.Skip("test configured to run on %s", rd.sp.backup.cloud)
+		rd.t.Skip("test configured to run on " + rd.sp.backup.cloud)
 	}
 
 	rd.c.Put(ctx, rd.t.Cockroach(), "./cockroach")


### PR DESCRIPTION
Currently we limit the number of restore workers per node to 4, for example: 1 core -> 1 worker
4 cores -> 3 workers
32 cores -> 4 workers
These numbers were picked when users had smaller nodes, and now 32 cores is a common size.

This pr allows up to 16 workers on large nodes, setting the number of workers on large nodes to be half of the cores, which is conservative, to avoid OOMs.

Also adding a couple of roachtests to verify restore on large nodes with low memory per core.

Epic: CRDB-20916
Fixes: #98015

Release note: None