### PR TITLE
release-22.2: sql: alter database should defer locality validation

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -2,7 +2,7 @@ new-server name=s1 allow-implicit-access localities=us-east-1,us-west-1,eu-centr
 ----
 
 exec-sql
-CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1";
+CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1" SURVIVE REGION FAILURE;
 CREATE TABLE d.t (x INT);
 INSERT INTO d.t VALUES (1), (2), (3);
 ----
@@ -41,7 +41,7 @@ RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database_backup/';
 query-sql
 SHOW DATABASES;
 ----
-d root us-east-1  {eu-central-1,us-east-1,us-west-1} zone
+d root us-east-1  {eu-central-1,us-east-1,us-west-1} region
 data root <nil> <nil> {} <nil>
 defaultdb root <nil> <nil> {} <nil>
 postgres root <nil> <nil> {} <nil>
@@ -68,6 +68,7 @@ RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' WITH skip_localities
 ----
 
 exec-sql
+ALTER DATABASE d SURVIVE ZONE FAILURE;
 ALTER DATABASE d SET PRIMARY REGION "eu-central-1";
 ALTER DATABASE d DROP REGION "us-east-1";
 ALTER DATABASE d DROP REGION "us-west-1";
@@ -79,6 +80,7 @@ RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/' WITH skip_loc
 ----
 
 exec-sql
+ALTER DATABASE d_new SURVIVE ZONE FAILURE;
 ALTER DATABASE d_new SET PRIMARY REGION "eu-central-1";
 ALTER DATABASE d_new DROP REGION "us-east-1";
 ALTER DATABASE d_new DROP REGION "us-west-1";

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1162,6 +1162,9 @@ func (n *alterDatabaseSurvivalGoalNode) startExec(params runParams) error {
 		return err
 	}
 
+	// Validate the final zone config at the end of the transaction, since
+	// we will not be validating localities right now.
+	*params.p.extendedEvalCtx.validateDbZoneConfig = true
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
@@ -1170,7 +1173,7 @@ func (n *alterDatabaseSurvivalGoalNode) startExec(params runParams) error {
 		params.p.txn,
 		params.p.execCfg,
 		params.p.Descriptors(),
-		true, /* validateLocalities */
+		false, /* validateLocalities */
 	); err != nil {
 		return err
 	}
@@ -1293,6 +1296,9 @@ func (n *alterDatabasePlacementNode) startExec(params runParams) error {
 		return err
 	}
 
+	// Validate the final zone config at the end of the transaction, since
+	// we will not be validating localities right now.
+	*params.extendedEvalCtx.validateDbZoneConfig = true
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
@@ -1301,7 +1307,7 @@ func (n *alterDatabasePlacementNode) startExec(params runParams) error {
 		params.p.txn,
 		params.p.execCfg,
 		params.p.Descriptors(),
-		true, /* validateLocalities */
+		false, /* validateLocalities */
 	); err != nil {
 		return err
 	}
@@ -1838,8 +1844,9 @@ func (n *alterDatabaseSecondaryRegion) startExec(params runParams) error {
 		return err
 	}
 
+	// Validate the final zone config at the end of the transaction, since
+	// we will not be validating localities right now.
 	*params.extendedEvalCtx.validateDbZoneConfig = true
-
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
@@ -1848,7 +1855,7 @@ func (n *alterDatabaseSecondaryRegion) startExec(params runParams) error {
 		params.p.txn,
 		params.p.execCfg,
 		params.p.Descriptors(),
-		true, /* validateLocalities */
+		false, /* validateLocalities */
 	); err != nil {
 		return err
 	}
@@ -1948,6 +1955,9 @@ func (n *alterDatabaseDropSecondaryRegion) startExec(params runParams) error {
 		return err
 	}
 
+	// Validate the final zone config at the end of the transaction, since
+	// we will not be validating localities right now.
+	*params.extendedEvalCtx.validateDbZoneConfig = true
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
@@ -1956,7 +1966,7 @@ func (n *alterDatabaseDropSecondaryRegion) startExec(params runParams) error {
 		params.p.txn,
 		params.p.execCfg,
 		params.p.Descriptors(),
-		true, /* validateLocalities */
+		false, /* validateLocalities */
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #103874.

/cc @cockroachdb/release

---

Previously, it was not possible to change the survival goal of a database after a restore, if the required number of regions are removed. This was because the validation was done in the statement phase. Preventing switches
from region to zone based configurations. This patch, blanket moves all alter database to do deferred
locality validation on transaction commit.

Fixes: #103862

Release note: None
Release justification: low risk and addresses issues restore multi-region databases back into a single region
