### PR TITLE
kvserver: add cluster setting to disable queues

### DIFF
--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -100,6 +101,7 @@ func newConsistencyQueue(store *Store) *consistencyQueue {
 			pending:              store.metrics.ConsistencyQueuePending,
 			processingNanos:      store.metrics.ConsistencyQueueProcessingNanos,
 			processTimeoutFunc:   makeRateLimitedTimeoutFunc(consistencyCheckRate),
+			disabledConfig:       kvserverbase.ConsistencyQueueEnabled,
 		},
 	)
 	return q

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -45,6 +45,51 @@ var ReplicateQueueEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
+// ReplicaGCQueueEnabled is a setting that controls whether the replica GC queue
+// is enabled.
+var ReplicaGCQueueEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.replica_gc_queue.enabled",
+	"whether the replica gc queue is enabled",
+	true,
+)
+
+// RaftLogQueueEnabled is a setting that controls whether the raft log queue is
+// enabled.
+var RaftLogQueueEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.raft_log_queue.enabled",
+	"whether the raft log queue is enabled",
+	true,
+)
+
+// RaftSnapshotQueueEnabled is a setting that controls whether the raft snapshot
+// queue is enabled.
+var RaftSnapshotQueueEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.raft_snapshot_queue.enabled",
+	"whether the raft snapshot queue is enabled",
+	true,
+)
+
+// ConsistencyQueueEnabled is a setting that controls whether the consistency
+// queue is enabled.
+var ConsistencyQueueEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.consistency_queue.enabled",
+	"whether the consistency queue is enabled",
+	true,
+)
+
+// TimeSeriesMaintenanceQueueEnabled is a setting that controls whether the
+// timeseries maintenance queue is enabled.
+var TimeSeriesMaintenanceQueueEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.timeseries_maintenance_queue.enabled",
+	"whether the timeseries maintenance queue is enabled",
+	true,
+)
+
 // SplitQueueEnabled is a setting that controls whether the split queue is
 // enabled.
 var SplitQueueEnabled = settings.RegisterBoolSetting(

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -17,10 +17,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/benignerror"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -65,6 +67,7 @@ func TestBaseQueueConcurrent(t *testing.T) {
 		pending:         metric.NewGauge(metric.Metadata{Name: "pending"}),
 		processingNanos: metric.NewCounter(metric.Metadata{Name: "processingnanos"}),
 		purgatory:       metric.NewGauge(metric.Metadata{Name: "purgatory"}),
+		disabledConfig:  &settings.BoolSetting{},
 	}
 
 	// Set up a fake store with just exactly what the code calls into. Ideally
@@ -75,6 +78,7 @@ func TestBaseQueueConcurrent(t *testing.T) {
 			Clock:             hlc.NewClockForTesting(nil),
 			AmbientCtx:        log.MakeTestingAmbientContext(tr),
 			DefaultSpanConfig: roachpb.TestingDefaultSpanConfig(),
+			Settings:          cluster.MakeTestingClusterSettingsWithVersions(clusterversion.TestingBinaryVersion, clusterversion.TestingBinaryVersion, true),
 		},
 	}
 

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
@@ -106,6 +108,7 @@ func makeTestBaseQueue(name string, impl queueImpl, store *Store, cfg queueConfi
 	cfg.pending = metric.NewGauge(metric.Metadata{Name: "pending"})
 	cfg.processingNanos = metric.NewCounter(metric.Metadata{Name: "processingnanos"})
 	cfg.purgatory = metric.NewGauge(metric.Metadata{Name: "purgatory"})
+	cfg.disabledConfig = &settings.BoolSetting{}
 	return newBaseQueue(name, impl, store, cfg)
 }
 
