### PR TITLE
sql: alter database should defer locality validation

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -4,7 +4,7 @@ new-cluster name=s1 allow-implicit-access disable-tenant localities=us-east-1,us
 ----
 
 exec-sql
-CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1";
+CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1" SURVIVE REGION FAILURE;
 CREATE TABLE d.t (x INT);
 INSERT INTO d.t VALUES (1), (2), (3);
 ----
@@ -43,7 +43,7 @@ RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/';
 query-sql
 SHOW DATABASES;
 ----
-d root us-east-1  {eu-central-1,us-east-1,us-west-1} zone
+d root us-east-1  {eu-central-1,us-east-1,us-west-1} region
 data root <nil> <nil> {} <nil>
 defaultdb root <nil> <nil> {} <nil>
 postgres root <nil> <nil> {} <nil>
@@ -70,10 +70,14 @@ RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' WITH skip_localities
 ----
 
 exec-sql
+SET enable_multiregion_placement_policy='true';
+ALTER DATABASE d SURVIVE ZONE FAILURE;
+ALTER DATABASE d PLACEMENT RESTRICTED;
 ALTER DATABASE d SET PRIMARY REGION 'eu-central-1';
 ALTER DATABASE d DROP REGION 'us-east-1';
 ALTER DATABASE d DROP REGION 'us-west-1';
 ALTER DATABASE d ADD REGION 'eu-north-1';
+ALTER DATABASE d SET SECONDARY REGION 'eu-north-1';
 ----
 
 exec-sql
@@ -81,10 +85,14 @@ RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/' WITH skip_loc
 ----
 
 exec-sql
+SET enable_multiregion_placement_policy='true';
+ALTER DATABASE d_new SURVIVE ZONE FAILURE;
+ALTER DATABASE d PLACEMENT RESTRICTED;
 ALTER DATABASE d_new SET PRIMARY REGION 'eu-central-1';
 ALTER DATABASE d_new DROP REGION 'us-east-1';
 ALTER DATABASE d_new DROP REGION 'us-west-1';
 ALTER DATABASE d_new ADD REGION 'eu-north-1';
+ALTER DATABASE d_new SET SECONDARY REGION 'eu-north-1';
 ----
 
 exec-sql

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -833,15 +833,8 @@ func (n *alterDatabasePrimaryRegionNode) switchPrimaryRegion(params runParams) e
 	if err != nil {
 		return err
 	}
