### PR TITLE
sql, util: update CapturedIndexUsageStats payload

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2724,6 +2724,15 @@ An event of type `captured_index_usage_stats`
 | `IsInverted` | IsInverted indicates if the index is an inverted index. | no |
 | `CreatedAt` | CreatedAt is the timestamp at which the index was created. | no |
 | `SchemaName` | SchemaName is the name of the schema in which the index was created. | no |
+| `IsVisible` | IsVisible indicates whether the index is visible or not. | no |
+| `IsSharded` | IsSharded indicates whether the index is sharded or not. | no |
+| `ShardBucketCount` | ShardBucketCount indicates the number of shards the index is divided into. | no |
+| `TableDropTime` | DropTime is the timestamp at which the table was dropped. | no |
+| `TableModTime` | ModTime is the timestamp at which the table was last modified. | no |
+| `TableModTimeLogical` | ModTimeLogical is the unix nanos at which the table was last modified. | no |
+| `TableAuditMode` | AuditMode indicates if the table has audit logging set. | no |
+| `TableLocality` | Locality is the location associated with the table. | no |
+| `MVCCStats` | MVCCStats is a message containing replica stats related to a given table name. | yes |
 
 
 #### Common fields

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1669,7 +1669,7 @@ func (s *SQLServer) preStart(
 
 	scheduledlogging.Start(
 		ctx, stopper, s.execCfg.InternalDB, s.execCfg.Settings,
-		s.execCfg.CaptureIndexUsageStatsKnobs,
+		s.execCfg.CaptureIndexUsageStatsKnobs, s.execCfg.Codec, s.execCfg.TenantStatusServer.SpanStats,
 	)
 	s.execCfg.SyntheticPrivilegeCache.Start(ctx)
 

--- a/pkg/sql/scheduledlogging/BUILD.bazel
+++ b/pkg/sql/scheduledlogging/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/scheduledlogging",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/settings",

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -86,6 +87,8 @@ type CaptureIndexUsageStatsLoggingScheduler struct {
 	st                      *cluster.Settings
 	knobs                   *CaptureIndexUsageStatsTestingKnobs
 	currentCaptureStartTime time.Time
+	codec                   keys.SQLCodec
+	getSpanStats            func(context.Context, *roachpb.SpanStatsRequest) (*roachpb.SpanStatsResponse, error)
 }
 
 func (s *CaptureIndexUsageStatsLoggingScheduler) getLoggingDuration() time.Duration {
@@ -122,11 +125,15 @@ func Start(
 	db isql.DB,
 	cs *cluster.Settings,
 	knobs *CaptureIndexUsageStatsTestingKnobs,
+	codec keys.SQLCodec,
+	getSpanStats func(context.Context, *roachpb.SpanStatsRequest) (*roachpb.SpanStatsResponse, error),
 ) {
 	scheduler := CaptureIndexUsageStatsLoggingScheduler{
-		db:    db,
-		st:    cs,
-		knobs: knobs,
+		db:           db,
+		st:           cs,
+		knobs:        knobs,
+		codec:        codec,
+		getSpanStats: getSpanStats,
 	}
 	scheduler.start(ctx, stopper)
 }
@@ -147,7 +154,7 @@ func (s *CaptureIndexUsageStatsLoggingScheduler) start(ctx context.Context, stop
 					continue
 				}
 				s.currentCaptureStartTime = timeutil.Now()
-				err := captureIndexUsageStats(ctx, ie, stopper, telemetryCaptureIndexUsageStatsLoggingDelay.Get(&s.st.SV))
+				err := s.captureIndexUsageStats(ctx, ie, stopper, telemetryCaptureIndexUsageStatsLoggingDelay.Get(&s.st.SV))
 				if err != nil {
 					log.Warningf(ctx, "error capturing index usage stats: %+v", err)
 				}
@@ -166,7 +173,7 @@ func (s *CaptureIndexUsageStatsLoggingScheduler) start(ctx context.Context, stop
 	})
 }
 
