### PR TITLE
util/parquet: refactor random testing types

### DIFF
--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -26,8 +26,8 @@ var (
 	// SeedTypes includes the following types that form the basis of randomly
 	// generated types:
 	//   - All scalar types, except UNKNOWN and ANY
-	//   - ARRAY of ANY, where the ANY will be replaced with one of the legal
-	//     array element types in RandType
+	//   - ARRAY of ANY and TUPLE of ANY, where the ANY will be replaced with
+	//     one of the legal array element types in RandType
 	//   - OIDVECTOR and INT2VECTOR types
 	SeedTypes []*types.T
 
@@ -126,24 +126,24 @@ func RandTypeFromSlice(rng *rand.Rand, typs []*types.T) *types.T {
 			return types.MakeArray(inner)
 		}
 		if typ.ArrayContents().Family() == types.TupleFamily {
-			// Generate tuples between 0 and 4 datums in length
-			len := rng.Intn(5)
-			contents := make([]*types.T, len)
-			for i := range contents {
-				contents[i] = RandTypeFromSlice(rng, typs)
-			}
-			return types.MakeArray(types.MakeTuple(contents))
+			return types.MakeArray(RandTupleFromSlice(rng, typs))
 		}
 	case types.TupleFamily:
-		// Generate tuples between 0 and 4 datums in length
-		len := rng.Intn(5)
-		contents := make([]*types.T, len)
-		for i := range contents {
-			contents[i] = RandTypeFromSlice(rng, typs)
-		}
-		return types.MakeTuple(contents)
+		return RandTupleFromSlice(rng, typs)
 	}
 	return typ
+}
+
+// RandTupleFromSlice returns a random tuple which has field chosen randomly
+// from the input slice of types.
+func RandTupleFromSlice(rng *rand.Rand, typs []*types.T) *types.T {
+	// Generate tuples between 0 and 4 datums in length
+	len := rng.Intn(5)
+	contents := make([]*types.T, len)
+	for i := range contents {
+		contents[i] = RandTypeFromSlice(rng, typs)
+	}
+	return types.MakeTuple(contents)
 }
 
 // RandColumnType returns a random type that is a legal column type (e.g. no


### PR DESCRIPTION
This change refactors randomized testing to use `randgen.RandType`. `randgen.RandType` is better as it takes into account all allowable types which can appear in CRDB (ex. array of tuple). The previous code only generated random types which are supported by the writer which leaves a gap when new types are added. Now, the code defaults to all types and filters out unsupported ones.

Informs: #99028
Epic: https://cockroachlabs.atlassian.net/browse/CRDB-15071
Release note: None