### PR TITLE
c2c: clean up job termination

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -328,7 +328,7 @@ func TestTenantStreamingCancelIngestion(t *testing.T) {
 
 		c.DestSysSQL.Exec(t, fmt.Sprintf("CANCEL JOB %d", ingestionJobID))
 		jobutils.WaitForJobToCancel(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
-		jobutils.WaitForJobToCancel(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
+		jobutils.WaitForJobToFail(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 
 		// Check if the producer job has released protected timestamp.
 		stats := replicationutils.TestingGetStreamIngestionStatsFromReplicationJob(t, ctx, c.DestSysSQL, ingestionJobID)
@@ -398,7 +398,7 @@ func TestTenantStreamingDropTenantCancelsStream(t *testing.T) {
 		c.DestSysSQL.Exec(t, "ALTER RANGE tenants CONFIGURE ZONE USING gc.ttlseconds = 1;")
 		c.DestSysSQL.Exec(t, fmt.Sprintf("DROP TENANT %s", c.Args.DestTenantName))
 		jobutils.WaitForJobToCancel(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
-		jobutils.WaitForJobToCancel(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
+		jobutils.WaitForJobToFail(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 
 		// Check if the producer job has released protected timestamp.
 		stats := replicationutils.TestingGetStreamIngestionStatsFromReplicationJob(t, ctx, c.DestSysSQL, ingestionJobID)
@@ -807,7 +807,7 @@ func TestTenantReplicationProtectedTimestampManagement(t *testing.T) {
 
 		if !completeReplication {
 			jobutils.WaitForJobToCancel(c.T, c.DestSysSQL, jobspb.JobID(replicationJobID))
-			jobutils.WaitForJobToCancel(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
+			jobutils.WaitForJobToFail(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 		}
 
 		// Check if the producer job has released protected timestamp.

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -605,7 +605,7 @@ func TestCompleteStreamReplication(t *testing.T) {
 		if successfulIngestion {
 			jobutils.WaitForJobToSucceed(t, h.SysSQL, jobspb.JobID(streamID))
 		} else {
-			jobutils.WaitForJobToCancel(t, h.SysSQL, jobspb.JobID(streamID))
+			jobutils.WaitForJobToFail(t, h.SysSQL, jobspb.JobID(streamID))
 		}
 		// Verify protected timestamp record gets released.
 		jr := h.SysServer.JobRegistry().(*jobs.Registry)


### PR DESCRIPTION
This patch changes the Resume() function of the producer and consumer jobs to return an error if the jobs do not complete successfully. This prevents the job state machine from inadvertently entering the `succeeded` state. Note that all consumer job errors are marked as Pausable, ensuring the consumer job still pauses on error. Also note that if the consumer job fails or cancels, the producer job now fails instead of cancels.

This patch also cleans up a few log and error messages.

Fixes #103513, #103512

Release note: None