### PR TITLE
release-22.2: kvserver: improve system lease observability

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -154,6 +154,12 @@ var (
 		Measurement: "Replicas",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaLeaseLivenessCount = metric.Metadata{
+		Name:        "leases.liveness",
+		Help:        "Number of replica leaseholders for the liveness range(s)",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// Storage metrics.
 	metaLiveBytes = metric.Metadata{
@@ -1674,6 +1680,7 @@ type StoreMetrics struct {
 	LeaseTransferErrorCount   *metric.Counter
 	LeaseExpirationCount      *metric.Gauge
 	LeaseEpochCount           *metric.Gauge
+	LeaseLivenessCount        *metric.Gauge
 
 	// Storage metrics.
 	ResolveCommitCount *metric.Counter
@@ -2208,6 +2215,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		LeaseTransferErrorCount:   metric.NewCounter(metaLeaseTransferErrorCount),
 		LeaseExpirationCount:      metric.NewGauge(metaLeaseExpirationCount),
 		LeaseEpochCount:           metric.NewGauge(metaLeaseEpochCount),
+		LeaseLivenessCount:        metric.NewGauge(metaLeaseLivenessCount),
 
 		// Intent resolution metrics.
 		ResolveCommitCount: metric.NewCounter(metaResolveCommit),

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -368,6 +368,17 @@ func (r *Replica) leasePostApplyLocked(
 		r.gossipFirstRangeLocked(ctx)
 	}
 
+	// Log acquisition of meta and liveness range leases. These are critical to
+	// cluster health, so it's useful to know their location over time.
+	if leaseChangingHands && iAmTheLeaseHolder &&
+		r.descRLocked().StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax)) {
+		if r.ownsValidLeaseRLocked(ctx, now) {
+			log.Health.Infof(ctx, "acquired system range lease: %s", newLease)
+		} else {
+			log.Health.Warningf(ctx, "applied system range lease after it expired: %s", newLease)
+		}
+	}
+
 	if (leaseChangingHands || maybeSplit) && iAmTheLeaseHolder && hasExpirationBasedLease {
 		if requiresExpirationBasedLease {
 			// Whenever we first acquire an expiration-based lease for a range that

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3264,6 +3264,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		leaseHolderCount              int64
 		leaseExpirationCount          int64
 		leaseEpochCount               int64
+		leaseLivenessCount            int64
 		raftLeaderNotLeaseHolderCount int64
 		raftLeaderInvalidLeaseCount   int64
 		quiescentCount                int64
@@ -3333,6 +3334,9 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			case roachpb.LeaseEpoch:
 				leaseEpochCount++
 			}
+			if metrics.LivenessLease {
+				leaseLivenessCount++
+			}
 		}
 		if metrics.Quiescent {
 			quiescentCount++
@@ -3396,6 +3400,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.LeaseHolderCount.Update(leaseHolderCount)
 	s.metrics.LeaseExpirationCount.Update(leaseExpirationCount)
 	s.metrics.LeaseEpochCount.Update(leaseEpochCount)
+	s.metrics.LeaseLivenessCount.Update(leaseLivenessCount)
 	s.metrics.QuiescentCount.Update(quiescentCount)
 	s.metrics.UninitializedCount.Update(uninitializedCount)
 	s.metrics.AverageQueriesPerSecond.Update(averageQueriesPerSecond)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1692,6 +1692,7 @@ var charts = []sectionDescription{
 				Metrics: []string{
 					"leases.epoch",
 					"leases.expiration",
+					"leases.liveness",
 					"replicas.leaseholders",
 					"replicas.leaders_not_leaseholders",
 					"replicas.leaders_invalid_lease",


### PR DESCRIPTION
Backport 2/2 commits from #104008.

/cc @cockroachdb/release

---

**kvserver: add `leases.liveness` metric**

This patch adds the metric `leases.liveness` tracking the number of liveness range leases per node (generally 1 or 0). This is useful to find out which node had the liveness lease at a particular time.

I ran a 10k range cluster to look at the CPU cost of the key comparisons, it didn't show up on CPU profiles.

Epic: none
Release note (ops change): added the metric `leases.liveness` showing the number of liveness range leases per node (generally 1 or 0), to track the liveness range leaseholder.
  
**kvserver: log system range lease acquisition**

This patch logs acquisition of meta/liveness range leases to the health log. These leases are critical to cluster health, and during debugging it's useful to know their location over time.

Resolves #99472.

Epic: none
Release note: none
