### PR TITLE
server, ui: more search criteria options on SQL Activity

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -93,7 +93,18 @@ func getCombinedStatementStats(
 	activityHasAllData := false
 	reqStartTime := getTimeFromSeconds(req.Start)
 	if settings.Version.IsActive(ctx, clusterversion.V23_1AddSystemActivityTables) {
-		activityHasAllData, err = activityTablesHaveFullData(ctx, ie, testingKnobs, reqStartTime)
+		sort := serverpb.StatsSortOptions_SERVICE_LAT
+		if req.FetchMode != nil {
+			sort = req.FetchMode.Sort
+		}
+		activityHasAllData, err = activityTablesHaveFullData(
+			ctx,
+			ie,
+			testingKnobs,
+			reqStartTime,
+			req.Limit,
+			sort,
+		)
 		if err != nil {
 			log.Errorf(ctx, "Error on activityTablesHaveFullData: %s", err)
 		}
@@ -173,7 +184,12 @@ func activityTablesHaveFullData(
 	ie *sql.InternalExecutor,
 	testingKnobs *sqlstats.TestingKnobs,
 	reqStartTime *time.Time,
+	limit int64,
+	order serverpb.StatsSortOptions,
 ) (result bool, err error) {
+	if (limit > 0 && !isLimitOnActivityTable(limit)) || !isSortOptionOnActivityTable(order) {
+		return false, nil
+	}
 	var auxDate time.Time
 	dateFormat := "2006-01-02 15:04:05.00"
 	auxDate, err = time.Parse(dateFormat, timeutil.Now().String())
@@ -343,14 +359,42 @@ FROM %s
 	return stmtsRuntime, txnsRuntime, err
 }
 
-// Common stmt and txn columns to sort on.
+// Return true is the limit request is within the limit
+// on the Activity tables (500)
+func isLimitOnActivityTable(limit int64) bool {
+	return limit <= 500
+}
+
+func isSortOptionOnActivityTable(sort serverpb.StatsSortOptions) bool {
+	switch sort {
+	case serverpb.StatsSortOptions_SERVICE_LAT,
+		serverpb.StatsSortOptions_CPU_TIME,
+		serverpb.StatsSortOptions_EXECUTION_COUNT,
+		serverpb.StatsSortOptions_P99_STMTS_ONLY,
+		serverpb.StatsSortOptions_CONTENTION_TIME:
+		return true
+	}
+	return false
+}
+
 const (
 	sortSvcLatDesc         = `(statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT DESC`
-	sortCPUTimeDesc        = `(statistics -> 'statistics' -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::FLOAT DESC`
+	sortCPUTimeDesc        = `(statistics -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::FLOAT DESC`
 	sortExecCountDesc      = `(statistics -> 'statistics' ->> 'cnt')::INT DESC`
 	sortContentionTimeDesc = `(statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::FLOAT DESC`
 	sortPCTRuntimeDesc     = `((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT *
                          (statistics -> 'statistics' ->> 'cnt')::FLOAT) DESC`
+	sortLatencyInfoP50Desc = `(statistics -> 'statistics' -> 'latencyInfo' ->> 'p50')::FLOAT DESC`
+	sortLatencyInfoP90Desc = `(statistics -> 'statistics' -> 'latencyInfo' ->> 'p90')::FLOAT DESC`
+	sortLatencyInfoP99Desc = `(statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::FLOAT DESC`
+	sortLatencyInfoMinDesc = `(statistics -> 'statistics' -> 'latencyInfo' ->> 'min')::FLOAT DESC`
+	sortLatencyInfoMaxDesc = `(statistics -> 'statistics' -> 'latencyInfo' ->> 'max')::FLOAT DESC`
+	sortRowsProcessedDesc  = `((statistics -> 'statistics' -> 'rowsRead' ->> 'mean')::FLOAT + 
+												 (statistics -> 'statistics' -> 'rowsWritten' ->> 'mean')::FLOAT) DESC`
+	sortMaxMemoryDesc = `(statistics -> 'execution_statistics' -> 'maxMemUsage' ->> 'mean')::FLOAT DESC`
+	sortNetworkDesc   = `(statistics -> 'execution_statistics' -> 'networkBytes' ->> 'mean')::FLOAT DESC`
+	sortRetriesDesc   = `(statistics -> 'statistics' ->> 'maxRetries')::INT DESC`
+	sortLastExecDesc  = `(statistics -> 'statistics' ->> 'lastExecAt') DESC`
 )
 
 func getStmtColumnFromSortOption(sort serverpb.StatsSortOptions) string {
@@ -362,9 +406,27 @@ func getStmtColumnFromSortOption(sort serverpb.StatsSortOptions) string {
 	case serverpb.StatsSortOptions_EXECUTION_COUNT:
 		return sortExecCountDesc
 	case serverpb.StatsSortOptions_P99_STMTS_ONLY:
-		return `(statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::FLOAT DESC`
+		return sortLatencyInfoP99Desc
 	case serverpb.StatsSortOptions_CONTENTION_TIME:
 		return sortContentionTimeDesc
+	case serverpb.StatsSortOptions_LATENCY_INFO_P50:
+		return sortLatencyInfoP50Desc
+	case serverpb.StatsSortOptions_LATENCY_INFO_P90:
+		return sortLatencyInfoP90Desc
+	case serverpb.StatsSortOptions_LATENCY_INFO_MIN:
+		return sortLatencyInfoMinDesc
+	case serverpb.StatsSortOptions_LATENCY_INFO_MAX:
+		return sortLatencyInfoMaxDesc
+	case serverpb.StatsSortOptions_ROWS_PROCESSED:
+		return sortRowsProcessedDesc
+	case serverpb.StatsSortOptions_MAX_MEMORY:
+		return sortMaxMemoryDesc
+	case serverpb.StatsSortOptions_NETWORK:
+		return sortNetworkDesc
+	case serverpb.StatsSortOptions_RETRIES:
+		return sortRetriesDesc
+	case serverpb.StatsSortOptions_LAST_EXEC:
+		return sortLastExecDesc
 	default:
 		return sortSvcLatDesc
 	}
@@ -981,7 +1043,14 @@ func getStatementDetails(
 	activityHasData := false
 	reqStartTime := getTimeFromSeconds(req.Start)
 	if settings.Version.IsActive(ctx, clusterversion.V23_1AddSystemActivityTables) {
-		activityHasData, err = activityTablesHaveFullData(ctx, ie, testingKnobs, reqStartTime)
+		activityHasData, err = activityTablesHaveFullData(
+			ctx,
+			ie,
+			testingKnobs,
+			reqStartTime,
+			1,
+			serverpb.StatsSortOptions_SERVICE_LAT, //Order is not used on this endpoint, so any value can be passed here.
+		)
 		if err != nil {
 			log.Errorf(ctx, "Error on getStatementDetails: %s", err)
 		}

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1627,12 +1627,23 @@ message StatementsResponse {
 }
 
 enum StatsSortOptions {
+  // Sort options that exist on the top Activity tables.
   SERVICE_LAT = 0;
   CPU_TIME = 1;
   EXECUTION_COUNT = 2;
   P99_STMTS_ONLY = 3;
   CONTENTION_TIME = 4;
   PCT_RUNTIME = 5;
+  // Sort options only available on default stats tables.
+  LATENCY_INFO_P50 = 6;
+  LATENCY_INFO_P90 = 7;
+  LATENCY_INFO_MIN = 8;
+  LATENCY_INFO_MAX = 9;
+  ROWS_PROCESSED = 10;
+  MAX_MEMORY = 11;
+  NETWORK = 12;
+  RETRIES = 13;
+  LAST_EXEC = 14;
 }
 message CombinedStatementsStatsRequest {
   enum StatsType {

--- a/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
@@ -18,6 +18,7 @@ $colors--primary-blue-4: #005fb3;
 $colors--primary-blue-5: #00294d;
 $colors--primary-blue-6: #89b0ff;
 $colors--primary-blue-7: #b6ceff;
+$colors--primary-blue-8: #deebff;
 $colors--primary-blue-alert: #e1ecff;
 
 $colors--primary-green-0: #daf8d4;

--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
@@ -1,5 +1,17 @@
 @import "../core/index.module";
 
+:global(.ant-dropdown-menu-submenu-popup ul) {
+  padding-bottom: 5px;
+}
+
+:global(.ant-dropdown-menu-item:hover) {
+  background-color: $colors--primary-blue-8;
+}
+
+:global(.ant-dropdown-menu-submenu-title:hover) {
+  background-color: $colors--primary-blue-8;
+}
+
 .search-area {
   border: 1px solid $colors--neutral-3;
   border-radius: 3px;
@@ -17,10 +29,14 @@
 
   label {
     display: block;
-    margin-bottom: 0px;
+    margin-bottom: 0;
     font-family: $font-family--lato-regular;
     font-size: $font-size--medium;
     font-weight: $font-weight--light;
+
+    :global(.ant-btn) {
+      border-color: $colors--neutral-4;
+    }
   }
 
   ul {
@@ -41,4 +57,52 @@
 
 .margin-top-btn {
   margin-top: 22px;
+}
+
+.dropdown-area {
+  align-items: center;
+  border-color: $colors--neutral-4;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  color: $colors--neutral-6;
+  display: flex;
+  font-family: $font-family--lato-regular;
+  font-weight: $font-weight--light;
+  font-size: $font-size--medium;
+  line-height: $line-height--medium-small;
+  height: 43px;
+  padding-left: 8px;
+}
+
+.small {
+  width: 80px;
+}
+
+.medium {
+  width: 175px;
+}
+
+.large {
+  width: 210px;
+}
+
+.dropdown-value-small {
+  width: 50px;
+}
+
+.dropdown-value-medium {
+  width: 145px;
+}
+
+.arrow-down {
+  fill: $colors--neutral-4;
+}
+
+.options-warning {
+  font-family: $font-family--base;
+  font-size: $font-size--small;
+  color: $colors--neutral-6;
+  padding: 10px;
+  display: inline-block;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.tsx
@@ -13,24 +13,37 @@ import classNames from "classnames/bind";
 import styles from "./searchCriteria.module.scss";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
 import { Button } from "src/button";
-import { commonStyles, selectCustomStyles } from "src/common";
+import { commonStyles } from "src/common";
 import {
   TimeScale,
   timeScale1hMinOptions,
   TimeScaleDropdown,
 } from "src/timeScaleDropdown";
 import { applyBtn } from "../queryFilter/filterClasses";
-import Select from "react-select";
-import { limitOptions } from "../util/sqlActivityConstants";
-import { SqlStatsSortType } from "src/api/statementsApi";
+import { Menu, Dropdown } from "antd";
+import "antd/lib/menu/style";
+import "antd/lib/dropdown/style";
+import {
+  limitOptions,
+  limitMoreOptions,
+  getSortLabel,
+  stmtRequestSortOptions,
+  txnRequestSortOptions,
+  stmtRequestSortMoreOptions,
+  txnRequestSortMoreOptions,
+} from "../util/sqlActivityConstants";
+import { SqlStatsSortOptions, SqlStatsSortType } from "src/api/statementsApi";
+import { CaretDown } from "@cockroachlabs/icons";
+import { ClickParam } from "antd/lib/menu";
 const cx = classNames.bind(styles);
+const { SubMenu } = Menu;
 
 type SortOption = {
   label: string;
   value: SqlStatsSortType;
 };
 export interface SearchCriteriaProps {
-  sortOptions: SortOption[];
+  searchType: "Statement" | "Transaction";
   currentScale: TimeScale;
   topValue: number;
   byValue: SqlStatsSortType;
@@ -42,35 +55,69 @@ export interface SearchCriteriaProps {
 
 export function SearchCriteria(props: SearchCriteriaProps): React.ReactElement {
   const {
+    searchType,
     topValue,
     byValue,
     currentScale,
     onChangeTop,
     onChangeBy,
     onChangeTimeScale,
-    sortOptions,
   } = props;
-  const customStyles = { ...selectCustomStyles };
-  customStyles.indicatorSeparator = (provided: any) => ({
-    ...provided,
-    display: "none",
-  });
+  const sortOptions: SortOption[] =
+    searchType === "Statement" ? stmtRequestSortOptions : txnRequestSortOptions;
+  const sortMoreOptions: SortOption[] =
+    searchType === "Statement"
+      ? stmtRequestSortMoreOptions
+      : txnRequestSortMoreOptions;
 
-  const customStylesTop = { ...customStyles };
-  customStylesTop.container = (provided: any) => ({
-    ...provided,
-    width: "80px",
-    border: "none",
-    lineHeight: "29px",
-  });
+  const warning = (
+    <span className={cx("options-warning", "large")}>
+      You may experience a longer loading time when selecting options below.
+    </span>
+  );
 
-  const customStylesBy = { ...customStyles };
-  customStylesBy.container = (provided: any) => ({
-    ...provided,
-    width: "170px",
-    border: "none",
-    lineHeight: "29px",
-  });
+  const changeTop = (event: ClickParam): void => {
+    const top = Number(event.key);
+    if (top !== topValue) {
+      onChangeTop(top);
+    }
+  };
+  const changeBy = (event: ClickParam): void => {
+    const by = Object.values(SqlStatsSortOptions).find(
+      s => s === Number(event.key),
+    );
+    if (by !== byValue) {
+      onChangeBy(by as SqlStatsSortType);
+    }
+  };
+
+  const menuTop = (
+    <Menu onClick={changeTop}>
+      {limitOptions.map(option => (
+        <Menu.Item key={option.value}>{option.label}</Menu.Item>
+      ))}
+      <SubMenu title="More">
+        {warning}
+        {limitMoreOptions.map(option => (
+          <Menu.Item key={option.value}>{option.label}</Menu.Item>
+        ))}
+      </SubMenu>
+    </Menu>
+  );
+
+  const menuBy = (
+    <Menu onClick={changeBy}>
+      {sortOptions.map(option => (
+        <Menu.Item key={option.value}>{option.label}</Menu.Item>
+      ))}
+      <SubMenu title="More">
+        {warning}
+        {sortMoreOptions.map(option => (
+          <Menu.Item key={option.value}>{option.label}</Menu.Item>
+        ))}
+      </SubMenu>
+    </Menu>
+  );
 
   return (
     <div className={cx("search-area")}>
@@ -79,25 +126,25 @@ export function SearchCriteria(props: SearchCriteriaProps): React.ReactElement {
         <PageConfigItem>
           <label>
             <span className={cx("label")}>Top</span>
-            <Select
-              options={limitOptions}
-              value={limitOptions.filter(top => top.value === topValue)}
-              onChange={event => onChangeTop(event.value)}
-              styles={customStylesTop}
-            />
+            <Dropdown overlay={menuTop} trigger={["click"]}>
+              <div className={cx("dropdown-area", "small")}>
+                <div className={cx("dropdown-value-small")}>{topValue}</div>
+                <CaretDown className={cx("arrow-down")} />
+              </div>
+            </Dropdown>
           </label>
         </PageConfigItem>
         <PageConfigItem>
           <label>
             <span className={cx("label")}>By</span>
-            <Select
-              options={sortOptions}
-              value={sortOptions.filter(
-                (top: SortOption) => top.value === byValue,
-              )}
-              onChange={event => onChangeBy(event.value as SqlStatsSortType)}
-              styles={customStylesBy}
-            />
+            <Dropdown overlay={menuBy} trigger={["click"]}>
+              <div className={cx("dropdown-area", "medium")}>
+                <div className={cx("dropdown-value-medium")}>
+                  {getSortLabel(byValue, searchType)}
+                </div>
+                <CaretDown className={cx("arrow-down")} />
+              </div>
+            </Dropdown>
           </label>
         </PageConfigItem>
         <PageConfigItem>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -86,7 +86,6 @@ import {
 } from "../sqlActivity/util";
 import {
   STATS_LONG_LOADING_DURATION,
-  stmtRequestSortOptions,
   getSortLabel,
   getSortColumn,
   getSubsetWarning,
@@ -723,7 +722,7 @@ export class StatementsPage extends React.Component<
     return (
       <div className={cx("root")}>
         <SearchCriteria
-          sortOptions={stmtRequestSortOptions}
+          searchType="Statement"
           topValue={this.state.limit}
           byValue={this.state.reqSortSetting}
           currentScale={this.state.timeScale}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -75,7 +75,6 @@ import { TransactionViewType } from "./transactionsPageTypes";
 import { isSelectedColumn } from "../columnsSelector/utils";
 import {
   STATS_LONG_LOADING_DURATION,
-  txnRequestSortOptions,
   getSortLabel,
   getSortColumn,
   getSubsetWarning,
@@ -662,7 +661,7 @@ export class TransactionsPage extends React.Component<
     return (
       <>
         <SearchCriteria
-          sortOptions={txnRequestSortOptions}
+          searchType="Transaction"
           topValue={this.state.limit}
           byValue={this.state.reqSortSetting}
           currentScale={this.state.timeScale}


### PR DESCRIPTION
Fixes #101817

More Options were added on Search Criteria for SQL Activity page.
For top limit: 1000, 5000 and 10000.
<img width="437" alt="Screenshot 2023-05-26 at 10 03 10 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/09c1beb0-19dc-428d-8dd8-970e4852b594">


For Priority By On Statements page:
- Last Execution Time
- Max Latency
- Max Memory
- Min Latency
- Network
- P50 Latency
- P90 Latency
- Retries
- Rows Processed
<img width="552" alt="Screenshot 2023-05-26 at 10 03 20 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/b8bec8ff-e12c-46aa-8933-4faf4eaa2a01">


For Priority By on Transactions page:
- Max Memory
- Network
- Retries
- Rows Processed
<img width="542" alt="Screenshot 2023-05-26 at 10 03 36 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/ff8fef4e-71ff-42c7-9f75-3153a687adbc">


It also fixes the sort on CPU that was sorting by the wrong column.

Release note (ui change): On SQL Activity page add more Search Criteria options, by adding for "Top": 1000, 5000 and 10000. For "By" on Statements tab: - Last Execution Time, Max Latency, Max Memory, Min Latency, Network, P50 Latency, P90 Latency, Retries, Rows Processed.
For "By" on Transactions tab: Max Memory, Network, Retries, Rows Processed.
Release note (bug fix): Uses the correct column to sort by on CPU.