### PR TITLE
kvserver: fix rebalance obj callback ctx

### DIFF
--- a/pkg/kv/kvserver/rebalance_objective.go
+++ b/pkg/kv/kvserver/rebalance_objective.go
@@ -249,7 +249,7 @@ func (rom *RebalanceObjectiveManager) maybeUpdateRebalanceObjective(ctx context.
 	}
 
 	log.Infof(ctx, "Updating the rebalance objective from %s to %s",
-		prev.ToDimension(), next.ToDimension())
+		prev, next)
 
 	rom.mu.obj = next
 	rom.mu.onChange(ctx, rom.mu.obj)

--- a/pkg/kv/kvserver/rebalance_objective_test.go
+++ b/pkg/kv/kvserver/rebalance_objective_test.go
@@ -188,7 +188,9 @@ func TestRebalanceObjectiveManager(t *testing.T) {
 			callbacks = append(callbacks, obj)
 		}
 		return newRebalanceObjectiveManager(
-			ctx, st, cb, providerNotifier, providerNotifier,
+			ctx, log.MakeTestingAmbientCtxWithNewTracer(),
+			st, cb,
+			providerNotifier, providerNotifier,
 		), &callbacks
 	}
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1289,7 +1289,10 @@ func NewStore(
 		allocatorStorePool = cfg.StorePool
 		storePoolIsDeterministic = allocatorStorePool.IsDeterministic()
 
-		s.rebalanceObjManager = newRebalanceObjectiveManager(ctx, s.cfg.Settings,
+		s.rebalanceObjManager = newRebalanceObjectiveManager(
+			ctx,
+			s.cfg.AmbientCtx,
+			s.cfg.Settings,
 			func(ctx context.Context, obj LBRebalancingObjective) {
 				s.VisitReplicas(func(r *Replica) (wantMore bool) {
 					r.loadBasedSplitter.SetSplitObjective(


### PR DESCRIPTION
The `RebalanceObjectiveManager` updates the rebalance objective by using callbacks on cluster setting, cluster version and store descriptor gossip changes. The callback on store descriptor changes was re-using the initialization function's (`newRebalanceObjectiveManager`) context. This re-use could cause use of tracing spans after finish, if the callback path evaluates when initialized with a context containing tracing spans.

Use a background context in the store descriptor callback to prevent this problem.

This PR also adds an ambient context to the `RebalanceObjectiveManager`
and uses it to annotate callbacks.

Fixes: #103763

Release note: None