### PR TITLE
release-22.2: sql: validate primary / secondary region localities at end of txn

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -68,7 +68,21 @@ RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' WITH skip_localities
 ----
 
 exec-sql
+ALTER DATABASE d SET PRIMARY REGION "eu-central-1";
+ALTER DATABASE d DROP REGION "us-east-1";
+ALTER DATABASE d DROP REGION "us-west-1";
+ALTER DATABASE d ADD REGION "eu-north-1";
+----
+
+exec-sql
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/' WITH skip_localities_check, new_db_name='d_new';
+----
+
+exec-sql
+ALTER DATABASE d_new SET PRIMARY REGION "eu-central-1";
+ALTER DATABASE d_new DROP REGION "us-east-1";
+ALTER DATABASE d_new DROP REGION "us-west-1";
+ALTER DATABASE d_new ADD REGION "eu-north-1";
 ----
 
 exec-sql

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -782,6 +782,10 @@ func (n *alterDatabasePrimaryRegionNode) switchPrimaryRegion(params runParams) e
 		return err
 	}
 
+	// Validate the final zone config at the end of the transaction, since
+	// we will not be validating localities right now.
+	*params.extendedEvalCtx.validateDbZoneConfig = true
+
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
@@ -790,7 +794,7 @@ func (n *alterDatabasePrimaryRegionNode) switchPrimaryRegion(params runParams) e
 		params.p.txn,
 		params.p.execCfg,
 		params.p.Descriptors(),
-		true, /* validateLocalities */
+		false, /* validateLocalities */
 	); err != nil {
 		return err
 	}
@@ -1833,6 +1837,8 @@ func (n *alterDatabaseSecondaryRegion) startExec(params runParams) error {
 	if err != nil {
 		return err
 	}
+
+	*params.extendedEvalCtx.validateDbZoneConfig = true
 
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(

--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "uncommitted_descriptors.go",
         "validate.go",
         "virtual_descriptors.go",
+        "zone_config_validator.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descs",
     visibility = ["//visibility:public"],

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -352,6 +352,18 @@ func (tc *Collection) GetUncommittedTables() (tables []catalog.TableDescriptor) 
 	return tables
 }
 
+// GetUncommittedDatabases returns all the databases updated or created in the
+// transaction.
+func (tc *Collection) GetUncommittedDatabases() (databases []catalog.DatabaseDescriptor) {
+	_ = tc.uncommitted.iterateUncommittedByID(func(desc catalog.Descriptor) error {
+		if database, ok := desc.(catalog.DatabaseDescriptor); ok {
+			databases = append(databases, database)
+		}
+		return nil
+	})
+	return databases
+}
+
 func newMutableSyntheticDescriptorAssertionError(id descpb.ID) error {
 	return errors.AssertionFailedf("attempted mutable access of synthetic descriptor %d", id)
 }

--- a/pkg/sql/catalog/descs/validate.go
+++ b/pkg/sql/catalog/descs/validate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/validate"
+	"github.com/cockroachdb/errors"
 )
 
 // Validate returns any descriptor validation errors after validating using the
