### PR TITLE
replicationtestutils: increase c2c timeout under stress

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/testutils",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/contextutil",


### PR DESCRIPTION
TestTenantStreamingMultipleNodes is flaky under stress, we can't get the first highwater within 45 seconds. Locally it's not reproducible even with a 20 seconds timeout.

This pr increases the timeout by 3x under stress.

Epic: none

Fixes: #103273

Release note: None