### PR TITLE
release-22.1: cloud/amazon: add setting for buffered put-object uploads

### DIFF
--- a/pkg/ccl/backupccl/backup_cloud_test.go
+++ b/pkg/ccl/backupccl/backup_cloud_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/azure"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -48,6 +49,42 @@ func InitManualReplication(tc *testcluster.TestCluster) {
 func TestCloudBackupRestoreS3(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	creds, bucket := requiredS3CredsAndBucket(t)
+
+	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
+	defer lease.TestingDisableTableLeases()()
+	const numAccounts = 1000
+
+	ctx := context.Background()
+	tc, db, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, InitManualReplication)
+	defer cleanupFn()
+	prefix := fmt.Sprintf("TestBackupRestoreS3-%d", timeutil.Now().UnixNano())
+	uri := setupS3URI(t, db, bucket, prefix, creds)
+	backupAndRestore(ctx, t, tc, []string{uri.String()}, []string{uri.String()}, numAccounts)
+}
+
+// TestCloudBackupRestoreS3WithLegacyPut tests that backup/restore works when
+// cloudstorage.s3.buffer_and_put_uploads.enabled=true is set.
+func TestCloudBackupRestoreS3WithLegacyPut(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	creds, bucket := requiredS3CredsAndBucket(t)
+
+	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
+	defer lease.TestingDisableTableLeases()()
+	const numAccounts = 1000
+
+	ctx := context.Background()
+	tc, db, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, InitManualReplication)
+	defer cleanupFn()
+	prefix := fmt.Sprintf("TestBackupRestoreS3-%d", timeutil.Now().UnixNano())
+	db.Exec(t, "SET CLUSTER SETTING cloudstorage.s3.buffer_and_put_uploads.enabled=true")
+	uri := setupS3URI(t, db, bucket, prefix, creds)
+	backupAndRestore(ctx, t, tc, []string{uri.String()}, []string{uri.String()}, numAccounts)
+}
+
+func requiredS3CredsAndBucket(t *testing.T) (credentials.Value, string) {
+	t.Helper()
 	creds, err := credentials.NewEnvCredentials().Get()
 	if err != nil {
 		skip.IgnoreLintf(t, "No AWS env keys (%v)", err)
@@ -56,22 +93,28 @@ func TestCloudBackupRestoreS3(t *testing.T) {
 	if bucket == "" {
 		skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
 	}
+	return creds, bucket
+}
 
-	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
-	defer lease.TestingDisableTableLeases()()
-	const numAccounts = 1000
+func setupS3URI(
+	t *testing.T, db *sqlutils.SQLRunner, bucket string, prefix string, creds credentials.Value,
+) url.URL {
+	t.Helper()
+	endpoint := os.Getenv("AWS_ENDPOINT")
+	customCACert := os.Getenv("AWS_CUSTOM_CA_CERT")
+	if customCACert != "" {
+		db.Exec(t, fmt.Sprintf("SET CLUSTER SETTING cloudstorage.http.custom_ca='%s'", customCACert))
+	}
 
-	ctx := context.Background()
-	tc, _, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, InitManualReplication)
-	defer cleanupFn()
-	prefix := fmt.Sprintf("TestBackupRestoreS3-%d", timeutil.Now().UnixNano())
 	uri := url.URL{Scheme: "s3", Host: bucket, Path: prefix}
 	values := uri.Query()
 	values.Add(amazon.AWSAccessKeyParam, creds.AccessKeyID)
 	values.Add(amazon.AWSSecretParam, creds.SecretAccessKey)
+	if endpoint != "" {
+		values.Add(amazon.AWSEndpointParam, endpoint)
+	}
 	uri.RawQuery = values.Encode()
-
-	backupAndRestore(ctx, t, tc, []string{uri.String()}, []string{uri.String()}, numAccounts)
+	return uri
 }
 
 // TestBackupRestoreGoogleCloudStorage hits the real GCS and so could

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -498,8 +498,11 @@ func (s *s3Storage) putUploader(ctx context.Context, basename string) (io.WriteC
 	return &putUploader{
 		b: buf,
 		input: &s3.PutObjectInput{
-			Bucket: s.bucket,
-			Key:    aws.String(path.Join(s.prefix, basename)),
+			Bucket:               s.bucket,
+			Key:                  aws.String(path.Join(s.prefix, basename)),
+			ServerSideEncryption: nilIfEmpty(s.conf.ServerEncMode),
+			SSEKMSKeyId:          nilIfEmpty(s.conf.ServerKMSID),
+			StorageClass:         nilIfEmpty(s.conf.StorageClass),
 		},
 		client: client,
 	}, nil

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -493,7 +493,7 @@ func (s *s3Storage) putUploader(ctx context.Context, basename string) (io.WriteC
 		return nil, err
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 4<<20))
+	buf := bytes.NewBuffer(make([]byte, 0, 4<<20))
 
 	return &putUploader{
 		b: buf,

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -11,6 +11,7 @@
 package amazon
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -129,6 +130,13 @@ var reuseSession = settings.RegisterBoolSetting(
 	"cloudstorage.s3.session_reuse.enabled",
 	"persist the last opened s3 session and re-use it when opening a new session with the same arguments",
 	true,
+)
+
+var usePutObject = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"cloudstorage.s3.buffer_and_put_uploads.enabled",
+	"construct files in memory before uploading via PutObject (may cause crashes due to memory usage)",
+	false,
 )
 
 // s3ClientConfig is the immutable config used to initialize an s3 session.
@@ -463,7 +471,45 @@ func (s *s3Storage) Settings() *cluster.Settings {
 	return s.settings
 }
 
+type putUploader struct {
+	b      *bytes.Buffer
+	client *s3.S3
+	input  *s3.PutObjectInput
+}
+
+func (u *putUploader) Write(p []byte) (int, error) {
+	return u.b.Write(p)
+}
+
+func (u *putUploader) Close() error {
+	u.input.Body = bytes.NewReader(u.b.Bytes())
+	_, err := u.client.PutObject(u.input)
+	return err
+}
+
+func (s *s3Storage) putUploader(ctx context.Context, basename string) (io.WriteCloser, error) {
+	client, err := s.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 4<<20))
+
+	return &putUploader{
+		b: buf,
+		input: &s3.PutObjectInput{
+			Bucket: s.bucket,
+			Key:    aws.String(path.Join(s.prefix, basename)),
+		},
+		client: client,
+	}, nil
+}
+
 func (s *s3Storage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
+	if usePutObject.Get(&s.settings.SV) {
+		return s.putUploader(ctx, basename)
+	}
+
 	uploader, err := s.getUploader(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/settings/values.go
+++ b/pkg/settings/values.go
@@ -21,7 +21,7 @@ import (
 
 // MaxSettings is the maximum number of settings that the system supports.
 // Exported for tests.
-const MaxSettings = 511
+const MaxSettings = 1023
 
 // Values is a container that stores values for all registered settings.
 // Each setting is assigned a unique slot (up to MaxSettings).


### PR DESCRIPTION
Backport:
  * 1/1 commits from "cloud/amazon: add setting for buffered put-object uploads" (#87336)
  * 1/1 commits from "cloud/amazon: add params in put-upload case" (#87349)
  * 1/1 commits from "cloud: don't write empty buffer to s3" (#89643)

Please see individual PRs for details.

Release justification: Off by default feature that exists in 21.2.

/cc @cockroachdb/release
