### PR TITLE
row: fix some stats for txnKVStreamer

### DIFF
--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -136,7 +136,8 @@ type KVBatchFetcher interface {
 	GetBatchRequestsIssued() int64
 
 	// Close releases the resources of this KVBatchFetcher. Must be called once
-	// the fetcher is no longer in use.
+	// the fetcher is no longer in use. Note that observability-related methods
+	// can still be safely called after Close.
 	Close(ctx context.Context)
 }
 

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -213,5 +213,6 @@ func (f *txnKVStreamer) reset(ctx context.Context) {
 func (f *txnKVStreamer) Close(ctx context.Context) {
 	f.reset(ctx)
 	f.streamer.Close(ctx)
-	*f = txnKVStreamer{}
+	// Preserve observability-related fields.
+	*f = txnKVStreamer{kvBatchFetcherHelper: f.kvBatchFetcherHelper}
 }


### PR DESCRIPTION
This commit fixes the collection of "bytes read" and "gRPC calls" stats by the txnKVStreamer that was broken in a74ca72e09f2ad8d9a2e17deafa5b03ca8fbd716. In particular, that commit introduced a new helper that contained counters for those two metrics, and that helper was being reset on `Close` method (which is, somewhat unfortunately, can be called before the counters are retrieved via `Get*` methods of the `KVBatchFetcher` interface. The bug is fixed by preserving the helper state. The corresponding testing has been extended. Note that txnKVFetcher isn't affected that it (at least right now) doesn't deeply unset itself on `Close`.

Epic: None.

Release note (bug fix): The collection of `KV bytes read` and `KV gRPC calls` execution statistics during EXPLAIN ANALYZE could previously be incorrect (it would remain at zero) in some cases and is now fixed. The bug was introduced in 23.1 release.