### PR TITLE
kvserver: don't apply quota pool to lease requests

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -28,8 +28,14 @@ import (
 )
 
 func (r *Replica) maybeAcquireProposalQuota(
-	ctx context.Context, quota uint64,
+	ctx context.Context, ba *kvpb.BatchRequest, quota uint64,
 ) (*quotapool.IntAlloc, error) {
+	// We don't want to delay lease requests or transfers, in particular
+	// expiration lease extensions. These are small and latency-sensitive.
+	if ba.IsSingleRequestLeaseRequest() || ba.IsSingleTransferLeaseRequest() {
+		return nil, nil
+	}
+
 	r.mu.RLock()
 	quotaPool := r.mu.proposalQuota
 	desc := *r.mu.state.Desc

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -271,7 +271,7 @@ func (r *Replica) evalAndPropose(
 		))
 	}
 	var err error
-	proposal.quotaAlloc, err = r.maybeAcquireProposalQuota(ctx, quotaSize)
+	proposal.quotaAlloc, err = r.maybeAcquireProposalQuota(ctx, ba, quotaSize)
 	if err != nil {
 		return nil, nil, "", nil, kvpb.NewError(err)
 	}


### PR DESCRIPTION
Lease requests and transfers are latency sensitive and small, so we allow them to bypass the quota pool. This is particularly important for expiration lease extensions, which happen every 3 seconds.

During TPCC imports, the quota pool was often found to delay lease requests by as much as 3 seconds.

Resolves #98124.

Epic: none
Release note: None