### PR TITLE
ui: show detailed time of jobs executions in Db Console

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -25,8 +25,8 @@ import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import {
   TimestampToMoment,
   idAttr,
-  DATE_FORMAT_24_TZ,
   getMatchParamByName,
+  DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ,
 } from "src/util";
 
 import { HighwaterTimestamp } from "src/jobs/util/highwaterTimestamp";
@@ -119,7 +119,10 @@ export class JobDetails extends React.Component<JobDetailsProps> {
                 <SummaryCardItem
                   label="Next Planned Execution Time"
                   value={
-                    <Timestamp time={nextRun} format={DATE_FORMAT_24_TZ} />
+                    <Timestamp
+                      time={nextRun}
+                      format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
+                    />
                   }
                 />
               </>
@@ -129,16 +132,38 @@ export class JobDetails extends React.Component<JobDetailsProps> {
               value={
                 <Timestamp
                   time={TimestampToMoment(job.created)}
-                  format={DATE_FORMAT_24_TZ}
+                  format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
                 />
               }
             />
+            {job.modified && (
+              <SummaryCardItem
+                label="Last Modified Time"
+                value={
+                  <Timestamp
+                    time={TimestampToMoment(job.modified)}
+                    format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
+                  />
+                }
+              />
+            )}
+            {job.finished && (
+              <SummaryCardItem
+                label="Completed Time"
+                value={
+                  <Timestamp
+                    time={TimestampToMoment(job.finished)}
+                    format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
+                  />
+                }
+              />
+            )}
             <SummaryCardItem
               label="Last Execution Time"
               value={
                 <Timestamp
                   time={TimestampToMoment(job.last_run)}
-                  format={DATE_FORMAT_24_TZ}
+                  format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
                 />
               }
             />

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsTable.tsx
@@ -26,7 +26,7 @@ import {
   pauseJob,
   resumeJob,
 } from "src/util/docs";
-import { DATE_FORMAT } from "src/util/format";
+import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT } from "src/util/format";
 
 import { HighwaterTimestamp, JobStatusCell } from "../util";
 import { JobDescriptionCell } from "./jobDescriptionCell";
@@ -56,6 +56,7 @@ export const jobsColumnLabels: any = {
   creationTime: "Creation Time",
   lastModifiedTime: "Last Modified Time",
   lastExecutionTime: "Last Execution Time",
+  finishedTime: "Completed Time",
   executionCount: "Execution Count",
   highWaterTimestamp: "High-water Timestamp",
   coordinatorID: "Coordinator Node",
@@ -172,7 +173,7 @@ export function makeJobsColumns(): ColumnDescriptor<Job>[] {
       cell: job => (
         <Timestamp
           time={TimestampToMoment(job?.created)}
-          format={DATE_FORMAT}
+          format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT}
         />
       ),
       sort: job => TimestampToMoment(job?.created).valueOf(),
@@ -194,10 +195,36 @@ export function makeJobsColumns(): ColumnDescriptor<Job>[] {
       cell: job => (
         <Timestamp
           time={TimestampToMoment(job?.modified)}
-          format={DATE_FORMAT}
+          format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT}
         />
       ),
       sort: job => TimestampToMoment(job?.modified).valueOf(),
+      showByDefault: true,
+    },
+    {
+      name: "finishedTime",
+      title: (
+        <Tooltip
+          placement="bottom"
+          style="tableTitle"
+          content={
+            <p>
+              Date and time the job was either completed, failed or canceled.
+            </p>
+          }
+        >
+          <>
+            {jobsColumnLabels.finishedTime} <Timezone />
+          </>
+        </Tooltip>
+      ),
+      cell: job => (
+        <Timestamp
+          time={TimestampToMoment(job?.finished)}
+          format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT}
+        />
+      ),
+      sort: job => TimestampToMoment(job?.finished).valueOf(),
       showByDefault: true,
     },
     {
@@ -206,7 +233,7 @@ export function makeJobsColumns(): ColumnDescriptor<Job>[] {
         <Tooltip
           placement="bottom"
           style="tableTitle"
-          content={<p>Date and time the job was last executed.</p>}
+          content={<p>Date and time of the last attempted job execution.</p>}
         >
           <>
             {jobsColumnLabels.lastExecutionTime} <Timezone />
@@ -216,7 +243,7 @@ export function makeJobsColumns(): ColumnDescriptor<Job>[] {
       cell: job => (
         <Timestamp
           time={TimestampToMoment(job?.last_run)}
-          format={DATE_FORMAT}
+          format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT}
         />
       ),
       sort: job => TimestampToMoment(job?.last_run).valueOf(),


### PR DESCRIPTION
Initially, Job page didn't show seconds and milliseconds part for job creation/modification/last execution attempt fields. It could confuse users when job executed quickly (ie within a second or less) and in this case creation and rest of time stamps might show the same time.

This change introduces following:
- `Finished time` field is added to Jobs table and Job details;
- Timestamp changed to include seconds and milliseconds part;

Release note (ui change): added `finished time` field on Jobs and Job details pages; changed time format on those pages to include seconds and milliseconds;

Resolves: #93981

##### Jobs page:
![Screenshot 2023-05-25 at 10 53 10](https://github.com/cockroachdb/cockroach/assets/3106437/7ff303f7-8075-4236-b862-85bc700be2e3)
##### Job details page:
![Screenshot 2023-05-25 at 10 53 26](https://github.com/cockroachdb/cockroach/assets/3106437/6275e670-ad51-4f2a-b12c-7ff39d19e358)