@@ -47,7 +48,14 @@ func (tc *Collection) Validate(
 // descriptor set. We purposefully avoid using leased descriptors as those may
 // be one version behind, in which case it's possible (and legitimate) that
 // those are missing back-references which would cause validation to fail.
-func (tc *Collection) ValidateUncommittedDescriptors(ctx context.Context, txn *kv.Txn) (err error) {
+// Optionally, the zone config will be validated if validateZoneConfigs is
+// set to true.
+func (tc *Collection) ValidateUncommittedDescriptors(
+	ctx context.Context,
+	txn *kv.Txn,
+	validateZoneConfigs bool,
+	zoneConfigValidator ZoneConfigValidator,
+) (err error) {
 	if tc.skipValidationOnWrite || !ValidateOnWriteEnabled.Get(&tc.settings.SV) {
 		return nil
 	}
@@ -59,7 +67,27 @@ func (tc *Collection) ValidateUncommittedDescriptors(ctx context.Context, txn *k
 	if len(descs) == 0 {
 		return nil
 	}
-	return tc.Validate(ctx, txn, catalog.ValidationWriteTelemetry, validate.Write, descs...)
+	if err := tc.Validate(ctx, txn, catalog.ValidationWriteTelemetry, validate.Write, descs...); err != nil {
+		return err
+	}
+	// Next validate any zone configs that may have been modified
+	// in the descriptor set, only if this type of validation is required.
+	// We only do this type of validation if region configs are modified.
+	if validateZoneConfigs {
+		if zoneConfigValidator == nil {
+			return errors.AssertionFailedf("zone config validator is required to " +
+				"validate zone configs")
+		}
+		for _, desc := range descs {
+			switch t := desc.(type) {
+			case catalog.DatabaseDescriptor:
+				if err = zoneConfigValidator.ValidateDbZoneConfig(ctx, t); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (tc *Collection) newValidationDereferencer(txn *kv.Txn) validate.ValidationDereferencer {

--- a/pkg/sql/catalog/descs/zone_config_validator.go
+++ b/pkg/sql/catalog/descs/zone_config_validator.go
@@ -1,0 +1,22 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package descs
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+)
+
+// ZoneConfigValidator is used to validate zone configs
+type ZoneConfigValidator interface {
+	ValidateDbZoneConfig(ctx context.Context, db catalog.DatabaseDescriptor) error
+}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1359,6 +1359,9 @@ type connExecutor struct {
 		// comprising statements.
 		numRows int
 
+		// validateDbZoneConfig should the DB zone config on commit.
+		validateDbZoneConfig bool
+
 		// txnCounter keeps track of how many SQL txns have been open since
 		// the start of the session. This is used for logging, to
 		// distinguish statements that belong to separate SQL transactions.
@@ -1883,6 +1886,7 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) {
 			delete(ex.extraTxnState.schemaChangeJobRecords, k)
 		}
 		ex.extraTxnState.jobs.reset()
+		ex.extraTxnState.validateDbZoneConfig = false
 		ex.extraTxnState.schemaChangerState = &SchemaChangerState{
 			mode: ex.sessionData().NewSchemaChangerMode,
 		}
@@ -2979,9 +2983,9 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		TxnModesSetter:         ex,
 		Jobs:                   ex.extraTxnState.jobs,
 		SchemaChangeJobRecords: ex.extraTxnState.schemaChangeJobRecords,
-		statsProvider:          ex.server.sqlStats,
-		indexUsageStats:        ex.indexUsageStats,
-		statementPreparer:      ex,
+		validateDbZoneConfig:   &ex.extraTxnState.validateDbZoneConfig, statsProvider: ex.server.sqlStats,
+		indexUsageStats:   ex.indexUsageStats,
+		statementPreparer: ex,
 	}
 	evalCtx.copyFromExecCfg(ex.server.cfg)
 }

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -970,10 +970,12 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) error 
 		}
 	}
 
-	if err := ex.extraTxnState.descCollection.ValidateUncommittedDescriptors(ctx, ex.state.mu.txn); err != nil {
+	zoneConfigValidator := newZoneConfigValidator(ex.state.mu.txn,
+		ex.extraTxnState.descCollection,
+		ex.planner.execCfg)
+	if err := ex.extraTxnState.descCollection.ValidateUncommittedDescriptors(ctx, ex.state.mu.txn, ex.extraTxnState.validateDbZoneConfig, zoneConfigValidator); err != nil {
 		return err
 	}
-
 	if err := descs.CheckSpanCountLimit(
 		ctx,
 		ex.extraTxnState.descCollection,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -109,6 +109,9 @@ type extendedEvalContext struct {
 	SchemaChangerState *SchemaChangerState
 
 	statementPreparer statementPreparer
+
+	// validateDbZoneConfig should the DB zone config on commit.
+	validateDbZoneConfig *bool
 }
 
 // copyFromExecCfg copies relevant fields from an ExecutorConfig.

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -265,7 +265,10 @@ func (b *catalogChangeBatcher) DeleteZoneConfig(ctx context.Context, id descpb.I
 
 // ValidateAndRun implements the scexec.CatalogChangeBatcher interface.
 func (b *catalogChangeBatcher) ValidateAndRun(ctx context.Context) error {
-	if err := b.descsCollection.ValidateUncommittedDescriptors(ctx, b.txn); err != nil {
+	if err := b.descsCollection.ValidateUncommittedDescriptors(
+		ctx, b.txn,
+		false, /*validateZoneConfigs*/
+		nil /*zoneConfigValidator*/); err != nil {
 		return err
 	}
 	if err := b.txn.Run(ctx, b.batch); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #103362.

/cc @cockroachdb/release

---

Previously, if a database was restored with skip_localities, there was no way to modify this database to set the primary region since validation would kick in too early during the statement. This meant fixing the regions in a restored database was impossible if the primary region was no longer valid. To address this, this patch, delays locality validation till the end of the transaction.

Fixes: #103290

Release note (bug fix): SET PRIMARY REGION and SET SECONDARY REGION did not validate transactionally, which could prevent cleaning up removed regions after a restore.

Release justification: low-risk fix that addresses an issue that prevents skip_localities restores from being useful