### PR TITLE
cli/debug: collect namespaces, descriptors, and jobs with AOST

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -186,6 +186,7 @@ go_library(
         "//pkg/ts/tsutil",
         "//pkg/upgrade/upgrades",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/cgroups",
         "//pkg/util/encoding",
         "//pkg/util/envutil",

--- a/pkg/cli/doctor_test.go
+++ b/pkg/cli/doctor_test.go
@@ -34,6 +34,7 @@ func TestDoctorCluster(t *testing.T) {
 		"INSERT INTO system.users VALUES ('node', NULL, true, 3)",
 		"GRANT node TO root",
 		"DELETE FROM system.namespace WHERE name = 'foo'",
+		"SELECT pg_catalog.pg_sleep(1)",
 	}, ";\n"),
 	})
 


### PR DESCRIPTION
Previously, when collecting these tables for debug doctor or the debug.zip we did not use AOST queries. This could be problematic when there was contention against these tables, leading to retries. To address this, these tables will now always be collected with AOST.

Fixes: #103608

Release note: None