### PR TITLE
roachtest: speed up `failover` replication

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -346,6 +346,7 @@ func runFailoverPartialLeaseGateway(
 	// Create cluster.
 	opts := option.DefaultStartOpts()
 	settings := install.MakeClusterSettings()
+	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
 	failer := makeFailer(t, c, failureModeBlackhole, opts, settings).(PartialFailer)
 	failer.Setup(ctx)
@@ -499,6 +500,7 @@ func runFailoverPartialLeaseLeader(
 	opts := option.DefaultStartOpts()
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_DISABLE_LEADER_FOLLOWS_LEASEHOLDER=true")
+	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
 	failer := makeFailer(t, c, failureModeBlackhole, opts, settings).(PartialFailer)
 	failer.Setup(ctx)
@@ -652,6 +654,7 @@ func runFailoverPartialLeaseLiveness(
 	// Create cluster.
 	opts := option.DefaultStartOpts()
 	settings := install.MakeClusterSettings()
+	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
 	failer := makeFailer(t, c, failureModeBlackhole, opts, settings).(PartialFailer)
 	failer.Setup(ctx)
@@ -795,6 +798,7 @@ func runFailoverNonSystem(
 	opts := option.DefaultStartOpts()
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
+	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
 	failer := makeFailer(t, c, failureMode, opts, settings)
 	failer.Setup(ctx)
@@ -936,6 +940,7 @@ func runFailoverLiveness(
 	opts := option.DefaultStartOptsNoBackups()
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
+	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
 	failer := makeFailer(t, c, failureMode, opts, settings)
 	failer.Setup(ctx)
@@ -1081,6 +1086,7 @@ func runFailoverSystemNonLiveness(
 	opts := option.DefaultStartOpts()
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
+	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
 	failer := makeFailer(t, c, failureMode, opts, settings)
 	failer.Setup(ctx)


### PR DESCRIPTION
`failover` test upreplication can take a very long time, over 10 minutes. This patch significantly speeds up upreplication by setting `COCKROACH_SCAN_MAX_IDLE_TIME=100ms`, increasing the replicate queue scan rate.

Touches #103986.
Touches #104002.

Epic: none
Release note: None