### PR TITLE
CODEOWNERS: remove `dev-inf` as owner of files and packages not owned

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -228,7 +228,6 @@
 /pkg/server/testserver*.go               @cockroachdb/test-eng    @cockroachdb/server-prs
 /pkg/server/tracedumper/                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/user*.go                     @cockroachdb/obs-inf-prs @cockroachdb/server-prs @cockroachdb/prodsec
-/pkg/server/version_cluster*.go          @cockroachdb/dev-inf
 
 /pkg/configprofiles/                     @cockroachdb/multi-tenant @cockroachdb/server-prs
 
@@ -391,7 +390,7 @@
 #!/pkg/ccl/utilccl/          @cockroachdb/unowned
 /pkg/ccl/workloadccl/        @cockroachdb/test-eng #! @cockroachdb/sql-foundations-noreview
 /pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-foundations
-#!/pkg/clusterversion/       @cockroachdb/dev-inf-noreview  @cockroachdb/kv-prs-noreview
+#!/pkg/clusterversion/       @cockroachdb/kv-prs-noreview
 /pkg/cmd/allocsim/           @cockroachdb/kv-prs
 /pkg/cmd/bazci/              @cockroachdb/dev-inf
 /pkg/cmd/cloudupload/        @cockroachdb/dev-inf
@@ -403,7 +402,6 @@
 /pkg/cmd/cockroach-oss/      @cockroachdb/dev-inf @cockroachdb/cli-prs
 /pkg/cmd/cockroach-short/    @cockroachdb/dev-inf @cockroachdb/cli-prs
 /pkg/cmd/cockroach-sql/      @cockroachdb/sql-foundations @cockroachdb/cli-prs
-/pkg/cmd/compile-build/      @cockroachdb/dev-inf
 /pkg/cmd/cr2pg/              @cockroachdb/sql-foundations
 /pkg/cmd/dev/                @cockroachdb/dev-inf
 #!/pkg/cmd/docgen/             @cockroachdb/docs-infra-prs


### PR DESCRIPTION
Epic: None
Release note: None