### PR TITLE
syncutil: Add CondMutex

### DIFF
--- a/pkg/util/syncutil/BUILD.bazel
+++ b/pkg/util/syncutil/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "syncutil",
     srcs = [
         "atomic.go",
+        "condition.go",
         "int_map.go",
         "mutex_deadlock.go",  # keep
         "mutex_sync.go",  # keep
@@ -13,6 +14,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/syncutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/ctxutil",
         "@com_github_sasha_s_go_deadlock//:go-deadlock",  # keep
     ],
 )
@@ -22,6 +24,7 @@ go_test(
     size = "small",
     srcs = [
         "atomic_test.go",
+        "condition_test.go",
         "int_map_bench_test.go",
         "int_map_reference_test.go",
         "int_map_test.go",
@@ -29,7 +32,10 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":syncutil"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
+    ],
 )
 
 get_x_data(name = "get_x_data")

--- a/pkg/util/syncutil/condition.go
+++ b/pkg/util/syncutil/condition.go
@@ -1,0 +1,171 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package syncutil
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	_ "unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/util/ctxutil"
+)
+
+// Condition is the predicate used with CondMutex.
+// NB: condition function *must* be side effects free.
+// NB: condition function *must* be a function of the state protected by the lock.
+// If the above requires are not true, behavior is undefined.
+type Condition func() bool
+
+// CondMutex is a Mutex that adds conditional locking.
+// Zero initialized CondMutex is ready to use.
+type CondMutex struct {
+	w    Mutex
+	cond struct {
+		RWMutex // Acquired before w.
+		cv      sync.Cond
+		nw      int // Number of callers waiting for cond.
+	}
+}
+
+// Lock implements Locker interface.
+func (c *CondMutex) Lock() {
+	c.w.Lock()
+}
+
+// Unlock implements Locker interface.
+func (c *CondMutex) Unlock() {
+	c.cond.RLock()
+	if c.cond.nw > 0 {
+		c.cond.cv.Signal()
+	}
+	c.cond.RUnlock()
+	c.w.Unlock()
+}
+
+// LockWhen acquires the lock and waits for condition to be true.
+func (c *CondMutex) LockWhen(cond Condition) {
+	if err := c.condLock(noncancelable(cond)); err != nil {
+		panic(fmt.Sprintf("unexpected error %s", err))
+	}
+	c.w.AssertHeld()
+}
+
+// LockWhenCtx locks this lock and waits for condition to be true.
+// Acquires the lock and returns nil when condition becomes true.
+// Does not acquire the lock and returns context error if condition
+// failed to evaluate to true before context completion.
+func (c *CondMutex) LockWhenCtx(ctx context.Context, cond Condition) error {
+	if ctx.Done() == nil {
+		c.LockWhen(cond)
+		return nil
+	}
+
+	cCond := cancelable{cond: cond}
+	if err := ctxutil.WhenDone(ctx, func(err error) {
+		cCond.cancel.Store(err)
+		c.cond.cv.Signal()
+	}); err != nil {
+		return err
+	}
+
+	if err := c.condLock(&cCond); err != nil {
+		return err
+	}
+	c.w.AssertHeld()
+	return nil
+}
+
+// LockCtx acquires the lock, or returns an error if the lock could not
+// be acquired prior to context completion.
+func (c *CondMutex) LockCtx(ctx context.Context) error {
+	return c.LockWhenCtx(ctx, func() bool { return true })
+}
+
+type condition interface {
+	holds() bool
+	err() error
+}
+
+type cancelable struct {
+	cond   Condition
+	cancel atomic.Value // of error
+}
+
+func (c *cancelable) holds() bool {
+	return c.cond()
+}
+func (c *cancelable) err() error {
+	if v := c.cancel.Load(); v != nil {
+		return v.(error)
+	}
+	return nil
+}
+
+type noncancelable Condition
+
+func (c noncancelable) holds() bool {
+	return c()
+}
+func (c noncancelable) err() error {
+	return nil
+}
+
+func (c *CondMutex) condLock(cond condition) error {
+	{
+		// Fast path.
+		c.cond.RLock()
+		locked := false
+		if c.w.TryLock() {
+			if cond.holds() {
+				locked = true
+			} else {
+				c.w.Unlock() // Condition was false.  Drop write lock; go on slow path below.
+			}
+		}
+		c.cond.RUnlock()
+		if locked {
+			return nil
+		}
+	}
+
+	c.cond.Lock()
+	if c.cond.cv.L == nil {
+		c.cond.cv.L = &c.cond.RWMutex
+	}
+	c.cond.nw++
+	defer func() {
+		c.cond.nw--
+		c.cond.Unlock()
+	}()
+
+	for {
+		if c.w.TryLock() {
+			if cond.holds() {
+				return nil // c.cond mutex released by defer.
+			}
+			c.w.Unlock() // Drop write lock; we need to wait on cond.
+		}
+
+		// Before we return an error or go sleep to wait on cv,
+		// make sure to wake up any other waiters that may be sleeping, waiting for signal.
+		if c.cond.nw > 1 {
+			c.cond.cv.Signal()
+		}
+
+		if err := cond.err(); err != nil {
+			return err // c.cond mutex released by defer.
+		}
+
+		c.cond.cv.Wait()
+	}
+}

