### PR TITLE
release-23.1: ui: persist sort setting in Hot Ranges page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/hotRanges.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/hotRanges.ts
@@ -11,8 +11,10 @@
 import { AdminUIState } from "src/redux/state";
 import { createSelector } from "reselect";
 import { cockroach } from "src/js/protos";
+import { LocalSetting } from "./localsettings";
 
 const hotRangesState = (state: AdminUIState) => state.cachedData.hotRanges;
+const localSettingsSelector = (state: AdminUIState) => state.localSettings;
 
 export const hotRangesSelector = createSelector(hotRangesState, hotRanges =>
   Object.values(hotRanges?.data || {})
@@ -42,4 +44,10 @@ export const lastSetAtSelector = createSelector(
 export const isLoadingSelector = createSelector(
   hotRangesState,
   hotRanges => hotRanges?.inFlight,
+);
+
+export const sortSettingLocalSetting = new LocalSetting(
+  "sortSetting/hotRanges",
+  localSettingsSelector,
+  { ascending: true, columnTitle: "qps" },
 );

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -32,6 +32,9 @@ import {
   uiDebugPages,
 } from "src/util/docs";
 import emptyTableResultsImg from "assets/emptyState/empty-table-results.svg";
+import { sortSettingLocalSetting } from "oss/src/redux/hotRanges";
+import { AdminUIState } from "oss/src/redux/state";
+import { connect } from "react-redux";
 
 const PAGE_SIZE = 50;
 const cx = classNames.bind(styles);
@@ -41,6 +44,8 @@ interface HotRangesTableProps {
   lastUpdate?: string;
   nodeIdToLocalityMap: Map<number, string>;
   clearFilterContainer: React.ReactNode;
+  sortSetting?: SortSetting;
+  onSortChange?: (ss: SortSetting) => void;
 }
 
 const HotRangesTable = ({
@@ -48,14 +53,12 @@ const HotRangesTable = ({
   nodeIdToLocalityMap,
   lastUpdate,
   clearFilterContainer,
+  sortSetting,
+  onSortChange,
 }: HotRangesTableProps) => {
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,
     current: 1,
-  });
-  const [sortSetting, setSortSetting] = useState<SortSetting>({
-    ascending: false,
-    columnTitle: "qps",
   });
 
   const columns: ColumnDescriptor<cockroach.server.serverpb.HotRangesResponseV2.IHotRange>[] =
@@ -313,12 +316,7 @@ const HotRangesTable = ({
         columns={columns}
         tableWrapperClassName={cx("hotranges-table")}
         sortSetting={sortSetting}
-        onChangeSortSetting={(ss: SortSetting) =>
-          setSortSetting({
-            ascending: ss.ascending,
-            columnTitle: ss.columnTitle,
-          })
-        }
+        onChangeSortSetting={(ss: SortSetting) => onSortChange(ss)}
         pagination={pagination}
         renderNoResult={
           <EmptyTable
@@ -347,4 +345,16 @@ const HotRangesTable = ({
   );
 };
 
-export default HotRangesTable;
+const mapDispatchToProps = {
+  onSortChange: (ss: SortSetting) =>
+    sortSettingLocalSetting.set({
+      ascending: ss.ascending,
+      columnTitle: ss.columnTitle,
+    }),
+};
+
+const mapStateToProps = (state: AdminUIState) => ({
+  sortSetting: sortSettingLocalSetting.selector(state),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(HotRangesTable);


### PR DESCRIPTION
Backport 1/1 commits from #103981.

/cc @cockroachdb/release

Release justification: low risk, high benefit changes to existing functionality

---

Previously, the sort setting was not preserved when users navigated away
from the page or reloaded it. This commit implements the persistence of
the sort setting in the Redux store.

Fixes #102025.

Loom [demo](https://www.loom.com/share/14446773db8f44428b9253d27559c8c7).

Release note (ui change): Sort setting in the Hot Ranges page is now
persisted across page reloads and navigation.
