### PR TITLE
changefeedccl: total timestamp ordering for changefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -197,6 +197,7 @@ go_test(
         "sink_test.go",
         "sink_webhook_test.go",
         "testfeed_test.go",
+        "total_ordering_test.go",
         "validations_test.go",
     ],
     args = select({

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1330,7 +1330,7 @@ func TestAlterChangefeedAddTargetsDuringBackfill(t *testing.T) {
 				expectedValues[j] = fmt.Sprintf(`foo: [%d]->{"after": {"val": %d}}`, j, j)
 				expectedValues[j+numRowsPerTable] = fmt.Sprintf(`bar: [%d]->{"after": {"val": %d}}`, j, j)
 			}
-			return assertPayloadsBaseErr(context.Background(), testFeed, expectedValues, false, false)
+			return assertPayloadsBaseErr(context.Background(), testFeed, expectedValues, false, changefeedbase.OptOrderingNone)
 		})
 
 		defer func() {

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -166,6 +166,7 @@ var changefeedResultTypes = []*types.T{
 	types.String, // topic
 	types.Bytes,  // key
 	types.Bytes,  // value
+	types.Bytes,  // ordered rows update
 }
 
 // fetchSpansForTable returns the set of spans for the specified table.

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1027,6 +1027,14 @@ func validateDetailsAndOptions(
 		}
 	}
 
+	encodingOpts, err := opts.GetEncodingOptions()
+	if err != nil {
+		return err
+	}
+	if opts.TotalOrdering() && encodingOpts.Format == changefeedbase.OptFormatParquet {
+		return errors.Errorf(`total ordering is unsupported for the parquet format`)
+	}
+
 	{
 		if details.Select != "" {
 			if len(details.TargetSpecifications) != 1 {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -260,6 +260,134 @@ func TestChangefeedBasics(t *testing.T) {
 	// cloudStorageTest is a regression test for #36994.
 }
 
+func TestChangefeedTotalOrderingInitialScan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo(a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo (a) SELECT * FROM generate_series(1, 1000)`)
+
+		knobs := s.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+
+		// Disallow any processing of resolved spans on the frontier to simulate
+		// not being able to note progress on an aggregator.
+		knobs.FilterFrontierResolvedSpan = func() bool {
+			return true
+		}
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH ordering='total'`)
+		defer closeFeed(t, foo)
+
+		// On initial scan, the feed should emit events regardless of never
+		// observing resolved progress on the frontier as all events are expected to
+		// have the same timestamp.
+		foundMsg := false
+		for msg, err := foo.Next(); msg != nil; msg, err = foo.Next() {
+			require.NoError(t, err)
+			if msg.Key != nil {
+				foundMsg = true
+				break
+			}
+		}
+		require.True(t, foundMsg)
+	}
+
+	// enterprise test needs work to sort rows by crdb_internal_mvcc_timestamp
+	cdcTestWithSystem(t, testFn, feedTestOmitSinks("enterprise"))
+}
+
+func TestChangefeedTotalOrderingBasics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		// By the time this is available the old sinks won't be enabled.
+		sqlDB.Exec(t, "SET CLUSTER SETTING changefeed.new_webhook_sink_enabled = true")
+		sqlDB.Exec(t, "SET CLUSTER SETTING changefeed.new_pubsub_sink_enabled = true")
+
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		for i := 0; i < 1000; i++ {
+			sqlDB.Exec(t, fmt.Sprintf(`INSERT INTO foo VALUES (%d)`, i))
+		}
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH updated, ordering='total', resolved='5s'`)
+		defer closeFeed(t, foo)
+		for i := 1000; i < 2000; i++ {
+			sqlDB.Exec(t, fmt.Sprintf(`INSERT INTO foo VALUES (%d)`, i))
+		}
+
+		var expectedBackfillMessages []string
+		for i := 0; i < 1000; i++ {
+			expectedBackfillMessages = append(expectedBackfillMessages, fmt.Sprintf(
+				`foo: [%d]->{"after": {"a": %d}}`, i, i,
+			))
+		}
+		var expectedMessages []string
+		for i := 1000; i < 2000; i++ {
+			expectedMessages = append(expectedMessages, fmt.Sprintf(
+				`foo: [%d]->{"after": {"a": %d}}`, i, i,
+			))
+		}
+
+		assertPayloadsStripTs(t, foo, expectedBackfillMessages)
+		assertPayloadsTotalOrdering(t, foo, expectedMessages)
+	}
+
+	// enterprise test needs work to sort rows by crdb_internal_mvcc_timestamp
+	cdcTest(t, testFn, feedTestOmitSinks("enterprise"))
+}
+
+func TestChangefeedTotalOrderingMultiNode(t *testing.T) {
+	defer log.Scope(t).Close(t)
+
+	cluster, db, cleanup := startTestCluster(t)
+	defer cleanup()
+
+	f := makeKafkaFeedFactory(cluster, db)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+
+	sqlDB.ExecMultiple(t,
+		`INSERT INTO foo (a) SELECT * FROM generate_series(1, 1000);`,
+		`ALTER TABLE foo SPLIT AT (SELECT * FROM generate_series(1, 1000, 50));`,
+		`ALTER TABLE foo SCATTER;`,
+	)
+
+	foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH updated, ordering='total', resolved='1s', initial_scan='yes'`)
+	defer closeFeed(t, foo)
+	var expectedBackfillMessages []string
+	for i := 1; i <= 1000; i++ {
+		expectedBackfillMessages = append(expectedBackfillMessages, fmt.Sprintf(
+			`foo: [%d]->{"after": {"a": %d}}`, i, i,
+		))
+	}
+	assertPayloadsStripTs(t, foo, expectedBackfillMessages)
+
+	for i := 1001; i <= 2000; i++ {
+		sqlDB.Exec(t, fmt.Sprintf(`INSERT INTO foo VALUES (%d)`, i))
+	}
+	sqlDB2 := sqlutils.MakeSQLRunner(cluster.ServerConn(1))
+	for i := 2001; i <= 3000; i++ {
+		sqlDB2.Exec(t, fmt.Sprintf(`INSERT INTO foo VALUES (%d)`, i))
+	}
+	sqlDB3 := sqlutils.MakeSQLRunner(cluster.ServerConn(2))
+	for i := 3001; i <= 4000; i++ {
+		sqlDB3.Exec(t, fmt.Sprintf(`INSERT INTO foo VALUES (%d)`, i))
+	}
+
+	var expectedMessages []string
+	for i := 1001; i <= 4000; i++ {
+		expectedMessages = append(expectedMessages, fmt.Sprintf(
+			`foo: [%d]->{"after": {"a": %d}}`, i, i,
+		))
+	}
+	assertPayloadsTotalOrdering(t, foo, expectedMessages)
+}
+
 func TestChangefeedBasicQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1078,7 +1206,7 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 			for i, id := range expectedRowIDs {
 				assertedPayloads[i] = fmt.Sprintf(`seed: [%s]->{"rowid": %s}`, id, id)
 			}
