### PR TITLE
changefeedccl: freeze the hashing algorithm

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -15,6 +15,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"math"
 	"net/url"
 	"strings"
@@ -711,9 +712,7 @@ var _ sarama.Partitioner = &changefeedPartitioner{}
 var _ sarama.PartitionerConstructor = newChangefeedPartitioner
 
 func newChangefeedPartitioner(topic string) sarama.Partitioner {
-	return &changefeedPartitioner{
-		hash: sarama.NewHashPartitioner(topic),
-	}
+	return sarama.NewCustomHashPartitioner(fnv.New32a)(topic)
 }
 
 func (p *changefeedPartitioner) RequiresConsistency() bool { return true }


### PR DESCRIPTION
In almost every place where we need consistent hashing, we specify it. But in the Kafka sink, we just used Sarama's default, which is subject to change. This PR specifies the algorithm explicitly there too, and adds a test with hardcoded values so that future updates can't cause inconsistent behavior in a running changefeed.

Fixes #101779