### PR TITLE
cli: fix bug in missing-flag warning

### DIFF
--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -46,6 +46,19 @@ interrupt
 eexpect ":/# "
 end_test
 
+start_test "Check that using --advertise-addr does not cause a user warning."
+send "$argv start-single-node --insecure --advertise-addr=172.31.11.189\r"
+expect {
+  "WARNING: neither --listen-addr nor --advertise-addr was specified" {
+    report "unexpected WARNING: neither --listen-addr nor --advertise-addr was specified"
+	  exit 1
+  }
+}
+eexpect "node starting"
+interrupt
+eexpect ":/# "
+end_test
+
 start_test "Check that --listening-url-file gets created with the right data"
 send "$argv start-single-node --insecure --listening-url-file=foourl\r"
 eexpect "node starting"

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1264,7 +1264,7 @@ func hintServerCmdFlags(ctx context.Context, cmd *cobra.Command) {
 	}
 
 	changed := func(flagName string) bool {
-		fl := pf.Lookup(cliflags.ListenAddr.Name)
+		fl := pf.Lookup(flagName)
 		return fl != nil && fl.Changed
 	}
 


### PR DESCRIPTION
When the server starts, the user is supposed to see a warning if neither `--listen-addr` nor `--advertise-addr` flags are specified. Currently, even if `--advertise-addr` is specified, the warning is displayed. This patch fixes the small bug causing this behavior.

Fixes: #103897

Epic: CRDB-28249

Release note (bug fix): Warning message for missing `--advertise-addr` flag is no longer displayed when the flag is specified upon server start.