### PR TITLE
sql: prevent panic when reading annotation in COPY TO

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2887,7 +2887,7 @@ func (ex *connExecutor) setCopyLoggingFields(stmt statements.Statement[tree.Stat
 	ex.planner.stmt = Statement{
 		Statement: stmt,
 	}
-	ann := tree.MakeAnnotations(0)
+	ann := tree.MakeAnnotations(stmt.NumAnnotations)
 	ex.planner.extendedEvalCtx.Context.Annotations = &ann
 	ex.planner.extendedEvalCtx.Context.Placeholders = &tree.PlaceholderInfo{}
 	ex.planner.curPlan.init(&ex.planner.stmt, &ex.planner.instrumentation)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/103541

Release note (bug fix): Fixed a panic that could occur if a COPY TO statement that had a subquery was logged with redaction markers.