### PR TITLE
kvclient: add x-region, x-zone metrics to DistSender

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -13,6 +13,7 @@ package kvcoord
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"runtime"
 	"runtime/pprof"
 	"strings"
@@ -62,6 +63,54 @@ var (
 		Help:        "Number of partial batches processed after being divided on range boundaries",
 		Measurement: "Partial Batches",
 		Unit:        metric.Unit_COUNT,
+	}
+	metaDistSenderReplicaAddressedBatchRequestBytes = metric.Metadata{
+		Name:        "distsender.batch_requests.replica_addressed.bytes",
+		Help:        `Total byte count of replica-addressed batch requests processed`,
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	metaDistSenderReplicaAddressedBatchResponseBytes = metric.Metadata{
+		Name:        "distsender.batch_responses.replica_addressed.bytes",
+		Help:        `Total byte count of replica-addressed batch responses received`,
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	metaDistSenderCrossRegionBatchRequestBytes = metric.Metadata{
+		Name: "distsender.batch_requests.cross_region.bytes",
+		Help: `Total byte count of replica-addressed batch requests processed cross
+		region when region tiers are configured`,
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	metaDistSenderCrossRegionBatchResponseBytes = metric.Metadata{
+		Name: "distsender.batch_responses.cross_region.bytes",
+		Help: `Total byte count of replica-addressed batch responses received cross
+		region when region tiers are configured`,
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	metaDistSenderCrossZoneBatchRequestBytes = metric.Metadata{
+		Name: "distsender.batch_requests.cross_zone.bytes",
+		Help: `Total byte count of replica-addressed batch requests processed cross
+		zone within the same region when region and zone tiers are configured.
+		However, if the region tiers are not configured, this count may also include
+		batch data sent between different regions. Ensuring consistent configuration
+		of region and zone tiers across nodes helps to accurately monitor the data
+		transmitted.`,
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	metaDistSenderCrossZoneBatchResponseBytes = metric.Metadata{
+		Name: "distsender.batch_responses.cross_zone.bytes",
+		Help: `Total byte count of replica-addressed batch responses received cross
+		zone within the same region when region and zone tiers are configured.
+		However, if the region tiers are not configured, this count may also include
+		batch data received between different regions. Ensuring consistent
+		configuration of region and zone tiers across nodes helps to accurately
+		monitor the data transmitted.`,
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
 	}
 	metaDistSenderAsyncSentCount = metric.Metadata{
 		Name:        "distsender.batches.async.sent",
@@ -241,44 +290,56 @@ func max(a, b int64) int64 {
 
 // DistSenderMetrics is the set of metrics for a given distributed sender.
 type DistSenderMetrics struct {
-	BatchCount              *metric.Counter
-	PartialBatchCount       *metric.Counter
-	AsyncSentCount          *metric.Counter
-	AsyncThrottledCount     *metric.Counter
-	SentCount               *metric.Counter
-	LocalSentCount          *metric.Counter
-	NextReplicaErrCount     *metric.Counter
-	NotLeaseHolderErrCount  *metric.Counter
-	InLeaseTransferBackoffs *metric.Counter
-	RangeLookups            *metric.Counter
-	SlowRPCs                *metric.Gauge
-	RangefeedRanges         *metric.Gauge
-	RangefeedCatchupRanges  *metric.Gauge
-	RangefeedErrorCatchup   *metric.Counter
-	RangefeedRestartRanges  *metric.Counter
-	RangefeedRestartStuck   *metric.Counter
-	MethodCounts            [kvpb.NumMethods]*metric.Counter
-	ErrCounts               [kvpb.NumErrors]*metric.Counter
+	BatchCount                         *metric.Counter
+	PartialBatchCount                  *metric.Counter
+	ReplicaAddressedBatchRequestBytes  *metric.Counter
+	ReplicaAddressedBatchResponseBytes *metric.Counter
+	CrossRegionBatchRequestBytes       *metric.Counter
+	CrossRegionBatchResponseBytes      *metric.Counter
+	CrossZoneBatchRequestBytes         *metric.Counter
+	CrossZoneBatchResponseBytes        *metric.Counter
+	AsyncSentCount                     *metric.Counter
+	AsyncThrottledCount                *metric.Counter
+	SentCount                          *metric.Counter
+	LocalSentCount                     *metric.Counter
+	NextReplicaErrCount                *metric.Counter
+	NotLeaseHolderErrCount             *metric.Counter
+	InLeaseTransferBackoffs            *metric.Counter
+	RangeLookups                       *metric.Counter
+	SlowRPCs                           *metric.Gauge
+	RangefeedRanges                    *metric.Gauge
+	RangefeedCatchupRanges             *metric.Gauge
+	RangefeedErrorCatchup              *metric.Counter
+	RangefeedRestartRanges             *metric.Counter
+	RangefeedRestartStuck              *metric.Counter
+	MethodCounts                       [kvpb.NumMethods]*metric.Counter
+	ErrCounts                          [kvpb.NumErrors]*metric.Counter
 }
 
 func makeDistSenderMetrics() DistSenderMetrics {
 	m := DistSenderMetrics{
-		BatchCount:              metric.NewCounter(metaDistSenderBatchCount),
-		PartialBatchCount:       metric.NewCounter(metaDistSenderPartialBatchCount),
-		AsyncSentCount:          metric.NewCounter(metaDistSenderAsyncSentCount),
-		AsyncThrottledCount:     metric.NewCounter(metaDistSenderAsyncThrottledCount),
-		SentCount:               metric.NewCounter(metaTransportSentCount),
-		LocalSentCount:          metric.NewCounter(metaTransportLocalSentCount),
-		NextReplicaErrCount:     metric.NewCounter(metaTransportSenderNextReplicaErrCount),
-		NotLeaseHolderErrCount:  metric.NewCounter(metaDistSenderNotLeaseHolderErrCount),
-		InLeaseTransferBackoffs: metric.NewCounter(metaDistSenderInLeaseTransferBackoffsCount),
-		RangeLookups:            metric.NewCounter(metaDistSenderRangeLookups),
-		SlowRPCs:                metric.NewGauge(metaDistSenderSlowRPCs),
-		RangefeedRanges:         metric.NewGauge(metaDistSenderRangefeedTotalRanges),
-		RangefeedCatchupRanges:  metric.NewGauge(metaDistSenderRangefeedCatchupRanges),
-		RangefeedErrorCatchup:   metric.NewCounter(metaDistSenderRangefeedErrorCatchupRanges),
-		RangefeedRestartRanges:  metric.NewCounter(metaDistSenderRangefeedRestartRanges),
-		RangefeedRestartStuck:   metric.NewCounter(metaDistSenderRangefeedRestartStuck),
+		BatchCount:                         metric.NewCounter(metaDistSenderBatchCount),
+		PartialBatchCount:                  metric.NewCounter(metaDistSenderPartialBatchCount),
+		AsyncSentCount:                     metric.NewCounter(metaDistSenderAsyncSentCount),
+		AsyncThrottledCount:                metric.NewCounter(metaDistSenderAsyncThrottledCount),
+		SentCount:                          metric.NewCounter(metaTransportSentCount),
+		LocalSentCount:                     metric.NewCounter(metaTransportLocalSentCount),
+		ReplicaAddressedBatchRequestBytes:  metric.NewCounter(metaDistSenderReplicaAddressedBatchRequestBytes),
+		ReplicaAddressedBatchResponseBytes: metric.NewCounter(metaDistSenderReplicaAddressedBatchResponseBytes),
+		CrossRegionBatchRequestBytes:       metric.NewCounter(metaDistSenderCrossRegionBatchRequestBytes),
+		CrossRegionBatchResponseBytes:      metric.NewCounter(metaDistSenderCrossRegionBatchResponseBytes),
+		CrossZoneBatchRequestBytes:         metric.NewCounter(metaDistSenderCrossZoneBatchRequestBytes),
+		CrossZoneBatchResponseBytes:        metric.NewCounter(metaDistSenderCrossZoneBatchResponseBytes),
+		NextReplicaErrCount:                metric.NewCounter(metaTransportSenderNextReplicaErrCount),
+		NotLeaseHolderErrCount:             metric.NewCounter(metaDistSenderNotLeaseHolderErrCount),
+		InLeaseTransferBackoffs:            metric.NewCounter(metaDistSenderInLeaseTransferBackoffsCount),
+		RangeLookups:                       metric.NewCounter(metaDistSenderRangeLookups),
+		SlowRPCs:                           metric.NewGauge(metaDistSenderSlowRPCs),
+		RangefeedRanges:                    metric.NewGauge(metaDistSenderRangefeedTotalRanges),
+		RangefeedCatchupRanges:             metric.NewGauge(metaDistSenderRangefeedCatchupRanges),
+		RangefeedErrorCatchup:              metric.NewCounter(metaDistSenderRangefeedErrorCatchupRanges),
+		RangefeedRestartRanges:             metric.NewCounter(metaDistSenderRangefeedRestartRanges),
+		RangefeedRestartStuck:              metric.NewCounter(metaDistSenderRangefeedRestartStuck),
 	}
 	for i := range m.MethodCounts {
 		method := kvpb.Method(i).String()
@@ -295,6 +356,43 @@ func makeDistSenderMetrics() DistSenderMetrics {
 		m.ErrCounts[i] = metric.NewCounter(meta)
 	}
 	return m
+}
+
+// getDistSenderCounterMetrics fetches the count of each specified DisSender
+// metric from the `metricNames` parameter and returns the result as a map. The
+// keys in the map represent the metric metadata names, while the corresponding
+// values indicate the count of each metric. If any of the specified metric
+// cannot be found or is not a counter, the function will return an error.
+//
+// Assumption: 1. The metricNames parameter should consist of string literals
+// that match the metadata names used for metric counters. 2. Each metric name
+// provided in `metricNames` must exist, unique and be a counter type.
+func (dm *DistSenderMetrics) getDistSenderCounterMetrics(
+	metricsName []string,
+) (map[string]int64, error) {
+	metricCountMap := make(map[string]int64)
+	getFirstDistSenderMetric := func(metricName string) int64 {
+		metricsStruct := reflect.ValueOf(*dm)
+		for i := 0; i < metricsStruct.NumField(); i++ {
+			field := metricsStruct.Field(i)
+			switch t := field.Interface().(type) {
+			case *metric.Counter:
+				if t.Name == metricName {
+					return t.Count()
+				}
+			}
+		}
+		return -1
+	}
+
+	for _, metricName := range metricsName {
+		count := getFirstDistSenderMetric(metricName)
+		if count == -1 {
+			return map[string]int64{}, errors.Errorf("cannot find metric for %s", metricName)
+		}
+		metricCountMap[metricName] = count
+	}
+	return metricCountMap, nil
 }
 
 // FirstRangeProvider is capable of providing DistSender with the descriptor of
@@ -366,6 +464,14 @@ type DistSender struct {
 	latencyFunc LatencyFunc
 
 	onRangeSpanningNonTxnalBatch func(ba *kvpb.BatchRequest) *kvpb.Error
+
+	// BatchRequestInterceptor intercepts DistSender.Send() to pass the actual
+	// batch request byte count to the test.
+	BatchRequestInterceptor func(ba *kvpb.BatchRequest)
+
+	// BatchRequestInterceptor intercepts DistSender.Send() to pass the actual
+	// batch response byte count to the test.
+	BatchResponseInterceptor func(br *kvpb.BatchResponse)
 
 	// locality is the description of the topography of the server on which the
 	// DistSender is running. It is used to estimate the latency to other nodes
@@ -520,8 +626,12 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 		ds.latencyFunc = ds.rpcContext.RemoteClocks.Latency
 	}
 
-	if cfg.TestingKnobs.OnRangeSpanningNonTxnalBatch != nil {
-		ds.onRangeSpanningNonTxnalBatch = cfg.TestingKnobs.OnRangeSpanningNonTxnalBatch
+	if cfg.TestingKnobs.BatchRequestInterceptor != nil {
+		ds.BatchRequestInterceptor = cfg.TestingKnobs.BatchRequestInterceptor
+	}
+
+	if cfg.TestingKnobs.BatchResponseInterceptor != nil {
+		ds.BatchResponseInterceptor = cfg.TestingKnobs.BatchResponseInterceptor
 	}
 
 	return ds
@@ -2178,7 +2288,16 @@ func (ds *DistSender) sendToReplicas(
 			ExplicitlyRequested: ba.ClientRangeInfo.ExplicitlyRequested ||
 				(desc.Generation == 0 && routing.LeaseSeq() == 0),
 		}
+
+		if ds.BatchRequestInterceptor != nil {
+			ds.BatchRequestInterceptor(ba)
+		}
+		shouldIncCrossRegion, shouldIncCrossZone := ds.checkAndUpdateBatchRequestMetrics(ctx, ba)
 		br, err = transport.SendNext(ctx, ba)
+		if ds.BatchResponseInterceptor != nil {
+			ds.BatchResponseInterceptor(br)
+		}
+		ds.checkAndUpdateBatchResponseMetrics(br, shouldIncCrossRegion, shouldIncCrossZone)
 		ds.maybeIncrementErrCounters(br, err)
 
 		if err != nil {
@@ -2431,6 +2550,75 @@ func (ds *DistSender) sendToReplicas(
 			log.Eventf(ctx, "%v", err)
 			return nil, err
 		}
+	}
+}
+
+// isCrossRegionCrossZoneBatch returns (bool, bool) - indicating if the given
+// batch request is cross-region and cross-zone respectively.
+func (ds *DistSender) isCrossRegionCrossZoneBatch(
+	ctx context.Context, ba *kvpb.BatchRequest,
+) (bool, bool) {
+	gatewayNodeDesc, err := ds.nodeDescs.GetNodeDescriptor(ba.GatewayNodeID)
+	if err != nil {
+		log.VEventf(ctx, 2, "failed to perform look up for node descriptor %s", err)
+		return false, false
+	}
+	destinationNodeDesc, err := ds.nodeDescs.GetNodeDescriptor(ba.Replica.NodeID)
+	if err != nil {
+		log.VEventf(ctx, 2, "failed to perform look up for node descriptor %s", err)
+		return false, false
+	}
+	isCrossRegion, regionErr, isCrossZone, zoneErr := gatewayNodeDesc.Locality.IsCrossRegionCrossZone(destinationNodeDesc.Locality)
+	if regionErr != nil {
+		log.VEventf(ctx, 2, "%v", regionErr)
+	}
+	if zoneErr != nil {
+		log.VEventf(ctx, 2, "%v", zoneErr)
+	}
+	return isCrossRegion, isCrossZone
+}
+
+// checkAndUpdateBatchRequestMetrics updates the batch requests metrics in a
+// more meaningful way. Cross-region metrics monitor activities across different
+// regions. Cross-zone metrics monitor cross-zone activities within the same
+// region or in cases where region tiers are not configured. The check result is
+// returned here to avoid redundant check for metrics updates after receiving
+// batch responses.
+func (ds *DistSender) checkAndUpdateBatchRequestMetrics(
+	ctx context.Context, ba *kvpb.BatchRequest,
+) (shouldIncCrossRegion bool, shouldIncCrossZone bool) {
+	ds.metrics.ReplicaAddressedBatchRequestBytes.Inc(int64(ba.Size()))
+	isCrossRegion, isCrossZone := ds.isCrossRegionCrossZoneBatch(ctx, ba)
+	if isCrossRegion {
+		if !isCrossZone {
+			log.VEventf(ctx, 2, "unexpected: cross region but same zone")
+		} else {
+			ds.metrics.CrossRegionBatchRequestBytes.Inc(int64(ba.Size()))
+			shouldIncCrossRegion = true
+		}
+	} else {
+		if isCrossZone {
+			ds.metrics.CrossZoneBatchRequestBytes.Inc(int64(ba.Size()))
+			shouldIncCrossZone = true
+		}
+	}
+	return shouldIncCrossRegion, shouldIncCrossZone
+}
+
+// checkAndUpdateBatchResponseMetrics updates the batch response metrics based
+// on the shouldIncCrossRegion and shouldIncCrossZone parameters. These
+// parameters are determined during the initial check for batch requests. The
+// underlying assumption is that if requests were cross-region or cross-zone,
+// the response should be as well.
+func (ds *DistSender) checkAndUpdateBatchResponseMetrics(
+	br *kvpb.BatchResponse, shouldIncCrossRegion bool, shouldIncCrossZone bool,
+) {
+	ds.metrics.ReplicaAddressedBatchResponseBytes.Inc(int64(br.Size()))
+	if shouldIncCrossRegion {
+		ds.metrics.CrossRegionBatchResponseBytes.Inc(int64(br.Size()))
+	}
+	if shouldIncCrossZone {
+		ds.metrics.CrossZoneBatchResponseBytes.Inc(int64(br.Size()))
 	}
 }
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -5651,6 +5651,203 @@ func TestDistSenderRPCMetrics(t *testing.T) {
 	require.Equal(t, ds.metrics.ErrCounts[kvpb.ConditionFailedErrType].Count(), int64(1))
 }
 
+// getMapsDiff returns the difference between the values of corresponding
+// metrics in two maps. Assumption: beforeMap and afterMap contain the same set
+// of keys.
+func getMapsDiff(beforeMap map[string]int64, afterMap map[string]int64) map[string]int64 {
+	diffMap := make(map[string]int64)
+	for metricName, beforeValue := range beforeMap {
+		if v, ok := afterMap[metricName]; ok {
+			diffMap[metricName] = v - beforeValue
+		}
+	}
+	return diffMap
+}
+
+// TestDistSenderBatchMetrics verifies that the DistSender.Send()
+// correctly updates the cross-region, cross-zone byte count metrics.
+func TestDistSenderBatchMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	// The initial setup ensures the correct setup for three nodes (with different
+	// localities), single-range, three replicas (on different nodes).
+	clock := hlc.NewClockForTesting(nil)
+	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
+	rangeDesc := testUserRangeDescriptor3Replicas
+	replicas := rangeDesc.InternalReplicas
+
+	// The servers localities are configured so that the first batch request sent
+	// from server0 to server0 is same-region, same-zone. The second batch request
+	// sent from server0 to server1 is cross-region. The second batch request sent
+	// from server0 to server2 is cross-zone within the same region.
+	const numNodes = 3
+	serverLocality := [numNodes]roachpb.Locality{
+		{Tiers: []roachpb.Tier{{Key: "region", Value: "us-east"}, {Key: "az", Value: "us-east-1"}}},
+		{Tiers: []roachpb.Tier{{Key: "region", Value: "us-west"}, {Key: "az", Value: "us-west-1"}}},
+		{Tiers: []roachpb.Tier{{Key: "region", Value: "us-east"}, {Key: "az", Value: "us-east-2"}}},
+	}
+
+	nodes := make([]roachpb.NodeDescriptor, 3)
+	for i := 0; i < numNodes; i++ {
+		nodes[i] = roachpb.NodeDescriptor{
+			NodeID:   roachpb.NodeID(i + 1 /* 0 is not a valid NodeID */),
+			Address:  util.UnresolvedAddr{},
+			Locality: serverLocality[i],
+		}
+	}
+	ns := &mockNodeStore{nodes: nodes}
+
+	var transportFn = func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
+		return ba.CreateReply(), nil
+	}
+	interceptedBatchRequestBytes, interceptedBatchResponseBytes := int64(-1), int64(-1)
+	cfg := DistSenderConfig{
+		AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
+		Clock:             clock,
+		NodeDescs:         ns,
+		RPCContext:        rpcContext,
+		RangeDescriptorDB: mockRangeDescriptorDBForDescs(rangeDesc),
+		TestingKnobs: ClientTestingKnobs{
+			TransportFactory: adaptSimpleTransport(transportFn),
+			BatchRequestInterceptor: func(ba *kvpb.BatchRequest) {
+				interceptedBatchRequestBytes = int64(ba.Size())
+			},
+			BatchResponseInterceptor: func(br *kvpb.BatchResponse) {
+				interceptedBatchResponseBytes = int64(br.Size())
+			},
+		},
+		Settings: cluster.MakeTestingClusterSettings(),
+	}
+
+	distSender := NewDistSender(cfg)
+	metricsNames := []string{
+		"distsender.batch_requests.replica_addressed.bytes",
+		"distsender.batch_responses.replica_addressed.bytes",
+		"distsender.batch_requests.cross_region.bytes",
+		"distsender.batch_responses.cross_region.bytes",
+		"distsender.batch_requests.cross_zone.bytes",
+		"distsender.batch_responses.cross_zone.bytes"}
+
+	getExpectedDelta := func(
+		isCrossRegion bool, isCrossZone bool, interceptedRequest int64, interceptedResponse int64,
+	) map[string]int64 {
+		ternaryOp := func(b bool, num int64) (res int64) {
+			if b {
+				res = num
+			}
+			return res
+		}
+
+		expectedDelta := make(map[string]int64)
+		expectedDelta[metricsNames[0]] = interceptedRequest
+		expectedDelta[metricsNames[1]] = interceptedResponse
+		expectedDelta[metricsNames[2]] = ternaryOp(isCrossRegion, interceptedRequest)
+		expectedDelta[metricsNames[3]] = ternaryOp(isCrossRegion, interceptedResponse)
+		expectedDelta[metricsNames[4]] = ternaryOp(isCrossZone, interceptedRequest)
+		expectedDelta[metricsNames[5]] = ternaryOp(isCrossZone, interceptedResponse)
+		return expectedDelta
+	}
+
+	sameRegionSameZoneRequest := int64(0)
+	sameRegionSameZoneResponse := int64(0)
+
+	for _, tc := range []struct {
+		toReplica     int
+		isCrossRegion bool
+		isCrossZone   bool
+	}{
+		// First test sets replica[0] as leaseholder, enforcing a within-region,
+		// within-zone batch request / response.
+		{toReplica: 0, isCrossRegion: false, isCrossZone: false},
+		// Second test sets replica[1] as leaseholder, enforcing a cross-region,
+		// batch request / response. Note that although the request is cross-zone,
+		// the cross-zone metrics is not expected to increment.
+		{toReplica: 1, isCrossRegion: true, isCrossZone: false},
+		// Third test sets replica[2] as leaseholder, enforcing a within-region,
+		// cross-zone batch request / response. Cross-zone metrics is only expected
+		// to increment when it is cross-zone, same-region activities.
+		{toReplica: 2, isCrossRegion: false, isCrossZone: true},
+	} {
+		t.Run(fmt.Sprintf("isCrossRegion:%t-isCrossZone:%t", tc.isCrossRegion, tc.isCrossZone), func(t *testing.T) {
+			beforeMetrics, err := distSender.metrics.getDistSenderCounterMetrics(metricsNames)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ba := &kvpb.BatchRequest{}
+			if tc.toReplica == 0 {
+				// Send a different request type for the first request to avoid having
+				// the same byte count for three requests and coincidental correct
+				// results.
+				get := &kvpb.GetRequest{}
+				get.Key = rangeDesc.StartKey.AsRawKey()
+				ba.Add(get)
+			} else {
+				put := &kvpb.PutRequest{}
+				put.Key = rangeDesc.StartKey.AsRawKey()
+				ba.Add(put)
+			}
+
+			ba.Header = kvpb.Header{
+				// DistSender is set to be at the server0.
+				GatewayNodeID: 1,
+			}
+			distSender.rangeCache.Insert(ctx, roachpb.RangeInfo{
+				Desc: rangeDesc,
+				Lease: roachpb.Lease{
+					Replica: replicas[tc.toReplica],
+				},
+			})
+
+			if _, err := distSender.Send(ctx, ba); err != nil {
+				t.Fatal(err)
+			}
+
+			require.NotEqual(t, interceptedBatchRequestBytes, int64(-1),
+				"expected bytes not set correctly")
+			require.NotEqual(t, interceptedBatchResponseBytes, int64(-1),
+				"expected bytes not set correctly")
+			if tc.toReplica == 0 {
+				// Record the first batch request and response that was sent same
+				// region, same zone for future testing.
+				sameRegionSameZoneRequest = interceptedBatchRequestBytes
+				sameRegionSameZoneResponse = interceptedBatchResponseBytes
+			}
+
+			expected := getExpectedDelta(tc.isCrossRegion, tc.isCrossZone,
+				interceptedBatchRequestBytes, interceptedBatchResponseBytes)
+			afterMetrics, err := distSender.metrics.getDistSenderCounterMetrics(metricsNames)
+			diffMetrics := getMapsDiff(beforeMetrics, afterMetrics)
+			if err != nil {
+				t.Error(err)
+			}
+			require.Equal(t, expected, diffMetrics)
+		})
+		t.Run("SameRegionSameZone", func(t *testing.T) {
+			// Since the region and zone tiers are all configured in this test, we
+			// expect that the byte count of batch requests sent within the same
+			// region and same zone should equal to the total byte count of requests
+			// minus the combined byte count of cross-region and cross-zone requests
+			// metrics. Similar expectation for batch responses.
+			metrics, err := distSender.metrics.getDistSenderCounterMetrics(metricsNames)
+			if err != nil {
+				t.Error(err)
+			}
+			totalRequest := metrics["distsender.batch_requests.replica_addressed.bytes"]
+			totalResponse := metrics["distsender.batch_responses.replica_addressed.bytes"]
+			crossRegionRequest := metrics["distsender.batch_requests.cross_region.bytes"]
+			crossRegionResponse := metrics["distsender.batch_responses.cross_region.bytes"]
+			crossZoneRequest := metrics["distsender.batch_requests.cross_zone.bytes"]
+			crossZoneResponse := metrics["distsender.batch_responses.cross_zone.bytes"]
+			require.Equal(t, sameRegionSameZoneRequest, totalRequest-crossRegionRequest-crossZoneRequest)
+			require.Equal(t, sameRegionSameZoneResponse, totalResponse-crossRegionResponse-crossZoneResponse)
+		})
+	}
+}
+
 // TestDistSenderNLHEFromUninitializedReplicaDoesNotCauseUnboundedBackoff
 // ensures that a NLHE from an uninitialized replica, which points to a replica
 // that isn't part of the range, doesn't result in the dist sender getting

--- a/pkg/kv/kvclient/kvcoord/testing_knobs.go
+++ b/pkg/kv/kvclient/kvcoord/testing_knobs.go
@@ -61,6 +61,19 @@ type ClientTestingKnobs struct {
 	// error which, if non-nil, becomes the result of the batch. Otherwise, execution
 	// continues.
 	OnRangeSpanningNonTxnalBatch func(ba *kvpb.BatchRequest) *kvpb.Error
+
+	// Currently, BatchRequestInterceptor and BatchResponseInterceptor only
+	// intercepts DistSender.Send() to pass the actual batch request and response
+	// byte count to the test. However, it can be easily extended to validate
+	// other properties of batch requests / response if required.
+
+	// BatchRequestInterceptor is designed to intercept calls to DistSender
+	// function calls to validate BatchRequest properties.
+	BatchRequestInterceptor func(ba *kvpb.BatchRequest)
+
+	// BatchResponseInterceptor is designed to intercept calls to DistSender
+	// function calls to validate BatchResponse properties.
+	BatchResponseInterceptor func(br *kvpb.BatchResponse)
 }
 
 var _ base.ModuleTestingKnobs = &ClientTestingKnobs{}


### PR DESCRIPTION
Previously, there were no metrics to observe cross-region, cross-zone traffic in
batch requests / responses at DistSender.

To improve this issue, this commit introduces six new distsender metrics -
```
"distsender.batch_requests.replica_addressed.bytes"
"distsender.batch_responses.replica_addressed.bytes"
"distsender.batch_requests.cross_region.bytes"
"distsender.batch_responses.cross_region.bytes"
"distsender.batch_requests.cross_zone.bytes"
"distsender.batch_responses.cross_zone.bytes"
```

The first two metrics track the total byte count of batch requests processed and
batch responses received at DistSender. Additionally, there are four metrics to
track the aggregate counts processed and received across different regions and
zones. Note that these metrics only track the sender node and not the receiver
node as DistSender resides on the gateway node receiving SQL queries.

Part of: https://github.com/cockroachdb/cockroach/issues/103983

Release note (ops change): Six new metrics -
"distsender.batch_requests.replica_addressed.bytes",
"distsender.batch_responses.replica_addressed.bytes",
"distsender.batch_requests.cross_region.bytes",
"distsender.batch_responses.cross_region.bytes",
"distsender.batch_requests.cross_zone.bytes",
"distsender.batch_responses.cross_zone.bytes"- are now added to DistSender 
metrics.

For accurate metrics, follow these assumptions:
- Configure region and zone tier keys consistently across nodes.
- Within a node locality, ensure unique region and zone tier keys.
- Maintain consistent configuration of region and zone tiers across nodes.