### PR TITLE
cloud: consolidate ReadFile APIs [draft WIP]

### DIFF
--- a/pkg/ccl/backupccl/backupencryption/encryption.go
+++ b/pkg/ccl/backupccl/backupencryption/encryption.go
@@ -447,7 +447,7 @@ func ReadEncryptionOptions(
 	// encrypt the backup recently, so we iterate the ENCRYPTION-INFO
 	// files from latest to oldest.
 	for i := len(files) - 1; i >= 0; i-- {
-		r, err := src.ReadFile(ctx, files[i])
+		r, _, err := src.ReadFile(ctx, files[i], cloud.ReadOptions{NoFileSize: true})
 		if err != nil {
 			return nil, errors.Wrap(err, encryptionReadErrorMsg)
 		}
@@ -491,7 +491,7 @@ func GetEncryptionInfoFiles(ctx context.Context, dest cloud.ExternalStorage) ([]
 func WriteEncryptionInfoIfNotExists(
 	ctx context.Context, opts *jobspb.EncryptionInfo, dest cloud.ExternalStorage,
 ) error {
-	r, err := dest.ReadFile(ctx, backupEncryptionInfoFile)
+	r, _, err := dest.ReadFile(ctx, backupEncryptionInfoFile, cloud.ReadOptions{NoFileSize: true})
 	if err == nil {
 		r.Close(ctx)
 		// If the file already exists, then we don't need to create a new one.

--- a/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
@@ -293,7 +293,7 @@ func checkStats(
 func testingReadBackupManifest(
 	ctx context.Context, store cloud.ExternalStorage, file string,
 ) (*backuppb.BackupManifest, error) {
-	r, err := store.ReadFile(ctx, file)
+	r, _, err := store.ReadFile(ctx, file, cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -289,7 +289,7 @@ func ReadBackupManifest(
 	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.ReadBackupManifest")
 	defer sp.Finish()
 
-	manifestFile, err := exportStore.ReadFile(ctx, filename)
+	manifestFile, _, err := exportStore.ReadFile(ctx, filename, cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		return backuppb.BackupManifest{}, 0, err
 	}
@@ -297,7 +297,7 @@ func ReadBackupManifest(
 
 	// Look for a checksum, if one is not found it could be an older backup,
 	// but we want to continue anyway.
-	checksumFile, err := exportStore.ReadFile(ctx, filename+BackupManifestChecksumSuffix)
+	checksumFile, _, err := exportStore.ReadFile(ctx, filename+BackupManifestChecksumSuffix, cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
 			return backuppb.BackupManifest{}, 0, err
@@ -424,7 +424,7 @@ func readBackupPartitionDescriptor(
 	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.readBackupPartitionDescriptor")
 	defer sp.Finish()
 
-	r, err := exportStore.ReadFile(ctx, filename)
+	r, _, err := exportStore.ReadFile(ctx, filename, cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		return backuppb.BackupPartitionDescriptor{}, 0, err
 	}
@@ -487,7 +487,7 @@ func readTableStatistics(
 	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.readTableStatistics")
 	defer sp.Finish()
 
-	r, err := exportStore.ReadFile(ctx, filename)
+	r, _, err := exportStore.ReadFile(ctx, filename, cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		return nil, err
 	}
@@ -1120,7 +1120,7 @@ func CheckForBackupLock(
 	// corresponding to `jobID`. If present, we have already laid claim on the
 	// location and do not need to check further.
 	lockFileName := fmt.Sprintf("%s%s", BackupLockFilePrefix, strconv.FormatInt(int64(jobID), 10))
-	r, err := defaultStore.ReadFile(ctx, lockFileName)
+	r, _, err := defaultStore.ReadFile(ctx, lockFileName, cloud.ReadOptions{NoFileSize: true})
 	if err == nil {
 		r.Close(ctx)
 		return true, nil
@@ -1167,7 +1167,7 @@ func CheckForPreviousBackup(
 	defer defaultStore.Close()
 
 	redactedURI := backuputils.RedactURIForErrorMessage(defaultURI)
-	r, err := defaultStore.ReadFile(ctx, backupbase.BackupManifestName)
+	r, _, err := defaultStore.ReadFile(ctx, backupbase.BackupManifestName, cloud.ReadOptions{NoFileSize: true})
 	if err == nil {
 		r.Close(ctx)
 		return pgerror.Newf(pgcode.FileAlreadyExists,
@@ -1365,7 +1365,11 @@ func WriteBackupManifestCheckpoint(
 		// TODO (darryl): We should do this only for file not found or directory
 		// does not exist errors. As of right now we only specifically wrap
 		// ReadFile errors for file not found so this is not possible yet.
-		if r, err := defaultStore.ReadFile(ctx, BackupProgressDirectory+"/"+BackupManifestCheckpointName); err != nil {
+		if r, _, err := defaultStore.ReadFile(
+			ctx,
+			BackupProgressDirectory+"/"+BackupManifestCheckpointName,
+			cloud.ReadOptions{NoFileSize: true},
+		); err != nil {
 			// Since we did not find the checkpoint file this is the first time
 			// we are going to write a checkpoint, so write it with the well
 			// known filename.
@@ -1429,7 +1433,7 @@ func readLatestCheckpointFile(
 	// directly. This can still fail if it is a mixed cluster and the
 	// checkpoint was written in the base directory.
 	if errors.Is(err, cloud.ErrListingUnsupported) {
-		r, err = exportStore.ReadFile(ctx, BackupProgressDirectory+"/"+filename)
+		r, _, err = exportStore.ReadFile(ctx, BackupProgressDirectory+"/"+filename, cloud.ReadOptions{NoFileSize: true})
 		// If we found the checkpoint in progress, then don't bother reading
 		// from base, just return the reader.
 		if err == nil {
@@ -1440,15 +1444,19 @@ func readLatestCheckpointFile(
 	}
 
 	if checkpointFound {
+		var name string
 		if strings.HasSuffix(filename, BackupManifestChecksumSuffix) {
-			return exportStore.ReadFile(ctx, BackupProgressDirectory+"/"+checkpoint+BackupManifestChecksumSuffix)
+			name = BackupProgressDirectory + "/" + checkpoint + BackupManifestChecksumSuffix
+		} else {
+			name = BackupProgressDirectory + "/" + checkpoint
 		}
-		return exportStore.ReadFile(ctx, BackupProgressDirectory+"/"+checkpoint)
+		r, _, err = exportStore.ReadFile(ctx, name, cloud.ReadOptions{NoFileSize: true})
+		return r, err
 	}
 
 	// If the checkpoint wasn't found in the progress directory, then try
 	// reading from the base directory instead.
-	r, err = exportStore.ReadFile(ctx, filename)
+	r, _, err = exportStore.ReadFile(ctx, filename, cloud.ReadOptions{NoFileSize: true})
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s could not be read in the base or progress directory", filename)

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -1319,7 +1319,7 @@ func BenchmarkExternalIOAccounting(b *testing.B) {
 			cloud.WithIOAccountingInterceptor(interceptor))
 		require.NoError(b, err)
 		return func(ctx context.Context) error {
-				r, err := es.ReadFile(ctx, "")
+				r, _, err := es.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 				if err != nil {
 					return err
 				}

--- a/pkg/ccl/storageccl/external_sst_reader.go
+++ b/pkg/ccl/storageccl/external_sst_reader.go
@@ -51,7 +51,7 @@ func getFileWithRetry(
 	const maxAttempts = 3
 	if err := retry.WithMaxAttempts(ctx, base.DefaultRetryOptions(), maxAttempts, func() error {
 		var err error
-		f, sz, err = e.ReadFileAt(ctx, basename, 0)
+		f, sz, err = e.ReadFile(ctx, basename, cloud.ReadOptions{})
 		return err
 	}); err != nil {
 		return nil, 0, err
@@ -140,7 +140,10 @@ func ExternalSSTReader(
 			sz:   sizeStat(sz),
 			body: f,
 			openAt: func(offset int64) (ioctx.ReadCloserCtx, error) {
-				reader, _, err := store.ReadFileAt(ctx, filePath, offset)
+				reader, _, err := store.ReadFile(ctx, filePath, cloud.ReadOptions{
+					Offset:     offset,
+					NoFileSize: true,
+				})
 				return reader, err
 			},
 		}

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -360,6 +360,7 @@ go_test(
         "//pkg/cli/clisqlexec",
         "//pkg/cli/democluster",
         "//pkg/cli/exit",
+        "//pkg/cloud",
         "//pkg/clusterversion",
         "//pkg/gossip",
         "//pkg/jobs",

--- a/pkg/cli/import_test.go
+++ b/pkg/cli/import_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -75,7 +76,7 @@ func runImportCLICommand(
 	store, err := c.ExecutorConfig().(sql.ExecutorConfig).DistSQLSrv.ExternalStorageFromURI(ctx,
 		userfileURI, username.RootUserName())
 	require.NoError(t, err)
-	_, err = store.ReadFile(ctx, "")
+	_, _, err = store.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 	testutils.IsError(err, "file doesn't exist")
 
 	var output []string

--- a/pkg/cli/userfile.go
+++ b/pkg/cli/userfile.go
@@ -460,7 +460,7 @@ func listUserFile(ctx context.Context, conn clisqlclient.Conn, glob string) ([]s
 func downloadUserfile(
 	ctx context.Context, store cloud.ExternalStorage, src, dst string,
 ) (int64, error) {
-	remoteFile, err := store.ReadFile(ctx, src)
+	remoteFile, _, err := store.ReadFile(ctx, src, cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/cli/userfiletable_test.go
+++ b/pkg/cli/userfiletable_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -365,7 +366,7 @@ func checkUserFileContent(
 	store, err := execcCfg.(sql.ExecutorConfig).DistSQLSrv.ExternalStorageFromURI(ctx,
 		userfileURI, user)
 	require.NoError(t, err)
-	reader, err := store.ReadFile(ctx, "")
+	reader, _, err := store.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 	require.NoError(t, err)
 	got, err := ioctx.ReadAll(ctx, reader)
 	require.NoError(t, err)

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -447,7 +447,7 @@ func TestS3BucketDoesNotExist(t *testing.T) {
 		t.Fatalf("conf does not roundtrip: started with %+v, got back %+v", conf, readConf)
 	}
 
-	_, err = s.ReadFile(ctx, "")
+	_, _, err = s.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 	require.Error(t, err, "")
 	require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist), "error is not cloud.ErrFileDoesNotExist: %v", err)
 }

--- a/pkg/cloud/cloudcheck/cloudcheck_processor.go
+++ b/pkg/cloud/cloudcheck/cloudcheck_processor.go
@@ -139,7 +139,7 @@ func checkStorage(
 
 	// Now read the file back and time it.
 	beforeRead := timeutil.Now()
-	r, err := store.ReadFile(ctx, filename)
+	r, _, err := store.ReadFile(ctx, filename, cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		return res, errors.Wrap(err, "opening reader")
 	}

--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -222,7 +222,10 @@ func CheckExportStore(
 					byteReader := bytes.NewReader(testingContent)
 					offset, length := rng.Int63n(size), rng.Intn(32*1024)
 					t.Logf("read %d of file at %d", length, offset)
-					reader, size, err := s.ReadFile(ctx, testingFilename, cloud.ReadOptions{Offset: offset})
+					reader, size, err := s.ReadFile(ctx, testingFilename, cloud.ReadOptions{
+						Offset:     offset,
+						LengthHint: int64(length),
+					})
 					require.NoError(t, err)
 					defer reader.Close(ctx)
 					require.Equal(t, int64(len(testingContent)), size)

--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -171,7 +171,7 @@ func CheckExportStore(
 				t.Errorf("size mismatch, got %d, expected %d", sz, len(payload))
 			}
 
-			r, err := s.ReadFile(ctx, name)
+			r, _, err := s.ReadFile(ctx, name, cloud.ReadOptions{NoFileSize: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -202,7 +202,7 @@ func CheckExportStore(
 		}
 
 		// Attempt to read (or fetch) it back.
-		res, err := s.ReadFile(ctx, testingFilename)
+		res, _, err := s.ReadFile(ctx, testingFilename, cloud.ReadOptions{NoFileSize: true})
 		if err != nil {
 			t.Fatalf("Could not get reader for %s: %+v", testingFilename, err)
 		}
@@ -222,7 +222,7 @@ func CheckExportStore(
 					byteReader := bytes.NewReader(testingContent)
 					offset, length := rng.Int63n(size), rng.Intn(32*1024)
 					t.Logf("read %d of file at %d", length, offset)
-					reader, size, err := s.ReadFileAt(ctx, testingFilename, offset)
+					reader, size, err := s.ReadFile(ctx, testingFilename, cloud.ReadOptions{Offset: offset})
 					require.NoError(t, err)
 					defer reader.Close(ctx)
 					require.Equal(t, int64(len(testingContent)), size)
@@ -253,7 +253,7 @@ func CheckExportStore(
 			user, db, testSettings)
 		defer singleFile.Close()
 
-		res, err := singleFile.ReadFile(ctx, "")
+		res, _, err := singleFile.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -278,7 +278,7 @@ func CheckExportStore(
 			t.Fatal(err)
 		}
 
-		res, err := s.ReadFile(ctx, testingFilename)
+		res, _, err := s.ReadFile(ctx, testingFilename, cloud.ReadOptions{NoFileSize: true})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -306,7 +306,7 @@ func CheckExportStore(
 		defer singleFile.Close()
 
 		// Read a valid file.
-		res, err := singleFile.ReadFile(ctx, testingFilename)
+		res, _, err := s.ReadFile(ctx, testingFilename, cloud.ReadOptions{NoFileSize: true})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -321,15 +321,11 @@ func CheckExportStore(
 		}
 
 		// Attempt to read a file which does not exist.
-		_, err = singleFile.ReadFile(ctx, "file_does_not_exist")
+		_, _, err = s.ReadFile(ctx, "file does not exist", cloud.ReadOptions{NoFileSize: true})
 		require.Error(t, err)
 		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist), "Expected a file does not exist error but returned %s")
 
-		_, _, err = singleFile.ReadFileAt(ctx, "file_does_not_exist", 0)
-		require.Error(t, err)
-		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist), "Expected a file does not exist error but returned %s")
-
-		_, _, err = singleFile.ReadFileAt(ctx, "file_does_not_exist", 24)
+		_, _, err = singleFile.ReadFile(ctx, "file_does_not_exist", cloud.ReadOptions{Offset: 24})
 		require.Error(t, err)
 		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist), "Expected a file does not exist error but returned %s")
 
@@ -542,7 +538,7 @@ func CheckAntagonisticRead(
 	require.NoError(t, err)
 	defer s.Close()
 
-	stream, err := s.ReadFile(ctx, basename)
+	stream, _, err := s.ReadFile(ctx, basename, cloud.ReadOptions{NoFileSize: true})
 	require.NoError(t, err)
 	defer stream.Close(ctx)
 	read, err := ioctx.ReadAll(ctx, stream)

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -60,15 +60,12 @@ type ExternalStorage interface {
 	// ExternalStorage implementation.
 	Settings() *cluster.Settings
 
-	// ReadFile is shorthand for ReadFileAt with offset 0.
+	// ReadFile returns a Reader for requested name reading at opts.Offset, along
+	// with the total size of the file (unless opts.NoFileSize is true).
+	//
 	// ErrFileDoesNotExist is raised if `basename` cannot be located in storage.
 	// This can be leveraged for an existence check.
-	ReadFile(ctx context.Context, basename string) (ioctx.ReadCloserCtx, error)
-
-	// ReadFileAt returns a Reader for requested name reading at offset.
-	// ErrFileDoesNotExist is raised if `basename` cannot be located in storage.
-	// This can be leveraged for an existence check.
-	ReadFileAt(ctx context.Context, basename string, offset int64) (ioctx.ReadCloserCtx, int64, error)
+	ReadFile(ctx context.Context, basename string, opts ReadOptions) (_ ioctx.ReadCloserCtx, fileSize int64, _ error)
 
 	// Writer returns a writer for the requested name.
 	//
@@ -93,6 +90,14 @@ type ExternalStorage interface {
 
 	// Size returns the length of the named file in bytes.
 	Size(ctx context.Context, basename string) (int64, error)
+}
+
+type ReadOptions struct {
+	Offset int64
+
+	// NoFileSize is set if the ReadFile caller is not interested in the fileSize
+	// return value (potentially making the call more efficient).
+	NoFileSize bool
 }
 
 // ListingFn describes functions passed to ExternalStorage.ListFiles.

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -95,6 +95,14 @@ type ExternalStorage interface {
 type ReadOptions struct {
 	Offset int64
 
+	// LengthHint is set when the caller will not read more than this many bytes
+	// from the returned ReadCloserCtx. This allows backend implementation to make
+	// more efficient limited requests.
+	//
+	// There is no guarantee that the reader won't produce more bytes; backends
+	// are free to ignore this value.
+	LengthHint int64
+
 	// NoFileSize is set if the ReadFile caller is not interested in the fileSize
 	// return value (potentially making the call more efficient).
 	NoFileSize bool

--- a/pkg/cloud/externalconn/utils/connection_utils.go
+++ b/pkg/cloud/externalconn/utils/connection_utils.go
@@ -67,7 +67,7 @@ func CheckExternalStorageConnection(
 	}
 
 	// Read the sentinel file.
-	reader, err := es.ReadFile(ctx, markerFile)
+	reader, _, err := es.ReadFile(ctx, markerFile, cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		return errors.Wrap(err, "failed to read sentinel ExternalStorage file")
 	}

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -286,7 +286,7 @@ func TestHttpGet(t *testing.T) {
 			}()
 
 			// Read the file and verify results.
-			file, err = store.ReadFile(ctx, "/something")
+			file, _, err = store.ReadFile(ctx, "/something", cloud.ReadOptions{NoFileSize: true})
 			require.NoError(t, err)
 
 			b, err := ioctx.ReadAll(ctx, file)
@@ -314,7 +314,7 @@ func TestHttpGetWithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err = store.ReadFile(ctx, "/something")
+	_, _, err = store.ReadFile(ctx, "/something", cloud.ReadOptions{NoFileSize: true})
 	require.Error(t, context.Canceled, err)
 }
 
@@ -386,7 +386,7 @@ func TestExternalStorageCanUseHTTPProxy(t *testing.T) {
 		cloud.NilMetrics,
 	)
 	require.NoError(t, err)
-	stream, err := s.ReadFile(context.Background(), "file")
+	stream, _, err := s.ReadFile(context.Background(), "file", cloud.ReadOptions{NoFileSize: true})
 	require.NoError(t, err)
 	defer stream.Close(ctx)
 	data, err := ioctx.ReadAll(ctx, stream)
@@ -441,6 +441,6 @@ func TestExhaustRetries(t *testing.T) {
 		require.NoError(t, store.Close())
 	}()
 
-	_, err = store.ReadFile(context.Background(), "/something")
+	_, _, err = store.ReadFile(context.Background(), "/something", cloud.ReadOptions{NoFileSize: true})
 	require.Error(t, err)
 }

--- a/pkg/cloud/impl_registry.go
+++ b/pkg/cloud/impl_registry.go
@@ -327,19 +327,10 @@ func (e *esWrapper) wrapWriter(ctx context.Context, w io.WriteCloser) io.WriteCl
 	return w
 }
 
-func (e *esWrapper) ReadFile(ctx context.Context, basename string) (ioctx.ReadCloserCtx, error) {
-	r, err := e.ExternalStorage.ReadFile(ctx, basename)
-	if err != nil {
-		return r, err
-	}
-
-	return e.wrapReader(ctx, r), nil
-}
-
-func (e *esWrapper) ReadFileAt(
-	ctx context.Context, basename string, offset int64,
+func (e *esWrapper) ReadFile(
+	ctx context.Context, basename string, opts ReadOptions,
 ) (ioctx.ReadCloserCtx, int64, error) {
-	r, s, err := e.ExternalStorage.ReadFileAt(ctx, basename, offset)
+	r, s, err := e.ExternalStorage.ReadFile(ctx, basename, opts)
 	if err != nil {
 		return r, s, err
 	}

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -155,18 +155,10 @@ func (l *localFileStorage) Writer(ctx context.Context, basename string) (io.Writ
 	return l.blobClient.Writer(ctx, joinRelativePath(l.base, basename))
 }
 
-// ReadFile is shorthand for ReadFileAt with offset 0.
 func (l *localFileStorage) ReadFile(
-	ctx context.Context, basename string,
-) (ioctx.ReadCloserCtx, error) {
-	body, _, err := l.ReadFileAt(ctx, basename, 0)
-	return body, err
-}
-
-func (l *localFileStorage) ReadFileAt(
-	ctx context.Context, basename string, offset int64,
+	ctx context.Context, basename string, opts cloud.ReadOptions,
 ) (ioctx.ReadCloserCtx, int64, error) {
-	reader, size, err := l.blobClient.ReadFile(ctx, joinRelativePath(l.base, basename), offset)
+	reader, size, err := l.blobClient.ReadFile(ctx, joinRelativePath(l.base, basename), opts.Offset)
 	if err != nil {
 		// The format of the error returned by the above ReadFile call differs based
 		// on whether we are reading from a local or remote nodelocal store.

--- a/pkg/cloud/nullsink/nullsink_storage.go
+++ b/pkg/cloud/nullsink/nullsink_storage.go
@@ -70,14 +70,7 @@ func (n *nullSinkStorage) Settings() *cluster.Settings {
 }
 
 func (n *nullSinkStorage) ReadFile(
-	ctx context.Context, basename string,
-) (ioctx.ReadCloserCtx, error) {
-	reader, _, err := n.ReadFileAt(ctx, basename, 0)
-	return reader, err
-}
-
-func (n *nullSinkStorage) ReadFileAt(
-	_ context.Context, _ string, _ int64,
+	_ context.Context, _ string, _ cloud.ReadOptions,
 ) (ioctx.ReadCloserCtx, int64, error) {
 	return nil, 0, io.EOF
 }

--- a/pkg/cloud/nullsink/nullsink_storage_test.go
+++ b/pkg/cloud/nullsink/nullsink_storage_test.go
@@ -53,6 +53,6 @@ func TestNullSinkReadAndWrite(t *testing.T) {
 	sz, err := s.Size(ctx, "")
 	require.NoError(t, err)
 	require.Equal(t, int64(0), sz)
-	_, err = s.ReadFile(ctx, "")
+	_, _, err = s.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 	require.True(t, errors.Is(err, io.EOF))
 }

--- a/pkg/cloud/userfile/file_table_storage.go
+++ b/pkg/cloud/userfile/file_table_storage.go
@@ -213,24 +213,16 @@ func checkBaseAndJoinFilePath(prefix, basename string) (string, error) {
 	return path.Join(prefix, basename), nil
 }
 
-// ReadFile is shorthand for ReadFileAt with offset 0.
-func (f *fileTableStorage) ReadFile(
-	ctx context.Context, basename string,
-) (ioctx.ReadCloserCtx, error) {
-	body, _, err := f.ReadFileAt(ctx, basename, 0)
-	return body, err
-}
-
 // ReadFile implements the ExternalStorage interface and returns the contents of
 // the file stored in the user scoped FileToTableSystem.
-func (f *fileTableStorage) ReadFileAt(
-	ctx context.Context, basename string, offset int64,
+func (f *fileTableStorage) ReadFile(
+	ctx context.Context, basename string, opts cloud.ReadOptions,
 ) (ioctx.ReadCloserCtx, int64, error) {
 	filepath, err := checkBaseAndJoinFilePath(f.prefix, basename)
 	if err != nil {
 		return nil, 0, err
 	}
-	reader, size, err := f.fs.ReadFile(ctx, filepath, offset)
+	reader, size, err := f.fs.ReadFile(ctx, filepath, opts.Offset)
 	if oserror.IsNotExist(err) {
 		return nil, 0, errors.Wrapf(cloud.ErrFileDoesNotExist,
 			"file %s does not exist in the UserFileTableSystem", filepath)

--- a/pkg/cloud/userfile/file_table_storage_test.go
+++ b/pkg/cloud/userfile/file_table_storage_test.go
@@ -128,7 +128,7 @@ func TestUserScoping(t *testing.T) {
 		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user2, db, nil,
 		cloud.NilMetrics)
 	require.NoError(t, err)
-	_, err = fileTableSystem2.ReadFile(ctx, filename)
+	_, _, err = fileTableSystem2.ReadFile(ctx, filename, cloud.ReadOptions{NoFileSize: true})
 	require.Error(t, err)
 	require.Error(t, cloud.WriteFile(ctx, fileTableSystem2, filename, bytes.NewReader([]byte("aaa"))))
 
@@ -137,6 +137,6 @@ func TestUserScoping(t *testing.T) {
 		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, username.RootUserName(), db,
 		nil, cloud.NilMetrics)
 	require.NoError(t, err)
-	_, err = fileTableSystem3.ReadFile(ctx, filename)
+	_, _, err = fileTableSystem3.ReadFile(ctx, filename, cloud.ReadOptions{NoFileSize: true})
 	require.NoError(t, err)
 }

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
@@ -65,7 +66,7 @@ func checkIfFileExists(ctx context.Context, c *copyMachine, dest, copyTargetTabl
 	}
 	defer store.Close()
 
-	_, err = store.ReadFile(ctx, "")
+	_, _, err = store.ReadFile(ctx, "", cloud.ReadOptions{})
 	if err == nil {
 		// Can ignore this parse error as it would have been caught when creating a
 		// new ExternalStorage above and so we never expect it to non-nil.

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/ingeststopped"
@@ -870,7 +871,7 @@ func parseAndCreateBundleTableDescs(
 	}
 	defer store.Close()
 
-	raw, err := store.ReadFile(ctx, "")
+	raw, _, err := store.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		return tableDescs, schemaDescs, err
 	}

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -1095,7 +1095,7 @@ func parseAvroOptions(
 			}
 			defer store.Close()
 
-			raw, err := store.ReadFile(ctx, "")
+			raw, _, err := store.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -6125,7 +6125,7 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 			}))
 			for i, file := range files {
 				require.Equal(t, file, path.Join(dirName, logSubdir, fmt.Sprintf("%d.log", i)))
-				content, err := store.ReadFile(ctx, file)
+				content, _, err := store.ReadFile(ctx, file, cloud.ReadOptions{NoFileSize: true})
 				require.NoError(t, err)
 				descBytes, err := ioctx.ReadAll(ctx, content)
 				require.NoError(t, err)

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -191,7 +191,7 @@ func readInputFiles(
 				// readability (e.g. permissions).
 				// If there's only one file, skip that check because it provides no
 				// advantage.
-				raw, err := es.ReadFile(ctx, "")
+				raw, _, err := es.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 				if err != nil {
 					return err
 				}
@@ -230,7 +230,7 @@ func readInputFiles(
 				return err
 			}
 			defer es.Close()
-			raw, err := es.ReadFile(ctx, "")
+			raw, _, err := es.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/importer/testutils_test.go
+++ b/pkg/sql/importer/testutils_test.go
@@ -272,15 +272,13 @@ func (es *generatorExternalStorage) Conf() cloudpb.ExternalStorage {
 func (es *generatorExternalStorage) RequiresExternalIOAccounting() bool { return false }
 
 func (es *generatorExternalStorage) ReadFile(
-	ctx context.Context, basename string,
-) (ioctx.ReadCloserCtx, error) {
-	return es.gen.Open()
-}
-
-func (es *generatorExternalStorage) ReadFileAt(
-	ctx context.Context, basename string, offset int64,
-) (ioctx.ReadCloserCtx, int64, error) {
-	panic("unimplemented")
+	ctx context.Context, basename string, opts cloud.ReadOptions,
+) (_ ioctx.ReadCloserCtx, fileSize int64, _ error) {
+	if opts.Offset != 0 || !opts.NoFileSize {
+		panic("unimplemented")
+	}
+	r, err := es.gen.Open()
+	return r, 0, err
 }
 
 func (es *generatorExternalStorage) Close() error {

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -788,7 +788,7 @@ func (p *planner) ExternalReadFile(ctx context.Context, uri string) ([]byte, err
 		return nil, err
 	}
 
-	file, err := conn.ReadFile(ctx, "")
+	file, _, err := conn.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/base",
         "//pkg/bench",
         "//pkg/ccl",
+        "//pkg/cloud",
         "//pkg/cloud/impl:cloudimpl",
         "//pkg/clusterversion",
         "//pkg/config/zonepb",

--- a/pkg/sql/tests/copy_file_upload_test.go
+++ b/pkg/sql/tests/copy_file_upload_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -148,7 +149,7 @@ func checkUserFileContent(
 	store, err := s.ExecutorConfig().(sql.ExecutorConfig).DistSQLSrv.ExternalStorageFromURI(ctx, uri,
 		user)
 	require.NoError(t, err)
-	reader, err := store.ReadFile(ctx, "")
+	reader, _, err := store.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 	require.NoError(t, err)
 	got, err := ioctx.ReadAll(ctx, reader)
 	require.NoError(t, err)

--- a/pkg/storage/shared_storage.go
+++ b/pkg/storage/shared_storage.go
@@ -36,7 +36,10 @@ type externalStorageReader struct {
 var _ shared.ObjectReader = (*externalStorageReader)(nil)
 
 func (r *externalStorageReader) ReadAt(ctx context.Context, p []byte, offset int64) error {
-	reader, _, err := r.es.ReadFileAt(ctx, r.objName, offset)
+	reader, _, err := r.es.ReadFile(ctx, r.objName, cloud.ReadOptions{
+		Offset:     offset,
+		NoFileSize: true,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/shared_storage.go
+++ b/pkg/storage/shared_storage.go
@@ -38,6 +38,7 @@ var _ shared.ObjectReader = (*externalStorageReader)(nil)
 func (r *externalStorageReader) ReadAt(ctx context.Context, p []byte, offset int64) error {
 	reader, _, err := r.es.ReadFile(ctx, r.objName, cloud.ReadOptions{
 		Offset:     offset,
+		LengthHint: int64(len(p)),
 		NoFileSize: true,
 	})
 	if err != nil {


### PR DESCRIPTION
This change consolidates the `ReadFile` and `ReadFileAt` APIs in `cloud.ExternalStorage`. We use a `ReadOptions` struct to optionally specify the offset or that we don't care about the size. This will allow us to add more options without large code changes.

Epic: none
Release note: None