### PR TITLE
roachtest: deflake `failover/chaos` deadlock failures

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -303,6 +303,7 @@ func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
 }
 
 func (s *dmsetupDiskStaller) Cleanup(ctx context.Context) {
+	s.c.Run(ctx, s.c.All(), `sudo dmsetup resume data1`)
 	s.c.Run(ctx, s.c.All(), `sudo umount /mnt/data1`)
 	s.c.Run(ctx, s.c.All(), `sudo dmsetup remove_all`)
 	s.c.Run(ctx, s.c.All(), `sudo mount /mnt/data1`)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6316,7 +6316,7 @@ DO NOT USE -- USE 'CREATE TENANT' INSTEAD`,
 				}); err != nil {
 					return nil, err
 				} else if replicaMu == nil {
-					return nil, kvpb.NewRangeNotFoundError(rangeID, 0)
+					return tree.DBoolFalse, nil // return false for easier race handling in tests
 				}
 
 				log.Warningf(ctx, "crdb_internal.unsafe_lock_replica on r%d with lock=%t", rangeID, lock)


### PR DESCRIPTION
The deadlock failure mode used `SHOW RANGES` to fetch range and lease information from the cluster. However, if this was run concurrently with other failures in chaos tests it could hang and time out, since it needed to read lease information from each individual range.

This patch restructures the deadlock failure mode to fetch range/lease information from the cluster before running failures, and skipping any replicas that have since moved.

Resolves #104045.
Resolves #104086.
Resolves #104140.
Resolves #104144.

Epic: none
Release note: None