### PR TITLE
resolver: avoid mutating TableName argument in ResolveMutableExistingTableObject

### DIFF
--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -141,7 +141,9 @@ func ResolveMutableExistingTableObject(
 	if err != nil || desc == nil {
 		return prefix, nil, err
 	}
-	tn.ObjectNamePrefix = prefix.NamePrefix()
+	if tn.ObjectNamePrefix.SchemaName == "" || tn.ObjectNamePrefix.CatalogName == "" {
+		tn.ObjectNamePrefix = prefix.NamePrefix()
+	}
 	return prefix, desc.(*tabledesc.Mutable), nil
 }
 


### PR DESCRIPTION
Sometimes a global variable is passed in for the table name, so there's no need to mutate that name each time.

Epic: None
Release note: None