### PR TITLE
admission: change sgc.allocateIOOnTick interval

### DIFF
--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -70,6 +70,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",
+        "//pkg/testutils/skip",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/humanizeutil",
         "//pkg/util/leaktest",

--- a/pkg/util/admission/admission.go
+++ b/pkg/util/admission/admission.go
@@ -258,19 +258,23 @@ type granterWithLockedCalls interface {
 // The interface is used by the entity that periodically looks at load and
 // computes the tokens to grant (ioLoadListener).
 type granterWithIOTokens interface {
-	// setAvailableTokens bounds the available {io,elastic disk bandwidth}
-	// tokens that can be granted to the value provided in the
-	// {io,elasticDiskBandwidth}Tokens parameter. elasticDiskBandwidthTokens
-	// bounds what can be granted to elastic work, and is based on disk
-	// bandwidth being a bottleneck resource. These are not tight bounds when
-	// the callee has negative available tokens, due to the use of
-	// granter.tookWithoutPermission, since in that the case the callee
-	// increments that negative value with the value provided by tokens. This
-	// method needs to be called periodically. The return value is the number of
-	// used tokens in the interval since the prior call to this method. Note
-	// that tokensUsed can be negative, though that will be rare, since it is
+	// setAvailableTokens bounds the available {io,elastic disk bandwidth} tokens
+	// that can be granted to the value provided in the
+	// {io,elasticDiskBandwidth}Tokens parameter. elasticDiskBandwidthTokens bounds
+	// what can be granted to elastic work, and is based on disk bandwidth being a
+	// bottleneck resource. These are not tight bounds when the callee has negative
+	// available tokens, due to the use of granter.tookWithoutPermission, since in
+	// that the case the callee increments that negative value with the value
+	// provided by tokens. This method needs to be called periodically.
+	// {io, elasticDiskBandwidth}TokensCapacity is the ceiling up to which we allow
+	// elastic or disk bandwidth tokens to accumulate. The return value is the
+	// number of used tokens in the interval since the prior call to this method.
+	// Note that tokensUsed can be negative, though that will be rare, since it is
 	// possible for tokens to be returned.
-	setAvailableTokens(ioTokens int64, elasticDiskBandwidthTokens int64) (tokensUsed int64)
+	setAvailableTokens(
+		ioTokens int64, elasticDiskBandwidthTokens int64,
+		ioTokensCapacity int64, elasticDiskBandwidthTokensCapacity int64,
+	) (tokensUsed int64)
 	// getDiskTokensUsedAndReset returns the disk bandwidth tokens used
 	// since the last such call.
 	getDiskTokensUsedAndReset() [admissionpb.NumWorkClasses]int64

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -219,14 +219,49 @@ func TestGranterBasic(t *testing.T) {
 				kvsa.slotAdjusterIncrementsMetric.Count(), kvsa.slotAdjusterDecrementsMetric.Count(),
 			)
 
+		case "set-tokens-loop":
+			var ioTokens int
+			var elasticTokens int
+			var loop int
+			d.ScanArgs(t, "io-tokens", &ioTokens)
+			d.ScanArgs(t, "elastic-disk-bw-tokens", &elasticTokens)
+			d.ScanArgs(t, "loop", &loop)
+
+			for loop > 0 {
+				loop--
+				// We are not using a real ioLoadListener, and simply setting the
+				// tokens (the ioLoadListener has its own test).
+				coord.granters[KVWork].(*kvStoreTokenGranter).setAvailableTokens(
+					int64(ioTokens), int64(elasticTokens),
+					int64(ioTokens*250), int64(elasticTokens*250),
+				)
+			}
+			coord.testingTryGrant()
+			return flushAndReset()
+
 		case "set-tokens":
 			var ioTokens int
 			var elasticTokens int
+			var tickInterval int
 			d.ScanArgs(t, "io-tokens", &ioTokens)
 			d.ScanArgs(t, "elastic-disk-bw-tokens", &elasticTokens)
+			if d.HasArg("tick-interval") {
+				d.ScanArgs(t, "tick-interval", &tickInterval)
+			}
+			var burstMultiplier = 1
+			if tickInterval == 1 {
+				burstMultiplier = 250
+			} else if tickInterval == 250 {
+			} else {
+				return "unsupported tick rate"
+			}
+
 			// We are not using a real ioLoadListener, and simply setting the
 			// tokens (the ioLoadListener has its own test).
-			coord.granters[KVWork].(*kvStoreTokenGranter).setAvailableTokens(int64(ioTokens), int64(elasticTokens))
+			coord.granters[KVWork].(*kvStoreTokenGranter).setAvailableTokens(
+				int64(ioTokens), int64(elasticTokens),
+				int64(ioTokens*burstMultiplier), int64(elasticTokens*burstMultiplier),
+			)
 			coord.testingTryGrant()
 			return flushAndReset()
 

--- a/pkg/util/admission/io_load_listener.go
+++ b/pkg/util/admission/io_load_listener.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/pebble"
@@ -213,13 +214,19 @@ const unlimitedTokens = math.MaxInt64
 
 // Token changes are made at a coarse time granularity of 15s since
 // compactions can take ~10s to complete. The totalNumByteTokens to give out over
-// the 15s interval are given out in a smoothed manner, at 250ms intervals.
+// the 15s interval are given out in a smoothed manner, at either 1ms intervals,
+// or 250ms intervals depending on system load.
 // This has similarities with the following kinds of token buckets:
 //   - Zero replenishment rate and a burst value that is changed every 15s. We
 //     explicitly don't want a huge burst every 15s.
-//   - A replenishment rate equal to totalNumByteTokens/60, with a burst capped at
-//     totalNumByteTokens/60. The only difference with the code here is that if
-//     totalNumByteTokens is small, the integer rounding effects are compensated for.
+//   - For loaded systems, a replenishment rate equal to
+//     totalNumByteTokens/15000(once per ms), with a burst capped at
+//     totalNumByteTokens/60.
+//   - For unloaded systems, a replenishment rate equal to
+//     totalNumByteTokens/60(once per 250ms), with a burst capped at
+//     totalNumByteTokens/60.
+//   - The only difference with the code here is that if totalNumByteTokens is
+//     small, the integer rounding effects are compensated for.
 //
 // In an experiment with extreme overload using KV0 with block size 64KB,
 // and 4096 clients, we observed the following states of L0 at 1min
@@ -249,21 +256,101 @@ const unlimitedTokens = math.MaxInt64
 // complete (as opposed to also tracking progress in bytes of on-going
 // compactions).
 //
-// The 250ms interval to hand out the computed tokens is due to the needs of
-// flush tokens. For compaction tokens, a 1s interval is fine-grained enough.
+// An interval < 250ms is picked to hand out the computed tokens due to the needs
+// of flush tokens. For compaction tokens, a 1s interval is fine-grained enough.
 //
-// If flushing a memtable take 100ms, then 10 memtables can be sustainably
+// If flushing a memtable takes 100ms, then 10 memtables can be sustainably
 // flushed in 1s. If we dole out flush tokens in 1s intervals, then there are
 // enough tokens to create 10 memtables at the very start of a 1s interval,
 // which will cause a write stall. Intuitively, the faster it is to flush a
 // memtable, the smaller the interval for doling out these tokens. We have
-// observed flushes taking ~0.5s, so we picked a 250ms interval for doling out
-// these tokens. We could use a value smaller than 250ms, but we've observed
-// CPU utilization issues at lower intervals (see the discussion in
-// runnable.go).
+// observed flushes taking ~0.5s, so we need to pick an interval less than 0.5s,
+// say 250ms, for doling out these tokens.
+//
+// We use a 1ms interval for handing out tokens, to avoid upto 250ms wait times
+// for high priority requests. As a simple example, consider a scenario where
+// each request needs 1 byte token, and there are 1000 tokens added every 250ms.
+// There is a uniform arrival rate of 2000 high priority requests/s, so 500
+// requests uniformly distributed over 250ms. And a uniform arrival rate of
+// 10,000/s of low priority requests, so 2500 requests uniformly distributed over
+// 250ms. There are more than enough tokens to fully satisfy the high priority
+// tokens (they use only 50% of the tokens), but not enough for the low priority
+// requests. Ignore the fact that the latter will result in indefinite queue
+// growth in the admission control WorkQueue. At a particular 250ms tick, the
+// token bucket will go from 0 tokens to 1000 tokens. Any queued high priority
+// requests will be immediately granted their token, until there are no queued
+// high priority requests. Then since there are always a large number of low
+// priority requests waiting, they will be granted until 0 tokens remain. Now we
+// have a 250ms duration until the next replenishment and 0 tokens, so any high
+// priority requests arriving will have to wait. The maximum wait time is 250ms.
+//
+// We use a 250ms intervals for underloaded systems, to avoid CPU utilization
+// issues (see the discussion in runnable.go).
 const adjustmentInterval = 15
-const ticksInAdjustmentInterval = 60
-const ioTokenTickDuration = 250 * time.Millisecond
+
+type tickDuration time.Duration
+
+func (t tickDuration) ticksInAdjustmentInterval() int64 {
+	return 15 * int64(time.Second/time.Duration(t))
+}
+
+const unloadedDuration = tickDuration(250 * time.Millisecond)
+const loadedDuration = tickDuration(1 * time.Millisecond)
+
+// tokenAllocationTicker wraps a time.Ticker, and also computes the remaining
+// ticks in the adjustment interval, given an expected tick rate. If every tick
+// from the ticker was always equal to the expected tick rate, then we could
+// easily determine the remaining ticks, but each tick of time.Ticker can have
+// drift, especially for tiny tick rates like 1ms.
+type tokenAllocationTicker struct {
+	expectedTickDuration        time.Duration
+	adjustmentIntervalStartTime time.Time
+	ticker                      *time.Ticker
+}
+
+// Start a new adjustment interval. adjustmentStart must be called before tick
+// is called. After the initial call, adjustmentStart must also be called if
+// remainingticks returns 0, to indicate that a new adjustment interval has
+// started.
+func (t *tokenAllocationTicker) adjustmentStart(loaded bool) {
+	// For each adjustmentInterval, we pick a tick rate depending on the system
+	// load. If the system is unloaded, we tick at a 250ms rate, and if the system
+	// is loaded, we tick at a 1ms rate. See the comment above the
+	// adjustmentInterval definition to see why we tick at different rates.
+	tickDuration := unloadedDuration
+	if loaded {
+		tickDuration = loadedDuration
+	}
+	t.expectedTickDuration = time.Duration(tickDuration)
+	if t.ticker == nil {
+		t.ticker = time.NewTicker(t.expectedTickDuration)
+	} else {
+		t.ticker.Reset(t.expectedTickDuration)
+	}
+	t.adjustmentIntervalStartTime = timeutil.Now()
+}
+
+func (t *tokenAllocationTicker) tick() {
+	<-t.ticker.C
+}
+
+// remainingTicks will return the remaining ticks before the next adjustment
+// interval is reached while assuming that all future ticks will have a duration of
+// expectedTickDuration. A return value of 0 indicates that adjustmentStart must
+// be called, as the previous adjustmentInterval is over.
+func (t *tokenAllocationTicker) remainingTicks() uint64 {
+	timePassed := timeutil.Since(t.adjustmentIntervalStartTime)
+	if timePassed > adjustmentInterval*time.Second {
+		return 0
+	}
+	remainingTime := adjustmentInterval*time.Second - timePassed
+	return uint64((remainingTime + t.expectedTickDuration - 1) / t.expectedTickDuration)
+}
+
+func (t *tokenAllocationTicker) stop() {
+	t.ticker.Stop()
+	*t = tokenAllocationTicker{}
+}
 
 func cumLSMWriteAndIngestedBytes(
 	m *pebble.Metrics,
@@ -276,8 +363,9 @@ func cumLSMWriteAndIngestedBytes(
 }
 
 // pebbleMetricsTicks is called every adjustmentInterval seconds, and decides
-// the token allocations until the next call.
-func (io *ioLoadListener) pebbleMetricsTick(ctx context.Context, metrics StoreMetrics) {
+// the token allocations until the next call. Returns true iff the system is
+// loaded.
+func (io *ioLoadListener) pebbleMetricsTick(ctx context.Context, metrics StoreMetrics) bool {
 	ctx = logtags.AddTag(ctx, "s", io.storeID)
 	m := metrics.Metrics
 	if !io.statsInitialized {
@@ -307,24 +395,37 @@ func (io *ioLoadListener) pebbleMetricsTick(ctx context.Context, metrics StoreMe
 		io.diskBW.incomingLSMBytes = cumLSMIncomingBytes
 		io.cumFlushWriteThroughput = metrics.Flush.WriteThroughput
 		io.copyAuxEtcFromPerWorkEstimator()
-		return
+
+		// Assume system starts off unloaded.
+		return false
 	}
 	io.adjustTokens(ctx, metrics)
 	io.cumFlushWriteThroughput = metrics.Flush.WriteThroughput
+	// We assume that the system is loaded if there is less than unlimited tokens
+	// available.
+	return io.totalNumByteTokens < unlimitedTokens
 }
 
-// allocateTokensTick gives out 1/ticksInAdjustmentInterval of the
-// various tokens every 250ms.
-func (io *ioLoadListener) allocateTokensTick() {
-	allocateFunc := func(total int64, allocated int64) (toAllocate int64) {
-		// unlimitedTokens==MaxInt64, so avoid overflow in the rounding up
-		// calculation.
-		if total >= unlimitedTokens-(ticksInAdjustmentInterval-1) {
-			toAllocate = total / ticksInAdjustmentInterval
+// For both byte and disk bandwidth tokens, allocateTokensTick gives out
+// remainingTokens/remainingTicks tokens in the current tick.
+func (io *ioLoadListener) allocateTokensTick(remainingTicks int64) {
+	allocateFunc := func(total int64, allocated int64, remainingTicks int64) (toAllocate int64) {
+		remainingTokens := total - allocated
+		// remainingTokens can be equal to unlimitedTokens(MaxInt64) if allocated ==
+		// 0. In such cases remainingTokens + remainingTicks - 1 will overflow.
+		if remainingTokens >= unlimitedTokens-(remainingTicks-1) {
+			toAllocate = remainingTokens / remainingTicks
 		} else {
-			// Round up so that we don't accumulate tokens to give in a burst on the
-			// last tick.
-			toAllocate = (total + ticksInAdjustmentInterval - 1) / ticksInAdjustmentInterval
+			// Round up so that we don't accumulate tokens to give in a burst on
+			// the last tick.
+			//
+			// TODO(bananabrick): Rounding up is a problem for 1ms tick rate as we tick
+			// up to 15000 times. Say totalNumByteTokens is 150001. We round up to give
+			// 11 tokens per ms. So, we'll end up distributing the 150001 available
+			// tokens in 150000/11 == 13637 remainingTicks. So, we'll have over a
+			// second where we grant no tokens. Larger values of totalNumBytesTokens
+			// will ease this problem.
+			toAllocate = (remainingTokens + remainingTicks - 1) / remainingTicks
 			if toAllocate < 0 {
 				panic(errors.AssertionFailedf("toAllocate is negative %d", toAllocate))
 			}
@@ -335,12 +436,20 @@ func (io *ioLoadListener) allocateTokensTick() {
 		return toAllocate
 	}
 	// INVARIANT: toAllocate* >= 0.
-	toAllocateByteTokens := allocateFunc(io.totalNumByteTokens, io.byteTokensAllocated)
+	toAllocateByteTokens := allocateFunc(
+		io.totalNumByteTokens,
+		io.byteTokensAllocated,
+		remainingTicks,
+	)
 	if toAllocateByteTokens < 0 {
 		panic(errors.AssertionFailedf("toAllocateByteTokens is negative %d", toAllocateByteTokens))
 	}
 	toAllocateElasticDiskBWTokens :=
-		allocateFunc(io.elasticDiskBWTokens, io.elasticDiskBWTokensAllocated)
+		allocateFunc(
+			io.elasticDiskBWTokens,
+			io.elasticDiskBWTokensAllocated,
+			remainingTicks,
+		)
 	if toAllocateElasticDiskBWTokens < 0 {
 		panic(errors.AssertionFailedf("toAllocateElasticDiskBWTokens is negative %d",
 			toAllocateElasticDiskBWTokens))
@@ -352,7 +461,18 @@ func (io *ioLoadListener) allocateTokensTick() {
 	}
 	io.elasticDiskBWTokensAllocated += toAllocateElasticDiskBWTokens
 
-	io.byteTokensUsed += io.kvGranter.setAvailableTokens(toAllocateByteTokens, toAllocateElasticDiskBWTokens)
+	tokensMaxCapacity := allocateFunc(
+		io.totalNumByteTokens, 0, unloadedDuration.ticksInAdjustmentInterval(),
+	)
+	diskBWTokenMaxCapacity := allocateFunc(
+		io.elasticDiskBWTokens, 0, unloadedDuration.ticksInAdjustmentInterval(),
+	)
+	io.byteTokensUsed += io.kvGranter.setAvailableTokens(
+		toAllocateByteTokens,
+		toAllocateElasticDiskBWTokens,
+		tokensMaxCapacity,
+		diskBWTokenMaxCapacity,
+	)
 }
 
 func computeIntervalDiskLoadInfo(

--- a/pkg/util/admission/io_load_listener_test.go
+++ b/pkg/util/admission/io_load_listener_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/redact"
@@ -160,6 +162,10 @@ func TestIOLoadListener(t *testing.T) {
 				if d.HasArg("print-only-first-tick") {
 					d.ScanArgs(t, "print-only-first-tick", &printOnlyFirstTick)
 				}
+				currDuration := unloadedDuration
+				if d.HasArg("loaded") {
+					currDuration = loadedDuration
+				}
 
 				ioll.pebbleMetricsTick(ctx, StoreMetrics{
 					Metrics:         &metrics,
@@ -180,8 +186,8 @@ func TestIOLoadListener(t *testing.T) {
 					fmt.Fprintf(&buf, "%s\n", req.buf.String())
 					req.buf.Reset()
 				}
-				for i := 0; i < ticksInAdjustmentInterval; i++ {
-					ioll.allocateTokensTick()
+				for i := 0; i < int(currDuration.ticksInAdjustmentInterval()); i++ {
+					ioll.allocateTokensTick(currDuration.ticksInAdjustmentInterval() - int64(i))
 					if i == 0 || !printOnlyFirstTick {
 						fmt.Fprintf(&buf, "tick: %d, %s\n", i, kvGranter.buf.String())
 					}
@@ -210,8 +216,8 @@ func TestIOLoadListenerOverflow(t *testing.T) {
 		// Override the totalNumByteTokens manually to trigger the overflow bug.
 		ioll.totalNumByteTokens = math.MaxInt64 - i
 		ioll.byteTokensAllocated = 0
-		for j := 0; j < ticksInAdjustmentInterval; j++ {
-			ioll.allocateTokensTick()
+		for j := 0; j < int(unloadedDuration.ticksInAdjustmentInterval()); j++ {
+			ioll.allocateTokensTick(unloadedDuration.ticksInAdjustmentInterval() - i)
 		}
 	}
 	// Bug2: overflow when bytes added delta is 0.
@@ -222,7 +228,7 @@ func TestIOLoadListenerOverflow(t *testing.T) {
 	}
 	ioll.pebbleMetricsTick(ctx, StoreMetrics{Metrics: &m})
 	ioll.pebbleMetricsTick(ctx, StoreMetrics{Metrics: &m})
-	ioll.allocateTokensTick()
+	ioll.allocateTokensTick(unloadedDuration.ticksInAdjustmentInterval())
 }
 
 // TODO(sumeer): we now do more work outside adjustTokensInner, so the parts
@@ -311,8 +317,8 @@ func TestBadIOLoadListenerStats(t *testing.T) {
 			Metrics:   &m,
 			DiskStats: d,
 		})
-		for j := 0; j < ticksInAdjustmentInterval; j++ {
-			ioll.allocateTokensTick()
+		for j := 0; j < int(loadedDuration.ticksInAdjustmentInterval()); j++ {
+			ioll.allocateTokensTick(loadedDuration.ticksInAdjustmentInterval() - int64(i))
 			require.LessOrEqual(t, int64(0), ioll.smoothedIntL0CompactedBytes)
 			require.LessOrEqual(t, float64(0), ioll.smoothedCompactionByteTokens)
 			require.LessOrEqual(t, float64(0), ioll.smoothedNumFlushTokens)
@@ -355,11 +361,14 @@ type testGranterWithIOTokens struct {
 var _ granterWithIOTokens = &testGranterWithIOTokens{}
 
 func (g *testGranterWithIOTokens) setAvailableTokens(
-	ioTokens int64, elasticDiskBandwidthTokens int64,
+	ioTokens int64, elasticDiskBandwidthTokens int64, maxIOTokens int64, maxElasticTokens int64,
 ) (tokensUsed int64) {
-	fmt.Fprintf(&g.buf, "setAvailableTokens: io-tokens=%s elastic-disk-bw-tokens=%s",
+	fmt.Fprintf(&g.buf, "setAvailableTokens: io-tokens=%s elastic-disk-bw-tokens=%s max-byte-tokens=%s max-disk-bw-tokens=%s",
 		tokensForTokenTickDurationToString(ioTokens),
-		tokensForTokenTickDurationToString(elasticDiskBandwidthTokens))
+		tokensForTokenTickDurationToString(elasticDiskBandwidthTokens),
+		tokensForTokenTickDurationToString(maxIOTokens),
+		tokensForTokenTickDurationToString(maxElasticTokens),
+	)
 	if g.allTokensUsed {
 		return ioTokens * 2
 	}
@@ -383,7 +392,7 @@ func (g *testGranterWithIOTokens) setLinearModels(
 }
 
 func tokensForTokenTickDurationToString(tokens int64) string {
-	if tokens >= unlimitedTokens/ticksInAdjustmentInterval {
+	if tokens >= unlimitedTokens/loadedDuration.ticksInAdjustmentInterval() {
 		return "unlimited"
 	}
 	return fmt.Sprintf("%d", tokens)
@@ -398,7 +407,7 @@ type testGranterNonNegativeTokens struct {
 var _ granterWithIOTokens = &testGranterNonNegativeTokens{}
 
 func (g *testGranterNonNegativeTokens) setAvailableTokens(
-	ioTokens int64, elasticDiskBandwidthTokens int64,
+	ioTokens int64, elasticDiskBandwidthTokens int64, _ int64, _ int64,
 ) (tokensUsed int64) {
 	require.LessOrEqual(g.t, int64(0), ioTokens)
 	require.LessOrEqual(g.t, int64(0), elasticDiskBandwidthTokens)
@@ -418,4 +427,76 @@ func (g *testGranterNonNegativeTokens) setLinearModels(
 	require.LessOrEqual(g.t, int64(0), l0IngestLM.constant)
 	require.LessOrEqual(g.t, 0.5, ingestLM.multiplier)
 	require.LessOrEqual(g.t, int64(0), ingestLM.constant)
+}
+
+// Tests if the tokenAllocationTicker produces correct adjustment interval
+// durations for both loaded and unloaded systems.
+func TestTokenAllocationTickerAdjustmentCalculation(t *testing.T) {
+	// TODO(bananabrick): We might want to use a timeutil.TimeSource and
+	// ManualTime for the tokenAllocationTicker, so that we can run this test
+	// without any worry about flakes.
+	skip.IgnoreLint(t)
+
+	ticker := tokenAllocationTicker{}
+	defer ticker.stop()
+	currTime := timeutil.Now()
+	ticker.adjustmentStart(true /* loaded */)
+	adjustmentChanged := false
+	for {
+		ticker.tick()
+		remainingTicks := ticker.remainingTicks()
+		if remainingTicks == 0 {
+			if adjustmentChanged {
+				break
+			}
+			abs := func(diff time.Duration) time.Duration {
+				if diff < 0 {
+					return -diff
+				}
+				return diff
+			}
+			timeElapsed := timeutil.Since(currTime)
+			diff := abs(timeElapsed - (15 * time.Second))
+			if diff > 1*time.Second {
+				t.FailNow()
+			}
+			ticker.adjustmentStart(false /* loaded */)
+			currTime = timeutil.Now()
+			adjustmentChanged = true
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+}
+
+func TestTokenAllocationTicker(t *testing.T) {
+	// TODO(bananabrick): This might be flaky, in which case we should use a
+	// timeutil.TimeSource and ManualTime in the tokenAllocationTicker for these
+	// tests.
+	ticker := tokenAllocationTicker{}
+	defer ticker.stop()
+
+	// Test remainingTicks calculations.
+	ticker.adjustmentStart(false /* loaded */)
+	require.Equal(t, 60, int(ticker.remainingTicks()))
+	time.Sleep(1 * time.Second)
+	// At least one second has passed, we assume that 2 seconds could've passed.
+	// So, we have 13-14 seconds remaining.
+	remaining := ticker.remainingTicks()
+	if remaining < 52 || remaining > 56 {
+		t.FailNow()
+	}
+
+	ticker.adjustmentStart(true /* unloaded */)
+	require.Equal(t, 15000, int(ticker.remainingTicks()))
+	time.Sleep(1 * time.Second)
+	// At least one second has passed. Assume an error of at most one seconds, so
+	// at most 2 seconds have passed. So, we have 13-14 seconds remaining.
+	remaining = ticker.remainingTicks()
+	if remaining > 14000 || remaining < 13000 {
+		t.FailNow()
+	}
+
+	// Skip to the future in which case remainingTicks must be exhausted.
+	ticker.adjustmentIntervalStartTime = timeutil.Now().Add(-17 * time.Second)
+	require.Equal(t, 0, int(ticker.remainingTicks()))
 }

--- a/pkg/util/admission/testdata/granter
+++ b/pkg/util/admission/testdata/granter
@@ -379,7 +379,7 @@ GrantCoordinator:
 sql-sql-response: avail: -1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 #####################################################################
-# Test store grant coordinator.
+# Test store grant coordinator with a 250ms tick rate for the tokens.
 init-store-grant-coordinator
 ----
 GrantCoordinator:
@@ -387,7 +387,7 @@ GrantCoordinator:
 
 # Set tokens to a large value that permits all request sizes in this file.
 # Set elastic tokens to a large value that permits all request sizes.
-set-tokens io-tokens=100000 elastic-disk-bw-tokens=100000
+set-tokens io-tokens=100000 elastic-disk-bw-tokens=100000 tick-interval=250
 ----
 GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: 100000, elastic-disk-bw-tokens-avail: 100000
@@ -400,7 +400,7 @@ GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: 90000, elastic-disk-bw-tokens-avail: 100000
 
 # Set the io tokens to a smaller value.
-set-tokens io-tokens=500 elastic-disk-bw-tokens=100000
+set-tokens io-tokens=500 elastic-disk-bw-tokens=100000 tick-interval=250
 ----
 GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: 500, elastic-disk-bw-tokens-avail: 100000
@@ -453,7 +453,7 @@ GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: -100, elastic-disk-bw-tokens-avail: 99900
 
 # Increment by 50 tokens.
-set-tokens io-tokens=50 elastic-disk-bw-tokens=99900
+set-tokens io-tokens=50 elastic-disk-bw-tokens=99900 tick-interval=250
 ----
 GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: -50, elastic-disk-bw-tokens-avail: 99900
@@ -504,20 +504,20 @@ GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: -99, elastic-disk-bw-tokens-avail: 100300
 
 # kv-elastic is granted.
-set-tokens io-tokens=100 elastic-disk-bw-tokens=100300
+set-tokens io-tokens=100 elastic-disk-bw-tokens=100300 tick-interval=250
 ----
 kv-elastic: granted in chain 0, and returning 200
 GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: -199, elastic-disk-bw-tokens-avail: 100100
 
 # Nothing is granted.
-set-tokens io-tokens=0 elastic-disk-bw-tokens=50
+set-tokens io-tokens=0 elastic-disk-bw-tokens=50 tick-interval=250
 ----
 GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: -199, elastic-disk-bw-tokens-avail: 50
 
 # Both kinds of tokens are decremented and become negative.
-set-tokens io-tokens=200 elastic-disk-bw-tokens=50
+set-tokens io-tokens=200 elastic-disk-bw-tokens=50 tick-interval=250
 ----
 kv-elastic: granted in chain 0, and returning 200
 GrantCoordinator:
@@ -525,7 +525,7 @@ GrantCoordinator:
 
 # IO tokens become positive. But no grant to elastic work since
 # elastic-disk-bw tokens are negative.
-set-tokens io-tokens=300 elastic-disk-bw-tokens=0
+set-tokens io-tokens=300 elastic-disk-bw-tokens=0 tick-interval=250
 ----
 GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: 101, elastic-disk-bw-tokens-avail: -150
@@ -545,20 +545,20 @@ GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: 91, elastic-disk-bw-tokens-avail: -150
 
 # Still negative. Add elastic-disk-bw-tokens, but don't change io tokens.
-set-tokens io-tokens=91 elastic-disk-bw-tokens=50
+set-tokens io-tokens=91 elastic-disk-bw-tokens=50 tick-interval=250
 ----
 GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: 91, elastic-disk-bw-tokens-avail: -100
 
 # Add some io-tokens.
-set-tokens io-tokens=400 elastic-disk-bw-tokens=0
+set-tokens io-tokens=400 elastic-disk-bw-tokens=0 tick-interval=250
 ----
 GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: 400, elastic-disk-bw-tokens-avail: -100
 
 # Finally both tokens are positive and we grant until the elastic-disk-bw
 # tokens become negative.
-set-tokens io-tokens=400 elastic-disk-bw-tokens=120
+set-tokens io-tokens=400 elastic-disk-bw-tokens=120 tick-interval=250
 ----
 kv-elastic: granted in chain 0, and returning 200
 GrantCoordinator:
@@ -584,3 +584,118 @@ store-write-done work=kv-elastic orig-tokens=400 write-bytes=40
 ----
 GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: 650, elastic-disk-bw-tokens-avail: -10
+
+#####################################################################
+# Test store grant coordinator with 1ms tick rates for set-tokens, and transitions
+# between the 1ms and 250ms tick rates. Note the the previous test tests how
+# the kvStoreTokenGranter behaves given the amount of available tokens it has.
+# This test is trying to see if the value of the available tokens is correct on
+# calls to set-tokens.
+
+# The system starts off with a large number of tokens available.
+init-store-grant-coordinator
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 153722867280912930, elastic-disk-bw-tokens-avail: 153722867280912930
+
+# Tokens set to 250 * 10 = 2500.
+set-tokens io-tokens=10 elastic-disk-bw-tokens=10 tick-interval=1
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 2500, elastic-disk-bw-tokens-avail: 2500
+
+try-get work=kv-elastic v=2490
+----
+kv-elastic: tryGet(2490) returned true
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 10, elastic-disk-bw-tokens-avail: 10
+
+# Initial tokens are effectively unlimited.
+try-get work=kv v=1
+----
+kv-regular: tryGet(1) returned true
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 9, elastic-disk-bw-tokens-avail: 10
+
+# Set the io tokens to a smaller value. Note that since the IO tokens can
+# increase up to 6*250 and 10*250, we expect the tokens to increase to 15, and
+# 20 respectively.
+set-tokens io-tokens=6 elastic-disk-bw-tokens=10 tick-interval=1
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 15, elastic-disk-bw-tokens-avail: 20
+
+# Subtract 10 tokens for elastic work. Note that elastic-disk-bw-tokens-avail also decreases by 10.
+took-without-permission work=kv-elastic v=10
+----
+kv-elastic: tookWithoutPermission(10)
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 5, elastic-disk-bw-tokens-avail: 10
+
+# Add 10 tokens.
+return-grant work=kv-elastic v=10
+----
+kv-elastic: returnGrant(10)
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 15, elastic-disk-bw-tokens-avail: 20
+
+# If io-tokens is 10, we expect the tokens to accumulate upto 2500. So, we call
+# set-tokens 250 times, and ensure that the tokens are capped at 2500.
+set-tokens-loop io-tokens=10 elastic-disk-bw-tokens=10 loop=250
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 2500, elastic-disk-bw-tokens-avail: 2500
+
+# Setup waiting requests that want 1300 tokens each.
+set-has-waiting-requests work=kv-elastic v=true
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 2500, elastic-disk-bw-tokens-avail: 2500
+
+set-return-value-from-granted work=kv-elastic v=1300
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 2500, elastic-disk-bw-tokens-avail: 2500
+
+# Returning tokens triggers granting and 2 requests will be granted until the
+# tokens become <= 0.
+return-grant work=kv v=1
+----
+kv-regular: returnGrant(1)
+kv-elastic: granted in chain 0, and returning 1300
+kv-elastic: granted in chain 0, and returning 1300
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: -99, elastic-disk-bw-tokens-avail: -100
+
+# No tokens to give.
+try-get work=kv
+----
+kv-regular: tryGet(1) returned false
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: -99, elastic-disk-bw-tokens-avail: -100
+
+set-has-waiting-requests work=kv-elastic v=false
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: -99, elastic-disk-bw-tokens-avail: -100
+
+# Negative tokens available should be respected on a subsequent call to set-tokens.
+set-tokens io-tokens=100 elastic-disk-bw-tokens=0 tick-interval=1
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 1, elastic-disk-bw-tokens-avail: -100
+
+# No elastic tokens to give.
+try-get work=kv-elastic
+----
+kv-elastic: tryGet(1) returned false
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 1, elastic-disk-bw-tokens-avail: -100
+
+# Switch to an unloaded system which ticks at a 250ms rate. With this interval,
+# we expect the available tokens to be at most 50, 110 respectively. We see the
+# io-tokens clamp at 50, and the elastic-disk-bw-tokens increase to 10.
+set-tokens io-tokens=50 elastic-disk-bw-tokens=110 tick-interval=250
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 50, elastic-disk-bw-tokens-avail: 10

--- a/pkg/util/admission/testdata/io_load_listener
+++ b/pkg/util/admission/testdata/io_load_listener
@@ -13,66 +13,66 @@ set-state l0-bytes=10000 l0-added-write=1000 l0-files=21 l0-sublevels=21
 ----
 compaction score 0.000 (21 ssts, 21 sub-levels), L0 growth 0 B (write 0 B ingest 0 B ignored 0 B): requests 0 (0 bypassed) with 0 B acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
 {ioLoadListenerState:{cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:1000} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
-tick: 0, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 1, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 2, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 3, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 4, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 5, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 6, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 7, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 8, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 9, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 10, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 11, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 12, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 13, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 14, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 15, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 16, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 17, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 18, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 19, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 20, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 21, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 22, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 23, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 24, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 25, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 26, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 27, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 28, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 29, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 30, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 31, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 32, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 33, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 34, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 35, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 36, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 37, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 38, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 39, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 40, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 41, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 42, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 43, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 44, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 45, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 46, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 47, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 48, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 49, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 50, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 51, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 52, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 53, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 54, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 55, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 56, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 57, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 58, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
-tick: 59, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
+tick: 0, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 1, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 2, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 3, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 4, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 5, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 6, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 7, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 8, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 9, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 10, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 11, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 12, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 13, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 14, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 15, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 16, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 17, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 18, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 19, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 20, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 21, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 22, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 23, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 24, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 25, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 26, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 27, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 28, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 29, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 30, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 31, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 32, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 33, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 34, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 35, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 36, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 37, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 38, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 39, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 40, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 41, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 42, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 43, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 44, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 45, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 46, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 47, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 48, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 49, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 50, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 51, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 52, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 53, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 54, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 55, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 56, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 57, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 58, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+tick: 59, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
 
 prep-admission-stats admitted=10000 write-bytes=40000
 ----
@@ -88,66 +88,66 @@ compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 98 KiB (
 {ioLoadListenerState:{cumL0AddedBytes:101000 curL0Bytes:10000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:101000} smoothedIntL0CompactedBytes:50000 smoothedCompactionByteTokens:12500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:12500 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:5} l0WriteLM:{multiplier:2 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10000 intL0WriteBytes:100000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:40000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:2.25 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:100000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 5
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 2.00x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 1, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 2, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 3, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 4, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 5, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 6, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 7, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 8, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 9, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 10, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 11, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 12, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 13, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 14, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 15, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 16, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 17, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 18, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 19, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 20, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 21, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 22, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 23, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 24, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 25, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 26, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 27, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 28, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 29, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 30, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 31, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 32, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 33, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 34, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 35, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 36, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 37, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 38, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 39, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 40, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 41, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 42, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 43, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 44, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 45, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 46, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 47, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 48, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 49, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 50, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 51, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 52, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 53, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 54, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 55, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 56, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 57, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 58, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited
-tick: 59, setAvailableTokens: io-tokens=169 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 1, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 2, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 3, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 4, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 5, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 6, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 7, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 8, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 9, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 10, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 11, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 12, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 13, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 14, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 15, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 16, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 17, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 18, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 19, setAvailableTokens: io-tokens=209 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 20, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 21, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 22, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 23, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 24, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 25, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 26, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 27, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 28, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 29, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 30, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 31, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 32, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 33, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 34, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 35, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 36, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 37, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 38, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 39, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 40, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 41, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 42, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 43, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 44, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 45, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 46, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 47, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 48, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 49, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 50, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 51, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 52, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 53, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 54, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 55, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 56, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 57, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 58, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+tick: 59, setAvailableTokens: io-tokens=208 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
 
 prep-admission-stats admitted=20000 write-bytes=80000
 ----
@@ -160,66 +160,66 @@ compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 98 KiB (
 {ioLoadListenerState:{cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:201000} smoothedIntL0CompactedBytes:75000 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:7} l0WriteLM:{multiplier:2.125 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10000 intL0WriteBytes:100000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:40000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:2.25 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:100000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 7
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 2.12x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 1, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 2, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 3, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 4, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 5, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 6, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 7, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 8, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 9, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 10, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 11, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 12, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 13, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 14, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 15, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 16, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 17, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 18, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 19, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 20, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 21, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 22, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 23, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 24, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 25, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 26, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 27, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 28, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 29, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 30, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 31, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 32, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 33, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 34, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 35, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 36, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 37, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 38, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 39, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 40, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 41, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 42, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 43, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 44, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 45, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 46, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 47, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 48, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 49, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 50, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 51, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 52, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 53, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 54, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 55, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 56, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 57, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 58, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
-tick: 59, setAvailableTokens: io-tokens=397 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 1, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 2, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 3, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 4, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 5, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 6, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 7, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 8, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 9, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 10, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 11, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 12, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 13, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 14, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 15, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 16, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 17, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 18, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 19, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 20, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 21, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 22, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 23, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 24, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 25, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 26, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 27, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 28, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 29, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 30, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 31, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 32, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 33, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 34, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 35, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 36, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 37, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 38, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 39, setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 40, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 41, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 42, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 43, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 44, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 45, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 46, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 47, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 48, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 49, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 50, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 51, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 52, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 53, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 54, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 55, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 56, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 57, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 58, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
+tick: 59, setAvailableTokens: io-tokens=416 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
 
 # No delta. This used to trigger an overflow bug.
 set-state l0-bytes=10000 l0-added-write=201000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
@@ -228,7 +228,7 @@ compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 0 B (wri
 {ioLoadListenerState:{cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:201000} smoothedIntL0CompactedBytes:37500 smoothedCompactionByteTokens:21875 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:21875 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:7} l0WriteLM:{multiplier:2.125 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 7
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 2.12x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=365 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=365 elastic-disk-bw-tokens=unlimited max-byte-tokens=365 max-disk-bw-tokens=unlimited
 
 prep-admission-stats admitted=30000 write-bytes=120000
 ----
@@ -242,7 +242,7 @@ compaction score 1.000 (21 ssts, 20 sub-levels), L0 growth 293 KiB (write 293 Ki
 {ioLoadListenerState:{cumL0AddedBytes:501000 curL0Bytes:10000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:501000} smoothedIntL0CompactedBytes:168750 smoothedCompactionByteTokens:160937.5 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:18} l0WriteLM:{multiplier:2.5625 constant:9} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:300000 intL0CompactedBytes:300000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10000 intL0WriteBytes:300000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:40000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:3 constant:18} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:300000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 18
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 2.56x+9 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
 
 # Test cases with more information in storeAdmissionStats.
 init
@@ -256,7 +256,7 @@ set-state l0-bytes=1000 l0-added-write=1000 l0-added-ingested=0 l0-files=21 l0-s
 ----
 compaction score 0.000 (21 ssts, 21 sub-levels), L0 growth 0 B (write 0 B ingest 0 B ignored 0 B): requests 0 (0 bypassed) with 0 B acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
 {ioLoadListenerState:{cumL0AddedBytes:1000 curL0Bytes:1000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:1000} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
-tick: 0, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
+tick: 0, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
 
 # L0 will see an addition of 200,000 bytes. 150,000 bytes were mentioned by
 # the admitted requests.
@@ -275,7 +275,7 @@ compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 195 KiB 
 {ioLoadListenerState:{cumL0AddedBytes:201000 curL0Bytes:1000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:201000} smoothedIntL0CompactedBytes:100000 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:10000} l0WriteLM:{multiplier:1.5288076923076923 constant:1} l0IngestLM:{multiplier:1.125 constant:1} ingestLM:{multiplier:1.2497500000000001 constant:1} aux:{intL0AddedBytes:200000 intL0CompactedBytes:200000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:170000 intL0IngestedBytes:30000 intLSMIngestedBytes:30000 intL0WriteAccountedBytes:130000 intIngestedAccountedBytes:20000 intL0WriteLinearModel:{multiplier:1.3076153846153846 constant:1} intL0IngestedLinearModel:{multiplier:1.4995 constant:1} intIngestedLinearModel:{multiplier:1.4995 constant:1} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:200000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 10000
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.53x+1 l0-ingest-lm: 1.12x+1 ingest-lm: 1.25x+1
-setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=417 elastic-disk-bw-tokens=unlimited max-byte-tokens=417 max-disk-bw-tokens=unlimited
 
 # L0 will see an addition of 20,000 bytes, all of which are accounted for.
 # Since the ingested bytes in this interval are 0, the constant for the
@@ -290,7 +290,7 @@ compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 20 KiB (
 {ioLoadListenerState:{cumL0AddedBytes:221000 curL0Bytes:1000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:221000} smoothedIntL0CompactedBytes:60000 smoothedCompactionByteTokens:27500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:27500 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:6000} l0WriteLM:{multiplier:1.2641538461538462 constant:1} l0IngestLM:{multiplier:1.125 constant:1} ingestLM:{multiplier:1.2497500000000001 constant:1} aux:{intL0AddedBytes:20000 intL0CompactedBytes:20000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:20000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:20000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0.9995 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:20000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 6000
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.26x+1 l0-ingest-lm: 1.12x+1 ingest-lm: 1.25x+1
-setAvailableTokens: io-tokens=459 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=459 elastic-disk-bw-tokens=unlimited max-byte-tokens=459 max-disk-bw-tokens=unlimited
 
 # L0 will see an addition of 20,000 bytes, but we think we have added 100,000
 # bytes to L0. We don't let unaccounted bytes become negative.
@@ -304,7 +304,7 @@ compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 20 KiB (
 {ioLoadListenerState:{cumL0AddedBytes:241000 curL0Bytes:1000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:241000} smoothedIntL0CompactedBytes:40000 smoothedCompactionByteTokens:23750 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:23750 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:4000} l0WriteLM:{multiplier:0.8820769230769231 constant:1} l0IngestLM:{multiplier:1.125 constant:1} ingestLM:{multiplier:1.2497500000000001 constant:1} aux:{intL0AddedBytes:20000 intL0CompactedBytes:20000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:20000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:100000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0.5 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:20000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 4000
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 0.88x+1 l0-ingest-lm: 1.12x+1 ingest-lm: 1.25x+1
-setAvailableTokens: io-tokens=396 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=396 elastic-disk-bw-tokens=unlimited max-byte-tokens=396 max-disk-bw-tokens=unlimited
 
 # Test case with flush tokens.
 init
@@ -318,7 +318,7 @@ set-state l0-bytes=10000 l0-added-write=1000 l0-files=1 l0-sublevels=1 print-onl
 ----
 compaction score 0.000 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B ignored 0 B): requests 0 (0 bypassed) with 0 B acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
 {ioLoadListenerState:{cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:1000} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
-tick: 0, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
+tick: 0, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
 
 # Flush loop utilization is too low for the interval flush tokens to
 # contribute to the smoothed value, or for tokens to become limited.
@@ -328,7 +328,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 9.8 KiB (write 9.8 KiB 
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:1000 WorkDuration:2000000000 IdleDuration:100000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:5000 smoothedCompactionByteTokens:5000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:10000 intL0CompactedBytes:10000 intFlushTokens:7500 intFlushUtilization:0.0196078431372549 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:10000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:10000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
 
 # Flush loop utilization is high enough, so we compute flush tokens for limiting admission.
 set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=1000 flush-work-sec=2 flush-idle-sec=10 print-only-first-tick=true
@@ -337,7 +337,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:2000 WorkDuration:4000000000 IdleDuration:110000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:2500 smoothedCompactionByteTokens:2500 smoothedNumFlushTokens:7500 flushUtilTargetFraction:1.5 totalNumByteTokens:11250 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:7500 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=188 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=188 elastic-disk-bw-tokens=unlimited max-byte-tokens=188 max-disk-bw-tokens=unlimited
 
 # Write stalls are happening, so decrease the flush utilization target
 # fraction from 1.5 to 1.475. But the peak flush rate has also increased since
@@ -348,7 +348,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:1 cumFlushWriteThroughput:{Bytes:12000 WorkDuration:6000000000 IdleDuration:120000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:1250 smoothedCompactionByteTokens:1250 smoothedNumFlushTokens:41250 flushUtilTargetFraction:1.475 totalNumByteTokens:60843 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1015 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1015 elastic-disk-bw-tokens=unlimited max-byte-tokens=1015 max-disk-bw-tokens=unlimited
 
 # Two write stalls happened, so decrease the flush utilization target fraction
 # by a bigger step, from 1.475 to 1.425. Since the smoothed peak flush rate is
@@ -359,7 +359,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:3 cumFlushWriteThroughput:{Bytes:22000 WorkDuration:8000000000 IdleDuration:130000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:625 smoothedCompactionByteTokens:625 smoothedNumFlushTokens:58125 flushUtilTargetFraction:1.4250000000000003 totalNumByteTokens:82828 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:2 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1381 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1381 elastic-disk-bw-tokens=unlimited max-byte-tokens=1381 max-disk-bw-tokens=unlimited
 
 # Five more write stalls, so the the flush utilization target fraction is
 # decreased to 1.35. The smoothed peak flush rate continues to increase.
@@ -369,7 +369,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:8 cumFlushWriteThroughput:{Bytes:32000 WorkDuration:10000000000 IdleDuration:140000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:312 smoothedCompactionByteTokens:312.5 smoothedNumFlushTokens:66562.5 flushUtilTargetFraction:1.3500000000000005 totalNumByteTokens:89859 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:5 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1498 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1498 elastic-disk-bw-tokens=unlimited max-byte-tokens=1498 max-disk-bw-tokens=unlimited
 
 # Another write stall, and the flush utilization target fraction drops to 1.325.
 set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=9 print-only-first-tick=true
@@ -378,7 +378,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:9 cumFlushWriteThroughput:{Bytes:42000 WorkDuration:12000000000 IdleDuration:150000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:156 smoothedCompactionByteTokens:156.25 smoothedNumFlushTokens:70781.25 flushUtilTargetFraction:1.3250000000000006 totalNumByteTokens:93785 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1564 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1564 elastic-disk-bw-tokens=unlimited max-byte-tokens=1564 max-disk-bw-tokens=unlimited
 
 # Set a lower bound of 1.3 on the flush utilization target fraction.
 set-min-flush-util percent=130
@@ -392,7 +392,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:10 cumFlushWriteThroughput:{Bytes:52000 WorkDuration:14000000000 IdleDuration:160000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:78 smoothedCompactionByteTokens:78.125 smoothedNumFlushTokens:72890.625 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:94757 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1580 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1580 elastic-disk-bw-tokens=unlimited max-byte-tokens=1580 max-disk-bw-tokens=unlimited
 
 # Despite another write stall, the flush utilization target fraction does not
 # decrease since it is already at the lower bound.
@@ -402,7 +402,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:11 cumFlushWriteThroughput:{Bytes:62000 WorkDuration:16000000000 IdleDuration:170000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:39 smoothedCompactionByteTokens:39.0625 smoothedNumFlushTokens:73945.3125 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:96128 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1603 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1603 elastic-disk-bw-tokens=unlimited max-byte-tokens=1603 max-disk-bw-tokens=unlimited
 
 # Bump up the lower bound to 1.35, which is greater than the current flush
 # utilization target fraction.
@@ -417,7 +417,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:12 cumFlushWriteThroughput:{Bytes:72000 WorkDuration:18000000000 IdleDuration:180000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:19 smoothedCompactionByteTokens:19.53125 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:100538 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1676 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1676 elastic-disk-bw-tokens=unlimited max-byte-tokens=1676 max-disk-bw-tokens=unlimited
 
 # The flush utilization is too low, so there is no limit on flush tokens.
 set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=100 write-stall-count=13 print-only-first-tick=true
@@ -426,7 +426,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 cumFlushWriteThroughput:{Bytes:82000 WorkDuration:20000000000 IdleDuration:280000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:9 smoothedCompactionByteTokens:9.765625 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.0196078431372549 intWriteStalls:1 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
 
 # Flush utilization is high enough, so flush tokens are again limited.
 set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 print-only-first-tick=true
@@ -435,7 +435,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 cumFlushWriteThroughput:{Bytes:92000 WorkDuration:22000000000 IdleDuration:290000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:4 smoothedCompactionByteTokens:4.8828125 smoothedNumFlushTokens:74736.328125 flushUtilTargetFraction:1.35 totalNumByteTokens:100894 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1682 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1682 elastic-disk-bw-tokens=unlimited max-byte-tokens=1682 max-disk-bw-tokens=unlimited
 
 # No write stalls, and token utilization is high, which will have an effect
 # in the next pebbleMetricsTick.
@@ -445,7 +445,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 cumFlushWriteThroughput:{Bytes:102000 WorkDuration:24000000000 IdleDuration:300000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:2 smoothedCompactionByteTokens:2.44140625 smoothedNumFlushTokens:74868.1640625 flushUtilTargetFraction:1.35 totalNumByteTokens:101072 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1685 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1685 elastic-disk-bw-tokens=unlimited max-byte-tokens=1685 max-disk-bw-tokens=unlimited
 
 # No write stalls, and token utilization was high, so flush utilization
 # target fraction is increased to 1.375.
@@ -455,7 +455,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 cumFlushWriteThroughput:{Bytes:112000 WorkDuration:26000000000 IdleDuration:310000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:1 smoothedCompactionByteTokens:1.220703125 smoothedNumFlushTokens:74934.08203125 flushUtilTargetFraction:1.375 totalNumByteTokens:103034 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:202144 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1718 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1718 elastic-disk-bw-tokens=unlimited max-byte-tokens=1718 max-disk-bw-tokens=unlimited
 
 # No write stalls, and token utilization was high, so flush utilization
 # target fraction is increased to 1.4.
@@ -465,7 +465,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 cumFlushWriteThroughput:{Bytes:122000 WorkDuration:28000000000 IdleDuration:320000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0.6103515625 smoothedNumFlushTokens:74967.041015625 flushUtilTargetFraction:1.4 totalNumByteTokens:104953 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:206068 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1750 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1750 elastic-disk-bw-tokens=unlimited max-byte-tokens=1750 max-disk-bw-tokens=unlimited
 
 # There is a write stall, so even though token utilization is high, we
 # decrease flush utilization target fraction to 1.375.
@@ -475,7 +475,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0
 {ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:14 cumFlushWriteThroughput:{Bytes:132000 WorkDuration:30000000000 IdleDuration:330000000000} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:11000} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0.30517578125 smoothedNumFlushTokens:74983.5205078125 flushUtilTargetFraction:1.375 totalNumByteTokens:103102 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:209906 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=1719 elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=1719 elastic-disk-bw-tokens=unlimited max-byte-tokens=1719 max-disk-bw-tokens=unlimited
 
 # Test disk bandwidth tokens.
 init
@@ -485,7 +485,7 @@ set-state l0-bytes=100 l0-added-write=0 bytes-read=0 bytes-written=0 provisioned
 ----
 compaction score 0.000 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B ignored 0 B): requests 0 (0 bypassed) with 0 B acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
 {ioLoadListenerState:{cumL0AddedBytes:0 curL0Bytes:100 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:0} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
-tick: 0, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
+tick: 0, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
 
 set-state l0-bytes=100 l0-added-write=100000 bytes-read=1000000 bytes-written=2000000 provisioned-bandwidth=10 disk-bw-tokens-used=(100,100) l0-files=1 l0-sublevels=1 print-only-first-tick=true
 ----
@@ -493,7 +493,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 98 KiB (write 0 B inges
 {ioLoadListenerState:{cumL0AddedBytes:100000 curL0Bytes:100 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:1000000 bytesWritten:2000000 incomingLSMBytes:100000} smoothedIntL0CompactedBytes:50000 smoothedCompactionByteTokens:50000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:6250 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:66666 writeBandwidth:133333 provisionedBandwidth:10} intervalLSMInfo:{incomingBytes:100000 regularTokensUsed:100 elasticTokensUsed:100}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=105
+setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=105 max-byte-tokens=unlimited max-disk-bw-tokens=105
 
 # Considered moderate load because not enough history at low load. Elastic
 # tokens don't increase since not fully utilized.
@@ -503,7 +503,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 98 KiB (write 98 KiB in
 {ioLoadListenerState:{cumL0AddedBytes:200000 curL0Bytes:100 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:2000000 bytesWritten:4000000 incomingLSMBytes:200000} smoothedIntL0CompactedBytes:75000 smoothedCompactionByteTokens:75000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:6250 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:100000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:66666 writeBandwidth:133333 provisionedBandwidth:4000000} intervalLSMInfo:{incomingBytes:100000 regularTokensUsed:100 elasticTokensUsed:100}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=105
+setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=105 max-byte-tokens=unlimited max-disk-bw-tokens=105
 
 # Stay at moderate load since utilization increasing.
 set-state l0-bytes=100 l0-added-write=300000 bytes-read=4000000 bytes-written=8000000 provisioned-bandwidth=4000000 disk-bw-tokens-used=(100,100) l0-files=1 l0-sublevels=1 print-only-first-tick=true
@@ -512,7 +512,7 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 98 KiB (write 98 KiB in
 {ioLoadListenerState:{cumL0AddedBytes:300000 curL0Bytes:100 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:4000000 bytesWritten:8000000 incomingLSMBytes:300000} smoothedIntL0CompactedBytes:87500 smoothedCompactionByteTokens:87500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:6250 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:100000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:133333 writeBandwidth:266666 provisionedBandwidth:4000000} intervalLSMInfo:{incomingBytes:100000 regularTokensUsed:100 elasticTokensUsed:100}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=105
+setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=105 max-byte-tokens=unlimited max-disk-bw-tokens=105
 
 # Drop to low load.
 set-state l0-bytes=100 l0-added-write=400000 bytes-read=5000000 bytes-written=9000000 provisioned-bandwidth=5000000 disk-bw-tokens-used=(100,100) l0-files=1 l0-sublevels=1 print-only-first-tick=true
@@ -521,4 +521,53 @@ compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 98 KiB (write 98 KiB in
 {ioLoadListenerState:{cumL0AddedBytes:400000 curL0Bytes:100 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:5000000 bytesWritten:9000000 incomingLSMBytes:400000} smoothedIntL0CompactedBytes:93750 smoothedCompactionByteTokens:93750 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:100000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:66666 writeBandwidth:66666 provisionedBandwidth:5000000} intervalLSMInfo:{incomingBytes:100000 regularTokensUsed:100 elasticTokensUsed:100}}} ioThreshold:<nil>}
 store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
-setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited
+setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+
+# Test out max capacity calculations for a 1ms tick rate.
+init
+----
+
+prep-admission-stats admitted=0
+----
+{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{IngestOperationStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0}} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+
+# Even though above the threshold, the first 60 ticks don't limit the tokens.
+set-state l0-bytes=10000 l0-added-write=1000 l0-files=21 l0-sublevels=21 print-only-first-tick=true loaded=true
+----
+compaction score 0.000 (21 ssts, 21 sub-levels), L0 growth 0 B (write 0 B ingest 0 B ignored 0 B): requests 0 (0 bypassed) with 0 B acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
+{ioLoadListenerState:{cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:1000} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
+tick: 0, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+
+prep-admission-stats admitted=10000 write-bytes=40000
+----
+{workCount:10000 writeAccountedBytes:40000 ingestedAccountedBytes:0 statsToIgnore:{IngestOperationStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0}} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+
+# Delta added is 100,000. The l0-bytes are the same, so compactions removed
+# 100,000 bytes. Smoothed removed by compactions is 50,000. Each admitted is
+# expected to add 10 bytes. We want to add only 25,000 (half the smoothed
+# removed), but smoothing it drops the tokens to 12,500.
+set-state l0-bytes=10000 l0-added-write=101000 l0-files=21 l0-sublevels=21 print-only-first-tick=true loaded=true
+----
+compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 98 KiB (write 98 KiB ingest 0 B ignored 0 B): requests 10000 (0 bypassed) with 39 KiB acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 2.25x+1 B (smoothed 2.00x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 5 B, compacted 98 KiB [≈49 KiB], flushed 0 B [≈0 B]; admitting 12 KiB (rate 833 B/s) due to L0 growth (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:101000 curL0Bytes:10000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:101000} smoothedIntL0CompactedBytes:50000 smoothedCompactionByteTokens:12500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:12500 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:5} l0WriteLM:{multiplier:2 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10000 intL0WriteBytes:100000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:40000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:2.25 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:100000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 5
+tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 2.00x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
+setAvailableTokens: io-tokens=1 elastic-disk-bw-tokens=unlimited max-byte-tokens=209 max-disk-bw-tokens=unlimited
+
+# Restrict disk bandwidth tokens, and then check the cap.
+init
+----
+
+set-state l0-bytes=100 l0-added-write=0 bytes-read=0 bytes-written=0 provisioned-bandwidth=10 l0-files=1 l0-sublevels=1 print-only-first-tick=true loaded=true
+----
+compaction score 0.000 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B ignored 0 B): requests 0 (0 bypassed) with 0 B acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
+{ioLoadListenerState:{cumL0AddedBytes:0 curL0Bytes:100 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:0} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:0 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
+tick: 0, setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=unlimited max-byte-tokens=unlimited max-disk-bw-tokens=unlimited
+
+set-state l0-bytes=100 l0-added-write=100000 bytes-read=1000000 bytes-written=2000000 provisioned-bandwidth=10 disk-bw-tokens-used=(100,100) l0-files=1 l0-sublevels=1 print-only-first-tick=true loaded=true
+----
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 98 KiB (write 0 B ingest 0 B ignored 0 B): requests 0 (0 bypassed) with 0 B acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 98 KiB [≈49 KiB], flushed 0 B [≈0 B]; admitting all; elastic tokens 6.1 KiB (used 100 B, regular used 100 B): write model 1.75x+1 B ingest model 1.00x+1 B, disk bw read 65 KiB write 130 KiB provisioned 10 B
+{ioLoadListenerState:{cumL0AddedBytes:100000 curL0Bytes:100 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:1000000 bytesWritten:2000000 incomingLSMBytes:100000} smoothedIntL0CompactedBytes:50000 smoothedCompactionByteTokens:50000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 byteTokensAllocated:0 byteTokensUsed:0 elasticDiskBWTokens:6250 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.75 constant:1} l0IngestLM:{multiplier:0.7505 constant:1} ingestLM:{multiplier:1 constant:1} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:false diskBW:{intervalDiskLoadInfo:{readBandwidth:66666 writeBandwidth:133333 provisionedBandwidth:10} intervalLSMInfo:{incomingBytes:100000 regularTokensUsed:100 elasticTokensUsed:100}}} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.75x+1 l0-ingest-lm: 0.75x+1 ingest-lm: 1.00x+1
+setAvailableTokens: io-tokens=unlimited elastic-disk-bw-tokens=1 max-byte-tokens=unlimited max-disk-bw-tokens=105


### PR DESCRIPTION
We currently allocate tokens for the kvStoreTokenGranter
every 250ms. This prs moves this allocation interval to
1ms. Since unloaded systems use too much CPU with a 1ms
interval, we implement a mechanism to switch back and forth
between a 250ms interval, when the system is unloaded, and
a 1ms interval when the system is unloaded. We maintain a
given interval for this allocation, over every adjustment
interval. That is, we make the decision to switch to a
different allocation interval at the end of the adjustment
interval.

Fixes: https://github.com/cockroachdb/cockroach/issues/91509
Epic: none
Release note: None