### PR TITLE
sql: fix test flake on `node_contention_events`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/contention_event
+++ b/pkg/sql/logictest/testdata/logic_test/contention_event
@@ -6,11 +6,17 @@
 # that do get emitted in various contention scenarios.
 
 statement ok
-GRANT ADMIN TO testuser
+GRANT CREATE ON DATABASE test TO testuser
 
 statement ok
 CREATE TABLE kv (k VARCHAR PRIMARY KEY, v VARCHAR);
 ALTER TABLE kv SPLIT AT VALUES ('b'), ('d'), ('q'), ('z')
+
+statement ok
+GRANT INSERT ON TABLE kv TO testuser
+
+statement ok
+GRANT SYSTEM VIEWACTIVITYREDACTED TO testuser
 
 query TT
 SELECT * FROM kv
@@ -42,6 +48,14 @@ user testuser nodeidx=3
 
 statement ok
 ROLLBACK
+
+# Check keys are redacted based on privileges
+user testuser
+
+query T
+SELECT key::STRING FROM crdb_internal.node_contention_events LIMIT 1
+----
+\x
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1359,10 +1359,8 @@ GRANT SYSTEM VIEWACTIVITYREDACTED TO testuser
 
 user testuser
 
-query T
-SELECT key::STRING FROM crdb_internal.node_contention_events LIMIT 1
-----
-\x
+statement ok
+SELECT * FROM crdb_internal.node_contention_events
 
 statement ok
 SELECT * FROM crdb_internal.transaction_contention_events


### PR DESCRIPTION
This change fixes a test flake that can occur when checking the values of the keys in `node_contention_events` and the table may not have rows. The change moves the test into the `contention_events` logic test where there should be a contention event and thus the table should have rows to check,

Release note: None