### PR TITLE
ui: Network latency page improvements

### DIFF
--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -585,6 +585,7 @@ describe("Routing to", () => {
       screen.getByText(NETWORK_DIAGNOSTICS_REPORT_HEADER, {
         selector: "h3",
       });
+      expect(history.location.pathname).toBe("/reports/network/region");
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -408,7 +408,10 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                       path={`/reports/network/:${nodeIDAttr}`}
                       component={Network}
                     />
-                    <Route exact path="/reports/network" component={Network} />
+                    <Redirect
+                      from={`/reports/network`}
+                      to={`/reports/network/region`}
+                    />
                     <Route exact path="/reports/nodes" component={Nodes} />
                     <Route
                       exact

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -528,6 +528,15 @@ const tenantsListObj = new CachedDataReducer(
 
 export const refreshTenantsList = tenantsListObj.refresh;
 
+const connectivityObj = new CachedDataReducer(
+  api.getNetworkConnectivity,
+  "connectivity",
+  moment.duration(30, "s"),
+  moment.duration(1, "minute"),
+);
+
+export const refreshConnectivity = connectivityObj.refresh;
+
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
   events: CachedDataReducerState<
@@ -592,6 +601,7 @@ export interface APIReducersState {
   snapshot: KeyedCachedDataReducerState<clusterUiApi.GetTracingSnapshotResponse>;
   rawTrace: KeyedCachedDataReducerState<clusterUiApi.GetTraceResponse>;
   tenants: CachedDataReducerState<api.ListTenantsResponseMessage>;
+  connectivity: CachedDataReducerState<api.NetworkConnectivityResponse>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -647,6 +657,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [statementFingerprintInsightsReducerObj.actionNamespace]:
     statementFingerprintInsightsReducerObj.reducer,
   [tenantsListObj.actionNamespace]: tenantsListObj.reducer,
+  [connectivityObj.actionNamespace]: connectivityObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/redux/connectivity.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/connectivity.ts
@@ -1,0 +1,14 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { AdminUIState } from "src/redux/state";
+
+export const connectivitySelector = (state: AdminUIState) =>
+  state.cachedData.connectivity;

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -208,6 +208,11 @@ export type ListTenantsRequestMessage =
 export type ListTenantsResponseMessage =
   protos.cockroach.server.serverpb.ListTenantsResponse;
 
+export type NetworkConnectivityRequest =
+  protos.cockroach.server.serverpb.NetworkConnectivityRequest;
+export type NetworkConnectivityResponse =
+  protos.cockroach.server.serverpb.NetworkConnectivityResponse;
+
 // API constants
 
 export const API_PREFIX = "_admin/v1";
@@ -846,6 +851,18 @@ export function getTenants(
   return timeoutFetch(
     serverpb.ListTenantsResponse,
     `${API_PREFIX}/tenants`,
+    req as any,
+    timeout,
+  );
+}
+
+export function getNetworkConnectivity(
+  req: NetworkConnectivityRequest,
+  timeout?: moment.Duration,
+): Promise<NetworkConnectivityResponse> {
+  return timeoutFetch(
+    serverpb.NetworkConnectivityResponse,
+    `${STATUS_PREFIX}/connectivity`,
     req as any,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/app/components/chip/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/chip/index.tsx
@@ -12,8 +12,16 @@ import React from "react";
 import "./styles.styl";
 
 interface IChipProps {
-  title: string;
-  type?: "green" | "lightgreen" | "grey" | "blue" | "lightblue" | "yellow";
+  title: React.ReactChild;
+  type?:
+    | "green"
+    | "lightgreen"
+    | "grey"
+    | "blue"
+    | "lightblue"
+    | "yellow"
+    | "red"
+    | "white";
 }
 
 export const Chip: React.SFC<IChipProps> = ({ title, type }) => (

--- a/pkg/ui/workspaces/db-console/src/views/app/components/chip/styles.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/chip/styles.styl
@@ -35,3 +35,10 @@
     background $chip-blue
   &--yellow
     background $chip-yellow
+  &--red
+    background $chip-red
+  &--white
+    background $colors--neutral-0
+    border-color $colors--neutral-4
+    border-style solid
+    border-width 1px

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
@@ -16,10 +16,16 @@ import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { createSelector } from "reselect";
 import { withRouter, RouteComponentProps } from "react-router-dom";
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import NodeLivenessStatus = protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus;
 
-import { refreshLiveness, refreshNodes } from "src/redux/apiReducers";
 import {
-  LivenessStatus,
+  CachedDataReducerState,
+  refreshConnectivity,
+  refreshLiveness,
+  refreshNodes,
+} from "src/redux/apiReducers";
+import {
   NodesSummary,
   nodesSummarySelector,
   selectLivenessRequestStatus,
@@ -27,7 +33,6 @@ import {
 } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import { util } from "@cockroachlabs/cluster-ui";
-import { FixLong } from "src/util/fixLong";
 import { trackFilter, trackCollapseNodes } from "src/util/analytics";
 import {
   getFilters,
@@ -41,20 +46,26 @@ import { Legend } from "./legend";
 import Sort from "./sort";
 import { getMatchParamByName } from "src/util/query";
 import "./network.styl";
+import { connectivitySelector } from "src/redux/connectivity";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 
 interface NetworkOwnProps {
   nodesSummary: NodesSummary;
   nodeSummaryErrors: Error[];
+  connectivity: CachedDataReducerState<cockroach.server.serverpb.NetworkConnectivityResponse>;
   refreshNodes: typeof refreshNodes;
   refreshLiveness: typeof refreshLiveness;
+  refreshConnectivity: typeof refreshConnectivity;
 }
 
-export interface Identity {
+export type Identity = {
   nodeID: number;
   address: string;
   locality?: string;
   updatedAt: moment.Moment;
-}
+  livenessStatus: protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus;
+  connectivity: protos.cockroach.server.serverpb.NetworkConnectivityResponse.IConnectivity;
+};
 
 export interface NoConnection {
   from: Identity;
@@ -86,6 +97,30 @@ function contentAvailable(nodesSummary: NodesSummary) {
   );
 }
 
+export const isHealthyLivenessStatus = (
+  status: NodeLivenessStatus,
+): boolean => {
+  switch (status) {
+    case cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+      .NODE_STATUS_LIVE:
+    case cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+      .NODE_STATUS_DRAINING:
+    case cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+      .NODE_STATUS_DECOMMISSIONING:
+    case cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+      .NODE_STATUS_UNKNOWN:
+    case cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+      .NODE_STATUS_UNAVAILABLE:
+      return true;
+    case cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+      .NODE_STATUS_DEAD:
+    case cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+      .NODE_STATUS_DECOMMISSIONED:
+    default:
+      return false;
+  }
+};
+
 export function getValueFromString(
   key: string,
   params: string,
@@ -110,9 +145,10 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     filter: null,
   };
 
-  refresh(props = this.props) {
-    props.refreshLiveness();
-    props.refreshNodes();
+  refresh() {
+    this.props.refreshLiveness();
+    this.props.refreshNodes();
+    this.props.refreshConnectivity();
   }
 
   componentDidMount() {
@@ -120,10 +156,8 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     this.refresh();
   }
 
-  componentDidUpdate(prevProps: NetworkProps) {
-    if (!_.isEqual(this.props.location, prevProps.location)) {
-      this.refresh(this.props);
-    }
+  componentDidUpdate(_prevProps: NetworkProps) {
+    this.refresh();
   }
 
   onChangeCollapse = (collapsed: boolean) => {
@@ -206,13 +240,7 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     return data;
   };
 
-  renderLatencyTable(
-    latencies: number[],
-    staleIDs: Set<number>,
-    nodesSummary: NodesSummary,
-    displayIdentities: Identity[],
-    noConnections: NoConnection[],
-  ) {
+  renderLatencyTable(latencies: number[], displayIdentities: Identity[]) {
     const { match } = this.props;
     const nodeId = getMatchParamByName(match, "node_id");
     const { collapsed, filter } = this.state;
@@ -231,11 +259,9 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     const latencyTable = (
       <Latency
         displayIdentities={this.filteredDisplayIdentities(displayIdentities)}
-        staleIDs={staleIDs}
         multipleHeader={nodeId !== "cluster"}
         node_id={nodeId}
         collapsed={collapsed}
-        nodesSummary={nodesSummary}
         std={{
           stddev,
           stddevMinus2,
@@ -251,45 +277,55 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     }
 
     // legend is just a quick table showing the standard deviation values.
-    return [
-      <Sort
-        onChangeCollapse={this.onChangeCollapse}
-        collapsed={collapsed}
-        sort={sortParams}
-        filter={filter}
-        onChangeFilter={this.onChangeFilter}
-        deselectFilterByKey={this.deselectFilterByKey}
-      />,
-      <div className="section">
-        <Legend
-          stddevMinus2={stddevMinus2}
-          stddevMinus1={stddevMinus1}
-          mean={mean}
-          stddevPlus1={stddevPlus1}
-          stddevPlus2={stddevPlus2}
-          noConnections={noConnections}
+    return (
+      <Fragment>
+        <Sort
+          onChangeCollapse={this.onChangeCollapse}
+          collapsed={collapsed}
+          sort={sortParams}
+          filter={filter}
+          onChangeFilter={this.onChangeFilter}
+          deselectFilterByKey={this.deselectFilterByKey}
         />
-        {latencyTable}
-      </div>,
-    ];
+        <div className="section">
+          <Legend
+            stddevMinus2={stddevMinus2}
+            stddevMinus1={stddevMinus1}
+            mean={mean}
+            stddevPlus1={stddevPlus1}
+            stddevPlus2={stddevPlus2}
+          />
+          {latencyTable}
+        </div>
+      </Fragment>
+    );
   }
 
-  getSortParams = (data: Identity[]) => {
+  // getSortParams builds a list of sorting and filtering options based on provided list of nodes.
+  // It is possible to filter data by: nodes ID, region, or availability zone. For instance this
+  // function returns can return NetworkSort instance { id: "region", filters: [{name: "us-west1", ...}, {name: "us-west2"}]}
+  // that later used to populate Sort and Filter dropdowns with available options.
+  getSortParams = (data: Identity[]): NetworkSort[] => {
     const sort: NetworkSort[] = [];
     const searchQuery = (params: string) => `cluster,${params}`;
-    data.forEach(values => {
-      const localities = searchQuery(values.locality).split(",");
-      localities.forEach((locality: string) => {
-        if (locality !== "") {
+    data
+      .filter(d => !!d.locality) // filter out dead nodes that don't have locality props
+      .forEach(values => {
+        const localities = searchQuery(values.locality).split(",");
+        localities.forEach((locality: string) => {
+          if (locality === "") return;
           const value = locality.match(/^\w+/gi)
             ? locality.match(/^\w+/gi)[0]
             : null;
-          if (!sort.some(x => x.id === value)) {
-            const sortValue: NetworkSort = { id: value, filters: [] };
-            data.forEach(item => {
+          if (sort.some(x => x.id === value)) return;
+          const sortValue: NetworkSort = { id: value, filters: [] };
+          data
+            .filter(d => !!d.locality) // filter out dead nodes that don't have locality props
+            .forEach(item => {
               const valueLocality = searchQuery(values.locality).split(",");
               const itemLocality = searchQuery(item.locality);
               valueLocality.forEach(val => {
+                const address = item.address ?? "";
                 const itemLocalitySplited = val.match(/^\w+/gi)
                   ? val.match(/^\w+/gi)[0]
                   : null;
@@ -298,47 +334,37 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
                     ...sortValue.filters,
                     {
                       name: item.nodeID.toString(),
-                      address: item.address,
+                      address: address,
                     },
                   ];
                 } else if (
                   itemLocalitySplited === value &&
-                  !sortValue.filters.reduce(
-                    (accumulator, vendor) =>
-                      accumulator ||
-                      vendor.name === getValueFromString(value, itemLocality),
-                    false,
+                  !sortValue.filters.some(
+                    f => f.name === getValueFromString(value, itemLocality),
                   )
                 ) {
                   sortValue.filters = [
                     ...sortValue.filters,
                     {
                       name: getValueFromString(value, itemLocality),
-                      address: item.address,
+                      address: address,
                     },
                   ];
                 }
               });
             });
-            sort.push(sortValue);
-          }
-        }
+          sort.push(sortValue);
+        });
       });
-    });
     return sort;
   };
 
-  getDisplayIdentities = (
-    healthyIDsContext: _.CollectionChain<number>,
-    staleIDsContext: _.CollectionChain<number>,
-    identityByID: Map<number, Identity>,
-  ) => {
+  getDisplayIdentities = (identityByID: Map<number, Identity>): Identity[] => {
     const { match } = this.props;
     const nodeId = getMatchParamByName(match, "node_id");
-    const identityContent = healthyIDsContext
-      .union(staleIDsContext.value())
-      .map(nodeID => identityByID.get(nodeID))
-      .sortBy(identity => identity.nodeID);
+    const identityContent = _.chain(Array.from(identityByID.values())).sortBy(
+      identity => identity.nodeID,
+    );
     const sort = this.getSortParams(identityContent.value());
     if (sort.some(x => x.id === nodeId)) {
       return identityContent
@@ -348,126 +374,92 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     return identityContent.value();
   };
 
-  renderContent(nodesSummary: NodesSummary, filters: NodeFilterListProps) {
+  renderContent(
+    nodesSummary: NodesSummary,
+    filters: NodeFilterListProps,
+    connections: protos.cockroach.server.serverpb.NetworkConnectivityResponse["connections"],
+  ) {
     if (!contentAvailable(nodesSummary)) {
       return null;
     }
+    // Following states can be observed:
+    // 1. live connection
+    // 2. partitioned connection
+
+    // Combine Node Ids known by gossip client (from `connectivity`) and from
+    // Nodes api to make sure we show all known nodes.
+    const knownNodeIds = _.union(
+      Object.keys(nodesSummary.livenessByNodeID),
+      Object.keys(connections),
+    );
+
     // List of node identities.
     const identityByID: Map<number, Identity> = new Map();
-    _.forEach(nodesSummary.nodeStatuses, status => {
-      identityByID.set(status.desc.node_id, {
-        nodeID: status.desc.node_id,
-        address: status.desc.address.address_field,
-        locality: localityToString(status.desc.locality),
-        updatedAt: util.LongToMoment(status.updated_at),
+
+    knownNodeIds.forEach(nodeId => {
+      const nodeIdInt = _.parseInt(nodeId);
+      const status = nodesSummary.nodeStatusByID[nodeId];
+      identityByID.set(nodeIdInt, {
+        nodeID: nodeIdInt,
+        address: status?.desc.address.address_field,
+        locality: status && localityToString(status.desc.locality),
+        updatedAt: status && util.LongToMoment(status.updated_at),
+        livenessStatus:
+          nodesSummary.livenessStatusByNodeID[nodeId] ||
+          protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+            .NODE_STATUS_UNKNOWN,
+        connectivity: connections[nodeId],
       });
     });
 
-    // Calculate the mean and sampled standard deviation.
-    let healthyIDsContext = _.chain(nodesSummary.nodeIDs)
-      .filter(
-        nodeID =>
-          nodesSummary.livenessStatusByNodeID[nodeID] ===
-          LivenessStatus.NODE_STATUS_LIVE,
-      )
-      .filter(nodeID => !_.isNil(nodesSummary.nodeStatusByID[nodeID].activity))
-      .map(nodeID => Number.parseInt(nodeID, 0));
-    let staleIDsContext = _.chain(nodesSummary.nodeIDs)
-      .filter(
-        nodeID =>
-          nodesSummary.livenessStatusByNodeID[nodeID] ===
-          LivenessStatus.NODE_STATUS_UNAVAILABLE,
-      )
-      .map(nodeID => Number.parseInt(nodeID, 0));
-    if (!_.isNil(filters.nodeIDs) && filters.nodeIDs.size > 0) {
-      healthyIDsContext = healthyIDsContext.filter(nodeID =>
-        filters.nodeIDs.has(nodeID),
-      );
-      staleIDsContext = staleIDsContext.filter(nodeID =>
-        filters.nodeIDs.has(nodeID),
-      );
-    }
-    if (!_.isNil(filters.localityRegex)) {
-      healthyIDsContext = healthyIDsContext.filter(nodeID =>
-        filters.localityRegex.test(
-          localityToString(nodesSummary.nodeStatusByID[nodeID].desc.locality),
-        ),
-      );
-      staleIDsContext = staleIDsContext.filter(nodeID =>
-        filters.localityRegex.test(
-          localityToString(nodesSummary.nodeStatusByID[nodeID].desc.locality),
-        ),
-      );
-    }
-    const healthyIDs = healthyIDsContext.value();
-    const staleIDs = new Set(staleIDsContext.value());
-    const displayIdentities: Identity[] = this.getDisplayIdentities(
-      healthyIDsContext,
-      staleIDsContext,
-      identityByID,
-    );
-    const latencies = _.flatMap(healthyIDs, nodeIDa =>
-      _.chain(healthyIDs)
-        .without(nodeIDa)
-        .map(nodeIDb => nodesSummary.nodeStatusByID[nodeIDa].activity[nodeIDb])
-        .filter(activity => !_.isNil(activity) && !_.isNil(activity.latency))
-        .map(activity => util.NanoToMilli(FixLong(activity.latency).toNumber()))
-        .filter(ms => _.isFinite(ms) && ms > 0)
-        .value(),
-    );
+    // apply filters to exclude items that don't satisfy filter conditions.
+    identityByID.forEach((identity, nodeId) => {
+      if (
+        (filters.nodeIDs?.size > 0 && !filters.nodeIDs?.has(nodeId)) ||
+        (!!filters.localityRegex &&
+          filters.localityRegex?.test(identity.locality)) ||
+        !isHealthyLivenessStatus(identity.livenessStatus)
+      ) {
+        identityByID.delete(nodeId);
+      }
+    });
 
-    const noConnections: NoConnection[] = _.flatMap(healthyIDs, nodeIDa =>
-      _.chain(nodesSummary.nodeStatusByID[nodeIDa].activity)
-        .keys()
-        .map(nodeIDb => Number.parseInt(nodeIDb, 10))
-        .difference(healthyIDs)
-        .map(nodeIDb => ({
-          from: identityByID.get(nodeIDa),
-          to: identityByID.get(nodeIDb),
-        }))
-        .sortBy(noConnection => noConnection.to.nodeID)
-        .sortBy(noConnection => noConnection.to.locality)
-        .sortBy(noConnection => noConnection.from.nodeID)
-        .sortBy(noConnection => noConnection.from.locality)
-        .value(),
-    );
+    const displayIdentities: Identity[] =
+      this.getDisplayIdentities(identityByID);
 
-    let content: JSX.Element | JSX.Element[];
-    if (_.isEmpty(healthyIDs)) {
-      content = (
-        <h2 className="base-heading">No healthy nodes match the filters</h2>
-      );
-    } else if (latencies.length < 1) {
-      content = (
+    const latencies: number[] = _.chain(connections)
+      .values()
+      .flatMap(v => Object.values(v.peers))
+      .flatMap(v => v.latency)
+      .filter(v => v !== undefined && v.nanos !== undefined)
+      .map(v => util.NanoToMilli(v.nanos))
+      .value();
+
+    if (_.isEmpty(identityByID)) {
+      return <h2 className="base-heading">No nodes match the filters</h2>;
+    }
+    if (knownNodeIds.length < 2) {
+      return (
         <h2 className="base-heading">
-          Cannot show latency chart without two healthy nodes.
+          Cannot show latency chart for cluster with less than 2 nodes.
         </h2>
       );
-    } else {
-      content = this.renderLatencyTable(
-        latencies,
-        staleIDs,
-        nodesSummary,
-        displayIdentities,
-        noConnections,
-      );
     }
-    return [
-      content,
-      // staleTable(staleIdentities),
-      // noConnectionTable(noConnections),
-    ];
+    return this.renderLatencyTable(latencies, displayIdentities);
   }
 
   render() {
-    const { nodesSummary, location } = this.props;
+    const { nodesSummary, location, connectivity } = this.props;
     const filters = getFilters(location);
+
     return (
       <Fragment>
-        <Helmet title="Network | Debug" />
+        <Helmet title="Network" />
         <h3 className="base-heading">Network</h3>
         <Loading
-          loading={!contentAvailable(nodesSummary)}
+          loading={
+            !contentAvailable(nodesSummary) || !connectivity?.data?.connections
+          }
           page={"network"}
           error={this.props.nodeSummaryErrors}
           className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
@@ -477,7 +469,11 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
                 nodeIDs={filters.nodeIDs}
                 localityRegex={filters.localityRegex}
               />
-              {this.renderContent(nodesSummary, filters)}
+              {this.renderContent(
+                nodesSummary,
+                filters,
+                connectivity?.data?.connections,
+              )}
             </div>
           )}
         />
@@ -495,11 +491,13 @@ const nodeSummaryErrors = createSelector(
 const mapStateToProps = (state: AdminUIState) => ({
   nodesSummary: nodesSummarySelector(state),
   nodeSummaryErrors: nodeSummaryErrors(state),
+  connectivity: connectivitySelector(state),
 });
 
 const mapDispatchToProps = {
   refreshNodes,
   refreshLiveness,
+  refreshConnectivity,
 };
 
 export default withRouter(

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/index.tsx
@@ -8,19 +8,25 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { Divider, Tooltip } from "antd";
+import { Badge, Divider, Icon, Tooltip } from "antd";
+import "antd/lib/icon/style";
+import "antd/lib/badge/style";
 import "antd/lib/divider/style";
 import "antd/lib/tooltip/style";
 import classNames from "classnames";
 import _ from "lodash";
 import { util } from "@cockroachlabs/cluster-ui";
-import { FixLong } from "src/util/fixLong";
 import { Chip } from "src/views/app/components/chip";
 import React from "react";
 import { Link } from "react-router-dom";
-import { getValueFromString, Identity } from "..";
+import { getValueFromString, Identity, isHealthyLivenessStatus } from "..";
 import "./latency.styl";
 import { Empty } from "src/components/empty";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { livenessNomenclature } from "src/redux/nodes";
+import { BadgeProps } from "antd/lib/badge";
+import NodeLivenessStatus = cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus;
+import ConnectionStatus = cockroach.server.serverpb.NetworkConnectivityResponse.ConnectionStatus;
 
 interface StdDev {
   stddev: number;
@@ -32,10 +38,8 @@ interface StdDev {
 
 export interface ILatencyProps {
   displayIdentities: Identity[];
-  staleIDs: Set<number>;
   multipleHeader: boolean;
   collapsed?: boolean;
-  nodesSummary: any;
   std?: StdDev;
   node_id?: string;
 }
@@ -50,22 +54,69 @@ type DetailedIdentity = Identity & {
 
 // createHeaderCell creates and decorates a header cell.
 function createHeaderCell(
-  staleIDs: Set<number>,
-  id: DetailedIdentity,
-  key: string,
+  identity: DetailedIdentity,
   isMultiple?: boolean,
   collapsed?: boolean,
 ) {
-  const node = `n${id.nodeID.toString()}`;
+  const node = `n${identity.nodeID.toString()}`;
   const className = classNames(
     "latency-table__cell",
     "latency-table__cell--header",
-    { "latency-table__cell--header-warning": staleIDs.has(id.nodeID) },
     { "latency-table__cell--start": isMultiple },
   );
+  const isDecommissioned =
+    identity.livenessStatus === NodeLivenessStatus.NODE_STATUS_DECOMMISSIONED;
+
+  let nodeBadgeStatus: BadgeProps["status"];
+
+  switch (identity.livenessStatus) {
+    case NodeLivenessStatus.NODE_STATUS_LIVE:
+      nodeBadgeStatus = "success";
+      break;
+    case NodeLivenessStatus.NODE_STATUS_DRAINING:
+    case NodeLivenessStatus.NODE_STATUS_UNAVAILABLE:
+    case NodeLivenessStatus.NODE_STATUS_DECOMMISSIONING:
+      nodeBadgeStatus = "warning";
+      break;
+    case NodeLivenessStatus.NODE_STATUS_DEAD:
+      nodeBadgeStatus = "error";
+      break;
+    case NodeLivenessStatus.NODE_STATUS_DECOMMISSIONED:
+    default:
+      nodeBadgeStatus = "default";
+  }
+  // Render cell header without link to node details as it is not available
+  // for dead and decommissioned nodes.
+  if (!isHealthyLivenessStatus(identity.livenessStatus)) {
+    return (
+      <td className={className}>
+        <div>
+          <Tooltip
+            placement="bottom"
+            title={livenessNomenclature(identity.livenessStatus)}
+          >
+            {collapsed ? "" : node}
+            {!collapsed && (
+              <Badge status={nodeBadgeStatus} style={{ marginLeft: "4px" }} />
+            )}
+          </Tooltip>
+        </div>
+      </td>
+    );
+  }
   return (
-    <td key={key} className={className}>
-      <Link to={`/node/${id.nodeID}`}>{collapsed ? "" : node}</Link>
+    <td className={className}>
+      <Tooltip
+        placement="bottom"
+        title={livenessNomenclature(identity.livenessStatus)}
+      >
+        <Link to={!isDecommissioned ? `/node/${identity.nodeID}` : "#"}>
+          {collapsed ? "" : node}
+          {!collapsed && (
+            <Badge status={nodeBadgeStatus} style={{ marginLeft: "4px" }} />
+          )}
+        </Link>
+      </Tooltip>
     </td>
   );
 }
@@ -117,32 +168,43 @@ const generateCollapsedData = (
 const renderMultipleHeaders = (
   displayIdentities: Identity[],
   collapsed: boolean,
-  nodesSummary: any,
-  staleIDs: Set<number>,
   nodeId: string,
   multipleHeader: boolean,
 ) => {
   const data: any = [];
   let rowLength = 0;
   const filteredData = displayIdentities.map(identityA => {
-    const row: any[] = [];
+    const row: Array<{
+      latency: number;
+      identityB: Identity;
+      connectivity: cockroach.server.serverpb.NetworkConnectivityResponse.ConnectionStatus;
+    }> = [];
     displayIdentities.forEach(identityB => {
-      const a = nodesSummary.nodeStatusByID[identityA.nodeID].activity;
-      const nano = FixLong(a[identityB.nodeID]?.latency || 0);
+      const connStatus =
+        identityA.connectivity?.peers[identityB.nodeID]?.status ??
+        ConnectionStatus.UNKNOWN;
+      const latency = util.NanoToMilli(
+        identityA.connectivity?.peers[identityB.nodeID]?.latency?.nanos ?? 0,
+      );
+      // When source and target nodes are the same.
       if (identityA.nodeID === identityB.nodeID) {
-        row.push({ latency: 0, identityB });
-      } else if (
-        staleIDs.has(identityA.nodeID) ||
-        staleIDs.has(identityB.nodeID) ||
-        _.isNil(a) ||
-        _.isNil(a[identityB.nodeID])
-      ) {
-        row.push({ latency: -2, identityB });
-      } else if (nano.eq(0)) {
-        row.push({ latency: -1, identityB });
+        row.push({
+          latency: 0,
+          identityB,
+          connectivity: undefined,
+        });
+      } else if (latency === 0) {
+        row.push({
+          latency: -1,
+          identityB,
+          connectivity: connStatus,
+        });
       } else {
-        const latency = util.NanoToMilli(nano.toNumber());
-        row.push({ latency, identityB });
+        row.push({
+          latency,
+          identityB,
+          connectivity: connStatus,
+        });
       }
     });
     rowLength = row.length;
@@ -187,7 +249,13 @@ const getLatencyCell = (
     latency,
     identityB,
     identityA,
-  }: { latency: number; identityB: Identity; identityA: DetailedIdentity },
+    connectivity,
+  }: {
+    latency: number;
+    identityB: Identity;
+    identityA: DetailedIdentity;
+    connectivity: cockroach.server.serverpb.NetworkConnectivityResponse.ConnectionStatus;
+  },
   verticalLine: boolean,
   isMultiple?: boolean,
   std?: StdDev,
@@ -199,6 +267,8 @@ const getLatencyCell = (
       { "latency-table__cell--start": verticalLine },
       ...names,
     );
+
+  // Case when identityA == identityB, display empty cell.
   if (latency === 0) {
     return (
       <td
@@ -209,18 +279,35 @@ const getLatencyCell = (
       />
     );
   }
-  if (latency === -1) {
-    return (
-      <td
-        className={generateClassName([
-          "latency-table__cell",
-          "latency-table__cell--stddev-even",
-        ])}
-      >
-        <Chip title="loading..." type="yellow" />
-      </td>
-    );
+
+  const isHealthyTargetNode = isHealthyLivenessStatus(identityB.livenessStatus);
+  const isHealthyNodes =
+    isHealthyLivenessStatus(identityA.livenessStatus) && isHealthyTargetNode;
+
+  const isEstablished = connectivity === ConnectionStatus.ESTABLISHED;
+  const isErrored = isHealthyNodes && connectivity === ConnectionStatus.ERROR;
+  const isEstablishing =
+    isHealthyNodes && connectivity === ConnectionStatus.ESTABLISHING;
+  const isUnknown = isHealthyNodes && connectivity === ConnectionStatus.UNKNOWN;
+
+  const errorMessage = identityA.connectivity?.peers[identityB.nodeID]?.error;
+
+  let showError = !!errorMessage;
+  // Show errors for all connection statuses except ESTABLISHING status that is treated exceptionally.
+  if (showError && connectivity !== ConnectionStatus.ESTABLISHING) {
+    showError = true;
+  } else {
+    // Don't show errors for nodes that try to establish connections to dead/decommissioned nodes.
+    // It will always return error as `not yet heartbeated` due to target node is not alive. Connectivity
+    // endpoint fans out requests to all known nodes to check connection status and it also might initiate new
+    // connections to nodes that considered not alive (it is known limitation) and in this case we don't
+    // want to show this error.
+    showError =
+      showError &&
+      isHealthyTargetNode &&
+      connectivity === ConnectionStatus.ESTABLISHING;
   }
+
   const className = classNames({
     "latency-table__cell": true,
     "latency-table__cell--end": isMultiple,
@@ -241,7 +328,9 @@ const getLatencyCell = (
       std.stddev > 0 && latency > std.stddevPlus2,
   });
   const type: any = classNames({
-    yellow: latency === -2,
+    _: !isHealthyTargetNode,
+    red: isErrored,
+    yellow: isEstablishing || isUnknown,
     green: latency > 0 && std.stddev > 0 && latency < std.stddevMinus2,
     lightgreen:
       latency > 0 &&
@@ -282,26 +371,65 @@ const getLatencyCell = (
             <div>
               <div className="Chip--tooltip__nodes">
                 <div className="Chip--tooltip__nodes--item">
-                  <p className="Chip--tooltip__nodes--item-title">{`Node ${identityB.nodeID}`}</p>
-                  {renderDescription(identityB.locality)}
-                </div>
-                <Divider type="vertical" />
-                <div className="Chip--tooltip__nodes--item">
+                  <div className="Chip--tooltip__nodes--item-title Chip--tooltip__nodes--header">
+                    From
+                  </div>
                   <p className="Chip--tooltip__nodes--item-title">{`Node ${identityA.nodeID}`}</p>
                   {renderDescription(identityA.locality)}
                 </div>
+                <Divider type="vertical" />
+                <div className="Chip--tooltip__nodes--item">
+                  <div className="Chip--tooltip__nodes--item-title Chip--tooltip__nodes--header">
+                    To
+                  </div>
+                  <p className="Chip--tooltip__nodes--item-title">{`Node ${identityB.nodeID}`}</p>
+                  {renderDescription(identityB.locality)}
+                </div>
               </div>
-              {latency > 0 && (
+              {latency > 0 && isEstablished && (
                 <p
                   className={`color--${type} Chip--tooltip__latency`}
                 >{`${latency.toFixed(2)}ms roundtrip`}</p>
+              )}
+              {isErrored && (
+                <p className={`color--${type} Chip--tooltip__latency`}>
+                  Failed connection
+                </p>
+              )}
+              {isEstablishing && (
+                <p className={`color--${type} Chip--tooltip__latency`}>
+                  Attempting to connect
+                </p>
+              )}
+              {isUnknown && (
+                <p className={`color--${type} Chip--tooltip__latency`}>
+                  Unknown connection state
+                </p>
+              )}
+              {/* Show errors for ESTABLISHING status only if target node is */}
+              {showError && (
+                <p className={`color--red Chip--tooltip__latency`}>
+                  {errorMessage}
+                </p>
               )}
             </div>
           }
         >
           <div>
             <Chip
-              title={latency > 0 ? latency.toFixed(2) + "ms" : "--"}
+              title={
+                isErrored ? (
+                  <Icon type="stop" />
+                ) : isEstablishing ? (
+                  "--"
+                ) : isUnknown ? (
+                  <Icon type="exclamation-circle" />
+                ) : latency > 0 ? (
+                  latency.toFixed(2) + "ms"
+                ) : (
+                  "--"
+                )
+              }
               type={type}
             />
           </div>
@@ -313,18 +441,14 @@ const getLatencyCell = (
 
 export const Latency: React.SFC<ILatencyProps> = ({
   displayIdentities,
-  staleIDs,
   multipleHeader,
   collapsed,
-  nodesSummary,
   std,
   node_id,
 }) => {
   const data = renderMultipleHeaders(
     displayIdentities,
     collapsed,
-    nodesSummary,
-    staleIDs,
     node_id,
     multipleHeader,
   );
@@ -351,7 +475,11 @@ export const Latency: React.SFC<ILatencyProps> = ({
             <th style={{ width: 115 }} />
             <th style={{ width: 45 }} />
             {_.map(data, (value, index) => (
-              <th className="region-name" colSpan={data[index].length}>
+              <th
+                className="region-name"
+                colSpan={data[index].length}
+                key={index}
+              >
                 {value[0].title}
               </th>
             ))}
@@ -361,14 +489,10 @@ export const Latency: React.SFC<ILatencyProps> = ({
           <tr className="latency-table__row">
             {multipleHeader && <td />}
             <td className="latency-table__cell latency-table__cell--spacer" />
-            {_.map(data, value =>
-              _.map(value, (identity, index: number) =>
-                createHeaderCell(
-                  staleIDs,
-                  identity,
-                  `0-${value.nodeID}`,
-                  index === 0,
-                  collapsed,
+            {React.Children.toArray(
+              _.map(data, value =>
+                _.map(value, (identity, index: number) =>
+                  createHeaderCell(identity, index === 0, collapsed),
                 ),
               ),
             )}
@@ -376,41 +500,37 @@ export const Latency: React.SFC<ILatencyProps> = ({
         )}
       </thead>
       <tbody>
-        {_.map(data, (value, index) =>
-          _.map(data[index], (identityA, indA: number) => {
-            return (
-              <tr
-                key={index}
-                className={`latency-table__row ${
-                  data[index].length === indA + 1
-                    ? "latency-table__row--end"
-                    : ""
-                }`}
-              >
-                {multipleHeader && Number(indA) === 0 && (
-                  <th rowSpan={collapsed ? 1 : data[index][0].rowCount}>
-                    {value[0].title}
-                  </th>
-                )}
-                {createHeaderCell(
-                  staleIDs,
-                  identityA,
-                  `${identityA.nodeID}-0`,
-                  false,
-                  collapsed,
-                )}
-                {_.map(identityA.row, (identity: any, indexB: number) =>
-                  getLatencyCell(
-                    { ...identity, identityA },
-                    getVerticalLines(data, indexB),
-                    false,
-                    std,
-                    collapsed,
-                  ),
-                )}
-              </tr>
-            );
-          }),
+        {React.Children.toArray(
+          _.map(data, (value, index) =>
+            _.map(data[index], (identityA, indA: number) => {
+              return (
+                <tr
+                  className={`latency-table__row ${
+                    data[index].length === indA + 1
+                      ? "latency-table__row--end"
+                      : ""
+                  }`}
+                  key={`${index}-${indA}`}
+                >
+                  {multipleHeader && Number(indA) === 0 && (
+                    <th rowSpan={collapsed ? 1 : data[index][0].rowCount}>
+                      {value[0].title}
+                    </th>
+                  )}
+                  {createHeaderCell(identityA, false, collapsed)}
+                  {_.map(identityA.row, (identity: any, indexB: number) =>
+                    getLatencyCell(
+                      { ...identity, identityA },
+                      getVerticalLines(data, indexB),
+                      false,
+                      std,
+                      collapsed,
+                    ),
+                  )}
+                </tr>
+              );
+            }),
+          ),
         )}
       </tbody>
     </table>

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.fixtures.ts
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.fixtures.ts
@@ -9,143 +9,122 @@
 // licenses/APL.txt.
 
 import moment from "moment-timezone";
-import Long from "long";
 import { ILatencyProps } from ".";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import NodeLivenessStatus = cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus;
+import IPeer = cockroach.server.serverpb.NetworkConnectivityResponse.IPeer;
+import ConnectionStatus = cockroach.server.serverpb.NetworkConnectivityResponse.ConnectionStatus;
 
-const node1 = {
-  desc: {
-    node_id: 1,
-    locality: {
-      tiers: [
-        { key: "region", value: "local" },
-        { key: "zone", value: "local" },
-      ],
-    },
-  },
-  activity: {
-    "1": { incoming: 85125, outgoing: 204928, latency: Long.fromInt(843506) },
-    "2": {
-      incoming: 1641005,
-      outgoing: 196537462,
-      latency: Long.fromInt(12141),
-    },
-    "3": { incoming: 27851, outgoing: 15530093 },
-    "4": {
-      incoming: 4346803,
-      outgoing: 180065134,
-      latency: Long.fromInt(505076),
-    },
-  },
-};
-const node2 = {
-  desc: {
-    node_id: 2,
-    locality: {
-      tiers: [
-        { key: "region", value: "local" },
-        { key: "zone", value: "local" },
-      ],
-    },
-  },
-  activity: {
-    "1": {
-      incoming: 8408467,
-      outgoing: 97930352,
-      latency: Long.fromInt(1455817),
-    },
-    "2": {},
-    "3": { incoming: 22800, outgoing: 13925347 },
-    "4": {
-      incoming: 1328435,
-      outgoing: 63271505,
-      latency: Long.fromInt(766402),
-    },
-  },
-};
-const node3 = {
-  desc: {
-    node_id: 3,
-    locality: {
-      tiers: [
-        { key: "region", value: "local" },
-        { key: "zone", value: "local" },
-      ],
-    },
-  },
-  activity: {
-    "1": { incoming: 49177, outgoing: 173961 },
-    "2": { incoming: 98747, outgoing: 80848 },
-    "3": {},
-    "4": { incoming: 18239, outgoing: 12407 },
-  },
-};
-const node4 = {
-  desc: {
-    node_id: 4,
-    locality: {
-      tiers: [
-        { key: "region", value: "local" },
-        { key: "zone", value: "local" },
-      ],
-    },
-  },
-
-  activity: {
-    "1": {
-      incoming: 4917367,
-      outgoing: 51102302,
-      latency: Long.fromInt(1589900),
-    },
-    "2": {
-      incoming: 2657214,
-      outgoing: 24963000,
-      latency: Long.fromInt(1807269),
-    },
-    "3": { incoming: 26480, outgoing: 251052 },
-    "4": {},
-  },
+const makePeer = (params?: Partial<IPeer>): IPeer => {
+  const peer: IPeer = {
+    latency: { nanos: Math.random() * 1000000 },
+    status: ConnectionStatus.ESTABLISHED,
+    address: "127.0.0.1:26257",
+    locality: { tiers: [{ key: "az", value: "us" }] },
+    ...params,
+  };
+  return peer;
 };
 
 export const latencyFixture: ILatencyProps = {
   displayIdentities: [
     {
       nodeID: 1,
+      livenessStatus: NodeLivenessStatus.NODE_STATUS_LIVE,
+      connectivity: {
+        peers: {
+          "1": makePeer(),
+          "2": makePeer({ status: ConnectionStatus.ERROR }),
+          "3": makePeer({
+            status: ConnectionStatus.ERROR,
+            latency: { nanos: 0 },
+          }),
+          "4": makePeer(),
+          "5": makePeer(),
+        },
+      },
       address: "127.0.0.1:26257",
       locality: "region=local,zone=local",
       updatedAt: moment("2020-05-04T16:26:08.122Z"),
     },
     {
+      livenessStatus: NodeLivenessStatus.NODE_STATUS_LIVE,
+      connectivity: {
+        peers: {
+          "1": makePeer(),
+          "2": makePeer(),
+          "3": makePeer(),
+          "4": makePeer({
+            status: ConnectionStatus.ESTABLISHING,
+          }),
+          "5": makePeer({
+            status: ConnectionStatus.ESTABLISHING,
+            latency: { nanos: 0 },
+          }),
+        },
+      },
       nodeID: 2,
       address: "127.0.0.1:26259",
       locality: "region=local,zone=local",
       updatedAt: moment("2020-05-04T16:26:08.674Z"),
     },
     {
+      livenessStatus: NodeLivenessStatus.NODE_STATUS_LIVE,
+      connectivity: {
+        peers: {
+          "1": makePeer({ status: ConnectionStatus.UNKNOWN }),
+          "2": makePeer({
+            status: ConnectionStatus.UNKNOWN,
+            latency: { nanos: 0 },
+          }),
+          "3": makePeer(),
+          "4": makePeer(),
+          "5": makePeer(),
+        },
+      },
       nodeID: 3,
       address: "127.0.0.1:26261",
       locality: "region=local,zone=local",
       updatedAt: moment("2020-05-04T16:25:52.640Z"),
     },
     {
+      livenessStatus: NodeLivenessStatus.NODE_STATUS_LIVE,
+      connectivity: {
+        peers: {
+          "1": makePeer({ status: ConnectionStatus.UNKNOWN }),
+          "2": makePeer({
+            status: ConnectionStatus.UNKNOWN,
+            latency: { nanos: 0 },
+          }),
+          "3": makePeer(),
+          "4": makePeer(),
+          "5": makePeer(),
+        },
+      },
       nodeID: 4,
       address: "127.0.0.1:26263",
       locality: "region=local,zone=local",
       updatedAt: moment("2020-05-04T16:26:09.871Z"),
     },
+    {
+      livenessStatus: NodeLivenessStatus.NODE_STATUS_LIVE,
+      connectivity: {
+        peers: {
+          "1": makePeer(),
+          "2": makePeer(),
+          "3": makePeer(),
+          "4": makePeer(),
+          "5": makePeer(),
+        },
+      },
+      nodeID: 5,
+      address: "127.0.0.1:26263",
+      locality: "region=local,zone=local",
+      updatedAt: moment("2020-05-04T16:26:09.871Z"),
+    },
   ],
-  staleIDs: new Set([3]),
   multipleHeader: true,
   collapsed: false,
-  nodesSummary: {
-    nodeStatuses: [node1, node2, node3, node4],
-    nodeIDs: [1, 2, 3, 4],
-    nodeStatusByID: {
-      "1": node1,
-      "2": node2,
-      "3": node3,
-      "4": node4,
-    },
-  },
   std: {
     stddev: 0.3755919319616704,
     stddevMinus2: 0.29658363607665916,
@@ -156,123 +135,67 @@ export const latencyFixture: ILatencyProps = {
   node_id: "region",
 };
 
-const nodeNoLocality1 = {
-  desc: {
-    node_id: 1,
-  },
-  activity: {
-    "1": { incoming: 85125, outgoing: 204928, latency: Long.fromInt(843506) },
-    "2": {
-      incoming: 1641005,
-      outgoing: 196537462,
-      latency: Long.fromInt(12141),
-    },
-    "3": { incoming: 27851, outgoing: 15530093 },
-    "4": {
-      incoming: 4346803,
-      outgoing: 180065134,
-      latency: Long.fromInt(505076),
-    },
-  },
-};
-const nodeNoLocality2 = {
-  desc: {
-    node_id: 2,
-  },
-  activity: {
-    "1": {
-      incoming: 8408467,
-      outgoing: 97930352,
-      latency: Long.fromInt(1455817),
-    },
-    "2": {},
-    "3": { incoming: 22800, outgoing: 13925347 },
-    "4": {
-      incoming: 1328435,
-      outgoing: 63271505,
-      latency: Long.fromInt(766402),
-    },
-  },
-};
-const nodeNoLocality3 = {
-  desc: {
-    node_id: 3,
-  },
-  activity: {
-    "1": { incoming: 49177, outgoing: 173961 },
-    "2": { incoming: 98747, outgoing: 80848 },
-    "3": {},
-    "4": { incoming: 18239, outgoing: 12407 },
-  },
-};
-const nodeNoLocality4 = {
-  desc: {
-    node_id: 4,
-    locality: {
-      tiers: [
-        { key: "region", value: "local" },
-        { key: "zone", value: "local" },
-      ],
-    },
-  },
-
-  activity: {
-    "1": {
-      incoming: 4917367,
-      outgoing: 51102302,
-      latency: Long.fromInt(1589900),
-    },
-    "2": {
-      incoming: 2657214,
-      outgoing: 24963000,
-      latency: Long.fromInt(1807269),
-    },
-    "3": { incoming: 26480, outgoing: 251052 },
-    "4": {},
-  },
-};
-
-export const latencyFixtureNoLocality: ILatencyProps = {
+export const latencyFixtureWithNodeStatuses: ILatencyProps = {
   displayIdentities: [
     {
       nodeID: 1,
+      livenessStatus: NodeLivenessStatus.NODE_STATUS_LIVE,
+      connectivity: {
+        peers: {
+          "1": makePeer(),
+          "2": makePeer({ status: ConnectionStatus.ERROR }),
+          "3": makePeer({
+            status: ConnectionStatus.ERROR,
+            latency: { nanos: 0 },
+          }),
+          "4": makePeer({ status: ConnectionStatus.ERROR }),
+          "5": makePeer(),
+        },
+      },
       address: "127.0.0.1:26257",
+      locality: "region=local,zone=local",
       updatedAt: moment("2020-05-04T16:26:08.122Z"),
     },
     {
+      livenessStatus: NodeLivenessStatus.NODE_STATUS_DEAD,
+      connectivity: null,
       nodeID: 2,
       address: "127.0.0.1:26259",
+      locality: "region=local,zone=local",
       updatedAt: moment("2020-05-04T16:26:08.674Z"),
     },
     {
+      livenessStatus: NodeLivenessStatus.NODE_STATUS_UNAVAILABLE,
+      connectivity: null,
       nodeID: 3,
       address: "127.0.0.1:26261",
+      locality: "region=local,zone=local",
       updatedAt: moment("2020-05-04T16:25:52.640Z"),
     },
     {
+      livenessStatus: NodeLivenessStatus.NODE_STATUS_DECOMMISSIONED,
+      connectivity: null,
       nodeID: 4,
       address: "127.0.0.1:26263",
+      locality: "region=local,zone=local",
+      updatedAt: moment("2020-05-04T16:26:09.871Z"),
+    },
+    {
+      livenessStatus: NodeLivenessStatus.NODE_STATUS_DECOMMISSIONING,
+      connectivity: {
+        peers: {
+          "1": makePeer(),
+          "5": makePeer(),
+        },
+      },
+      nodeID: 5,
+      address: "127.0.0.1:26263",
+      locality: "region=local,zone=local",
       updatedAt: moment("2020-05-04T16:26:09.871Z"),
     },
   ],
-  staleIDs: new Set([3]),
   multipleHeader: true,
   collapsed: false,
-  nodesSummary: {
-    nodeStatuses: [
-      nodeNoLocality1,
-      nodeNoLocality2,
-      nodeNoLocality3,
-      nodeNoLocality4,
-    ],
-    nodeIDs: [1, 2, 3, 4],
-    nodeStatusByID: {
-      "1": nodeNoLocality1,
-      "2": nodeNoLocality2,
-      "3": nodeNoLocality3,
-      "4": nodeNoLocality4,
-    },
-  },
   std: {
     stddev: 0.3755919319616704,
     stddevMinus2: 0.29658363607665916,

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.stories.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.stories.tsx
@@ -10,11 +10,59 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import { RenderFunction } from "storybook__react";
 import { Latency } from "./index";
-import { latencyFixture, latencyFixtureNoLocality } from "./latency.fixtures";
+import {
+  latencyFixture,
+  latencyFixtureWithNodeStatuses,
+} from "./latency.fixtures";
 import { withRouterDecorator } from "src/util/decorators";
 
 storiesOf("Latency Table", module)
   .addDecorator(withRouterDecorator)
-  .add("Default state", () => <Latency {...latencyFixture} />)
-  .add("No localites state", () => <Latency {...latencyFixtureNoLocality} />);
+  .addDecorator((storyFn: RenderFunction) => (
+    <div style={{ marginLeft: "1rem" }}>{storyFn()}</div>
+  ))
+  .add("Healthy nodes with connection problems", () => (
+    <>
+      <h3>Network partitioned with healthy nodes</h3>
+      <ul>
+        <li>
+          <b>n1-n2, n1-n3</b> - failed connection
+        </li>
+        <li>
+          <b>n2-n4, n2-n5</b> - not connected
+        </li>
+        <li>
+          <b>n3-n1, n3-n2</b> - unknown status
+        </li>
+        <li>
+          <b>n4-n1, n4-n2</b> - closed connection
+        </li>
+      </ul>
+      <Latency {...latencyFixture} />
+    </>
+  ))
+  .add("Unhealthy nodes", () => (
+    <>
+      <h3>Different node statuses</h3>
+      <ul>
+        <li>
+          <b>n1</b> - live node
+        </li>
+        <li>
+          <b>n2</b> - dead node
+        </li>
+        <li>
+          <b>n3</b> - unavailable node
+        </li>
+        <li>
+          <b>n4</b> - decommissioned node
+        </li>
+        <li>
+          <b>n5</b> - decommissioning node
+        </li>
+      </ul>
+      <Latency {...latencyFixtureWithNodeStatuses} />
+    </>
+  ));

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.styl
@@ -36,16 +36,16 @@
     text-align center
     width 95px
     padding 9px 0
-    a
+    a, div
       font-family SourceSansPro-SemiBold
       font-size 12px
       font-weight 600
       line-height 1.67
       letter-spacing 0.3px
       color $adminui-grey-2
-      &:hover
-        color $colors--primary-blue-3
-        text-decoration underline
+    a:hover
+      color $colors--primary-blue-3
+      text-decoration underline
     &:first-child
       border-right 2px solid $colors--neutral-2
     .Chip
@@ -98,7 +98,7 @@
     letter-spacing 0.1px
     color $table-border-color
   .Chip--tooltip__latency
-     margin-top 25px
+     margin-bottom 4px
   .Chip--tooltip__nodes
     display flex
     justify-content space-between
@@ -120,6 +120,8 @@
       margin 0
     &--item-title
       line-height 1.71
+    &--header
+      border-bottom solid #3b4a60 1px
   .color
     &--green, &--lightgreen
       color $colors--primary-green-2
@@ -129,3 +131,5 @@
       color $colors--primary-blue-2
     &--yellow
       color $colors--functional-yellow-3
+    &--red
+      color $colors--functional-red-3

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/legend/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/legend/index.tsx
@@ -8,14 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { Divider, Tooltip } from "antd";
+import { Tooltip } from "antd";
 import "antd/lib/divider/style";
 import "antd/lib/tooltip/style";
 import { Chip } from "src/views/app/components/chip";
-import Modal from "src/views/app/components/modal";
-import { getDisplayName } from "src/redux/nodes";
 import React from "react";
-import { NoConnection } from "..";
 import "./legend.styl";
 import { Text, TextTypes } from "src/components";
 
@@ -25,7 +22,6 @@ interface ILegendProps {
   mean: number;
   stddevPlus1: number;
   stddevPlus2: number;
-  noConnections: NoConnection[];
 }
 
 export const Legend: React.SFC<ILegendProps> = ({
@@ -34,7 +30,6 @@ export const Legend: React.SFC<ILegendProps> = ({
   mean,
   stddevPlus1,
   stddevPlus2,
-  noConnections,
 }) => (
   <div key="legend" className="Legend">
     <div className="Legend--container">
@@ -104,70 +99,6 @@ export const Legend: React.SFC<ILegendProps> = ({
             </Text>
           </span>
         </div>
-      </div>
-    </div>
-    <Divider type="vertical" />
-    <div className="Legend--container">
-      <div className="Legend--container__head">
-        <Modal
-          title={`No Connections (${noConnections.length})`}
-          trigger={
-            noConnections.length === 0 && (
-              <Tooltip
-                placement="bottom"
-                title="This legend represents the loss of a connection between nodes and will help you understand if there is a one-way partition in your cluster."
-              >
-                <span
-                  className={"underline"}
-                >{`No Connections (${noConnections.length})`}</span>
-              </Tooltip>
-            )
-          }
-          triggerStyle="Legend--container__head--title color--link"
-          triggerTitle={`No Connections (${noConnections.length})`}
-        >
-          <table className="noConnections__table">
-            <tr className="noConnections__table--head">
-              <th>From Node</th>
-              <th>From Locality</th>
-              <th>To Node</th>
-              <th>To Locality</th>
-            </tr>
-            {noConnections.map(value => (
-              <tr className="noConnections__table--item">
-                <td>
-                  <span className="noConnections__table--item__bold">
-                    {getDisplayName(value)}
-                  </span>
-                  <span className="noConnections__table--item__normal">
-                    {value.from.address}
-                  </span>
-                </td>
-                <td>
-                  <span className="noConnections__table--item__normal">
-                    {value.from.locality}
-                  </span>
-                </td>
-                <td>
-                  <span className="noConnections__table--item__bold">
-                    {getDisplayName(value)}
-                  </span>
-                  <span className="noConnections__table--item__normal">
-                    {value.to.address}
-                  </span>
-                </td>
-                <td>
-                  <span className="noConnections__table--item__normal">
-                    {value.to.locality}
-                  </span>
-                </td>
-              </tr>
-            ))}
-          </table>
-        </Modal>
-      </div>
-      <div className="Legend--container__body">
-        <Chip title="--" type="yellow" />
       </div>
     </div>
   </div>

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/sort/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/sort/index.tsx
@@ -42,20 +42,8 @@ class Sort extends React.Component<ISortProps & RouteComponentProps, {}> {
   navigateTo = (selected: DropdownOption) => {
     trackNetworkSort(selected.label);
     this.props.onChangeCollapse(false);
-    this.props.history.push(`/reports/network/${selected.value}`);
-  };
-
-  componentDidMount() {
-    this.setDefaultSortValue("region");
-  }
-
-  setDefaultSortValue = (sortValue: string) => {
-    const isDefaultValuePresent = this.getSortValues(this.props.sort).find(
-      e => e.value === sortValue,
-    );
-    if (isDefaultValuePresent) {
-      this.navigateTo(isDefaultValuePresent);
-    }
+    this.props.location.pathname = `/reports/network/${selected.value}`;
+    this.props.history.push(this.props.location);
   };
 
   getSortValues = (sort: NetworkSort[]) =>

--- a/pkg/ui/workspaces/db-console/styl/base/palette.styl
+++ b/pkg/ui/workspaces/db-console/styl/base/palette.styl
@@ -74,3 +74,4 @@ $chip-grey = $colors--neutral-1
 $chip-blue = #74bdfd80 // $colors--primary-blue-2 + 0.5 opacity
 $chip-lightblue = $colors--primary-blue-1
 $chip-yellow = $colors--functional-orange-1
+$chip-red = $colors--functional-red-1


### PR DESCRIPTION
- use connectivity endpoint as a source of connection statuses and latency;
- removed popup with disconnected peers, instead it will be shown
on latency matrix;

Resolves: #96101 

Release note (ui change): add "Show dead nodes" option
to show/hide dead/decommissioned nodes from latency matrix.

Release note (ui change): "No connections" popup menu is removed. Now failed
connections are displayed on the latencies matrix.

- [x] test coverage (storybook added for visual validation)

This PR depends on following PRs that should be merged before this one:
- #95429
- #99191

#### example 1. one node cannot establish connection to another one.
![Screenshot 2023-06-26 at 12 33 46](https://github.com/cockroachdb/cockroach/assets/3106437/2534e0fe-f5ba-48b5-8825-1c17a8112870)

#### example 2. Node 5 is stopped and it is considered as `unavailable` before setting as `dead`
![Screenshot 2023-06-26 at 10 52 20](https://github.com/cockroachdb/cockroach/assets/3106437/bd703d4c-9812-4061-9140-4a8f8d3a5da9)

#### example 3. Node 3 is dead. No connection from/to node. Show error message.
<img width="954" alt="Screenshot 2023-06-23 at 14 07 25" src="https://github.com/cockroachdb/cockroach/assets/3106437/8078c421-aeaa-4038-adf5-e3c69ba6d863">

#### example 4. Decommissioned node.
 
![Screenshot 2023-06-26 at 18 11 23](https://github.com/cockroachdb/cockroach/assets/3106437/dc4cb22e-34b7-4cd3-a391-b8ea5fd0232d)



