### PR TITLE
roachtest: add admission-control/database-drop

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -106,6 +106,10 @@ type TestSpec struct {
 	// SnapshotPrefix is set by tests that make use of volume snapshots.
 	// Prefixes must be not only be unique across tests, but one cannot be a
 	// prefix of another.
+	//
+	// TODO(irfansharif): Search by taking in the other parts of the snapshot
+	// fingerprint, i.e. the node count, the version, etc. that appear in the
+	// infix. This will get rid of this awkward prefix naming restriction.
 	SnapshotPrefix string
 }
 

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "activerecord.go",
         "activerecord_blocklist.go",
         "admission_control.go",
+        "admission_control_database_drop.go",
         "admission_control_elastic_backup.go",
         "admission_control_elastic_cdc.go",
         "admission_control_index_backfill.go",

--- a/pkg/cmd/roachtest/tests/admission_control.go
+++ b/pkg/cmd/roachtest/tests/admission_control.go
@@ -37,4 +37,5 @@ func registerAdmission(r registry.Registry) {
 	registerTPCCSevereOverload(r)
 	registerIndexOverload(r)
 	registerIndexBackfill(r)
+	registerDatabaseDrop(r)
 }

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -1,0 +1,289 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
+)
+
+func registerDatabaseDrop(r registry.Registry) {
+	clusterSpec := r.MakeClusterSpec(
+		10, /* nodeCount */
+		spec.CPU(8),
+		spec.Zones("us-east1-b"),
+		spec.VolumeSize(500),
+		spec.Cloud(spec.GCE),
+	)
+	clusterSpec.InstanceType = "n2-standard-8"
+	clusterSpec.GCEMinCPUPlatform = "Intel Ice Lake"
+	clusterSpec.GCEVolumeType = "pd-ssd"
+
+	r.Add(registry.TestSpec{
+		Name:    "admission-control/database-drop",
+		Timeout: 10 * time.Hour,
+		Owner:   registry.OwnerAdmissionControl,
+		Skip:    "TC builder agents need new GCE permissions",
+		// TODO(irfansharif): Reduce to weekly cadence once stabilized.
+		// Tags:            registry.Tags(`weekly`),
+		Cluster:         clusterSpec,
+		RequiresLicense: true,
+		SnapshotPrefix:  "droppable-database-tpce-100k",
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			crdbNodes := c.Spec().NodeCount - 1
+			workloadNode := c.Spec().NodeCount
+
+			snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
+				NamePrefix: t.SnapshotPrefix(),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(snapshots) == 0 {
+				t.L().Printf("no existing snapshots found for %s (%s), doing pre-work",
+					t.Name(), t.SnapshotPrefix())
+
+				pred, err := version.PredecessorVersion(*t.BuildVersion())
+				if err != nil {
+					t.Fatal(err)
+				}
+				path, err := clusterupgrade.UploadVersion(ctx, t, t.L(), c, c.All(), pred)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Copy over the binary to ./cockroach and run it from there.
+				// This test captures disk snapshots, which are fingerprinted
+				// using the binary version found in this path. The reason it
+				// can't just poke at the running CRDB process is because when
+				// grabbing snapshots, CRDB is not running.
+				//
+				// TODO(irfansharif): Make this versioning business a bit more
+				// explicit throughout. It works, but too tacitly.
+				c.Run(ctx, c.All(), fmt.Sprintf("cp %s ./cockroach", path))
+
+				// Opportunistically try to make use of the tpce-100k snapshot,
+				// which another test creates.
+				tpce100kSnapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
+					NamePrefix: tpce100kSnapshotPrefix,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(tpce100kSnapshots) == 0 {
+					// Welp -- we don't have that either. Start from the start
+					// of time, by creating the first TPC-E 100k data set.
+					t.L().Printf("inner: no existing snapshots found for %s, doing pre-work",
+						t.SnapshotPrefix())
+
+					// Set up TPC-E with 100k customers. Do so using a published
+					// CRDB release, since we'll use this state to generate disk
+					// snapshots.
+					runTPCE(ctx, t, c, tpceOptions{
+						start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+							settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
+							if err := c.StartE(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, c.Range(1, crdbNodes)); err != nil {
+								t.Fatal(err)
+							}
+						},
+						customers:          100_000,
+						disablePrometheus:  true,
+						setupType:          usingTPCEInit,
+						estimatedSetupTime: 4 * time.Hour,
+						nodes:              crdbNodes,
+						cpus:               clusterSpec.CPUs,
+						ssds:               1,
+						onlySetup:          true,
+					})
+
+					// NB: Intentionally don't try to create tpce-100k snapshots
+					// here. There's no way to guarantee that there's only one
+					// writer writing these snapshots, and we leave it to the
+					// test that actually defined these tests.
+					//
+					// TODO(irfansharif): This is a bit awkward. Using snapshots
+					// across tests that use the same cluster spec is a
+					// reasonable pattern. We could do the
+					// following:
+					// - Creating snapshot-creation-only tests.
+					// - Including a UUID when creating snapshots, and then when
+					//   listing them, listing only the one that sorts earliest
+					//   alphabetically. This circumvents the multi-writer
+					//   problem.
+					// - Opportunistically prune lower-sorted snapshots since
+					//   they're not actually being used.
+				} else {
+					// Great! We can start with an existing tpce-100k dataset.
+					// Apply it and then make relevant changes on top.
+					t.L().Printf("inner: using %d pre-existing snapshot(s) with prefix %q",
+						len(tpce100kSnapshots), "tpce-100k")
+					if err := c.ApplySnapshots(ctx, tpce100kSnapshots); err != nil {
+						t.Fatal(err)
+					}
+
+					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
+					if err := c.StartE(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, c.Range(1, crdbNodes)); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				// We have to create the droppable database next. We're going to
+				// do it by renaming the existing TPC-E database and re-creating
+				// another one using the same init process above.
+				//
+				// TODO(irfansharif): The TPC-E workload hardcodes the name of
+				// the database it uses, hence this renaming dance. We could
+				// change that. We could also load up some other data heavy
+				// fixture, like TPC-C. All we're going to do is drop it. We
+				// could also use CREATE TABLE AS.
+
+				db := c.Conn(ctx, t.L(), 1)
+				defer db.Close()
+
+				if _, err := db.ExecContext(ctx,
+					"ALTER DATABASE tpce RENAME TO droppable_tpce;",
+				); err != nil {
+					t.Fatal(err)
+				}
+
+				// Set up TPC-E with 100k customers, again.
+				runTPCE(ctx, t, c, tpceOptions{
+					start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+						// Things are already staged/setup above. There's
+						// nothing to do here.
+					},
+					customers:          100_000,
+					disablePrometheus:  true,
+					setupType:          usingTPCEInit,
+					estimatedSetupTime: 4 * time.Hour,
+					nodes:              crdbNodes,
+					cpus:               clusterSpec.CPUs,
+					ssds:               1,
+					onlySetup:          true,
+				})
+
+				// Stop all nodes before capturing cluster snapshots.
+				c.Stop(ctx, t.L(), option.DefaultStopOpts())
+
+				// Create the aforementioned snapshots.
+				snapshots, err = c.CreateSnapshot(ctx, t.SnapshotPrefix())
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.L().Printf("created %d new snapshot(s) with prefix %q, using this state",
+					len(snapshots), t.SnapshotPrefix())
+			} else {
+				t.L().Printf("using %d pre-existing snapshot(s) with prefix %q",
+					len(snapshots), t.SnapshotPrefix())
+
+				if !t.SkipInit() {
+					// Creating and attaching volumes takes some time. This test
+					// is written to be re-entrant. Assume the user passing in
+					// --skip-init knows this particular test behavior.
+					if err := c.ApplySnapshots(ctx, snapshots); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+
+			promCfg := &prometheus.Config{}
+			promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
+				WithNodeExporter(c.Range(1, crdbNodes).InstallNodes()).
+				WithCluster(c.Range(1, crdbNodes).InstallNodes()).
+				WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana").
+				WithScrapeConfigs(
+					prometheus.MakeWorkloadScrapeConfig("workload", "/",
+						makeWorkloadScrapeNodes(
+							c.Node(workloadNode).InstallNodes()[0],
+							[]workloadInstance{{nodes: c.Node(workloadNode)}},
+						),
+					),
+				)
+
+			// Run the foreground TPC-E workload. Drop a full database while
+			// it's running.
+			//
+			// TODO(irfansharif): This doesn't show much of a foreground
+			// latency/throughput impact. Likely because TPC-E is very read
+			// heavy and in the short spurt where we there's a burst of
+			// compactions, we're not using disk bandwidth sufficiently to need
+			// something like disk bandwidth tokens. Find a more appropriate
+			// foreground load to run and refresh this test.
+			runTPCE(ctx, t, c, tpceOptions{
+				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
+					startOpts := option.DefaultStartOptsNoBackups()
+					startOpts.RoachprodOpts.Sequential = false // the cluster's already bootstrapped
+					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
+					if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
+						t.Fatal(err)
+					}
+				},
+				customers:        100_000,
+				activeCustomers:  20_000,
+				threads:          400,
+				skipCleanup:      true,
+				ssds:             1,
+				setupType:        usingExistingTPCEData,
+				nodes:            clusterSpec.NodeCount - 1,
+				cpus:             clusterSpec.CPUs,
+				prometheusConfig: promCfg,
+				workloadDuration: 30 * time.Minute,
+				during: func(ctx context.Context) error {
+					db := c.Conn(ctx, t.L(), 1)
+					defer db.Close()
+
+					t.Status(fmt.Sprintf("recording baseline performance (<%s)", 5*time.Minute))
+					time.Sleep(5 * time.Minute)
+
+					t.Status(fmt.Sprintf("issuing drop statements (happens asynchronously within <%s)", 15*time.Minute))
+					for _, dropStatement := range []string{
+						`DROP TABLE droppable_tpce.trade CASCADE`,
+						`DROP TABLE droppable_tpce.cash_transaction CASCADE`,
+						`DROP TABLE droppable_tpce.trade_history CASCADE`,
+						`DROP TABLE droppable_tpce.settlement CASCADE`,
+
+						// TODO(irfansharif): We'd rather drop the entire
+						// database of course, but there's a real bug:
+						// https://github.com/cockroachdb/cockroach/issues/104044.
+						// Change once fixed. The individual tables above amount
+						// to ~4TiB of data dropped. It exercises the same code
+						// paths as indexes being dropped.
+						//
+						// `DROP DATABASE droppable_tpce CASCADE`,
+					} {
+						if _, err := db.ExecContext(ctx,
+							dropStatement,
+						); err != nil {
+							return err
+						}
+					}
+
+					// TODO(irfansharif): Wait for "GC for DROP ..." jobs to
+					// finish explicitly.
+					t.Status(fmt.Sprintf("waiting for workload to finish (<%s)", 20*time.Minute))
+					return nil
+				},
+			})
+		},
+	})
+}

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -54,20 +54,6 @@ func registerIndexBackfill(r registry.Registry) {
 			crdbNodes := c.Spec().NodeCount - 1
 			workloadNode := c.Spec().NodeCount
 
-			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
-				WithNodeExporter(c.Range(1, crdbNodes).InstallNodes()).
-				WithCluster(c.Range(1, crdbNodes).InstallNodes()).
-				WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana").
-				WithScrapeConfigs(
-					prometheus.MakeWorkloadScrapeConfig("workload", "/",
-						makeWorkloadScrapeNodes(
-							c.Node(workloadNode).InstallNodes()[0],
-							[]workloadInstance{{nodes: c.Node(workloadNode)}},
-						),
-					),
-				)
-
 			snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
 				// TODO(irfansharif): Search by taking in the other parts of the
 				// snapshot fingerprint, i.e. the node count, the version, etc.
@@ -132,22 +118,39 @@ func registerIndexBackfill(r registry.Registry) {
 					len(snapshots), t.SnapshotPrefix())
 
 				if !t.SkipInit() {
-					// Creating and attaching volumes takes some time. This test is
-					// written to be re-entrant.
+					// Creating and attaching volumes takes some time. This test
+					// is written to be re-entrant. Assume the user passing in
+					// --skip-init knows this particular test behavior.
 					if err := c.ApplySnapshots(ctx, snapshots); err != nil {
 						t.Fatal(err)
 					}
 				}
 			}
 
