### PR TITLE
ui: add Created SQL Connections chart on SQL dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -20,6 +20,8 @@ import {
   StatementDenialsClusterSettingsTooltip,
   TransactionRestartsToolTip,
 } from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import TimeSeriesQueryAggregator = cockroach.ts.tspb.TimeSeriesQueryAggregator;
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodeSources, tooltipSelection, nodeDisplayNameByID } = props;
@@ -39,6 +41,26 @@ export default function (props: GraphDashboardProps) {
             title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Created SQL Connections"
+      isKvGraph={false}
+      sources={nodeSources}
+      tooltip={`Counter of the number of SQL connections created ${tooltipSelection}`}
+    >
+      <Axis label="connections">
+        {_.map(nodeIDs, node => (
+          <Metric
+            key={node}
+            name="cr.node.sql.new_conns"
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
+            sources={[node]}
+            downsampler={TimeSeriesQueryAggregator.SUM}
+            nonNegativeRate
           />
         ))}
       </Axis>


### PR DESCRIPTION
Added Created SQL Connections chart that shows rate of created SQL connection over time.

Release note (ui change): added Created SQL Connections chart on
Metrics page, SQL Dashboard in DB Console.

Resolves: #93486

![Screenshot 2023-05-25 at 21 24 48](https://github.com/cockroachdb/cockroach/assets/3106437/9fbba32e-3bdc-4bce-ac51-4e57d141b926)
