### PR TITLE
kvserver: reduce unused app batch max size parameter

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -859,7 +859,6 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	var appTask apply.Task
 	if hasMsg(msgStorageApply) {
 		appTask = apply.MakeTask(sm, dec)
-		appTask.SetMaxBatchSize(r.store.TestingKnobs().MaxApplicationBatchSize)
 		defer appTask.Close()
 		if err := appTask.Decode(ctx, msgStorageApply.Entries); err != nil {
 			return stats, err

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -333,10 +333,6 @@ type StoreTestingKnobs struct {
 	// to its client if it failed to transfer the lease to the first voting
 	// replica in the set of relocation targets.
 	DontIgnoreFailureToTransferLease bool
-	// MaxApplicationBatchSize enforces a maximum size on application batches.
-	// This can be useful for testing conditions which require commands to be
-	// applied in separate batches.
-	MaxApplicationBatchSize int
 	// RangeFeedPushTxnsInterval overrides the default value for
 	// rangefeed.Config.PushTxnsInterval.
 	RangeFeedPushTxnsInterval time.Duration


### PR DESCRIPTION
Dead code.

Noticed during https://github.com/cockroachlabs/support/issues/2287.

Epic: none
Release note: None
