### PR TITLE
c2c: reset ingestion job retry counter if retained timestamp advanced 

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/protoutil",
+        "//pkg/util/retry",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -39,9 +39,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
+
+const TestingMaxDistSQLRetries = 4
 
 type srcInitExecFunc func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner)
 type destInitExecFunc func(t *testing.T, sysSQL *sqlutils.SQLRunner) // Tenant is created by the replication stream
@@ -219,6 +222,15 @@ func waitForTenantPodsActive(
 func CreateTenantStreamingClusters(
 	ctx context.Context, t *testing.T, args TenantStreamingClustersArgs,
 ) (*TenantStreamingClusters, func()) {
+
+	if args.TestingKnobs != nil && args.TestingKnobs.DistSQLRetryPolicy == nil {
+		args.TestingKnobs.DistSQLRetryPolicy = &retry.Options{
+			InitialBackoff: time.Microsecond,
+			Multiplier:     2,
+			MaxBackoff:     2 * time.Microsecond,
+			MaxRetries:     TestingMaxDistSQLRetries,
+		}
+	}
 	serverArgs := base.TestServerArgs{
 		// Test fails because it tries to set a cluster setting only accessible
 		// to system tenants. Tracked with #76378.

--- a/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
@@ -8,10 +8,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/streamingccl/streamclient",
+        "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/kv/kvpb",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",
+        "//pkg/sql/isql",
         "//pkg/storage",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -276,18 +276,23 @@ func ingest(ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.
 	return completeIngestion(ctx, execCtx, ingestionJob)
 }
 
+func getRetryPolicy(knobs *sql.StreamingTestingKnobs) retry.Options {
+	if knobs != nil && knobs.DistSQLRetryPolicy != nil {
+		return *knobs.DistSQLRetryPolicy
+	}
+	return retry.Options{
+		InitialBackoff: time.Microsecond,
+		Multiplier:     1,
+		MaxBackoff:     2 * time.Microsecond,
+		MaxRetries:     20}
+}
+
 func ingestWithRetries(
 	ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.Job,
 ) error {
-	ro := retry.Options{
-		InitialBackoff: 3 * time.Second,
-		Multiplier:     2,
-		MaxBackoff:     1 * time.Minute,
-		MaxRetries:     60,
-	}
-
+	ro := getRetryPolicy(execCtx.ExecCfg().StreamingTestingKnobs)
 	var err error
-	retryCount := 0
+	var lastReplicatedTime hlc.Timestamp
 	for r := retry.Start(ro); r.Next(); {
 		err = ingest(ctx, execCtx, ingestionJob)
 		if err == nil {
@@ -304,7 +309,11 @@ func ingestWithRetries(
 		log.Warningf(ctx, msgFmt, err)
 		updateRunningStatus(ctx, ingestionJob, jobspb.ReplicationError,
 			fmt.Sprintf(msgFmt, err))
-		retryCount++
+		newReplicatedTime := loadReplicatedTime(ctx, execCtx.ExecCfg().InternalDB, ingestionJob)
+		if lastReplicatedTime.Less(newReplicatedTime) {
+			r.Reset()
+			lastReplicatedTime = newReplicatedTime
+		}
 	}
 	if err != nil {
 		return err
@@ -312,6 +321,15 @@ func ingestWithRetries(
 	updateRunningStatus(ctx, ingestionJob, jobspb.ReplicationCuttingOver,
 		"stream ingestion finished successfully")
 	return nil
+}
+
+func loadReplicatedTime(ctx context.Context, db isql.DB, ingestionJob *jobs.Job) hlc.Timestamp {
+	latestProgress, err := replicationutils.LoadIngestionProgress(ctx, db, ingestionJob.ID())
+	if err != nil {
+		log.Warningf(ctx, "error loading job progress: %s", err)
+		return hlc.Timestamp{}
+	}
+	return latestProgress.ReplicatedTime
 }
 
 // The ingestion job should never fail, only pause, as progress should never be lost.

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
-	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -1161,39 +1160,8 @@ type cutoverFromJobProgress struct {
 	jobID jobspb.JobID
 }
 
-func (c *cutoverFromJobProgress) loadIngestionProgress(
-	ctx context.Context,
-) (*jobspb.StreamIngestionProgress, error) {
-	var (
-		progressBytes []byte
-		exists        bool
-	)
-	if err := c.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		infoStorage := jobs.InfoStorageForJob(txn, c.jobID)
-		var err error
-		progressBytes, exists, err = infoStorage.GetLegacyProgress(ctx)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, nil
-	}
-	progress := &jobspb.Progress{}
-	if err := protoutil.Unmarshal(progressBytes, progress); err != nil {
-		return nil, err
-	}
-
-	sp, ok := progress.GetDetails().(*jobspb.Progress_StreamIngest)
-	if !ok {
-		return nil, errors.Newf("unknown progress details type %T in stream ingestion job %d",
-			progress.GetDetails(), c.jobID)
-	}
-	return sp.StreamIngest, nil
-}
-
 func (c *cutoverFromJobProgress) cutoverReached(ctx context.Context) (bool, error) {
-	ingestionProgress, err := c.loadIngestionProgress(ctx)
+	ingestionProgress, err := replicationutils.LoadIngestionProgress(ctx, c.db, c.jobID)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -112,6 +112,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -1767,6 +1768,8 @@ type StreamingTestingKnobs struct {
 	// CutoverProgressShouldUpdate overrides the standard logic
 	// for whether the job record is updated on a progress update.
 	CutoverProgressShouldUpdate func() bool
+
+	DistSQLRetryPolicy *retry.Options
 }
 
 var _ base.ModuleTestingKnobs = &StreamingTestingKnobs{}


### PR DESCRIPTION
Previously, the replication stream would pause after 60 retryable errors
bubbled up to the job coordinator. This patch changes the policy such that:
 1. the coordinator resets the retry counter if the replicated timestamp
advanced between two retryable errors.
 2. the max number of retries without replicated timestamp progress is now 20.

Epic: None

Release note: None