### PR TITLE
ccl/sqlproxyccl: fix flake on TestWatchTenants

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -414,6 +414,7 @@ func TestPrivateEndpointsACL(t *testing.T) {
 					time.Second, 5*time.Millisecond,
 					"Expected the connection to eventually fail",
 				)
+				require.Error(t, err)
 				require.Regexp(t, "connection reset by peer|unexpected EOF", err.Error())
 				require.Equal(t, int64(1), s.metrics.ExpiredClientConnCount.Count())
 			},
@@ -1203,6 +1204,7 @@ func TestDenylistUpdate(t *testing.T) {
 		time.Second, 5*time.Millisecond,
 		"Expected the connection to eventually fail",
 	)
+	require.Error(t, err)
 	require.Regexp(t, "closed|bad connection", err.Error())
 	require.Equal(t, int64(1), s.metrics.ExpiredClientConnCount.Count())
 }

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -204,12 +204,13 @@ func TestWatchTenants(t *testing.T) {
 		if tds.WatchTenantsListenersCount() != 0 {
 			return errors.New("watchers have not been removed yet")
 		}
+
+		// Make sure watcher has attempted to restart, and invalidates entries.
+		if _, err := dir.LookupTenant(ctx, tenant10); err == nil {
+			return errors.New("entries have not been invalidated")
+		}
 		return nil
 	})
-
-	// Entry was invalidated.
-	_, err = dir.LookupTenant(ctx, tenant10)
-	require.Regexp(t, "directory server has not been started", err.Error())
 
 	// Trigger events, which will be missed by the tenant watcher.
 	tds.DeleteTenant(tenant10)


### PR DESCRIPTION
Fixes #103494.

This commit fixes a flake on TestWatchTenants. There's a possibility where the cache invalidation logic races with the watcher termination logic in the test. This commit updates the test to wait for the cache invalidation before proceeding.

Release note: None

Epic: none