### PR TITLE
ui: rename idle latency to client wait and move to another chart

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -163,3 +163,18 @@
 .margin-left-neg {
   margin-left: -11px !important;
 }
+
+.crl-anchor {
+  font-weight: $font-weight--bold;
+  font-size: $font-size--small;
+  line-height: $line-height--small;
+  letter-spacing: 0.3px;
+  color: $colors--neutral-0;
+  text-decoration: underline;
+
+  &:hover {
+    opacity: 0.7;
+    color: $colors--neutral-0;
+    text-decoration: underline;
+  }
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -21,16 +21,28 @@ export function generateExecuteAndPlanningTimeseries(
   const ts: Array<number> = [];
   const execution: Array<number> = [];
   const planning: Array<number> = [];
-  const idle: Array<number> = [];
 
   stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
     ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
     execution.push(stat.stats.run_lat.mean * 1e9);
     planning.push(stat.stats.plan_lat.mean * 1e9);
-    idle.push(stat.stats.idle_lat.mean * 1e9);
   });
 
-  return [ts, execution, planning, idle];
+  return [ts, execution, planning];
+}
+
+export function generateClientWaitTimeseries(
+  stats: statementStatisticsPerAggregatedTs[],
+): AlignedData {
+  const ts: Array<number> = [];
+  const clientWait: Array<number> = [];
+
+  stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
+    ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
+    clientWait.push(stat.stats.idle_lat.mean * 1e9);
+  });
+
+  return [ts, clientWait];
 }
 
 export function generateRowsProcessedTimeseries(

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -60,6 +60,7 @@ export const statementsSql = docsURL(
 export const statementsRetries = docsURL(
   "transactions.html#transaction-retries",
 );
+export const batchStatements = docsURL("transactions.html#batched-statements");
 export const readFromDisk = docsURL(
   "architecture/life-of-a-distributed-transaction.html#reads-from-the-storage-layer",
 );


### PR DESCRIPTION
Previously, the name "idle latency" was confusing, and being grouped with other statement time was also a cause of confusion. This commit renames the latency to "Client Wait Time" to be more accurate, including a proper tooltip. It also moves it to its own chart on Statement Details page.

Fixes #102361

Statement Time chart without idle time
<img width="751" alt="Screenshot 2023-05-25 at 12 19 54 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/5d27ecf0-ec31-4740-a05a-acca1944b759">

New Client Wait Time chart
<img width="798" alt="Screenshot 2023-05-25 at 12 20 38 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/3a84512d-4a52-4cdc-ab59-f193f75b14c6">



Release note (ui change): On Statement Details page rename the metric Idle Latency to Client Wait Time and separate it into its own chart.