-	found := false
-	for _, r := range prevRegionConfig.Regions() {
-		if r == catpb.RegionName(n.n.PrimaryRegion) {
-			found = true
-			break
-		}
-	}
-
-	if !found {
+	if !prevRegionConfig.Regions().Contains(catpb.RegionName(n.n.PrimaryRegion)) &&
+		!prevRegionConfig.AddingRegions().Contains(catpb.RegionName(n.n.PrimaryRegion)) {
 		return errors.WithHintf(
 			pgerror.Newf(pgcode.InvalidName,
 				"region %s has not been added to the database",
@@ -1288,6 +1281,9 @@ func (p *planner) alterDatabaseSurvivalGoal(
 		return err
 	}
 
+	// Validate the final zone config at the end of the transaction, since
+	// we will not be validating localities right now.
+	*p.extendedEvalCtx.validateDbZoneConfig = true
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		ctx,
@@ -1295,7 +1291,7 @@ func (p *planner) alterDatabaseSurvivalGoal(
 		regionConfig,
 		p.InternalSQLTxn(),
 		p.execCfg,
-		true, /* validateLocalities */
+		false, /* validateLocalities */
 		p.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	); err != nil {
 		return err
@@ -1483,6 +1479,9 @@ func (n *alterDatabasePlacementNode) startExec(params runParams) error {
 		return err
 	}
 
+	// Validate the final zone config at the end of the transaction, since
+	// we will not be validating localities right now.
+	*params.extendedEvalCtx.validateDbZoneConfig = true
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
@@ -1490,7 +1489,7 @@ func (n *alterDatabasePlacementNode) startExec(params runParams) error {
 		regionConfig,
 		params.p.InternalSQLTxn(),
 		params.p.execCfg,
-		true, /* validateLocalities */
+		false, /* validateLocalities */
 		params.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	); err != nil {
 		return err
@@ -1963,7 +1962,8 @@ func (n *alterDatabaseSecondaryRegion) startExec(params runParams) error {
 		return nil
 	}
 
-	if !prevRegionConfig.Regions().Contains(catpb.RegionName(n.n.SecondaryRegion)) {
+	if !prevRegionConfig.Regions().Contains(catpb.RegionName(n.n.SecondaryRegion)) &&
+		!prevRegionConfig.AddingRegions().Contains(catpb.RegionName(n.n.SecondaryRegion)) {
 		return errors.WithHintf(
 			pgerror.Newf(pgcode.InvalidDatabaseDefinition,
 				"region %s has not been added to the database",
@@ -2025,8 +2025,9 @@ func (n *alterDatabaseSecondaryRegion) startExec(params runParams) error {
 		return err
 	}
 
+	// Validate the final zone config at the end of the transaction, since
+	// we will not be validating localities right now.
 	*params.extendedEvalCtx.validateDbZoneConfig = true
-
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
@@ -2034,7 +2035,7 @@ func (n *alterDatabaseSecondaryRegion) startExec(params runParams) error {
 		updatedRegionConfig,
 		params.p.InternalSQLTxn(),
 		params.p.execCfg,
-		true, /* validateLocalities */
+		false, /* validateLocalities */
 		params.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	); err != nil {
 		return err
@@ -2133,6 +2134,9 @@ func (n *alterDatabaseDropSecondaryRegion) startExec(params runParams) error {
 		return err
 	}
 
+	// Validate the final zone config at the end of the transaction, since
+	// we will not be validating localities right now.
+	*params.extendedEvalCtx.validateDbZoneConfig = true
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
@@ -2140,7 +2144,7 @@ func (n *alterDatabaseDropSecondaryRegion) startExec(params runParams) error {
 		updatedRegionConfig,
 		params.p.InternalSQLTxn(),
 		params.p.execCfg,
-		true, /* validateLocalities */
+		false, /* validateLocalities */
 		params.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	); err != nil {
 		return err

--- a/pkg/sql/catalog/multiregion/region_config.go
+++ b/pkg/sql/catalog/multiregion/region_config.go
@@ -36,6 +36,7 @@ type RegionConfig struct {
 	survivalGoal         descpb.SurvivalGoal
 	regions              catpb.RegionNames
 	transitioningRegions catpb.RegionNames
+	addingRegions        catpb.RegionNames
 	primaryRegion        catpb.RegionName
 	regionEnumID         descpb.ID
 	placement            descpb.DataPlacement
@@ -124,6 +125,12 @@ func (r RegionConfig) PrimaryRegionString() string {
 // from or to being PUBLIC.
 func (r RegionConfig) TransitioningRegions() catpb.RegionNames {
 	return r.transitioningRegions
+}
+
+// AddingRegions returns all the regions which are currently transitioning
+// to being PUBLIC.
+func (r RegionConfig) AddingRegions() catpb.RegionNames {
+	return r.addingRegions
 }
 
 // RegionEnumID returns the multi-region enum ID.
@@ -303,6 +310,14 @@ type MakeRegionConfigOption func(r *RegionConfig)
 func WithTransitioningRegions(transitioningRegions catpb.RegionNames) MakeRegionConfigOption {
 	return func(r *RegionConfig) {
 		r.transitioningRegions = transitioningRegions
+	}
+}
+
+// WithAddingRegions is an option to include adding regions into
+// MakeRegionConfig.
+func WithAddingRegions(addingRegions catpb.RegionNames) MakeRegionConfigOption {
+	return func(r *RegionConfig) {
+		r.addingRegions = addingRegions
 	}
 }
 

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1417,13 +1417,14 @@ func SynthesizeRegionConfig(
 
 	regionConfig := multiregion.RegionConfig{}
 
-	var regionNames, transitioningRegionNames catpb.RegionNames
+	var regionNames, transitioningRegionNames, addingRegionNames catpb.RegionNames
 	_ = regionEnumDesc.ForEachRegion(func(name catpb.RegionName, transition descpb.TypeDescriptor_EnumMember_Direction) error {
 		switch transition {
 		case descpb.TypeDescriptor_EnumMember_NONE:
 			regionNames = append(regionNames, name)
 		case descpb.TypeDescriptor_EnumMember_ADD:
 			transitioningRegionNames = append(transitioningRegionNames, name)
+			addingRegionNames = append(addingRegionNames, name)
 		case descpb.TypeDescriptor_EnumMember_REMOVE:
 			transitioningRegionNames = append(transitioningRegionNames, name)
 			if o.forValidation {
@@ -1447,6 +1448,7 @@ func SynthesizeRegionConfig(
 		regionEnumDesc.TypeDesc().RegionConfig.SuperRegions,
 		regionEnumDesc.TypeDesc().RegionConfig.ZoneConfigExtensions,
 		multiregion.WithTransitioningRegions(transitioningRegionNames),
+		multiregion.WithAddingRegions(addingRegionNames),
 		multiregion.WithSecondaryRegion(dbDesc.GetRegionConfig().SecondaryRegion),
 	)
 


### PR DESCRIPTION
Previously, it was not possible to change the survival goal of a database after a restore, if the required number of regions are removed. This was because the validation was done in the statement phase. Preventing switches
from region to zone based configurations. This patch, blanket moves all alter database to do deferred
locality validation on transaction commit.

Fixes: #103862

Release note: None