### PR TITLE
kv: remove stale TODO about commit triggers

### DIFF
--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1008,7 +1008,8 @@ func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) 
 // PrepareForRetry needs to be called before a retry to perform some
 // book-keeping and clear errors when possible.
 func (txn *Txn) PrepareForRetry(ctx context.Context) {
-	// TODO(andrei): I think commit triggers are reset in the wrong place. See #18170.
+	// Reset commit triggers. These must be reconfigured by the client during the
+	// next retry.
 	txn.commitTriggers = nil
 
 	txn.mu.Lock()


### PR DESCRIPTION
Closes #18170.

As of c00ea847, `Txn.PrepareForRetry` is called for all transaction retries, regardless of whether they're automatically performed by `Txn.exec` or manually performed by the client. As a result, the TODO describing the need to reset commit triggers separately for user-directed retry attempts is no longer relevant.

Release note: None