### PR TITLE
kvserver: add `COCKROACH_RAFT_ENABLE_CHECKQUORUM`

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -242,6 +242,38 @@ var (
 	defaultRaftReproposalTimeoutTicks = envutil.EnvOrDefaultInt(
 		"COCKROACH_RAFT_REPROPOSAL_TIMEOUT_TICKS", 6)
 
+	// defaultRaftEnableCheckQuorum specifies whether to enable CheckQuorum in
+	// Raft. This makes a leader keep track of when it last heard from followers,
+	// and automatically step down if it hasn't heard from a quorum in the last
+	// election timeout. This is particularly important with asymmetric or partial
+	// network partitions, where a leader can otherwise hold on to leadership via
+	// heartbeats even though many/all replicas are unable to reach the leader.
+	//
+	// In etcd/raft, this also has the effect of fully enabling PreVote, such that
+	// a follower will not grant a PreVote for a candidate if it has heard from an
+	// established leader in the past election timeout. This is particularly
+	// important to prevent nodes rejoining a cluster after a restart or network
+	// partition from stealing away leadership from an established leader
+	// (assuming they have an up-to-date log, which they do with a read-only
+	// workload). With asymmetric or partial network partitions, this can allow an
+	// unreachable node to steal away leadership, leading to range unavailability.
+	//
+	// The asymmetric partition concerns have largely been addressed by RPC
+	// dialback (see rpc.dialback.enabled), but the partial partition concerns
+	// remain.
+	//
+	// etcd/raft does register MsgHeartbeatResp as follower activity, and these
+	// are sent across the low-latency system RPC class, so it shouldn't be
+	// affected by RPC head-of-line blocking for MsgApp traffic.
+	//
+	// Note that time will not appear to progress on a quiesced range, so when
+	// unquiescing it may take some time before a leader steps down or a candidate
+	// is able to obtain prevotes.
+	//
+	// For now, we disable this by default, due to liveness concerns.
+	defaultRaftEnableCheckQuorum = envutil.EnvOrDefaultBool(
+		"COCKROACH_RAFT_ENABLE_CHECKQUORUM", false)
+
 	// defaultRaftLogTruncationThreshold specifies the upper bound that a single
 	// Range's Raft log can grow to before log truncations are triggered while at
 	// least one follower is missing. If all followers are active, the quota pool
@@ -482,6 +514,11 @@ type RaftConfig struct {
 	// means always renew.
 	RangeLeaseRenewalFraction float64
 
+	// RaftEnableCheckQuorum will enable Raft CheckQuorum, which in etcd/raft also
+	// fully enables PreVote. See comment on defaultRaftEnableCheckQuorum for
+	// details.
+	RaftEnableCheckQuorum bool
+
 	// RaftLogTruncationThreshold controls how large a single Range's Raft log
 	// can grow. When a Range's Raft log grows above this size, the Range will
 	// begin performing log truncations.
@@ -586,6 +623,9 @@ func (cfg *RaftConfig) SetDefaults() {
 	// SetDefaults is called multiple times (see NewStore()). So, we leave -1
 	// alone and ask all the users to handle it specially.
 
+	if !cfg.RaftEnableCheckQuorum {
+		cfg.RaftEnableCheckQuorum = defaultRaftEnableCheckQuorum
+	}
 	if cfg.RaftLogTruncationThreshold == 0 {
 		cfg.RaftLogTruncationThreshold = defaultRaftLogTruncationThreshold
 	}

--- a/pkg/base/testdata/raft_config
+++ b/pkg/base/testdata/raft_config
@@ -7,6 +7,7 @@ echo
  RaftHeartbeatIntervalTicks: (int) 2,
  RangeLeaseDuration: (time.Duration) 6s,
  RangeLeaseRenewalFraction: (float64) 0.5,
+ RaftEnableCheckQuorum: (bool) false,
  RaftLogTruncationThreshold: (int64) 16777216,
  RaftProposalQuota: (int64) 8388608,
  RaftMaxUncommittedEntriesSize: (uint64) 16777216,

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -296,8 +296,8 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 		return truncateDecision{}, nil
 	}
 
-	// For all our followers, overwrite the RecentActive field (which is always
-	// true since we don't use CheckQuorum) with our own activity check.
+	// For all our followers, overwrite the RecentActive field with our own
+	// activity check.
 	r.mu.RLock()
 	log.Eventf(ctx, "raft status before lastUpdateTimes check: %+v", raftStatus.Progress)
 	log.Eventf(ctx, "lastUpdateTimes: %+v", r.mu.lastUpdateTimes)
@@ -541,6 +541,8 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 		// be split many times over, resulting in a flurry of snapshots with
 		// overlapping bounds that put significant stress on the Raft snapshot
 		// queue.
+		//
+		// NB: RecentActive is populated by updateRaftProgressFromActivity().
 		if progress.RecentActive {
 			if progress.State == tracker.StateProbe {
 				decision.ProtectIndex(input.FirstIndex, truncatableIndexChosenViaProbingFollower)

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -702,10 +702,10 @@ type Replica struct {
 
 		// The most recently updated time for each follower of this range. This is updated
 		// every time a Raft message is received from a peer.
+		//
 		// Note that superficially it seems that similar information is contained in the
 		// Progress of a RaftStatus, which has a RecentActive field. However, that field
-		// is always true unless CheckQuorum is active, which at the time of writing in
-		// CockroachDB is not the case.
+		// is always true unless CheckQuorum is active.
 		//
 		// The lastUpdateTimes map is also updated when a leaseholder steps up
 		// (making the assumption that all followers are live at that point),

--- a/pkg/kv/kvserver/replica_raft_overload.go
+++ b/pkg/kv/kvserver/replica_raft_overload.go
@@ -124,6 +124,7 @@ func computeExpendableOverloadedFollowers(
 			prs = d.getProgressMap(ctx)
 			nonLive = map[roachpb.ReplicaID]nonLiveReason{}
 			for id, pr := range prs {
+				// NB: RecentActive is populated by updateRaftProgressFromActivity().
 				if !pr.RecentActive {
 					nonLive[roachpb.ReplicaID(id)] = nonLiveReasonInactive
 				}

--- a/pkg/kv/kvserver/split_delay_helper.go
+++ b/pkg/kv/kvserver/split_delay_helper.go
@@ -156,6 +156,7 @@ func maybeDelaySplitToAvoidSnapshot(ctx context.Context, sdh splitDelayHelperI) 
 
 		for replicaID, pr := range raftStatus.Progress {
 			if pr.State != tracker.StateReplicate {
+				// NB: RecentActive is populated by updateRaftProgressFromActivity().
 				if !pr.RecentActive {
 					if slept < tickDur {
 						// We don't want to delay splits for a follower who hasn't responded within a tick.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -311,7 +311,8 @@ func newRaftConfig(
 		Storage:                   strg,
 		Logger:                    logger,
 
-		PreVote: true,
+		PreVote:     true,
+		CheckQuorum: storeCfg.RaftEnableCheckQuorum,
 	}
 }
 


### PR DESCRIPTION
This patch adds `COCKROACH_RAFT_ENABLE_CHECKQUORUM`, which enables Raft CheckQuorum (and as a side-effect also fully enables PreVote). See code comment for details. It defaults to false, since we need to investigate liveness concerns from when CheckQuorum was previously enabled in the ancient past.

Raft uses the field `Progress.RecentActive` to track follower activity for CheckQuorum. When CheckQuorum is disabled, this is always `true`, but when enabled it will be reset to `false` regularly (with an interval that equals the election timeout). There are some uses of this field in CRDB, but we always replace this field with our own notion of activity via `updateRaftProgressFromActivity` (tracked in wall time with a timeout equaling the range lease interval).

Touches #92088.

Epic: none
Release note: None