### PR TITLE
release-23.1: sql: apply system privileges to crdb_internal contention tables

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -956,14 +956,23 @@ func (p *planner) HasViewActivityOrViewActivityRedactedRole(ctx context.Context)
 	} else if hasView {
 		return true, nil
 	}
-	if hasViewRedacted, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWACTIVITYREDACTED, p.User()); err != nil {
+	if hasView, err := p.HasRoleOption(ctx, roleoption.VIEWACTIVITY); err != nil {
+		return false, err
+	} else if hasView {
+		return true, nil
+	}
+	if hasViewRedacted, err := p.HasViewActivityRedacted(ctx); err != nil {
 		return false, err
 	} else if hasViewRedacted {
 		return true, nil
 	}
-	if hasView, err := p.HasRoleOption(ctx, roleoption.VIEWACTIVITY); err != nil {
+	return false, nil
+}
+
+func (p *planner) HasViewActivityRedacted(ctx context.Context) (bool, error) {
+	if hasViewRedacted, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWACTIVITYREDACTED, p.User()); err != nil {
 		return false, err
-	} else if hasView {
+	} else if hasViewRedacted {
 		return true, nil
 	}
 	if hasViewRedacted, err := p.HasRoleOption(ctx, roleoption.VIEWACTIVITYREDACTED); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1328,3 +1328,57 @@ user root
 
 statement ok
 REVOKE SYSTEM MODIFYSQLCLUSTERSETTING FROM testuser
+
+# test privileges/roles for contention related tables
+user testuser
+
+statement error pq: user testuser does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege
+SELECT * FROM crdb_internal.node_contention_events
+
+statement error pq: user testuser does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege
+SELECT * FROM crdb_internal.transaction_contention_events
+
+statement error pq: user testuser does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege
+SELECT * FROM crdb_internal.cluster_locks
+
+user root
+
+statement ok
+GRANT SYSTEM VIEWACTIVITYREDACTED TO testuser
+
+user testuser
+
+query T
+SELECT key::STRING FROM crdb_internal.node_contention_events LIMIT 1
+----
+\x
+
+statement ok
+SELECT * FROM crdb_internal.transaction_contention_events
+
+statement ok
+SELECT * FROM crdb_internal.cluster_locks
+
+user root
+
+statement ok
+REVOKE SYSTEM VIEWACTIVITYREDACTED FROM testuser
+
+statement ok
+GRANT SYSTEM VIEWACTIVITY TO testuser
+
+user testuser
+
+statement ok
+SELECT * FROM crdb_internal.node_contention_events
+
+statement ok
+SELECT * FROM crdb_internal.transaction_contention_events
+
+statement ok
+SELECT * FROM crdb_internal.cluster_locks
+
+user root
+
+statement ok
+REVOKE SYSTEM VIEWACTIVITY FROM testuser


### PR DESCRIPTION
Backport 1/1 commits from #102293.

/cc @cockroachdb/release

---

This change makes it so that crdb_internal.transaction_contention_events, crdb_internal.node_contention_events and crdb_internal.cluster_locks redact keys should the user have `VIEWACTIVITYREDACTED` and in the case of node_contention_events check the user has any of `admin`, `VIEWACTIVITY` or `VIEWACTIVITYREDACTED` to use the table.

Fixes: #102130

Release note (sql change): crdb_internal.transaction_contention_events, crdb_internal.node_contention_events and crdb_internal.cluster_locks redact keys provided the user has `VIEWACTIVITYREDACTED`. crdb_internal.node_contention_events now can only be viewed if the user has any of `admin`, `VIEWACTIVITY` or `VIEWACTIVITYREDACTED`.

Release justification: low risk, high benefit changes to existing functionality.