### PR TITLE
release-22.2: more details about desc validity errors during upgrades

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -84,6 +84,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/collector"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // CrdbInternalName is the name of the crdb_internal schema.
@@ -5011,7 +5012,8 @@ CREATE TABLE crdb_internal.invalid_objects (
   database_name STRING,
   schema_name   STRING,
   obj_name      STRING,
-  error         STRING
+  error         STRING,
+  error_redactable STRING NOT VISIBLE
 )`,
 	populate: func(
 		ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
@@ -5061,6 +5063,7 @@ CREATE TABLE crdb_internal.invalid_objects (
 				tree.NewDString(scName),
 				tree.NewDString(objName),
 				tree.NewDString(validationError.Error()),
+				tree.NewDString(string(redact.Sprint(validationError))),
 			)
 		}
 

--- a/pkg/upgrade/upgrades/precondition_before_starting_an_upgrade_external_test.go
+++ b/pkg/upgrade/upgrades/precondition_before_starting_an_upgrade_external_test.go
@@ -119,8 +119,8 @@ func TestPreconditionBeforeStartingAnUpgrade(t *testing.T) {
 		require.Error(t, err, "upgrade should be refused because precondition is violated.")
 		require.Equal(t, "pq: verifying precondition for version 22.1-2: "+
 			"there exists invalid descriptors as listed below; fix these descriptors before attempting to upgrade again:\n"+
-			"invalid descriptor: defaultdb.public.t (104) because 'relation \"t\" (104): invalid depended-on-by relation back reference: referenced descriptor ID 53: referenced descriptor not found'\n"+
-			"invalid descriptor: defaultdb.public.temp_tbl (104) because 'no matching name info found in non-dropped relation \"t\"'",
+			"invalid descriptor: defaultdb.public.t (104) because relation \"t\" (104): invalid depended-on-by relation back reference: referenced descriptor ID 53: referenced descriptor not found\n"+
+			"invalid descriptor: defaultdb.public.temp_tbl (104) because no matching name info found in non-dropped relation \"t\"",
 			strings.ReplaceAll(err.Error(), "1000022", "22"))
 		// The cluster version should remain at `v0`.
 		ts.tdb.CheckQueryResults(t, "SHOW CLUSTER SETTING version", [][]string{{v0.String()}})


### PR DESCRIPTION
Fixes #102757.
Informs #104049.
Epic: CRDB-27642.

Before this patch:

```
ignoring invalid descriptor
‹defaultdb.public.test_upload_payload› (‹107›) with error because it
looks like known userfile-related corruption: ‹mutation job 800353382687703041: job not found›
```
which resulted after redaction into:
```
ignoring invalid descriptor ‹×› (‹×›) with error because it looks like
known userfile-related corruption: ‹×›
```

After this patch:

```
ignoring invalid descriptor
‹defaultdb.public.test_upload_payload› (107) with error because it
looks like known userfile-related corruption: mutation job 800353382687703041: job not found
```
which results after redaction into:
```
ignoring invalid descriptor ‹×› (107) with error because it looks like
known userfile-related corruption: mutation job 800353382687703041: job not found
```

Release note (cli change): Failures during descriptor validity checks
during cluster upgrades are now more detailed in redacted logs.

----
Release justification: better troubleshootability