### PR TITLE
schedulerlatency: improve panic verbosity

### DIFF
--- a/pkg/util/schedulerlatency/sampler.go
+++ b/pkg/util/schedulerlatency/sampler.go
@@ -233,7 +233,7 @@ func sample() *metrics.Float64Histogram {
 	metrics.Read(m)
 	v := &m[0].Value
 	if v.Kind() != metrics.KindFloat64Histogram {
-		panic("unexpected metric type")
+		panic(fmt.Sprintf("unexpected metric type: %d (v=%+v m=%+v)", v.Kind(), v, m))
 	}
 	h := v.Float64Histogram()
 	return h


### PR DESCRIPTION
Fixes #97004. It doesn't actually fix it, but it's an assertion we've seen fire exactly once without understanding how -- our usage of the runtime APIs seem sane and an audit of the runtime code didn't uncover new insights. Add some for panic verbosity for better luck next time, perhaps indicating an upstream bug. We checked open/closed golang/go issues with little luck.

Release note: None