### PR TITLE
release-22.2: server, ui: more search criteria options on SQL Activity

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -244,13 +244,18 @@ FROM crdb_internal.%s_statistics%s
 	return stmtsRuntime, txnsRuntime, err
 }
 
-// Common stmt and txn columns to sort on.
 const (
 	sortSvcLatDesc         = `(statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT DESC`
 	sortExecCountDesc      = `(statistics -> 'statistics' ->> 'cnt')::INT DESC`
 	sortContentionTimeDesc = `(statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::FLOAT DESC`
 	sortPCTRuntimeDesc     = `((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT *
                          (statistics -> 'statistics' ->> 'cnt')::FLOAT) DESC`
+	sortRowsProcessedDesc = `((statistics -> 'statistics' -> 'rowsRead' ->> 'mean')::FLOAT + 
+												 (statistics -> 'statistics' -> 'rowsWritten' ->> 'mean')::FLOAT) DESC`
+	sortMaxMemoryDesc = `(statistics -> 'execution_statistics' -> 'maxMemUsage' ->> 'mean')::FLOAT DESC`
+	sortNetworkDesc   = `(statistics -> 'execution_statistics' -> 'networkBytes' ->> 'mean')::FLOAT DESC`
+	sortRetriesDesc   = `(statistics -> 'statistics' ->> 'maxRetries')::INT DESC`
+	sortLastExecDesc  = `(statistics -> 'statistics' ->> 'lastExecAt') DESC`
 )
 
 func getStmtColumnFromSortOption(sort serverpb.StatsSortOptions) string {
@@ -261,6 +266,16 @@ func getStmtColumnFromSortOption(sort serverpb.StatsSortOptions) string {
 		return sortExecCountDesc
 	case serverpb.StatsSortOptions_CONTENTION_TIME:
 		return sortContentionTimeDesc
+	case serverpb.StatsSortOptions_ROWS_PROCESSED:
+		return sortRowsProcessedDesc
+	case serverpb.StatsSortOptions_MAX_MEMORY:
+		return sortMaxMemoryDesc
+	case serverpb.StatsSortOptions_NETWORK:
+		return sortNetworkDesc
+	case serverpb.StatsSortOptions_RETRIES:
+		return sortRetriesDesc
+	case serverpb.StatsSortOptions_LAST_EXEC:
+		return sortLastExecDesc
 	default:
 		return sortSvcLatDesc
 	}

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1575,9 +1575,19 @@ enum StatsSortOptions {
   SERVICE_LAT = 0;
   reserved 1; // This is for  CPU Time in 23.1
   EXECUTION_COUNT = 2;
-  reserved 3; // This is for P99 in 23.1
+  reserved 3; // This is for Latency Info P99 in 23.1
   CONTENTION_TIME = 4;
   PCT_RUNTIME = 5;
+  // Sort options only available on default stats tables.
+  reserved 6; // This is for Latency Info P50 in 23.1
+  reserved 7; // This is for Latency Info P90 in 23.1
+  reserved 8; // This is for Latency Info Min in 23.1
+  reserved 9; // This is for Latency Info Max in 23.1
+  ROWS_PROCESSED = 10;
+  MAX_MEMORY = 11;
+  NETWORK = 12;
+  RETRIES = 13;
+  LAST_EXEC = 14;
 }
 message CombinedStatementsStatsRequest {
   enum StatsType {

--- a/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
@@ -18,6 +18,7 @@ $colors--primary-blue-4: #005fb3;
 $colors--primary-blue-5: #00294d;
 $colors--primary-blue-6: #89b0ff;
 $colors--primary-blue-7: #b6ceff;
+$colors--primary-blue-8: #deebff;
 $colors--primary-blue-alert: #e1ecff;
 
 $colors--primary-green-0: #daf8d4;

--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
@@ -17,10 +17,14 @@
 
   label {
     display: block;
-    margin-bottom: 0px;
+    margin-bottom: 0;
     font-family: $font-family--lato-regular;
     font-size: $font-size--medium;
     font-weight: $font-weight--light;
+
+    :global(.ant-btn) {
+      border-color: $colors--neutral-4;
+    }
   }
 
   ul {

--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.tsx
@@ -11,19 +11,21 @@
 import React from "react";
 import classNames from "classnames/bind";
 import styles from "./searchCriteria.module.scss";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
+import { Button } from "src/button";
+import { commonStyles, selectCustomStyles } from "src/common";
 import {
-  Button,
-  commonStyles,
-  PageConfig,
-  PageConfigItem,
-  selectCustomStyles,
   TimeScale,
   timeScale1hMinOptions,
   TimeScaleDropdown,
-} from "src";
+} from "src/timeScaleDropdown";
 import { applyBtn } from "../queryFilter/filterClasses";
 import Select from "react-select";
-import { limitOptions } from "../util/sqlActivityConstants";
+import {
+  limitOptions,
+  stmtRequestSortOptions,
+  txnRequestSortOptions,
+} from "../util/sqlActivityConstants";
 import { SqlStatsSortType } from "src/api/statementsApi";
 const cx = classNames.bind(styles);
 
@@ -32,7 +34,7 @@ type SortOption = {
   value: SqlStatsSortType;
 };
 export interface SearchCriteriaProps {
-  sortOptions: SortOption[];
+  searchType: "Statement" | "Transaction";
   currentScale: TimeScale;
   topValue: number;
   byValue: SqlStatsSortType;
@@ -44,13 +46,13 @@ export interface SearchCriteriaProps {
 
 export function SearchCriteria(props: SearchCriteriaProps): React.ReactElement {
   const {
+    searchType,
     topValue,
     byValue,
     currentScale,
     onChangeTop,
     onChangeBy,
     onChangeTimeScale,
-    sortOptions,
   } = props;
   const customStyles = { ...selectCustomStyles };
   customStyles.indicatorSeparator = (provided: any) => ({
@@ -61,7 +63,7 @@ export function SearchCriteria(props: SearchCriteriaProps): React.ReactElement {
   const customStylesTop = { ...customStyles };
   customStylesTop.container = (provided: any) => ({
     ...provided,
-    width: "80px",
+    width: "90px",
     border: "none",
     lineHeight: "29px",
   });
@@ -73,6 +75,9 @@ export function SearchCriteria(props: SearchCriteriaProps): React.ReactElement {
     border: "none",
     lineHeight: "29px",
   });
+
+  const sortOptions: SortOption[] =
+    searchType === "Statement" ? stmtRequestSortOptions : txnRequestSortOptions;
 
   return (
     <div className={cx("search-area")}>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -79,7 +79,6 @@ import { StatementViewType } from "./statementPageTypes";
 import moment from "moment";
 import {
   STATS_LONG_LOADING_DURATION,
-  stmtRequestSortOptions,
   getSortLabel,
   getSortColumn,
   getSubsetWarning,
@@ -801,7 +800,7 @@ export class StatementsPage extends React.Component<
     return (
       <div className={cx("root")}>
         <SearchCriteria
-          sortOptions={stmtRequestSortOptions}
+          searchType="Statement"
           topValue={this.state.limit}
           byValue={this.state.reqSortSetting}
           currentScale={this.state.timeScale}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -76,7 +76,6 @@ import { isSelectedColumn } from "../columnsSelector/utils";
 import moment from "moment";
 import {
   STATS_LONG_LOADING_DURATION,
-  txnRequestSortOptions,
   getSortLabel,
   getSortColumn,
   getSubsetWarning,
@@ -654,7 +653,7 @@ export class TransactionsPage extends React.Component<
     return (
       <>
         <SearchCriteria
-          sortOptions={txnRequestSortOptions}
+          searchType="Transaction"
           topValue={this.state.limit}
           byValue={this.state.reqSortSetting}
           currentScale={this.state.timeScale}

--- a/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.tsx
@@ -25,7 +25,20 @@ export const limitOptions = [
   { value: 50, label: "50" },
   { value: 100, label: "100" },
   { value: 500, label: "500" },
+  { value: 1000, label: "1000" },
+  { value: 5000, label: "5000" },
+  { value: 10000, label: "10000" },
 ];
+
+function isSortOptionForStatementOnly(sort: SqlStatsSortType): boolean {
+  switch (sort) {
+    case SqlStatsSortOptions.PCT_RUNTIME:
+    case SqlStatsSortOptions.LAST_EXEC:
+      return true;
+    default:
+      return false;
+  }
+}
 
 export function getSortLabel(
   sort: SqlStatsSortType,
@@ -40,6 +53,16 @@ export function getSortLabel(
       return "Contention Time";
     case SqlStatsSortOptions.PCT_RUNTIME:
       return "% of All Runtime";
+    case SqlStatsSortOptions.ROWS_PROCESSED:
+      return "Rows Processed";
+    case SqlStatsSortOptions.MAX_MEMORY:
+      return "Max Memory";
+    case SqlStatsSortOptions.NETWORK:
+      return "Network";
+    case SqlStatsSortOptions.RETRIES:
+      return "Retries";
+    case SqlStatsSortOptions.LAST_EXEC:
+      return "Last Execution Time";
     default:
       return "";
   }
@@ -55,6 +78,16 @@ export function getSortColumn(sort: SqlStatsSortType): string {
       return "contention";
     case SqlStatsSortOptions.PCT_RUNTIME:
       return "workloadPct";
+    case SqlStatsSortOptions.ROWS_PROCESSED:
+      return "rowsProcessed";
+    case SqlStatsSortOptions.MAX_MEMORY:
+      return "maxMemUsage";
+    case SqlStatsSortOptions.NETWORK:
+      return "networkBytes";
+    case SqlStatsSortOptions.RETRIES:
+      return "retries";
+    case SqlStatsSortOptions.LAST_EXEC:
+      return "lastExecTimestamp";
     default:
       return "";
   }
@@ -70,6 +103,16 @@ export function getReqSortColumn(sort: string): SqlStatsSortType {
       return SqlStatsSortOptions.CONTENTION_TIME;
     case "workloadPct":
       return SqlStatsSortOptions.PCT_RUNTIME;
+    case "rowsProcessed":
+      return SqlStatsSortOptions.ROWS_PROCESSED;
+    case "maxMemUsage":
+      return SqlStatsSortOptions.MAX_MEMORY;
+    case "networkBytes":
+      return SqlStatsSortOptions.NETWORK;
+    case "retries":
+      return SqlStatsSortOptions.RETRIES;
+    case "lastExecTimestamp":
+      return SqlStatsSortOptions.LAST_EXEC;
     default:
       return SqlStatsSortOptions.SERVICE_LAT;
   }
@@ -87,6 +130,7 @@ export const stmtRequestSortOptions = Object.values(SqlStatsSortOptions)
   });
 
 export const txnRequestSortOptions = Object.values(SqlStatsSortOptions)
+  .filter(sort => !isSortOptionForStatementOnly(sort as SqlStatsSortType))
   .map(sortVal => ({
     value: sortVal as SqlStatsSortType,
     label: getSortLabel(sortVal as SqlStatsSortType, "Transaction"),
@@ -95,8 +139,7 @@ export const txnRequestSortOptions = Object.values(SqlStatsSortOptions)
     if (a.label < b.label) return -1;
     if (a.label > b.label) return 1;
     return 0;
-  })
-  .filter(option => option.value !== SqlStatsSortOptions.PCT_RUNTIME);
+  });
 
 export const STATS_LONG_LOADING_DURATION = duration(2, "s");
 


### PR DESCRIPTION
Backport 1/1 commits from #103984.

/cc @cockroachdb/release

Note to Reviewers: We don't have Activity tables on 22.2, so it doesn't make sense to add the new options on a separate menu, since they all behave the same one on 22.2. So this backport keeps the usage of select without separating into  "More"

On 22.2: https://www.loom.com/share/6351f82c505c4cd6a6cab28e70d200da

---

Fixes #101817

More Options were added on Search Criteria for SQL Activity page.
For top limit: 1000, 5000 and 10000.


For Priority By On Statements page:
- Last Execution Time
- Max Memory
- Network
- Retries
- Rows Processed

For Priority By on Transactions page:
- Max Memory
- Network
- Retries
- Rows Processed


Release note (ui change): On SQL Activity page add more Search Criteria options, by adding for "Top": 1000, 5000 and 10000. For "By" on Statements tab: - Last Execution Time, Max Memory, Network, Retries, Rows Processed.
For "By" on Transactions tab: Max Memory, Network, Retries, Rows Processed.

---
Release justification: improvement to fix regression
