### PR TITLE
tracing: enable fine-grained redactability for unstructured events

### DIFF
--- a/pkg/kv/kvclient/kvtenant/tenant_trace_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_trace_test.go
@@ -79,12 +79,11 @@ func testTenantTracesAreRedactedImpl(t *testing.T, redactable bool) {
 	}
 
 	s, db, _ := serverutils.StartServer(t, args)
-	if redactable {
-		runner := sqlutils.MakeSQLRunner(db)
-		runner.Exec(t, "SET CLUSTER SETTING trace.redactable.enabled = true")
-	}
 	defer db.Close()
 	defer s.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(db)
+	runner.Exec(t, "SET CLUSTER SETTING trace.redactable.enabled = $1", redactable)
 
 	// Queries from the system tenant will receive unredacted traces
 	// since the tracer will not have the redactable flag set.

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -108,11 +108,8 @@ const (
 var enableTraceRedactable = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"trace.redactable.enabled",
-	"set to true to enable redactability for unstructured events "+
-		"in traces and to redact traces sent to tenants. "+
-		"Set to false to coarsely mark unstructured events as redactable "+
-		" and eliminate them from tenant traces.",
-	false,
+	"set to true to enable finer-grainer redactability for unstructured events in traces",
+	true,
 )
 
 var enableNetTrace = settings.RegisterBoolSetting(


### PR DESCRIPTION
Fixes #103883
Epic: CRDB-27642

This enables finer-grain redraction for unstructured events in traces. See #103883 for a discussion. (This can be reverted in case performance is found to be unacceptable.)

Release note: None