### PR TITLE
roachtest: fix `failover` chaos tests

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -253,7 +253,7 @@ func runFailoverChaos(
 					}
 				}
 				if d, ok := failer.(*deadlockFailer); ok { // randomize deadlockFailer
-					d.numReplicas = 1 + rng.Intn(10)
+					d.numReplicas = 1 + rng.Intn(3)
 					d.onlyLeaseholders = rng.Float64() < 0.5
 				}
 				failer.Ready(ctx, m)
@@ -1284,7 +1284,7 @@ func makeFailerWithoutLocalNoop(
 			startOpts:        opts,
 			startSettings:    settings,
 			onlyLeaseholders: true,
-			numReplicas:      5,
+			numReplicas:      3,
 		}
 	case failureModeDiskStall:
 		return &diskStallFailer{

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -46,10 +46,11 @@ func registerFailover(r registry.Registry) {
 				suffix = "/read-write" + suffix
 			}
 			r.Add(registry.TestSpec{
-				Name:    "failover/chaos" + suffix,
-				Owner:   registry.OwnerKV,
-				Timeout: 60 * time.Minute,
-				Cluster: r.MakeClusterSpec(10, spec.CPU(4), spec.PreferLocalSSD(false)), // uses disk stalls
+				Name:                "failover/chaos" + suffix,
+				Owner:               registry.OwnerKV,
+				Timeout:             60 * time.Minute,
+				Cluster:             r.MakeClusterSpec(10, spec.CPU(4), spec.PreferLocalSSD(false)),
+				SkipPostValidations: registry.PostValidationNoDeadNodes, // cleanup kills nodes
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runFailoverChaos(ctx, t, c, readOnly, expirationLeases)
 				},


### PR DESCRIPTION
**roachtest: skip dead node checks in `failover/chaos`**

The disk stall dmsetup cleanup needs to kill the nodes first, so we have to disable the dead node validation.

Resolves #104022.
Resolves #104021.
Resolves #104019.

**roachtest: reduce `failover` deadlock replica count**

The deadlock failure mode acquires replica locks sequentially. The chaos test randomly acquired up to 10 replica locks. This could cause the locking to exceed the 20 second context timeout.

This patch reduces the number of locked replicas to 3. This should still be sufficient to cover most failure modes.

Resolves #104020.

Epic: none
Release note: None