@@ -1221,6 +1224,92 @@ func TestBaseQueueDisable(t *testing.T) {
 
 	if pc := testQueue.getProcessed(); pc > 0 {
 		t.Errorf("expected processed count of 0; got %d", pc)
+	}
+}
+
+// TestQueueDisable verifies that setting the set of queue.enabled cluster
+// settings actually disables the base queue. This test works alongside
+// TestBaseQueueDisable to verify the entire disable workflow.
+func TestQueueDisable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	tc := testContext{}
+	stopper := stop.NewStopper()
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+	tc.Start(ctx, t, stopper)
+
+	testCases := []struct {
+		name           string
+		clusterSetting *settings.BoolSetting
+		queue          *baseQueue
+	}{
+		{
+			name:           "Merge Queue",
+			clusterSetting: kvserverbase.MergeQueueEnabled,
+			queue:          tc.store.mergeQueue.baseQueue,
+		},
+		{
+			name:           "Replicate Queue",
+			clusterSetting: kvserverbase.ReplicateQueueEnabled,
+			queue:          tc.store.replicateQueue.baseQueue,
+		},
+		{
+			name:           "Replica GC Queue",
+			clusterSetting: kvserverbase.ReplicaGCQueueEnabled,
+			queue:          tc.store.replicaGCQueue.baseQueue,
+		},
+		{
+			name:           "Raft Log Queue",
+			clusterSetting: kvserverbase.RaftLogQueueEnabled,
+			queue:          tc.store.raftLogQueue.baseQueue,
+		},
+		{
+			name:           "Raft Snapshot Queue",
+			clusterSetting: kvserverbase.RaftSnapshotQueueEnabled,
+			queue:          tc.store.raftSnapshotQueue.baseQueue,
+		},
+		{
+			name:           "Consistency Queue",
+			clusterSetting: kvserverbase.ConsistencyQueueEnabled,
+			queue:          tc.store.consistencyQueue.baseQueue,
+		},
+		{
+			name:           "Split Queue",
+			clusterSetting: kvserverbase.SplitQueueEnabled,
+			queue:          tc.store.splitQueue.baseQueue,
+		},
+		{
+			name:           "MVCC GC Queue",
+			clusterSetting: kvserverbase.MVCCGCQueueEnabled,
+			queue:          tc.store.mvccGCQueue.baseQueue,
+		},
+	}
+
+	if tc.store.tsMaintenanceQueue != nil {
+		testCases = append(testCases, struct {
+			name           string
+			clusterSetting *settings.BoolSetting
+			queue          *baseQueue
+		}{
+			name:           "Timeseries Maintenance Queue",
+			clusterSetting: kvserverbase.TimeSeriesMaintenanceQueueEnabled,
+			queue:          tc.store.tsMaintenanceQueue.baseQueue,
+		})
+	}
+
+	// Disable and verify all queues are disabled
+	for _, testCase := range testCases {
+		testCase.clusterSetting.Override(ctx, &tc.store.ClusterSettings().SV, false)
+		if testCase.queue == nil {
+			continue
+		}
+		testCase.queue.mu.Lock()
+		disabled := testCase.queue.mu.disabled
+		testCase.queue.mu.Unlock()
+		if disabled != true {
+			t.Errorf("%s should be disabled", testCase.name)
+		}
 	}
 }
 

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -183,6 +184,7 @@ func newRaftLogQueue(store *Store, db *kv.DB) *raftLogQueue {
 			failures:             store.metrics.RaftLogQueueFailures,
 			pending:              store.metrics.RaftLogQueuePending,
 			processingNanos:      store.metrics.RaftLogQueueProcessingNanos,
+			disabledConfig:       kvserverbase.RaftLogQueueEnabled,
 		},
 	)
 	return rlq

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -57,6 +58,7 @@ func newRaftSnapshotQueue(store *Store) *raftSnapshotQueue {
 			failures:             store.metrics.RaftSnapshotQueueFailures,
 			pending:              store.metrics.RaftSnapshotQueuePending,
 			processingNanos:      store.metrics.RaftSnapshotQueueProcessingNanos,
+			disabledConfig:       kvserverbase.RaftSnapshotQueueEnabled,
 		},
 	)
 	return rq

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -106,6 +107,7 @@ func newReplicaGCQueue(store *Store, db *kv.DB) *replicaGCQueue {
 			failures:                 store.metrics.ReplicaGCQueueFailures,
 			pending:                  store.metrics.ReplicaGCQueuePending,
 			processingNanos:          store.metrics.ReplicaGCQueueProcessingNanos,
+			disabledConfig:           kvserverbase.ReplicaGCQueueEnabled,
 		},
 	)
 	return rgcq

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -126,6 +126,7 @@ func newSplitQueue(store *Store, db *kv.DB) *splitQueue {
 			pending:              store.metrics.SplitQueuePending,
 			processingNanos:      store.metrics.SplitQueueProcessingNanos,
 			purgatory:            store.metrics.SplitQueuePurgatory,
+			disabledConfig:       kvserverbase.SplitQueueEnabled,
 		},
 	)
 	return sq
@@ -176,11 +177,6 @@ func shouldSplitRange(
 	return shouldQ, priority
 }
 
-func (sq *splitQueue) enabled() bool {
-	st := sq.store.ClusterSettings()
-	return kvserverbase.SplitQueueEnabled.Get(&st.SV)
-}
-
 // shouldQueue determines whether a range should be queued for
 // splitting. This is true if the range is intersected by a zone config
 // prefix or if the range's size in bytes exceeds the limit for the zone,
@@ -188,10 +184,6 @@ func (sq *splitQueue) enabled() bool {
 func (sq *splitQueue) shouldQueue(
 	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
 ) (shouldQ bool, priority float64) {
-	if !sq.enabled() {
-		return false, 0
-	}
-
 	shouldQ, priority = shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
 		repl.GetMaxBytes(), repl.shouldBackpressureWrites(), confReader)
 
@@ -217,11 +209,6 @@ var _ PurgatoryError = unsplittableRangeError{}
 func (sq *splitQueue) process(
 	ctx context.Context, r *Replica, confReader spanconfig.StoreReader,
 ) (processed bool, err error) {
-	if !sq.enabled() {
-		log.VEventf(ctx, 2, "skipping split: queue has been disabled")
-		return false, nil
-	}
-
 	processed, err = sq.processAttempt(ctx, r, confReader)
 	if errors.HasType(err, (*kvpb.ConditionFailedError)(nil)) {
 		// ConditionFailedErrors are an expected outcome for range split

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -118,6 +119,7 @@ func newTimeSeriesMaintenanceQueue(
 			failures:             store.metrics.TimeSeriesMaintenanceQueueFailures,
 			pending:              store.metrics.TimeSeriesMaintenanceQueuePending,
 			processingNanos:      store.metrics.TimeSeriesMaintenanceQueueProcessingNanos,
+			disabledConfig:       kvserverbase.TimeSeriesMaintenanceQueueEnabled,
 		},
 	)
 


### PR DESCRIPTION
This patch introduces a new set of cluster settings to disable work queues in the `Store` object. It makes use of the underlying `disabled` property of the `BaseQueue`.

Fixes: #102031

Release note: None