### PR TITLE
ui: show active txn status as 'Idle' when it is not executing a stmt

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/recentStatementUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/recentStatementUtils.ts
@@ -150,7 +150,8 @@ export function getRecentExecutionsFromSessions(
             ? session.last_active_query
             : null),
         statementID: activeStmt?.statementID,
-        status: "Executing" as ExecutionStatus,
+        status:
+          activeStmt != null ? ExecutionStatus.Executing : ExecutionStatus.Idle,
         start: TimestampToMoment(activeTxn.start),
         elapsedTime: DurationToMomentDuration(activeTxn.elapsed_time),
         application: session.application_name,

--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/statusIcon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/statusIcon.tsx
@@ -14,6 +14,7 @@ import { CircleFilled } from "src/icon";
 import { ExecutionStatus } from "./types";
 
 import styles from "./executionStatusIcon.module.scss";
+
 const cx = classNames.bind(styles);
 
 export type StatusIconProps = {
@@ -21,6 +22,7 @@ export type StatusIconProps = {
 };
 
 export const StatusIcon: React.FC<StatusIconProps> = ({ status }) => {
-  const statusClassName = status !== "Waiting" ? "executing" : "waiting";
+  const statusClassName =
+    status === ExecutionStatus.Executing ? "executing" : "waiting";
   return <CircleFilled className={cx("status-icon", statusClassName)} />;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/types.ts
@@ -20,6 +20,7 @@ export enum ExecutionStatus {
   Waiting = "Waiting",
   Executing = "Executing",
   Preparing = "Preparing",
+  Idle = "Idle",
 }
 export type ExecutionType = "statement" | "transaction";
 


### PR DESCRIPTION
For the active txns pages, we preivously showed txns in two different statuses: 'Executing' or 'Waiting'. This commit introduces the 'Idle' status for txns that have began but are not currently executing a stmt.

Fixes: #100236

Release note (ui change): Active Transactions pages - Transaction status will be 'Idle' if the executing txn is not currently executing a statement, instead of having an 'Executing' status.


<img width="1690" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20136951/eb76ed8a-7d6b-4f83-9fc1-b2c4b29ddd98">
<img width="1717" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20136951/56106589-60be-4ae1-bd1a-29d06c4b13cb">
