### PR TITLE
kvnemesis: update outdated signatures or repro.go

### DIFF
--- a/pkg/kv/kvnemesis/testdata/TestApplier/change-replicas
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/change-replicas
@@ -1,0 +1,3 @@
+echo
+----
+db0.AdminChangeReplicas(ctx, tk(1), getRangeDesc(ctx, tk(1), db0), kvpb.ReplicationChange{ChangeType: roachpb.ADD_VOTER, Target: roachpb.ReplicationTarget{NodeID: 1, StoreID: 1}}) // trying to add a voter to a store that already has a VOTER_FULL

--- a/pkg/kv/kvnemesis/testdata/TestApplier/split
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/split
@@ -1,3 +1,3 @@
 echo
 ----
-db1.AdminSplit(ctx, tk(2)) // <nil>
+db1.AdminSplit(ctx, tk(2), hlc.MaxTimestamp) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/split-again
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/split-again
@@ -1,3 +1,3 @@
 echo
 ----
-db1.AdminSplit(ctx, tk(2)) // context canceled
+db1.AdminSplit(ctx, tk(2), hlc.MaxTimestamp) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/transfer
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/transfer
@@ -1,3 +1,3 @@
 echo
 ----
-db1.TransferLeaseOperation(ctx, tk(6), 1) // <nil>
+db1.AdminTransferLease(ctx, tk(6), 1) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/transfer-again
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/transfer-again
@@ -1,3 +1,3 @@
 echo
 ----
-db0.TransferLeaseOperation(ctx, tk(6), 1) // context canceled
+db0.AdminTransferLease(ctx, tk(6), 1) // context canceled


### PR DESCRIPTION
Signatures for Split/Merge/LeaseTransfer were out of date in generated knvemesis code. This made repro.go non compilable. This PR fixes strings used to generate repro code for test failures.

Epic: none

Release note: None