### PR TITLE
ui: add Merge Queue Processing and Failures metrics on charts 

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -43,6 +43,11 @@ export default function (props: GraphDashboardProps) {
           nonNegativeRate
         />
         <Metric
+          name="cr.store.queue.merge.process.failure"
+          title="Merge"
+          nonNegativeRate
+        />
+        <Metric
           name="cr.store.queue.consistency.process.failure"
           title="Consistency"
           nonNegativeRate
@@ -85,6 +90,11 @@ export default function (props: GraphDashboardProps) {
         <Metric
           name="cr.store.queue.split.processingnanos"
           title="Split"
+          nonNegativeRate
+        />
+        <Metric
+          name="cr.store.queue.merge.processingnanos"
+          title="Merge"
           nonNegativeRate
         />
         <Metric


### PR DESCRIPTION
`Queue Processing Failures` and `Queue Processing Times` charts didn't include metrics about merge queues. Now corespondent metrics added to charts as well.

Release note (ui change): added Merge Queue failures and Merge queue processing time metrics to `Queue Processing Failures` and `Queue Processing Times` charts respectively.

Resolves: #84098

![Screenshot 2023-05-25 at 23 13 18](https://github.com/cockroachdb/cockroach/assets/3106437/ec23fa4b-29bc-4ea8-839f-cf214dc47185)

