### PR TITLE
goschedstats: support go1.20

### DIFF
--- a/pkg/util/goschedstats/BUILD.bazel
+++ b/pkg/util/goschedstats/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "runnable.go",
         "runtime_go1.19.go",
+        "runtime_go1.20.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/goschedstats",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
There was one field added to the `p` that matters: needspinning (see https://github.com/golang/go/commit/8cb350d69a1b0765c1c81301583d6fd99fb9d74b).

All of the relevant symbols and structs were re-copied. Some `uintptr`s were replaced with real pointers, and some things were ported to use new atomic types.

Relates to https://github.com/cockroachdb/cockroach/issues/96443.

Epic: none

Release note: None