### PR TITLE
kvserver: don't quiesce with follower in StateProbe

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10065,9 +10065,9 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 						LeadTransferee: 0,
 					},
 					Progress: map[uint64]tracker.Progress{
-						1: {Match: logIndex},
-						2: {Match: logIndex},
-						3: {Match: logIndex},
+						1: {Match: logIndex, State: tracker.StateReplicate},
+						2: {Match: logIndex, State: tracker.StateReplicate},
+						3: {Match: logIndex, State: tracker.StateReplicate},
 					},
 				},
 				lastIndex:              logIndex,
@@ -10207,6 +10207,12 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 	})
 	test(false, func(q *testQuiescer) *testQuiescer {
 		q.raftReady = true
+		return q
+	})
+	test(false, func(q *testQuiescer) *testQuiescer {
+		pr := q.status.Progress[2]
+		pr.State = tracker.StateProbe
+		q.status.Progress[2] = pr
 		return q
 	})
 	// Create a mismatch between the raft progress replica IDs and the


### PR DESCRIPTION
shouldReplicaQuiesce checks that all followers are fully caught up, but it's
still possible to have a follower in StateProbe (because we call
`rawNode.ReportUnreachable` when an outgoing message gets dropped).

Persistent StateProbe is problematic: we check for it before lease transfers, so
despite the follower being fully caught up, we'd refuse the transfer.

Unfortunately, this commit itself is not enough: even if the range is not
quiesced, it needs to replicate a new entry to rectify the situation (i.e.
switch follower back to StateReplicate). This is because at the time of writing,
receipt of a heartbeat response from the follower is not enough to move it back
to StateReplicate.
This was fixed upstream, in https://github.com/cockroachdb/cockroach/pull/103826.

However, this is still not enough! If the range quiesces successfully, and
*then* `ReportUnreachable` is called, we still end up in the same state; this is now tracked in https://github.com/cockroachdb/cockroach/issues/103828.

I ran into the above issue on
https://github.com/cockroachdb/cockroach/pull/99191, which adds persistent
circuit breakers, when stressing `TestStoreMetrics`. That test happens to
restart n2 when it's fully caught up and due to the persistence of the circuit
breakers when it comes up the leader will move it into StateProbe (since we can
end up dropping the first heartbeat sent to it as it comes up, since the breaker
hasn't untripped yet).

But, I believe that this bug is real even without this breaker re-work, just
harder to trigger.

Epic: none
Release note (bug fix): fixed a problem that could lead to erroneously refused
lease transfers (error message: "refusing to transfer lease to [...] because
target may need a Raft snapshot: replica in StateProbe"
