### PR TITLE
release-22.2: build: fix `make` build

### DIFF
--- a/pkg/cmd/protoc-gen-gogoroach/main.go
+++ b/pkg/cmd/protoc-gen-gogoroach/main.go
@@ -35,6 +35,7 @@ func fixImports(s string) string {
 		}
 
 		line = strings.ReplaceAll(line, "github.com/cockroachdb/cockroach/pkg/etcd", "go.etcd.io/etcd")
+		line = strings.ReplaceAll(line, "github.com/cockroachdb/cockroach/pkg/go.etcd.io", "go.etcd.io")
 		line = strings.ReplaceAll(line, "github.com/cockroachdb/cockroach/pkg/errorspb", "github.com/cockroachdb/errors/errorspb")
 		line = strings.ReplaceAll(line, "golang.org/x/net/context", "context")
 		if builtinRegex.MatchString(line) {

--- a/pkg/ui/workspaces/cluster-ui/tsconfig.json
+++ b/pkg/ui/workspaces/cluster-ui/tsconfig.json
@@ -25,6 +25,9 @@
   "exclude": [
     "node_modules",
     "dist",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.stories.tsx",
     "**/*.test.*",
     ".jest"
   ]

--- a/pkg/ui/workspaces/db-console/tsconfig.json
+++ b/pkg/ui/workspaces/db-console/tsconfig.json
@@ -40,6 +40,9 @@
   },
   "exclude": [
     "cluster-ui",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.stories.tsx",
     "dist"
   ]
 }


### PR DESCRIPTION
The `make` build has regressed a bit on release-22.2. This is deprecated but still technically supported. We make some tweaks in the `Makefile` and the `tsconfig.json` files to keep it on life support.

Closes #101880.

Epic: none
Release note: None
Release justification: fix `make` build