### PR TITLE
release-22.1: server, sql: show in-memory data when no data is persisted

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -38,6 +39,16 @@ func getTimeFromSeconds(seconds int64) *time.Time {
 		return &t
 	}
 	return nil
+}
+
+func closeIterator(it sqlutil.InternalRows, err error) error {
+	if it != nil {
+		closeErr := it.Close()
+		if closeErr != nil {
+			err = errors.CombineErrors(err, closeErr)
+		}
+	}
+	return err
 }
 
 func (s *statusServer) CombinedStatementStats(
@@ -147,7 +158,7 @@ COALESCE(
     (statistics-> 'statistics' ->> 'cnt')::FLOAT
   )
 , 0)
-FROM crdb_internal.%s_statistics_persisted
+FROM crdb_internal.%s_statistics%s
 %s
 `
 
@@ -157,32 +168,58 @@ FROM crdb_internal.%s_statistics_persisted
 			fmt.Sprintf(`%s-total-runtime`, table),
 			nil,
 			sessiondata.NodeUserSessionDataOverride,
-			fmt.Sprintf(queryWithPlaceholders, table, whereClause),
+			fmt.Sprintf(queryWithPlaceholders, table, `_persisted`, whereClause),
 			args...)
+
+		defer func() {
+			err = closeIterator(it, err)
+		}()
 
 		if err != nil {
 			return 0, err
 		}
-
-		defer func() {
-			closeErr := it.Close()
-			if closeErr != nil {
-				err = errors.CombineErrors(err, closeErr)
-			}
-		}()
-
 		ok, err := it.Next(ctx)
 		if err != nil {
 			return 0, err
 		}
-
 		if !ok {
-			return 0, errors.New("expected one row but got none")
+			return 0, errors.New("expected one row but got none on getTotalRuntimeSecs")
 		}
 
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return 0, errors.New("unexpected null row")
+			return 0, errors.New("unexpected null row on getTotalRuntimeSecs")
+		}
+
+		// If the total runtime is 0 there were no results from the persisted table,
+		// so we retrieve the data from the combined view with data in-memory.
+		if tree.MustBeDFloat(row[0]) == 0 {
+			err := closeIterator(it, err)
+			if err != nil {
+				return 0, err
+			}
+			it, err = ie.QueryIteratorEx(
+				ctx,
+				fmt.Sprintf(`%s-total-runtime-with-memory`, table),
+				nil,
+				sessiondata.NodeUserSessionDataOverride,
+				fmt.Sprintf(queryWithPlaceholders, table, ``, whereClause),
+				args...)
+
+			if err != nil {
+				return 0, err
+			}
+			ok, err = it.Next(ctx)
+			if err != nil {
+				return 0, err
+			}
+			if !ok {
+				return 0, errors.New("expected one row but got none on getTotalRuntimeSecs")
+			}
+
+			if row = it.Cur(); row == nil {
+				return 0, errors.New("unexpected null row on getTotalRuntimeSecs")
+			}
 		}
 
 		return float32(tree.MustBeDFloat(row[0])), nil
@@ -347,7 +384,8 @@ func collectCombinedStatements(
 	testingKnobs *sqlstats.TestingKnobs,
 ) ([]serverpb.StatementsResponse_CollectedStatementStatistics, error) {
 	aostClause := testingKnobs.GetAOSTClause()
-	query := fmt.Sprintf(`
+	const expectedNumDatums = 6
+	queryFormat := `
 SELECT * FROM (
 SELECT
     fingerprint_id,
@@ -356,43 +394,62 @@ SELECT
     max(aggregated_ts) as aggregated_ts,
     metadata,
     crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
-FROM crdb_internal.statement_statistics_persisted %s
+FROM %s %s
 GROUP BY
     fingerprint_id,
     transaction_fingerprint_id,
     app_name,
     metadata
 ) %s
-%s`, whereClause, aostClause, orderAndLimit)
+%s`
 
-	const expectedNumDatums = 6
-
+	query := fmt.Sprintf(
+		queryFormat,
+		`crdb_internal.statement_statistics_persisted`,
+		whereClause,
+		aostClause,
+		orderAndLimit)
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-by-interval", nil,
 		sessiondata.InternalExecutorOverride{
 			User: security.NodeUserName(),
 		}, query, args...)
 
+	defer func() {
+		err = closeIterator(it, err)
+	}()
+
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
 
-	defer func() {
-		closeErr := it.Close()
-		if closeErr != nil {
-			err = errors.CombineErrors(err, closeErr)
+	// If there are no results from the persisted table, retrieve the data from the combined view
+	// with data in-memory.
+	if !it.HasResults() {
+		err = closeIterator(it, err)
+
+		query = fmt.Sprintf(
+			queryFormat,
+			`crdb_internal.statement_statistics`,
+			whereClause,
+			aostClause,
+			orderAndLimit)
+		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-by-interval-with-memory", nil,
+			sessiondata.NodeUserSessionDataOverride, query, args...)
+		if err != nil {
+			return nil, serverError(ctx, err)
 		}
-	}()
+	}
 
 	var statements []serverpb.StatementsResponse_CollectedStatementStatistics
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return nil, errors.New("unexpected null row")
+			return nil, errors.New("unexpected null row on collectCombinedStatements")
 		}
 
 		if row.Len() != expectedNumDatums {
-			return nil, errors.Newf("expected %d columns, received %d", expectedNumDatums)
+			return nil, errors.Newf("expected %d columns on collectCombinedStatements, received %d", expectedNumDatums)
 		}
 
 		var statementFingerprintID uint64
@@ -452,8 +509,8 @@ func collectCombinedTransactions(
 	testingKnobs *sqlstats.TestingKnobs,
 ) ([]serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics, error) {
 	aostClause := testingKnobs.GetAOSTClause()
-
-	query := fmt.Sprintf(`
+	const expectedNumDatums = 5
+	queryFormat := `
 SELECT * FROM (
 SELECT
     app_name,
@@ -461,42 +518,62 @@ SELECT
     fingerprint_id,
     metadata,
     crdb_internal.merge_transaction_stats(array_agg(statistics)) AS statistics
-FROM crdb_internal.transaction_statistics_persisted %s
+FROM %s %s
 GROUP BY
     app_name,
     fingerprint_id,
     metadata
 ) %s
-%s`, whereClause, aostClause, orderAndLimit)
+%s`
 
-	const expectedNumDatums = 5
+	query := fmt.Sprintf(
+		queryFormat,
+		`crdb_internal.transaction_statistics_persisted`,
+		whereClause,
+		aostClause,
+		orderAndLimit)
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-txns-by-interval", nil,
 		sessiondata.InternalExecutorOverride{
 			User: security.NodeUserName(),
 		}, query, args...)
 
+	defer func() {
+		err = closeIterator(it, err)
+	}()
+
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
 
-	defer func() {
-		closeErr := it.Close()
-		if closeErr != nil {
-			err = errors.CombineErrors(err, closeErr)
+	// If there are no results from the persisted table, retrieve the data from the combined view
+	// with data in-memory.
+	if !it.HasResults() {
+		err = closeIterator(it, err)
+
+		query = fmt.Sprintf(
+			queryFormat,
+			`crdb_internal.transaction_statistics`,
+			whereClause,
+			aostClause,
+			orderAndLimit)
+		it, err = ie.QueryIteratorEx(ctx, "combined-txn-by-interval-with-memory", nil,
+			sessiondata.NodeUserSessionDataOverride, query, args...)
+		if err != nil {
+			return nil, serverError(ctx, err)
 		}
-	}()
+	}
 
 	var transactions []serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return nil, errors.New("unexpected null row")
+			return nil, errors.New("unexpected null row on collectCombinedTransactions")
 		}
 
 		if row.Len() != expectedNumDatums {
-			return nil, errors.Newf("expected %d columns, received %d", expectedNumDatums, row.Len())
+			return nil, errors.Newf("expected %d columns on collectCombinedTransactions, received %d", expectedNumDatums, row.Len())
 		}
 
 		app := string(tree.MustBeDString(row[0]))
@@ -679,18 +756,17 @@ func getStatementDetailsQueryClausesAndArgs(
 func getTotalStatementDetails(
 	ctx context.Context, ie *sql.InternalExecutor, whereClause string, args []interface{},
 ) (serverpb.StatementDetailsResponse_CollectedStatementSummary, error) {
-	query := fmt.Sprintf(
-		`SELECT
+	const expectedNumDatums = 3
+	var statement serverpb.StatementDetailsResponse_CollectedStatementSummary
+	queryFormat := `SELECT
 				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
 				array_agg(app_name) as app_names,
 				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
-		FROM crdb_internal.statement_statistics_persisted %s
+		FROM %s %s
 		GROUP BY
 				fingerprint_id
-		LIMIT 1`, whereClause)
-
-	const expectedNumDatums = 3
-	var statement serverpb.StatementDetailsResponse_CollectedStatementSummary
+		LIMIT 1`
+	query := fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics_persisted`, whereClause)
 
 	row, err := ie.QueryRowEx(ctx, "combined-stmts-details-total", nil,
 		sessiondata.InternalExecutorOverride{
@@ -700,11 +776,25 @@ func getTotalStatementDetails(
 	if err != nil {
 		return statement, serverError(ctx, err)
 	}
-	if len(row) == 0 {
+
+	// If there are no results from the persisted table, retrieve the data from the combined view
+	// with data in-memory.
+	if row.Len() == 0 {
+		query = fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics`, whereClause)
+		row, err = ie.QueryRowEx(ctx, "combined-stmts-details-total-with-memory", nil,
+			sessiondata.NodeUserSessionDataOverride, query, args...)
+		if err != nil {
+			return statement, serverError(ctx, err)
+		}
+	}
+
+	// If there are no results in-memory, return empty statement object.
+	if row.Len() == 0 {
 		return statement, nil
 	}
 	if row.Len() != expectedNumDatums {
-		return statement, serverError(ctx, errors.Newf("expected %d columns, received %d", expectedNumDatums))
+		return statement, serverError(ctx, errors.Newf(
+			"expected %d columns on getTotalStatementDetails, received %d", expectedNumDatums))
 	}
 
 	var statistics roachpb.CollectedStatementStatistics
@@ -747,46 +837,54 @@ func getStatementDetailsPerAggregatedTs(
 	args []interface{},
 	limit int64,
 ) ([]serverpb.StatementDetailsResponse_CollectedStatementGroupedByAggregatedTs, error) {
-	query := fmt.Sprintf(
-		`SELECT
+	const expectedNumDatums = 3
+	queryFormat := `SELECT
 				aggregated_ts,
 				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
 				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
-		FROM crdb_internal.statement_statistics_persisted %s
+		FROM %s %s
 		GROUP BY
 				aggregated_ts
 		ORDER BY aggregated_ts ASC
-		LIMIT $%d`, whereClause, len(args)+1)
-
+		LIMIT $%d`
+	query := fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics_persisted`, whereClause, len(args)+1)
 	args = append(args, limit)
-	const expectedNumDatums = 3
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-details-by-aggregated-timestamp", nil,
 		sessiondata.InternalExecutorOverride{
 			User: security.NodeUserName(),
 		}, query, args...)
 
+	defer func() {
+		err = closeIterator(it, err)
+	}()
+
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
 
-	defer func() {
-		closeErr := it.Close()
-		if closeErr != nil {
-			err = errors.CombineErrors(err, closeErr)
+	// If there are no results from the persisted table, retrieve the data from the combined view
+	// with data in-memory.
+	if !it.HasResults() {
+		err = closeIterator(it, err)
+		query = fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics`, whereClause, len(args))
+		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-details-by-aggregated-timestamp-with-memory", nil,
+			sessiondata.NodeUserSessionDataOverride, query, args...)
+		if err != nil {
+			return nil, serverError(ctx, err)
 		}
-	}()
+	}
 
 	var statements []serverpb.StatementDetailsResponse_CollectedStatementGroupedByAggregatedTs
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return nil, errors.New("unexpected null row")
+			return nil, errors.New("unexpected null row on getStatementDetailsPerAggregatedTs")
 		}
 
 		if row.Len() != expectedNumDatums {
-			return nil, errors.Newf("expected %d columns, received %d", expectedNumDatums)
+			return nil, errors.Newf("expected %d columns on getStatementDetailsPerAggregatedTs, received %d", expectedNumDatums)
 		}
 
 		aggregatedTs := tree.MustBeDTimestampTZ(row[0]).Time
@@ -831,6 +929,10 @@ func getExplainPlanFromGist(ctx context.Context, ie *sql.InternalExecutor, planG
 			User: security.NodeUserName(),
 		}, query, args...)
 
+	defer func() {
+		err = closeIterator(it, err)
+	}()
+
 	if err != nil {
 		return planError
 	}
@@ -862,47 +964,55 @@ func getStatementDetailsPerPlanHash(
 	args []interface{},
 	limit int64,
 ) ([]serverpb.StatementDetailsResponse_CollectedStatementGroupedByPlanHash, error) {
-	query := fmt.Sprintf(
-		`SELECT
+	expectedNumDatums := 4
+	queryFormat := `SELECT
 				plan_hash,
 				(statistics -> 'statistics' -> 'planGists'->>0) as plan_gist,
 				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
 				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
-		FROM crdb_internal.statement_statistics_persisted %s
+		FROM %s %s
 		GROUP BY
 				plan_hash,
 				plan_gist
-		LIMIT $%d`, whereClause, len(args)+1)
-
+		LIMIT $%d`
+	query := fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics_persisted`, whereClause, len(args)+1)
 	args = append(args, limit)
-	const expectedNumDatums = 4
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-details-by-plan-hash", nil,
 		sessiondata.InternalExecutorOverride{
 			User: security.NodeUserName(),
 		}, query, args...)
 
+	defer func() {
+		err = closeIterator(it, err)
+	}()
+
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
 
-	defer func() {
-		closeErr := it.Close()
-		if closeErr != nil {
-			err = errors.CombineErrors(err, closeErr)
+	// If there are no results from the persisted table, retrieve the data from the combined view
+	// with data in-memory.
+	if !it.HasResults() {
+		err = closeIterator(it, err)
+		query = fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics`, whereClause, len(args))
+		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-details-by-plan-hash-with-memory", nil,
+			sessiondata.NodeUserSessionDataOverride, query, args...)
+		if err != nil {
+			return nil, serverError(ctx, err)
 		}
-	}()
+	}
 
 	var statements []serverpb.StatementDetailsResponse_CollectedStatementGroupedByPlanHash
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return nil, errors.New("unexpected null row")
+			return nil, errors.New("unexpected null row on getStatementDetailsPerPlanHash")
 		}
 
 		if row.Len() != expectedNumDatums {
-			return nil, errors.Newf("expected %d columns, received %d", expectedNumDatums)
+			return nil, errors.Newf("expected %d columns on getStatementDetailsPerPlanHash, received %d", expectedNumDatums)
 		}
 
 		var planHash uint64

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -374,6 +374,10 @@ func (r *rowsIterator) Types() colinfo.ResultColumns {
 	return r.resultCols
 }
 
+func (r *rowsIterator) HasResults() bool {
+	return r.first.row != nil
+}
+
 // QueryBuffered executes the supplied SQL statement and returns the resulting
 // rows (meaning all of them are buffered at once). If no user has been
 // previously set through SetSessionData, the statement is executed as the root

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -845,6 +845,8 @@ func (ie *InternalExecutor) execInternal(
 	// Note that if a context cancellation error has occurred, we still return
 	// the iterator and nil retErr so that the iterator is properly closed by
 	// the caller which will clean up the connExecutor goroutine.
+	// TODO(yuzefovich): reconsider this and return an error explicitly if
+	// r.lastErr is non-nil.
 	return r, nil
 }
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -375,7 +375,7 @@ func (r *rowsIterator) Types() colinfo.ResultColumns {
 }
 
 func (r *rowsIterator) HasResults() bool {
-	return r.first.row != nil
+	return r.first != nil && r.first.row != nil
 }
 
 // QueryBuffered executes the supplied SQL statement and returns the resulting
@@ -844,7 +844,7 @@ func (ie *InternalExecutor) execInternal(
 
 	// Note that if a context cancellation error has occurred, we still return
 	// the iterator and nil retErr so that the iterator is properly closed by
-	// the caller which will cleanup the connExecutor goroutine.
+	// the caller which will clean up the connExecutor goroutine.
 	return r, nil
 }
 

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -194,6 +194,9 @@ type InternalRows interface {
 	// WARNING: this method is safe to call anytime *after* the first call to
 	// Next() (including after Close() was called).
 	Types() colinfo.ResultColumns
+
+	// HasResults returns true if there are results to the query, false otherwise.
+	HasResults() bool
 }
 
 // SessionBoundInternalExecutorFactory is a function that produces a "session


### PR DESCRIPTION
Backport:
  * 1/1 commits from "server, sql: show in-memory data when no data is persisted" (#100440)
  * 2/2 commits from "sql: fix recently introduced bug around the internal rowsIterator" (#103514)

Please see individual PRs for details.

Test on 22.1 cluster: https://www.loom.com/share/bda5eb4282134d1ba07689e88c6bec10

/cc @cockroachdb/release

---
Release justification: improvement on performance
