### PR TITLE
sql: fix comment and remove TODO

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -8561,7 +8561,6 @@ project
       └── filters (true)
 
 # Query requiring a zigzag join with a remaining filter.
-# TODO(itsbilal): remove filter from index join if zigzag join covers it.
 opt expect=GenerateInvertedIndexZigzagJoins
 SELECT j, k FROM b WHERE j @> '{"a": "b", "c": "d"}'
 ----

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2347,8 +2347,6 @@ func typeCheckComparisonOp(
 		// a::TEXT @@ b::TEXT             |  to_tsvector(a) @@ plainto_tsquery(b)
 		// a::TEXT @@ b::TSQUERY          |  to_tsvector(a) @@ b
 		// a::TSQUERY @@ b::TEXT          |  a @@ to_tsvector(b)
-		// a::TSVECTOR @@ b::TEXT         |  a @@ b::TSQUERY
-		// a::TEXT @@ b::TSVECTOR         |  a::TSQUERY @@ b
 		if leftFamily == types.StringFamily {
 			if rightFamily == types.StringFamily || rightFamily == types.TSQueryFamily {
 				leftExprs := make(Exprs, 1)


### PR DESCRIPTION
#### opt: remove unnecessary TODO

This commit removes a TODO that was addressed in #95638.

Release note: None

#### sql: fix comment in type_check.go

This commit fixes a comment that has been outdated since #100704.

Epic: None

Release note: None
