### PR TITLE
roachtest: fix disk-stalled/* roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -160,15 +160,15 @@ func runDiskStalledDetection(
 		m.ExpectDeath()
 	}
 	s.Stall(ctx, c.Node(1))
-	{
-		// NB: We use a background context in the defer'ed unstall command,
-		// otherwise on test failure our c.Run calls will be ignored. Leaving
-		// the disk stalled will prevent artifact collection, making debugging
-		// difficult.
+	// NB: We use a background context in the defer'ed unstall command,
+	// otherwise on test failure our c.Run calls will be ignored. Leaving
+	// the disk stalled will prevent artifact collection, making debugging
+	// difficult.
+	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
-		defer s.Unstall(ctx, c.Node(1))
-	}
+		s.Unstall(ctx, c.Node(1))
+	}()
 
 	// Wait twice the maximum sync duration and check if our SQL connection to
 	// node 1 is still alive. It should've been terminated.


### PR DESCRIPTION
In #103198, I mistakenly constructed a context with a timeout outside the deferral, resulting in the defer'd Unstall always timing out if the remainder of test took longer than a minute.

Epic: None
Fixes: #103664.
Fixes: #103663.
Fixes: #103662.
Fixes: #103661.
Release note: none