### PR TITLE
release-22.2: gossip: reintroduce `GossipClientsKey` gossip

### DIFF
--- a/pkg/gossip/BUILD.bazel
+++ b/pkg/gossip/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/config",
         "//pkg/config/zonepb",
         "//pkg/roachpb",

--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -83,6 +83,11 @@ const (
 	// KeyDistSQLDrainingPrefix is the key prefix for each node's DistSQL
 	// draining state.
 	KeyDistSQLDrainingPrefix = "distsql-draining"
+
+	// KeyGossipClientsPrefix is the prefix for keys that indicate which gossip
+	// client connections a node has open. This is used by other nodes in the
+	// cluster to build a map of the gossip network.
+	KeyGossipClientsPrefix = "gossip-clients"
 )
 
 // MakeKey creates a canonical key under which to gossip a piece of
@@ -123,6 +128,11 @@ func DecodeNodeDescKey(key string, prefix string) (roachpb.NodeID, error) {
 		return 0, errors.Wrapf(err, "failed parsing NodeID from key %q", key)
 	}
 	return roachpb.NodeID(nodeID), nil
+}
+
+// MakeGossipClientsKey returns the gossip client key for the given node.
+func MakeGossipClientsKey(nodeID roachpb.NodeID) string {
+	return MakeKey(KeyGossipClientsPrefix, nodeID.String())
 }
 
 // MakeNodeHealthAlertKey returns the gossip key under which the given node can


### PR DESCRIPTION
In 2114678b, we stopped gossiping the connectivity graph via `GossipClientsKey`. However, this broke backwards compatibility with `cockroach node status` which relied on this key to determine `is_live` liveness.

This patch partially reverts that change, by reintroducing gossip of these keys in mixed 22.1/22.2 clusters, but otherwise not using them for anything. We stop gossiping them in finalized 22.2 clusters. This breaks backwards compatibility with <22.2.3, we'll just have to live with that.

Touches #89613.
Touches #51838.

Epic: none
Release note (bug fix): Fixed a bug where `cockroach node status` could incorrectly report nodes as `is_live = false` in mixed 22.1/22.2 clusters. The bug still exists between 22.2 patch versions before and after 22.2.3.