### PR TITLE
roachtest: fix param type in `failover` deadlock mode

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -1510,9 +1510,9 @@ func (f *deadlockFailer) Fail(ctx context.Context, nodeID int) {
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second) // can take a while to lock
 	defer cancel()
 
-	predicate := `$1 = ANY(replicas)`
+	predicate := `$1::int = ANY(replicas)`
 	if f.onlyLeaseholders {
-		predicate += ` AND lease_holder = $1`
+		predicate += ` AND lease_holder = $1::int`
 	}
 
 	conn := f.c.Conn(ctx, f.t.L(), nodeID)


### PR DESCRIPTION
Sorry for the noise!

Resolves #103992.
Resolves #103994.
Resolves #103996.
Resolves #103997.
Resolves #103998.
Resolves #103999.
Resolves #104001.
Resolves #104003.
Resolves #104004.

Epic: none
Release note: None