### PR TITLE
liveness: introduce NodeVitality

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -500,7 +500,7 @@ func TestPartialZip(t *testing.T) {
 	// is no risk to see the override bumped due to a gossip update
 	// because this setting is not otherwise set in the test cluster.
 	s := tc.Server(0)
-	liveness.TimeUntilStoreDead.Override(ctx, &s.ClusterSettings().SV, liveness.TestTimeUntilStoreDead)
+	liveness.TimeUntilNodeDead.Override(ctx, &s.ClusterSettings().SV, liveness.TestTimeUntilNodeDead)
 
 	// This last case may take a little while to converge. To make this work with datadriven and at the same
 	// time retain the ability to use the `-rewrite` flag, we use a retry loop within that already checks the

--- a/pkg/cmd/roachtest/tests/autoupgrade.go
+++ b/pkg/cmd/roachtest/tests/autoupgrade.go
@@ -45,7 +45,7 @@ func registerAutoUpgrade(r registry.Registry) {
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
 
 		const stageDuration = 30 * time.Second
-		const timeUntilStoreDead = 90 * time.Second
+		const timeUntilNodeDead = 90 * time.Second
 		const buff = 10 * time.Second
 
 		sleep := func(ts time.Duration) error {
@@ -62,7 +62,7 @@ func registerAutoUpgrade(r registry.Registry) {
 		defer db.Close()
 
 		if _, err := db.ExecContext(ctx,
-			"SET CLUSTER SETTING server.time_until_store_dead = $1", timeUntilStoreDead.String(),
+			"SET CLUSTER SETTING server.time_until_store_dead = $1", timeUntilNodeDead.String(),
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -168,7 +168,7 @@ func registerAutoUpgrade(r registry.Registry) {
 		if err := decommissionAndStop(nodeDecommissioned); err != nil {
 			t.Fatal(err)
 		}
-		if err := sleep(timeUntilStoreDead + buff); err != nil {
+		if err := sleep(timeUntilNodeDead + buff); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/kv/kvserver/allocator/allocatorimpl/test_helpers.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/test_helpers.go
@@ -41,7 +41,7 @@ func CreateTestAllocatorWithKnobs(
 ) (*stop.Stopper, *gossip.Gossip, *storepool.StorePool, Allocator, *timeutil.ManualTime) {
 	st := cluster.MakeTestingClusterSettings()
 	stopper, g, manual, storePool, _ := storepool.CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDeadOff, deterministic,
+		liveness.TestTimeUntilNodeDeadOff, deterministic,
 		func() int { return numNodes },
 		livenesspb.NodeLivenessStatus_LIVE)
 	a := MakeAllocator(st, deterministic, func(id roachpb.NodeID) (time.Duration, bool) {

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
@@ -50,12 +50,12 @@ var _ AllocatorStorePool = &OverrideStorePool{}
 func OverrideNodeLivenessFunc(
 	overrides map[roachpb.NodeID]livenesspb.NodeLivenessStatus, realNodeLivenessFunc NodeLivenessFunc,
 ) NodeLivenessFunc {
-	return func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+	return func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilNodeDead time.Duration) livenesspb.NodeLivenessStatus {
 		if override, ok := overrides[nid]; ok {
 			return override
 		}
 
-		return realNodeLivenessFunc(nid, now, timeUntilStoreDead)
+		return realNodeLivenessFunc(nid, now, timeUntilNodeDead)
 	}
 }
 

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
@@ -37,19 +37,19 @@ func TestOverrideStorePoolStatusString(t *testing.T) {
 	const nodeCount = 5
 
 	stopper, g, _, testStorePool, mnl := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return nodeCount }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
 
 	livenessOverrides := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus)
-	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilNodeDead time.Duration) livenesspb.NodeLivenessStatus {
 		if overriddenLiveness, ok := livenessOverrides[nid]; ok {
 			return overriddenLiveness
 		}
 
-		return mnl.NodeLivenessFunc(nid, now, timeUntilStoreDead)
+		return mnl.NodeLivenessFunc(nid, now, timeUntilNodeDead)
 	}, func() int {
 		excluded := 0
 		for _, overriddenLiveness := range livenessOverrides {
@@ -118,19 +118,19 @@ func TestOverrideStorePoolDecommissioningReplicas(t *testing.T) {
 	const nodeCount = 5
 
 	stopper, g, _, testStorePool, mnl := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return nodeCount }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
 
 	livenessOverrides := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus)
-	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilNodeDead time.Duration) livenesspb.NodeLivenessStatus {
 		if overriddenLiveness, ok := livenessOverrides[nid]; ok {
 			return overriddenLiveness
 		}
 
-		return mnl.NodeLivenessFunc(nid, now, timeUntilStoreDead)
+		return mnl.NodeLivenessFunc(nid, now, timeUntilNodeDead)
 	}, func() int {
 		excluded := 0
 		for _, overriddenLiveness := range livenessOverrides {
@@ -235,19 +235,19 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 
 	// We're going to manually mark stores dead in this test.
 	stopper, g, _, testStorePool, mnl := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return nodeCount }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
 
 	livenessOverrides := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus)
-	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilNodeDead time.Duration) livenesspb.NodeLivenessStatus {
 		if overriddenLiveness, ok := livenessOverrides[nid]; ok {
 			return overriddenLiveness
 		}
 
-		return mnl.NodeLivenessFunc(nid, now, timeUntilStoreDead)
+		return mnl.NodeLivenessFunc(nid, now, timeUntilNodeDead)
 	}, func() int {
 		excluded := 0
 		for _, overriddenLiveness := range livenessOverrides {

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -44,30 +44,6 @@ var FailedReservationsTimeout = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
-const timeAfterStoreSuspectSettingName = "server.time_after_store_suspect"
-
-// TimeAfterStoreSuspect measures how long we consider a store suspect since
-// it's last failure.
-var TimeAfterStoreSuspect = settings.RegisterDurationSetting(
-	settings.SystemOnly,
-	timeAfterStoreSuspectSettingName,
-	"the amount of time we consider a store suspect for after it fails a node liveness heartbeat."+
-		" A suspect node would not receive any new replicas or lease transfers, but will keep the replicas it has.",
-	30*time.Second,
-	settings.NonNegativeDuration,
-	func(v time.Duration) error {
-		// We enforce a maximum value of 5 minutes for this settings, as setting this
-		// to high may result in a prolonged period of unavailability as a recovered
-		// store will not be able to acquire leases or replicas for a long time.
-		const maxTimeAfterStoreSuspect = 5 * time.Minute
-		if v > maxTimeAfterStoreSuspect {
-			return errors.Errorf("cannot set %s to more than %v: %v",
-				timeAfterStoreSuspectSettingName, maxTimeAfterStoreSuspect, v)
-		}
-		return nil
-	},
-)
-
 // The NodeCountFunc returns a count of the total number of nodes the user
 // intends for their to be in the cluster. The count includes dead nodes, but
 // not decommissioned nodes.
@@ -75,9 +51,9 @@ type NodeCountFunc func() int
 
 // A NodeLivenessFunc accepts a node ID and current time and returns whether or
 // not the node is live. A node is considered dead if its liveness record has
-// expired by more than TimeUntilStoreDead.
+// expired by more than TimeUntilNodeDead.
 type NodeLivenessFunc func(
-	nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration,
+	nid roachpb.NodeID, now hlc.Timestamp, timeUntilNodeDead time.Duration,
 ) livenesspb.NodeLivenessStatus
 
 // MakeStorePoolNodeLivenessFunc returns a function which determines
@@ -85,13 +61,13 @@ type NodeLivenessFunc func(
 // NodeLiveness.
 func MakeStorePoolNodeLivenessFunc(nodeLiveness *liveness.NodeLiveness) NodeLivenessFunc {
 	return func(
-		nodeID roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration,
+		nodeID roachpb.NodeID, now hlc.Timestamp, timeUntilNodeDead time.Duration,
 	) livenesspb.NodeLivenessStatus {
 		liveness, ok := nodeLiveness.GetLiveness(nodeID)
 		if !ok {
 			return livenesspb.NodeLivenessStatus_UNKNOWN
 		}
-		return LivenessStatus(liveness.Liveness, now, timeUntilStoreDead)
+		return LivenessStatus(liveness.Liveness, now, timeUntilNodeDead)
 	}
 }
 
@@ -178,11 +154,11 @@ type storeStatus int
 const (
 	_ storeStatus = iota
 	// The store's node is not live or no gossip has been received from
-	// the store for more than the timeUntilStoreDead threshold.
+	// the store for more than the timeUntilNodeDead threshold.
 	storeStatusDead
 	// The store isn't available because it hasn't gossiped yet. This
 	// status lasts until either gossip is received from the store or
-	// the timeUntilStoreDead threshold has passed, at which point its
+	// the timeUntilNodeDead threshold has passed, at which point its
 	// status will change to dead.
 	storeStatusUnknown
 	// The store is alive but it is throttled.
@@ -491,13 +467,13 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) string {
 
 	var buf bytes.Buffer
 	now := sp.clock.Now()
-	timeUntilStoreDead := liveness.TimeUntilStoreDead.Get(&sp.st.SV)
-	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
+	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
+	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	for _, id := range ids {
 		detail := sp.DetailsMu.StoreDetails[id]
 		fmt.Fprintf(&buf, "%d", id)
-		status := detail.status(now, timeUntilStoreDead, nl, timeAfterStoreSuspect)
+		status := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect)
 		if status != storeStatusAvailable {
 			fmt.Fprintf(&buf, " (status=%d)", status)
 		}
@@ -784,12 +760,12 @@ func (sp *StorePool) decommissioningReplicasWithLiveness(
 	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
 	now := sp.clock.Now()
-	timeUntilStoreDead := liveness.TimeUntilStoreDead.Get(&sp.st.SV)
-	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
+	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
+	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	for _, repl := range repls {
 		detail := sp.GetStoreDetailLocked(repl.StoreID)
-		switch detail.status(now, timeUntilStoreDead, nl, timeAfterStoreSuspect) {
+		switch detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect) {
 		case storeStatusDecommissioning:
 			decommissioningReplicas = append(decommissioningReplicas, repl)
 		}
@@ -828,9 +804,9 @@ func (sp *StorePool) IsDead(storeID roachpb.StoreID) (bool, time.Duration, error
 	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
 	now := sp.clock.Now()
-	timeUntilStoreDead := liveness.TimeUntilStoreDead.Get(&sp.st.SV)
+	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
 
-	deadAsOf := sd.LastUpdatedTime.AddDuration(timeUntilStoreDead)
+	deadAsOf := sd.LastUpdatedTime.AddDuration(timeUntilNodeDead)
 	if now.After(deadAsOf) {
 		return true, 0, nil
 	}
@@ -904,9 +880,9 @@ func (sp *StorePool) storeStatus(
 	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
 	now := sp.clock.Now()
-	timeUntilStoreDead := liveness.TimeUntilStoreDead.Get(&sp.st.SV)
-	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
-	return sd.status(now, timeUntilStoreDead, nl, timeAfterStoreSuspect), nil
+	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
+	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
+	return sd.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect), nil
 }
 
 // LiveAndDeadReplicas divides the provided repls slice into two slices: the
@@ -938,13 +914,13 @@ func (sp *StorePool) liveAndDeadReplicasWithLiveness(
 	defer sp.DetailsMu.Unlock()
 
 	now := sp.clock.Now()
-	timeUntilStoreDead := liveness.TimeUntilStoreDead.Get(&sp.st.SV)
-	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
+	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
+	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	for _, repl := range repls {
 		detail := sp.GetStoreDetailLocked(repl.StoreID)
 		// Mark replica as dead if store is dead.
-		status := detail.status(now, timeUntilStoreDead, nl, timeAfterStoreSuspect)
+		status := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect)
 		switch status {
 		case storeStatusDead:
 			deadReplicas = append(deadReplicas, repl)
@@ -1214,8 +1190,8 @@ func (sp *StorePool) getStoreListFromIDsLocked(
 	var storeDescriptors []roachpb.StoreDescriptor
 
 	now := sp.clock.Now()
-	timeUntilStoreDead := liveness.TimeUntilStoreDead.Get(&sp.st.SV)
-	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
+	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
+	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	for _, storeID := range storeIDs {
 		detail, ok := sp.DetailsMu.StoreDetails[storeID]
@@ -1223,7 +1199,7 @@ func (sp *StorePool) getStoreListFromIDsLocked(
 			// Do nothing; this store is not in the StorePool.
 			continue
 		}
-		switch s := detail.status(now, timeUntilStoreDead, nl, timeAfterStoreSuspect); s {
+		switch s := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect); s {
 		case storeStatusThrottled:
 			aliveStoreCount++
 			throttled = append(throttled, detail.throttledBecause)

--- a/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
@@ -55,7 +55,7 @@ func TestStorePoolGossipUpdate(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	stopper, g, _, sp, _ := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 0 }, /* NodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
@@ -125,7 +125,7 @@ func TestStorePoolGetStoreList(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	// We're going to manually mark stores dead in this test.
 	stopper, g, _, sp, mnl := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
@@ -421,7 +421,7 @@ func TestStorePoolGetStoreDetails(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	stopper, g, _, sp, _ := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
@@ -444,7 +444,7 @@ func TestStorePoolFindDeadReplicas(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	stopper, g, _, sp, mnl := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
@@ -550,7 +550,7 @@ func TestStorePoolDefaultState(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	stopper, _, _, sp, _ := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
@@ -581,7 +581,7 @@ func TestStorePoolThrottle(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	stopper, g, _, sp, _ := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
@@ -609,18 +609,18 @@ func TestStorePoolSuspected(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	stopper, g, _, sp, mnl := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDeadOff, false, /* deterministic */
+		liveness.TestTimeUntilNodeDeadOff, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
 
 	now := sp.clock.Now()
-	timeUntilStoreDead := liveness.TimeUntilStoreDead.Get(&sp.st.SV)
-	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
+	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
+	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	// Verify a store that we haven't seen yet is unknown status.
 	detail := sp.GetStoreDetailLocked(0)
-	s := detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	s := detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusUnknown)
 	require.Equal(t, hlc.Timestamp{}, detail.LastUnavailable)
 
@@ -635,54 +635,54 @@ func TestStorePoolSuspected(t *testing.T) {
 	detail = sp.GetStoreDetailLocked(store.StoreID)
 	defer sp.DetailsMu.Unlock()
 
-	s = detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusAvailable)
 	require.Equal(t, hlc.Timestamp{}, detail.LastUnavailable)
 
 	// When the store transitions to unavailable, its status changes to temporarily unknown.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_UNAVAILABLE)
-	s = detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusUnknown)
 	require.NotEqual(t, hlc.Timestamp{}, detail.LastUnavailable)
 
 	// When the store transitions back to live, it passes through suspect for a period.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
-	s = detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusSuspect)
 
 	// Once the window has passed, it will return to available.
-	now = now.AddDuration(timeAfterStoreSuspect).AddDuration(time.Millisecond)
-	s = detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	now = now.AddDuration(timeAfterNodeSuspect).AddDuration(time.Millisecond)
+	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusAvailable)
 
 	// Return a liveness of dead.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_DEAD)
-	s = detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusDead)
 
 	// When the store transitions back to live, it passes through suspect for a period.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
-	s = detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusSuspect)
 
 	// Verify it also returns correctly to available after suspect time.
-	now = now.AddDuration(timeAfterStoreSuspect).AddDuration(time.Millisecond)
-	s = detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	now = now.AddDuration(timeAfterNodeSuspect).AddDuration(time.Millisecond)
+	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusAvailable)
 
 	// Verify that restart after draining also makes it temporarily suspect.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_DRAINING)
-	s = detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusDraining)
 
 	// Verify suspect when restarting after a drain.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
-	s = detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusSuspect)
 
-	now = now.AddDuration(timeAfterStoreSuspect).AddDuration(time.Millisecond)
+	now = now.AddDuration(timeAfterNodeSuspect).AddDuration(time.Millisecond)
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
-	s = detail.status(now, timeUntilStoreDead, sp.NodeLivenessFn, timeAfterStoreSuspect)
+	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusAvailable)
 }
 
@@ -692,7 +692,7 @@ func TestGetLocalities(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	stopper, g, _, sp, _ := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
@@ -774,7 +774,7 @@ func TestStorePoolDecommissioningReplicas(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	stopper, g, _, sp, mnl := CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)

--- a/pkg/kv/kvserver/allocator/storepool/test_helpers.go
+++ b/pkg/kv/kvserver/allocator/storepool/test_helpers.go
@@ -71,7 +71,7 @@ func (m *MockNodeLiveness) NodeLivenessFunc(
 func CreateTestStorePool(
 	ctx context.Context,
 	st *cluster.Settings,
-	timeUntilStoreDeadValue time.Duration,
+	timeUntilNodeDeadValue time.Duration,
 	deterministic bool,
 	nodeCount NodeCountFunc,
 	defaultNodeStatus livenesspb.NodeLivenessStatus,
@@ -84,7 +84,7 @@ func CreateTestStorePool(
 	g := gossip.NewTest(1, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	mnl := NewMockNodeLiveness(defaultNodeStatus)
 
-	liveness.TimeUntilStoreDead.Override(ctx, &st.SV, timeUntilStoreDeadValue)
+	liveness.TimeUntilNodeDead.Override(ctx, &st.SV, timeUntilNodeDeadValue)
 	storePool := NewStorePool(
 		ambientCtx,
 		st,

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -968,7 +968,7 @@ func (s *state) SetNodeLiveness(nodeID NodeID, status livenesspb.NodeLivenessSta
 // liveness of the Node with ID NodeID.
 // TODO(kvoli): Find a better home for this method, required by the storepool.
 func (s *state) NodeLivenessFn() storepool.NodeLivenessFunc {
-	return func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+	return func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilNodeDead time.Duration) livenesspb.NodeLivenessStatus {
 		return s.quickLivenessMap[NodeID(nid)]
 	}
 }

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
@@ -1003,8 +1002,8 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 		}
 	}
 	// We need to wait until 2 and 3 are considered to be dead.
-	timeUntilStoreDead := liveness.TimeUntilStoreDead.Get(&tc.GetFirstStoreFromServer(t, 0).GetStoreConfig().Settings.SV)
-	wait(timeUntilStoreDead)
+	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&tc.GetFirstStoreFromServer(t, 0).GetStoreConfig().Settings.SV)
+	wait(timeUntilNodeDead)
 
 	checkDead := func(store *kvserver.Store, storeIdx int) error {
 		if dead, timetoDie, err := store.GetStoreConfig().StorePool.IsDead(
@@ -1285,7 +1284,7 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 	}
 	testutils.SucceedsSoon(t, allLeasesOnNonSuspectStores)
 	// Wait out the suspect time.
-	suspectDuration := storepool.TimeAfterStoreSuspect.Get(&tc.GetFirstStoreFromServer(t, 0).GetStoreConfig().Settings.SV)
+	suspectDuration := liveness.TimeAfterNodeSuspect.Get(&tc.GetFirstStoreFromServer(t, 0).GetStoreConfig().Settings.SV)
 	for i := 0; i < int(math.Ceil(suspectDuration.Seconds())); i++ {
 		manualClock.Increment(time.Second.Nanoseconds())
 		heartbeat(0, 1, 2, 3)

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -227,7 +227,7 @@ func (s *Store) RaftSchedulerPriorityIDs() []roachpb.RangeID {
 }
 
 func NewTestStorePool(cfg StoreConfig) *storepool.StorePool {
-	liveness.TimeUntilStoreDead.Override(context.Background(), &cfg.Settings.SV, liveness.TestTimeUntilStoreDeadOff)
+	liveness.TimeUntilNodeDead.Override(context.Background(), &cfg.Settings.SV, liveness.TestTimeUntilNodeDeadOff)
 	return storepool.NewStorePool(
 		cfg.AmbientCtx,
 		cfg.Settings,

--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -18,6 +18,8 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
+        "//pkg/rpc",
+        "//pkg/rpc/nodedialer",
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/liveness/cache.go
+++ b/pkg/kv/kvserver/liveness/cache.go
@@ -13,6 +13,7 @@ package liveness
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
@@ -21,6 +22,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
+
+type UpdateInfo struct {
+	lastUpdateTime      hlc.Timestamp
+	lastUnavailableTime hlc.Timestamp
+}
 
 // cache stores updates to both Liveness records and the store descriptor map.
 // It doesn't store the entire StoreDescriptor, only the time when it is
@@ -41,7 +47,7 @@ type cache struct {
 		// This is tracking based on NodeID, so any store that is updated on this
 		// node will update teh lastNodeUpdate. We don't have the ability to handle
 		// "1 stalled store" on a node from a liveness perspective.
-		lastNodeUpdate map[roachpb.NodeID]hlc.Timestamp
+		lastNodeUpdate map[roachpb.NodeID]UpdateInfo
 		// nodes stores liveness records read from Gossip
 		nodes map[roachpb.NodeID]Record
 	}
@@ -54,7 +60,7 @@ func newCache(
 	c.gossip = g
 	c.clock = clock
 	c.mu.nodes = make(map[roachpb.NodeID]Record)
-	c.mu.lastNodeUpdate = make(map[roachpb.NodeID]hlc.Timestamp)
+	c.mu.lastNodeUpdate = make(map[roachpb.NodeID]UpdateInfo)
 
 	c.notifyLivenessChanged = cbFn
 
@@ -107,7 +113,12 @@ func (c *cache) storeGossipUpdate(_ string, content roachpb.Value) {
 		return
 	}
 	c.mu.Lock()
-	c.mu.lastNodeUpdate[nodeID] = c.clock.Now()
+	previousRec, found := c.mu.lastNodeUpdate[nodeID]
+	if !found {
+		previousRec = UpdateInfo{}
+	}
+	previousRec.lastUpdateTime = c.clock.Now()
+	c.mu.lastNodeUpdate[nodeID] = previousRec
 	c.mu.Unlock()
 }
 
@@ -116,6 +127,10 @@ func (c *cache) storeGossipUpdate(_ string, content roachpb.Value) {
 func (c *cache) maybeUpdate(ctx context.Context, newLivenessRec Record) {
 	if newLivenessRec.Liveness == (livenesspb.Liveness{}) {
 		log.Fatal(ctx, "invalid new liveness record; found to be empty")
+	}
+
+	if newLivenessRec.NodeID == 0 {
+		log.Fatal(ctx, "attempt to cache liveness record with nid 0")
 	}
 
 	shouldReplace := true
@@ -170,9 +185,7 @@ func livenessChanged(old, new Record) bool {
 // Self returns the raw, encoded value that the database has for this liveness
 // record in addition to the decoded liveness proto.
 func (c *cache) Self() (_ Record, ok bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.getLivenessLocked(c.selfID())
+	return c.GetLiveness(c.selfID())
 }
 
 // GetLiveness returns the liveness record for the specified nodeID. If the
@@ -183,14 +196,6 @@ func (c *cache) Self() (_ Record, ok bool) {
 func (c *cache) GetLiveness(nodeID roachpb.NodeID) (_ Record, ok bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.getLivenessLocked(nodeID)
-}
-
-// getLivenessLocked returns the liveness record for the specified nodeID,
-// consulting the in-memory cache. If nothing is found (could happen due to
-// gossip propagation delays or the node not existing), we surface that to the
-// caller.
-func (c *cache) getLivenessLocked(nodeID roachpb.NodeID) (_ Record, ok bool) {
 	if l, ok := c.mu.nodes[nodeID]; ok {
 		return l, true
 	}
@@ -217,4 +222,44 @@ func (c *cache) GetIsLiveMap() livenesspb.IsLiveMap {
 		}
 	}
 	return lMap
+}
+
+// getAllLivenessEntries returns a copy of all the entries currently in the
+// liveness cache. Most places should avoid calling this method and instead just
+// get the entry they need. In a few places in the code it is more efficient to
+// get the entries once and keep the map in memory for later iteration.
+func (c *cache) getAllLivenessEntries() []livenesspb.Liveness {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	cpy := make([]livenesspb.Liveness, 0, len(c.mu.nodes))
+	for _, l := range c.mu.nodes {
+		cpy = append(cpy, l.Liveness)
+	}
+	return cpy
+}
+
+// LastDescriptorUpdate returns when this node last had an update.
+func (c *cache) LastDescriptorUpdate(nodeID roachpb.NodeID) (UpdateInfo, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if l, ok := c.mu.lastNodeUpdate[nodeID]; ok {
+		return l, true
+	}
+	// If there is no timestamp, use the "0" timestamp.
+	return UpdateInfo{}, false
+}
+
+// CheckForStaleEntries checks if any of the cached node updates have not been
+// updated for longer than the interval. If they become stale, they remain stale
+// for the suspect interval to prevent flapping nodes from impacting system
+// stability.
+func (c *cache) CheckForStaleEntries(interval time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.clock.Now()
+	for _, l := range c.mu.lastNodeUpdate {
+		if l.lastUpdateTime.AddDuration(interval).Less(now) {
+			l.lastUnavailableTime = now
+		}
+	}
 }

--- a/pkg/kv/kvserver/liveness/client_test.go
+++ b/pkg/kv/kvserver/liveness/client_test.go
@@ -245,7 +245,7 @@ func TestNodeLivenessStatusMap(t *testing.T) {
 				// doesn't allow durations below 1m15s, which is much too long
 				// for a test.
 				// We do this in every SucceedsSoon attempt, so we'll be good.
-				liveness.TimeUntilStoreDead.Override(ctx, &firstServer.ClusterSettings().SV, liveness.TestTimeUntilStoreDead)
+				liveness.TimeUntilNodeDead.Override(ctx, &firstServer.ClusterSettings().SV, liveness.TestTimeUntilNodeDead)
 
 				log.Infof(ctx, "checking expected status (%s) for node %d", expectedStatus, nodeID)
 				resp, err := admin.Liveness(ctx, &serverpb.LivenessRequest{})

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -42,21 +42,22 @@ import (
 )
 
 const (
-	// TestTimeUntilStoreDead is the test value for TimeUntilStoreDead to
-	// quickly mark stores as dead.
-	TestTimeUntilStoreDead = 5 * time.Millisecond
+	// TestTimeUntilNodeDead is the test value for TimeUntilNodeDead to quickly
+	// mark stores as dead. This needs to be longer than gossip.StoresInterval
+	TestTimeUntilNodeDead = 15 * time.Second
 
-	// TestTimeUntilStoreDeadOff is the test value for TimeUntilStoreDead that
+	// TestTimeUntilNodeDeadOff is the test value for TimeUntilNodeDead that
 	// prevents the store pool from marking stores as dead.
-	TestTimeUntilStoreDeadOff = 24 * time.Hour
+	TestTimeUntilNodeDeadOff = 24 * time.Hour
 
-	timeUntilStoreDeadSettingName = "server.time_until_store_dead"
+	timeUntilNodeDeadSettingName    = "server.time_until_store_dead"
+	timeAfterNodeSuspectSettingName = "server.time_after_store_suspect"
 )
 
-// TimeUntilStoreDead wraps "server.time_until_store_dead".
-var TimeUntilStoreDead = settings.RegisterDurationSetting(
+// TimeUntilNodeDead wraps "server.time_until_store_dead".
+var TimeUntilNodeDead = settings.RegisterDurationSetting(
 	settings.TenantWritable,
-	timeUntilStoreDeadSettingName,
+	timeUntilNodeDeadSettingName,
 	"the time after which if there is no new gossiped information about a store, it is considered dead",
 	5*time.Minute,
 	func(v time.Duration) error {
@@ -64,14 +65,45 @@ var TimeUntilStoreDead = settings.RegisterDurationSetting(
 		// no-no, since this value is compared to the age of the most recent gossip
 		// from each store to determine whether that store is live. Put a buffer of
 		// 15 seconds on top to allow time for gossip to propagate.
-		const minTimeUntilStoreDead = gossip.StoresInterval + 15*time.Second
-		if v < minTimeUntilStoreDead {
+		const minTimeUntilNodeDead = gossip.StoresInterval + 15*time.Second
+		if v < minTimeUntilNodeDead {
 			return errors.Errorf("cannot set %s to less than %v: %v",
-				timeUntilStoreDeadSettingName, minTimeUntilStoreDead, v)
+				timeUntilNodeDeadSettingName, minTimeUntilNodeDead, v)
 		}
 		return nil
 	},
 ).WithPublic()
+
+// TimeAfterNodeSuspect measures how long we consider a store suspect since
+// it's last failure.
+var TimeAfterNodeSuspect = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	timeAfterNodeSuspectSettingName,
+	"the amount of time we consider a node suspect for after it becomes unavailable."+
+		" A suspect node is typically treated the same as an unavailable node.",
+	30*time.Second,
+	func(v time.Duration) error {
+		// Setting this to less than the interval for gossiping stores is a big
+		// no-no, since this value is compared to the age of the most recent gossip
+		// from each store to determine whether that store is live.
+		const minTimeUntilNodeSuspect = gossip.StoresInterval
+		if v < minTimeUntilNodeSuspect {
+			return errors.Errorf("cannot set %s to less than %v: %v",
+				timeAfterNodeSuspectSettingName, minTimeUntilNodeSuspect, v)
+		}
+		return nil
+	}, func(v time.Duration) error {
+		// We enforce a maximum value of 5 minutes for this settings, as setting this
+		// to high may result in a prolonged period of unavailability as a recovered
+		// store will not be able to acquire leases or replicas for a long time.
+		const maxTimeAfterNodeSuspect = 5 * time.Minute
+		if v > maxTimeAfterNodeSuspect {
+			return errors.Errorf("cannot set %s to more than %v: %v",
+				timeAfterNodeSuspectSettingName, maxTimeAfterNodeSuspect, v)
+		}
+		return nil
+	},
+)
 
 var (
 	// ErrMissingRecord is returned when asking for liveness information

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.go
@@ -11,6 +11,7 @@
 package livenesspb
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -20,6 +21,17 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// NodeVitalityInterface is the interface code that uses NodeLiveness should
+// use. Only these three exposed methods are intended to be publicly used by the
+// reset of the codebase. Various tests mock out different parts of this
+// interface, and TestNodeVitality is intended to be used in tests that need a
+// specific NodeLiveness set up.
+type NodeVitalityInterface interface {
+	GetNodeVitalityFromCache(roachpb.NodeID) NodeVitality
+	ScanNodeVitalityFromCache() NodeVitalityMap
+	ScanNodeVitalityFromKV(context.Context) (NodeVitalityMap, error)
+}
 
 // IsLive returns whether the node is considered live at the given time.
 //
@@ -31,21 +43,21 @@ import (
 // considered expired. For that purpose, it's better to pass in
 // clock.Now().GoTime() rather than clock.PhysicalNow() - the former takes into
 // consideration clock signals from other nodes, the latter doesn't.
-func (l *Liveness) IsLive(now hlc.Timestamp) bool {
+func (l Liveness) IsLive(now hlc.Timestamp) bool {
 	return now.Less(l.Expiration.ToTimestamp())
 }
 
 // IsDead returns true if the liveness expired more than threshold ago.
 //
 // Note that, because of threshold, IsDead() is not the inverse of IsLive().
-func (l *Liveness) IsDead(now hlc.Timestamp, threshold time.Duration) bool {
+func (l Liveness) IsDead(now hlc.Timestamp, threshold time.Duration) bool {
 	expiration := l.Expiration.ToTimestamp().AddDuration(threshold)
 	return !now.Less(expiration)
 }
 
 // Compare returns an integer comparing two pieces of liveness information,
 // based on which liveness information is more recent.
-func (l *Liveness) Compare(o Liveness) int {
+func (l Liveness) Compare(o Liveness) int {
 	// Compare Epoch, and if no change there, Expiration.
 	if l.Epoch != o.Epoch {
 		if l.Epoch < o.Epoch {
@@ -139,7 +151,10 @@ func ValidateTransition(old Liveness, newStatus MembershipStatus) (bool, error) 
 }
 
 // IsLiveMapEntry encapsulates data about current liveness for a
-// node.
+// node based on the liveness range.
+// TODO(abaptist): This should only be used for epoch leases as it uses an
+// overly strict version of liveness. Once epoch leases are removed, this will
+// be also.
 type IsLiveMapEntry struct {
 	Liveness
 	IsLive bool
@@ -147,3 +162,238 @@ type IsLiveMapEntry struct {
 
 // IsLiveMap is a type alias for a map from NodeID to IsLiveMapEntry.
 type IsLiveMap map[roachpb.NodeID]IsLiveMapEntry
+
+// VitalityStatus tracks the current health of a node.
+type VitalityStatus int
+
+const (
+	_ VitalityStatus = iota
+	// VitalityAlive means the node is able to publish gossip updates.
+	VitalityAlive
+	// VitalitySuspect means the node is able to currently publish gossip updates, but has been recently unavailable.
+	VitalitySuspect
+	// VitalityUnavailable means the node is not currently publishing gossip updates.
+	VitalityUnavailable
+	// VitalityDead means The node has not published a gossip update for an extended period.
+	VitalityDead
+)
+
+// NodeVitality should be used any place other than epoch leases where it is
+// necessary to determine if a node is currently alive and what its health is.
+// Aliveness and deadness are concepts that refer to our best guess of the
+// health of this node. An alive node is one that should be treated as healthy
+// for most decisions. A dead node is one that should be treated as unavailable
+// for most decisions. A node can be neither dead or alive, if it has gone
+// offline recently or if failing to consistently gossip. Different areas of the
+// code have the flexibility to treat this condition differently.
+type NodeVitality struct {
+	// draining is whether this node currently draining.
+	draining bool
+	// membership is whether the node is active or in a state of decommissioning.
+	membership MembershipStatus
+	// health is the best estimate of the current health of this node.
+	health VitalityStatus
+	// connected is whether we are currently directly connect to this node.
+	connected bool
+	// The underlying liveness record this NodeVitality record was created from.
+	// Most code should not access this directly, however epoch leases need the
+	// underlying liveness record. Additionally some admin methods directly report
+	// the Liveness protobuf record to the end user.
+	// TODO(baptist): Don't expose directly, use explicit methods to access this.
+	Liveness Liveness
+}
+
+type NodeVitalityMap map[roachpb.NodeID]NodeVitality
+
+// IsAvailableNotDraining returns whether or not the specified node is available
+// to serve requests (i.e. it is live and not decommissioned) and is not in the
+// process of draining/decommissioning. Note that draining/decommissioning nodes
+// could still be leaseholders for ranges until drained, so this should not be
+// used when the caller needs to be able to contact leaseholders directly.
+// Returns false if the node is not in the local liveness table.
+func (nv NodeVitality) IsAvailableNotDraining() bool {
+	return nv.IsValid() &&
+		nv.IsAlive() &&
+		!nv.membership.Decommissioning() &&
+		!nv.membership.Decommissioned() &&
+		!nv.draining
+}
+
+func (nv NodeVitality) IsAliveAndConnected() bool {
+	return nv.IsAlive() && nv.connected
+}
+
+func (nv NodeVitality) IsAlive() bool {
+	return nv.IsValid() && nv.health == VitalityAlive && !nv.IsDecommissioned()
+}
+
+func (nv NodeVitality) IsDecommissioning() bool {
+	return nv.IsValid() && nv.membership.Decommissioning()
+}
+
+func (nv NodeVitality) IsDecommissioned() bool {
+	return nv.IsValid() && nv.membership.Decommissioned()
+}
+
+// MembershipStatus returns the current membership status of this node.
+// It is preferable to use IsDecommissioning or IsDecommissined since they will
+// check if the entry is valid first.
+func (nv NodeVitality) MembershipStatus() MembershipStatus {
+	return nv.membership
+}
+
+// IsValid returns whether this entry was found.
+func (nv NodeVitality) IsValid() bool {
+	return nv != NodeVitality{}
+}
+
+// GetInternalLiveness should be used for only two purposes:
+// 1) Compatibility with existing APIs that expose the Liveness record
+// 2) Epoch leases
+// Avoid using this method as the Liveness expiration is not always populated.
+func (nv NodeVitality) GetInternalLiveness() Liveness {
+	return nv.Liveness
+}
+
+// LivenessStatus returns a NodeLivenessStatus enumeration value for the
+// provided Liveness based on the provided timestamp and threshold.
+//
+// See the note on IsLive() for considerations on what should be passed in as
+// `now`.
+//
+// The timeline of the states that a liveness goes through as time passes after
+// the respective liveness record is written is the following:
+//
+//	-----|-------LIVE---|------UNAVAILABLE---|------DEAD------------> time
+//	     tWrite         tExp                 tExp+threshold
+//
+// Explanation:
+//
+//   - Let's say a node write its liveness record at tWrite. It sets the
+//     Expiration field of the record as tExp=tWrite+livenessThreshold.
+//     The node is considered LIVE (or DECOMMISSIONING or DRAINING).
+//   - At tExp, the IsLive() method starts returning false. The state becomes
+//     UNAVAILABLE (or stays DECOMMISSIONING or DRAINING).
+//   - Once threshold passes, the node is considered DEAD (or DECOMMISSIONED).
+//
+// NB: There's a bit of discrepancy between what "Decommissioned" represents, as
+// seen by NodeStatusLiveness, and what "Decommissioned" represents as
+// understood by MembershipStatus. Currently it's possible for a live node, that
+// was marked as fully decommissioned, to have a NodeLivenessStatus of
+// "Decommissioning". This was kept this way for backwards compatibility, and
+// ideally we should remove usage of NodeLivenessStatus altogether. See #50707
+// for more details.
+// TODO(baptist): Remove NodeLivenessStatus and all usages.
+func (nv NodeVitality) LivenessStatus() NodeLivenessStatus {
+	// If we don't have a liveness expiration time, treat the status as unknown.
+	// This is different than unavailable as it doesn't transition through being
+	// marked as suspect. In unavailable we still won't transfer leases or
+	// replicas to it in this state. A node that is in UNKNOWN status can
+	// immediately transition to Available once it passes a liveness heartbeat.
+	if !nv.IsValid() {
+		return NodeLivenessStatus_UNKNOWN
+	}
+
+	if nv.health == VitalityDead {
+		if !nv.membership.Active() {
+			return NodeLivenessStatus_DECOMMISSIONED
+		}
+		return NodeLivenessStatus_DEAD
+	}
+	if nv.health == VitalityAlive {
+		if !nv.membership.Active() {
+			return NodeLivenessStatus_DECOMMISSIONING
+		}
+		if nv.draining {
+			return NodeLivenessStatus_DRAINING
+		}
+		return NodeLivenessStatus_LIVE
+	}
+	// Not yet dead, but has not heartbeated recently enough to be alive either.
+	return NodeLivenessStatus_UNAVAILABLE
+}
+
+// CreateNodeVitality creates a NodeVitality record based on a liveness record
+// and information whether it should be treated as dead or alive. Computing
+// whether it is dead or alive requires external data sources so the information
+// must be passed in.
+func (l Liveness) CreateNodeVitality(health VitalityStatus, connected bool) NodeVitality {
+	// Dead means that there is low chance this node is online.
+	// Alive means that there is a high probability the node is online.
+	// A node can be neither dead nor alive (but not both).
+	return NodeVitality{
+		draining:   l.Draining,
+		membership: l.Membership,
+		health:     health,
+		connected:  connected,
+		Liveness:   l,
+	}
+}
+
+// These should not be used as they are only for testing. NodeStatusEntries are
+// generally meant to be immutable and passed by value.
+
+// TestDecommission marks a given node as decommissioned.
+func (nv *NodeVitality) TestDecommission() {
+	nv.membership = MembershipStatus_DECOMMISSIONED
+}
+
+// TestDownNode marks a given node as down (not alive, but not dead).
+func (nv *NodeVitality) TestDownNode() {
+	nv.health = VitalityUnavailable
+}
+
+// TestRestartNode marks a node as alive.
+func (nv *NodeVitality) TestRestartNode() {
+	nv.health = VitalityAlive
+}
+
+// TestNodeVitalityEntry is here to minimize the impact on tests of changing to
+// the new interface for tests that previously used IsLiveMap. It doesn't
+// directly look at timestamps, so the status must be manually updated.
+type TestNodeVitalityEntry struct {
+	Liveness Liveness
+	Health   VitalityStatus
+}
+
+// TestNodeVitality is a test class for simulating and modifying NodeLiveness
+// directly. The map is intended to be manually modified prior to running a
+// test.
+type TestNodeVitality map[roachpb.NodeID]TestNodeVitalityEntry
+
+// TestCreateNodeVitality creates a test instance of node vitality which is easy
+// to simulate different health conditions without requiring the need to take
+// nodes down or publish anything through gossip.  This method takes an optional
+// list of ides which are all marked as healthy when created.
+func TestCreateNodeVitality(ids ...roachpb.NodeID) TestNodeVitality {
+	m := TestNodeVitality{}
+	for _, id := range ids {
+		m[id] = TestNodeVitalityEntry{
+			Liveness: Liveness{},
+			Health:   VitalityAlive,
+		}
+	}
+	return m
+}
+
+func (m TestNodeVitality) GetNodeVitalityFromCache(id roachpb.NodeID) NodeVitality {
+	val, found := m[id]
+	if !found {
+		return NodeVitality{}
+	}
+	return val.Liveness.CreateNodeVitality(val.Health, true)
+}
+
+// ScanNodeVitalityFromKV is only for testing so doesn't actually scan KV,
+// instead it returns the cached values.
+func (m TestNodeVitality) ScanNodeVitalityFromKV(_ context.Context) (NodeVitalityMap, error) {
+	return m.ScanNodeVitalityFromCache(), nil
+}
+
+func (m TestNodeVitality) ScanNodeVitalityFromCache() NodeVitalityMap {
+	nvm := make(NodeVitalityMap, len(m))
+	for key, entry := range m {
+		nvm[key] = entry.Liveness.CreateNodeVitality(entry.Health, true)
+	}
+	return nvm
+}

--- a/pkg/kv/kvserver/replica_range_lease_test.go
+++ b/pkg/kv/kvserver/replica_range_lease_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -127,6 +128,7 @@ func TestReplicaLeaseStatus(t *testing.T) {
 				Clock: clock,
 				Gossip: gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry(),
 					zonepb.DefaultZoneConfigRef()),
+				Settings: cluster.MakeTestingClusterSettings(),
 			})
 			r := Replica{store: &Store{
 				Ident: &roachpb.StoreIdent{StoreID: 1, NodeID: 1},

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -11733,7 +11733,7 @@ func TestReplicaShouldCampaignOnLeaseRequestRedirect(t *testing.T) {
 	livenessMap := livenesspb.IsLiveMap{
 		1: livenesspb.IsLiveMapEntry{
 			IsLive:   true,
-			Liveness: livenesspb.Liveness{Expiration: now.Add(1, 0).ToLegacyTimestamp()},
+			Liveness: livenesspb.Liveness{Epoch: 1, Expiration: now.Add(1, 0).ToLegacyTimestamp()},
 		},
 		2: livenesspb.IsLiveMapEntry{
 			// NOTE: we purposefully set IsLive to true in disagreement with the
@@ -11741,7 +11741,7 @@ func TestReplicaShouldCampaignOnLeaseRequestRedirect(t *testing.T) {
 			// in shouldCampaignOnLeaseRequestRedirect and not at whether this node is
 			// reachable from the local node.
 			IsLive:   true,
-			Liveness: livenesspb.Liveness{Expiration: now.Add(-1, 0).ToLegacyTimestamp()},
+			Liveness: livenesspb.Liveness{Epoch: 1, Expiration: now.Add(-1, 0).ToLegacyTimestamp()},
 		},
 	}
 

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -45,7 +45,7 @@ func TestStorePoolUpdateLocalStore(t *testing.T) {
 	// We're going to manually mark stores dead in this test.
 	st := cluster.MakeTestingClusterSettings()
 	stopper, g, _, sp, _ := storepool.CreateTestStorePool(ctx, st,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
@@ -217,7 +217,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	cfg := TestStoreConfig(clock)
 	var stopper *stop.Stopper
 	stopper, _, _, cfg.StorePool, _ = storepool.CreateTestStorePool(ctx, cfg.Settings,
-		liveness.TestTimeUntilStoreDead, false, /* deterministic */
+		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2217,7 +2217,7 @@ func getLivenessStatusMap(
 	if err != nil {
 		return nil, err
 	}
-	threshold := liveness.TimeUntilStoreDead.Get(&st.SV)
+	threshold := liveness.TimeUntilNodeDead.Get(&st.SV)
 
 	statusMap := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus, len(livenesses))
 	for _, liveness := range livenesses {
@@ -2238,7 +2238,7 @@ func getLivenessResponse(
 		return nil, serverError(ctx, err)
 	}
 
-	threshold := liveness.TimeUntilStoreDead.Get(&st.SV)
+	threshold := liveness.TimeUntilNodeDead.Get(&st.SV)
 
 	statusMap := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus, len(livenesses))
 	for _, liveness := range livenesses {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -522,6 +522,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 				log.Ops.Warningf(ctx, "writing last up timestamp: %v", err)
 			}
 		},
+		NodeDialer: nodeDialer,
 	})
 
 	registry.AddMetricStruct(nodeLiveness.Metrics())

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -202,7 +202,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		HistogramWindowInterval: cfg.HistogramWindowInterval,
 		Engines:                 []storage.Engine{ltc.Eng},
 	})
-	liveness.TimeUntilStoreDead.Override(ctx, &cfg.Settings.SV, liveness.TestTimeUntilStoreDead)
+	liveness.TimeUntilNodeDead.Override(ctx, &cfg.Settings.SV, liveness.TestTimeUntilNodeDead)
 	cfg.StorePool = storepool.NewStorePool(
 		cfg.AmbientCtx,
 		cfg.Settings,

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -201,6 +201,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		Settings:                cfg.Settings,
 		HistogramWindowInterval: cfg.HistogramWindowInterval,
 		Engines:                 []storage.Engine{ltc.Eng},
+		NodeDialer:              cfg.NodeDialer,
 	})
 	liveness.TimeUntilNodeDead.Override(ctx, &cfg.Settings.SV, liveness.TestTimeUntilNodeDead)
 	cfg.StorePool = storepool.NewStorePool(

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -240,7 +240,7 @@ func (s *Server) Query(
 	// dead. This is a conservatively long span, but gives us a good indication of
 	// when a gap likely indicates an outage (and thus missing values should not
 	// be interpolated).
-	interpolationLimit := liveness.TimeUntilStoreDead.Get(&s.db.st.SV).Nanoseconds()
+	interpolationLimit := liveness.TimeUntilNodeDead.Get(&s.db.st.SV).Nanoseconds()
 
 	// Get the estimated number of nodes on the cluster, used to compute more
 	// accurate memory usage estimates. Set a minimum of 1 in order to avoid


### PR DESCRIPTION
Introduce a new NodeVitality concept which is derived from liveness and
StoreDescriptor updates. It will be used everywhere other than in
epoch leases which depend directly on the liveness range.

Epic: none

Release note: None