### PR TITLE
server: skip TestStatusEngineStatsJson

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -262,6 +262,7 @@ func TestStatusGossipJson(t *testing.T) {
 // stats contains the required fields.
 func TestStatusEngineStatsJson(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 99261, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	dir, cleanupFn := testutils.TempDir(t)


### PR DESCRIPTION
Refs: #99261

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes
Release note: None
Epic: None