### PR TITLE
sql: fix idle latency for internal queries

### DIFF
--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -126,20 +126,20 @@ func (ex *connExecutor) recordStatementSummary(
 
 	// Collect the statistics.
 	idleLatRaw := phaseTimes.GetIdleLatency(ex.statsCollector.PreviousPhaseTimes())
-	idleLat := idleLatRaw.Seconds()
+	idleLatSec := idleLatRaw.Seconds()
 	runLatRaw := phaseTimes.GetRunLatency()
-	runLat := runLatRaw.Seconds()
-	parseLat := phaseTimes.GetParsingLatency().Seconds()
-	planLat := phaseTimes.GetPlanningLatency().Seconds()
+	runLatSec := runLatRaw.Seconds()
+	parseLatSec := phaseTimes.GetParsingLatency().Seconds()
+	planLatSec := phaseTimes.GetPlanningLatency().Seconds()
 	// We want to exclude any overhead to reduce possible confusion.
 	svcLatRaw := phaseTimes.GetServiceLatencyNoOverhead()
-	svcLat := svcLatRaw.Seconds()
+	svcLatSec := svcLatRaw.Seconds()
 
 	// processing latency: contributing towards SQL results.
-	processingLat := parseLat + planLat + runLat
+	processingLatSec := parseLatSec + planLatSec + runLatSec
 
 	// overhead latency: txn/retry management, error checking, etc
-	execOverhead := svcLat - processingLat
+	execOverheadSec := svcLatSec - processingLatSec
 
 	stmt := &planner.stmt
 	shouldIncludeInLatencyMetrics := shouldIncludeStmtInLatencyMetrics(stmt)
@@ -198,12 +198,12 @@ func (ex *connExecutor) recordStatementSummary(
 		AutoRetryCount:       automaticRetryCount,
 		AutoRetryReason:      ex.state.mu.autoRetryReason,
 		RowsAffected:         rowsAffected,
-		IdleLatency:          idleLat,
-		ParseLatency:         parseLat,
-		PlanLatency:          planLat,
-		RunLatency:           runLat,
-		ServiceLatency:       svcLat,
-		OverheadLatency:      execOverhead,
+		IdleLatencySec:       idleLatSec,
+		ParseLatencySec:      parseLatSec,
+		PlanLatencySec:       planLatSec,
+		RunLatencySec:        runLatSec,
+		ServiceLatencySec:    svcLatSec,
+		OverheadLatencySec:   execOverheadSec,
 		BytesRead:            stats.bytesRead,
 		RowsRead:             stats.rowsRead,
 		RowsWritten:          stats.rowsWritten,
@@ -291,10 +291,10 @@ func (ex *connExecutor) recordStatementSummary(
 				"overhead %.2fµs (%.1f%%), "+
 				"session age %.4fs",
 			rowsAffected, automaticRetryCount,
-			parseLat*1e6, 100*parseLat/svcLat,
-			planLat*1e6, 100*planLat/svcLat,
-			runLat*1e6, 100*runLat/svcLat,
-			execOverhead*1e6, 100*execOverhead/svcLat,
+			parseLatSec*1e6, 100*parseLatSec/svcLatSec,
+			planLatSec*1e6, 100*planLatSec/svcLatSec,
+			runLatSec*1e6, 100*runLatSec/svcLatSec,
+			execOverheadSec*1e6, 100*execOverheadSec/svcLatSec,
 			sessionAge,
 		)
 	}

--- a/pkg/sql/sessionphase/session_phase.go
+++ b/pkg/sql/sessionphase/session_phase.go
@@ -234,10 +234,17 @@ func (t *Times) GetIdleLatency(previous *Times) time.Duration {
 	// of the previous execution.
 	waitingSince := previousQueryServiced
 
+	transactionStarted := t.times[SessionTransactionStarted]
+	// Transaction started is not set. Assume it's an implicit
+	// transaction so there is no idle time.
+	if transactionStarted.IsZero() {
+		return 0
+	}
+
 	// Although we really only want to measure idle latency *within*
 	// an open transaction. So if we're in a new transaction, measure
 	// from its start time instead.
-	if transactionStarted := t.times[SessionTransactionStarted]; transactionStarted.After(waitingSince) {
+	if transactionStarted.After(waitingSince) {
 		waitingSince = transactionStarted
 	}
 

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -652,6 +652,18 @@ func verifyInMemoryStatsCorrectness(
 			if tc.fingerprint == statistics.Key.Query {
 				require.Equal(t, tc.count, statistics.Stats.Count, "fingerprint: %s", tc.fingerprint)
 			}
+
+			// All the queries should be under 1 minute
+			require.Less(t, statistics.Stats.ServiceLat.Mean, 60.0)
+			require.Less(t, statistics.Stats.RunLat.Mean, 60.0)
+			require.Less(t, statistics.Stats.PlanLat.Mean, 60.0)
+			require.Less(t, statistics.Stats.ParseLat.Mean, 60.0)
+			require.Less(t, statistics.Stats.IdleLat.Mean, 60.0)
+			require.GreaterOrEqual(t, statistics.Stats.ServiceLat.Mean, 0.0)
+			require.GreaterOrEqual(t, statistics.Stats.RunLat.Mean, 0.0)
+			require.GreaterOrEqual(t, statistics.Stats.PlanLat.Mean, 0.0)
+			require.GreaterOrEqual(t, statistics.Stats.ParseLat.Mean, 0.0)
+			require.GreaterOrEqual(t, statistics.Stats.IdleLat.Mean, 0.0)
 			return nil
 		})
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -74,7 +74,7 @@ func (s *Container) RecordStatement(
 	// recorded we don't need to create an entry in the stmts map for it. We do
 	// still need stmtFingerprintID for transaction level metrics tracking.
 	t := sqlstats.StatsCollectionLatencyThreshold.Get(&s.st.SV)
-	if !sqlstats.StmtStatsEnable.Get(&s.st.SV) || (t > 0 && t.Seconds() >= value.ServiceLatency) {
+	if !sqlstats.StmtStatsEnable.Get(&s.st.SV) || (t > 0 && t.Seconds() >= value.ServiceLatencySec) {
 		createIfNonExistent = false
 	}
 
@@ -126,12 +126,12 @@ func (s *Container) RecordStatement(
 
 	stats.mu.data.SQLType = value.StatementType.String()
 	stats.mu.data.NumRows.Record(stats.mu.data.Count, float64(value.RowsAffected))
-	stats.mu.data.IdleLat.Record(stats.mu.data.Count, value.IdleLatency)
-	stats.mu.data.ParseLat.Record(stats.mu.data.Count, value.ParseLatency)
-	stats.mu.data.PlanLat.Record(stats.mu.data.Count, value.PlanLatency)
-	stats.mu.data.RunLat.Record(stats.mu.data.Count, value.RunLatency)
-	stats.mu.data.ServiceLat.Record(stats.mu.data.Count, value.ServiceLatency)
-	stats.mu.data.OverheadLat.Record(stats.mu.data.Count, value.OverheadLatency)
+	stats.mu.data.IdleLat.Record(stats.mu.data.Count, value.IdleLatencySec)
+	stats.mu.data.ParseLat.Record(stats.mu.data.Count, value.ParseLatencySec)
+	stats.mu.data.PlanLat.Record(stats.mu.data.Count, value.PlanLatencySec)
+	stats.mu.data.RunLat.Record(stats.mu.data.Count, value.RunLatencySec)
+	stats.mu.data.ServiceLat.Record(stats.mu.data.Count, value.ServiceLatencySec)
+	stats.mu.data.OverheadLat.Record(stats.mu.data.Count, value.OverheadLatencySec)
 	stats.mu.data.BytesRead.Record(stats.mu.data.Count, float64(value.BytesRead))
 	stats.mu.data.RowsRead.Record(stats.mu.data.Count, float64(value.RowsRead))
 	stats.mu.data.RowsWritten.Record(stats.mu.data.Count, float64(value.RowsWritten))
@@ -148,8 +148,8 @@ func (s *Container) RecordStatement(
 	// so there is no need to force a flush when retrieving the data during this step.
 	latencies := s.latencyInformation.GetPercentileValues(stmtFingerprintID, false)
 	latencyInfo := appstatspb.LatencyInfo{
-		Min: value.ServiceLatency,
-		Max: value.ServiceLatency,
+		Min: value.ServiceLatencySec,
+		Max: value.ServiceLatencySec,
 		P50: latencies.P50,
 		P90: latencies.P90,
 		P99: latencies.P99,
@@ -210,7 +210,7 @@ func (s *Container) RecordStatement(
 	s.insights.ObserveStatement(value.SessionID, &insights.Statement{
 		ID:                   value.StatementID,
 		FingerprintID:        stmtFingerprintID,
-		LatencyInSeconds:     value.ServiceLatency,
+		LatencyInSeconds:     value.ServiceLatencySec,
 		Query:                value.Query,
 		Status:               getStatus(value.StatementError),
 		StartTime:            value.StartTime,

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -199,12 +199,12 @@ type RecordedStmtStats struct {
 	AutoRetryCount       int
 	AutoRetryReason      error
 	RowsAffected         int
-	IdleLatency          float64
-	ParseLatency         float64
-	PlanLatency          float64
-	RunLatency           float64
-	ServiceLatency       float64
-	OverheadLatency      float64
+	IdleLatencySec       float64
+	ParseLatencySec      float64
+	PlanLatencySec       float64
+	RunLatencySec        float64
+	ServiceLatencySec    float64
+	OverheadLatencySec   float64
 	BytesRead            int64
 	RowsRead             int64
 	RowsWritten          int64


### PR DESCRIPTION
Previously internal query would show an idle time of 9 billion seconds. This is because conn_executor_exec.recordTransactionStart is not called for internal queries. This cause 
the time to be set to the default value.

This commit fixes this by adding a check to validate the transaction start time. If the 
transaction start time is zero it return the idle latency as 0.

Epic: none
Fixes: #102037

Release note (sql change): Fixes the idle latency for internal queries.