### PR TITLE
roachtest: fix drain test's log searching

### DIFF
--- a/pkg/cmd/roachtest/tests/drain.go
+++ b/pkg/cmd/roachtest/tests/drain.go
@@ -135,7 +135,7 @@ func runEarlyExitInConnectionWait(ctx context.Context, t test.Test, c cluster.Cl
 			return err
 		}
 
-		expectedDrain := drainWaitDuration + connectionWaitDuration + queryWaitDuration*2 + leaseTransferWaitDuration + 10*time.Second
+		expectedDrain := drainWaitDuration + connectionWaitDuration + queryWaitDuration*2 + leaseTransferWaitDuration
 		if !strings.Contains(
 			results.Stderr,
 			fmt.Sprintf(


### PR DESCRIPTION
c4b6958ea04 changed how the --drain-wait calculation is done, so we must update the test to account for that.

fixes https://github.com/cockroachdb/cockroach/issues/103577
Release note: None