### PR TITLE
kvstreamer: allow debt when reservation is almost enough for response

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -381,6 +381,8 @@ func NewStreamer(
 		s:                      s,
 		txn:                    txn,
 		lockWaitPolicy:         lockWaitPolicy,
+		singleReqDebtAllowance: streamerSingleReqDebtThreshold.Get(&st.SV),
+		singleReqDebtRatio:     streamerSingleReqDebtRatio.Get(&st.SV),
 		requestAdmissionHeader: txn.AdmissionHeader(),
 		responseAdmissionQ:     txn.DB().SQLKVResponseAdmissionQ,
 	}
@@ -789,6 +791,9 @@ type workerCoordinator struct {
 
 	asyncSem *quotapool.IntPool
 
+	singleReqDebtAllowance int64
+	singleReqDebtRatio     float64
+
 	// For request and response admission control.
 	requestAdmissionHeader kvpb.AdmissionHeader
 	responseAdmissionQ     *admission.WorkQueue
@@ -1064,6 +1069,10 @@ func (w *workerCoordinator) issueRequestsForAsyncProcessing(
 		// responses (except in a degenerate case for head-of-the-line request
 		// that will get a very large single row in response which will exceed
 		// this limit).
+		// TODO(yuzefovich): in some cases the Streamer might be issuing
+		// requests too eagerly with small TargetBytes limits which results in
+		// many small BatchResponses. Instead, it should dynamically adjust its
+		// concurrency once it has better estimate of the average response size.
 		targetBytes := int64(len(singleRangeReqs.reqs)) * avgResponseSize
 		// Make sure that targetBytes is sufficient to receive non-empty
 		// response. Our estimate might be an under-estimate when responses vary
@@ -1079,9 +1088,6 @@ func (w *workerCoordinator) issueRequestsForAsyncProcessing(
 			// might reduce the TargetBytes limit. This is ok since our
 			// estimates are on the best effort basis, and we'll do precise
 			// accounting when we receive the BatchResponse.
-			// TODO(yuzefovich): consider not including all of the requests from
-			// singleRangeReqs.reqs into the BatchRequest in cases when we're
-			// low on the available budget.
 			if targetBytes > availableBudget {
 				// The estimate tells us that we don't have enough budget to
 				// receive non-empty responses for all requests in the
@@ -1089,6 +1095,9 @@ func (w *workerCoordinator) issueRequestsForAsyncProcessing(
 				// budget fully, we can still issue this BatchRequest with the
 				// truncated TargetBytes value hoping to receive non-empty
 				// results at least for some requests.
+				//
+				// Note that we have checked above that we have enough budget to
+				// receive a non-empty response (or we're the head of the line).
 				targetBytes = availableBudget
 				responsesOverhead = 0
 			} else {
@@ -1172,6 +1181,29 @@ func (w *workerCoordinator) asyncRequestCleanup(budgetMuAlreadyLocked bool) {
 	w.s.adjustNumRequestsInFlight(-1 /* delta */)
 	w.s.waitGroup.Done()
 }
+
+// streamerSingleReqDebtThreshold controls the "allowance" for a single-range
+// non-head-of-the-line request that it could go in debt for, above its
+// reservation, when in absolute terms the debt is small enough.
+var streamerSingleReqDebtThreshold = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
+	"kv.streamer.single_request_debt.threshold",
+	"absolute number (in bytes) that a single-range request could receive in debt",
+	256,
+	settings.NonNegativeInt,
+)
+
+// streamerSingleReqDebtRatio controls the "allowance" for a single-range
+// non-head-of-the-line request that it could go in debt for, above its
+// reservation, when in relative (to the response footprint) terms the debt is
+// small enough.
+var streamerSingleReqDebtRatio = settings.RegisterFloatSetting(
+	settings.TenantWritable,
+	"kv.streamer.single_request_debt.ratio",
+	"ratio of debt to response footprint that a single-range request could ask for",
+	0.03,
+	settings.NonNegativeFloat,
+)
 
 // AsyncRequestOp is the operation name (in tracing) of all requests issued by
 // the Streamer asynchronously.
@@ -1288,7 +1320,12 @@ func (w *workerCoordinator) performRequestAsync(
 				// There is an under-accounting at the moment, so we have to
 				// increase the memory reservation.
 				//
-				// This under-accounting can occur in a couple of edge cases:
+				// Most likely this is due to not having enough budget to
+				// account for TargetBytes as well as responsesOverhead and us
+				// prioritizing the former in issueRequestsForAsyncProcessing.
+				//
+				// Additionally, this under-accounting can occur in a couple of
+				// edge cases:
 				// 1) the estimate of the response sizes is pretty good (i.e.
 				// respOverestimate is around 0), but we received many partial
 				// responses with ResumeSpans that take up much more space than
@@ -1297,13 +1334,34 @@ func (w *workerCoordinator) performRequestAsync(
 				// headOfLine must be true (targetBytes might be 1 or higher,
 				// but not enough for that large row).
 				toConsume := -overaccountedTotal
-				if err = w.s.budget.consume(ctx, toConsume, headOfLine /* allowDebt */); err != nil {
+				allowDebt := headOfLine
+				if !headOfLine {
+					// We're allowing non-head-of-the-line request to go in debt
+					// in some cases in order to not waste the work we already
+					// did to process the current batch. In particular, if the
+					// under-accounting is small in absolute terms or relative
+					// to the memory footprint of the response, we're allowing
+					// debt here.
+					//
+					// Note that this "debt allowance" is only for the
+					// streamer's budget, and, thus, if the root SQL monitor is
+					// running close to the limit, this memory request will
+					// still be denied. In other words, the Streamer might
+					// exceed its workmem budget but will never put the root
+					// monitor in debt.
+					allowDebt = toConsume <= w.singleReqDebtAllowance ||
+						float64(toConsume)/float64(targetBytes) <= w.singleReqDebtRatio
+				}
+				if err = w.s.budget.consume(ctx, toConsume, allowDebt); err != nil {
+					// TODO(yuzefovich): introduce testing framework for the
+					// Streamer's batching behavior - how large responses it
+					// receives, how many are wasted (i.e. dropped), etc.
 					// TODO(yuzefovich): rather than dropping the response
 					// altogether, consider blocking to wait for the budget to
 					// open up, up to some limit.
 					atomic.AddInt64(&w.s.atomics.droppedBatchResponses, 1)
 					w.s.budget.release(ctx, targetBytes)
-					if !headOfLine {
+					if !allowDebt {
 						// Since this is not the head of the line, we'll just
 						// discard the result and add the request back to be
 						// served.


### PR DESCRIPTION
This commit improves the behavior of the Streamer when a single-range request's footprint happens barely exceed its reservation and the additional budget allocation is denied. In particular, previously if non-head-of-the-line request already received a response but it slightly exceeded its reservation, we would drop that response and would reissue it from scratch again. This commit, instead, allows for this request to "go in debt" if the debt happens to be small enough (in absolute terms or in relative terms in comparison to the response's footprint) (both of these things are controlled by newly introduced cluster settings). Note that this "going in debt" means that the Streamer might use more memory than its workmem allows for, but it'll never put the SQL root monitor above the limit, so this adjustment seems reasonable.

It's worth calling out the most likely case when this "going in debt" case occurs. I believe this is the case when we made the reservation large enough for TargetBytes limit but not for (at least not for the whole) "responses overhead" (introduced in 40d28a575696ba12d24dd4cba6becb75a4491fa9). In some cases I observed manually we could have a scenario where we received 3MiB worth of data in the response yet the "responses overhead" of 150B couldn't be "consumed", so we dropped the whole thing.

Epic: None

Release note: None