### PR TITLE
backupccl: speed up full cluster backup/restore tests

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -134,10 +134,14 @@ CREATE TABLE data2.foo (a int);
 	if util.RaceEnabled {
 		numUsers = 10
 	}
+
+	sqlDB.Exec(t, "BEGIN")
 	for i := 0; i < numUsers; i++ {
 		sqlDB.Exec(t, fmt.Sprintf("CREATE USER maxroach%d", i))
 		sqlDB.Exec(t, fmt.Sprintf("ALTER USER maxroach%d CREATEDB", i))
 	}
+	sqlDB.Exec(t, "COMMIT")
+
 	// Populate system.zones.
 	sqlDB.Exec(t, `ALTER TABLE data.bank CONFIGURE ZONE USING gc.ttlseconds = 3600`)
 	sqlDB.Exec(t, `ALTER TABLE defaultdb.foo CONFIGURE ZONE USING gc.ttlseconds = 45`)
@@ -620,10 +624,11 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 
 	// Setup the system systemTablesToVerify to ensure that they are copied to the new cluster.
 	// Populate system.users.
+	sqlDB.Exec(t, "BEGIN")
 	for i := 0; i < 1000; i++ {
 		sqlDB.Exec(t, fmt.Sprintf("CREATE USER maxroach%d", i))
 	}
-
+	sqlDB.Exec(t, "COMMIT")
 	sqlDB.Exec(t, `BACKUP TO 'nodelocal://1/missing-ssts'`)
 
 	// Bugger the backup by removing the SST files. (Note this messes up all of
@@ -1078,7 +1083,7 @@ func TestRestoreWithRecreatedDefaultDB(t *testing.T) {
 
 	sqlDB.Exec(t, `
 DROP DATABASE defaultdb;
-CREATE DATABASE defaultdb; 
+CREATE DATABASE defaultdb;
 `)
 	sqlDB.Exec(t, `BACKUP TO $1`, localFoo)
 


### PR DESCRIPTION
CREATE USER and ALTER USER create schema change jobs in order to bump the descriptor version on the users and role_options tables in order to refresh the authentication cache.

Adding these users in a single transaction means we only need to wait for 3 such jobs rather than 3000 jobs.

This is particularly useful since we occasionally observe massive slow downs in processing these jobs. While we should get to the bottom of such slow downs, let's not slow down CI.

Supersedes #81276

Epic: none

Release note: None