### PR TITLE
roachtest: update activerecord adapter version

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -30,7 +30,7 @@ import (
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
 var supportedRailsVersion = "7.0.3"
-var activerecordAdapterVersion = "v7.0.0"
+var activerecordAdapterVersion = "v7.0.2"
 
 // This test runs activerecord's full test suite against a single cockroach node.
 


### PR DESCRIPTION
This patch updates the version of the CockroachDB activerecord adapter
used for testing to v7.0.2.

Informs #97283
Informs #99620

Release note: None