### PR TITLE
telemetry: add sampling rate option for stmt fingerprints

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -419,9 +419,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		idxRecommendationsCache: idxrecommendations.NewIndexRecommendationsCache(cfg.Settings),
 	}
 
-	telemetryLoggingMetrics := &TelemetryLoggingMetrics{}
-
-	telemetryLoggingMetrics.Knobs = cfg.TelemetryLoggingTestingKnobs
+	telemetryLoggingMetrics := newTelemetryLoggingmetrics(cfg.TelemetryLoggingTestingKnobs)
 	s.TelemetryLoggingMetrics = telemetryLoggingMetrics
 
 	sqlStatsInternalExecutorMonitor := MakeInternalExecutorMemMonitor(MemoryMetrics{}, s.GetExecutorConfig().Settings)

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -273,16 +273,29 @@ func (p *planner) maybeLogStatementInternal(
 	}
 
 	if telemetryLoggingEnabled && !p.SessionData().TroubleshootingMode {
+		stmtFingerprintSamplingEnabled := telemetrySamplingPerFingerprintEnabled.Get(&p.execCfg.Settings.SV)
 		// We only log to the telemetry channel if enough time has elapsed from
 		// the last event emission.
-		requiredTimeElapsed := 1.0 / float64(maxEventFrequency)
+		requiredElapsedTime := time.Second / time.Duration(maxEventFrequency)
+
+		var requiredElapsedTimeFingerprint time.Duration
+		if stmtFingerprintSamplingEnabled {
+			requiredElapsedTimeFingerprint = time.Second / time.Duration(telemetryEventFrequencyStmtFingerprint.Get(&p.execCfg.Settings.SV))
+		}
+
 		tracingEnabled := telemetryMetrics.isTracing(p.curPlan.instrumentation.Tracing())
 		// Always sample if the current statement is not of type DML or tracing
 		// is enabled for this statement.
 		if p.stmt.AST.StatementType() != tree.TypeDML || tracingEnabled {
-			requiredTimeElapsed = 0
+			requiredElapsedTime = 0
+			requiredElapsedTimeFingerprint = 0
 		}
-		if telemetryMetrics.maybeUpdateLastEmittedTime(telemetryMetrics.timeNow(), requiredTimeElapsed) {
+
+		if telemetryMetrics.maybeUpdateLastEmittedTime(telemetryMetrics.timeNow(),
+			requiredElapsedTime,
+			stmtFingerprintSamplingEnabled,
+			stmtFingerprintID,
+			requiredElapsedTimeFingerprint) {
 			var txnID string
 			// p.txn can be nil for COPY.
 			if p.txn != nil {

--- a/pkg/sql/telemetry_logging.go
+++ b/pkg/sql/telemetry_logging.go
@@ -15,7 +15,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -32,8 +34,29 @@ var TelemetryMaxEventFrequency = settings.RegisterIntSetting(
 		"note that this value shares a log-line limit of 10 logs per second on the "+
 		"telemetry pipeline with all other telemetry events",
 	defaultMaxEventFrequency,
-	settings.NonNegativeInt,
+	settings.PositiveInt,
 )
+
+var telemetryEventFrequencyStmtFingerprint = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"sql.telemetry.query_sampling.stmt_fingerprint.max_event_frequency",
+	"the max event frequency at which we sample each stmt fingerprint for telemetry",
+	5,
+	settings.PositiveInt,
+)
+
+var telemetrySamplingPerFingerprintEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.telemetry.query_sampling.stmt_fingerprint.enabled",
+	"if on, we apply an additional max event frequency for each statement fingerprint id "+
+		"in addition to the one set by sql.telemetry.query_sampling.max_event_frequency",
+	false,
+)
+
+type telemetryEvent struct {
+	// The timestamp of the last emitted telemetry event.
+	lastEmittedTime time.Time
+}
 
 // TelemetryLoggingMetrics keeps track of the last time at which an event
 // was logged to the telemetry channel, and the number of skipped queries
@@ -43,11 +66,28 @@ type TelemetryLoggingMetrics struct {
 		syncutil.RWMutex
 		// The timestamp of the last emitted telemetry event.
 		lastEmittedTime time.Time
+
+		// stmtFingerprintLoggingRecord is used to track when a stmt fingerprint
+		// id was last emitted to telemetry. Note this field is only updated when
+		// sql.telemetry.query_sampling.stmt_fingerprint.enabled is true.
+		stmtFingerprintLoggingRecord *cache.UnorderedCache
 	}
 	Knobs *TelemetryLoggingTestingKnobs
 
 	// skippedQueryCount is used to produce the count of non-sampled queries.
 	skippedQueryCount uint64
+}
+
+func newTelemetryLoggingmetrics(knobs *TelemetryLoggingTestingKnobs) *TelemetryLoggingMetrics {
+	t := TelemetryLoggingMetrics{Knobs: knobs}
+	t.mu.stmtFingerprintLoggingRecord = cache.NewUnorderedCache(cache.Config{
+		Policy: cache.CacheLRU,
+		ShouldEvict: func(size int, key, value interface{}) bool {
+			return size > 4096
+		},
+	})
+
+	return &t
 }
 
 // TelemetryLoggingTestingKnobs provides hooks and knobs for unit tests.
@@ -86,19 +126,49 @@ func (t *TelemetryLoggingMetrics) timeNow() time.Time {
 
 // maybeUpdateLastEmittedTime updates the lastEmittedTime if the amount of time
 // elapsed between lastEmittedTime and newTime is greater than requiredSecondsElapsed.
+// It also updates the corresponding entry in stmtFingerprintLoggingRecord for the
+// provided fingerprint id if specified to do so.
 func (t *TelemetryLoggingMetrics) maybeUpdateLastEmittedTime(
-	newTime time.Time, requiredSecondsElapsed float64,
+	newTime time.Time,
+	requiredElapsedTime time.Duration,
+	shouldUpdateFingerprintEmittedTime bool,
+	stmtFingerprintID appstatspb.StmtFingerprintID,
+	requiredElapsedTimeFingerprint time.Duration,
 ) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	lastEmittedTime := t.mu.lastEmittedTime
-	if float64(newTime.Sub(lastEmittedTime))*1e-9 >= requiredSecondsElapsed {
-		t.mu.lastEmittedTime = newTime
-		return true
+	allStmtsRequiredTimeElapsed := newTime.Sub(t.mu.lastEmittedTime) >= requiredElapsedTime
+	stmtFingerprintRequiredTimeElapsed := true
+
+	// Check if we are applying a sampling rate per stmt fingerprint id.
+	var stmtFingerprintEntry *telemetryEvent
+	if shouldUpdateFingerprintEmittedTime {
+		entry, ok := t.mu.stmtFingerprintLoggingRecord.Get(stmtFingerprintID)
+
+		if ok {
+			stmtFingerprintEntry = entry.(*telemetryEvent)
+			// Check if enough time has elapsed for this fingerprint ID.
+			stmtFingerprintRequiredTimeElapsed =
+				newTime.Sub(stmtFingerprintEntry.lastEmittedTime) >= requiredElapsedTimeFingerprint
+		} else {
+			// Create new entry and add it to the cache.
+			stmtFingerprintEntry = &telemetryEvent{}
+			t.mu.stmtFingerprintLoggingRecord.Add(stmtFingerprintID, stmtFingerprintEntry)
+		}
 	}
 
-	return false
+	if !allStmtsRequiredTimeElapsed || !stmtFingerprintRequiredTimeElapsed {
+		// Not enough time has elapsed to emit this event.
+		return false
+	}
+
+	if stmtFingerprintEntry != nil {
+		stmtFingerprintEntry.lastEmittedTime = newTime
+	}
+
+	t.mu.lastEmittedTime = newTime
+	return true
 }
 
 func (t *TelemetryLoggingMetrics) getQueryLevelStats(


### PR DESCRIPTION
This commit introduces 2 new cluster settings to enable statement fingerprint id  sampling telmetry channel.

- sql.telemetry.query_sampling.stmt_fingerprint.enabled which if true turns on applying a max event frequency for telemetyr logging for each stmt fingerprint, in addition to the top level query frequency controlled by sql.telemetry.max_event_frequency.
- sql.telemetry.query_sampling.stmt_fingerprint.max_event_frequency controls the max event frequency for sampling fingerprint ids to telemetry

The max event frequency for stmt fingerprint ids will be applied in addition to the overall max event frequency for all queries to telemetry, which is set by `sql.telemetry.query_sampling.max_event_frequency`.

Thus if one wanted stmt fingerprint ids to have a maximum frequency of 10 log lines per second while limiting the entire event frequency to 100 log lines per second, one would set the following:
```
SET CLUSTER SETTING sql.telemetry.query_sampling.stmt_fingerprint.max_event_frequency = 10;
SET CLUSTER SETTING sql.telemetry.query_sampling.max_event_frequency = 100;
```

The motivation for this introduciton is to provide customers with a way to be able track a more complete set  of queries in the workload rather than just the most frequently executed.

Part of: #103518

Release note (sql change): New cluster settings:
- sql.telemetry.query_sampling.stmt_fingerprint.enabled which if true turns on applying a max event frequency for telemetyr logging for each stmt fingerprint, in addition to the top level query frequency controlled by sql.telemetry.max_event_frequency.
- sql.telemetry.query_sampling.stmt_fingerprint.max_event_frequency controls the max event frequency for sampling fingerprint ids to telemetry