### PR TITLE
release: fix commit message

### DIFF
--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -519,7 +519,7 @@ func hasVersionTxt(version *semver.Version) bool {
 func updateCommitMessage(released, next *semver.Version) string {
 	var nextVersionMsg string
 	if hasVersionTxt(released) {
-		nextVersionMsg = ". Next version: %s" + next.String()
+		nextVersionMsg = ". Next version: " + next.String()
 	}
 	return fmt.Sprintf(commitTemplate, released, nextVersionMsg)
 }


### PR DESCRIPTION
This removes an unused `%s` from the commit message string.

Epic: none
Release note: None