-func captureIndexUsageStats(
+func (s *CaptureIndexUsageStatsLoggingScheduler) captureIndexUsageStats(
 	ctx context.Context, ie isql.Executor, stopper *stop.Stopper, loggingDelay time.Duration,
 ) error {
 	allDatabaseNames, err := getAllDatabaseNames(ctx, ie)
@@ -176,8 +183,9 @@ func captureIndexUsageStats(
 
 	// Capture index usage statistics for each database.
 	var ok bool
-	expectedNumDatums := 11
-	var allCapturedIndexUsageStats []logpb.EventPayload
+	expectedNumDatums := 19
+	var allCapturedIndexUsageStats []*eventpb.CapturedIndexUsageStats
+	var allStats []logpb.EventPayload
 	for _, databaseName := range allDatabaseNames {
 		// Omit index usage statistics on the default databases 'system',
 		// 'defaultdb', and 'postgres'.
@@ -196,12 +204,21 @@ func captureIndexUsageStats(
 		 total_reads,
 		 last_read,
 		 ti.created_at,
-		 ns.nspname::string
+		 ns.nspname::string,
+		 ti.is_visible,
+		 ti.is_sharded,
+		 ti.shard_bucket_count,
+		 t.drop_time,
+		 t.mod_time,
+		 t.mod_time_logical,
+		 t.audit_mode,
+		 t.locality
 		FROM crdb_internal.index_usage_statistics AS us
     JOIN crdb_internal.table_indexes AS ti ON us.index_id = ti.index_id
                                           AND us.table_id = ti.descriptor_id
     JOIN pg_catalog.pg_class AS c ON ti.descriptor_id = c.oid
     JOIN pg_catalog.pg_namespace AS ns ON ns.oid = c.relnamespace
+	JOIN crdb_internal.tables AS t ON ti.descriptor_id = t.table_id
 ORDER BY total_reads ASC`
 
 		it, err := ie.QueryIteratorEx(
@@ -218,6 +235,12 @@ ORDER BY total_reads ASC`
 			return err
 		}
 
+		type stashType struct {
+			span roachpb.Span
+			rows map[int]struct{}
+		}
+		rowsForIndexSpan := make(map[string]stashType)
+		rowIndex := 0
 		for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 			var row tree.Datums
 			if err != nil {
@@ -248,29 +271,114 @@ ORDER BY total_reads ASC`
 				createdAt = tree.MustBeDTimestamp(row[9]).Time
 			}
 			schemaName := tree.MustBeDString(row[10])
-
-			capturedIndexStats := &eventpb.CapturedIndexUsageStats{
-				TableID:        uint32(roachpb.TableID(tableID)),
-				IndexID:        uint32(roachpb.IndexID(indexID)),
-				TotalReadCount: uint64(totalReads),
-				LastRead:       lastRead.String(),
-				DatabaseName:   databaseName.String(),
-				TableName:      string(tableName),
-				IndexName:      string(indexName),
-				IndexType:      string(indexType),
-				IsUnique:       bool(isUnique),
-				IsInverted:     bool(isInverted),
-				CreatedAt:      createdAt.String(),
-				SchemaName:     string(schemaName),
+			isVisible := tree.MustBeDBool(row[11])
+			isSharded := tree.MustBeDBool(row[12])
+			shardBucketCount := 0
+			if row[13] != tree.DNull {
+				shardBucketCount = int(tree.MustBeDInt(row[13]))
+			}
+			dropTime := time.Time{}
+			if row[14] != tree.DNull {
+				dropTime = tree.MustBeDTimestamp(row[14]).Time
+			}
+			// ModTime can't be null.
+			modTime := tree.MustBeDTimestamp(row[15]).Time
+			modTimeLogical := tree.MustBeDDecimal(row[16]).Decimal
+			modTimeLogicalFloat, err := modTimeLogical.Float64()
+			if err != nil {
+				log.Infof(ctx, "Error retrieving float from decimal: %s ", err)
+			}
+			auditMode := tree.MustBeDString(row[17])
+			locality := ""
+			if row[18] != tree.DNull {
+				locality = string(tree.MustBeDString(row[18]))
 			}
 
+			capturedIndexStats := &eventpb.CapturedIndexUsageStats{
+				TableID:             uint32(roachpb.TableID(tableID)),
+				IndexID:             uint32(roachpb.IndexID(indexID)),
+				TotalReadCount:      uint64(totalReads),
+				LastRead:            lastRead.String(),
+				DatabaseName:        databaseName.String(),
+				TableName:           string(tableName),
+				IndexName:           string(indexName),
+				IndexType:           string(indexType),
+				IsUnique:            bool(isUnique),
+				IsInverted:          bool(isInverted),
+				CreatedAt:           createdAt.String(),
+				SchemaName:          string(schemaName),
+				IsVisible:           bool(isVisible),
+				IsSharded:           bool(isSharded),
+				ShardBucketCount:    int32(shardBucketCount),
+				TableDropTime:       dropTime.String(),
+				TableModTime:        modTime.String(),
+				TableModTimeLogical: float32(modTimeLogicalFloat),
+				TableAuditMode:      auditMode.String(),
+				TableLocality:       locality,
+			}
+
+			// Determine the span for the index. We'll use this span to
+			// query for MVCC statistics via SpanStats.
+			indexPrefix := s.codec.IndexPrefix(uint32(tableID), uint32(indexID))
+			indexSpan := roachpb.Span{
+				Key:    indexPrefix,
+				EndKey: indexPrefix.PrefixEnd(),
+			}
+			indexSpanString := indexSpan.String()
+
+			// In case multiple rows refer to the same table and index,
+			// we'll do the following:
+			// 1) Maintain a unique set of spans.
+			// 2) Associate a span back to the original row(s).
+			if _, ok := rowsForIndexSpan[indexSpanString]; !ok {
+				// This is the first time we've seen this span.
+				rowsForIndexSpan[indexSpanString] = stashType{
+					span: indexSpan,
+					rows: map[int]struct{}{rowIndex: {}},
+				}
+			} else {
+				// We've seen this span before.
+				rowsForIndexSpan[indexSpanString].rows[rowIndex] = struct{}{}
+			}
+
+			rowIndex++
 			allCapturedIndexUsageStats = append(allCapturedIndexUsageStats, capturedIndexStats)
 		}
+
+		// Now that we've finished iterating, we can do a batched
+		// SpanStats request with the spans we've collected.
+		spans := make([]roachpb.Span, 0, len(rowsForIndexSpan))
+		for _, v := range rowsForIndexSpan {
+			spans = append(spans, v.span)
+		}
+
+		spanStatsRes, err := s.getSpanStats(ctx, &roachpb.SpanStatsRequest{
+			NodeID: "0", // Fan-out to all nodes.
+			Spans:  spans,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		// Assign the returned MVCC stats to the appropriate
+		// capturedUsageIndexStats entry.
+		for span, stats := range spanStatsRes.SpanToStats {
+			for rowIndex := range rowsForIndexSpan[span].rows {
+				allCapturedIndexUsageStats[rowIndex].MVCCStats = &stats.TotalStats
+			}
+		}
+
+		// LogEventsWithDelay expects a []logpb.EventPayload.
+		for _, usageStat := range allCapturedIndexUsageStats {
+			allStats = append(allStats, usageStat)
+		}
+
 		if err = it.Close(); err != nil {
 			return err
 		}
 	}
-	logutil.LogEventsWithDelay(ctx, allCapturedIndexUsageStats, stopper, loggingDelay)
+	logutil.LogEventsWithDelay(ctx, allStats, stopper, loggingDelay)
 	return nil
 }
 

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -270,6 +270,30 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 		require.Greater(t, actualDuration+timeBuffer, expectedDuration, "%v+%v <= %v", expectedDuration, actualDuration, timeBuffer)
 		previousTimestamp = currentTimestamp
 	}
+
+	// Verify we logged data in the message to telemetry by checking some of the fields that can't be null/empty.
+	for _, entry := range entries {
+		var payload struct {
+			TableID        int    `json:"TableID"`
+			IndexID        int    `json:"IndexID"`
+			CreatedAt      string `json:"CreatedAt"`
+			IsVisible      bool   `json:"IsVisible"`
+			TableModTime   string `json:"TableModTime"`
+			TableAuditMode string `json:"TableAUditMode"`
+			MVCCStats      struct {
+				LastUpdateNanos string `json:"lastUpdateNanos"`
+			}
+		}
+		err = json.Unmarshal([]byte(entry.Message), &payload)
+		require.NoError(t, err)
+		require.True(t, payload.TableID > 0)
+		require.True(t, payload.IndexID > 0)
+		require.True(t, payload.CreatedAt != "")
+		require.True(t, payload.IsVisible)
+		require.True(t, payload.TableModTime != "")
+		require.True(t, payload.TableAuditMode == "'DISABLED'")
+		require.True(t, payload.MVCCStats.LastUpdateNanos != "")
+	}
 }
 
 // checkNumTotalEntriesAndNumIndexEntries is a helper function that verifies that

--- a/pkg/util/log/eventpb/BUILD.bazel
+++ b/pkg/util/log/eventpb/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     args = ["-test.timeout=55s"],
     embed = [":eventpb"],
     deps = [
+        "//pkg/storage/enginepb",
         "//pkg/util/log/logpb",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//assert",
@@ -67,6 +68,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/catalog/descpb:descpb_proto",
+        "//pkg/storage/enginepb:enginepb_proto",
         "//pkg/util/log/logpb:logpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
     ],
@@ -80,6 +82,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/catalog/descpb",
+        "//pkg/storage/enginepb",
         "//pkg/util/log/logpb",
         "@com_github_gogo_protobuf//gogoproto",
     ],

--- a/pkg/util/log/eventpb/event_test.go
+++ b/pkg/util/log/eventpb/event_test.go
@@ -13,6 +13,7 @@ package eventpb
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/assert"
@@ -64,6 +65,10 @@ func TestEventJSON(t *testing.T) {
 		{
 			&StoreStats{Levels: []LevelStats{{Level: 0, NumFiles: 1}, {Level: 6, NumFiles: 2}}},
 			`"Levels":[{"Level":0,"NumFiles":1},{"Level":6,"NumFiles":2}]`,
+		},
+		{
+			&CapturedIndexUsageStats{TotalReadCount: 1, MVCCStats: &enginepb.MVCCStats{LiveBytes: 1, LiveCount: 1}},
+			`"TotalReadCount":1,"MVCCStats":{"liveBytes":"1","liveCount":"1"}`,
 		},
 	}
 

--- a/pkg/util/log/eventpb/eventpbgen/gen.go
+++ b/pkg/util/log/eventpb/eventpbgen/gen.go
@@ -387,7 +387,7 @@ func readInput(
 			switch typ {
 			case "google.protobuf.Timestamp":
 				typ = "timestamp"
-			case "cockroach.sql.sqlbase.Descriptor":
+			case "cockroach.sql.sqlbase.Descriptor", "cockroach.storage.enginepb.MVCCStats":
 				typ = "protobuf"
 			}
 

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -819,6 +819,92 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		b = append(b, '"')
 	}
 
+	if m.IsVisible {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IsVisible\":true"...)
+	}
+
+	if m.IsSharded {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IsSharded\":true"...)
+	}
+
+	if m.ShardBucketCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ShardBucketCount\":"...)
+		b = strconv.AppendInt(b, int64(m.ShardBucketCount), 10)
+	}
+
+	if m.TableDropTime != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableDropTime\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableDropTime)))
+		b = append(b, '"')
+	}
+
+	if m.TableModTime != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableModTime\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableModTime)))
+		b = append(b, '"')
+	}
+
+	if m.TableModTimeLogical != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableModTimeLogical\":"...)
+		b = strconv.AppendFloat(b, float64(m.TableModTimeLogical), 'f', -1, 32)
+	}
+
+	if m.TableAuditMode != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableAuditMode\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableAuditMode)))
+		b = append(b, '"')
+	}
+
+	if m.TableLocality != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableLocality\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableLocality)))
+		b = append(b, '"')
+	}
+
+	if m.MVCCStats != nil {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		jsonEncoder := jsonpb.Marshaler{}
+		if str, err := jsonEncoder.MarshalToString(m.MVCCStats); err == nil {
+			b = append(b, "\"MVCCStats\":"...)
+			b = append(b, []byte(str)...)
+		}
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -14,6 +14,7 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "sql/catalog/descpb/structured.proto";
+import "storage/enginepb/mvcc.proto";
 import "util/log/eventpb/events.proto";
 import "util/log/eventpb/sql_audit_events.proto";
 import "util/log/logpb/event.proto";
@@ -326,6 +327,33 @@ message CapturedIndexUsageStats {
 
   // SchemaName is the name of the schema in which the index was created.
   string schema_name = 13 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // IsVisible indicates whether the index is visible or not.
+  bool is_visible = 14 [(gogoproto.jsontag) = ",omitempty"];
+
+  // IsSharded indicates whether the index is sharded or not.
+  bool is_sharded = 15 [(gogoproto.jsontag) = ",omitempty"];
+
+  // ShardBucketCount indicates the number of shards the index is divided into.
+  int32 shard_bucket_count = 16 [(gogoproto.jsontag) = ",omitempty"];
+
+  // DropTime is the timestamp at which the table was dropped.
+  string table_drop_time = 17 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // ModTime is the timestamp at which the table was last modified.
+  string table_mod_time = 18 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // ModTimeLogical is the unix nanos at which the table was last modified.
+  float table_mod_time_logical = 19 [(gogoproto.jsontag) = ",omitempty"];
+
+  // AuditMode indicates if the table has audit logging set.
+  string table_audit_mode = 20 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // Locality is the location associated with the table.
+  string table_locality = 21 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  
+  // MVCCStats is a message containing replica stats related to a given table name.
+  cockroach.storage.enginepb.MVCCStats mvcc_stats = 22 [(gogoproto.customname) = "MVCCStats", (gogoproto.jsontag) = ",omitempty"];
 }
 
 // CreateChangefeed is an event for any CREATE CHANGEFEED query that


### PR DESCRIPTION
This PR adds the following fields to CapturedIndexUsageStats in order to be logged to the telemetry channel:
- is_visible
- is_sharded
- shard_bucket_count
- drop_time
- mod_time
- mod_time_logical
- audit_mode
- locality
- mvcc_stats mvcc_stats defines mvcc stats related to the table id and index id retrieved in the CapturedIndexUsageStats query. The stats are defined in storage/enginepb/mvcc.proto.

Fixes: #85411, #92170


This PR is a follow up to the work done in #98172.  It replaces the previous implementation of a SpanStats invocation per descriptor to a single batched invocation.

cc @Santamaura 


Release note: None

