### PR TITLE
release-22.1: delegate: handle mixed-case in SHOW DEFAULT PRIVILEGES

### DIFF
--- a/pkg/sql/delegate/show_default_privileges.go
+++ b/pkg/sql/delegate/show_default_privileges.go
@@ -31,19 +31,19 @@ func (d *delegator) delegateShowDefaultPrivileges(
 
 	schemaClause := " AND schema_name IS NULL"
 	if n.Schema != "" {
-		schemaClause = fmt.Sprintf(" AND schema_name = %s", lexbase.EscapeSQLString(n.Schema.String()))
+		schemaClause = fmt.Sprintf(" AND schema_name = %s", lexbase.EscapeSQLString(string(n.Schema)))
 	}
 
 	query := fmt.Sprintf(
 		"SELECT role, for_all_roles, object_type, grantee, privilege_type FROM crdb_internal.default_privileges WHERE database_name = %s%s",
-		lexbase.EscapeSQLString(currentDatabase.Normalize()),
+		lexbase.EscapeSQLString(string(currentDatabase)),
 		schemaClause,
 	)
 	if d.evalCtx.Settings.Version.IsActive(d.ctx, clusterversion.ValidateGrantOption) {
 		query = fmt.Sprintf(
 			"SELECT role, for_all_roles, object_type, grantee, privilege_type, is_grantable "+
 				"FROM crdb_internal.default_privileges WHERE database_name = %s%s",
-			lexbase.EscapeSQLString(currentDatabase.Normalize()),
+			lexbase.EscapeSQLString(string(currentDatabase)),
 			schemaClause,
 		)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/show_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/show_default_privileges
@@ -265,3 +265,32 @@ NULL  true  tables  foo     DROP        true
 NULL  true  tables  foo     GRANT       true
 NULL  true  tables  foo     ZONECONFIG  true
 NULL  true  types   public  USAGE       false
+
+statement ok
+CREATE DATABASE "MixedCaseDB"
+
+statement ok
+CREATE SCHEMA "MixedCaseDB"."MixedCaseSchema"
+
+statement ok
+USE "MixedCaseDB"
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA "MixedCaseSchema" GRANT SELECT ON TABLES TO foo WITH GRANT OPTION
+
+query TBTTTB colnames
+SHOW DEFAULT PRIVILEGES
+----
+role  for_all_roles  object_type  grantee  privilege_type  is_grantable
+root  false          schemas      root     ALL             true
+root  false          sequences    root     ALL             true
+root  false          tables       root     ALL             true
+root  false          types        public   USAGE           false
+root  false          types        root     ALL             true
+
+
+query TBTTTB colnames
+SHOW DEFAULT PRIVILEGES IN SCHEMA "MixedCaseSchema"
+----
+role  for_all_roles  object_type  grantee  privilege_type  is_grantable
+root  false          tables       foo      SELECT          true


### PR DESCRIPTION
Backport 1/1 commits from #103906.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/103902

Release note (bug fix): Fixed a bug where SHOW DEFAULT PRIVILEGES did not work correctly if the database name or schema name being inspected had upper-case or special characters.
