### PR TITLE
bulk,mon,rangefeed: add a thread safe BoundAccount object

### DIFF
--- a/pkg/ccl/backupccl/backuputils/BUILD.bazel
+++ b/pkg/ccl/backupccl/backuputils/BUILD.bazel
@@ -30,7 +30,6 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/mon",
         "//pkg/util/quotapool",
-        "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/backupccl/backuputils/memory_backed_quota_pool_test.go
+++ b/pkg/ccl/backupccl/backuputils/memory_backed_quota_pool_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -135,8 +134,7 @@ func TestMemoryBackedQuotaPoolConcurrent(t *testing.T) {
 				nil, nil, 1, 0,
 				cluster.MakeTestingClusterSettings())
 			mm.Start(ctx, nil, mon.NewStandaloneBudget(quota))
-			mem := mm.MakeBoundAccount()
-			mem.Mu = &syncutil.Mutex{}
+			mem := mm.MakeConcurrentBoundAccount()
 
 			qp := NewMemoryBackedQuotaPool(ctx, mm, "test-qp", quota)
 			res := make(chan error, numGoroutines)

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -587,7 +587,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 			// TODO(rui): we can change this to the processor's bound account, but
 			// currently there seems to be some accounting errors that will cause
 			// tests to fail.
-			rd.flowCtx.Cfg.BackupMonitor.MakeBoundAccount(),
+			rd.flowCtx.Cfg.BackupMonitor.MakeConcurrentBoundAccount(),
 			rd.flowCtx.Cfg.BulkSenderLimiter,
 		)
 		if err != nil {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -305,7 +305,7 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 	rc := sip.FlowCtx.Cfg.RangeCache
 	var err error
 	sip.batcher, err = bulk.MakeStreamSSTBatcher(
-		ctx, db.KV(), rc, evalCtx.Settings, sip.flowCtx.Cfg.BackupMonitor.MakeBoundAccount(),
+		ctx, db.KV(), rc, evalCtx.Settings, sip.flowCtx.Cfg.BackupMonitor.MakeConcurrentBoundAccount(),
 		sip.flowCtx.Cfg.BulkSenderLimiter, func(batchSummary kvpb.BulkOpSummary) {
 			// OnFlush update the ingested logical and SST byte metrics.
 			sip.metrics.IngestedLogicalBytes.Inc(batchSummary.DataSize)

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -106,7 +105,7 @@ func MakeBulkAdder(
 			disallowShadowingBelow: opts.DisallowShadowingBelow,
 			batchTS:                opts.BatchTimestamp,
 			writeAtBatchTS:         opts.WriteAtBatchTimestamp,
-			mem:                    bulkMon.MakeBoundAccount(),
+			mem:                    bulkMon.MakeConcurrentBoundAccount(),
 			limiter:                sendLimiter,
 		},
 		timestamp:      timestamp,
@@ -125,7 +124,6 @@ func MakeBulkAdder(
 	b.sink.mu.onFlush = func(batchSummary kvpb.BulkOpSummary) {
 		b.curBufSummary.Add(batchSummary)
 	}
-	b.sink.mem.Mu = &syncutil.Mutex{}
 	// At minimum a bulk adder needs enough space to store a buffer of
 	// curBufferSize, and a subsequent SST of SSTSize in-memory. If the memory
 	// account is unable to reserve this minimum threshold we cannot continue.

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -101,7 +101,7 @@ type SSTBatcher struct {
 	db       *kv.DB
 	rc       *rangecache.RangeCache
 	settings *cluster.Settings
-	mem      mon.BoundAccount
+	mem      *mon.ConcurrentBoundAccount
 	limiter  limit.ConcurrentRequestLimiter
 
 	// disallowShadowingBelow is described on kvpb.AddSSTableRequest.
@@ -217,7 +217,7 @@ func MakeSSTBatcher(
 	disallowShadowingBelow hlc.Timestamp,
 	writeAtBatchTs bool,
 	scatterSplitRanges bool,
-	mem mon.BoundAccount,
+	mem *mon.ConcurrentBoundAccount,
 	sendLimiter limit.ConcurrentRequestLimiter,
 ) (*SSTBatcher, error) {
 	b := &SSTBatcher{
@@ -243,12 +243,10 @@ func MakeStreamSSTBatcher(
 	db *kv.DB,
 	rc *rangecache.RangeCache,
 	settings *cluster.Settings,
-	mem mon.BoundAccount,
+	mem *mon.ConcurrentBoundAccount,
 	sendLimiter limit.ConcurrentRequestLimiter,
 	onFlush func(summary kvpb.BulkOpSummary),
 ) (*SSTBatcher, error) {
-	// A mutex is needed because flushes on range boundaries can Grow and Shrink memory asynchronously.
-	mem.Mu = &syncutil.Mutex{}
 	b := &SSTBatcher{db: db, rc: rc, settings: settings, ingestAll: true, mem: mem, limiter: sendLimiter}
 	b.SetOnFlush(onFlush)
 	err := b.Reset(ctx)
@@ -263,7 +261,7 @@ func MakeTestingSSTBatcher(
 	settings *cluster.Settings,
 	skipDuplicates bool,
 	ingestAll bool,
-	mem mon.BoundAccount,
+	mem *mon.ConcurrentBoundAccount,
 	sendLimiter limit.ConcurrentRequestLimiter,
 ) (*SSTBatcher, error) {
 	b := &SSTBatcher{

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -199,7 +199,7 @@ func TestDuplicateHandling(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			b, err := bulk.MakeTestingSSTBatcher(ctx, kvDB, s.ClusterSettings(),
-				tc.skipDuplicates, tc.ingestAll, mem.MakeBoundAccount(), reqs)
+				tc.skipDuplicates, tc.ingestAll, mem.MakeConcurrentBoundAccount(), reqs)
 			require.NoError(t, err)
 			defer b.Close(ctx)
 			k := func(i int, ts int) storage.MVCCKey {

--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/util/retry",
         "//pkg/util/span",
         "//pkg/util/stop",
-        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -675,9 +675,7 @@ func (mm *BytesMonitor) Resource() Resource {
 // are used in CockroachDB.
 //
 // A normal BoundAccount is not safe for concurrent use by multiple goroutines,
-// however if the Mu field is set to a non-nil mutex, some methods such as Grow,
-// Shrink, and Resize calls will lock and unlock that mutex making them safe;
-// such methods are identified in their comments.
+// use ConcurrentBoundAccount if thread safety is needed.
 type BoundAccount struct {
 	used int64
 	// reserved is a small buffer to amortize the cost of growing an account. It
@@ -686,9 +684,82 @@ type BoundAccount struct {
 	mon      *BytesMonitor
 
 	earmark int64
+}
 
-	// Mu, if non-nil, is used in some methods such as Grow and Shrink.
-	Mu *syncutil.Mutex
+// ConcurrentBoundAccount is a thread safe wrapper around BoundAccount.
+type ConcurrentBoundAccount struct {
+	syncutil.Mutex
+	wrapped BoundAccount
+}
+
+// Used wraps BoundAccount.Used().
+func (c *ConcurrentBoundAccount) Used() int64 {
+	if c == nil {
+		return 0
+	}
+	c.Lock()
+	defer c.Unlock()
+	return c.wrapped.Used()
+}
+
+// Reserve wraps BoundAccount.Reserve().
+func (c *ConcurrentBoundAccount) Reserve(ctx context.Context, x int64) error {
+	if c == nil {
+		return nil
+	}
+	c.Lock()
+	defer c.Unlock()
+	return c.wrapped.Reserve(ctx, x)
+}
+
+// Close wraps BoundAccount.Close().
+func (c *ConcurrentBoundAccount) Close(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.Lock()
+	defer c.Unlock()
+	c.wrapped.Close(ctx)
+}
+
+// Resize wraps BoundAccount.Resize().
+func (c *ConcurrentBoundAccount) Resize(ctx context.Context, oldSz, newSz int64) error {
+	if c == nil {
+		return nil
+	}
+	c.Lock()
+	defer c.Unlock()
+	return c.wrapped.Resize(ctx, oldSz, newSz)
+}
+
+// ResizeTo wraps BoundAccount.ResizeTo().
+func (c *ConcurrentBoundAccount) ResizeTo(ctx context.Context, newSz int64) error {
+	if c == nil {
+		return nil
+	}
+	c.Lock()
+	defer c.Unlock()
+	return c.wrapped.ResizeTo(ctx, newSz)
+}
+
+// Grow wraps BoundAccount.Grow().
+func (c *ConcurrentBoundAccount) Grow(ctx context.Context, x int64) error {
+	if c == nil {
+		return nil
+	}
+	c.Lock()
+	defer c.Unlock()
+	return c.wrapped.Grow(ctx, x)
+}
+
+// Shrink wraps BoundAccount.Shrink().
+func (c *ConcurrentBoundAccount) Shrink(ctx context.Context, delta int64) {
+	if c == nil || delta == 0 {
+		return
+	}
+	c.Lock()
+	defer c.Unlock()
+	c.wrapped.Shrink(ctx, delta)
 }
 
 // NewStandaloneBudget creates a BoundAccount suitable for root monitors.
@@ -697,14 +768,9 @@ func NewStandaloneBudget(capacity int64) *BoundAccount {
 }
 
 // Used returns the number of bytes currently allocated through this account.
-// If Mu is set, it is safe for use by concurrent goroutines.
 func (b *BoundAccount) Used() int64 {
 	if b == nil {
 		return 0
-	}
-	if b.Mu != nil {
-		b.Mu.Lock()
-		defer b.Mu.Unlock()
 	}
 	return b.used
 }
@@ -728,6 +794,12 @@ func (b *BoundAccount) Allocated() int64 {
 // MakeBoundAccount creates a BoundAccount connected to the given monitor.
 func (mm *BytesMonitor) MakeBoundAccount() BoundAccount {
 	return BoundAccount{mon: mm}
+}
+
+// MakeConcurrentBoundAccount creates ConcurrentBoundAccount, which is a thread
+// safe wrapper around BoundAccount.
+func (mm *BytesMonitor) MakeConcurrentBoundAccount() *ConcurrentBoundAccount {
+	return &ConcurrentBoundAccount{wrapped: mm.MakeBoundAccount()}
 }
 
 // TransferAccount creates a new account with the budget
@@ -763,15 +835,9 @@ func (b *BoundAccount) Init(ctx context.Context, mon *BytesMonitor) {
 // reservation by use by future Grow() calls, and configuring the account to
 // consider that amount "earmarked" for this account, meaning that that Shrink()
 // calls will not release it back to the parent monitor.
-//
-// If Mu is set, it is safe for use by concurrent goroutines.
 func (b *BoundAccount) Reserve(ctx context.Context, x int64) error {
 	if b == nil {
 		return nil
-	}
-	if b.Mu != nil {
-		b.Mu.Lock()
-		defer b.Mu.Unlock()
 	}
 	minExtra := b.mon.roundSize(x)
 	if err := b.mon.reserveBytes(ctx, minExtra); err != nil {
@@ -839,15 +905,9 @@ func (b *BoundAccount) Close(ctx context.Context) {
 // If one is interested in specifying the new size of the account as a whole (as
 // opposed to resizing one object among many in the account), ResizeTo() should
 // be used.
-//
-// If Mu is set, it is safe for use by concurrent goroutines.
 func (b *BoundAccount) Resize(ctx context.Context, oldSz, newSz int64) error {
 	if b == nil {
 		return nil
-	}
-	if b.Mu != nil {
-		b.Mu.Lock()
-		defer b.Mu.Unlock()
 	}
 	delta := newSz - oldSz
 	switch {
@@ -860,15 +920,9 @@ func (b *BoundAccount) Resize(ctx context.Context, oldSz, newSz int64) error {
 }
 
 // ResizeTo resizes (grows or shrinks) the account to a specified size.
-//
-// If Mu is set, it is safe for use by concurrent goroutines.
 func (b *BoundAccount) ResizeTo(ctx context.Context, newSz int64) error {
 	if b == nil {
 		return nil
-	}
-	if b.Mu != nil {
-		b.Mu.Lock()
-		defer b.Mu.Unlock()
 	}
 	if newSz == b.used {
 		// Performance optimization to avoid an unnecessary dispatch.
@@ -878,15 +932,9 @@ func (b *BoundAccount) ResizeTo(ctx context.Context, newSz int64) error {
 }
 
 // Grow is an accessor for b.mon.GrowAccount.
-//
-// If Mu is set, it is safe for use by concurrent goroutines.
 func (b *BoundAccount) Grow(ctx context.Context, x int64) error {
 	if b == nil {
 		return nil
-	}
-	if b.Mu != nil {
-		b.Mu.Lock()
-		defer b.Mu.Unlock()
 	}
 	if b.reserved < x {
 		minExtra := b.mon.roundSize(x - b.reserved)
@@ -901,15 +949,9 @@ func (b *BoundAccount) Grow(ctx context.Context, x int64) error {
 }
 
 // Shrink releases part of the cumulated allocations by the specified size.
-//
-// If Mu is set, it is safe for use by concurrent goroutines.
 func (b *BoundAccount) Shrink(ctx context.Context, delta int64) {
 	if b == nil || delta == 0 {
 		return
-	}
-	if b.Mu != nil {
-		b.Mu.Lock()
-		defer b.Mu.Unlock()
 	}
 	if b.used < delta {
 		logcrash.ReportOrPanic(ctx, &b.mon.settings.SV,


### PR DESCRIPTION
Followup from #103537.

`BoundAccount` has an optional mutex which callers may forget to set. For example the `SSTBatcher` was `Grow`ing and `Shrink`ing from multiple goroutines without a mutex which produced errors.

This pr removes the optional mutex and instead adds a thread safe object `ConcurrentBoundAccount`.

Epic: none

Release note: None