### PR TITLE
pkg/ccl/storageccl/engineccl: ensure encryption percentage does not e…

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -269,7 +269,7 @@ func TestPebbleEncryption(t *testing.T) {
 	require.NoError(t, err)
 	// Opening the DB should've created OPTIONS, CURRENT, MANIFEST and the
 	// WAL.
-	require.Equal(t, uint64(4), stats.TotalFiles)
+	require.GreaterOrEqual(t, stats.TotalFiles, uint64(4))
 	// We also created markers for the format version and the manifest.
 	require.Equal(t, uint64(6), stats.ActiveKeyFiles)
 	var s enginepbccl.EncryptionStatus
@@ -310,7 +310,7 @@ func TestPebbleEncryption(t *testing.T) {
 	stats, err = db.GetEnvStats()
 	require.NoError(t, err)
 	t.Logf("EnvStats:\n%+v\n\n", *stats)
-	require.Equal(t, uint64(5), stats.TotalFiles)
+	require.GreaterOrEqual(t, stats.TotalFiles, uint64(5))
 	require.LessOrEqual(t, uint64(5), stats.ActiveKeyFiles)
 	require.Equal(t, stats.TotalBytes, stats.ActiveKeyBytes)
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1871,6 +1871,17 @@ func (p *Pebble) GetEnvStats() (*EnvStats, error) {
 		}
 		stats.ActiveKeyBytes += sstSizes[pebble.FileNum(u)]
 	}
+
+	// Ensure that encryption percentage does not exceed 100%.
+	frFileLen := uint64(len(fr.Files))
+	if stats.TotalFiles < frFileLen {
+		stats.TotalFiles = frFileLen
+	}
+
+	if stats.TotalBytes < stats.ActiveKeyBytes {
+		stats.TotalBytes = stats.ActiveKeyBytes
+	}
+
 	return stats, nil
 }
 


### PR DESCRIPTION
ensure encryption percentage does not exceed 100%

package: pkg/ccl/storageccl/engineccl

Previously, the `TotalFiles` property from `GenEnvStats()` returned the
total number of files known to Pebble, however this results in encryption
percentages that are greater than 100%. The fix is to set TotalFiles to
be the maximum of the files known to Pebble and the files known by the
file registry. This applies to the `TotalBytes` property as well.

Fixes: #97874

Release note: None