### PR TITLE
kv: allow commit triggers for manually-ended transactions

### DIFF
--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -705,11 +705,6 @@ func (txn *Txn) commit(ctx context.Context) error {
 	et := endTxnReq(true, txn.deadline())
 	ba := &kvpb.BatchRequest{Requests: et.unionArr[:]}
 	_, pErr := txn.Send(ctx, ba)
-	if pErr == nil {
-		for _, t := range txn.commitTriggers {
-			t(ctx)
-		}
-	}
 	return pErr.GoError()
 }
 
@@ -1089,7 +1084,15 @@ func (txn *Txn) Send(
 	sender := txn.mu.sender
 	txn.mu.Unlock()
 	br, pErr := txn.db.sendUsingSender(ctx, ba, sender)
+
 	if pErr == nil {
+		// Invoking the commit triggers here ensures they run even in the case when a
+		// commit request is issued manually (not via Commit).
+		if et, ok := ba.GetArg(kvpb.EndTxn); ok && et.(*kvpb.EndTxnRequest).Commit {
+			for _, t := range txn.commitTriggers {
+				t(ctx)
+			}
+		}
 		return br, nil
 	}
 


### PR DESCRIPTION
Previously, commit triggers were only invoked upon an explicit transaction Commit(). However, sometimes transactions are committed with a separate EndTxnRequest instead, and in those cases the commit triggers were not invoked. This patch fixes the issue by invoking commit triggers as part of Send().

Part of: #82538

Release note: None