### PR TITLE
tracingpb: fix missing return in `Recording.SafeFormat()`

### DIFF
--- a/pkg/util/tracing/tracingpb/recording.go
+++ b/pkg/util/tracing/tracingpb/recording.go
@@ -146,6 +146,7 @@ func (r Recording) String() string {
 func (r Recording) SafeFormat(w redact.SafePrinter, _ rune) {
 	if len(r) == 0 {
 		w.SafeString("<empty recording>")
+		return
 	}
 
 	start := r[0].StartTime


### PR DESCRIPTION
This led to out of bounds panics, e.g.:

```
<empty recording>%!v(PANIC=SafeFormat method: runtime error: index out of range [0] with length 0)
```

Follows #103034.
Touches #103692.

Epic: none
Release note: None