### PR TITLE
changefeedccl: improve cursor test 

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -72,6 +72,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -792,21 +793,23 @@ func TestChangefeedCursor(t *testing.T) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 
-		// To make sure that these timestamps are after 'before' and before
-		// 'after', throw a couple sleeps around them. We round timestamps to
-		// Microsecond granularity for Postgres compatibility, so make the
-		// sleeps 10x that.
+		// NB: The test server is a single node and the hlc clock is a
+		// singleton. Any transaction (ie. `INSERT INTO`) or call to
+		// s.Server.Clock().Now() will share this clock. Any read of the clock
+		// increments its current logical time. Thus, the operations below which
+		// happen in sequence will have strictly increasing logical timestamps.
 		beforeInsert := s.Server.Clock().Now()
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'before')`)
-		time.Sleep(10 * time.Microsecond)
+		insertTimestamp := s.Server.Clock().Now()
 
-		var tsLogical string
-		sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsLogical)
-		var tsClock time.Time
-		sqlDB.QueryRow(t, `SELECT clock_timestamp()`).Scan(&tsClock)
+		tsLogical := s.Server.Clock().Now()
+		tsClock := timeutil.FromUnixNanos(tsLogical.WallTime)
 
-		time.Sleep(10 * time.Microsecond)
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (2, 'after')`)
+
+		// Sanity check that operations happened in the expected order.
+		require.True(t, beforeInsert.Less(insertTimestamp) && insertTimestamp.Less(tsLogical) && tsLogical.Less(s.Server.Clock().Now()),
+			fmt.Sprintf("beforeInsert: %s, insertTimestamp: %s, tsLogical: %s", beforeInsert, insertTimestamp, tsLogical))
 
 		// The below function is currently used to test negative timestamp in cursor i.e of the form
 		// "-3us".
@@ -834,7 +837,7 @@ func TestChangefeedCursor(t *testing.T) {
 		// We do not need to override for the remaining cases
 		knobs.OverrideCursor = nil
 
-		fooLogical := feed(t, f, `CREATE CHANGEFEED FOR foo WITH cursor=$1`, tsLogical)
+		fooLogical := feed(t, f, `CREATE CHANGEFEED FOR foo WITH cursor=$1`, eval.TimestampToDecimalDatum(tsLogical).String())
 		defer closeFeed(t, fooLogical)
 		assertPayloads(t, fooLogical, []string{
 			`foo: [2]->{"after": {"a": 2, "b": "after"}}`,
@@ -863,7 +866,7 @@ func TestChangefeedCursor(t *testing.T) {
 				jobutils.InternalSystemJobsBaseQuery), e.JobID()).Scan(&bytes)
 			var payload jobspb.Payload
 			require.NoError(t, protoutil.Unmarshal(bytes, &payload))
-			require.Equal(t, parseTimeToHLC(t, tsLogical), payload.GetChangefeed().StatementTime)
+			require.Equal(t, tsLogical, payload.GetChangefeed().StatementTime)
 		}
 	}
 


### PR DESCRIPTION
The previous implementation of TestChangefeedCursor
relied on `SELECT clock_timestamp()` and `time.Sleep()`
which are not sufficient for testing changefeed cursors
that are used to navigate logical timestamps.
This change updates the test to rely on the server HLC.

The original failure observed in https://github.com/cockroachdb/cockroach/issues/103566
was that `assertPayloads` timed out. Although I could not
reproduce this, I suspected the most likely cause was
incorrect cursors.

This change also adds some assertions around timestamp
ordering along with an explanation.

Release note: None
Epic: None
Closes: https://github.com/cockroachdb/cockroach/issues/103566
