### PR TITLE
ui: add per tenant options to custom chart

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/tenants.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/tenants.ts
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 import { createSelector } from "reselect";
 import { DropdownOption } from "../views/shared/components/dropdown";
+import { SYSTEM_TENANT_NAME } from "./cookies";
 import { AdminUIState } from "./state";
 
 export const tenantsSelector = (state: AdminUIState) =>
@@ -30,3 +31,9 @@ export const tenantDropdownOptions = createSelector(
     return tenantOptions;
   },
 );
+
+// isSystemTenant checks whether the provided tenant name is the
+// system tenant.
+export const isSystemTenant = (tenantName: string): boolean => {
+  return tenantName === SYSTEM_TENANT_NAME;
+};

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -90,8 +90,8 @@ import {
   selectCrossClusterReplicationEnabled,
 } from "src/redux/clusterSettings";
 import { getDataFromServer } from "src/util/dataFromServer";
-import { getCookieValue, SYSTEM_TENANT_NAME } from "src/redux/cookies";
-import { tenantDropdownOptions } from "src/redux/tenants";
+import { getCookieValue } from "src/redux/cookies";
+import { tenantDropdownOptions, isSystemTenant } from "src/redux/tenants";
 
 interface GraphDashboard {
   label: string;
@@ -254,7 +254,7 @@ export class NodeGraphs extends React.Component<
     // settings won't change frequently so it's safe to request one
     // when page is loaded.
     this.props.refreshNodeSettings();
-    if (this.props.currentTenant === SYSTEM_TENANT_NAME) {
+    if (isSystemTenant(this.props.currentTenant)) {
       this.props.refreshTenantsList();
     }
   }
@@ -320,10 +320,9 @@ export class NodeGraphs extends React.Component<
 
     const selectedNode = getMatchParamByName(match, nodeIDAttr) || "";
     const nodeSources = selectedNode !== "" ? [selectedNode] : null;
-    const selectedTenant =
-      currentTenant === SYSTEM_TENANT_NAME
-        ? getMatchParamByName(match, tenantNameAttr) || ""
-        : "";
+    const selectedTenant = isSystemTenant(currentTenant)
+      ? getMatchParamByName(match, tenantNameAttr) || ""
+      : "";
     // When "all" is the selected source, some graphs display a line for every
     // node in the cluster using the nodeIDs collection. However, if a specific
     // node is already selected, these per-node graphs should only display data
@@ -405,7 +404,7 @@ export class NodeGraphs extends React.Component<
         <Helmet title={"Metrics"} />
         <h3 className="base-heading">Metrics</h3>
         <PageConfig>
-          {currentTenant === SYSTEM_TENANT_NAME && tenantOptions.length > 1 && (
+          {isSystemTenant(currentTenant) && tenantOptions.length > 1 && (
             <PageConfigItem>
               <Dropdown
                 title="Tenant"

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
@@ -15,6 +15,7 @@ import Select from "react-select";
 import * as protos from "src/js/protos";
 import { AxisUnits } from "@cockroachlabs/cluster-ui";
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
+import { isSystemTenant } from "src/redux/tenants";
 
 import { MetricOption } from "./metricOption";
 
@@ -54,7 +55,9 @@ export class CustomMetricState {
   aggregator = TimeSeriesQueryAggregator.SUM;
   derivative = TimeSeriesQueryDerivative.NONE;
   perNode = false;
+  perTenant = false;
   source = "";
+  tenantSource = "";
 }
 
 export class CustomChartState {
@@ -69,6 +72,8 @@ export class CustomChartState {
 interface CustomMetricRowProps {
   metricOptions: DropdownOption[];
   nodeOptions: DropdownOption[];
+  tenantOptions: DropdownOption[];
+  canViewTenantOptions: boolean;
   index: number;
   rowState: CustomMetricState;
   onChange: (index: number, newState: CustomMetricState) => void;
@@ -113,9 +118,21 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
     });
   };
 
+  changeTenant = (selectedOption: DropdownOption) => {
+    this.changeState({
+      tenantSource: selectedOption.value,
+    });
+  };
+
   changePerNode = (selection: React.FormEvent<HTMLInputElement>) => {
     this.changeState({
       perNode: selection.currentTarget.checked,
+    });
+  };
+
+  changePerTenant = (selection: React.FormEvent<HTMLInputElement>) => {
+    this.changeState({
+      perTenant: selection.currentTarget.checked,
     });
   };
 
@@ -127,6 +144,8 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
     const {
       metricOptions,
       nodeOptions,
+      tenantOptions,
+      canViewTenantOptions,
       rowState: {
         metric,
         downsampler,
@@ -134,6 +153,8 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
         derivative,
         source,
         perNode,
+        tenantSource,
+        perTenant,
       },
     } = this.props;
 
@@ -209,6 +230,29 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
             onChange={this.changePerNode}
           />
         </td>
+        {canViewTenantOptions && (
+          <td>
+            <div className="metric-table-dropdown">
+              <Select
+                className="metric-table-dropdown__select"
+                clearable={false}
+                searchable={false}
+                value={tenantSource}
+                options={tenantOptions}
+                onChange={this.changeTenant}
+              />
+            </div>
+          </td>
+        )}
+        {canViewTenantOptions && (
+          <td className="metric-table__cell">
+            <input
+              type="checkbox"
+              checked={perTenant}
+              onChange={this.changePerTenant}
+            />
+          </td>
+        )}
         <td className="metric-table__cell">
           <button
             className="edit-button metric-edit-button"
@@ -225,6 +269,8 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
 interface CustomChartTableProps {
   metricOptions: DropdownOption[];
   nodeOptions: DropdownOption[];
+  tenantOptions: DropdownOption[];
+  currentTenant: string | null;
   index: number;
   chartState: CustomChartState;
   onChange: (index: number, newState: CustomChartState) => void;
@@ -276,7 +322,10 @@ export class CustomChartTable extends React.Component<CustomChartTableProps> {
   };
 
   render() {
+    const { tenantOptions, currentTenant } = this.props;
     const metrics = this.currentMetrics();
+    const canViewTenantOptions =
+      isSystemTenant(currentTenant) && tenantOptions.length > 1;
     let table: JSX.Element = (
       <h3>Click "Add Metric" to add a metric to the custom chart.</h3>
     );
@@ -292,6 +341,12 @@ export class CustomChartTable extends React.Component<CustomChartTableProps> {
               <td className="metric-table__header">Rate</td>
               <td className="metric-table__header">Source</td>
               <td className="metric-table__header">Per Node</td>
+              {canViewTenantOptions && (
+                <td className="metric-table__header">Tenant</td>
+              )}
+              {canViewTenantOptions && (
+                <td className="metric-table__header">Per Tenant</td>
+              )}
               <td className="metric-table__header"></td>
             </tr>
           </thead>
@@ -301,6 +356,8 @@ export class CustomChartTable extends React.Component<CustomChartTableProps> {
                 key={i}
                 metricOptions={this.props.metricOptions}
                 nodeOptions={this.props.nodeOptions}
+                tenantOptions={tenantOptions}
+                canViewTenantOptions={canViewTenantOptions}
                 index={i}
                 rowState={row}
                 onChange={this.updateMetricRow}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
@@ -15,7 +15,11 @@ import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { createSelector } from "reselect";
 
-import { refreshMetricMetadata, refreshNodes } from "src/redux/apiReducers";
+import {
+  refreshMetricMetadata,
+  refreshNodes,
+  refreshTenantsList,
+} from "src/redux/apiReducers";
 import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import LineGraph from "src/views/cluster/components/linegraph";
@@ -34,7 +38,11 @@ import {
 } from "src/redux/metricMetadata";
 import { INodeStatus } from "src/util/proto";
 
-import { CustomChartState, CustomChartTable } from "./customMetric";
+import {
+  CustomChartState,
+  CustomChartTable,
+  CustomMetricState,
+} from "./customMetric";
 import "./customChart.styl";
 import { queryByName } from "src/util/query";
 import { PayloadAction } from "src/interfaces/action";
@@ -45,16 +53,21 @@ import {
   setTimeScale,
 } from "src/redux/timeScale";
 import { BackToAdvanceDebug } from "src/views/reports/containers/util";
+import { getCookieValue } from "src/redux/cookies";
+import { tenantDropdownOptions } from "src/redux/tenants";
 
 export interface CustomChartProps {
   refreshNodes: typeof refreshNodes;
   nodesQueryValid: boolean;
   nodesSummary: NodesSummary;
   refreshMetricMetadata: typeof refreshMetricMetadata;
+  refreshTenantsList: typeof refreshTenantsList;
   metricsMetadata: MetricsMetadata;
   setMetricsFixedWindow: (tw: TimeWindow) => PayloadAction<TimeWindow>;
   timeScale: TimeScale;
   setTimeScale: (ts: TimeScale) => PayloadAction<TimeScale>;
+  tenantOptions: ReturnType<() => DropdownOption[]>;
+  currentTenant: string | null;
 }
 
 interface UrlState {
@@ -119,6 +132,7 @@ export class CustomChart extends React.Component<
   componentDidMount() {
     this.refresh();
     this.props.refreshMetricMetadata();
+    this.props.refreshTenantsList();
   }
 
   componentDidUpdate() {
@@ -194,12 +208,89 @@ export class CustomChart extends React.Component<
     );
   };
 
+  // This function handles the logic related to creating Metric components
+  // based on perNode and perTenant flags.
+  renderMetricComponents = (metrics: CustomMetricState[], index: number) => {
+    const { nodesSummary, tenantOptions } = this.props;
+    const tenants = tenantOptions.length > 1 ? tenantOptions.slice(1) : [];
+    return metrics.map((m, i) => {
+      if (m.metric === "") {
+        return "";
+      }
+      if (m.perNode && m.perTenant) {
+        return _.flatMap(nodesSummary.nodeIDs, nodeID => {
+          return tenants.map(tenant => (
+            <Metric
+              key={`${index}${i}${nodeID}${tenant.value}`}
+              title={`${nodeID}-${tenant.value}: ${m.metric} (${i})`}
+              name={m.metric}
+              aggregator={m.aggregator}
+              downsampler={m.downsampler}
+              derivative={m.derivative}
+              sources={
+                isStoreMetric(nodesSummary.nodeStatuses[0], m.metric)
+                  ? _.map(nodesSummary.storeIDsByNodeID[nodeID] || [], n =>
+                      n.toString(),
+                    )
+                  : [nodeID]
+              }
+              tenantSource={tenant.value}
+            />
+          ));
+        });
+      } else if (m.perNode) {
+        return _.map(nodesSummary.nodeIDs, nodeID => (
+          <Metric
+            key={`${index}${i}${nodeID}`}
+            title={`${nodeID}: ${m.metric} (${i})`}
+            name={m.metric}
+            aggregator={m.aggregator}
+            downsampler={m.downsampler}
+            derivative={m.derivative}
+            sources={
+              isStoreMetric(nodesSummary.nodeStatuses[0], m.metric)
+                ? _.map(nodesSummary.storeIDsByNodeID[nodeID] || [], n =>
+                    n.toString(),
+                  )
+                : [nodeID]
+            }
+            tenantSource={m.tenantSource}
+          />
+        ));
+      } else if (m.perTenant) {
+        return tenants.map(tenant => (
+          <Metric
+            key={`${index}${i}${tenant.value}`}
+            title={`${tenant.value}: ${m.metric} (${i})`}
+            name={m.metric}
+            aggregator={m.aggregator}
+            downsampler={m.downsampler}
+            derivative={m.derivative}
+            sources={m.source === "" ? [] : [m.source]}
+            tenantSource={tenant.value}
+          />
+        ));
+      } else {
+        return (
+          <Metric
+            key={`${index}${i}`}
+            title={`${m.metric} (${i}) `}
+            name={m.metric}
+            aggregator={m.aggregator}
+            downsampler={m.downsampler}
+            derivative={m.derivative}
+            sources={m.source === "" ? [] : [m.source]}
+            tenantSource={m.tenantSource}
+          />
+        );
+      }
+    });
+  };
+
   // Render a chart of the currently selected metrics.
   renderChart = (chart: CustomChartState, index: number) => {
     const metrics = chart.metrics;
     const units = chart.axisUnits;
-    const { nodesSummary } = this.props;
-
     return (
       <MetricsDataProvider
         id={`debug-custom-chart.${index}`}
@@ -210,43 +301,7 @@ export class CustomChart extends React.Component<
       >
         <LineGraph title={metrics.map(m => m.metric).join(", ")}>
           <Axis units={units} label={AxisUnits[units]}>
-            {metrics.map((m, i) => {
-              if (m.metric !== "") {
-                if (m.perNode) {
-                  return _.map(nodesSummary.nodeIDs, nodeID => (
-                    <Metric
-                      key={`${index}${i}${nodeID}`}
-                      title={`${nodeID}: ${m.metric} (${i})`}
-                      name={m.metric}
-                      aggregator={m.aggregator}
-                      downsampler={m.downsampler}
-                      derivative={m.derivative}
-                      sources={
-                        isStoreMetric(nodesSummary.nodeStatuses[0], m.metric)
-                          ? _.map(
-                              nodesSummary.storeIDsByNodeID[nodeID] || [],
-                              n => n.toString(),
-                            )
-                          : [nodeID]
-                      }
-                    />
-                  ));
-                } else {
-                  return (
-                    <Metric
-                      key={`${index}${i}`}
-                      title={`${m.metric} (${i}) `}
-                      name={m.metric}
-                      aggregator={m.aggregator}
-                      downsampler={m.downsampler}
-                      derivative={m.derivative}
-                      sources={m.source === "" ? [] : [m.source]}
-                    />
-                  );
-                }
-              }
-              return "";
-            })}
+            {this.renderMetricComponents(metrics, index)}
           </Axis>
         </LineGraph>
       </MetricsDataProvider>
@@ -266,7 +321,8 @@ export class CustomChart extends React.Component<
   // Render a table containing all of the currently added metrics, with editing
   // inputs for each metric.
   renderChartTables() {
-    const { nodesSummary, metricsMetadata } = this.props;
+    const { nodesSummary, metricsMetadata, tenantOptions, currentTenant } =
+      this.props;
     const charts = this.currentCharts();
 
     return (
@@ -275,6 +331,8 @@ export class CustomChart extends React.Component<
           <CustomChartTable
             metricOptions={this.metricOptions(nodesSummary, metricsMetadata)}
             nodeOptions={this.nodeOptions(nodesSummary)}
+            tenantOptions={tenantOptions}
+            currentTenant={currentTenant}
             index={i}
             key={i}
             chartState={chart}
@@ -327,11 +385,14 @@ const mapStateToProps = (state: AdminUIState) => ({
   nodesQueryValid: state.cachedData.nodes.valid,
   metricsMetadata: metricsMetadataSelector(state),
   timeScale: selectTimeScale(state),
+  tenantOptions: tenantDropdownOptions(state),
+  currentTenant: getCookieValue("tenant"),
 });
 
 const mapDispatchToProps = {
   refreshNodes,
   refreshMetricMetadata,
+  refreshTenantsList,
   setMetricsFixedWindow: setMetricsFixedWindow,
   setTimeScale: setTimeScale,
 };


### PR DESCRIPTION
This change adds the following to custom charts:
- a dropdown option to select tenant which will scope the
timeseries query to that tenant
- a checkbox option which will render timeseries for each =
tenant
Neither of these options are available unless on the system tenant.
If both the dropdown option and checkbox are set, the query ignores the
dropdown selection and renders for each tenant.

Fixes: https://github.com/cockroachdb/cockroach/issues/97737

Release note (ui change): add tenant dropdown and per tenant checkbox to
custom chart

<img width="1344" alt="Screenshot 2023-05-23 at 11 19 09 AM" src="https://github.com/cockroachdb/cockroach/assets/17861665/5f535c50-02aa-4cac-9e6d-02f24a1a5a9a">