### PR TITLE
tracing: do not panic with naked strings

### DIFF
--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/petermattis/goid"
 	"go.opentelemetry.io/otel/attribute"
@@ -178,7 +179,7 @@ func (sp *Span) detectUseAfterFinish() bool {
 		} else {
 			finishStack = sp.finishStack
 		}
-		panic(fmt.Sprintf("use of Span after Finish. Span: %s. Finish previously called at: %s",
+		panic(errors.AssertionFailedf("use of Span after Finish. Span: %s. Finish previously called at: %s",
 			sp.i.OperationName(), finishStack))
 	}
 
@@ -201,13 +202,13 @@ func (sp *Span) incRef() {
 func (sp *Span) decRef() bool {
 	refCnt := atomic.AddInt32(&sp.refCnt, -1)
 	if refCnt < 0 {
-		panic(fmt.Sprintf("refCnt below 0: %s", sp))
+		panic(errors.AssertionFailedf("refCnt below 0: %s", sp))
 	}
 	// If this was the last reference, make the span available for re-use.
 	if refCnt == 0 {
 		alreadyFinished := atomic.LoadInt32(&sp.finished) != 0
 		if !alreadyFinished {
-			panic("Span reference count dropped to zero before the span was Finish()ed")
+			panic(errors.AssertionFailedf("Span reference count dropped to zero before the span was Finish()ed"))
 		}
 		if detectSpanRefLeaks {
 			sp.setFinalizer(nil)
@@ -642,13 +643,13 @@ func (sp *Span) reset(
 ) {
 	if sp.i.crdb == nil {
 		// We assume that spans being reset have come from the sync.Pool.
-		panic("unexpected reset of no-op Spans")
+		panic(errors.AssertionFailedf("unexpected reset of no-op Spans"))
 	}
 
 	if refCnt := sp.refCnt; refCnt != 0 {
 		// The span should not have been made available for reuse with live
 		// references.
-		panic(fmt.Sprintf("expected 0 refCnt but found %d: %s", refCnt, sp))
+		panic(errors.AssertionFailedf("expected 0 refCnt but found %d: %s", refCnt, sp))
 	}
 
 	// Take a self-reference. This will be held until Finish(), ensuring that the
@@ -670,7 +671,7 @@ func (sp *Span) reset(
 			if sp.i.Tracer().closed() {
 				return
 			}
-			panic(fmt.Sprintf("Span not finished or references not released; "+
+			panic(errors.AssertionFailedf("Span not finished or references not released; "+
 				"span: %s, finished: %t, refCnt: %d.\n"+
 				"If running multiple tests, it's possible that the leaked span came from a previous "+
 				"test. In particular, if a previous test failed, the failure might have caused some unclean "+
@@ -695,7 +696,7 @@ func (sp *Span) reset(
 	c.startTime = startTime
 	c.logTags = logTags
 	if len(c.eventListeners) != 0 {
-		panic(fmt.Sprintf("unexpected event listeners in span being reset: %v", c.eventListeners))
+		panic(errors.AssertionFailedf("unexpected event listeners in span being reset: %v", c.eventListeners))
 	}
 	c.eventListeners = eventListeners
 	{
@@ -704,19 +705,19 @@ func (sp *Span) reset(
 		// after Finish().
 		c.mu.Lock()
 		if len(c.mu.openChildren) != 0 {
-			panic(fmt.Sprintf("unexpected children in span being reset: %v", c.mu.openChildren))
+			panic(errors.AssertionFailedf("unexpected children in span being reset: %v", c.mu.openChildren))
 		}
 		if len(c.mu.tags) != 0 {
-			panic(fmt.Sprintf("unexpected tags in span being reset: %v", c.mu.tags))
+			panic(errors.AssertionFailedf("unexpected tags in span being reset: %v", c.mu.tags))
 		}
 		if !c.mu.recording.finishedChildren.Empty() {
-			panic(fmt.Sprintf("unexpected finished children in span being reset: %v", c.mu.recording.finishedChildren))
+			panic(errors.AssertionFailedf("unexpected finished children in span being reset: %v", c.mu.recording.finishedChildren))
 		}
 		if c.mu.recording.structured.Len() != 0 {
-			panic("unexpected structured recording in span being reset")
+			panic(errors.AssertionFailedf("unexpected structured recording in span being reset"))
 		}
 		if c.mu.recording.logs.Len() != 0 {
-			panic("unexpected logs in span being reset")
+			panic(errors.AssertionFailedf("unexpected logs in span being reset"))
 		}
 
 		h := sp.helper

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -11,9 +11,8 @@
 package tracing
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -420,10 +419,10 @@ func WithRecording(recType tracingpb.RecordingType) SpanOption {
 	case tracingpb.RecordingVerbose:
 		return verboseRecordingSingleton
 	case tracingpb.RecordingOff:
-		panic("invalid recording option: RecordingOff")
+		panic(errors.AssertionFailedf("invalid recording option: RecordingOff"))
 	default:
 		recCpy := recType // copy excaping to the heap
-		panic(fmt.Sprintf("invalid recording option: %d", recCpy))
+		panic(errors.AssertionFailedf("invalid recording option: %d", recCpy))
 	}
 }
 


### PR DESCRIPTION
Error objects get sent to Sentry. Naked strings don't.

Epic: None
Release note: None