### PR TITLE
roachtest: get debug zip with --include-range-info

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1318,7 +1318,7 @@ func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger) error
 			// so this would only cause duplication.
 			excludeFiles := "*.log,*.txt,*.pprof"
 			cmd := fmt.Sprintf(
-				"%s debug zip --exclude-files='%s' --url {pgurl:%d} %s",
+				"%s debug zip --include-range-info --exclude-files='%s' --url {pgurl:%d} %s",
 				defaultCockroachPath, excludeFiles, i, zipName,
 			)
 			if err := c.RunE(ctx, c.Node(i), cmd); err != nil {


### PR DESCRIPTION
Noticed in https://github.com/cockroachdb/cockroach/issues/103552 that we are
missing the ranges.jsons, which is sad.

This flag is new as of https://github.com/cockroachdb/cockroach/pull/102289.

Epic: none
Release note: None
