### PR TITLE
release: create docker manifest without amending

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -146,7 +146,8 @@ The `bazelbuilder` image is used exclusively for performing builds using Bazel. 
     docker push cockroachdb/bazel:amd64-$TAG
     docker build --platform linux/arm64 -t cockroachdb/bazel:arm64-$TAG build/bazelbuilder
     docker push cockroachdb/bazel:arm64-$TAG
-    docker manifest create cockroachdb/bazel:$TAG --amend cockroachdb/bazel:amd64-$TAG --amend cockroachdb/bazel:arm64-$TAG
+    docker manifest rm cockroachdb/bazel:$TAG
+    docker manifest create cockroachdb/bazel:$TAG cockroachdb/bazel:amd64-$TAG cockroachdb/bazel:arm64-$TAG
     docker manifest push cockroachdb/bazel:$TAG
 ```
 - Then, update `build/.bazelbuilderversion` with the new tag and commit all your changes.

--- a/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
@@ -96,8 +96,8 @@ tc_end_block "Copy binaries"
 
 
 tc_start_block "Make and push multiarch docker images"
-declare -a gcr_amends
-declare -a dockerhub_amends
+declare -a gcr_arch_tags
+declare -a dockerhub_arch_tags
 dockerhub_tag="${dockerhub_repository}:${version}"
 gcr_tag="${gcr_repository}:${version}"
 
@@ -115,23 +115,29 @@ for platform_name in amd64 arm64; do
   docker_login_gcr "$gcr_repository" "$gcr_credentials"
   docker push "$gcr_arch_tag"
   docker push "$dockerhub_arch_tag"
-  gcr_amends+=("--amend" "$gcr_arch_tag")
-  dockerhub_amends+=("--amend" "$dockerhub_arch_tag")
+  gcr_arch_tags+=("$gcr_arch_tag")
+  dockerhub_arch_tags+=("$dockerhub_arch_tag")
 done
 
 docker_login_gcr "$gcr_repository" "$gcr_credentials"
 
-docker manifest create "${gcr_tag}" "${gcr_amends[@]}"
+docker manifest rm "${gcr_tag}" || :
+docker manifest create "${gcr_tag}" "${gcr_arch_tags[@]}"
 docker manifest push "${gcr_tag}"
 
-docker manifest create "${dockerhub_tag}" "${dockerhub_amends[@]}"
+docker manifest rm "${dockerhub_tag}" || :
+docker manifest create "${dockerhub_tag}" "${dockerhub_arch_tags[@]}"
 docker manifest push "${dockerhub_tag}"
 
-docker manifest create "${gcr_repository}:latest" "${gcr_amends[@]}"
-docker manifest create "${gcr_repository}:latest-${release_branch}" "${gcr_amends[@]}"
+docker manifest rm "${gcr_repository}:latest" || :
+docker manifest create "${gcr_repository}:latest" "${gcr_arch_tags[@]}"
+docker manifest rm "${gcr_repository}:latest-${release_branch}" || :
+docker manifest create "${gcr_repository}:latest-${release_branch}" "${gcr_arch_tags[@]}"
 
-docker manifest create "${dockerhub_repository}:latest" "${dockerhub_amends[@]}"
-docker manifest create "${dockerhub_repository}:latest-${release_branch}" "${dockerhub_amends[@]}"
+docker manifest rm "${dockerhub_repository}:latest" || :
+docker manifest create "${dockerhub_repository}:latest" "${dockerhub_arch_tags[@]}"
+docker manifest rm "${dockerhub_repository}:latest-${release_branch}" || :
+docker manifest create "${dockerhub_repository}:latest-${release_branch}" "${dockerhub_arch_tags[@]}"
 tc_end_block "Make and push multiarch docker images"
 
 

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
@@ -68,7 +68,7 @@ configure_docker_creds
 docker_login_with_google
 
 gcr_tag="${gcr_repository}:${build_name}"
-declare -a docker_manifest_amends
+declare -a dockerhub_arch_tags
 
 for platform_name in amd64 arm64; do
   cp --recursive "build/deploy" "build/deploy-${platform_name}"
@@ -87,10 +87,11 @@ for platform_name in amd64 arm64; do
   build_docker_tag="${gcr_repository}:${platform_name}-${build_name}"
   docker build --no-cache --pull --platform "linux/${platform_name}" --tag="${build_docker_tag}" "build/deploy-${platform_name}"
   docker push "$build_docker_tag"
-  docker_manifest_amends+=("--amend" "${build_docker_tag}")
+dockerhub_arch_tags+=("${build_docker_tag}")
 done
 
-docker manifest create "${gcr_tag}" "${docker_manifest_amends[@]}"
+docker manifest rm "${gcr_tag}" || :
+docker manifest create "${gcr_tag}" "${dockerhub_arch_tags[@]}"
 docker manifest push "${gcr_tag}"
 tc_end_block "Make and push multiarch docker images"
 


### PR DESCRIPTION
Previously, we used `docker manifest NAME --amend name1 --amend name2` in order to create multi-arch docker images. Using `--amend` implies either create a new manifest if it doesn't exist or amending an existing manifest by adding a new entry.

In case there is an existing manifest on a developer or CI machine, this may cause unpredicted results, like having more than 1 image per platform.

This PR adds `docker manifest rm` command to make sure we do not amend an existing manifest. It also changes the `docker manifest create` parameters to specify the final list of "arch" images instead of "amending" them. This command exits non-zero in case a manifest with the same name exists.

Epic: none
Release note: None