### PR TITLE
keys: add pretty print for RangeGCHint key type

### DIFF
--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -121,6 +121,7 @@ var (
 		{name: "RangeStats", suffix: LocalRangeStatsLegacySuffix},
 		{name: "RangeGCThreshold", suffix: LocalRangeGCThresholdSuffix},
 		{name: "RangeVersion", suffix: LocalRangeVersionSuffix},
+		{name: "RangeGCHint", suffix: LocalRangeGCHintSuffix},
 	}
 
 	rangeSuffixDict = []struct {

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -248,6 +248,7 @@ func TestPrettyPrint(t *testing.T) {
 		{keys.RangePriorReadSummaryKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangePriorReadSummary", revertSupportUnknown},
 		{keys.RangeGCThresholdKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeGCThreshold", revertSupportUnknown},
 		{keys.RangeVersionKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeVersion", revertSupportUnknown},
+		{keys.RangeGCHintKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeGCHint", revertSupportUnknown},
 
 		{keys.RaftHardStateKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RaftHardState", revertSupportUnknown},
 		{keys.RangeTombstoneKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RangeTombstone", revertSupportUnknown},


### PR DESCRIPTION
This commit adds pretty print for RangeGCHint. Previously it was printed by raw value which is different from the rest of range local leys.

Epic: none

Release note: None