-			// Run the foreground TPC-E workload. Run a large index backfill
-			// while it's running.
+			promCfg := &prometheus.Config{}
+			promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
+				WithNodeExporter(c.Range(1, crdbNodes).InstallNodes()).
+				WithCluster(c.Range(1, crdbNodes).InstallNodes()).
+				WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana").
+				WithScrapeConfigs(
+					prometheus.MakeWorkloadScrapeConfig("workload", "/",
+						makeWorkloadScrapeNodes(
+							c.Node(workloadNode).InstallNodes()[0],
+							[]workloadInstance{{nodes: c.Node(workloadNode)}},
+						),
+					),
+				)
+
+			// Run the foreground TPC-E workload for 20k customers for 1hr. Run
+			// large index backfills while it's running.
 			runTPCE(ctx, t, c, tpceOptions{
 				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
 					c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-					for i := 1; i <= crdbNodes; i++ {
-						c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, c.Node(i))
+					startOpts := option.DefaultStartOptsNoBackups()
+					startOpts.RoachprodOpts.Sequential = false // the cluster's already bootstrapped
+					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
+					if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
+						t.Fatal(err)
 					}
 				},
 				customers:        100_000,
@@ -161,24 +164,55 @@ func registerIndexBackfill(r registry.Registry) {
 				prometheusConfig: promCfg,
 				workloadDuration: time.Hour,
 				during: func(ctx context.Context) error {
-					t.Status(fmt.Sprintf("recording baseline performance (<%s)",
-						5*time.Minute))
-					time.Sleep(5 * time.Minute)
-
 					db := c.Conn(ctx, t.L(), 1)
 					defer db.Close()
-					// Choose an index creation that takes ~30 minutes.
-					t.Status(fmt.Sprintf("starting index creation (<%s)", 30*time.Minute))
+
+					// Gently wind up AddSST concurrency, to increase the
+					// likelihood of getting into IO overload regime due to
+					// follower activity.
 					if _, err := db.ExecContext(ctx,
-						fmt.Sprintf("CREATE INDEX index_%s ON tpce.cash_transaction (ct_dts)",
-							timeutil.Now().Format("20060102_T150405"),
-						),
+						"SET CLUSTER SETTING kv.bulk_io_write.concurrent_addsstable_requests = 3",
 					); err != nil {
-						t.Fatalf("failed to create index: %v", err)
+						t.Fatal(err)
 					}
 
-					t.Status("index creation complete, waiting for workload to finish (<%s)",
-						25*time.Minute)
+					// Defeat https://github.com/cockroachdb/cockroach/issues/98311.
+					if _, err := db.ExecContext(ctx,
+						"SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false;",
+					); err != nil {
+						t.Fatal(err)
+					}
+
+					t.Status(fmt.Sprintf("recording baseline performance (<%s)", 5*time.Minute))
+					time.Sleep(5 * time.Minute)
+
+					// Choose index creations that would take ~30 minutes each.
+					// Offset them by 5 minutes.
+					m := c.NewMonitor(ctx, c.Range(1, crdbNodes))
+					m.Go(func(ctx context.Context) error {
+						t.Status(fmt.Sprintf("starting first index creation (<%s)", 30*time.Minute))
+						_, err := db.ExecContext(ctx,
+							fmt.Sprintf("CREATE INDEX index_%s ON tpce.cash_transaction (ct_dts)",
+								timeutil.Now().Format("20060102_T150405"),
+							),
+						)
+						t.Status("finished first index creation")
+						return err
+					})
+					m.Go(func(ctx context.Context) error {
+						time.Sleep(5 * time.Minute)
+						t.Status(fmt.Sprintf("starting second index creation (<%s)", 30*time.Minute))
+						_, err := db.ExecContext(ctx,
+							fmt.Sprintf("CREATE INDEX index_%s ON tpce.holding_history (hh_before_qty)",
+								timeutil.Now().Format("20060102_T150405"),
+							),
+						)
+						t.Status("finished second index creation")
+						return err
+					})
+					m.Wait()
+
+					t.Status("waiting for workload to finish (<%s)", 20*time.Minute)
 					return nil
 				},
 			})

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1636,8 +1636,11 @@ func setupPrometheusForRoachtest(
 		t.Fatal(err)
 	}
 	cleanupFunc := func() {
+		if t.IsDebug() {
+			return // nothing to do
+		}
 		if err := c.StopGrafana(ctx, quietLogger, t.ArtifactsDir()); err != nil {
-			t.L().ErrorfCtx(ctx, "Error(s) shutting down prom/grafana %s", err)
+			t.L().ErrorfCtx(ctx, "error(s) shutting down prom/grafana: %s", err)
 		}
 	}
 	return cfg, cleanupFunc

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1762,6 +1762,11 @@ func ApplySnapshots(
 		res := &install.RunResultDetails{Node: node}
 
 		volumeOpts := opts // make a copy
+		volumeOpts.Labels = map[string]string{}
+		for k, v := range opts.Labels {
+			volumeOpts.Labels[k] = v
+		}
+
 		cVM := &c.VMs[i]
 		if err := vm.ForProvider(cVM.Provider, func(provider vm.Provider) error {
 			volumeOpts.Zone = cVM.Zone
@@ -1782,9 +1787,6 @@ func ApplySnapshots(
 				}
 			}
 
-			if volumeOpts.Labels == nil {
-				volumeOpts.Labels = map[string]string{}
-			}
 			volumeOpts.Labels[vm.TagCluster] = clusterName
 			volumeOpts.Labels[vm.TagLifetime] = cVM.Lifetime.String()
 			volumeOpts.Labels[vm.TagRoachprod] = "true"

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -379,6 +379,9 @@ func (p *Provider) ListVolumeSnapshots(
 
 	var snapshots []vm.VolumeSnapshot
 	for _, snapshotJson := range snapshotsJSONResponse {
+		if !strings.HasPrefix(snapshotJson.Name, vslo.NamePrefix) {
+			continue
+		}
 		snapshots = append(snapshots, vm.VolumeSnapshot{
 			ID:   snapshotJson.ID,
 			Name: snapshotJson.Name,


### PR DESCRIPTION
**roachtest: add admission-control/database-drop**

Part of #89208. We've seen incidents where a large index being dropped
caused a moderate latency/throughput impact on foreground load.
Index/table/database drop all share the same underlying code, we make
metadata only changes on the descriptor, wait out the GC TTL, and issue
range deletion tombstones over the now-deleted keyspace. On subsequent
pebble compactions, storage space is reclaimed. See
pkg/sql/schema_changer.go for where all this work originates.

This particular test makes two copies of the 4TiB replicated TPC-E 100k
dataset, runs foreground workload against one and drops the other. It
makes use of disk snapshots of course, because we're impatient.

**roachprod/gce: use prefix search in snapshot listing API**

Like the API intended. Only noticed in the subsequent commit when
introducing a second use of disk snapshots that happened to use
"tpcc-100k" in its name, somewhere.

**roachtest: update index-backfill roachtest**

Adding a bit more commentary, throwing in another concurrent index
backfill for free, and fighting some open CRDB bugs unrelated to the
test.

**roachtest: fix race with concurrent map writes**

This author forgot that struct copies weren't deep enough.