### PR TITLE
release-23.1: roachtest: partially disable clearrange checks=true configuration

### DIFF
--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -100,7 +100,9 @@ func runClearRange(
 		// This slows down merges, so it might hide some races.
 		//
 		// NB: the below invocation was found to actually make it to the server at the time of writing.
-		settings.Env = append(settings.Env, []string{"COCKROACH_CONSISTENCY_AGGRESSIVE=true", "COCKROACH_ENFORCE_CONSISTENT_STATS=true"}...)
+		// NB: We omit "COCKROACH_ENFORCE_CONSISTENT_STATS=true" on the
+		// release-23.1 branch due to #93896.
+		settings.Env = append(settings.Env, []string{"COCKROACH_CONSISTENCY_AGGRESSIVE=true"}...)
 	}
 
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings)


### PR DESCRIPTION
Previously, the checks=true configuration of the clearrange roachtest would fatal on stats divergences. Due to #93896, this test can fatal with a SysBytes divergence. This is fixed on master, but the fix will not be backported to 23.1 or 22.2. Disable the enforcement of consistent stats on this branch.

Fixes #104078.
Informs #104011.
Epic: none
Release note: none
Release justification: non-production code changes