### PR TITLE
logictest: disable metamorphic distsql_workmem for UDF test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1,3 +1,9 @@
+# Set the distsql_workmem to the default production value because metamorphic
+# values may be too low for the legacy schema changer.
+onlyif config local-legacy-schema-changer
+statement ok
+SET distsql_workmem = '64MiB'
+
 statement ok
 CREATE TABLE ab (
   a INT PRIMARY KEY,


### PR DESCRIPTION
UDF logic tests fail with the legacy schema change when
`distsql_workmem` is low. This commit disables metamorphic values for
`distsql_workmem` in this configuration.

Fixes #103797

Release note: None