-			err = assertPayloadsBaseErr(context.Background(), seedFeed, assertedPayloads, false, false)
+			err = assertPayloadsBaseErr(context.Background(), seedFeed, assertedPayloads, false, changefeedbase.OptOrderingNone)
 			closeFeedIgnoreError(t, seedFeed)
 			if err != nil {
 				t.Error(err)
@@ -7870,10 +7998,14 @@ func (s *memoryHoggingSink) Dial() error {
 	return nil
 }
 
+func (s *memoryHoggingSink) NameTopic(topic TopicDescriptor) (string, error) {
+	return "", nil
+}
+
 func (s *memoryHoggingSink) EmitRow(
 	ctx context.Context,
-	topic TopicDescriptor,
 	key, value []byte,
+	topic sinkTopic,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {
@@ -8179,7 +8311,7 @@ func TestChangefeedTestTimesOut(t *testing.T) {
 					nada, expectTimeout,
 					func(ctx context.Context) error {
 						return assertPayloadsBaseErr(
-							ctx, nada, []string{`nada: [2]->{"after": {}}`}, false, false)
+							ctx, nada, []string{`nada: [2]->{"after": {}}`}, false, changefeedbase.OptOrderingNone)
 					})
 				return nil
 			}, 20*expectTimeout))

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -38,6 +38,9 @@ type StatementOptions struct {
 // EnvelopeType configures the information in the changefeed events for a row.
 type EnvelopeType string
 
+// OrderingType configures the ordering guarantees for emitted rows.
+type OrderingType string
+
 // FormatType configures the encoding format.
 type FormatType string
 
@@ -97,6 +100,7 @@ const (
 	OptWebhookClientTimeout    = `webhook_client_timeout`
 	OptOnError                 = `on_error`
 	OptMetricsScope            = `metrics_label`
+	OptOrdering                = `ordering`
 	OptUnordered               = `unordered`
 	OptVirtualColumns          = `virtual_columns`
 	OptExecutionLocality       = `execution_locality`
@@ -145,6 +149,10 @@ const (
 	OptEnvelopeDeprecatedRow EnvelopeType = `deprecated_row`
 	OptEnvelopeWrapped       EnvelopeType = `wrapped`
 	OptEnvelopeBare          EnvelopeType = `bare`
+
+	OptOrderingTotal OrderingType = "total"
+	OptOrderingKey   OrderingType = "key"
+	OptOrderingNone  OrderingType = "none"
 
 	OptFormatJSON    FormatType = `json`
 	OptFormatAvro    FormatType = `avro`
@@ -342,6 +350,7 @@ var ChangefeedOptionExpectValues = map[string]OptionPermittedValues{
 	OptWebhookClientTimeout:               durationOption,
 	OptOnError:                            enum("pause", "fail"),
 	OptMetricsScope:                       stringOption,
+	OptOrdering:                           enum("total", "key").orEmptyMeans("key"),
 	OptUnordered:                          flagOption,
 	OptVirtualColumns:                     enum("omitted", "null"),
 	OptExecutionLocality:                  stringOption,
@@ -355,7 +364,7 @@ var CommonOptions = makeStringSet(OptCursor, OptEndTime, OptEnvelope,
 	OptMVCCTimestamps, OptDiff, OptSplitColumnFamilies,
 	OptSchemaChangeEvents, OptSchemaChangePolicy,
 	OptOnError,
-	OptInitialScan, OptNoInitialScan, OptInitialScanOnly, OptUnordered, OptCustomKeyColumn,
+	OptInitialScan, OptNoInitialScan, OptInitialScanOnly, OptOrdering, OptUnordered, OptCustomKeyColumn,
 	OptMinCheckpointFrequency, OptMetricsScope, OptVirtualColumns, Topics, OptExpirePTSAfter,
 	OptExecutionLocality,
 )
@@ -946,6 +955,11 @@ func (s StatementOptions) IncludeVirtual() bool {
 // KeyOnly returns true if we are using the 'key_only' envelope.
 func (s StatementOptions) KeyOnly() bool {
 	return s.m[OptEnvelope] == string(OptEnvelopeKeyOnly)
+}
+
+// TotalOrdering returns true if we are using ordering='total'
+func (s StatementOptions) TotalOrdering() bool {
+	return s.m[OptOrdering] == string(OptOrderingTotal)
 }
 
 // GetMinCheckpointFrequency returns the minimum frequency with which checkpoints should be

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -181,26 +181,50 @@ func checkPerKeyOrdering(payloads []cdctest.TestFeedMessage) (bool, error) {
 	return true, nil
 }
 
+func checkTotalOrdering(payloads []cdctest.TestFeedMessage) (bool, error) {
+	lastTimestamp := 0.0
+	for _, msg := range payloads {
+		updatedTimestamp, err := extractUpdatedFromValue(msg.Value)
+		if err != nil {
+			return false, err
+		}
+		if updatedTimestamp < lastTimestamp {
+			return false, nil
+		}
+		lastTimestamp = updatedTimestamp
+	}
+	return true, nil
+}
+
 func assertPayloadsBase(
-	t testing.TB, f cdctest.TestFeed, expected []string, stripTs bool, perKeyOrdered bool,
+	t testing.TB,
+	f cdctest.TestFeed,
+	expected []string,
+	stripTs bool,
+	ordering changefeedbase.OrderingType,
 ) {
 	t.Helper()
 	timeout := assertPayloadsTimeout()
 	if len(expected) > 100 {
 		// Webhook sink is very slow; We have few tests that read 1000 messages.
 		timeout += time.Duration(math.Log(float64(len(expected)))) * time.Minute
+
 	}
 
 	require.NoError(t,
 		withTimeout(f, timeout,
 			func(ctx context.Context) (err error) {
-				return assertPayloadsBaseErr(ctx, f, expected, stripTs, perKeyOrdered)
+				return assertPayloadsBaseErr(ctx, f, expected, stripTs, ordering)
 			},
 		))
 }
 
 func assertPayloadsBaseErr(
-	ctx context.Context, f cdctest.TestFeed, expected []string, stripTs bool, perKeyOrdered bool,
+	ctx context.Context,
+	f cdctest.TestFeed,
+	expected []string,
+	stripTs bool,
+	ordering changefeedbase.OrderingType,
 ) error {
 	actual, err := readNextMessages(ctx, f, len(expected))
 	if err != nil {
@@ -212,13 +236,22 @@ func assertPayloadsBaseErr(
 		actualFormatted = append(actualFormatted, fmt.Sprintf(`%s: %s->%s`, m.Topic, m.Key, m.Value))
 	}
 
-	if perKeyOrdered {
+	if ordering == changefeedbase.OptOrderingKey {
 		ordered, err := checkPerKeyOrdering(actual)
 		if err != nil {
 			return err
 		}
 		if !ordered {
 			return errors.Newf("payloads violate CDC per-key ordering guarantees:\n  %s",
+				strings.Join(actualFormatted, "\n  "))
+		}
+	} else if ordering == changefeedbase.OptOrderingTotal {
+		ordered, err := checkTotalOrdering(actual)
+		if err != nil {
+			return err
+		}
+		if !ordered {
+			return errors.Newf("payloads violate total ordering guarantee:\n  %s",
 				strings.Join(actualFormatted, "\n  "))
 		}
 	}
@@ -232,8 +265,10 @@ func assertPayloadsBaseErr(
 		}
 	}
 
-	sort.Strings(expected)
-	sort.Strings(actualFormatted)
+	if ordering != changefeedbase.OptOrderingTotal {
+		sort.Strings(expected)
+		sort.Strings(actualFormatted)
+	}
 	if !reflect.DeepEqual(expected, actualFormatted) {
 		return errors.Newf("expected\n  %s\ngot\n  %s",
 			strings.Join(expected, "\n  "), strings.Join(actualFormatted, "\n  "))
@@ -266,19 +301,24 @@ func withTimeout(
 
 func assertPayloads(t testing.TB, f cdctest.TestFeed, expected []string) {
 	t.Helper()
-	assertPayloadsBase(t, f, expected, false, false)
+	assertPayloadsBase(t, f, expected, false, changefeedbase.OptOrderingNone)
+}
+
+func assertPayloadsTotalOrdering(t testing.TB, f cdctest.TestFeed, expected []string) {
+	t.Helper()
+	assertPayloadsBase(t, f, expected, true, changefeedbase.OptOrderingTotal)
 }
 
 func assertPayloadsStripTs(t testing.TB, f cdctest.TestFeed, expected []string) {
 	t.Helper()
-	assertPayloadsBase(t, f, expected, true, false)
+	assertPayloadsBase(t, f, expected, true, changefeedbase.OptOrderingNone)
 }
 
 // assert that the messages received by the sink maintain per-key ordering guarantees. then,
 // strip the timestamp from the messages and compare them to the expected payloads.
 func assertPayloadsPerKeyOrderedStripTs(t testing.TB, f cdctest.TestFeed, expected []string) {
 	t.Helper()
-	assertPayloadsBase(t, f, expected, true, true)
+	assertPayloadsBase(t, f, expected, true, changefeedbase.OptOrderingKey)
 }
 
 func avroToJSON(t testing.TB, reg *cdctest.SchemaRegistry, avroBytes []byte) []byte {

--- a/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
@@ -92,12 +92,16 @@ func (parquetSink *parquetCloudStorageSink) getConcreteType() sinkType {
 	return parquetSink.wrapped.getConcreteType()
 }
 
+func (parquetSink *parquetCloudStorageSink) NameTopic(topic TopicDescriptor) (string, error) {
+	return parquetSink.wrapped.NameTopic(topic)
+}
+
 // EmitRow does not do anything. It must not be called. It is present so that
 // parquetCloudStorageSink implements the Sink interface.
 func (parquetSink *parquetCloudStorageSink) EmitRow(
 	ctx context.Context,
-	topic TopicDescriptor,
 	key, value []byte,
+	topic sinkTopic,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {
@@ -135,7 +139,7 @@ func (parquetSink *parquetCloudStorageSink) EncodeAndEmitRow(
 	ctx context.Context,
 	updatedRow cdcevent.Row,
 	prevRow cdcevent.Row,
-	topic TopicDescriptor,
+	topic sinkTopic,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -333,21 +333,20 @@ type messageMetadata struct {
 	mvcc          hlc.Timestamp
 }
 
+func (s *kafkaSink) NameTopic(topicDescr TopicDescriptor) (string, error) {
+	return s.topics.Name(topicDescr)
+}
+
 // EmitRow implements the Sink interface.
 func (s *kafkaSink) EmitRow(
 	ctx context.Context,
-	topicDescr TopicDescriptor,
 	key, value []byte,
+	topic sinkTopic,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {
-	topic, err := s.topics.Name(topicDescr)
-	if err != nil {
-		return err
-	}
-
 	msg := &sarama.ProducerMessage{
-		Topic:    topic,
+		Topic:    topic.name,
 		Key:      sarama.ByteEncoder(key),
 		Value:    sarama.ByteEncoder(value),
 		Metadata: messageMetadata{alloc: alloc, mvcc: mvcc, updateMetrics: s.metrics.recordOneMessage()},

--- a/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
@@ -51,9 +51,13 @@ func (e *externalConnectionKafkaSink) Close() error {
 
 // EmitRow implements the Sink interface.
 func (e *externalConnectionKafkaSink) EmitRow(
-	_ context.Context, _ TopicDescriptor, _, _ []byte, _, _ hlc.Timestamp, _ kvevent.Alloc,
+	_ context.Context, _, _ []byte, _ sinkTopic, _, _ hlc.Timestamp, _ kvevent.Alloc,
 ) error {
 	return nil
+}
+
+func (e *externalConnectionKafkaSink) NameTopic(_ TopicDescriptor) (string, error) {
+	return "", nil
 }
 
 // Flush implements the Sink interface.

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -191,26 +191,25 @@ func (p *deprecatedPubsubSink) Dial() error {
 	return p.client.init()
 }
 
+func (p *deprecatedPubsubSink) NameTopic(topic TopicDescriptor) (string, error) {
+	return p.topicNamer.Name(topic)
+}
+
 // EmitRow pushes a message to event channel where it is consumed by workers
 func (p *deprecatedPubsubSink) EmitRow(
 	ctx context.Context,
-	topic TopicDescriptor,
 	key, value []byte,
+	topic sinkTopic,
 	updated hlc.Timestamp,
 	mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {
 	p.metrics.recordMessageSize(int64(len(key) + len(value)))
-
-	topicName, err := p.topicNamer.Name(topic)
-	if err != nil {
-		return err
-	}
 	m := pubsubMessage{
 		alloc: alloc, isFlush: false, mvcc: mvcc, message: payload{
 			Key:   key,
 			Value: value,
-			Topic: topicName,
+			Topic: topic.name,
 		}}
 
 	// calculate index by hashing key

--- a/pkg/ccl/changefeedccl/sink_sql.go
+++ b/pkg/ccl/changefeedccl/sink_sql.go
@@ -64,6 +64,8 @@ type sqlSink struct {
 	metrics metricsRecorder
 }
 
+var _ Sink = (*sqlSink)(nil)
+
 func (s *sqlSink) getConcreteType() sinkType {
 	return sinkTypeSQL
 }
@@ -121,21 +123,20 @@ func (s *sqlSink) Dial() error {
 	return nil
 }
 
+func (s *sqlSink) NameTopic(topic TopicDescriptor) (string, error) {
+	return s.topicNamer.Name(topic)
+}
+
 // EmitRow implements the Sink interface.
 func (s *sqlSink) EmitRow(
 	ctx context.Context,
-	topicDescr TopicDescriptor,
 	key, value []byte,
+	topic sinkTopic,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {
 	defer alloc.Release(ctx)
 	defer s.metrics.recordOneMessage()(mvcc, len(key)+len(value), sinkDoesNotCompress)
-
-	topic, err := s.topicNamer.Name(topicDescr)
-	if err != nil {
-		return err
-	}
 
 	// Hashing logic copied from sarama.HashPartitioner.
 	s.hasher.Reset()
@@ -148,7 +149,7 @@ func (s *sqlSink) EmitRow(
 	}
 
 	var noResolved []byte
-	return s.emit(ctx, topic, partition, key, value, noResolved)
+	return s.emit(ctx, topic.name, partition, key, value, noResolved)
 }
 
 // EmitResolvedTimestamp implements the Sink interface.

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -211,14 +211,8 @@ func (p *asyncProducerMock) outstanding() int {
 	return len(p.mu.outstanding)
 }
 
-func topic(name string) *tableDescriptorTopic {
-	tableDesc := tabledesc.NewBuilder(&descpb.TableDescriptor{Name: name}).BuildImmutableTable()
-	spec := changefeedbase.Target{
-		Type:              jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY,
-		TableID:           tableDesc.GetID(),
-		StatementTimeName: changefeedbase.StatementTimeName(name),
-	}
-	return &tableDescriptorTopic{Metadata: makeMetadata(tableDesc), spec: spec}
+func topic(name string) sinkTopic {
+	return sinkTopic{name: name}
 }
 
 const noTopicPrefix = ""
@@ -314,7 +308,7 @@ func TestKafkaSink(t *testing.T) {
 
 	// Timeout
 	require.NoError(t,
-		sink.EmitRow(ctx, topic(`t`), []byte(`1`), nil, zeroTS, zeroTS, zeroAlloc))
+		sink.EmitRow(ctx, []byte(`1`), nil, topic(`t`), zeroTS, zeroTS, zeroAlloc))
 
 	m1 := <-p.inputCh
 	for i := 0; i < 2; i++ {
@@ -331,14 +325,14 @@ func TestKafkaSink(t *testing.T) {
 	// Mixed success and error.
 	var pool testAllocPool
 	require.NoError(t, sink.EmitRow(ctx,
-		topic(`t`), []byte(`2`), nil, zeroTS, zeroTS, pool.alloc()))
+		[]byte(`2`), nil, topic(`t`), zeroTS, zeroTS, pool.alloc()))
 	m2 := <-p.inputCh
 	require.NoError(t, sink.EmitRow(
-		ctx, topic(`t`), []byte(`3`), nil, zeroTS, zeroTS, pool.alloc()))
+		ctx, []byte(`3`), nil, topic(`t`), zeroTS, zeroTS, pool.alloc()))
 
 	m3 := <-p.inputCh
 	require.NoError(t, sink.EmitRow(
-		ctx, topic(`t`), []byte(`4`), nil, zeroTS, zeroTS, pool.alloc()))
+		ctx, []byte(`4`), nil, topic(`t`), zeroTS, zeroTS, pool.alloc()))
 
 	m4 := <-p.inputCh
 	go func() { p.successesCh <- m2 }()
@@ -353,7 +347,7 @@ func TestKafkaSink(t *testing.T) {
 
 	// Check simple success again after error
 	require.NoError(t, sink.EmitRow(
-		ctx, topic(`t`), []byte(`5`), nil, zeroTS, zeroTS, pool.alloc()))
+		ctx, []byte(`5`), nil, topic(`t`), zeroTS, zeroTS, pool.alloc()))
 
 	m5 := <-p.inputCh
 	go func() { p.successesCh <- m5 }()
@@ -371,7 +365,7 @@ func TestKafkaSinkEscaping(t *testing.T) {
 	sink, cleanup := makeTestKafkaSink(t, noTopicPrefix, defaultTopicName, p, `☃`)
 	defer cleanup()
 
-	if err := sink.EmitRow(ctx, topic(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc); err != nil {
+	if err := sink.EmitRow(ctx, []byte(`k☃`), []byte(`v☃`), topic(`☃`), zeroTS, zeroTS, zeroAlloc); err != nil {
 		t.Fatal(err)
 	}
 	m := <-p.inputCh
@@ -392,7 +386,7 @@ func TestKafkaTopicNameProvided(t *testing.T) {
 	defer cleanup()
 
 	//all messages go to the general topic
-	require.NoError(t, sink.EmitRow(ctx, topic("particular0"), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc))
+	require.NoError(t, sink.EmitRow(ctx, []byte(`k☃`), []byte(`v☃`), topic("particular0"), zeroTS, zeroTS, zeroAlloc))
 	m := <-p.inputCh
 	require.Equal(t, topicOverride, m.Topic)
 }
@@ -410,7 +404,7 @@ func TestKafkaTopicNameWithPrefix(t *testing.T) {
 	defer clenaup()
 
 	//the prefix is applied and the name is escaped
-	require.NoError(t, sink.EmitRow(ctx, topic("particular0"), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc))
+	require.NoError(t, sink.EmitRow(ctx, []byte(`k☃`), []byte(`v☃`), topic("particular0"), zeroTS, zeroTS, zeroAlloc))
 	m := <-p.inputCh
 	require.Equal(t, `prefix-_u2603_`, m.Topic)
 }
@@ -437,7 +431,7 @@ func BenchmarkEmitRow(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		require.NoError(b, sink.EmitRow(ctx, topic, []byte(`k☃`), []byte(`v☃`), hlc.Timestamp{}, zeroTS, zeroAlloc))
+		require.NoError(b, sink.EmitRow(ctx, []byte(`k☃`), []byte(`v☃`), topic, hlc.Timestamp{}, zeroTS, zeroAlloc))
 	}
 
 	b.ReportAllocs()
@@ -463,15 +457,14 @@ func TestSQLSink(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	overrideTopic := func(name string) *tableDescriptorTopic {
+	overrideTopic := func(name string) (sinkTopic, changefeedbase.Target) {
 		id, _ := strconv.ParseUint(name, 36, 64)
 		td := tabledesc.NewBuilder(&descpb.TableDescriptor{Name: name, ID: descpb.ID(id)}).BuildImmutableTable()
-		spec := changefeedbase.Target{
+		return sinkTopic{name: name}, changefeedbase.Target{
 			Type:              jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY,
 			TableID:           td.GetID(),
 			StatementTimeName: changefeedbase.StatementTimeName(name),
 		}
-		return &tableDescriptorTopic{Metadata: makeMetadata(td), spec: spec}
 	}
 
 	ctx := context.Background()
@@ -484,11 +477,11 @@ func TestSQLSink(t *testing.T) {
 	defer cleanup()
 	pgURL.Path = `d`
 
-	fooTopic := overrideTopic(`foo`)
-	barTopic := overrideTopic(`bar`)
+	fooTopic, fooSpec := overrideTopic(`foo`)
+	barTopic, barSpec := overrideTopic(`bar`)
 	targets := changefeedbase.Targets{}
-	targets.Add(fooTopic.GetTargetSpecification())
-	targets.Add(barTopic.GetTargetSpecification())
+	targets.Add(fooSpec)
+	targets.Add(barSpec)
 
 	const testTableName = `sink`
 	sink, err := makeSQLSink(sinkURL{URL: &pgURL}, testTableName, targets, nilMetricsRecorderBuilder)
@@ -500,7 +493,7 @@ func TestSQLSink(t *testing.T) {
 	require.NoError(t, sink.Flush(ctx))
 
 	// With one row, nothing flushes until Flush is called.
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v0`), zeroTS, zeroTS, zeroAlloc))
+	require.NoError(t, sink.EmitRow(ctx, []byte(`k1`), []byte(`v0`), fooTopic, zeroTS, zeroTS, zeroAlloc))
 	sqlDB.CheckQueryResults(t, `SELECT key, value FROM sink ORDER BY PRIMARY KEY sink`,
 		[][]string{},
 	)
@@ -514,7 +507,7 @@ func TestSQLSink(t *testing.T) {
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM sink`, [][]string{{`0`}})
 	for i := 0; i < sqlSinkRowBatchSize+1; i++ {
 		require.NoError(t,
-			sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v`+strconv.Itoa(i)), zeroTS, zeroTS, zeroAlloc))
+			sink.EmitRow(ctx, []byte(`k1`), []byte(`v`+strconv.Itoa(i)), fooTopic, zeroTS, zeroTS, zeroAlloc))
 	}
 	// Should have auto flushed after sqlSinkRowBatchSize
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM sink`, [][]string{{`3`}})
@@ -524,9 +517,9 @@ func TestSQLSink(t *testing.T) {
 
 	// Two tables interleaved in time
 	var pool testAllocPool
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`kfoo`), []byte(`v0`), zeroTS, zeroTS, pool.alloc()))
-	require.NoError(t, sink.EmitRow(ctx, barTopic, []byte(`kbar`), []byte(`v0`), zeroTS, zeroTS, pool.alloc()))
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`kfoo`), []byte(`v1`), zeroTS, zeroTS, pool.alloc()))
+	require.NoError(t, sink.EmitRow(ctx, []byte(`kfoo`), []byte(`v0`), fooTopic, zeroTS, zeroTS, pool.alloc()))
+	require.NoError(t, sink.EmitRow(ctx, []byte(`kbar`), []byte(`v0`), barTopic, zeroTS, zeroTS, pool.alloc()))
+	require.NoError(t, sink.EmitRow(ctx, []byte(`kfoo`), []byte(`v1`), fooTopic, zeroTS, zeroTS, pool.alloc()))
 	require.NoError(t, sink.Flush(ctx))
 	require.EqualValues(t, 0, pool.used())
 	sqlDB.CheckQueryResults(t, `SELECT topic, key, value FROM sink ORDER BY PRIMARY KEY sink`,
@@ -538,11 +531,11 @@ func TestSQLSink(t *testing.T) {
 	// guarantee that at lease two of them end up in the same partition.
 	for i := 0; i < sqlSinkNumPartitions+1; i++ {
 		require.NoError(t,
-			sink.EmitRow(ctx, fooTopic, []byte(`v`+strconv.Itoa(i)), []byte(`v0`), zeroTS, zeroTS, zeroAlloc))
+			sink.EmitRow(ctx, []byte(`v`+strconv.Itoa(i)), []byte(`v0`), fooTopic, zeroTS, zeroTS, zeroAlloc))
 	}
 	for i := 0; i < sqlSinkNumPartitions+1; i++ {
 		require.NoError(t,
-			sink.EmitRow(ctx, fooTopic, []byte(`v`+strconv.Itoa(i)), []byte(`v1`), zeroTS, zeroTS, zeroAlloc))
+			sink.EmitRow(ctx, []byte(`v`+strconv.Itoa(i)), []byte(`v1`), fooTopic, zeroTS, zeroTS, zeroAlloc))
 	}
 	require.NoError(t, sink.Flush(ctx))
 	sqlDB.CheckQueryResults(t, `SELECT partition, key, value FROM sink ORDER BY PRIMARY KEY sink`,
@@ -562,7 +555,7 @@ func TestSQLSink(t *testing.T) {
 	// Emit resolved
 	var e testEncoder
 	require.NoError(t, sink.EmitResolvedTimestamp(ctx, e, zeroTS))
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`foo0`), []byte(`v0`), zeroTS, zeroTS, zeroAlloc))
+	require.NoError(t, sink.EmitRow(ctx, []byte(`foo0`), []byte(`v0`), fooTopic, zeroTS, zeroTS, zeroAlloc))
 	require.NoError(t, sink.EmitResolvedTimestamp(ctx, e, hlc.Timestamp{WallTime: 1}))
 	require.NoError(t, sink.Flush(ctx))
 	sqlDB.CheckQueryResults(t,
@@ -778,7 +771,7 @@ func TestKafkaSinkTracksMemory(t *testing.T) {
 	testTopic := topic(`t`)
 	var pool testAllocPool
 	for i := 0; i < 10; i++ {
-		require.NoError(t, sink.EmitRow(ctx, testTopic, key, val, zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sink.EmitRow(ctx, key, val, testTopic, zeroTS, zeroTS, pool.alloc()))
 	}
 	require.EqualValues(t, 10, pool.used())
 

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -628,10 +628,15 @@ func (s *deprecatedWebhookSink) sinkError() error {
 	}
 }
 
+// Webhook sink does not support topics.
+func (s *deprecatedWebhookSink) NameTopic(topic TopicDescriptor) (string, error) {
+	return "", nil
+}
+
 func (s *deprecatedWebhookSink) EmitRow(
 	ctx context.Context,
-	topic TopicDescriptor,
 	key, value []byte,
+	topic sinkTopic,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -621,7 +621,7 @@ func (s *notifyFlushSink) EncodeAndEmitRow(
 	ctx context.Context,
 	updatedRow cdcevent.Row,
 	prevRow cdcevent.Row,
-	topic TopicDescriptor,
+	topic sinkTopic,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {
@@ -1062,6 +1062,10 @@ func (f *cloudFeedFactory) Feed(
 
 		if string(opt.Key) == changefeedbase.OptFormat &&
 			opt.Value.String() != string(changefeedbase.OptFormatParquet) {
+			parquetPossible = false
+			break
+		}
+		if string(opt.Key) == changefeedbase.OptOrdering && opt.Value.String() == string(changefeedbase.OptOrderingTotal) {
 			parquetPossible = false
 			break
 		}

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -40,7 +40,8 @@ type TestingKnobs struct {
 	PubsubClientSkipClientCreation bool
 	// FilterSpanWithMutation is a filter returning true if the resolved span event should
 	// be skipped. This method takes a pointer in case resolved spans need to be mutated.
-	FilterSpanWithMutation func(resolved *jobspb.ResolvedSpan) bool
+	FilterSpanWithMutation     func(resolved *jobspb.ResolvedSpan) bool
+	FilterFrontierResolvedSpan func() bool
 	// FeedKnobs are kvfeed testing knobs.
 	FeedKnobs kvfeed.TestingKnobs
 	// NullSinkIsExternalIOAccounted controls whether we record

--- a/pkg/ccl/changefeedccl/topic.go
+++ b/pkg/ccl/changefeedccl/topic.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -56,9 +57,11 @@ type TopicNamer struct {
 
 	// FullNames are generated whenever Name() is actually called (usually during sink.EmitRow).
 	// They do not contain placeholder strings.
-	FullNames map[TopicIdentifier]string
-
-	sliceCache []string
+	mu struct {
+		syncutil.RWMutex
+		FullNames  map[TopicIdentifier]string
+		sliceCache []string
+	}
 }
 
 // TopicNameOption is an optional argument to MakeTopicNamer.
@@ -118,8 +121,8 @@ func MakeTopicNamer(targets changefeedbase.Targets, opts ...TopicNameOption) (*T
 	tn := &TopicNamer{
 		join:         '.',
 		DisplayNames: make(map[changefeedbase.Target]string, targets.Size),
-		FullNames:    make(map[TopicIdentifier]string),
 	}
+	tn.mu.FullNames = make(map[TopicIdentifier]string)
 	for _, opt := range opts {
 		opt.set(tn)
 	}
@@ -140,27 +143,40 @@ const familyPlaceholder = "{family}"
 
 // Name generates (with caching) a sink's topic identifier string.
 func (tn *TopicNamer) Name(td TopicDescriptor) (string, error) {
-	if name, ok := tn.FullNames[td.GetTopicIdentifier()]; ok {
+	if td == nil {
+		return "foo", nil
+	}
+	tn.mu.RLock()
+	if name, ok := tn.mu.FullNames[td.GetTopicIdentifier()]; ok {
+		defer tn.mu.RUnlock()
 		return name, nil
 	}
+	tn.mu.RUnlock()
+	tn.mu.Lock()
+	defer tn.mu.Unlock()
 	name, err := tn.makeName(td.GetTargetSpecification(), td)
-	tn.FullNames[td.GetTopicIdentifier()] = name
+	tn.mu.FullNames[td.GetTopicIdentifier()] = name
 	return name, err
 }
 
 // DisplayNamesSlice gives all topics that are going to be emitted to,
 // suitable for displaying to the user on feed creation.
 func (tn *TopicNamer) DisplayNamesSlice() []string {
-	if len(tn.sliceCache) > 0 {
-		return tn.sliceCache
+	tn.mu.RLock()
+	if len(tn.mu.sliceCache) > 0 {
+		defer tn.mu.RUnlock()
+		return tn.mu.sliceCache
 	}
+	tn.mu.RUnlock()
+	tn.mu.Lock()
+	defer tn.mu.Unlock()
 	for _, n := range tn.DisplayNames {
-		tn.sliceCache = append(tn.sliceCache, n)
+		tn.mu.sliceCache = append(tn.mu.sliceCache, n)
 		if tn.singleName != "" {
-			return tn.sliceCache
+			return tn.mu.sliceCache
 		}
 	}
-	return tn.sliceCache
+	return tn.mu.sliceCache
 }
 
 // Each is a convenience method that iterates a function over DisplayNamesSlice.

--- a/pkg/ccl/changefeedccl/total_ordering_test.go
+++ b/pkg/ccl/changefeedccl/total_ordering_test.go
@@ -1,0 +1,338 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+type testOrderedSink struct {
+	t *testing.T
+	orderedSink
+	pool testAllocPool
+}
+
+func (s *testOrderedSink) emitTs(wallTime int64) {
+	require.NoError(s.t, s.EmitRow(
+		context.Background(),
+		[]byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"topic:\":\"foo\"}"),
+		sinkTopic{name: "mock"},
+		hlc.Timestamp{WallTime: wallTime},
+		zeroTS,
+		s.pool.alloc()),
+	)
+}
+
+func (s *testOrderedSink) popPayload() jobspb.OrderedRows {
+	row := s.forwardingBuf.Pop(context.Background())
+	require.True(s.t, row[0].IsNull())
+	require.True(s.t, row[1].IsNull())
+	require.True(s.t, row[2].IsNull())
+	require.True(s.t, row[3].IsNull())
+	require.False(s.t, row[4].IsNull())
+	raw, ok := row[4].Datum.(*tree.DBytes)
+	require.True(s.t, ok)
+
+	var payload jobspb.OrderedRows
+	require.NoError(s.t, protoutil.Unmarshal([]byte(*raw), &payload))
+
+	return payload
+}
+
+func (s *testOrderedSink) flushToTs(wallTime int64) {
+	_, err := s.frontier.Forward(makeSpan(s.t, "a", "f"), hlc.Timestamp{WallTime: wallTime})
+	require.NoError(s.t, err)
+	require.NoError(s.t, s.Flush(context.Background()))
+}
+
+func (s *testOrderedSink) flushAndVerify(wallTime int64) (numFlushed int) {
+	s.flushToTs(wallTime)
+
+	if s.forwardingBuf.IsEmpty() {
+		return 0
+	}
+	payload := s.popPayload()
+	lastTs := hlc.Timestamp{}
+	for _, orderedRow := range payload.Rows {
+		require.False(s.t, orderedRow.Mvcc.Less(lastTs))
+		require.Equal(s.t, "mock", orderedRow.TopicName)
+		lastTs = orderedRow.Mvcc
+	}
+
+	return len(payload.Rows)
+}
+
+func getSliMetrics(t *testing.T) *sliMetrics {
+	metrics := MakeMetrics(base.DefaultHistogramWindowInterval()).(*Metrics)
+	sliMetrics, err := metrics.getSLIMetrics(defaultSLIScope)
+	require.NoError(t, err)
+	return sliMetrics
+}
+
+func TestOrderedSink(t *testing.T) {
+	sf, err := makeSchemaChangeFrontier(hlc.Timestamp{}, makeSpan(t, "a", "f"))
+	require.NoError(t, err)
+
+	sink := testOrderedSink{
+		orderedSink: orderedSink{
+			processorID: 42,
+			wrapped:     &mockSink{},
+			metrics:     getSliMetrics(t),
+			frontier:    sf,
+		}, t: t}
+
+	sink.emitTs(1)
+	sink.emitTs(3)
+	sink.emitTs(200)
+	sink.emitTs(2)
+	sink.emitTs(8)
+	sink.emitTs(5)
+	sink.emitTs(190)
+
+	require.Equal(t, sink.flushAndVerify(100), 5)
+	require.Equal(t, sink.flushAndVerify(200), 2)
+	require.Equal(t, sink.flushAndVerify(300), 0)
+
+	for ts := 1000; ts > 500; ts-- {
+		sink.emitTs(int64(ts))
+	}
+	sink.flushToTs(1001)
+	require.Greater(t, sink.flushAndVerify(1001), 0)
+	require.True(t, sink.forwardingBuf.IsEmpty())
+
+	for ts := 10000; ts > 1000; ts-- {
+		sink.emitTs(int64(ts))
+	}
+	for i := 1100; i <= 11000; i += 321 {
+		sink.flushAndVerify(int64(i))
+	}
+	require.Equal(t, sink.pool.used(), int64(0))
+}
+
+func makeSpan(t *testing.T, start string, end string) (s roachpb.Span) {
+	mkKey := func(k string) roachpb.Key {
+		vDatum := tree.DString(k)
+		key, err := keyside.Encode(keys.SystemSQLCodec.TablePrefix(42), &vDatum, encoding.Ascending)
+		require.NoError(t, err)
+		return key
+	}
+	s.Key = mkKey(start)
+	s.EndKey = mkKey(end)
+	return s
+}
+
+type mockSink struct {
+	t           *testing.T
+	frontier    *schemaChangeFrontier
+	buffered    int
+	emits       int
+	lastUpdated hlc.Timestamp
+}
+
+func (ms *mockSink) Flush(ctx context.Context) error {
+	ms.emits += ms.buffered
+	ms.buffered = 0
+	return nil
+}
+func (ms *mockSink) getConcreteType() sinkType {
+	return sinkTypeNull
+}
+func (ms *mockSink) Close() error {
+	return nil
+}
+func (ms *mockSink) Dial() error {
+	return nil
+}
+func (ms *mockSink) EmitRow(
+	ctx context.Context,
+	key, value []byte,
+	topic sinkTopic,
+	updated, mvcc hlc.Timestamp,
+	alloc kvevent.Alloc,
+) error {
+	require.True(ms.t, mvcc.LessEq(ms.frontier.Frontier()) || mvcc.Equal(ms.frontier.BackfillTS()))
+	require.False(ms.t, mvcc.Less(ms.lastUpdated), fmt.Sprintf("%s not less than %s", mvcc, ms.lastUpdated))
+	require.Equal(ms.t, "mock", topic.name)
+	ms.lastUpdated = mvcc
+	ms.buffered += 1
+	return nil
+}
+func (ms *mockSink) NameTopic(topic TopicDescriptor) (string, error) {
+	return "mock", nil
+}
+
+var _ EventSink = (*mockSink)(nil)
+
+func TestOrderedMerger(t *testing.T) {
+	sf, err := makeSchemaChangeFrontier(hlc.Timestamp{}, makeSpan(t, "a", "f"))
+	sf.initialHighWater = hlc.Timestamp{WallTime: 100}
+	require.NoError(t, err)
+
+	rng, _ := randutil.NewTestRand()
+	ctx := context.Background()
+
+	orderedSinks := make([]testOrderedSink, 5)
+	for i := 0; i < 5; i++ {
+		orderedSinks[i] = testOrderedSink{
+			orderedSink: orderedSink{
+				processorID: int32(i),
+				frontier:    sf,
+				metrics:     getSliMetrics(t),
+			}, t: t}
+
+		for j := 0; j < 100; j++ {
+			orderedSinks[i].emitTs(100)
+		}
+
+		for j := 0; j < 500; j++ {
+			ts := rng.Int63n(4999) + 101
+			orderedSinks[i].emitTs(ts)
+		}
+		for j := 500; j < 1000; j++ {
+			ts := rng.Int63n(4999) + 5101
+			orderedSinks[i].emitTs(ts)
+		}
+	}
+
+	sink := &mockSink{t: t, lastUpdated: hlc.Timestamp{}, frontier: sf}
+	merger := &orderedRowMerger{
+		orderedRows:        make(map[int32][]jobspb.OrderedRows_Row),
+		bufferedBytesLimit: 1 << 30,
+		frontier:           sf,
+		metrics:            getSliMetrics(t),
+		sink:               sink,
+	}
+
+	// Forwards the frontier and has all sinks flush their results to the merger.
+	forwardFrontier := func(start string, end string, ts int64) {
+		_, err := sf.Forward(makeSpan(t, start, end), hlc.Timestamp{WallTime: ts})
+		require.NoError(t, err)
+		for i := 0; i < 5; i++ {
+			require.NoError(t, orderedSinks[i].Flush(context.Background()))
+			for !orderedSinks[i].forwardingBuf.IsEmpty() {
+				require.NoError(t, merger.Append(ctx, orderedSinks[i].popPayload()))
+			}
+		}
+	}
+
+	// Should output results of initial scan
+	forwardFrontier("a", "f", 0)
+	require.NoError(t, merger.Flush(ctx))
+	require.Equal(t, sink.emits, 500)
+
+	forwardFrontier("a", "f", 2000)
+	require.NoError(t, merger.Flush(ctx))
+	prevEmits := sink.emits
+
+	// Should not emit anything if only part of the frontier advanced
+	forwardFrontier("a", "b", 10000)
+	require.NoError(t, merger.Flush(ctx))
+	require.Equal(t, sink.emits, prevEmits)
+
+	// Should not emit anything if only part of the frontier advanced
+	forwardFrontier("c", "f", 10000)
+	require.NoError(t, merger.Flush(ctx))
+	require.Equal(t, sink.emits, prevEmits)
+
+	// Should finally be able to emit
+	forwardFrontier("b", "c", 2500)
+	require.NoError(t, merger.Flush(ctx))
+	forwardFrontier("b", "c", 5000)
+	require.NoError(t, merger.Flush(ctx))
+	require.Greater(t, sink.emits, prevEmits)
+
+	require.NoError(t, merger.Flush(ctx))
+	forwardFrontier("a", "f", 11000)
+	require.NoError(t, merger.Flush(ctx))
+	require.Zero(t, merger.minHeap.Len())
+	require.Equal(t, sink.emits, 5500)
+
+	// Should handle a backfill where events are arriving at .Next of the resolved
+	// timestamp.
+	_, err = sf.ForwardResolvedSpan(jobspb.ResolvedSpan{
+		Span:         makeSpan(t, "a", "f"),
+		Timestamp:    hlc.Timestamp{WallTime: 20000}.Prev(),
+		BoundaryType: jobspb.ResolvedSpan_BACKFILL,
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 100; j++ {
+			orderedSinks[i].emitTs(20000)
+		}
+		orderedSinks[i].emitTs(20100)
+
+		require.NoError(t, orderedSinks[i].Flush(ctx))
+		for !orderedSinks[i].forwardingBuf.IsEmpty() {
+			require.NoError(t, merger.Append(ctx, orderedSinks[i].popPayload()))
+		}
+	}
+	prevEmits = sink.emits
+	require.NoError(t, merger.Flush(ctx))
+	require.Equal(t, sink.emits, prevEmits+500)
+	require.Equal(t, merger.bytesBuffered, 0)
+}
+
+func TestOrderedMergerBytesLimit(t *testing.T) {
+	ctx := context.Background()
+	sfAgg, err := makeSchemaChangeFrontier(hlc.Timestamp{}, makeSpan(t, "a", "b"))
+	require.NoError(t, err)
+
+	orderer := testOrderedSink{
+		orderedSink: orderedSink{
+			frontier: sfAgg,
+			metrics:  getSliMetrics(t),
+		}, t: t}
+
+	sfCoord, err := makeSchemaChangeFrontier(hlc.Timestamp{}, makeSpan(t, "a", "f"))
+	require.NoError(t, err)
+
+	sink := &mockSink{t: t, lastUpdated: hlc.Timestamp{}, frontier: sfCoord}
+	merger := &orderedRowMerger{
+		orderedRows: make(map[int32][]jobspb.OrderedRows_Row),
+		frontier:    sfCoord,
+		metrics:     getSliMetrics(t),
+		sink:        sink,
+	}
+
+	var payloads []jobspb.OrderedRows
+	payloadBytes := 0
+	for i := 1; i <= 3; i++ {
+		ts := int64(100 * i)
+		orderer.emitTs(ts)
+		_, err := sfAgg.Forward(makeSpan(t, "a", "b"), hlc.Timestamp{WallTime: ts})
+		require.NoError(t, err)
+		require.NoError(t, orderer.Flush(ctx))
+		payload := orderer.popPayload()
+		for _, row := range payload.Rows {
+			payloadBytes += row.Size()
+		}
+		payloads = append(payloads, payload)
+	}
+
+	merger.bufferedBytesLimit = payloadBytes - 1
+	require.NoError(t, merger.Append(ctx, payloads[0]))
+	require.NoError(t, merger.Append(ctx, payloads[1]))
+	require.Error(t, merger.Append(ctx, payloads[2]))
+}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1021,6 +1021,22 @@ message ResolvedSpans {
   Stats stats = 2 [(gogoproto.nullable) = false];
 }
 
+message OrderedRows {
+  int32 source_processor_id = 1 [(gogoproto.customname) = "SourceProcessorID"];
+
+  message Row {
+    bytes key = 1;
+    bytes value = 2;
+    string topic_name = 3;
+    uint64 topic_version = 4 [
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.DescriptorVersion"
+    ];
+    util.hlc.Timestamp updated = 5 [(gogoproto.nullable) = false];
+    util.hlc.Timestamp mvcc = 6 [(gogoproto.nullable) = false];
+  }
+  repeated Row rows = 2 [(gogoproto.nullable) = false];
+}
+
 message ChangefeedProgress {
   reserved 1;
 


### PR DESCRIPTION
Epic: CRDB-26472

Changefeeds until now only supported Key ordering, where a message for key `k1` at timestamp `t1` will never be emitted prior to `k1` at `t0`, however `{k1, t1}` _can_ emit prior to `{k2, t0}`.

This pr adds the `ordering='total'` option, where `{kx, t1}` will **always** be emitted after `{ky, t0}` regardless of `x != y`.  This is accomplished by a distributed merge where aggregator processors collect and sort batches of encoded messages, then forward them to the frontier which handles merging the events together via a heap to emit the events in order to a single threaded Sink.

---

The aggregator side is simply a custom Sink implementation called `orderedSink`, which buffers encoded events from EmitRow and upon being Flushed it sorts them all and forwards an `OrderedRows` payload of all events up to the highwatermark to the Frontier node in the same way Core changefeeds do.

The Frontier side is an `orderedRowMerger` struct which is fed the `OrderedRows` from each aggregator and keeps trying to call a proper Sink implementation's `Emit` with every row that is either ≤ the frontier or == the backfill timestamp.  Events arriving for an ongoing backfill are simply emitted immediately, otherwise the sorted-per-processor rows are buffered with their lowest member being stored in an overall minHeap to pop off events in ascending order and emit them.

These changes are pretty separate from the rest of the changefeed code.  The main change that actually involves the existing changefeed code is that `EmitRow` no longer takes an entire `TopicDescriptor` but instead takes a `sinkTopic{name, version}` struct which only has the minimal information needed by sinks.  I also made the topic the 4th parameter after key and value since it felt more natural to me.


### Performance

With an **initial scan** (no sorting needed) of TPCC 2000 outputting to Kafka, the single frontier node is able to emit **over 200k events per second**.  the total CPU usage of the Frontier node is around 30-40%.  The actual `orderedRowMerger` code took up 8% of the total cpu usage, the majority of the usage was from the aggregator encoding and from Sarama.  The purely aggregator nodes were steady at around 18% CPU usage.

<img width="639" alt="Screenshot 2023-05-31 at 2 38 18 PM" src="https://github.com/cockroachdb/cockroach/assets/6236424/4edccf78-99cc-47a6-aec2-391575615582">
<img width="639" alt="Screenshot 2023-05-31 at 2 40 04 PM" src="https://github.com/cockroachdb/cockroach/assets/6236424/964fc7c9-d892-44f9-9b39-76228f638eae">
<br></br>
When running without the initial scan and with the workload running (so now the actual sorting by timestamp is meaningful), we're able to keep up just fine with the full 20k events per second (this is limited by tpcc rate not by the changefeed).  Changefeed code was only 3.64% of the total node cpu usage, with the orderedSink doing 0.22% of the work and the orderedRowMerger doing 1.08%.
<img width="642" alt="Screenshot 2023-05-31 at 11 53 35 AM" src="https://github.com/cockroachdb/cockroach/assets/6236424/1dd782f1-0b9c-4134-b435-792dfd91cc60">

There's still room for optimizing by having the Aggregators do the emitting as well for the Initial scan (they'd still have to forward for any schema change backfills though).  If this PR is viewed positively then I'll probably do that as a followup / add it to this pr.

### Failure Cases

Given that the throughput works alright with TPCC 2000, I think performance won't be much of a concern here for the majority of our customers.

The main concern has to do with Backpressure, where the feed must never be allowed to OOM the cluster.

--

The case where the Sink is slow gets handled by:
- On the frontier, `sink.EmitRow` starts buffering up events until it hits its limit, after which the Frontier's `Next()` thread will be blocked on its `EmitRow` call.
- Since the Frontier is blocked from calling `Next()`, the aggregator node's `Next()` is never called and it never pops elements off of its `orderedRowBuf`
- The aggregator's `kvevent.Alloc`s aren't released until the `orderedRowBuf.Pop()` occurs, so the aggregator will eventually hit its alloc limit and then `blockingBuffer` will block the rest of the way.

--

The more problematic case is the Lagging Span case, since the Frontier will be receiving events but its frontier will never make progress, so it can't `sink.EmitRow` and rather than buffering in the sink the messages will buffer in the `orderedRowMerger`.  Since as far as I know we can't tell only all but the lagging aggregator to stop, the frontier node will simply keep buffering until it hits a limit and **the feed will stop making any progress**.  To avoid the risk of OOM'ing the node I just added a manual buffered bytes limit to the `orderedRowMerger` and once hitting it **the changefeed will just fail with an error and retry**.  For now this is just left as a "known issue" to keep things simple.

--

I also did not bother setting up Parquet to work just yet, given that its encoding and emitting are currently tied together.  This is left for future work if people ask for it.

--

Release note (general change): Changefeeds now support an ordering='total' option to emit events in order of their Updated timestamp across all keys.  All sink types except Parquet are supported.