### PR TITLE
release-22.2: pgwire: adds bounds check for FormatCodes

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -39,6 +39,7 @@ pkg/sql/catalog/descpb/structured.go | `DescriptorState`
 pkg/sql/catalog/descpb/structured.go | `DescriptorVersion`
 pkg/sql/catalog/descpb/structured.go | `IndexDescriptorVersion`
 pkg/sql/catalog/descpb/structured.go | `MutationID`
+pkg/sql/pgwire/pgwirebase/encoding.go | `FormatCode`
 pkg/sql/schemachanger/scplan/internal/scgraph/graph.go | `RuleName`
 pkg/sql/sem/catid/ids.go | `ColumnID`
 pkg/sql/sem/catid/ids.go | `ConstraintID`

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1376,6 +1376,9 @@ func (c *conn) bufferRow(ctx context.Context, row tree.Datums, r *commandResult)
 	for i, col := range row {
 		fmtCode := pgwirebase.FormatText
 		if r.formatCodes != nil {
+			if i >= len(r.formatCodes) {
+				return errors.AssertionFailedf("could not find format code for column %d in %v", i, r.formatCodes)
+			}
 			fmtCode = r.formatCodes[i]
 		}
 		switch fmtCode {
@@ -1414,6 +1417,9 @@ func (c *conn) bufferBatch(ctx context.Context, batch coldata.Batch, r *commandR
 			for vecIdx := 0; vecIdx < len(c.vecsScratch.Vecs); vecIdx++ {
 				fmtCode := pgwirebase.FormatText
 				if r.formatCodes != nil {
+					if vecIdx >= len(r.formatCodes) {
+						return errors.AssertionFailedf("could not find format code for column %d in %v", vecIdx, r.formatCodes)
+					}
 					fmtCode = r.formatCodes[vecIdx]
 				}
 				switch fmtCode {

--- a/pkg/sql/pgwire/pgwirebase/BUILD.bazel
+++ b/pkg/sql/pgwire/pgwirebase/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//pkg/util/timeutil/pgdate",
         "//pkg/util/uint128",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_lib_pq//oid",
     ],

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/dustin/go-humanize"
 	"github.com/lib/pq/oid"
 )
@@ -70,6 +71,11 @@ var ReadBufferMaxMessageSizeClusterSetting = settings.RegisterByteSizeSetting(
 //
 //go:generate stringer -type=FormatCode
 type FormatCode uint16
+
+var _ redact.SafeValue = FormatCode(0)
+
+// SafeValue implements the redact.SafeValue interface.
+func (i FormatCode) SafeValue() {}
 
 const (
 	// FormatText is the default, text format.


### PR DESCRIPTION
Backport 1/1 commits from #103645.

/cc @cockroachdb/release

Release justification: bug fix for a panic

---

fixes https://github.com/cockroachdb/cockroach/issues/103629

Now we check the bounds when looking for the format code to use.

Getting an out of bounds index is not expected, so we use an assertion error. This is less disruptive than a panic that crashes the node.

Release note: None
