### PR TITLE
demo,server: bump default --max-sql-memory from 128MiB to 256MiB

### DIFF
--- a/pkg/ccl/workloadccl/bench_test.go
+++ b/pkg/ccl/workloadccl/bench_test.go
@@ -35,7 +35,7 @@ func benchmarkImportFixture(b *testing.B, gen workload.Generator) {
 			b,
 			base.TestServerArgs{
 				UseDatabase:       `d`,
-				SQLMemoryPoolSize: 1 << 30, /* 1GiB */ // default 128MiB might be insufficient
+				SQLMemoryPoolSize: 1 << 30, /* 1GiB */ // default 256MiB might be insufficient
 			},
 		)
 		sqlDB := sqlutils.MakeSQLRunner(db)

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1345,7 +1345,7 @@ Maximum memory capacity available for each node to store temporary data for SQL
 clients, including prepared queries and intermediate data rows during query
 execution. Accepts numbers interpreted as bytes, size suffixes (e.g. 1GB and
 1GiB) or a percentage of physical memory (e.g. .25). If left unspecified,
-defaults to 128MiB.
+defaults to 256MiB.
 `,
 	}
 	DemoNodeCacheSize = FlagInfo{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -629,8 +629,8 @@ var demoCtx = struct {
 // test that exercises command-line parsing.
 func setDemoContextDefaults() {
 	demoCtx.NumNodes = 1
-	demoCtx.SQLPoolMemorySize = 128 << 20 // 128MB, chosen to fit 9 nodes on 2GB machine.
-	demoCtx.CacheSize = 64 << 20          // 64MB, chosen to fit 9 nodes on 2GB machine.
+	demoCtx.SQLPoolMemorySize = 256 << 20 // 256MiB, chosen to fit 9 nodes on 4GB machine.
+	demoCtx.CacheSize = 64 << 20          // 64MiB, chosen to fit 9 nodes on 4GB machine.
 	demoCtx.UseEmptyDatabase = false
 	demoCtx.SimulateLatency = false
 	demoCtx.RunWorkload = false

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -39,8 +39,8 @@ import (
 func newDemoCtx() *Context {
 	return &Context{
 		NumNodes:            1,
-		SQLPoolMemorySize:   128 << 20, // 128MB, chosen to fit 9 nodes on 2GB machine.
-		CacheSize:           64 << 20,  // 64MB, chosen to fit 9 nodes on 2GB machine.
+		SQLPoolMemorySize:   256 << 20, // 256MiB, chosen to fit 9 nodes on 4GB machine.
+		CacheSize:           64 << 20,  // 64MiB, chosen to fit 9 nodes on 4GB machine.
 		DefaultKeySize:      1024,
 		DefaultCALifetime:   24 * time.Hour,
 		DefaultCertLifetime: 2 * time.Hour,

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -55,14 +55,14 @@ import (
 
 // Context defaults.
 const (
-	// DefaultCacheSize is the default size of the RocksDB and Pebble caches. We
-	// default the cache size and SQL memory pool size to 128 MiB. Larger values
+	// DefaultCacheSize is the default size of the Pebble cache. We default the
+	// cache size to 128MiB and SQL memory pool size to 256 MiB. Larger values
 	// might provide significantly better performance, but we're not sure what
 	// type of system we're running on (development or production or some shared
 	// environment). Production users should almost certainly override these
 	// settings and we'll warn in the logs about doing so.
-	DefaultCacheSize         = 128 << 20 // 128 MB
-	defaultSQLMemoryPoolSize = 128 << 20 // 128 MB
+	DefaultCacheSize         = 128 << 20 // 128 MiB
+	defaultSQLMemoryPoolSize = 256 << 20 // 256 MiB
 	defaultScanInterval      = 10 * time.Minute
 	defaultScanMinIdleTime   = 10 * time.Millisecond
 	defaultScanMaxIdleTime   = 1 * time.Second

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1323,11 +1323,7 @@ func (t *logicTest) newCluster(
 	// it installs detects a transaction that doesn't have
 	// modifiedSystemConfigSpan set even though it should, for
 	// "testdata/rename_table". Figure out what's up with that.
-	if serverArgs.MaxSQLMemoryLimit == 0 {
-		// Specify a fixed memory limit (some test cases verify OOM conditions;
-		// we don't want those to take long on large machines).
-		serverArgs.MaxSQLMemoryLimit = 256 * 1024 * 1024
-	}
+
 	// We have some queries that bump into 100MB default temp storage limit
 	// when run with fakedist-disk config, so we'll use a larger limit here.
 	// There isn't really a downside to doing so.
@@ -4004,7 +4000,7 @@ var logicTestsConfigFilter = envutil.EnvOrDefaultString("COCKROACH_LOGIC_TESTS_C
 // want to specify for the test clusters to be created with.
 type TestServerArgs struct {
 	// MaxSQLMemoryLimit determines the value of --max-sql-memory startup
-	// argument for the server. If unset, then the default limit of 192MiB will
+	// argument for the server. If unset, then the default limit of 256MiB will
 	// be used.
 	MaxSQLMemoryLimit int64
 	// If set, mutations.MaxBatchSize, row.getKVBatchSize, and other values


### PR DESCRIPTION
This commit increases the default value that we use for `--max-sql-memory` parameter from 128MiB to 256MiB for the `demo` command as well as the testing servers (on the main production code path we use 25% of RAM by default, so it's unaffected). The rationale for this change is that over time we put more memory accounting in place, so we now need less headroom for the unaccounted stuff. An additional argument is that we're now occasionally hitting the too-low 128MiB limit in some cases on internal operations that make tests and `demo` experience less than ideal.

Epic: None

Release note (ops change): The default value for `--max-sql-memory` parameter of `demo` command has been increased from 128MiB to 256MiB.