### PR TITLE
fix(sec): upgrade vitess.io/vitess to 10.0.0-rc1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	honnef.co/go/tools v0.3.2
-	vitess.io/vitess v0.0.0-00010101000000-000000000000
+	vitess.io/vitess v10.0.0-rc1+incompatible
 )
 
 require (


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in vitess.io/vitess v0.0.0-00010101000000-000000000000
- [MPS-2022-13515](https://www.oscs1024.com/hd/MPS-2022-13515)


### What did I do？
Upgrade vitess.io/vitess from v0.0.0-00010101000000-000000000000 to 10.0.0-rc1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS