### PR TITLE
ui: add manual refresh option to the Active Executions in SQL Activity

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./refreshControl";

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/refreshControl.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/refreshControl.module.scss
@@ -1,0 +1,49 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@import "src/core/index.module";
+
+.refresh-timestamp {
+  vertical-align: middle;
+}
+
+.refresh-icon {
+  margin-left: 12px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.refresh-text {
+  color: $colors--primary-blue-3;
+  vertical-align: middle;
+  margin-right: 12px;
+}
+
+.ant-switch-checked {
+  background-color: $colors--primary-blue-3;
+}
+
+.refresh-button {
+  align-items: center;
+}
+
+.refresh-divider {
+  border-left: 1px solid $colors--neutral-4;
+  padding-left: 12px;
+  height: $line-height--large;
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
+
+.auto-refresh-label {
+  padding-right: 8px;
+  vertical-align: middle;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/refreshControl.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/refreshControl.tsx
@@ -1,0 +1,81 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Switch } from "antd";
+import "antd/lib/switch/style";
+import React from "react";
+import classNames from "classnames/bind";
+import styles from "./refreshControl.module.scss";
+import RefreshIcon from "src/icon/refreshIcon";
+import { Timestamp } from "src/timestamp";
+import { Moment } from "moment-timezone";
+import { DATE_WITH_SECONDS_FORMAT_24_TZ, capitalize } from "src/util";
+import { ExecutionType } from "../types";
+
+const cx = classNames.bind(styles);
+
+interface RefreshControlProps {
+  isAutoRefreshEnabled: boolean;
+  onToggleAutoRefresh: () => void;
+  onManualRefresh: () => void;
+  lastRefreshTimestamp: Moment;
+  execType: ExecutionType;
+}
+
+const REFRESH_BUTTON_COLOR = "#0055FF";
+
+interface RefreshButtonProps {
+  onManualRefresh: () => void;
+}
+
+// RefreshButton consists of the RefreshIcon and the text "Refresh".
+const RefreshButton: React.FC<RefreshButtonProps> = ({ onManualRefresh }) => (
+  <span className={cx("refresh-button")} onClick={onManualRefresh}>
+    <RefreshIcon color={REFRESH_BUTTON_COLOR} className={cx("refresh-icon")} />
+    <span className={cx("refresh-text")}>Refresh</span>
+  </span>
+);
+
+export const RefreshControl: React.FC<RefreshControlProps> = ({
+  isAutoRefreshEnabled,
+  onToggleAutoRefresh,
+  onManualRefresh,
+  lastRefreshTimestamp,
+  execType,
+}) => {
+  return (
+    <div>
+      <span className={cx("refresh-timestamp")}>
+        <span>Active {capitalize(execType)} Executions As Of: </span>
+        {lastRefreshTimestamp && lastRefreshTimestamp.isValid() ? (
+          <Timestamp
+            time={lastRefreshTimestamp}
+            format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+          />
+        ) : (
+          "N/A"
+        )}
+      </span>
+      <RefreshButton onManualRefresh={onManualRefresh} />
+      <span className={cx("refresh-divider")}>
+        <span className={cx("auto-refresh-label")}>Auto Refresh: </span>
+        <Switch
+          className={cx(`ant-switch-${isAutoRefreshEnabled ? "checked" : ""}`)}
+          checkedChildren={"On"}
+          unCheckedChildren={"Off"}
+          checked={isAutoRefreshEnabled}
+          onClick={onToggleAutoRefresh}
+        />
+      </span>
+    </div>
+  );
+};
+
+export default RefreshControl;

--- a/pkg/ui/workspaces/cluster-ui/src/icon/refreshIcon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/icon/refreshIcon.tsx
@@ -1,0 +1,45 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import * as React from "react";
+
+interface IconProps {
+  className?: string;
+  color?: string;
+}
+
+const RefreshIcon = ({ className, color }: IconProps) => (
+  <svg
+    className={className}
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill={color || "#394455"}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g clipPath="url(#clip0_11029_22359)">
+      <path
+        d="M1.77601 11.9912C1.77601 8.58278 3.43606 5.47461 6.17336 3.58499V7.04636H7.93937V0H0.893012V1.766H5.78484C2.19985 3.92053 0.0100098 7.7351 0.0100098 11.9912C0.0100098 17.5364 3.93054 22.4636 9.33451 23.6821L9.72303 21.9514C5.11376 20.9095 1.77601 16.7064 1.77601 11.9735V11.9912Z"
+        fill={color || "#394455"}
+      />
+      <path
+        d="M23.9924 11.9912C23.9924 6.35762 20.1601 1.53642 14.6678 0.300221L14.2793 2.03091C18.8886 3.07285 22.2263 7.27594 22.2263 12.0088C22.2263 15.4172 20.5663 18.5254 17.829 20.415V16.9536H16.063V24H23.1094V22.234H18.2175C21.8025 20.0795 23.9924 16.2649 23.9924 12.0088V11.9912Z"
+        fill={color || "#394455"}
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_11029_22359">
+        <rect width="24" height="24" fill="white" />
+      </clipPath>
+    </defs>
+  </svg>
+);
+
+export default RefreshIcon;

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -10,6 +10,7 @@
 
 import React, { useEffect, useState } from "react";
 import classNames from "classnames/bind";
+import moment, { Moment } from "moment-timezone";
 import { useHistory } from "react-router-dom";
 import {
   ISortedTablePagination,
@@ -43,6 +44,7 @@ import { Pagination } from "src/pagination";
 import { InlineAlert } from "@cockroachlabs/ui-components";
 
 import styles from "./statementsPage.module.scss";
+import RefreshControl from "src/activeExecutions/refreshControl/refreshControl";
 
 const cx = classNames.bind(styles);
 const PAGE_SIZE = 20;
@@ -52,6 +54,8 @@ export type ActiveStatementsViewDispatchProps = {
   onFiltersChange: (filters: ActiveStatementFilters) => void;
   onSortChange: (ss: SortSetting) => void;
   refreshLiveWorkload: () => void;
+  onAutoRefreshToggle: (isEnabled: boolean) => void;
+  onManualRefresh: () => void;
 };
 
 export type ActiveStatementsViewStateProps = {
@@ -63,6 +67,8 @@ export type ActiveStatementsViewStateProps = {
   internalAppNamePrefix: string;
   isTenant?: boolean;
   maxSizeApiReached?: boolean;
+  isAutoRefreshEnabled?: boolean;
+  lastUpdated: Moment | null;
 };
 
 export type ActiveStatementsViewProps = ActiveStatementsViewStateProps &
@@ -81,6 +87,10 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
   internalAppNamePrefix,
   isTenant,
   maxSizeApiReached,
+  isAutoRefreshEnabled,
+  onAutoRefreshToggle,
+  lastUpdated,
+  onManualRefresh,
 }: ActiveStatementsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,
@@ -90,15 +100,59 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
   const [search, setSearch] = useState<string>(
     queryByName(history.location, ACTIVE_STATEMENT_SEARCH_PARAM),
   );
+  // Local state to store the difference between the current time and the last
+  // time the data was updated, in minutes.
+  const [minutesSinceLastRefresh, setMinutesSinceLastRefresh] = useState(0);
+  // Local state to store whether or not to display the refresh alert.
+  const [displayRefreshAlert, setDisplayRefreshAlert] = useState(false);
 
   useEffect(() => {
-    // Refresh every 10 seconds.
-    refreshLiveWorkload();
-    const interval = setInterval(refreshLiveWorkload, 10 * 1000);
-    return () => {
-      clearInterval(interval);
+    // useEffect hook which triggers an immediate data refresh if auto-refresh
+    // is enabled. It fetches the latest workload details by dispatching a
+    // refresh action when the component mounts, ensuring that users see fresh
+    // data as soon as they land on the page if auto-refresh is on.
+    if (isAutoRefreshEnabled) {
+      refreshLiveWorkload();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    // Refresh the workload every 10 seconds if auto refresh is on.
+    if (isAutoRefreshEnabled) {
+      const interval = setInterval(refreshLiveWorkload, 10 * 1000);
+      return () => {
+        clearInterval(interval);
+      };
+    }
+  }, [isAutoRefreshEnabled, refreshLiveWorkload]);
+
+  useEffect(() => {
+    // This useEffect hook checks the difference between the current time and
+    // the last time the data was updated. It triggers a state change to display
+    // an alert if the difference is greater than 10 minutes and auto-refresh
+    // is disabled. The check is performed immediately when the component mounts
+    // and then every 10 seconds thereafter.
+    const checkTimeDifference = () => {
+      if (!isAutoRefreshEnabled && lastUpdated) {
+        // Calculate the difference between the last updated time and the current time in minutes
+        const diffMinutes = moment().diff(lastUpdated, "minutes");
+        if (diffMinutes >= 10) {
+          setDisplayRefreshAlert(true);
+          setMinutesSinceLastRefresh(diffMinutes);
+        } else {
+          setDisplayRefreshAlert(false);
+        }
+      }
     };
-  }, [refreshLiveWorkload]);
+
+    checkTimeDifference();
+    const intervalId = setInterval(checkTimeDifference, 10 * 1000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [lastUpdated, isAutoRefreshEnabled, setDisplayRefreshAlert]);
 
   useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),
@@ -162,6 +216,18 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
     resetPagination();
   };
 
+  const onSubmitToggleAutoRefresh = () => {
+    // Refresh immediately when toggling auto-refresh on.
+    if (!isAutoRefreshEnabled) {
+      refreshLiveWorkload();
+    }
+    onAutoRefreshToggle(!isAutoRefreshEnabled);
+  };
+
+  const handleRefresh = () => {
+    onManualRefresh();
+  };
+
   const clearSearch = () => onSubmitSearch("");
   const clearFilters = () =>
     onSubmitFilters({
@@ -209,7 +275,29 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
             filters={filters}
           />
         </PageConfigItem>
+        <PageConfigItem>
+          <RefreshControl
+            isAutoRefreshEnabled={isAutoRefreshEnabled}
+            onToggleAutoRefresh={onSubmitToggleAutoRefresh}
+            onManualRefresh={handleRefresh}
+            lastRefreshTimestamp={lastUpdated}
+            execType={"statement"}
+          />
+        </PageConfigItem>
       </PageConfig>
+      {displayRefreshAlert && (
+        <div className={cx("refresh-alert")}>
+          <InlineAlert
+            intent="warning"
+            title={
+              <>
+                Your active statements data is {minutesSinceLastRefresh} minutes
+                old. Consider refreshing for the latest information.
+              </>
+            }
+          />
+        </div>
+      )}
       <div className={cx("table-area")}>
         <Loading
           loading={statements == null}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -56,6 +56,13 @@ cl-table-container {
   margin-bottom: 0px;
 }
 
+.refresh-alert {
+  margin-top: 5px;
+  padding-top: 5px;
+  display: flex;
+  flex-direction: row;
+}
+
 .margin-bottom {
   margin-bottom: 10px;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
@@ -117,6 +117,17 @@ type ViewModeEvent = {
   value: string;
 };
 
+type AutoRefreshEvent = {
+  name: "Auto Refresh Toggle";
+  page: Page;
+  value: boolean;
+};
+
+type ManualRefreshEvent = {
+  name: "Manual Refresh";
+  page: Page;
+};
+
 type AnalyticsEvent =
   | ApplySearchCriteriaEvent
   | BackButtonClick
@@ -132,7 +143,9 @@ type AnalyticsEvent =
   | StatementDiagnosticEvent
   | TabChangedEvent
   | TimeScaleChangeEvent
-  | ViewModeEvent;
+  | ViewModeEvent
+  | AutoRefreshEvent
+  | ManualRefreshEvent;
 
 const PREFIX = `${DOMAIN_NAME}/analytics`;
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -38,6 +38,7 @@ export enum LocalStorageKeys {
   DB_DETAILS_TABLES_PAGE_SEARCH = "search/DatabasesDetailsTablesPage",
   DB_DETAILS_GRANTS_PAGE_SORT = "sortSetting/DatabasesDetailsGrantsPage",
   DB_DETAILS_VIEW_MODE = "viewMode/DatabasesDetailsPage",
+  ACTIVE_EXECUTIONS_IS_AUTOREFRESH_ENABLED = "isAutoRefreshEnabled/ActiveExecutions",
 }
 
 export type LocalStorageState = {
@@ -82,6 +83,7 @@ export type LocalStorageState = {
   "statusSetting/JobsPage": string;
   "showSetting/JobsPage": string;
   [LocalStorageKeys.DB_DETAILS_VIEW_MODE]: ViewMode;
+  [LocalStorageKeys.ACTIVE_EXECUTIONS_IS_AUTOREFRESH_ENABLED]: boolean;
 };
 
 type Payload = {
@@ -150,6 +152,8 @@ const defaultJobStatusSetting = "";
 const defaultJobShowSetting = "0";
 
 const defaultJobTypeSetting = 0;
+
+const defaultIsAutoRefreshEnabledSetting = true;
 
 // TODO (koorosh): initial state should be restored from preserved keys in LocalStorage
 const initialState: LocalStorageState = {
@@ -273,6 +277,12 @@ const initialState: LocalStorageState = {
   [LocalStorageKeys.DB_DETAILS_VIEW_MODE]:
     JSON.parse(localStorage.getItem(LocalStorageKeys.DB_DETAILS_VIEW_MODE)) ||
     defaultDatabaseDetailsViewMode,
+  [LocalStorageKeys.ACTIVE_EXECUTIONS_IS_AUTOREFRESH_ENABLED]:
+    JSON.parse(
+      localStorage.getItem(
+        LocalStorageKeys.ACTIVE_EXECUTIONS_IS_AUTOREFRESH_ENABLED,
+      ),
+    ) || defaultIsAutoRefreshEnabledSetting,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
@@ -16,16 +16,21 @@ import {
   ActiveTransactionsViewStateProps,
   AppState,
   SortSetting,
+  analyticsActions,
 } from "src";
 import {
   selectAppName,
   selectActiveTransactions,
   selectClusterLocksMaxApiSizeReached,
 } from "src/selectors/activeExecutions.selectors";
-import { actions as localStorageActions } from "src/store/localStorage";
+import {
+  LocalStorageKeys,
+  actions as localStorageActions,
+} from "src/store/localStorage";
 import { actions as sessionsActions } from "src/store/sessions";
 import { localStorageSelector } from "../store/utils/selectors";
 import { selectIsTenant } from "src/store/uiConfig";
+import { selectIsAutoRefreshEnabled } from "src/statementsPage/activeStatementsPage.selectors";
 
 export const selectSortSetting = (state: AppState): SortSetting =>
   localStorageSelector(state)["sortSetting/ActiveTransactionsPage"];
@@ -58,6 +63,8 @@ export const mapStateToActiveTransactionsPageProps = (
   internalAppNamePrefix: selectAppName(state),
   isTenant: selectIsTenant(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),
+  isAutoRefreshEnabled: selectIsAutoRefreshEnabled(state),
+  lastUpdated: state.adminUI?.sessions.lastUpdated,
 });
 
 export const mapDispatchToActiveTransactionsPageProps = (
@@ -85,4 +92,28 @@ export const mapDispatchToActiveTransactionsPageProps = (
         value: ss,
       }),
     ),
+  onAutoRefreshToggle: (isEnabled: boolean) => {
+    dispatch(
+      localStorageActions.update({
+        key: LocalStorageKeys.ACTIVE_EXECUTIONS_IS_AUTOREFRESH_ENABLED,
+        value: isEnabled,
+      }),
+    );
+    dispatch(
+      analyticsActions.track({
+        name: "Auto Refresh Toggle",
+        page: "Transactions",
+        value: isEnabled,
+      }),
+    );
+  },
+  onManualRefresh: () => {
+    dispatch(sessionsActions.refresh());
+    dispatch(
+      analyticsActions.track({
+        name: "Manual Refresh",
+        page: "Transactions",
+      }),
+    );
+  },
 });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
@@ -41,6 +41,9 @@ import { getTableSortFromURL } from "src/sortedtable/getTableSortFromURL";
 import { getActiveTransactionFiltersFromURL } from "src/queryFilter/utils";
 import { filterActiveTransactions } from "../activeExecutions/activeStatementUtils";
 import { InlineAlert } from "@cockroachlabs/ui-components";
+import { RefreshControl } from "src/activeExecutions/refreshControl";
+import moment, { Moment } from "moment-timezone";
+
 const cx = classNames.bind(styles);
 
 export type ActiveTransactionsViewDispatchProps = {
@@ -48,6 +51,8 @@ export type ActiveTransactionsViewDispatchProps = {
   onFiltersChange: (filters: ActiveTransactionFilters) => void;
   onSortChange: (ss: SortSetting) => void;
   refreshLiveWorkload: () => void;
+  onAutoRefreshToggle: (isEnabled: boolean) => void;
+  onManualRefresh: () => void;
 };
 
 export type ActiveTransactionsViewStateProps = {
@@ -59,6 +64,8 @@ export type ActiveTransactionsViewStateProps = {
   internalAppNamePrefix: string;
   isTenant?: boolean;
   maxSizeApiReached?: boolean;
+  isAutoRefreshEnabled?: boolean;
+  lastUpdated: Moment | null;
 };
 
 export type ActiveTransactionsViewProps = ActiveTransactionsViewStateProps &
@@ -80,6 +87,10 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
   filters,
   internalAppNamePrefix,
   maxSizeApiReached,
+  isAutoRefreshEnabled,
+  onAutoRefreshToggle,
+  lastUpdated,
+  onManualRefresh,
 }: ActiveTransactionsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,
@@ -90,16 +101,59 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
   const [search, setSearch] = useState<string>(
     queryByName(history.location, RECENT_TXN_SEARCH_PARAM),
   );
+  // Local state to store the difference between the current time and the last
+  // time the data was updated, in minutes.
+  const [minutesSinceLastRefresh, setMinutesSinceLastRefresh] = useState(0);
+  // Local state to store whether or not to display the refresh alert.
+  const [displayRefreshAlert, setDisplayRefreshAlert] = useState(false);
 
   useEffect(() => {
-    // Refresh  every 10 seconds.
-    refreshLiveWorkload();
+    // useEffect hook which triggers an immediate data refresh if auto-refresh
+    // is enabled. It fetches the latest workload details by dispatching a
+    // refresh action when the component mounts, ensuring that users see fresh
+    // data as soon as they land on the page if auto-refresh is on.
+    if (isAutoRefreshEnabled) {
+      refreshLiveWorkload();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-    const interval = setInterval(refreshLiveWorkload, 10 * 1000);
-    return () => {
-      clearInterval(interval);
+  useEffect(() => {
+    // Refresh every 10 seconds if auto refresh is on.
+    if (isAutoRefreshEnabled) {
+      const interval = setInterval(refreshLiveWorkload, 10 * 1000);
+      return () => {
+        clearInterval(interval);
+      };
+    }
+  }, [isAutoRefreshEnabled, refreshLiveWorkload]);
+
+  useEffect(() => {
+    // This useEffect hook checks the difference between the current time and
+    // the last time the data was updated. It triggers a state change to display
+    // an alert if the difference is greater than 10 minutes and auto-refresh
+    // is disabled. The check is performed immediately when the component mounts
+    // and then every 10 seconds thereafter.
+    const checkTimeDifference = () => {
+      if (!isAutoRefreshEnabled && lastUpdated) {
+        // Calculate the difference between the last updated time and the current time in minutes
+        const diffMinutes = moment().diff(lastUpdated, "minutes");
+        if (diffMinutes >= 10) {
+          setDisplayRefreshAlert(true);
+          setMinutesSinceLastRefresh(diffMinutes);
+        } else {
+          setDisplayRefreshAlert(false);
+        }
+      }
     };
-  }, [refreshLiveWorkload]);
+
+    checkTimeDifference();
+    const intervalId = setInterval(checkTimeDifference, 10 * 1000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [lastUpdated, isAutoRefreshEnabled, setDisplayRefreshAlert]);
 
   useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),
@@ -161,6 +215,18 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
     resetPagination();
   };
 
+  const onSubmitToggleAutoRefresh = () => {
+    // Refresh immediately when toggling auto-refresh on.
+    if (!isAutoRefreshEnabled) {
+      refreshLiveWorkload();
+    }
+    onAutoRefreshToggle(!isAutoRefreshEnabled);
+  };
+
+  const handleRefresh = () => {
+    onManualRefresh();
+  };
+
   const clearSearch = () => onSubmitSearch("");
   const clearFilters = () =>
     onSubmitFilters({
@@ -207,7 +273,29 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
             filters={filters}
           />
         </PageConfigItem>
+        <PageConfigItem>
+          <RefreshControl
+            isAutoRefreshEnabled={isAutoRefreshEnabled}
+            onToggleAutoRefresh={onSubmitToggleAutoRefresh}
+            onManualRefresh={handleRefresh}
+            lastRefreshTimestamp={lastUpdated}
+            execType={"transaction"}
+          />
+        </PageConfigItem>
       </PageConfig>
+      {displayRefreshAlert && (
+        <div className={cx("refresh-alert")}>
+          <InlineAlert
+            intent="warning"
+            title={
+              <>
+                Your active transactions data is {minutesSinceLastRefresh}{" "}
+                minutes old. Consider refreshing for the latest information.
+              </>
+            }
+          />
+        </div>
+      )}
       <div className={cx("table-area")}>
         <Loading
           loading={transactions == null}

--- a/pkg/ui/workspaces/db-console/src/redux/analyticsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/analyticsActions.ts
@@ -24,7 +24,6 @@ export const TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION =
   "cockroachui/analytics/TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION";
 export const TRACK_APPLY_SEARCH_CRITERIA =
   "cockroachui/analytics/TRACK_APPLY_SEARCH_CRITERIA";
-
 export interface TableSortActionPayload {
   tableName: string;
   columnName: string;

--- a/pkg/ui/workspaces/db-console/src/views/statements/activeStatementsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/activeStatementsSelectors.tsx
@@ -21,6 +21,7 @@ import {
 import { refreshLiveWorkload } from "src/redux/apiReducers";
 import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
+import { autoRefreshLocalSetting } from "../transactions/activeTransactionsSelectors";
 
 const selectedColumnsLocalSetting = new LocalSetting<
   AdminUIState,
@@ -59,6 +60,8 @@ export const mapStateToActiveStatementViewProps = (state: AdminUIState) => ({
   sessionsError: state.cachedData?.sessions.lastError,
   internalAppNamePrefix: selectAppName(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),
+  isAutoRefreshEnabled: autoRefreshLocalSetting.selector(state),
+  lastUpdated: state.cachedData?.sessions.setAt,
 });
 
 export const activeStatementsViewActions = {
@@ -68,4 +71,7 @@ export const activeStatementsViewActions = {
   onFiltersChange: (filters: ActiveStatementFilters) =>
     filtersLocalSetting.set(filters),
   onSortChange: (ss: SortSetting) => sortSettingLocalSetting.set(ss),
+  onAutoRefreshToggle: (isToggled: boolean) =>
+    autoRefreshLocalSetting.set(isToggled),
+  onManualRefresh: () => refreshLiveWorkload(),
 };

--- a/pkg/ui/workspaces/db-console/src/views/transactions/activeTransactionsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/activeTransactionsSelectors.tsx
@@ -23,6 +23,11 @@ import { refreshLiveWorkload } from "src/redux/apiReducers";
 import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
 
+export const ACTIVE_EXECUTIONS_IS_AUTOREFRESH_ENABLED =
+  "isAutoRefreshEnabled/ActiveExecutions";
+export const ACTIVE_EXECUTIONS_DISPLAY_REFRESH_ALERT =
+  "displayRefreshAlert/ActiveTransactionsPage";
+
 const transactionsColumnsLocalSetting = new LocalSetting<
   AdminUIState,
   string | null
@@ -52,6 +57,14 @@ const sortSettingLocalSetting = new LocalSetting<AdminUIState, SortSetting>(
   { ascending: false, columnTitle: "startTime" },
 );
 
+// autoRefreshLocalSetting is shared between the Active Statements and Active
+// Transactions components.
+export const autoRefreshLocalSetting = new LocalSetting<AdminUIState, boolean>(
+  ACTIVE_EXECUTIONS_IS_AUTOREFRESH_ENABLED,
+  (state: AdminUIState) => state.localSettings,
+  true,
+);
+
 export const mapStateToActiveTransactionsPageProps = (state: AdminUIState) => ({
   selectedColumns: transactionsColumnsLocalSetting.selectorToArray(state),
   transactions: selectActiveTransactions(state),
@@ -60,6 +73,8 @@ export const mapStateToActiveTransactionsPageProps = (state: AdminUIState) => ({
   sortSetting: sortSettingLocalSetting.selector(state),
   internalAppNamePrefix: selectAppName(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),
+  isAutoRefreshEnabled: autoRefreshLocalSetting.selector(state),
+  lastUpdated: state.cachedData?.sessions.setAt,
 });
 
 // This object is just for convenience so we don't need to supply dispatch to
@@ -72,4 +87,7 @@ export const activeTransactionsPageActionCreators: ActiveTransactionsViewDispatc
       filtersLocalSetting.set(filters),
     onSortChange: (ss: SortSetting) => sortSettingLocalSetting.set(ss),
     refreshLiveWorkload,
+    onAutoRefreshToggle: (isToggled: boolean) =>
+      autoRefreshLocalSetting.set(isToggled),
+    onManualRefresh: () => refreshLiveWorkload(),
   };


### PR DESCRIPTION
Previously, the Active Executions views in the SQL Activity pages only
only supported automatic refresh at a rate of every 10 seconds. This
is a papercut which may lead to some queries disappearing before a user
is able to investigate it. This commit adds adds support for manual
refresh in the Active Executions page as well as a toggle to switch
between automatic and manual refresh.

A summary of changes:

- A new component `RefreshControl` which contains an auto-refresh
  toggle, a manual refresh button, and a timestamp indicating when the
  last refresh was performed..
- `ActiveStatementsView` and `ActiveTransactionsView` make use of this
  component to control when their data gets refreshed. The toggle
  defaults to ON for both pages.
- Analytics for the auto refresh toggle and the manual refresh button.
- A inline alert if the data hasn't been refreshed in over 10 minutes.

Loom (DB): https://www.loom.com/share/5bdab5a62a0c4bc694c9c5d7f936759a
Loom (CC): https://www.loom.com/share/de399300225540059bc7c4f156bc8270

Release note (ui change): the active executions views in the SQL
Activity pages now support toggling between automatic and manual
refresh. A manual refresh button is also added along with a timestamp
indicating when the last refresh was performed.