### PR TITLE
release-22.2: ui: database details page now supports a large number of tables

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -152,6 +152,19 @@ export function sqlApiErrorMessage(message: string): string {
   return message;
 }
 
+export function createSqlExecutionRequest(
+  dbName: string,
+  statements: SqlStatement[],
+): SqlExecutionRequest {
+  return {
+    execute: true,
+    statements: statements,
+    database: dbName,
+    max_result_size: LARGE_RESULT_SIZE,
+    timeout: LONG_TIMEOUT,
+  };
+}
+
 export function isMaxSizeError(message: string): boolean {
   return !!message?.includes("max result size exceeded");
 }

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -49,6 +49,7 @@ import {
 import { merge } from "lodash";
 import { UIConfigState } from "src/store";
 import { TableStatistics } from "../tableStatistics";
+import { DatabaseDetailsPageProps } from "../databaseDetailsPage";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -254,7 +255,26 @@ export class DatabasesPage extends React.Component<
   };
 
   componentDidMount(): void {
-    this.refresh();
+    if (this.props.refreshNodes != null) {
+      this.props.refreshNodes();
+    }
+
+    if (this.props.refreshSettings != null) {
+      this.props.refreshSettings();
+    }
+
+    if (
+      !this.props.loaded &&
+      !this.props.loading &&
+      this.props.lastError === undefined
+    ) {
+      return this.props.refreshDatabases();
+    } else {
+      // If the props are already loaded then componentDidUpdate
+      // will not get called so call refresh to make sure details
+      // are loaded
+      this.refresh();
+    }
   }
 
   updateQueryParams(): void {
@@ -273,28 +293,17 @@ export class DatabasesPage extends React.Component<
     }
   }
 
-  componentDidUpdate(): void {
-    this.updateQueryParams();
-    this.refresh();
+  componentDidUpdate(
+    prevProp: Readonly<DatabasesPageProps>,
+    prevState: Readonly<DatabasesPageState>,
+  ): void {
+    if (this.shouldRefreshDatabaseInformation(prevState, prevProp)) {
+      this.updateQueryParams();
+      this.refresh();
+    }
   }
 
   private refresh(): void {
-    if (this.props.refreshNodes != null) {
-      this.props.refreshNodes();
-    }
-
-    if (this.props.refreshSettings != null) {
-      this.props.refreshSettings();
-    }
-
-    if (
-      !this.props.loaded &&
-      !this.props.loading &&
-      this.props.lastError === undefined
-    ) {
-      return this.props.refreshDatabases();
-    }
-
     let lastDetailsError: Error;
 
     // load everything by default
@@ -482,6 +491,44 @@ export class DatabasesPage extends React.Component<
         return foundRegion && foundNode;
       });
   };
+
+  private shouldRefreshDatabaseInformation(
+    prevState: Readonly<DatabasesPageState>,
+    prevProps: Readonly<DatabasesPageProps>,
+  ): boolean {
+    // No new dbs to update
+    if (
+      !this.props.databases ||
+      this.props.databases.length == 0 ||
+      this.props.databases.every(x => x.loaded || x.loading)
+    ) {
+      return false;
+    }
+
+    if (this.state.pagination.current != prevState.pagination.current) {
+      return true;
+    }
+
+    if (prevProps && this.props.search != prevProps.search) {
+      return true;
+    }
+
+    const filteredDatabases = this.filteredDatabasesData();
+    for (
+      let i = 0;
+      i < filteredDatabases.length && i < disableTableSortSize;
+      i++
+    ) {
+      const db = filteredDatabases[i];
+      if (db.loaded || db.loading || db.lastError != undefined) {
+        continue;
+      }
+      // Info is not loaded for a visible database.
+      return true;
+    }
+
+    return false;
+  }
 
   private renderIndexRecommendations = (
     database: DatabasesPageDataDatabase,


### PR DESCRIPTION
Backport 1/1 commits from #103752.

/cc @cockroachdb/release

---

Previous design:
1. The ui would attempt to a network call for all tables in a db.
2. The ui would completely fail if more than roughly 900 tables were present in a db. The number could be less if the table names were long.

New design:
1. The ui will only load the table details of the first 2 pages. This is a currently set to 20 tables per a page. If more than 40 tables are present in a db, the ui will disable sort. This is necessary because it would require loading the details of all tables which results in to many network calls overloading the db. The user can still filter using the table name.
2. The ui will now load all the table names. If a max size error is hit the ui will loop until it pulls all the table names.

Fixes: #98819
Epic: none

Before: https://www.loom.com/share/8b63f3ad96e74269be6a8873adf9673a
After: https://www.loom.com/share/0603d4f083b34f919aeaa0fe9f696ed1

Release note (ui change): The database details page now supports a
    large number of tables for a single database. Sort will be disabled
    if more than 40 tables are present in a database.

Release justification: bug fix