### PR TITLE
ui: add link to enqueue range from range status

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/enqueueRange/index.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/enqueueRange/index.styl
@@ -12,3 +12,43 @@
 
 .enqueue-range-table
   @extend $table-base
+
+label
+  display flex
+
+.label-text
+  margin-right 5px
+  line-height 35px
+  font-family $font-family--bold
+
+.label-tooltip
+  margin-left 10px
+  line-height 35px
+  font-family $font-family--base
+  font-style italic
+
+.dropdown-area
+  width fit-content
+  height 35px
+
+.input-text
+  border 1px solid $colors--neutral-4
+  border-radius 3px
+  color $colors--neutral-6
+  padding-left 5px
+  font-family $font-family--base
+
+.checkbox-area
+  margin-top 11px
+
+.button-crl
+  font-family $font-family--semi-bold
+  height: 40px;
+  min-width: 40px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: $colors--primary-purple-3;
+  color: $colors--neutral-0;
+  border: solid 1px $colors--primary-purple-3;
+  border-radius 3px
+  cursor pointer

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/enqueueRange/index.tsx
@@ -18,6 +18,7 @@ import { cockroach } from "src/js/protos";
 import Print from "src/views/reports/containers/range/print";
 import "./index.styl";
 
+import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 import EnqueueRangeRequest = cockroach.server.serverpb.EnqueueRangeRequest;
 import EnqueueRangeResponse = cockroach.server.serverpb.EnqueueRangeResponse;
 import { BackToAdvanceDebug } from "src/views/reports/containers/util";
@@ -33,6 +34,10 @@ const QUEUES = [
   "consistencyChecker",
   "timeSeriesMaintenance",
 ];
+
+const queueOptions = QUEUES.map(q => {
+  return { value: q, label: q };
+});
 
 interface EnqueueRangeProps {
   handleEnqueueRange: (
@@ -52,22 +57,31 @@ interface EnqueueRangeState {
   error: Error;
 }
 
+export type EnqueueRangeAllProps = EnqueueRangeProps & RouteComponentProps;
+
 export class EnqueueRange extends React.Component<
-  EnqueueRangeProps & RouteComponentProps,
+  EnqueueRangeAllProps,
   EnqueueRangeState
 > {
-  state: EnqueueRangeState = {
-    queue: QUEUES[0],
-    rangeID: "",
-    nodeID: "",
-    skipShouldQueue: false,
-    response: null,
-    error: null,
-  };
+  constructor(props: EnqueueRangeAllProps) {
+    super(props);
+    const { history } = this.props;
+    const searchParams = new URLSearchParams(history.location.search);
+    const rangeID = searchParams.get("rangeID") || "";
 
-  handleUpdateQueue = (evt: React.FormEvent<{ value: string }>) => {
+    this.state = {
+      queue: QUEUES[0],
+      rangeID: rangeID,
+      nodeID: "",
+      skipShouldQueue: false,
+      response: null,
+      error: null,
+    };
+  }
+
+  handleUpdateQueue = (selectedOption: DropdownOption) => {
     this.setState({
-      queue: evt.currentTarget.value,
+      queue: selectedOption.value,
     });
   };
 
@@ -213,18 +227,18 @@ export class EnqueueRange extends React.Component<
                 method="post"
               >
                 <label>
-                  Queue:{" "}
-                  <select onChange={this.handleUpdateQueue}>
-                    {QUEUES.map(queue => (
-                      <option key={queue} value={queue}>
-                        {queue}
-                      </option>
-                    ))}
-                  </select>
+                  <span className={"label-text"}>Queue:</span>
+                  <Dropdown
+                    title=""
+                    options={queueOptions}
+                    selected={this.state.queue}
+                    onChange={this.handleUpdateQueue}
+                    className={"dropdown-area"}
+                  />
                 </label>
                 <br />
                 <label>
-                  RangeID:{" "}
+                  <span className={"label-text"}>RangeID:</span>
                   <input
                     type="number"
                     name="rangeID"
@@ -236,7 +250,7 @@ export class EnqueueRange extends React.Component<
                 </label>
                 <br />
                 <label>
-                  NodeID:{" "}
+                  <span className={"label-text"}>NodeID:</span>
                   <input
                     type="number"
                     name="nodeID"
@@ -245,14 +259,16 @@ export class EnqueueRange extends React.Component<
                     value={this.state.nodeID}
                     placeholder="NodeID (optional)"
                   />
-                  &nbsp;If not specified, we'll attempt to enqueue on all the
-                  nodes.
+                  <span className={"label-tooltip"}>
+                    If not specified, we'll attempt to enqueue on all the nodes.
+                  </span>
                 </label>
                 <br />
                 <label>
-                  SkipShouldQueue:{" "}
+                  <span className={"label-text"}>SkipShouldQueue:</span>
                   <input
                     type="checkbox"
+                    className="checkbox-area"
                     checked={this.state.skipShouldQueue}
                     name="skipShouldQueue"
                     onChange={() =>
@@ -263,7 +279,7 @@ export class EnqueueRange extends React.Component<
                   />
                 </label>
                 <br />
-                <input type="submit" className="submit-button" value="Submit" />
+                <input type="submit" className="button-crl" value="Submit" />
               </form>
             </div>
           </section>

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/index.tsx
@@ -192,6 +192,11 @@ export class Range extends React.Component<RangeProps, {}> {
         <h1 className="base-heading">
           Range Report for r{responseRangeID.toString()}
         </h1>
+        <a
+          href={`/#/debug/enqueue_range?rangeID=${responseRangeID.toString()}`}
+        >
+          Enqueue Range
+        </a>
         <RangeTable infos={infos} replicas={replicas} />
         <LeaseTable info={_.head(infos)} />
         <ConnectionsTable range={range} />


### PR DESCRIPTION
Fixes #79315

A common flow during debug was to open the range
status page to a specific node, then navigating
to the enqueue range page and filling the same node id. This commit makes it possible to jump to the second page with the field for range id already selected.
This commit also updates the styles used on the
Enqueue Range pages to match other styles in other pages.

https://www.loom.com/share/9c2b3547fdfb4daaba3d8f9cda7e035e

Release note (ui change): New link added on Range Status page that opens the Enqueue Ranges page with the node id already filled in.