### PR TITLE
kvserver: skip TestTransferLeaseToLaggingNode under stress or deadlock

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1908,6 +1908,8 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes >1min under race")
+	skip.UnderDeadlock(t, "takes >1min under deadlock")
+	skip.UnderStressWithIssue(t, 53875)
 
 	ctx := context.Background()
 	clusterArgs := base.TestClusterArgs{


### PR DESCRIPTION
This has been failing at a pretty low rate when stressed under `deadlock`.

It's such a long-running test that it's better to skip it under stress, since
it takes up so much of the alloted time for running the package.

Fixes #53875.
x-ref #104039.

Epic: none
Release note: None
