### PR TITLE
release-22.2: ui: fix txn label

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -579,7 +579,7 @@ export class TransactionsPage extends React.Component<
                     ...pagination,
                     total: transactionsToDisplay.length,
                   }}
-                  pageName={"Statements"}
+                  pageName={"Transactions"}
                   search={search}
                 />
               </p>
@@ -592,7 +592,7 @@ export class TransactionsPage extends React.Component<
               >
                 <ClearStats
                   resetSQLStats={this.resetSQLStats}
-                  tooltipType="statement"
+                  tooltipType="transaction"
                 />
               </PageConfigItem>
             )}


### PR DESCRIPTION
Backport 1/1 commits from #101505.

/cc @cockroachdb/release

---

The label for the count was showing as Statement on the Transactions page.
This commit changes to the correct label.

Before
<img width="713" alt="Screenshot 2023-04-13 at 6 43 34 PM" src="https://user-images.githubusercontent.com/1017486/231899022-8cd6c713-6f42-488c-99f2-9d4e03f6b7a0.png">


After
<img width="736" alt="Screenshot 2023-04-13 at 6 43 47 PM" src="https://user-images.githubusercontent.com/1017486/231899046-270df02f-d82d-485b-89d5-f1851283a609.png">


Epic: None
Release note: None

---
Release justification: bug fix (wrong label)
