### PR TITLE
build: update to rules_go with experiment support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,12 +18,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "250e67034d87c48f5e6d62dde93ae435a996c8cd5708498047f5ee04dabbad91",
-    strip_prefix = "cockroachdb-rules_go-3bf3350",
+    sha256 = "d2b2e81ab44b46dc4c8f8ff6f82a6a3196118ee0c3f0c60bbaf2c7f38e8ca2ca",
+    strip_prefix = "cockroachdb-rules_go-1bc6b4a4",
     urls = [
-        # cockroachdb/rules_go as of 3bf3350c6c7dba353783bb8321f330eb6378bd44
+        # cockroachdb/rules_go as of 1bc6b4a4700d630ee556396217a00541ff3e5227 aka release-0.37-release-22.2
         # (upstream release-0.37 plus a few patches).
-        "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.27.0-241-g3bf3350.tar.gz",
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.37.0-1bc6b4a4.tar.gz",
     ],
 )
 

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -983,7 +983,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/bmatcuk-doublestar-v4.0.1-0-gf7a8118.tar.gz": "d11c3b3a45574f89d6a6b2f50e53feea50df60407b35f36193bf5815d32c79d1",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-protobuf-3f5d91f.tar.gz": "6d4e7fe1cbd958dee69ce9becbf8892d567f082b6782d3973a118d0aa00807a8",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_foreign_cc-6f7f1b1.tar.gz": "272ac2cde4efd316c8d7c0140dee411c89da104466701ac179286ef5a89c7b58",
-    "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.27.0-241-g3bf3350.tar.gz": "250e67034d87c48f5e6d62dde93ae435a996c8cd5708498047f5ee04dabbad91",
+    "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.37.0-1bc6b4a4.tar.gz": "d2b2e81ab44b46dc4c8f8ff6f82a6a3196118ee0c3f0c60bbaf2c7f38e8ca2ca",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_nodejs-5.5.0-1-g59a92cc.tar.gz": "7f3f747db3f924547b9ffdf86da6c604335ad95e09d4e5a69fdcfdb505099421",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/google-starlark-go-e043a3d.tar.gz": "a35c6468e0e0921833a63290161ff903295eaaf5915200bbce272cbc8dfd1c1c",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/googleapis-83c3605afb5a39952bf0a0809875d41cf2a558ca.zip": "ba694861340e792fd31cb77274eacaf6e4ca8bda97707898f41d8bebfd8a4984",


### PR DESCRIPTION
Previously, the rules_go version didn't support Go's "experiment" feature. Some of our users would like to use this, but it's not available in the rules_go version we use for 22.2.

This PR updates the rules_go version to use a version with 2 cherry picks to enable `experiments = ["boringcrypto"],` style argument to the `go_sdk` and friends.

Epic: none
Release note: None