### PR TITLE
base: set explicit small RPCHeartbeatInterval

### DIFF
--- a/pkg/testutils/base.go
+++ b/pkg/testutils/base.go
@@ -11,6 +11,8 @@
 package testutils
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/certnames"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -26,8 +28,9 @@ func NewNodeTestBaseContext() *base.Config {
 // NewTestBaseContext creates a secure base context for user.
 func NewTestBaseContext(user username.SQLUsername) *base.Config {
 	cfg := &base.Config{
-		Insecure: false,
-		User:     user,
+		Insecure:             false,
+		User:                 user,
+		RPCHeartbeatInterval: time.Millisecond,
 	}
 	FillCerts(cfg)
 	return cfg


### PR DESCRIPTION
Extracted from https://github.com/cockroachdb/cockroach/pull/99191.

----

The previous default, zero, effectively implied a tight loop of heartbeats.
This can't be good for race/stress builds, so add at least a little breath.

It's also just nice to explicitly see a value. The previous default of zero
was hard to spot.

Epic: None
Release note: None
