### PR TITLE
opt: fix bug in RejectNullsProject

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -969,3 +969,21 @@ SELECT (SELECT 2, 2) IN (SELECT x+1 FROM xy)
 # Outer scalar is a tuple with 2 elements. Subquery has 3 columns.
 query error pgcode 42601 subquery has too many columns
 SELECT (SELECT 2, 2) IN (SELECT x+1, y+1, x+y FROM xy)
+
+# Regression test for #100561.
+statement ok
+CREATE TABLE t100561a (a INT);
+CREATE TABLE t100561bc (b INT, c INT);
+INSERT INTO t100561bc (b) VALUES(1)
+
+# The query below should return a single row. Prior to the fix for #100561, no
+# rows were returned because the optimizer synthesized an incorrect
+# null-rejecting filter for column c.
+query IIII
+SELECT * FROM (
+  SELECT bc.c + 1 AS y, bc.b + 1 AS x
+  FROM t100561a a FULL OUTER JOIN t100561bc bc ON true
+) tmp, t100561bc bc
+WHERE tmp.x = bc.b + 1;
+----
+NULL  2  1  NULL

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -1293,3 +1293,29 @@ WITH RECURSIVE
 1
 2
 3
+
+# Regression test for #100561.
+statement ok
+CREATE TABLE t100561a (a INT);
+CREATE TABLE t100561b (k INT PRIMARY KEY, b INT);
+INSERT INTO t100561b VALUES (1, NULL)
+
+# Control: a query with a subquery.
+query II
+SELECT t3.c2, t3.c1 FROM (
+  SELECT t2.b AS c1, t2.k AS c2 FROM t100561a t1 FULL OUTER JOIN t100561b t2 ON true
+) AS t3, t100561b t2
+WHERE t3.c2 = t2.k
+----
+1  NULL
+
+# A query like the one above, rewritten with a CTE, should produce the same
+# result.
+query II
+WITH t3(c1, c2) AS (
+  SELECT t2.b AS c1, t2.k AS c2 FROM t100561a t1 FULL OUTER JOIN t100561b t2 ON true
+)
+SELECT t3.c2, t3.c1 FROM t3, t100561b t2
+WHERE t3.c2 = t2.k
+----
+1  NULL

--- a/pkg/sql/opt/norm/reject_nulls_funcs.go
+++ b/pkg/sql/opt/norm/reject_nulls_funcs.go
@@ -31,6 +31,9 @@ func (c *CustomFuncs) RejectNullCols(in memo.RelExpr) opt.ColSet {
 func (c *CustomFuncs) HasNullRejectingFilter(
 	filters memo.FiltersExpr, nullRejectCols opt.ColSet,
 ) bool {
+	if nullRejectCols.Empty() {
+		return false
+	}
 	for i := range filters {
 		constraints := filters[i].ScalarProps().Constraints
 		if constraints == nil {

--- a/pkg/sql/opt/norm/rules/reject_nulls.opt
+++ b/pkg/sql/opt/norm/rules/reject_nulls.opt
@@ -221,11 +221,13 @@
         ) &
         ^(ColsAreEmpty $rejectNullCols:(RejectNullCols $input))
     $filters:* &
-        (HasNullRejectingFilter
-            $filters
+        ^(ColsAreEmpty
             $nullRejectedCols:(IntersectionCols
-                $projectionCols
-                $rejectNullCols
+                (IntersectionCols
+                    $projectionCols
+                    $rejectNullCols
+                )
+                (GetNullRejectedCols $filters)
             )
         )
 )

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -1517,6 +1517,42 @@ project
       ├── x:7 * 2 [as="?column?":12, outer=(7), immutable]
       └── z:9 IS NULL [as="?column?":13, outer=(9)]
 
+# Case where the outer filter null-rejects one projected column, but not another
+# column.
+norm expect=RejectNullsProject
+SELECT * FROM (
+  SELECT xyz.z + 1 AS m, xyz.y + 1 AS n
+  FROM a FULL OUTER JOIN xyz ON true
+) tmp, xyz
+WHERE tmp.n = xyz.y
+----
+inner-join (hash)
+ ├── columns: m:12 n:13!null x:14!null y:15!null z:16
+ ├── immutable
+ ├── fd: (14)-->(15,16), (13)==(15), (15)==(13)
+ ├── project
+ │    ├── columns: m:12 n:13!null
+ │    ├── immutable
+ │    ├── left-join (cross)
+ │    │    ├── columns: y:8!null z:9
+ │    │    ├── select
+ │    │    │    ├── columns: y:8!null z:9
+ │    │    │    ├── scan xyz
+ │    │    │    │    └── columns: y:8 z:9
+ │    │    │    └── filters
+ │    │    │         └── y:8 IS NOT NULL [outer=(8), constraints=(/8: (/NULL - ]; tight)]
+ │    │    ├── scan a
+ │    │    └── filters (true)
+ │    └── projections
+ │         ├── z:9 + 1 [as=m:12, outer=(9), immutable]
+ │         └── y:8 + 1 [as=n:13, outer=(8), immutable]
+ ├── scan xyz
+ │    ├── columns: x:14!null y:15 z:16
+ │    ├── key: (14)
+ │    └── fd: (14)-->(15,16)
+ └── filters
+      └── n:13 = y:15 [outer=(13,15), constraints=(/13: (/NULL - ]; /15: (/NULL - ]), fd=(13)==(15), (15)==(13)]
+
 # No-op case because null-rejection is not requested for column k.
 norm expect-not=RejectNullsProject
 SELECT * FROM


### PR DESCRIPTION
#### opt: fix bug in RejectNullsProject

This commit fixes a bug in the `RejectNullsProject` rule that pushed
null-rejecting filters below a Project expression for _all_ projected
columns when _any_ of the projected columns had null-rejecting filters
above the projections. In other words, it could incorrectly synthesize a
null-rejecting filter for a projected column, causing incorrect results.

Fixes #100561

Release note (bug fix): A bug has been fixed that could cause queries
with with joins or subqueries to omit rows where column values are NULL
in very rare cases. This bug was present since v20.2.

#### opt: add fast-path to HasNullRejectingFilter

`HasNullRejectingFilter` now returns `false` immediately if the given
column set is empty, rather than unnecessarily extracting null columns
from filter constraints. This is valid because the function only returns
true if the given column set intersects with another column set, and the
empty set never intersects with any other set.

Release note: None
