### PR TITLE
log: add headers, compression config to http servers

### DIFF
--- a/docs/generated/logsinks.md
+++ b/docs/generated/logsinks.md
@@ -220,6 +220,8 @@ Type-specific configuration options:
 | `unsafe-tls` | enables certificate authentication to be bypassed. Defaults to false. Inherited from `http-defaults.unsafe-tls` if not specified. |
 | `timeout` | the HTTP timeout. Defaults to 0 for no timeout. Inherited from `http-defaults.timeout` if not specified. |
 | `disable-keep-alives` | causes the logging sink to re-establish a new connection for every outgoing log message. This option is intended for testing only and can cause excessive network overhead in production systems. Inherited from `http-defaults.disable-keep-alives` if not specified. |
+| `headers` | a list of headers to attach to each HTTP request Inherited from `http-defaults.headers` if not specified. |
+| `compression` | can be "none" or "gzip" to enable gzip compression. Set to "gzip" by default. Inherited from `http-defaults.compression` if not specified. |
 
 
 Configuration options shared across all sink types:

--- a/pkg/cli/log_flags_test.go
+++ b/pkg/cli/log_flags_test.go
@@ -53,6 +53,7 @@ func TestSetupLogging(t *testing.T) {
 		`unsafe-tls: false, ` +
 		`timeout: 0s, ` +
 		`disable-keep-alives: false, ` +
+		`compression: gzip, ` +
 		`filter: INFO, ` +
 		`format: json-compact, ` +
 		`redactable: true, ` +

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/util/encoding/encodingtype",
         "//pkg/util/envutil",
         "//pkg/util/fileutil",
+        "//pkg/util/httputil",
         "//pkg/util/jsonbytes",
         "//pkg/util/log/channel",
         "//pkg/util/log/logconfig",

--- a/pkg/util/log/http_sink.go
+++ b/pkg/util/log/http_sink.go
@@ -12,12 +12,14 @@ package log
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/errors"
 )
