### PR TITLE
release-22.2: sql: apply system privileges to crdb_internal contention tables

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2336,7 +2336,7 @@ var crdbInternalLocalContentionEventsTable = virtualSchemaTable{
 		if err != nil {
 			return err
 		}
-		return populateContentionEventsTable(ctx, addRow, response)
+		return populateContentionEventsTable(ctx, p, addRow, response)
 	},
 }
 
@@ -2350,15 +2350,36 @@ var crdbInternalClusterContentionEventsTable = virtualSchemaTable{
 		if err != nil {
 			return err
 		}
-		return populateContentionEventsTable(ctx, addRow, response)
+		return populateContentionEventsTable(ctx, p, addRow, response)
 	},
 }
 
 func populateContentionEventsTable(
 	ctx context.Context,
+	p *planner,
 	addRow func(...tree.Datum) error,
 	response *serverpb.ListContentionEventsResponse,
 ) error {
+	// Validate users have correct permission/role.
+	hasPermission, err := p.HasViewActivityOrViewActivityRedactedRole(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasPermission {
+		return noViewActivityOrViewActivityRedactedRoleError(p.User())
+	}
+	isAdmin, err := p.HasAdminRole(ctx)
+	if err != nil {
+		return err
+	}
+	var shouldRedactKey bool
+	if !isAdmin {
+		shouldRedactKey, err = p.HasViewActivityRedacted(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	key := tree.NewDBytes("")
 	for _, ice := range response.Events.IndexContentionEvents {
 		for _, skc := range ice.Events {
 			for _, stc := range skc.Txns {
@@ -2366,12 +2387,15 @@ func populateContentionEventsTable(
 					duration.MakeDuration(ice.CumulativeContentionTime.Nanoseconds(), 0 /* days */, 0 /* months */),
 					types.DefaultIntervalTypeMetadata,
 				)
+				if !shouldRedactKey {
+					key = tree.NewDBytes(tree.DBytes(skc.Key))
+				}
 				if err := addRow(
 					tree.NewDInt(tree.DInt(ice.TableID)),             // table_id
 					tree.NewDInt(tree.DInt(ice.IndexID)),             // index_id
 					tree.NewDInt(tree.DInt(ice.NumContentionEvents)), // num_contention_events
 					cumulativeContentionTime,                         // cumulative_contention_time
-					tree.NewDBytes(tree.DBytes(skc.Key)),             // key
+					key,                                              // key
 					tree.NewDUuid(tree.DUuid{UUID: stc.TxnID}),       // txn_id
 					tree.NewDInt(tree.DInt(stc.Count)),               // count
 				); err != nil {
@@ -2380,20 +2404,24 @@ func populateContentionEventsTable(
 			}
 		}
 	}
+	key = tree.NewDBytes("")
 	for _, nkc := range response.Events.NonSQLKeysContention {
 		for _, stc := range nkc.Txns {
 			cumulativeContentionTime := tree.NewDInterval(
 				duration.MakeDuration(nkc.CumulativeContentionTime.Nanoseconds(), 0 /* days */, 0 /* months */),
 				types.DefaultIntervalTypeMetadata,
 			)
+			if !shouldRedactKey {
+				key = tree.NewDBytes(tree.DBytes(nkc.Key))
+			}
 			if err := addRow(
 				tree.DNull, // table_id
 				tree.DNull, // index_id
 				tree.NewDInt(tree.DInt(nkc.NumContentionEvents)), // num_contention_events
 				cumulativeContentionTime,                         // cumulative_contention_time
-				tree.NewDBytes(tree.DBytes(nkc.Key)),             // key
-				tree.NewDUuid(tree.DUuid{UUID: stc.TxnID}),       // txn_id
-				tree.NewDInt(tree.DInt(stc.Count)),               // count
+				key,                                              // key
+				tree.NewDUuid(tree.DUuid{UUID: stc.TxnID}), // txn_id
+				tree.NewDInt(tree.DInt(stc.Count)),         // count
 			); err != nil {
 				return err
 			}
@@ -6201,7 +6229,7 @@ CREATE TABLE crdb_internal.transaction_contention_events (
 
 		shouldRedactContendingKey := false
 		if !isAdmin {
-			shouldRedactContendingKey, err = p.HasRoleOption(ctx, roleoption.VIEWACTIVITYREDACTED)
+			shouldRedactContendingKey, err = p.HasViewActivityRedacted(ctx)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -6356,7 +6384,7 @@ func genClusterLocksGenerator(
 		}
 		shouldRedactKeys := false
 		if !hasAdmin {
-			shouldRedactKeys, err = p.HasRoleOption(ctx, roleoption.VIEWACTIVITYREDACTED)
+			shouldRedactKeys, err = p.HasViewActivityRedacted(ctx)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1284,4 +1284,56 @@ user testuser
 
 awaitstatement sleepQuery
 
+# test privileges/roles for contention related tables
+user testuser
+
+statement error pq: user testuser does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege
+SELECT * FROM crdb_internal.node_contention_events
+
+statement error pq: user testuser does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege
+SELECT * FROM crdb_internal.transaction_contention_events
+
+statement error pq: user testuser does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege
+SELECT * FROM crdb_internal.cluster_locks
+
 user root
+
+statement ok
+GRANT SYSTEM VIEWACTIVITYREDACTED TO testuser
+
+user testuser
+
+query T
+SELECT key::STRING FROM crdb_internal.node_contention_events LIMIT 1
+----
+\x
+
+statement ok
+SELECT * FROM crdb_internal.transaction_contention_events
+
+statement ok
+SELECT * FROM crdb_internal.cluster_locks
+
+user root
+
+statement ok
+REVOKE SYSTEM VIEWACTIVITYREDACTED FROM testuser
+
+statement ok
+GRANT SYSTEM VIEWACTIVITY TO testuser
+
+user testuser
+
+statement ok
+SELECT * FROM crdb_internal.node_contention_events
+
+statement ok
+SELECT * FROM crdb_internal.transaction_contention_events
+
+statement ok
+SELECT * FROM crdb_internal.cluster_locks
+
+user root
+
+statement ok
+REVOKE SYSTEM VIEWACTIVITY FROM testuser


### PR DESCRIPTION
Backport 1/1 commits from #102293.

/cc @cockroachdb/release

---

This change makes it so that crdb_internal.transaction_contention_events, crdb_internal.node_contention_events and crdb_internal.cluster_locks redact keys should the user have `VIEWACTIVITYREDACTED` and in the case of node_contention_events check the user has any of `admin`, `VIEWACTIVITY` or `VIEWACTIVITYREDACTED` to use the table.

Fixes: #102130

Release note (sql change): crdb_internal.transaction_contention_events, crdb_internal.node_contention_events and crdb_internal.cluster_locks redact keys provided the user has `VIEWACTIVITYREDACTED`. crdb_internal.node_contention_events now can only be viewed if the user has any of `admin`, `VIEWACTIVITY` or `VIEWACTIVITYREDACTED`.

Release justification: low risk, high benefit changes to
existing functionality.
