### PR TITLE
roachprod: only keep ssh verbose logs for potential flakes

### DIFF
--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -134,8 +134,11 @@ func newRemoteSession(l *logger.Logger, command *remoteCommand) *remoteSession {
 }
 
 func (s *remoteSession) errWithDebug(err error) error {
-	if err != nil && s.logfile != "" {
-		err = errors.Wrapf(err, "ssh verbose log retained in %s", filepath.Base(s.logfile))
+	err = rperrors.ClassifyCmdError(err)
+	// The verbose logs are noisy and not useful for most errors, so only
+	// retain them for potential flakes.
+	if errors.Is(err, rperrors.ErrSSH255) && s.logfile != "" {
+		err = errors.Wrap(err, "_potential_ SSH flake (`ssh -vvv` log retained under ssh/)")
 		s.logfile = "" // prevent removal on close
 	}
 	return err
@@ -157,7 +160,7 @@ func (s *remoteSession) CombinedOutput(ctx context.Context) ([]byte, error) {
 		s.Close()
 		return nil, ctx.Err()
 	case <-commandFinished:
-		return b, rperrors.ClassifyCmdError(err)
+		return b, err
 	}
 }
 
@@ -174,12 +177,12 @@ func (s *remoteSession) Run(ctx context.Context) error {
 		s.Close()
 		return ctx.Err()
 	case <-commandFinished:
-		return rperrors.ClassifyCmdError(err)
+		return err
 	}
 }
 
 func (s *remoteSession) Start() error {
-	return rperrors.ClassifyCmdError(s.errWithDebug(s.Cmd.Start()))
+	return s.errWithDebug(s.Cmd.Start())
 }
 
 func (s *remoteSession) SetStdin(r io.Reader) {


### PR DESCRIPTION
Previously SSH debug logs would be kept for all command errors over SSH, even though they rarely provide much additional value unless the error was due to an SSH flake.

This change keeps the logs  only for errors identified as potential flakes.

Epic: none
Fixes: #102184

Release note: None