### PR TITLE
release-22.1: storage: lock database before initializing encryption-at-rest

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -633,6 +633,7 @@ type Pebble struct {
 	// intents.
 	settings     *cluster.Settings
 	encryption   *EncryptionEnv
+	fileLock     *pebble.Lock
 	fileRegistry *PebbleFileRegistry
 
 	// Stats updated by pebble.EventListener invocations, and returned in
@@ -762,6 +763,27 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 			filesystemCloser.Close()
 		}
 	}()
+	if !cfg.Opts.ReadOnly {
+		if err := cfg.Opts.FS.MkdirAll(cfg.Dir, os.ModePerm); err != nil {
+			return nil, err
+		}
+	}
+
+	// Acquire the database lock in the store directory to ensure that no other
+	// process is simultaneously accessing the same store. We manually acquire
+	// the database lock here (rather than allowing Pebble to acquire the lock)
+	// so that we hold the lock when we initialize encryption-at-rest subsystem.
+	cfg.Opts.Lock, err = pebble.LockDirectory(cfg.Dir, cfg.Opts.FS)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		// If we fail to open the database, release the file lock before
+		// returning.
+		if err != nil {
+			err = errors.WithSecondaryError(err, cfg.Opts.Lock.Close())
+		}
+	}()
 
 	cfg.Opts.EnsureDefaults()
 	cfg.Opts.ErrorIfNotExists = cfg.MustExist
@@ -841,6 +863,7 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 		properties:       storeProps,
 		settings:         cfg.Settings,
 		encryption:       env,
+		fileLock:         cfg.Opts.Lock,
 		fileRegistry:     fileRegistry,
 		fs:               cfg.Opts.FS,
 		unencryptedFS:    unencryptedFS,
@@ -1002,6 +1025,7 @@ func (p *Pebble) Close() {
 	if p.closer != nil {
 		_ = p.closer.Close()
 	}
+	_ = p.fileLock.Close()
 }
 
 // Closed implements the Engine interface.


### PR DESCRIPTION
22.1 backport of cockroachdb/pebble#2498.

----

Previously, it was possible to corrupt the encryption-at-rest state of a store by running commands that manipulate store state without first terminating the store's Cockroach process. Cockroach uses a file lock to provide mutual exclusion between processes. Previously, this file lock was acquired when the Pebble engine was opened. The engine is opened only after the encryption-at-rest environment has been initialized, including rotating the file registry. This corruption required replacing the entire corrupted store.

Fix an issue whereby encryption-at-rest disk state was not protectthe file lock that prevents

Fix #98294.
Release justification: Fixes node-local encryption-at-rest corruption issue.
Release note (bug fix): Fix bug whereby running a debug command that manipulates a store (eg, `debug compact`) without first terminating the node using the store could result in corruption of the node's store if encryption-at-rest was enabled.