### PR TITLE
release-23.1: privilege: mark Kind and List types as safe for redaction

### DIFF
--- a/pkg/sql/catalog/funcdesc/func_desc_test.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_test.go
@@ -190,7 +190,7 @@ func TestValidateFuncDesc(t *testing.T) {
 			},
 		},
 		{
-			"user testuser must not have SELECT privileges on function \"f\"",
+			"user testuser must not have [SELECT] privileges on function \"f\"",
 			descpb.FunctionDescriptor{
 				Name:           "f",
 				ID:             funcDescID,

--- a/pkg/sql/catalog/schemadesc/schema_desc_test.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_test.go
@@ -98,7 +98,7 @@ func TestValidateSchemaSelf(t *testing.T) {
 			},
 		},
 		{ // 3
-			err: `user testuser must not have SELECT privileges on schema "schema1"`,
+			err: `user testuser must not have [SELECT] privileges on schema "schema1"`,
 			desc: descpb.SchemaDescriptor{
 				ID:         52,
 				ParentID:   51,

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -706,7 +706,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			`user testuser must not have SELECT privileges on type "t"`,
+			`user testuser must not have [SELECT] privileges on type "t"`,
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,

--- a/pkg/sql/privilege/BUILD.bazel
+++ b/pkg/sql/privilege/BUILD.bazel
@@ -15,6 +15,8 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+        "@com_github_cockroachdb_redact//interfaces",
     ],
 )
 

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -18,6 +18,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/cockroachdb/redact/interfaces"
 )
 
 //go:generate stringer -type=Kind -linecomment
@@ -25,6 +27,11 @@ import (
 // Kind defines a privilege. This is output by the parser,
 // and used to generate the privilege bitfields in the PrivilegeDescriptor.
 type Kind uint32
+
+var _ redact.SafeValue = Kind(0)
+
+// SafeValue makes Kind a redact.SafeValue.
+func (k Kind) SafeValue() {}
 
 // List of privileges. ALL is specifically encoded so that it will automatically
 // pick up new privileges.
@@ -76,8 +83,20 @@ type Privilege struct {
 	GrantOption bool
 }
 
+var _ redact.SafeFormatter = Privilege{}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (k Privilege) SafeFormat(s interfaces.SafePrinter, _ rune) {
+	s.Printf("[kind=%s grantOption=%t]", k.Kind, k.GrantOption)
+}
+
 // ObjectType represents objects that can have privileges.
 type ObjectType string
+
+var _ redact.SafeValue = ObjectType("")
+
+// SafeValue makes ObjectType a redact.SafeValue.
+func (k ObjectType) SafeValue() {}
 
 const (
 	// Any represents any object type.
@@ -180,6 +199,20 @@ var ByName = map[string]Kind{
 
 // List is a list of privileges.
 type List []Kind
+
+var _ redact.SafeFormatter = List{}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (pl List) SafeFormat(s interfaces.SafePrinter, _ rune) {
+	s.SafeString("[")
+	for i, p := range pl {
+		if i > 0 {
+			s.SafeString(",")
+		}
+		s.Print(p)
+	}
+	s.SafeString("]")
+}
 
 // Len, Swap, and Less implement the Sort interface.
 func (pl List) Len() int {

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -128,6 +128,10 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase": {
 						"FormatCode": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/sql/privilege": {
+						"Kind":       {},
+						"ObjectType": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants": {
 						"ConstraintType": {},
 					},


### PR DESCRIPTION
Backport 1/1 commits from #103554.

/cc @cockroachdb/release

Release justification: logging improvement

---

This will create more actionable error reports.

informs https://github.com/cockroachdb/cockroach/issues/98205
informs https://github.com/cockroachdb/cockroach/issues/103503

Release note: None
