### PR TITLE
copy: new copy IO implementation

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1721,6 +1721,7 @@ GO_TARGETS = [
     "//pkg/sql/contention:contention_test",
     "//pkg/sql/contentionpb:contentionpb",
     "//pkg/sql/contentionpb:contentionpb_test",
+    "//pkg/sql/copy:copy",
     "//pkg/sql/copy:copy_test",
     "//pkg/sql/covering:covering",
     "//pkg/sql/covering:covering_test",

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -113,7 +113,7 @@ func runCopyFromPG(ctx context.Context, t test.Test, c cluster.Cluster, sf int) 
 
 func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int, atomic bool) {
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
+	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), c.All())
 	initTest(ctx, t, c, sf)
 	db, err := c.ConnE(ctx, t.L(), 1)
 	require.NoError(t, err)
@@ -151,6 +151,7 @@ func registerCopyFrom(r registry.Registry) {
 		nodes int
 	}{
 		{sf: 1, nodes: 1},
+		{sf: 1, nodes: 3},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -399,6 +399,7 @@ go_library(
         "//pkg/sql/contention",
         "//pkg/sql/contention/txnidcache",
         "//pkg/sql/contentionpb",
+        "//pkg/sql/copy",
         "//pkg/sql/covering",
         "//pkg/sql/decodeusername",
         "//pkg/sql/delegate",

--- a/pkg/sql/copy/BUILD.bazel
+++ b/pkg/sql/copy/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "copy_test",
@@ -53,5 +53,19 @@ go_test(
         "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+    ],
+)
+
+go_library(
+    name = "copy",
+    srcs = ["reader.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/copy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/settings",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/pgwire/pgwirebase",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/copy/copy_in_test.go
+++ b/pkg/sql/copy/copy_in_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package copy
+package copy_test
 
 import (
 	"context"

--- a/pkg/sql/copy/copy_out_test.go
+++ b/pkg/sql/copy/copy_out_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package copy
+package copy_test
 
 import (
 	"bytes"

--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package copy
+package copy_test
 
 import (
 	"bytes"

--- a/pkg/sql/copy/main_test.go
+++ b/pkg/sql/copy/main_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package copy
+package copy_test
 
 import (
 	"os"

--- a/pkg/sql/copy/reader.go
+++ b/pkg/sql/copy/reader.go
@@ -1,0 +1,150 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package copy
+
+import (
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
+	"github.com/cockroachdb/errors"
+)
+
+// Reader is an io.Reader that reads the COPY protocol from the underlying pgwire
+// buffer but removes the protocol bits and just returns the raw text. There's
+// no buffering, there's a buffer below it on top of the raw connection and
+// any buffering required above it (for line reading etc) is either
+// implemented in COPY or in the CSV reader.
+type Reader struct {
+	// We don't use this buffer but we use some of its helper methods.
+	readBuf pgwirebase.ReadBuffer
+	// pgr is the underlying pgwire reader we're reading from
+	pgr pgwirebase.BufferedReader
+	// Scratch space for Drain
+	scratch   [128]byte
+	remainder int
+	done      bool
+}
+
+var _ io.Reader = &Reader{}
+
+// NewReader creates and initializes a copy.Reader.
+func NewReader(pgr pgwirebase.BufferedReader, sv *settings.Values) *Reader {
+	c := &Reader{}
+	c.pgr = pgr
+	c.readBuf.SetOption(pgwirebase.ReadBufferOptionWithClusterSettings(sv))
+	return c
+}
+
+// Read implements the io.Reader interface.
+func (c *Reader) Read(p []byte) (int, error) {
+	// The CSV reader can eat an EOF and will come back for another read in some
+	// case's. Keep giving it EOF's in that case.
+	if c.done {
+		return 0, io.EOF
+	}
+	// If we had a short read, finish it.
+	if c.remainder == 0 {
+		// Go to pgwire to get next segment.
+		size, err := c.readTypedMessage()
+		if err != nil {
+			return 0, err
+		}
+		c.remainder = size
+	}
+	// We never want to overread from the wire, we might read past COPY data
+	// segments so limit p to remainder bytes.
+	if c.remainder < len(p) {
+		p = p[:c.remainder]
+	}
+	n, err := c.pgr.Read(p)
+	if err != nil {
+		return 0, err
+	}
+	c.remainder -= n
+	return n, nil
+}
+
+func (c *Reader) readTypedMessage() (size int, err error) {
+	b, err := c.pgr.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	typ := pgwirebase.ClientMessageType(b)
+	_, size, err = c.readBuf.ReadUntypedMsgSize(c.pgr)
+	if err != nil {
+		if pgwirebase.IsMessageTooBigError(err) && typ == pgwirebase.ClientMsgCopyData {
+			// Slurp the remaining bytes.
+			_, slurpErr := c.readBuf.SlurpBytes(c.pgr, pgwirebase.GetMessageTooBigSize(err))
+			if slurpErr != nil {
+				return 0, errors.CombineErrors(err, errors.Wrapf(slurpErr, "error slurping remaining bytes in COPY"))
+			}
+
+			// As per the pgwire spec, we must continue reading until we encounter
+			// CopyDone or CopyFail. We don't support COPY in the extended
+			// protocol, so we don't need to look for Sync messages. See
+			// https://www.postgresql.org/docs/13/protocol-flow.html#PROTOCOL-COPY
+			for {
+				typ, _, slurpErr = c.readBuf.ReadTypedMsg(c.pgr)
+				if typ == pgwirebase.ClientMsgCopyDone || typ == pgwirebase.ClientMsgCopyFail {
+					break
+				}
+				if slurpErr != nil && !pgwirebase.IsMessageTooBigError(slurpErr) {
+					return 0, errors.CombineErrors(err, errors.Wrapf(slurpErr, "error slurping remaining bytes in COPY"))
+				}
+
+				_, slurpErr = c.readBuf.SlurpBytes(c.pgr, pgwirebase.GetMessageTooBigSize(slurpErr))
+				if slurpErr != nil {
+					return 0, errors.CombineErrors(err, errors.Wrapf(slurpErr, "error slurping remaining bytes in COPY"))
+				}
+			}
+		}
+		return 0, err
+	}
+	switch typ {
+	case pgwirebase.ClientMsgCopyData:
+		// Just return size.
+	case pgwirebase.ClientMsgCopyDone:
+		c.done = true
+		return 0, io.EOF
+	case pgwirebase.ClientMsgCopyFail:
+		msg := make([]byte, size)
+		if _, err := io.ReadFull(c.pgr, msg); err != nil {
+			return 0, err
+		}
+		return 0, pgerror.Newf(pgcode.QueryCanceled, "COPY from stdin failed: %s", string(msg))
+	case pgwirebase.ClientMsgFlush, pgwirebase.ClientMsgSync:
+		// Spec says to "ignore Flush and Sync messages received during copy-in mode".
+	default:
+		// In order to gracefully handle bogus protocol, ie back to back copies, we have to
+		// slurp these bytes.
+		msg := make([]byte, size)
+		if _, err := io.ReadFull(c.pgr, msg); err != nil {
+			return 0, err
+		}
+		return 0, pgwirebase.NewUnrecognizedMsgTypeErr(typ)
+	}
+	return size, nil
+}
+
+// Drain will discard any bytes we haven't read yet.
+func (c *Reader) Drain() error {
+	for c.remainder > 0 {
+		n, err := c.pgr.Read(c.scratch[:])
+		if err != nil {
+			return err
+		}
+		c.remainder -= n
+	}
+	return nil
+}

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -369,6 +369,30 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SELECT 2"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# Test with \r\n instead of \n
+send
+Query {"String": "DELETE FROM t"}
+Query {"String": "COPY t FROM STDIN DELIMITER ','"}
+CopyData {"Data": "1,blah\r\n"}
+CopyData {"Data": "\\.\r\n"}
+CopyDone
+Query {"String": "SELECT * FROM t ORDER BY i"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DELETE 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"blah"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 send
 Query {"String": "DELETE FROM t"}
 Query {"String": "COPY t FROM STDIN HEADER CSV"}
@@ -393,7 +417,7 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
-{"Type":"CommandComplete","CommandTag":"DELETE 2"}
+{"Type":"CommandComplete","CommandTag":"DELETE 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 {"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
 {"Type":"CommandComplete","CommandTag":"COPY 0"}

--- a/pkg/util/encoding/csv/reader.go
+++ b/pkg/util/encoding/csv/reader.go
@@ -160,6 +160,9 @@ type Reader struct {
 	// By default, each call to Read returns newly allocated memory owned by the caller.
 	ReuseRecord bool
 
+	// Report parse error on empty lines.
+	DontSkipEmptyLines bool
+
 	r *bufio.Reader
 
 	// numLine is the current line being read in the CSV file.
@@ -189,6 +192,11 @@ func NewReader(r io.Reader) *Reader {
 		Escape: '"',
 		r:      bufio.NewReader(r),
 	}
+}
+
+// GetBuffer allows access to underlying buffer for memory accounting purposes.
+func (r *Reader) GetBuffer() *bufio.Reader {
+	return r.r
 }
 
 // Read reads one record (a slice of fields) from r.
@@ -331,7 +339,9 @@ func (r *Reader) readRecord(dst []Record) ([]Record, error) {
 		}
 		if errRead == nil && len(line) == lengthCRLF(line) {
 			line = nil
-			continue // Skip empty lines
+			if !r.DontSkipEmptyLines {
+				continue // Skip empty lines
+			}
 		}
 		fullLine = line
 		break


### PR DESCRIPTION

### copy: new copy IO implementation

Refactor COPY so that all the buffer reading takes place in a separate
implementation of the io.Reader interface. This does two things, it
enables the COPY implementation to efficiently handle small CopyData
frames by eliminating extra buffering and exposes the COPY bytes as
a pure stream of bytes which makes retry easier. It also cleans up the
COPY code that handles CopyData segments straddling line boundaries, now
we can just let the text/CSV reader do their thing and not have to do
any writeback.

The old implementation would read from a pgwire BufferedReader (copy 1)
into a pgwire "ReadBuffer" (copy 2) and then push those segments into a
bytes.Buffer "buf" (copy 3). The text and binary readers would read
right from buf the CSV reader has its own buffer and we would read
lines from buf and write them into the CSV reader's buffer (copy 4).

The new approach does away with all this and the text format
reads directly from a bufio.Reader (copy 1) stacked on the copy.Reader
(no buffering) stacked on the pgwire BufferedReader (copy 2). For CSV
the CSVReader reads directly from the copy.Reader since it has its
own buffer so again only two copies off the wire. Binary reads directly
from the copy.Reader since it requires no ReadLine (but the I/O is still
buffered at the pgwire level).

This doesn't seem to affect performance much but it gives the GC a nice
break and sets up a clean solution for #99327.

When encountering a memory usage error we used to try to let the encoder
finish the row but with the more efficient buffering this started
succeeds where it always failed before. Now we just don't do the hail
mary and if we hit the limit we bail and return immediately, this is
more OOM safe and simpler.

```
$ BENCHES=BenchmarkCopyCSVEndToEnd PKG=./pkg/sql/copy scripts/bench master
Executed 1 out of 1 test: 1 test passes.
name                old time/op    new time/op    delta
CopyCSVEndToEnd-10     3.94s ± 4%     3.76s ± 4%   -4.59%  (p=0.000 n=10+9)

name                old alloc/op   new alloc/op   delta
CopyCSVEndToEnd-10    8.92GB ± 1%    8.61GB ± 2%   -3.46%  (p=0.000 n=10+9)

name                old allocs/op  new allocs/op  delta
CopyCSVEndToEnd-10     13.8M ± 0%     11.6M ± 0%  -16.08%  (p=0.000 n=7+8)
```

Fixes: #93156
Informs: #99327
Release note: none
Epic: CRDB-25321


### copy: enhance copyfrom roachtest

Add 3 node config for more retry coverage and turn off backups since its
a perf test.

Release note: none
Epic: CRDB-25321
Informs: #99327


### copy: add copy carriage return test

Purely test change to get %100 line coverage in readTextData.

Informs: #99327
Epic: None
Release note: None
