### PR TITLE
release-22.2: privilege: mark Kind and List types as safe for redaction

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -40,6 +40,8 @@ pkg/sql/catalog/descpb/structured.go | `DescriptorVersion`
 pkg/sql/catalog/descpb/structured.go | `IndexDescriptorVersion`
 pkg/sql/catalog/descpb/structured.go | `MutationID`
 pkg/sql/pgwire/pgwirebase/encoding.go | `FormatCode`
+pkg/sql/privilege/privilege.go | `Kind`
+pkg/sql/privilege/privilege.go | `ObjectType`
 pkg/sql/schemachanger/scplan/internal/scgraph/graph.go | `RuleName`
 pkg/sql/sem/catid/ids.go | `ColumnID`
 pkg/sql/sem/catid/ids.go | `ConstraintID`

--- a/pkg/sql/catalog/funcdesc/func_desc_test.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_test.go
@@ -140,7 +140,7 @@ func TestValidateFuncDesc(t *testing.T) {
 			},
 		},
 		{
-			"user testuser must not have SELECT privileges on function \"f\"",
+			"user testuser must not have [SELECT] privileges on function \"f\"",
 			descpb.FunctionDescriptor{
 				Name:           "f",
 				ID:             funcDescID,

--- a/pkg/sql/catalog/schemadesc/schema_desc_test.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_test.go
@@ -98,7 +98,7 @@ func TestValidateSchemaSelf(t *testing.T) {
 			},
 		},
 		{ // 3
-			err: `user testuser must not have SELECT privileges on schema "schema1"`,
+			err: `user testuser must not have [SELECT] privileges on schema "schema1"`,
 			desc: descpb.SchemaDescriptor{
 				ID:         52,
 				ParentID:   51,

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -695,7 +695,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			`user testuser must not have SELECT privileges on type "t"`,
+			`user testuser must not have [SELECT] privileges on type "t"`,
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,

--- a/pkg/sql/privilege/BUILD.bazel
+++ b/pkg/sql/privilege/BUILD.bazel
@@ -15,6 +15,8 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+        "@com_github_cockroachdb_redact//interfaces",
     ],
 )
 


### PR DESCRIPTION
Backport 1/1 commits from #103554.

/cc @cockroachdb/release

Release justification: logging improvement

---

This will create more actionable error reports.

informs https://github.com/cockroachdb/cockroach/issues/98205
informs https://github.com/cockroachdb/cockroach/issues/103503

Release note: None
