### PR TITLE
rpc,circuitbreaker,stop,testutils,nodedialer: small extracts from #99191

### DIFF
--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -283,6 +283,14 @@ func (r *RemoteClockMonitor) UpdateOffset(
 	}
 }
 
+// GetOffset returns the last RemoteOffset seen for this node. Returns the
+// zero value if no offset is known.
+func (r *RemoteClockMonitor) GetOffset(id roachpb.NodeID) RemoteOffset {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.offsets[id]
+}
+
 // VerifyClockOffset calculates the number of nodes to which the known offset
 // is healthy (as defined by RemoteOffset.isHealthy). It returns nil iff more
 // than half the known offsets are healthy, and an error otherwise. A non-nil

--- a/pkg/rpc/nodedialer/nodedialer_test.go
+++ b/pkg/rpc/nodedialer/nodedialer_test.go
@@ -470,7 +470,7 @@ func newTestContext(
 	cfg := testutils.NewNodeTestBaseContext()
 	cfg.Insecure = true
 	cfg.RPCHeartbeatInterval = 100 * time.Millisecond
-	cfg.RPCHeartbeatTimeout = 100 * time.Millisecond
+	cfg.RPCHeartbeatTimeout = 500 * time.Millisecond
 	ctx := context.Background()
 	rctx := rpc.NewContext(ctx, rpc.ContextOptions{
 		TenantID:        roachpb.SystemTenantID,

--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -57,6 +58,9 @@ func SucceedsSoonError(fn func() error) error {
 func SucceedsWithin(t TB, fn func() error, duration time.Duration) {
 	t.Helper()
 	if err := SucceedsWithinError(fn, duration); err != nil {
+		if f, l, _, ok := errors.GetOneLineSource(err); ok {
+			err = errors.Wrapf(err, "from %s:%d", f, l)
+		}
 		t.Fatalf("condition failed to evaluate within %s: %s", duration, err)
 	}
 }

--- a/pkg/util/circuit/circuitbreaker_test.go
+++ b/pkg/util/circuit/circuitbreaker_test.go
@@ -384,6 +384,32 @@ func TestBreakerRealistic(t *testing.T) {
 	})
 }
 
+func TestTestingSetTripped(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	_, tl := testLogBridge(t)
+
+	// Spawn a never-terminating probe just to prove that we can simulate a
+	// breaker trip without communicating with the probe at all.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	br := NewBreaker(Options{
+		Name: "test",
+		AsyncProbe: func(report func(error), done func()) {
+			report(nil)
+			<-ctx.Done()
+		},
+		EventHandler: tl,
+	})
+
+	require.NoError(t, br.Signal().Err())
+	errBoom := errors.New("boom")
+	undo := TestingSetTripped(br, errBoom)
+	require.ErrorIs(t, br.Signal().Err(), errBoom)
+	undo()
+	require.NoError(t, br.Signal().Err())
+	require.Zero(t, tl.trip)
+}
+
 func BenchmarkBreaker_Signal(b *testing.B) {
 	br := NewBreaker(Options{
 		Name: redact.Sprint("Breaker"),

--- a/pkg/util/circuit/options.go
+++ b/pkg/util/circuit/options.go
@@ -44,4 +44,12 @@ type Options struct {
 	// EventHandler receives events from the Breaker. For an implementation that
 	// performs unstructured logging, see EventLogger.
 	EventHandler EventHandler
+
+	// signalInterceptor gets to see and change the return value of the Signal
+	// method. This is useful for testing, as it allows "pretending" that the
+	// breaker is tripped without having to replace the probe method and
+	// coordinating with a running probe.
+	//
+	// Accessible only via TestingSetTripped and TestingReset.
+	signalInterceptor func(Signal) Signal
 }

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -171,6 +171,7 @@ type Stopper struct {
 		// should execute immediately.
 		quiescing, stopping bool
 		closers             []Closer
+		quiescers           []func()
 
 		// idAlloc is incremented atomically under the read lock when adding a
 		// context to be canceled.
@@ -238,6 +239,19 @@ func (s *Stopper) addTask(delta int32) (updated int32) {
 // means that the stopper is either quiescing or stopping.
 func (s *Stopper) refuseRLocked() bool {
 	return s.mu.stopping || s.mu.quiescing
+}
+
+// OnQuiesce is like AddCloser, but invokes on quiesce.
+// If the Stopper is already quiescing, the function will be invoked
+// synchronously.
+func (s *Stopper) OnQuiesce(f func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.refuseRLocked() {
+		f()
+		return
+	}
+	s.mu.quiescers = append(s.mu.quiescers, f)
 }
 
 // AddCloser adds an object to close after the stopper has been stopped.
@@ -578,6 +592,9 @@ func (s *Stopper) Quiesce(ctx context.Context) {
 			s.mu.qCancels.Delete(k)
 			return true
 		})
+		for _, f := range s.mu.quiescers {
+			f()
+		}
 	}()
 
 	for s.NumTasks() > 0 {


### PR DESCRIPTION
See individual commits.

- nodedialer: up test heartbeat timeout to 500ms: this allowed stressing the tests "harder".
- testutils: print error source in SucceedsSoon: this was useful for understanding failures.
- stop: add OnQuiesce: this is used in #99191.
- breaker: allow testing override of Signal: this is used in #99191.
- rpc: add GetOffset method: this is used in #99191.
- rpc: improve ManualHeartbeatService: this is used in #99191.
- rpc: improve comment on onlyOnceDialer: the previous comment didn't reveal the reason for why this exists.

Epic: none
Release note: none
