### PR TITLE
opt: reduce filters allocations in lookupjoin.ConstraintBuilder

### DIFF
--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -111,6 +111,10 @@ type ConstraintBuilder struct {
 	// This is used to remap computed column expressions, and is only
 	// initialized if needed.
 	eqColMap opt.ColMap
+
+	// allFilters is a scratch slice that is used to combine all the filters
+	// passed to Build. It is reused in order to reduce allocations.
+	allFilters memo.FiltersExpr
 }
 
 // Init initializes a ConstraintBuilder. Once initialized, a ConstraintBuilder
@@ -132,6 +136,9 @@ func (b *ConstraintBuilder) Init(
 		table:     table,
 		leftCols:  leftCols,
 		rightCols: rightCols,
+		// Reuse the allFilters scratch slice to reduce allocations. Build
+		// truncates this slice, so there is no need to truncate it here.
+		allFilters: b.allFilters,
 	}
 }
 
@@ -147,13 +154,17 @@ func (b *ConstraintBuilder) Build(
 ) (_ Constraint, foundEqualityCols bool) {
 	// Combine the ON and derived FK filters which can contain equality
 	// conditions.
-	allFilters := make(memo.FiltersExpr, 0, len(onFilters)+len(derivedFkOnFilters)+len(optionalFilters))
-	allFilters = append(allFilters, onFilters...)
-	allFilters = append(allFilters, derivedFkOnFilters...)
+	if cap(b.allFilters) >= len(onFilters)+len(derivedFkOnFilters)+len(optionalFilters) {
+		b.allFilters = b.allFilters[:0]
+	} else {
+		b.allFilters = make(memo.FiltersExpr, 0, len(onFilters)+len(derivedFkOnFilters)+len(optionalFilters))
+	}
+	b.allFilters = append(b.allFilters, onFilters...)
+	b.allFilters = append(b.allFilters, derivedFkOnFilters...)
 
 	// Extract the equality columns from the ON and derived FK filters.
 	leftEq, rightEq, eqFilterOrds :=
-		memo.ExtractJoinEqualityColumnsWithFilterOrds(b.leftCols, b.rightCols, allFilters)
+		memo.ExtractJoinEqualityColumnsWithFilterOrds(b.leftCols, b.rightCols, b.allFilters)
 	rightEqSet := rightEq.ToSet()
 
 	// Retrieve the inequality columns from the ON and derived FK filters.
@@ -165,7 +176,7 @@ func (b *ConstraintBuilder) Build(
 	}
 
 	// Add the optional filters.
-	allFilters = append(allFilters, optionalFilters...)
+	b.allFilters = append(b.allFilters, optionalFilters...)
 
 	// Check if the first column in the index either:
 	//
@@ -180,7 +191,7 @@ func (b *ConstraintBuilder) Build(
 	firstIdxCol := b.table.IndexColumnID(index, 0)
 	if _, ok := rightEq.Find(firstIdxCol); !ok {
 		if _, ok := b.findComputedColJoinEquality(b.table, firstIdxCol, rightEqSet); !ok {
-			if !HasJoinFilterConstants(allFilters, firstIdxCol, b.evalCtx) {
+			if !HasJoinFilterConstants(b.allFilters, firstIdxCol, b.evalCtx) {
 				if _, ok := rightCmp.Find(firstIdxCol); !ok {
 					return Constraint{}, false
 				}
@@ -261,7 +272,7 @@ func (b *ConstraintBuilder) Build(
 		idxCol := b.table.IndexColumnID(index, j)
 		idxColIsDesc := index.Column(j).Descending
 		if eqIdx, ok := rightEq.Find(idxCol); ok {
-			allLookupFilters = append(allLookupFilters, allFilters[eqFilterOrds[eqIdx]])
+			allLookupFilters = append(allLookupFilters, b.allFilters[eqFilterOrds[eqIdx]])
 			addEqualityColumns(leftEq[eqIdx], idxCol)
 			filterOrdsToExclude.Add(eqFilterOrds[eqIdx])
 			foundEqualityCols = true
@@ -302,7 +313,7 @@ func (b *ConstraintBuilder) Build(
 		// constant values. We cannot use a NULL value because the lookup
 		// join implements logic equivalent to simple equality between
 		// columns (where NULL never equals anything).
-		foundVals, allIdx, ok := FindJoinFilterConstants(allFilters, idxCol, b.evalCtx)
+		foundVals, allIdx, ok := FindJoinFilterConstants(b.allFilters, idxCol, b.evalCtx)
 
 		// If a single constant value was found, project it in the input
 		// and use it as an equality column.
@@ -316,7 +327,7 @@ func (b *ConstraintBuilder) Build(
 				b.f.ConstructConstVal(foundVals[0], idxColType),
 				constColID,
 			))
-			allLookupFilters = append(allLookupFilters, allFilters[allIdx])
+			allLookupFilters = append(allLookupFilters, b.allFilters[allIdx])
 			addEqualityColumns(constColID, idxCol)
 			filterOrdsToExclude.Add(allIdx)
 			continue
@@ -329,7 +340,7 @@ func (b *ConstraintBuilder) Build(
 			// expressions in lookupExpr and clear keyCols.
 			convertToLookupExpr()
 
-			valsFilter := allFilters[allIdx]
+			valsFilter := b.allFilters[allIdx]
 			if !isCanonicalFilter(valsFilter) {
 				// Disable normalization rules when constructing the lookup
 				// expression so that it does not get normalized into a
@@ -339,7 +350,7 @@ func (b *ConstraintBuilder) Build(
 				})
 			}
 			lookupExpr = append(lookupExpr, valsFilter)
-			allLookupFilters = append(allLookupFilters, allFilters[allIdx])
+			allLookupFilters = append(allLookupFilters, b.allFilters[allIdx])
 			filterOrdsToExclude.Add(allIdx)
 			continue
 		}
@@ -347,19 +358,19 @@ func (b *ConstraintBuilder) Build(
 		// If constant equality values were not found, try to find filters that
 		// constrain this index column to a range on input columns.
 		startIdx, endIdx, foundStart, foundEnd := b.findJoinVariableRangeFilters(
-			rightCmp, inequalityFilterOrds, allFilters, idxCol, idxColIsDesc,
+			rightCmp, inequalityFilterOrds, b.allFilters, idxCol, idxColIsDesc,
 		)
 		if foundStart {
 			convertToLookupExpr()
-			lookupExpr = append(lookupExpr, allFilters[startIdx])
-			allLookupFilters = append(allLookupFilters, allFilters[startIdx])
+			lookupExpr = append(lookupExpr, b.allFilters[startIdx])
+			allLookupFilters = append(allLookupFilters, b.allFilters[startIdx])
 			filterOrdsToExclude.Add(startIdx)
 			foundLookupCols = true
 		}
 		if foundEnd {
 			convertToLookupExpr()
-			lookupExpr = append(lookupExpr, allFilters[endIdx])
-			allLookupFilters = append(allLookupFilters, allFilters[endIdx])
+			lookupExpr = append(lookupExpr, b.allFilters[endIdx])
+			allLookupFilters = append(allLookupFilters, b.allFilters[endIdx])
 			filterOrdsToExclude.Add(endIdx)
 			foundLookupCols = true
 		}
@@ -375,13 +386,13 @@ func (b *ConstraintBuilder) Build(
 		// an input column; in this case, it still may be possible to use a constant
 		// to form the other bound.
 		rangeFilter, remaining, filterIdx := b.findJoinConstantRangeFilter(
-			allFilters, idxCol, idxColIsDesc, !foundStart, !foundEnd,
+			b.allFilters, idxCol, idxColIsDesc, !foundStart, !foundEnd,
 		)
 		if rangeFilter != nil {
 			// A constant range filter could be found.
 			convertToLookupExpr()
 			lookupExpr = append(lookupExpr, *rangeFilter)
-			allLookupFilters = append(allLookupFilters, allFilters[filterIdx])
+			allLookupFilters = append(allLookupFilters, b.allFilters[filterIdx])
 			filterOrdsToExclude.Add(filterIdx)
 			if remaining != nil {
 				remainingFilters = make(memo.FiltersExpr, 0, len(onFilters))

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/idxconstraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/lookupjoin"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
@@ -36,6 +37,7 @@ type CustomFuncs struct {
 	norm.CustomFuncs
 	e  *explorer
 	im partialidx.Implicator
+	cb lookupjoin.ConstraintBuilder
 }
 
 // Init initializes a new CustomFuncs with the given explorer.

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -368,8 +368,8 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 		return
 	}
 
-	var cb lookupjoin.ConstraintBuilder
-	cb.Init(
+	// Initialize the constraint builder.
+	c.cb.Init(
 		c.e.f,
 		c.e.mem.Metadata(),
 		c.e.evalCtx,
@@ -431,7 +431,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 			derivedfkOnFilters = c.ForeignKeyConstraintFilters(
 				input2, scanPrivate2, indexCols2, onClauseLookupRelStrictKeyCols, lookupRelEquijoinCols, inputRelJoinCols)
 		}
-		lookupConstraint, foundEqualityCols := cb.Build(index, onFilters, optionalFilters, derivedfkOnFilters)
+		lookupConstraint, foundEqualityCols := c.cb.Build(index, onFilters, optionalFilters, derivedfkOnFilters)
 		if lookupConstraint.IsUnconstrained() {
 			// We couldn't find equality columns or a lookup expression to
 			// perform a lookup join on this index.


### PR DESCRIPTION
This commit reduces allocations in `lookupjoin.ConstraintBuilder` by
reusing a scratch `memo.FiltersExpr` between invocations of
`ConstraintBuilder.Build`.

Epic: None

Release note: None
