### PR TITLE
release-22.2: builtins: don't panic on placeholders in with_min_timestamp(to_timestamp($1))

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -332,3 +332,6 @@ PREPARE placeholder_min_timestamp_stmt AS SELECT * FROM t AS OF SYSTEM TIME with
 
 statement error expected interval argument for max_staleness
 PREPARE placeholder_bounded_staleness_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_max_staleness($1)
+
+statement error expected float argument for to_timestamp
+PREPARE placeholder_with_min_timestamp_to_timestamp_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(to_timestamp($1))

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2608,17 +2608,21 @@ var regularBuiltins = map[string]builtinDefinition{
 			Types:      tree.ArgTypes{{"timestamp", types.Float}},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ts := float64(tree.MustBeDFloat(args[0]))
-				if math.IsNaN(ts) {
+				ts, ok := tree.AsDFloat(args[0])
+				if !ok {
+					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected float argument for to_timestamp")
+				}
+				fts := float64(*ts)
+				if math.IsNaN(fts) {
 					return nil, pgerror.New(pgcode.DatetimeFieldOverflow, "timestamp cannot be NaN")
 				}
-				if ts == math.Inf(1) {
+				if fts == math.Inf(1) {
 					return tree.MakeDTimestampTZ(pgdate.TimeInfinity, time.Microsecond)
 				}
-				if ts == math.Inf(-1) {
+				if fts == math.Inf(-1) {
 					return tree.MakeDTimestampTZ(pgdate.TimeNegativeInfinity, time.Microsecond)
 				}
-				return tree.MakeDTimestampTZ(timeutil.Unix(0, int64(ts*float64(time.Second))), time.Microsecond)
+				return tree.MakeDTimestampTZ(timeutil.Unix(0, int64(fts*float64(time.Second))), time.Microsecond)
 			},
 			Info:       "Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.",
 			Volatility: volatility.Immutable,

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -846,6 +846,20 @@ func MustBeDFloat(e Expr) DFloat {
 	panic(errors.AssertionFailedf("expected *DFloat, found %T", e))
 }
 
+// AsDFloat attempts to retrieve a DFloat from an Expr, returning a DFloat and
+// a flag signifying whether the assertion was successful. The function should
+// be used instead of direct type assertions wherever a *DFloat wrapped by a
+// *DOidWrapper is possible.
+func AsDFloat(e Expr) (*DFloat, bool) {
+	switch t := e.(type) {
+	case *DFloat:
+		return t, true
+	case *DOidWrapper:
+		return AsDFloat(t.Wrapped)
+	}
+	return nil, false
+}
+
 // NewDFloat is a helper routine to create a *DFloat initialized from its
 // argument.
 func NewDFloat(d DFloat) *DFloat {


### PR DESCRIPTION
Backport 1/1 commits from #103434.

/cc @cockroachdb/release

---

fixes #102741
fixes #103423

Release note (bug fix): Fixed a crash/panic that could occur if placeholder arguments were used with the with_min_timestamp(to_timestamp($1)) functions.

Release justification: Fix a crash caused by a panic.
