### PR TITLE
sql: deflake schema_change_feature_flags test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags
@@ -260,13 +260,6 @@ COMMENT ON INDEX t1@i IS 'comment'
 statement error pq: feature COMMENT ON TABLE is part of the schema change category, which was disabled by the database administrator
 COMMENT ON TABLE t IS 'comment'
 
-# Reset feature flag to true so that test objects can be dropped.
-statement ok
-SET CLUSTER SETTING feature.schema_change.enabled = TRUE
-
-statement ok
-SET CLUSTER SETTING feature.schema_change.enabled = FALSE
-
 statement error pq: feature CREATE FUNCTION is part of the schema change category, which was disabled by the database administrator
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 
@@ -288,5 +281,6 @@ ALTER FUNCTION f() OWNER TO new_owner;
 statement error pq: feature ALTER FUNCTION is part of the schema change category, which was disabled by the database administrator
 ALTER FUNCTION f() SET SCHEMA new_schema;
 
+# Reset feature flag to true so that test objects can be dropped.
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = TRUE


### PR DESCRIPTION
We set the flag to true then false again before the test cases for FUNCTION. It's possible that the cluster setting is not propogated through fast enough and the feature gate does not take effect. This commit just removet the toggling seems it's not necessary.

Epic: None

Release note: None