### PR TITLE
startup: retry pgerror.Code == RangeUnavailable

### DIFF
--- a/pkg/util/startup/BUILD.bazel
+++ b/pkg/util/startup/BUILD.bazel
@@ -8,6 +8,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvpb",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/util",
         "//pkg/util/log",
         "//pkg/util/retry",

--- a/pkg/util/startup/retry.go
+++ b/pkg/util/startup/retry.go
@@ -60,6 +60,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -206,5 +208,8 @@ func inStartup() bool {
 
 // IsRetryableReplicaError returns true for replica availability errors.
 func IsRetryableReplicaError(err error) bool {
-	return errors.HasType(err, (*kvpb.ReplicaUnavailableError)(nil)) || errors.HasType(err, (*kvpb.AmbiguousResultError)(nil))
+	return errors.HasType(err, (*kvpb.ReplicaUnavailableError)(nil)) ||
+		errors.HasType(err, (*kvpb.AmbiguousResultError)(nil)) ||
+		// See https://github.com/cockroachdb/cockroach/issues/104016#issuecomment-1569719273.
+		pgerror.GetPGCode(err) == pgcode.RangeUnavailable
 }


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/104016.

Epic: None
Release note (bug fix): a bug was fixed due to which nodes could terminate with the following message:
    server startup failed: cockroach server exited with error:
    ‹migration-job-find-already-completed›: key range id:X is unavailable: ‹failed
    to send RPC: no replica node information available via gossip for rX›