@@ -94,7 +96,37 @@ func (hs *httpSink) output(b []byte, opt sinkOutputOptions) (err error) {
 }
 
 func doPost(hs *httpSink, b []byte) (*http.Response, error) {
-	resp, err := hs.client.Post(hs.address, hs.contentType, bytes.NewReader(b))
+	var buf = bytes.Buffer{}
+	var req *http.Request
+
+	if *hs.config.Compression == logconfig.GzipCompression {
+		g := gzip.NewWriter(&buf)
+		_, err := g.Write(b)
+		if err != nil {
+			return nil, err
+		}
+		err = g.Close()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		buf.Write(b)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, hs.address, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if *hs.config.Compression == logconfig.GzipCompression {
+		req.Header.Add(httputil.ContentEncodingHeader, httputil.GzipEncoding)
+	}
+
+	for k, v := range hs.config.Headers {
+		req.Header.Add(k, v)
+	}
+	req.Header.Add(httputil.ContentTypeHeader, hs.contentType)
+	resp, err := hs.client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -476,6 +476,9 @@ type FileSinkConfig struct {
 	prefix string
 }
 
+var GzipCompression = "gzip"
+var NoneCompression = "none"
+
 // HTTPDefaults refresents the configuration defaults for HTTP sinks.
 type HTTPDefaults struct {
 	// Address is the network address of the http server. The
@@ -501,6 +504,13 @@ type HTTPDefaults struct {
 	// intended for testing only and can cause excessive network
 	// overhead in production systems.
 	DisableKeepAlives *bool `yaml:"disable-keep-alives,omitempty"`
+
+	// Headers is a list of headers to attach to each HTTP request
+	Headers map[string]string `yaml:",omitempty,flow"`
+
+	// Compression can be "none" or "gzip" to enable gzip compression.
+	// Set to "gzip" by default.
+	Compression *string `yaml:",omitempty"`
 
 	CommonSinkConfig `yaml:",inline"`
 }

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -543,3 +543,122 @@ capture-stray-errors:
   enable: true
   dir: /default-dir
   max-group-size: 100MiB
+
+# Check that each component of buffering struct propagates to http-sinks
+# Ensure servers have gzip compression on by default and headers if set
+yaml
+http-defaults:
+  buffering:
+    max-staleness: 15s
+    flush-trigger-size: 10KiB
+    max-buffer-size: 2MiB
+sinks:
+  http-servers:
+    a:
+      address: a
+      channels: STORAGE
+      headers: {X-CRDB-HEADER: header-value-a}
+      buffering:
+        max-staleness: 10s
+    b:
+      address: b
+      channels: OPS
+      headers: {X-CRDB-HEADER: header-value-b, X-ANOTHER-HEADER: zz-yy-bb}
+      buffering:
+        flush-trigger-size: 5.0KiB
+    c:
+      address: c
+      channels: HEALTH
+      buffering:
+        max-buffer-size: 3MiB
+    d:
+      address: d
+      channels: SESSIONS
+      buffering: NONE
+----
+sinks:
+  file-groups:
+    default:
+      channels: {INFO: all}
+      filter: INFO
+  http-servers:
+    a:
+      channels: {INFO: [STORAGE]}
+      address: a
+      method: POST
+      unsafe-tls: false
+      timeout: 0s
+      disable-keep-alives: false
+      headers: {X-CRDB-HEADER: header-value-a}
+      compression: gzip
+      filter: INFO
+      format: json-compact
+      redact: false
+      redactable: true
+      exit-on-error: false
+      auditable: false
+      buffering:
+        max-staleness: 10s
+        flush-trigger-size: 10KiB
+        max-buffer-size: 2.0MiB
+        format: newline
+    b:
+      channels: {INFO: [OPS]}
+      address: b
+      method: POST
+      unsafe-tls: false
+      timeout: 0s
+      disable-keep-alives: false
+      headers: {X-ANOTHER-HEADER: zz-yy-bb, X-CRDB-HEADER: header-value-b}
+      compression: gzip
+      filter: INFO
+      format: json-compact
+      redact: false
+      redactable: true
+      exit-on-error: false
+      auditable: false
+      buffering:
+        max-staleness: 15s
+        flush-trigger-size: 5.0KiB
+        max-buffer-size: 2.0MiB
+        format: newline
+    c:
+      channels: {INFO: [HEALTH]}
+      address: c
+      method: POST
+      unsafe-tls: false
+      timeout: 0s
+      disable-keep-alives: false
+      compression: gzip
+      filter: INFO
+      format: json-compact
+      redact: false
+      redactable: true
+      exit-on-error: false
+      auditable: false
+      buffering:
+        max-staleness: 15s
+        flush-trigger-size: 10KiB
+        max-buffer-size: 3.0MiB
+        format: newline
+    d:
+      channels: {INFO: [SESSIONS]}
+      address: d
+      method: POST
+      unsafe-tls: false
+      timeout: 0s
+      disable-keep-alives: false
+      compression: gzip
+      filter: INFO
+      format: json-compact
+      redact: false
+      redactable: true
+      exit-on-error: false
+      auditable: false
+      buffering: NONE
+  stderr:
+    filter: NONE
+capture-stray-errors:
+  enable: true
+  dir: /default-dir
+  max-group-size: 100MiB

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -112,6 +112,7 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 		DisableKeepAlives: &bf,
 		Method:            func() *HTTPSinkMethod { m := HTTPSinkMethod(http.MethodPost); return &m }(),
 		Timeout:           &zeroDuration,
+		Compression:       &GzipCompression,
 	}
 
 	propagateCommonDefaults(&baseFileDefaults.CommonSinkConfig, baseCommonSinkConfig)
@@ -453,6 +454,9 @@ func (c *Config) validateHTTPSinkConfig(hsc *HTTPSinkConfig) error {
 	propagateHTTPDefaults(&hsc.HTTPDefaults, c.HTTPDefaults)
 	if hsc.Address == nil || len(*hsc.Address) == 0 {
 		return errors.New("address cannot be empty")
+	}
+	if *hsc.Compression != GzipCompression && *hsc.Compression != NoneCompression {
+		return errors.New("compression must be 'gzip' or 'none'")
 	}
 	return c.ValidateCommonSinkConfig(hsc.CommonSinkConfig)
 }

--- a/pkg/util/log/testdata/config
+++ b/pkg/util/log/testdata/config
@@ -119,6 +119,7 @@ sinks:
       unsafe-tls: false
       timeout: 0s
       disable-keep-alives: false
+      compression: gzip
       filter: INFO
       format: json-compact
       redact: false


### PR DESCRIPTION
This commit adds support for custom headers and gzip compression on requests made to `http-server` outputs in CRDB's logging configuration. Custom headers enable the inclusion of API keys for 3rd party sinks and gzip compression reduces network resource consumption.

Resolves #103477

Release note (ops change): `http-defaults` and `http-servers` sections of the log config will now accept a `headers` field containing a map of key value string pairs which will comprise custom HTTP headers appended to every request. Additionally a `compression` value is support which can be set to `gzip` or `none` to select a compression method for the HTTP requesst body. By default `gzip` is selected. This is a change from previous functionality that did not compress by default.