### PR TITLE
release-22.2: backupccl: support locality-aware incremental backups in SHOW BACKUP

### DIFF
--- a/pkg/ccl/backupccl/backupdest/incrementals_test.go
+++ b/pkg/ccl/backupccl/backupdest/incrementals_test.go
@@ -11,11 +11,97 @@ package backupdest_test
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupdest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuputils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCollectionsAndSubdir(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	type testcase struct {
+		name                string
+		paths               []string
+		subdir              string
+		expectedCollections []string
+		expectedSubdir      string
+		expectedError       string
+	}
+	testcases := []testcase{
+		{
+			name:                "non-empty subdir returns unmodified collection",
+			paths:               []string{"nodelocal://1/backup-dest/2023/05/10-160331.72/"},
+			subdir:              "foo",
+			expectedCollections: []string{"nodelocal://1/backup-dest/2023/05/10-160331.72/"},
+			expectedSubdir:      "foo",
+		},
+		{
+			name: "non-empty subdir returns all parts of unmodified collection",
+			paths: []string{
+				"nodelocal://1/backup-dest/",
+				"nodelocal://2/backup-dest/",
+			},
+			subdir: "foo",
+			expectedCollections: []string{
+				"nodelocal://1/backup-dest/",
+				"nodelocal://2/backup-dest/",
+			},
+			expectedSubdir: "foo",
+		},
+		{
+			name:                "date-based-path is returned as subdir if no subdir is provided",
+			paths:               []string{"nodelocal://1/backup-dest/2023/05/10-160331.72/"},
+			expectedCollections: []string{"nodelocal://1/backup-dest"},
+			expectedSubdir:      "2023/05/10-160331.72/",
+		},
+		{
+			name: "multiple date-based paths are returned as subdir if no subdir is provided",
+			paths: []string{
+				"nodelocal://1/backup-dest/2023/05/10-160331.72/",
+				"nodelocal://2/backup-dest/2023/05/10-160331.72/",
+			},
+			expectedCollections: []string{
+				"nodelocal://1/backup-dest",
+				"nodelocal://2/backup-dest",
+			},
+			expectedSubdir: "2023/05/10-160331.72/",
+		},
+		{
+			name: "paths that don't match are returned unmodified",
+			paths: []string{
+				"nodelocal://1/backup-dest/2023/05/9999/",
+				"nodelocal://2/backup-dest/2023/05/9999/",
+			},
+			expectedCollections: []string{
+				"nodelocal://1/backup-dest/2023/05/9999/",
+				"nodelocal://2/backup-dest/2023/05/9999/",
+			},
+			expectedSubdir: "",
+		},
+		{
+			name: "different date-based paths results in an error",
+			paths: []string{
+				"nodelocal://1/backup-dest/2023/05/10-160331.72/",
+				"nodelocal://2/backup-dest/2023/05/10-160331.73/",
+			},
+			expectedError: "provided backup locations appear to reference different full backups",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			collections, subdir, err := backupdest.CollectionsAndSubdir(tc.paths, tc.subdir)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+			} else {
+				require.Equal(t, tc.expectedSubdir, subdir)
+				require.Equal(t, tc.expectedCollections, collections)
+			}
+		})
+	}
+}
 
 func TestJoinURLPath(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -419,13 +419,16 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 			}
 		}
 
-		collection, computedSubdir := backupdest.CollectionAndSubdir(dest[0], subdir)
+		collections, computedSubdir, err := backupdest.CollectionsAndSubdir(dest, subdir)
+		if err != nil {
+			return err
+		}
 		fullyResolvedIncrementalsDirectory, err := backupdest.ResolveIncrementalsBackupLocation(
 			ctx,
 			p.User(),
 			p.ExecCfg(),
 			explicitIncPaths,
-			[]string{collection},
+			collections,
 			computedSubdir,
 		)
 		if err != nil {

--- a/pkg/ccl/backupccl/testdata/backup-restore/show-backup-multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show-backup-multiregion
@@ -1,0 +1,40 @@
+# These tests validate the SHOW BACKUP command for multi-region databases.
+
+new-server name=s1 allow-implicit-access localities=us-east-1,us-west-1,eu-central-1 disable-tenant
+----
+
+exec-sql
+CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1";
+CREATE TABLE d.t (x INT);
+INSERT INTO d.t VALUES (1), (2), (3);
+----
+
+exec-sql
+CREATE DATABASE foo;
+CREATE TABLE foo.t (x INT);
+INSERT INTO foo.t VALUES (1), (2), (3);
+----
+
+# Now create a locality aware backup and ensure that the SHOW command correctly shows the
+# backup.
+exec-sql
+BACKUP DATABASE d INTO ('nodelocal://1/database_backup_locality_aware_default?COCKROACH_LOCALITY=default', 'nodelocal://1/database_backup_locality_aware_west?COCKROACH_LOCALITY=region=us-west-1', 'nodelocal://1/database_backup_locality_aware_central?COCKROACH_LOCALITY=region=eu-central-1');
+----
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN ('nodelocal://1/database_backup_locality_aware_default?COCKROACH_LOCALITY=default', 'nodelocal://1/database_backup_locality_aware_west?COCKROACH_LOCALITY=region=us-west-1', 'nodelocal://1/database_backup_locality_aware_central?COCKROACH_LOCALITY=region=eu-central-1');
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN ('nodelocal://1/database_backup_locality_aware_default?COCKROACH_LOCALITY=default', 'nodelocal://1/database_backup_locality_aware_west?COCKROACH_LOCALITY=region=us-west-1', 'nodelocal://1/database_backup_locality_aware_central?COCKROACH_LOCALITY=region=eu-central-1')];
+----
+d database full
+crdb_internal_region type full
+public schema full
+_crdb_internal_region type full
+t table full
+d database incremental
+crdb_internal_region type incremental
+public schema incremental
+_crdb_internal_region type incremental
+t table incremental


### PR DESCRIPTION
Backport 1/1 commits from #103096.

/cc @cockroachdb/release

---

Previously, SHOW BACKUP would only resolve incremental locations for the first collection URI passed to SHOW BACKUP. As a result, SHOW BACKUP on a backup that contained incrementals would result in an error such as

    ERROR: expected manifest
    /20230510/160359.17/BACKUP_PART_1_zone=us-east not found in backup
    locations

This only affected `SHOW` because of code in `SHOW` designed to support the user passing the URI to a specific full backup rather than a collection and a subdirectory.

This commit changes the CollectionAndSubdir function to support an array of backup locations.

Epic: none

Release note: Fixes a bug in which SHOW BACKUP would fail to show a locality-aware backup that contained incremental backups.

Release justification: Low risk bug fix.
