### PR TITLE
opt: disallow SELECT FOR UPDATE under weak isolation levels

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1606,6 +1606,13 @@ func TestTenantLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestTenantLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestTenantLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/catalog/descpb/locking.proto
+++ b/pkg/sql/catalog/descpb/locking.proto
@@ -115,7 +115,7 @@ enum ScanLockingStrength {
   // on each key scanned.
   FOR_UPDATE = 4;
 }
-  
+
 // LockingWaitPolicy controls the policy used for handling conflicting locks
 // held by other active transactions when attempting to lock rows due to FOR
 // UPDATE/SHARE clauses (i.e. it represents the NOWAIT and SKIP LOCKED options).

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3512,6 +3512,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.TxnReadOnly = ex.state.readOnly
 	evalCtx.TxnImplicit = ex.implicitTxn()
 	evalCtx.TxnIsSingleStmt = false
+	evalCtx.TxnIsoLevel = ex.state.isolationLevel
 	if newTxn || !ex.implicitTxn() {
 		// Only update the stmt timestamp if in a new txn or an explicit txn. This is because this gets
 		// called multiple times during an extended protocol implicit txn, but we

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
@@ -1,0 +1,142 @@
+# LogicTest: !local-mixed-22.2-23.1
+
+# SELECT FOR UPDATE is prohibited under weaker isolation levels until we improve
+# locking. See #57031, #75457, #100144.
+
+statement ok
+CREATE TABLE supermarket (
+  person STRING PRIMARY KEY,
+  aisle INT NOT NULL,
+  starts_with STRING GENERATED ALWAYS AS (left(person, 1)) STORED,
+  ends_with STRING GENERATED ALWAYS AS (right(person, 3)) STORED,
+  INDEX (starts_with),
+  INDEX (ends_with)
+)
+
+statement ok
+INSERT INTO supermarket (person, aisle)
+  VALUES ('abbie', 1), ('gideon', 2), ('matilda', 3), ('michael', 4)
+
+# SELECT FOR UPDATE should still work under serializable isolation.
+statement ok
+BEGIN
+
+query I
+SELECT aisle FROM supermarket WHERE person = 'gideon' FOR UPDATE
+----
+2
+
+statement ok
+UPDATE supermarket SET aisle = 2 WHERE person = 'abbie'
+
+statement ok
+COMMIT
+
+# It should fail under read committed isolation.
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE
+
+statement ok
+ROLLBACK
+
+# It should also fail under snapshot isolation.
+statement ok
+SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SNAPSHOT
+
+query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under Snapshot isolation
+SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE
+
+statement ok
+ROLLBACK
+
+statement ok
+RESET CLUSTER SETTING sql.txn.snapshot_isolation.enabled
+
+# SELECT FOR UPDATE in a subquery should also fail under read committed.
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+UPDATE supermarket
+  SET aisle = (SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE)
+  WHERE person = 'michael'
+
+statement ok
+ROLLBACK
+
+# It should also fail in a CTE.
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+WITH s AS
+  (SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE)
+SELECT aisle + 1 FROM s
+
+statement ok
+ROLLBACK
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+# Creating a UDF using SELECT FOR UPDATE should succeed under read committed.
+statement ok
+CREATE FUNCTION wrangle (name STRING) RETURNS INT LANGUAGE SQL AS $$
+  SELECT aisle FROM supermarket WHERE person = name FOR UPDATE
+$$
+
+# But calling that function should fail.
+query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+INSERT INTO supermarket (person, aisle) VALUES ('grandma', wrangle('matilda'))
+
+statement ok
+DROP FUNCTION wrangle
+
+# Preparing a SELECT FOR UPDATE should succeed under read committed.
+statement ok
+PREPARE psa AS SELECT aisle FROM supermarket WHERE person = $1::STRING FOR UPDATE
+
+# But execution should fail.
+query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+EXECUTE psa('matilda')
+
+statement ok
+DEALLOCATE psa
+
+# SELECT FOR UPDATE using a lookup join should also fail.
+query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+WITH names AS MATERIALIZED
+  (SELECT 'matilda' AS person)
+SELECT aisle
+  FROM names
+  NATURAL INNER LOOKUP JOIN supermarket
+  FOR UPDATE
+
+# SELECT FOR UPDATE using an index join should also fail.
+query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+SELECT aisle
+  FROM supermarket@supermarket_starts_with_idx
+  WHERE starts_with = 'm'
+  FOR UPDATE
+
+# SELECT FOR UPDATE using a zigzag join should also fail.
+query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+SELECT aisle
+  FROM supermarket@{FORCE_ZIGZAG}
+  WHERE starts_with = 'm' AND ends_with = 'lda'
+  FOR UPDATE
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1584,6 +1584,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1584,6 +1584,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1598,6 +1598,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1563,6 +1563,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1591,6 +1591,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1731,6 +1731,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -973,8 +973,12 @@ func (b *Builder) canAutoCommit(rel memo.RelExpr) bool {
 
 // forUpdateLocking is the row-level locking mode used by mutations during their
 // initial row scan, when such locking is deemed desirable. The locking mode is
-// equivalent that used by a SELECT ... FOR UPDATE statement.
-var forUpdateLocking = opt.Locking{Strength: tree.ForUpdate}
+// equivalent to that used by a SELECT FOR UPDATE statement, except not durable.
+var forUpdateLocking = opt.Locking{
+	Strength:   tree.ForUpdate,
+	WaitPolicy: tree.LockWaitBlock,
+	Durability: tree.LockDurabilityBestEffort,
+}
 
 // shouldApplyImplicitLockingToMutationInput determines whether or not the
 // builder should apply a FOR UPDATE row-level locking mode to the initial row

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -618,18 +619,9 @@ func (b *Builder) scanParams(
 		return exec.ScanParams{}, opt.ColMap{}, err
 	}
 
-	locking := scan.Locking
-	if b.forceForUpdateLocking {
-		locking = locking.Max(forUpdateLocking)
-	}
-	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
-
-	// Raise error if row-level locking is part of a read-only transaction.
-	// TODO(nvanbenschoten): this check should be shared across all expressions
-	// that can perform row-level locking.
-	if locking.IsLocking() && b.evalCtx.TxnReadOnly {
-		return exec.ScanParams{}, opt.ColMap{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
-			"cannot execute %s in a read-only transaction", locking.Strength.String())
+	locking, err := b.buildLocking(scan.Locking)
+	if err != nil {
+		return exec.ScanParams{}, opt.ColMap{}, err
 	}
 
 	needed, outputMap := b.getColumns(scan.Cols, scan.Table)
@@ -2170,11 +2162,10 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	cols := join.Cols
 	needed, output := b.getColumns(cols, join.Table)
 
-	locking := join.Locking
-	if b.forceForUpdateLocking {
-		locking = locking.Max(forUpdateLocking)
+	locking, err := b.buildLocking(join.Locking)
+	if err != nil {
+		return execPlan{}, err
 	}
-	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	res := execPlan{outputCols: output}
 	b.recordJoinAlgorithm(exec.IndexJoin)
@@ -2491,11 +2482,10 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 	idx := tab.Index(join.Index)
 	b.IndexesUsed = util.CombineUnique(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
 
-	locking := join.Locking
-	if b.forceForUpdateLocking {
-		locking = locking.Max(forUpdateLocking)
+	locking, err := b.buildLocking(join.Locking)
+	if err != nil {
+		return execPlan{}, err
 	}
-	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	joinType, err := joinOpToJoinType(join.JoinType)
 	if err != nil {
@@ -2733,11 +2723,10 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 		return execPlan{}, err
 	}
 
-	locking := join.Locking
-	if b.forceForUpdateLocking {
-		locking = locking.Max(forUpdateLocking)
+	locking, err := b.buildLocking(join.Locking)
+	if err != nil {
+		return execPlan{}, err
 	}
-	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	joinType, err := joinOpToJoinType(join.JoinType)
 	if err != nil {
@@ -2813,13 +2802,14 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 	leftOrdinals, leftColMap := b.getColumns(leftCols, join.LeftTable)
 	rightOrdinals, rightColMap := b.getColumns(rightCols, join.RightTable)
 
-	leftLocking := join.LeftLocking
-	rightLocking := join.RightLocking
-	if b.forceForUpdateLocking {
-		leftLocking = leftLocking.Max(forUpdateLocking)
-		rightLocking = rightLocking.Max(forUpdateLocking)
+	leftLocking, err := b.buildLocking(join.LeftLocking)
+	if err != nil {
+		return execPlan{}, err
 	}
-	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || leftLocking.IsLocking() || rightLocking.IsLocking()
+	rightLocking, err := b.buildLocking(join.RightLocking)
+	if err != nil {
+		return execPlan{}, err
+	}
 
 	allCols := joinOutputMap(leftColMap, rightColMap)
 
@@ -2882,6 +2872,29 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 
 	// Apply a post-projection to retain only the columns we need.
 	return b.applySimpleProject(res, join, join.Cols, join.ProvidedPhysical().Ordering)
+}
+
+func (b *Builder) buildLocking(locking opt.Locking) (opt.Locking, error) {
+	if b.forceForUpdateLocking {
+		locking = locking.Max(forUpdateLocking)
+	}
+	if locking.IsLocking() {
+		// Raise error if row-level locking is part of a read-only transaction.
+		if b.evalCtx.TxnReadOnly {
+			return opt.Locking{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
+				"cannot execute %s in a read-only transaction", locking.Strength.String(),
+			)
+		}
+		if locking.Durability == tree.LockDurabilityGuaranteed &&
+			b.evalCtx.TxnIsoLevel != isolation.Serializable {
+			return opt.Locking{}, unimplemented.NewWithIssuef(
+				100144, "cannot execute SELECT FOR UPDATE statements under %s isolation",
+				b.evalCtx.TxnIsoLevel,
+			)
+		}
+		b.ContainsNonDefaultKeyLocking = true
+	}
+	return locking, nil
 }
 
 func (b *Builder) buildMax1Row(max1Row *memo.Max1RowExpr) (execPlan, error) {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -620,7 +620,7 @@ func (b *Builder) scanParams(
 
 	locking := scan.Locking
 	if b.forceForUpdateLocking {
-		locking = forUpdateLocking
+		locking = locking.Max(forUpdateLocking)
 	}
 	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
@@ -2172,7 +2172,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 
 	locking := join.Locking
 	if b.forceForUpdateLocking {
-		locking = forUpdateLocking
+		locking = locking.Max(forUpdateLocking)
 	}
 	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
@@ -2493,7 +2493,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 
 	locking := join.Locking
 	if b.forceForUpdateLocking {
-		locking = forUpdateLocking
+		locking = locking.Max(forUpdateLocking)
 	}
 	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
@@ -2735,7 +2735,7 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 
 	locking := join.Locking
 	if b.forceForUpdateLocking {
-		locking = forUpdateLocking
+		locking = locking.Max(forUpdateLocking)
 	}
 	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
@@ -2816,8 +2816,8 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 	leftLocking := join.LeftLocking
 	rightLocking := join.RightLocking
 	if b.forceForUpdateLocking {
-		leftLocking = forUpdateLocking
-		rightLocking = forUpdateLocking
+		leftLocking = leftLocking.Max(forUpdateLocking)
+		rightLocking = rightLocking.Max(forUpdateLocking)
 	}
 	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || leftLocking.IsLocking() || rightLocking.IsLocking()
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -28,6 +28,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE
@@ -41,6 +42,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for no key update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE
@@ -54,6 +56,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for share
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE
@@ -67,6 +70,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for key share
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE
@@ -80,6 +84,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for share
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
@@ -93,6 +98,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for no key update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
@@ -106,6 +112,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t
@@ -119,6 +126,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2
@@ -139,6 +147,7 @@ vectorized: true
       table: t@t_pkey
       spans: FULL SCAN
       locking strength: for update
+      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE
@@ -152,6 +161,7 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE
@@ -165,6 +175,7 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for no key update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE
@@ -178,6 +189,7 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for share
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE
@@ -191,6 +203,7 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for key share
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE
@@ -204,6 +217,7 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for share
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
@@ -217,6 +231,7 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for no key update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
@@ -230,6 +245,7 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t
@@ -243,6 +259,7 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for update
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2
@@ -263,6 +280,7 @@ vectorized: true
       table: t@t_pkey
       spans: /1/0
       locking strength: for update
+      locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with table aliases.
@@ -280,6 +298,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 FOR UPDATE OF t
@@ -296,6 +315,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM [$t_id AS t] FOR UPDATE
@@ -309,6 +329,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM [$t_id AS t] FOR UPDATE OF t
@@ -322,6 +343,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM [$t_id AS t] FOR UPDATE OF t2
@@ -342,6 +364,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF v
@@ -355,6 +378,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "v2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF v2
@@ -381,6 +405,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "v" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM v AS v2 FOR UPDATE OF v
@@ -397,6 +422,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with subqueries.
@@ -418,6 +444,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE)
@@ -431,6 +458,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
@@ -444,6 +472,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for no key update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
@@ -457,6 +486,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for no key update
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) FOR UPDATE OF t
@@ -473,6 +503,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
@@ -486,6 +517,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
@@ -499,6 +531,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE OF t
@@ -515,6 +548,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) FOR UPDATE
@@ -574,6 +608,7 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
+              locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) FOR UPDATE OF t
@@ -607,6 +642,7 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
+              locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) AS r FOR UPDATE
@@ -666,6 +702,7 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
+              locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) AS r FOR UPDATE OF t
@@ -699,6 +736,7 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
+              locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE
@@ -712,6 +750,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE)
@@ -737,6 +776,7 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE OF t)
@@ -766,6 +806,7 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
+    │ locking durability: guaranteed
     │
     └── • distinct
         │ columns: (b)
@@ -805,6 +846,7 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
+              locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE OF t
@@ -822,6 +864,7 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
+    │ locking durability: guaranteed
     │
     └── • distinct
         │ columns: (b)
@@ -861,6 +904,7 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
+              locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with common-table expressions.
@@ -934,6 +978,7 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
+              locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
@@ -964,6 +1009,7 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
+              locking durability: guaranteed
 
 # Verify that the unused CTE doesn't get eliminated.
 # TODO(radu): we should at least not buffer the rows in this case.
@@ -998,6 +1044,7 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
+              locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with joins.
@@ -1027,6 +1074,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1035,6 +1083,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
+          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
@@ -1060,6 +1109,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1099,6 +1149,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
+          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
@@ -1124,6 +1175,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1132,6 +1184,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
+          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
@@ -1157,6 +1210,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1165,6 +1219,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for share
+          locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
@@ -1193,6 +1248,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1201,6 +1257,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for share
+          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
@@ -1226,6 +1283,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1234,6 +1292,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
+          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
@@ -1259,6 +1318,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for no key update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1267,6 +1327,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for key share
+          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UPDATE OF u
@@ -1292,6 +1353,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for no key update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1300,6 +1362,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
+          locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with joins of aliased tables and aliased joins.
@@ -1329,6 +1392,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1337,6 +1401,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
+          locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t
@@ -1371,6 +1436,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1410,6 +1476,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
+          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
@@ -1435,6 +1502,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1443,6 +1511,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
+          locking durability: guaranteed
 
 # Postgres doesn't support applying locking clauses to joins. The following
 # queries all return the error: "FOR UPDATE cannot be applied to a join".
@@ -1472,6 +1541,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1480,6 +1550,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
+          locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF t
@@ -1514,6 +1585,7 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
+    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1522,6 +1594,7 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
+          locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with lateral joins.
@@ -1543,6 +1616,7 @@ vectorized: true
 │     table: t@t_pkey
 │     spans: FULL SCAN
 │     locking strength: for update
+│     locking durability: guaranteed
 │
 └── • scan
       columns: (a, b, c)
@@ -1550,6 +1624,7 @@ vectorized: true
       table: u@u_pkey
       spans: FULL SCAN
       locking strength: for update
+      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t, u FOR UPDATE OF t
@@ -1567,6 +1642,7 @@ vectorized: true
 │     table: t@t_pkey
 │     spans: FULL SCAN
 │     locking strength: for update
+│     locking durability: guaranteed
 │
 └── • scan
       columns: (a, b, c)
@@ -1590,6 +1666,7 @@ vectorized: true
 │     table: t@t_pkey
 │     spans: FULL SCAN
 │     locking strength: for share
+│     locking durability: guaranteed
 │
 └── • scan
       columns: (a, b, c)
@@ -1597,6 +1674,7 @@ vectorized: true
       table: u@u_pkey
       spans: FULL SCAN
       locking strength: for update
+      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
@@ -1614,6 +1692,7 @@ vectorized: true
 │     table: t@t_pkey
 │     spans: FULL SCAN
 │     locking strength: for update
+│     locking durability: guaranteed
 │
 └── • scan
       columns: (a, b, c)
@@ -1621,6 +1700,7 @@ vectorized: true
       table: u@u_pkey
       spans: FULL SCAN
       locking strength: for update
+      locking durability: guaranteed
 
 query error pgcode 42P01 relation "u" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF u
@@ -1647,6 +1727,7 @@ vectorized: true
       table: u@u_pkey
       spans: FULL SCAN
       locking strength: for update
+      locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with index joins.
@@ -1672,6 +1753,7 @@ vectorized: true
 │ table: indexed@indexed_pkey
 │ key columns: a
 │ locking strength: for update
+│ locking durability: guaranteed
 │
 └── • scan
       columns: (a, b)
@@ -1679,6 +1761,7 @@ vectorized: true
       table: indexed@b_idx
       spans: /2-/3
       locking strength: for update
+      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM indexed WHERE b BETWEEN 2 AND 10 FOR UPDATE
@@ -1692,6 +1775,7 @@ vectorized: true
 │ table: indexed@indexed_pkey
 │ key columns: a
 │ locking strength: for update
+│ locking durability: guaranteed
 │
 └── • scan
       columns: (a, b)
@@ -1699,6 +1783,7 @@ vectorized: true
       table: indexed@b_idx
       spans: /2-/11
       locking strength: for update
+      locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with lookup joins.
@@ -1720,6 +1805,7 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
+    │ locking durability: guaranteed
     │
     └── • scan
           columns: (a, b)
@@ -1727,6 +1813,7 @@ vectorized: true
           table: t@t_pkey
           spans: /2/0
           locking strength: for update
+          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a BETWEEN 2 AND 10 FOR UPDATE
@@ -1744,6 +1831,7 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
+    │ locking durability: guaranteed
     │
     └── • scan
           columns: (a, b)
@@ -1752,6 +1840,7 @@ vectorized: true
           spans: /2-/11
           parallel
           locking strength: for update
+          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN indexed ON t.b = indexed.b WHERE t.a = 2 FOR UPDATE
@@ -1766,6 +1855,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ locking durability: guaranteed
 │
 └── • lookup join (inner)
     │ columns: (a, b, a, b)
@@ -1773,6 +1863,7 @@ vectorized: true
     │ table: indexed@b_idx
     │ equality: (b) = (b)
     │ locking strength: for update
+    │ locking durability: guaranteed
     │
     └── • scan
           columns: (a, b)
@@ -1780,6 +1871,7 @@ vectorized: true
           table: t@t_pkey
           spans: /2/0
           locking strength: for update
+          locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with inverted filters and joins.
@@ -1806,6 +1898,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ locking durability: guaranteed
 │
 └── • project
     │ columns: (a)
@@ -1817,10 +1910,12 @@ vectorized: true
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
           left locking strength: for update
+          left locking durability: guaranteed
           right table: inverted@b_inv
           right columns: (a, b_inverted_key)
           right fixed values: 1 column
           right locking strength: for update
+          right locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM inverted WHERE b <@ '{1, 2}' FOR UPDATE
@@ -1839,6 +1934,7 @@ vectorized: true
     │ table: inverted@inverted_pkey
     │ key columns: a
     │ locking strength: for update
+    │ locking durability: guaranteed
     │
     └── • project
         │ columns: (a)
@@ -1855,6 +1951,7 @@ vectorized: true
                   table: inverted@b_inv
                   spans: /[]-/"D" /1-/3
                   locking strength: for update
+                  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM inverted@b_inv AS i1, inverted AS i2 WHERE i1.b @> i2.b FOR UPDATE
@@ -1873,6 +1970,7 @@ vectorized: true
     │ equality cols are key
     │ pred: b @> b
     │ locking strength: for update
+    │ locking durability: guaranteed
     │
     └── • project
         │ columns: (a, b, c, a)
@@ -1883,6 +1981,7 @@ vectorized: true
             │ table: inverted@b_inv
             │ inverted expr: b_inverted_key @> b
             │ locking strength: for update
+            │ locking durability: guaranteed
             │
             └── • scan
                   columns: (a, b, c)
@@ -1890,6 +1989,7 @@ vectorized: true
                   table: inverted@inverted_pkey
                   spans: FULL SCAN
                   locking strength: for update
+                  locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with zigzag joins.
@@ -1923,10 +2023,12 @@ vectorized: true
       left columns: (a, b)
       left fixed values: 1 column
       left locking strength: for update
+      left locking durability: guaranteed
       right table: zigzag@c_idx
       right columns: (a, c)
       right fixed values: 1 column
       right locking strength: for update
+      right locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * from zigzag where d @> '{"a": {"b": "c"}, "f": "g"}' FOR UPDATE
@@ -1941,6 +2043,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ locking durability: guaranteed
 │
 └── • project
     │ columns: (a)
@@ -1952,10 +2055,12 @@ vectorized: true
           left columns: (a, d_inverted_key)
           left fixed values: 1 column
           left locking strength: for update
+          left locking durability: guaranteed
           right table: zigzag@d_idx
           right columns: (a, d_inverted_key)
           right fixed values: 1 column
           right locking strength: for update
+          right locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with the NOWAIT lock wait policy.
@@ -1974,6 +2079,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE NOWAIT
@@ -1988,6 +2094,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for no key update
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE NOWAIT
@@ -2002,6 +2109,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for share
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE NOWAIT
@@ -2016,6 +2124,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for key share
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
@@ -2030,6 +2139,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for share
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
@@ -2044,6 +2154,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for no key update
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
@@ -2058,6 +2169,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t NOWAIT
@@ -2072,6 +2184,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2 NOWAIT
@@ -2093,6 +2206,7 @@ vectorized: true
       spans: FULL SCAN
       locking strength: for update
       locking wait policy: nowait
+      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE NOWAIT
@@ -2107,6 +2221,7 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE NOWAIT
@@ -2121,6 +2236,7 @@ vectorized: true
   spans: /1/0
   locking strength: for no key update
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE NOWAIT
@@ -2135,6 +2251,7 @@ vectorized: true
   spans: /1/0
   locking strength: for share
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE NOWAIT
@@ -2149,6 +2266,7 @@ vectorized: true
   spans: /1/0
   locking strength: for key share
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE NOWAIT
@@ -2163,6 +2281,7 @@ vectorized: true
   spans: /1/0
   locking strength: for share
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE NOWAIT
@@ -2177,6 +2296,7 @@ vectorized: true
   spans: /1/0
   locking strength: for no key update
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE NOWAIT
@@ -2191,6 +2311,7 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t NOWAIT
@@ -2205,6 +2326,7 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: nowait
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2 NOWAIT
@@ -2226,6 +2348,7 @@ vectorized: true
       spans: /1/0
       locking strength: for update
       locking wait policy: nowait
+      locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with the SKIP LOCKED lock wait policy.
@@ -2244,6 +2367,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
@@ -2258,6 +2382,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for no key update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE SKIP LOCKED
@@ -2272,6 +2397,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for share
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE SKIP LOCKED
@@ -2286,6 +2412,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for key share
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
@@ -2300,6 +2427,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for share
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
@@ -2314,6 +2442,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for no key update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
@@ -2328,6 +2457,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
@@ -2342,6 +2472,7 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2 SKIP LOCKED
@@ -2363,6 +2494,7 @@ vectorized: true
       spans: FULL SCAN
       locking strength: for update
       locking wait policy: skip locked
+      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE SKIP LOCKED
@@ -2377,6 +2509,7 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE SKIP LOCKED
@@ -2391,6 +2524,7 @@ vectorized: true
   spans: /1/0
   locking strength: for no key update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE SKIP LOCKED
@@ -2405,6 +2539,7 @@ vectorized: true
   spans: /1/0
   locking strength: for share
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE SKIP LOCKED
@@ -2419,6 +2554,7 @@ vectorized: true
   spans: /1/0
   locking strength: for key share
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE SKIP LOCKED
@@ -2433,6 +2569,7 @@ vectorized: true
   spans: /1/0
   locking strength: for share
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE SKIP LOCKED
@@ -2447,6 +2584,7 @@ vectorized: true
   spans: /1/0
   locking strength: for no key update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
@@ -2461,6 +2599,7 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t SKIP LOCKED
@@ -2475,6 +2614,7 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2 SKIP LOCKED
@@ -2496,6 +2636,7 @@ vectorized: true
       spans: /1/0
       locking strength: for update
       locking wait policy: skip locked
+      locking durability: guaranteed
 
 # Tests with a secondary index.
 
@@ -2512,6 +2653,7 @@ vectorized: true
   spans: /2-/3
   locking strength: for update
   locking wait policy: skip locked
+  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM u WHERE b = 2 FOR UPDATE SKIP LOCKED
@@ -2526,6 +2668,7 @@ vectorized: true
 │ key columns: a
 │ locking strength: for update
 │ locking wait policy: skip locked
+│ locking durability: guaranteed
 │
 └── • scan
       columns: (a, b)
@@ -2534,6 +2677,7 @@ vectorized: true
       spans: /2-/3
       locking strength: for update
       locking wait policy: skip locked
+      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM u WHERE b = 2 LIMIT 1 FOR UPDATE SKIP LOCKED
@@ -2552,6 +2696,7 @@ vectorized: true
     │ key columns: a
     │ locking strength: for update
     │ locking wait policy: skip locked
+    │ locking durability: guaranteed
     │
     └── • scan
           columns: (a, b)
@@ -2560,3 +2705,4 @@ vectorized: true
           spans: /2-/3
           locking strength: for update
           locking wait policy: skip locked
+          locking durability: guaranteed

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -1051,11 +1051,15 @@ func (e *emitter) emitLockingPolicy(locking opt.Locking) {
 func (e *emitter) emitLockingPolicyWithPrefix(keyPrefix string, locking opt.Locking) {
 	strength := descpb.ToScanLockingStrength(locking.Strength)
 	waitPolicy := descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
+	durability := locking.Durability
 	if strength != descpb.ScanLockingStrength_FOR_NONE {
 		e.ob.Attr(keyPrefix+"locking strength", strength.PrettyString())
 	}
 	if waitPolicy != descpb.ScanLockingWaitPolicy_BLOCK {
 		e.ob.Attr(keyPrefix+"locking wait policy", waitPolicy.PrettyString())
+	}
+	if durability != tree.LockDurabilityBestEffort {
+		e.ob.Attr(keyPrefix+"locking durability", durability.String())
 	}
 }
 

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -524,6 +524,7 @@ explain(shape):
               table: abc@abc_b_idx
               spans: FULL SCAN
               locking strength: for update
+              locking durability: guaranteed
 explain(gist):
 • root
 │

--- a/pkg/sql/opt/locking.go
+++ b/pkg/sql/opt/locking.go
@@ -13,7 +13,7 @@ package opt
 import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 
 // Locking represents the row-level locking properties of a relational operator.
-// Each relational operator clause consist of two different row-level locking
+// Each relational operator clause consists of three different row-level locking
 // properties.
 type Locking struct {
 	// The first property is locking strength (see tree.LockingStrength). Locking
@@ -43,6 +43,25 @@ type Locking struct {
 	//   NOWAIT
 	//
 	WaitPolicy tree.LockingWaitPolicy
+
+	// The third property is the durability of the locking. A guaranteed-durable
+	// lock always persists until commit time, while a best-effort lock may
+	// sometimes be lost before commit. We currently only require
+	// guaranteed-durable locks for SELECT FOR UPDATE statements under SNAPSHOT
+	// and READ COMMITTED isolation. Other locking statements, such as UPDATE,
+	// rely on the durability of intents for correctness, rather than the
+	// durability of locks.
+	Durability tree.LockingDurability
+}
+
+// Max returns a new set of locking properties where each property is the max of
+// the respective property in the two inputs.
+func (l Locking) Max(l2 Locking) Locking {
+	return Locking{
+		Strength:   l.Strength.Max(l2.Strength),
+		WaitPolicy: l.WaitPolicy.Max(l2.WaitPolicy),
+		Durability: l.Durability.Max(l2.Durability),
+	}
 }
 
 // IsLocking returns whether the receiver is configured to use a row-level

--- a/pkg/sql/opt/optbuilder/locking.go
+++ b/pkg/sql/opt/optbuilder/locking.go
@@ -78,6 +78,12 @@ func (lm lockingSpec) get() opt.Locking {
 		return opt.Locking{
 			Strength:   spec.Strength,
 			WaitPolicy: spec.WaitPolicy,
+			// We use fully-durable locks for all SELECT FOR UPDATE statements,
+			// regardless of locking strength and wait policy. Unlike mutation
+			// statements, SELECT FOR UPDATE statements do not lay down intents, so we
+			// cannot rely on the durability of intents to guarantee exclusion until
+			// commit as we do for mutation statements.
+			Durability: tree.LockDurabilityGuaranteed,
 		}
 	}
 	return opt.Locking{}

--- a/pkg/sql/querycache/query_cache.go
+++ b/pkg/sql/querycache/query_cache.go
@@ -56,9 +56,6 @@ type CachedData struct {
 	// PrepareMetadata is set for prepare queries. In this case the memo contains
 	// unassigned placeholders. For non-prepared queries, it is nil.
 	PrepareMetadata *PrepareMetadata
-	// IsCorrelated memoizes whether the query contained correlated
-	// subqueries during planning (prior to de-correlation).
-	IsCorrelated bool
 }
 
 func (cd *CachedData) memoryEstimate() int64 {

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -78,6 +79,8 @@ type Context struct {
 	// TxnIsSingleStmt specifies the current implicit transaction consists of only
 	// a single statement.
 	TxnIsSingleStmt bool
+	// TxnIsoLevel is the isolation level of the current transaction.
+	TxnIsoLevel isolation.Level
 
 	Settings *cluster.Settings
 	// ClusterID is the logical cluster ID for this tenant.

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -1199,6 +1199,42 @@ func (p LockingWaitPolicy) Max(p2 LockingWaitPolicy) LockingWaitPolicy {
 	return LockingWaitPolicy(max(byte(p), byte(p2)))
 }
 
+// LockingDurability represents the durability of a lock. It is currently not
+// exposed through SQL, but is instead set according to statement type and
+// isolation level. It is included here for completeness.
+type LockingDurability byte
+
+const (
+	// LockDurabilityBestEffort represents the default: make a best-effort attempt
+	// to hold the lock until commit while keeping it unreplicated and in-memory
+	// on the leaseholder of the locked row. Best-effort locks do not propagate
+	// via Raft to other nodes, and are therefore much faster to acquire than
+	// guaranteed-durable locks. For this reason we prefer to use best-effort
+	// locks when possible (i.e. when locking is used as an optimization rather
+	// than as a guarantor of exclusion).
+	LockDurabilityBestEffort LockingDurability = iota
+
+	// LockDurabilityGuaranteed guarantees that if the transaction commits, the
+	// lock was held until commit, even in the face of lease transfers, range
+	// splits, range merges, node failures, memory limits, etc. Guaranteed-durable
+	// locks *must* be used when correctness depends on locking.
+	LockDurabilityGuaranteed
+)
+
+var lockingDurabilityName = [...]string{
+	LockDurabilityBestEffort: "best-effort",
+	LockDurabilityGuaranteed: "guaranteed",
+}
+
+func (d LockingDurability) String() string {
+	return lockingDurabilityName[d]
+}
+
+// Max returns the most durable of the two locking durabilities.
+func (d LockingDurability) Max(d2 LockingDurability) LockingDurability {
+	return LockingDurability(max(byte(d), byte(d2)))
+}
+
 func max(a, b byte) byte {
 	if a > b {
 		return a


### PR DESCRIPTION
**querycache: remove unused field from CachedData**

Remove the `IsCorrelated` flag from `querycache.CachedData`, which is no
longer used.

Release note: None

---

**sql/opt: add locking durability**

In addition to strength and wait policy, we now add a third property to
locks: durability. Locks with `LockDurabilityGuaranteed` are guaranteed
to be held until commit (if the transaction commits). Durable locks must
be used when correctness depends on locking. This is never the case
under our `SERIALIZABLE` isolation, but under `SNAPSHOT` and `READ
COMMITTED` isolation it will be the case for `SELECT FOR UPDATE`
statements, which will be the first users of durable locks.

This commit adds locking durability to the optimizer and `EXPLAIN`
output, but does not plumb it into KV yet. It will be used in the next
commit to temporarily disallow `SELECT FOR UPDATE` statements under
`SNAPSHOT` and `READ COMMITTED` isolation.

Release note: None

---

**opt: disallow SELECT FOR UPDATE under weak isolation levels**

Temporarily disallow `SELECT FOR UPDATE` statements under all isolation
levels that are not `SERIALIZABLE` (i.e. `SNAPSHOT` and `READ
COMMITTED`). We will allow them again when the following issues are
fixed:

- #57031
- #75457
- #100193
- #100194

Fixes: #100144

Release note: None