### PR TITLE
workload/schemachange: avoid JSON columns in indexes for mixed version

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1602,8 +1602,8 @@ func NewTableDesc(
 				incTelemetryForNewColumn(d, col)
 			}
 
-			// Version gates for enabling primary keys for JSONB columns
-			if col.Type.Family() == types.JsonFamily && d.PrimaryKey.IsPrimaryKey && !version.IsActive(clusterversion.V23_2) {
+			// Version gates for enabling primary keys / unique indexes for JSONB columns
+			if col.Type.Family() == types.JsonFamily && (d.PrimaryKey.IsPrimaryKey || d.Unique.IsUnique) && !version.IsActive(clusterversion.V23_2) {
 				return nil, errors.WithHint(
 					pgerror.Newf(
 						pgcode.InvalidTableDefinition,

--- a/pkg/upgrade/upgrades/json_forward_indexes_test.go
+++ b/pkg/upgrade/upgrades/json_forward_indexes_test.go
@@ -85,6 +85,13 @@ func TestJSONForwardingIndexes(t *testing.T) {
 )`)
 	require.Error(t, err)
 
+	// Creating a table with an index on the JSON column should result in an error.
+	_, err = db.Exec(`CREATE TABLE test.tbl_json_unique(
+    j JSONB,
+    UNIQUE tbl_json_secondary_uidx (j)
+)`)
+	require.Error(t, err)
+
 	// Creating a primary key on a JSON column should result in an error.
 	_, err = db.Exec(`CREATE TABLE test.tbl_json_primary (
 	   key JSONB PRIMARY KEY
@@ -109,6 +116,13 @@ func TestJSONForwardingIndexes(t *testing.T) {
 	_, err = db.Exec(`CREATE TABLE test.tbl_json_secondary(
     j JSONB,
     INDEX tbl_json_secondary_idx (j)
+)`)
+	require.Error(t, err)
+
+	// Creating a table with an index on the JSON column should result in an error.
+	_, err = db.Exec(`CREATE TABLE test.tbl_json_secondary_unique(
+    j JSONB,
+    UNIQUE tbl_json_secondary_uidx (j)
 )`)
 	require.Error(t, err)
 


### PR DESCRIPTION
Previously, we could generate CREATE TABLE / INDEX statements with JSON index columns which could end up failing in a mixed version state. To address this, this patch detects JSON columns and expects the appropriate errors in a mixed version state.

Fixes: #103875
Release note: None