### PR TITLE
sql: show zone configuration for offline tables

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4363,7 +4363,7 @@ CREATE TABLE crdb_internal.zones (
 					continue
 				}
 			} else if zoneSpecifier.TableOrIndex.Table.ObjectName != "" {
-				tableEntry, err := p.LookupTableByID(ctx, descpb.ID(id))
+				tableEntry, err := p.Descriptors().ByID(p.txn).WithoutDropped().Get().Table(ctx, descpb.ID(id))
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Previously, SHOW ZONE CONFIGURATION would error
out if there were any importing tables. This,
could lead to a bad user experience. This patch,
displays the zone configuration for offline tables, which should still be valid.

Fixes: #100724

Release note: None