--- a/pkg/util/syncutil/condition_test.go
+++ b/pkg/util/syncutil/condition_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package syncutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCondMutex(t *testing.T) {
+	alwaysTrue := func() bool { return true }
+
+	t.Run("zero initialized", func(t *testing.T) {
+		var mu CondMutex
+		mu.Lock()
+		_ = 1 // defeat empty critical section warning.
+		mu.Unlock()
+		mu.LockWhen(alwaysTrue)
+		mu.Unlock()
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		mu := struct {
+			CondMutex
+			state bool
+		}{}
+
+		lockResult := make(chan error, 1)
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+			lockResult <- mu.LockWhenCtx(ctx, func() bool { return mu.state })
+		}()
+
+		select {
+		case err := <-lockResult:
+			require.True(t, errors.Is(err, context.DeadlineExceeded))
+		case <-time.After(30 * time.Second):
+			t.Fatalf("timeout reading lock result")
+		}
+	})
+
+	t.Run("timeout same thread", func(t *testing.T) {
+		mu := struct {
+			CondMutex
+			state bool
+		}{}
+		// This is a silly test where we try to lock twice; but the second attempt should time out.
+		mu.Lock()
+		defer mu.Unlock()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		require.True(t, errors.Is(context.DeadlineExceeded, mu.LockCtx(ctx)))
+	})
+}

--- a/pkg/util/syncutil/mutex_deadlock.go
+++ b/pkg/util/syncutil/mutex_deadlock.go
@@ -31,6 +31,17 @@ type Mutex struct {
 	deadlock.Mutex
 }
 
+// TryLock tries to lock m and reports whether it succeeded.
+//
+// Note that while correct uses of TryLock do exist, they are rare,
+// and use of TryLock is often a sign of a deeper problem
+// in a particular use of mutexes.
+// Note: Deadlock mutex lacks try lock method -- so, revert to regular lock.
+func (m *Mutex) TryLock() bool {
+	m.Lock()
+	return true
+}
+
 // AssertHeld is a no-op for deadlock mutexes.
 func (m *Mutex) AssertHeld() {
 }
@@ -38,6 +49,17 @@ func (m *Mutex) AssertHeld() {
 // An RWMutex is a reader/writer mutual exclusion lock.
 type RWMutex struct {
 	deadlock.RWMutex
+}
+
+// TryLock tries to lock m and reports whether it succeeded.
+//
+// Note that while correct uses of TryLock do exist, they are rare,
+// and use of TryLock is often a sign of a deeper problem
+// in a particular use of mutexes.
+// Note: Deadlock mutex lacks try lock method -- so, revert to regular lock.
+func (m *RWMutex) TryLock() bool {
+	m.Lock()
+	return true
 }
 
 // AssertHeld is a no-op for deadlock mutexes.

--- a/pkg/util/syncutil/mutex_sync_race.go
+++ b/pkg/util/syncutil/mutex_sync_race.go
@@ -33,6 +33,19 @@ func (m *Mutex) Lock() {
 	atomic.StoreInt32(&m.wLocked, 1)
 }
 
+// TryLock tries to lock m and reports whether it succeeded.
+//
+// Note that while correct uses of TryLock do exist, they are rare,
+// and use of TryLock is often a sign of a deeper problem
+// in a particular use of mutexes.
+func (m *Mutex) TryLock() bool {
+	if m.mu.TryLock() {
+		atomic.StoreInt32(&m.wLocked, 1)
+		return true
+	}
+	return false
+}
+
 // Unlock unlocks m.
 func (m *Mutex) Unlock() {
 	atomic.StoreInt32(&m.wLocked, 0)
@@ -64,6 +77,19 @@ type RWMutex struct {
 func (rw *RWMutex) Lock() {
 	rw.RWMutex.Lock()
 	atomic.StoreInt32(&rw.wLocked, 1)
+}
+
+// TryLock tries to lock m and reports whether it succeeded.
+//
+// Note that while correct uses of TryLock do exist, they are rare,
+// and use of TryLock is often a sign of a deeper problem
+// in a particular use of mutexes.
+func (m *RWMutex) TryLock() bool {
+	if m.RWMutex.TryLock() {
+		atomic.StoreInt32(&m.wLocked, 1)
+		return true
+	}
+	return false
 }
 
 // Unlock unlocks rw for writing.


### PR DESCRIPTION
Add `syncutil.CondMutex`.
One of a big problems around `sync.Cond` is that waiting for condition
to become true does not respect context cancellation.
This makes `sync.Cond` unusable in all but a handful situations.

`CondMutex` solves this problem by implementing conditional mutex:

```
data := struct {
  mu struct {
    CondMutex
    n int
 }
}{}

data.LockWhen(func() bool { data.mu.n > 0 })
```

In addition to locking when condition becomes true, CondMutex
respects context completion via `LockWhenCtx` method:
```

if err := data.LockWhenCtx(ctx, func() bool { data.mu.n > 100 }); err != nil {
 return errors.New("never got 100 items")
}
// Lock is held here
defer data.Unlock()
```

Epic: None
Release note: None