### PR TITLE
cluster-ui: database table page connected component with reusable combiner logic

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -8,20 +8,18 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React, { useContext } from "react";
+import React from "react";
 import { Col, Row, Tabs, Tooltip } from "antd";
 import "antd/lib/col/style";
 import "antd/lib/row/style";
 import "antd/lib/tabs/style";
-import { Link, RouteComponentProps } from "react-router-dom";
+import { RouteComponentProps } from "react-router-dom";
 import classNames from "classnames/bind";
 import classnames from "classnames/bind";
 import "antd/lib/tooltip/style";
 import { Heading } from "@cockroachlabs/ui-components";
 
 import { Anchor } from "src/anchor";
-import { Breadcrumbs } from "src/breadcrumbs";
-import { CaretRight } from "src/icon/caretRight";
 import { StackIcon } from "src/icon/stackIcon";
 import { SqlBox } from "src/sql";
 import { ColumnDescriptor, SortedTable, SortSetting } from "src/sortedtable";
@@ -31,13 +29,7 @@ import {
   SummaryCardItemBoolSetting,
 } from "src/summaryCard";
 import * as format from "src/util/format";
-import {
-  DATE_FORMAT,
-  DATE_FORMAT_24_TZ,
-  EncodeDatabaseTableUri,
-  EncodeDatabaseUri,
-  EncodeUriName,
-} from "src/util/format";
+import { DATE_FORMAT_24_TZ } from "src/util/format";
 import {
   ascendingAttr,
   columnTitleAttr,
@@ -49,19 +41,23 @@ import {
 import styles from "./databaseTablePage.module.scss";
 import { commonStyles } from "src/common";
 import { baseHeadingClasses } from "src/transactionsPage/transactionsPageClasses";
-import moment, { Moment } from "moment-timezone";
-import { Search as IndexIcon } from "@cockroachlabs/icons";
+import { Moment } from "moment-timezone";
 import booleanSettingStyles from "../settings/booleanSetting.module.scss";
-import { CircleFilled } from "../icon";
-import { performanceTuningRecipes } from "src/util/docs";
 import { CockroachCloudContext } from "../contexts";
-import IdxRecAction from "../insights/indexActionBtn";
 import { RecommendationType } from "../indexDetailsPage";
 import LoadingError from "../sqlActivity/errorComponent";
 import { Loading } from "../loading";
 import { UIConfigState } from "../store";
-import { QuoteIdentifier } from "../api/safesql";
 import { Timestamp, Timezone } from "../timestamp";
+import {
+  ActionCell,
+  DbTablesBreadcrumbs,
+  FormatMVCCInfo,
+  IndexRecCell,
+  LastReset,
+  LastUsed,
+  NameCell,
+} from "./helperComponents";
 
 const cx = classNames.bind(styles);
 const booleanSettingCx = classnames.bind(booleanSettingStyles);
@@ -112,9 +108,12 @@ const { TabPane } = Tabs;
 export interface DatabaseTablePageData {
   databaseName: string;
   name: string;
+  schemaName: string;
   details: DatabaseTablePageDataDetails;
   indexStats: DatabaseTablePageIndexStats;
   showNodeRegionsSection?: boolean;
+  indexUsageStatsEnabled: boolean;
+  showIndexRecommendations: boolean;
   automaticStatsCollectionEnabled?: boolean;
   hasAdminRole?: UIConfigState["hasAdminRole"];
 }
@@ -144,7 +143,7 @@ export interface DatabaseTablePageIndexStats {
   lastReset: Moment;
 }
 
-interface IndexStat {
+export interface IndexStat {
   indexName: string;
   totalReads: number;
   lastUsed: Moment;
@@ -179,6 +178,7 @@ interface DatabaseTablePageState {
   grantSortSetting: SortSetting;
   indexSortSetting: SortSetting;
   tab: string;
+  indexStatsColumns: ColumnDescriptor<IndexStat>[];
 }
 
 const indexTabKey = "overview";
@@ -192,6 +192,8 @@ export class DatabaseTablePage extends React.Component<
   DatabaseTablePageProps,
   DatabaseTablePageState
 > {
+  static contextType = CockroachCloudContext;
+
   constructor(props: DatabaseTablePageProps) {
     super(props);
 
@@ -221,6 +223,7 @@ export class DatabaseTablePage extends React.Component<
       indexSortSetting: indexSort,
       grantSortSetting: grantSort,
       tab: currentTab,
+      indexStatsColumns: this.indexStatsColumns(),
     };
   }
 
@@ -245,8 +248,13 @@ export class DatabaseTablePage extends React.Component<
     this.refresh();
   }
 
-  componentDidUpdate(): void {
+  componentDidUpdate(prevProp: Readonly<DatabaseTablePageProps>): void {
     this.refresh();
+    if (
+      prevProp.showIndexRecommendations !== this.props.showIndexRecommendations
+    ) {
+      this.setState({ indexStatsColumns: this.indexStatsColumns() });
+    }
   }
 
   private refresh() {
@@ -266,7 +274,11 @@ export class DatabaseTablePage extends React.Component<
       );
     }
 
-    if (!this.props.indexStats.loaded && !this.props.indexStats.loading) {
+    if (
+      !this.props.indexStats.loaded &&
+      !this.props.indexStats.loading &&
+      this.props.indexUsageStatsEnabled
+    ) {
       return this.props.refreshIndexStats(
         this.props.databaseName,
         this.props.name,
@@ -277,8 +289,6 @@ export class DatabaseTablePage extends React.Component<
       this.props.refreshSettings();
     }
   }
-
-  minDate = moment.utc("0001-01-01"); // minimum value as per UTC
 
   private changeIndexSortSetting(sortSetting: SortSetting) {
     const stateCopy = { ...this.state };
@@ -304,159 +314,73 @@ export class DatabaseTablePage extends React.Component<
     history.replace(history.location);
   }
 
-  private getLastReset() {
-    const lastReset = this.props.indexStats.lastReset;
-    if (lastReset.isSame(this.minDate)) {
-      return <>Last reset: Never</>;
-    } else {
-      return (
-        <>
-          Last reset: <Timestamp time={lastReset} format={DATE_FORMAT_24_TZ} />
-        </>
-      );
-    }
-  }
-
-  private getLastUsed(indexStat: IndexStat) {
-    // This case only occurs when we have no reads, resets, or creation time on
-    // the index.
-    if (indexStat.lastUsed.isSame(this.minDate)) {
-      return <>Never</>;
-    }
-    return (
-      <>
-        Last {indexStat.lastUsedType}:{" "}
-        <Timestamp time={indexStat.lastUsed} format={DATE_FORMAT} />
-      </>
-    );
-  }
-
-  private renderIndexRecommendations = (
-    indexStat: IndexStat,
-  ): React.ReactNode => {
-    const classname =
-      indexStat.indexRecommendations.length > 0
-        ? "index-recommendations-icon__exist"
-        : "index-recommendations-icon__none";
-
-    if (indexStat.indexRecommendations.length === 0) {
-      return (
-        <div>
-          <CircleFilled className={cx(classname)} />
-          <span>None</span>
-        </div>
-      );
-    }
-    return indexStat.indexRecommendations.map((recommendation, key) => {
-      let text: string;
-      switch (recommendation.type) {
-        case "DROP_UNUSED":
-          text = "Drop unused index";
+  private indexStatsColumns(): ColumnDescriptor<IndexStat>[] {
+    const indexStatsColumns: ColumnDescriptor<IndexStat>[] = [
+      {
+        name: "indexes",
+        title: "Indexes",
+        hideTitleUnderline: true,
+        className: cx("index-stats-table__col-indexes"),
+        cell: indexStat => (
+          <NameCell
+            indexStat={indexStat}
+            tableName={this.props.name}
+            showIndexRecommendations={this.props.showIndexRecommendations}
+          />
+        ),
+        sort: indexStat => indexStat.indexName,
+      },
+      {
+        name: "total reads",
+        title: "Total Reads",
+        hideTitleUnderline: true,
+        cell: indexStat => format.Count(indexStat.totalReads),
+        sort: indexStat => indexStat.totalReads,
+      },
+      {
+        name: "last used",
+        title: (
+          <>
+            Last Used <Timezone />
+          </>
+        ),
+        hideTitleUnderline: true,
+        className: cx("index-stats-table__col-last-used"),
+        cell: indexStat => <LastUsed indexStat={indexStat} />,
+        sort: indexStat => indexStat.lastUsed,
+      },
+    ];
+    if (this.props.showIndexRecommendations) {
+      indexStatsColumns.push({
+        name: "index recommendations",
+        title: (
+          <Tooltip
+            placement="bottom"
+            title="Index recommendations will appear if the system detects improper index usage, such as the occurrence of unused indexes. Following index recommendations may help improve query performance."
+          >
+            Index Recommendations
+          </Tooltip>
+        ),
+        cell: indexStat => <IndexRecCell indexStat={indexStat} />,
+        sort: indexStat => indexStat.indexRecommendations.length,
+      });
+      const isCockroachCloud = this.context;
+      if (!isCockroachCloud) {
+        indexStatsColumns.push({
+          name: "action",
+          title: "",
+          cell: indexStat => (
+            <ActionCell
+              indexStat={indexStat}
+              databaseName={this.props.databaseName}
+              tableName={this.props.name}
+            />
+          ),
+        });
       }
-      return (
-        <Tooltip
-          key={key}
-          placement="bottom"
-          title={
-            <div className={cx("index-recommendations-text__tooltip-anchor")}>
-              {recommendation.reason}{" "}
-              <Anchor href={performanceTuningRecipes} target="_blank">
-                Learn more
-              </Anchor>
-            </div>
-          }
-        >
-          <CircleFilled className={cx(classname)} />
-          <span className={cx("index-recommendations-text__border")}>
-            {text}
-          </span>
-        </Tooltip>
-      );
-    });
-  };
-
-  private renderActionCell = (indexStat: IndexStat): React.ReactNode => {
-    const isCockroachCloud = useContext(CockroachCloudContext);
-    if (isCockroachCloud || indexStat.indexRecommendations.length === 0) {
-      return <></>;
     }
-
-    const query = indexStat.indexRecommendations.map(recommendation => {
-      switch (recommendation.type) {
-        case "DROP_UNUSED":
-          return `DROP INDEX ${QuoteIdentifier(
-            this.props.name,
-          )}@${QuoteIdentifier(indexStat.indexName)};`;
-      }
-    });
-    if (query.length === 0) {
-      return <></>;
-    }
-
-    return (
-      <IdxRecAction
-        actionQuery={query.join(" ")}
-        actionType={"DropIndex"}
-        database={this.props.databaseName}
-      />
-    );
-  };
-
-  private indexStatsColumns: ColumnDescriptor<IndexStat>[] = [
-    {
-      name: "indexes",
-      title: "Indexes",
-      hideTitleUnderline: true,
-      className: cx("index-stats-table__col-indexes"),
-      cell: indexStat => (
-        <Link
-          to={`${this.props.name}/index/${EncodeUriName(indexStat.indexName)}`}
-          className={cx("icon__container")}
-        >
-          <IndexIcon className={cx("icon--s", "icon--primary")} />
-          {indexStat.indexName}
-        </Link>
-      ),
-      sort: indexStat => indexStat.indexName,
-    },
-    {
-      name: "total reads",
-      title: "Total Reads",
-      hideTitleUnderline: true,
-      cell: indexStat => format.Count(indexStat.totalReads),
-      sort: indexStat => indexStat.totalReads,
-    },
-    {
-      name: "last used",
-      title: (
-        <>
-          Last Used <Timezone />
-        </>
-      ),
-      hideTitleUnderline: true,
-      className: cx("index-stats-table__col-last-used"),
-      cell: indexStat => this.getLastUsed(indexStat),
-      sort: indexStat => indexStat.lastUsed,
-    },
-    {
-      name: "index recommendations",
-      title: (
-        <Tooltip
-          placement="bottom"
-          title="Index recommendations will appear if the system detects improper index usage, such as the occurrence of unused indexes. Following index recommendations may help improve query performance."
-        >
-          Index Recommendations
-        </Tooltip>
-      ),
-      cell: this.renderIndexRecommendations,
-      sort: indexStat => indexStat.indexRecommendations.length,
-    },
-    {
-      name: "action",
-      title: "",
-      cell: this.renderActionCell,
-    },
-  ];
+    return indexStatsColumns;
+  }
 
   private grantsColumns: ColumnDescriptor<Grant>[] = [
     {
@@ -481,48 +405,16 @@ export class DatabaseTablePage extends React.Component<
     },
   ];
 
-  formatMVCCInfo = (
-    details: DatabaseTablePageDataDetails,
-  ): React.ReactElement => {
-    return (
-      <>
-        {format.Percentage(details.livePercentage, 1, 1)}
-        {" ("}
-        <span className={cx("bold")}>
-          {format.Bytes(details.liveBytes)}
-        </span>{" "}
-        live data /{" "}
-        <span className={cx("bold")}>{format.Bytes(details.totalBytes)}</span>
-        {" total)"}
-      </>
-    );
-  };
-
   render(): React.ReactElement {
     const { hasAdminRole } = this.props;
     return (
       <div className="root table-area">
         <section className={baseHeadingClasses.wrapper}>
-          <Breadcrumbs
-            items={[
-              { link: "/databases", name: "Databases" },
-              {
-                link: EncodeDatabaseUri(this.props.databaseName),
-                name: "Tables",
-              },
-              {
-                link: EncodeDatabaseTableUri(
-                  this.props.databaseName,
-                  this.props.name,
-                ),
-                name: `Table: ${this.props.name}`,
-              },
-            ]}
-            divider={
-              <CaretRight className={cx("icon--xxs", "icon--primary")} />
-            }
+          <DbTablesBreadcrumbs
+            tableName={this.props.name}
+            schemaName={this.props.schemaName}
+            databaseName={this.props.databaseName}
           />
-
           <h3
             className={`${baseHeadingClasses.tableName} ${cx(
               "icon__container",
@@ -573,7 +465,9 @@ export class DatabaseTablePage extends React.Component<
                           />
                           <SummaryCardItem
                             label="% of Live Data"
-                            value={this.formatMVCCInfo(this.props.details)}
+                            value={
+                              <FormatMVCCInfo details={this.props.details} />
+                            }
                           />
                           {this.props.details.statsLastUpdated && (
                             <SummaryCardItem
@@ -635,62 +529,66 @@ export class DatabaseTablePage extends React.Component<
                         </SummaryCard>
                       </Col>
                     </Row>
-                    <Row gutter={18} className={cx("row-spaced")}>
-                      <SummaryCard
-                        className={cx(
-                          "summary-card",
-                          "index-stats__summary-card",
-                        )}
-                      >
-                        <div className={cx("index-stats__header")}>
-                          <Heading type="h5">Index Stats</Heading>
-                          <div className={cx("index-stats__reset-info")}>
-                            <Tooltip
-                              placement="bottom"
-                              title="Index stats accumulate from the time the index was created or had its stats reset. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster. Last reset is the timestamp at which the last reset started."
-                            >
-                              <div
-                                className={cx(
-                                  "index-stats__last-reset",
-                                  "underline",
-                                )}
-                              >
-                                {this.getLastReset()}
-                              </div>
-                            </Tooltip>
-                            {hasAdminRole && (
-                              <div>
-                                <a
-                                  className={cx(
-                                    "action",
-                                    "separator",
-                                    "index-stats__reset-btn",
-                                  )}
-                                  onClick={() =>
-                                    this.props.resetIndexUsageStats(
-                                      this.props.databaseName,
-                                      this.props.name,
-                                    )
-                                  }
-                                >
-                                  Reset all index stats
-                                </a>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                        <IndexUsageStatsTable
-                          className="index-stats-table"
-                          data={this.props.indexStats.stats}
-                          columns={this.indexStatsColumns}
-                          sortSetting={this.state.indexSortSetting}
-                          onChangeSortSetting={this.changeIndexSortSetting.bind(
-                            this,
+                    {this.props.indexUsageStatsEnabled && (
+                      <Row gutter={18} className={cx("row-spaced")}>
+                        <SummaryCard
+                          className={cx(
+                            "summary-card",
+                            "index-stats__summary-card",
                           )}
-                          loading={this.props.indexStats.loading}
-                        />
-                      </SummaryCard>
-                    </Row>
+                        >
+                          <div className={cx("index-stats__header")}>
+                            <Heading type="h5">Index Stats</Heading>
+                            <div className={cx("index-stats__reset-info")}>
+                              <Tooltip
+                                placement="bottom"
+                                title="Index stats accumulate from the time the index was created or had its stats reset. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster. Last reset is the timestamp at which the last reset started."
+                              >
+                                <div
+                                  className={cx(
+                                    "index-stats__last-reset",
+                                    "underline",
+                                  )}
+                                >
+                                  <LastReset
+                                    lastReset={this.props.indexStats.lastReset}
+                                  />
+                                </div>
+                              </Tooltip>
+                              {hasAdminRole && (
+                                <div>
+                                  <a
+                                    className={cx(
+                                      "action",
+                                      "separator",
+                                      "index-stats__reset-btn",
+                                    )}
+                                    onClick={() =>
+                                      this.props.resetIndexUsageStats(
+                                        this.props.databaseName,
+                                        this.props.name,
+                                      )
+                                    }
+                                  >
+                                    Reset all index stats
+                                  </a>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                          <IndexUsageStatsTable
+                            className="index-stats-table"
+                            data={this.props.indexStats.stats}
+                            columns={this.state.indexStatsColumns}
+                            sortSetting={this.state.indexSortSetting}
+                            onChangeSortSetting={this.changeIndexSortSetting.bind(
+                              this,
+                            )}
+                            loading={this.props.indexStats.loading}
+                          />
+                        </SummaryCard>
+                      </Row>
+                    )}
                   </>
                 )}
                 renderError={() =>

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePageConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePageConnected.ts
@@ -1,0 +1,133 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { RouteComponentProps } from "react-router";
+import { AppState, uiConfigActions } from "src/store";
+import {
+  databaseNameCCAttr,
+  generateTableID,
+  getMatchParamByName,
+  minDate,
+  schemaNameAttr,
+  tableNameCCAttr,
+  TimestampToMoment,
+} from "src/util";
+import {
+  actions as nodesActions,
+  nodeRegionsByIDSelector,
+} from "src/store/nodes";
+import {
+  selectAutomaticStatsCollectionEnabled,
+  selectIndexRecommendationsEnabled,
+  selectIndexUsageStatsEnabled,
+} from "src/store/clusterSettings/clusterSettings.selectors";
+import { selectHasAdminRole, selectIsTenant } from "src/store/uiConfig";
+import {
+  DatabaseTablePageActions,
+  DatabaseTablePageData,
+  DatabaseTablePage,
+} from "./databaseTablePage";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { Dispatch } from "redux";
+import { actions as tableDetailsActions } from "src/store/databaseTableDetails";
+import { actions as indexStatsActions } from "src/store/indexStats";
+import { actions as analyticsActions } from "src/store/analytics";
+import { actions as clusterSettingsActions } from "src/store/clusterSettings";
+import {
+  deriveIndexDetailsMemoized,
+  deriveTablePageDetailsMemoized,
+} from "../databases";
+import { withRouter } from "react-router-dom";
+import { connect } from "react-redux";
+
+export const mapStateToProps = (
+  state: AppState,
+  props: RouteComponentProps,
+): DatabaseTablePageData => {
+  const database = getMatchParamByName(props.match, databaseNameCCAttr);
+  const table = getMatchParamByName(props.match, tableNameCCAttr);
+  const schema = getMatchParamByName(props.match, schemaNameAttr);
+  const tableDetails = state.adminUI?.tableDetails;
+  const indexUsageStats = state.adminUI?.indexStats;
+  const details = tableDetails[generateTableID(database, table)];
+  const indexStatsState = indexUsageStats[generateTableID(database, table)];
+  const lastReset = TimestampToMoment(
+    indexStatsState?.data?.last_reset,
+    minDate,
+  );
+  const nodeRegions = nodeRegionsByIDSelector(state);
+  const isTenant = selectIsTenant(state);
+
+  return {
+    databaseName: database,
+    name: table,
+    schemaName: schema,
+    details: deriveTablePageDetailsMemoized({ details, nodeRegions, isTenant }),
+    showNodeRegionsSection: Object.keys(nodeRegions).length > 1 && !isTenant,
+    automaticStatsCollectionEnabled:
+      selectAutomaticStatsCollectionEnabled(state),
+    indexUsageStatsEnabled: selectIndexUsageStatsEnabled(state),
+    showIndexRecommendations: selectIndexRecommendationsEnabled(state),
+    hasAdminRole: selectHasAdminRole(state),
+    indexStats: {
+      loading: !!indexStatsState?.inFlight,
+      loaded: !!indexStatsState?.valid,
+      lastError: indexStatsState?.lastError,
+      stats: deriveIndexDetailsMemoized({ database, table, indexUsageStats }),
+      lastReset,
+    },
+  };
+};
+
+export const mapDispatchToProps = (
+  dispatch: Dispatch,
+): DatabaseTablePageActions => ({
+  refreshTableDetails: (database: string, table: string) => {
+    dispatch(tableDetailsActions.refresh({ database, table }));
+  },
+  refreshIndexStats: (database: string, table: string) => {
+    dispatch(
+      indexStatsActions.refresh(
+        new cockroach.server.serverpb.TableIndexStatsRequest({
+          database,
+          table,
+        }),
+      ),
+    );
+  },
+  resetIndexUsageStats: (database: string, table: string) => {
+    dispatch(
+      indexStatsActions.reset({
+        database,
+        table,
+      }),
+    );
+    dispatch(
+      analyticsActions.track({
+        name: "Reset Index Usage",
+        page: "Index Details",
+      }),
+    );
+  },
+  refreshNodes: () => {
+    dispatch(nodesActions.refresh());
+  },
+  refreshSettings: () => {
+    dispatch(clusterSettingsActions.refresh());
+  },
+  refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
+});
+
+export const ConnectedDatabaseTablePage = withRouter(
+  connect<DatabaseTablePageData, DatabaseTablePageActions, RouteComponentProps>(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(DatabaseTablePage),
+);

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/helperComponents.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/helperComponents.tsx
@@ -1,0 +1,222 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  DATE_FORMAT,
+  DATE_FORMAT_24_TZ,
+  EncodeDatabaseTableUri,
+  EncodeDatabaseUri,
+  EncodeUriName,
+  minDate,
+  performanceTuningRecipes,
+} from "../util";
+import { Timestamp } from "../timestamp";
+import React, { useContext } from "react";
+import { Moment } from "moment-timezone";
+import { DatabaseTablePageDataDetails, IndexStat } from "./databaseTablePage";
+import { CircleFilled } from "../icon";
+import { Tooltip } from "antd";
+import "antd/lib/tooltip/style";
+import { Anchor } from "../anchor";
+import classNames from "classnames/bind";
+import styles from "./databaseTablePage.module.scss";
+import { QuoteIdentifier } from "../api/safesql";
+import IdxRecAction from "../insights/indexActionBtn";
+import * as format from "../util/format";
+import { Link } from "react-router-dom";
+import { Search as IndexIcon } from "@cockroachlabs/icons";
+import { Breadcrumbs } from "../breadcrumbs";
+import { CaretRight } from "../icon/caretRight";
+import { CockroachCloudContext } from "../contexts";
+const cx = classNames.bind(styles);
+
+export const NameCell = ({
+  indexStat,
+  showIndexRecommendations,
+  tableName,
+}: {
+  indexStat: IndexStat;
+  showIndexRecommendations: boolean;
+  tableName: string;
+}): JSX.Element => {
+  const isCockroachCloud = useContext(CockroachCloudContext);
+  if (showIndexRecommendations) {
+    const linkURL = isCockroachCloud
+      ? `${location.pathname}/${indexStat.indexName}`
+      : `${tableName}/index/${EncodeUriName(indexStat.indexName)}`;
+    return (
+      <Link to={linkURL} className={cx("icon__container")}>
+        <IndexIcon className={cx("icon--s", "icon--primary")} />
+        {indexStat.indexName}
+      </Link>
+    );
+  }
+  return (
+    <>
+      <IndexIcon className={cx("icon--s", "icon--primary")} />
+      {indexStat.indexName}
+    </>
+  );
+};
+
+export const DbTablesBreadcrumbs = ({
+  tableName,
+  schemaName,
+  databaseName,
+}: {
+  tableName: string;
+  schemaName: string;
+  databaseName: string;
+}): JSX.Element => {
+  const isCockroachCloud = useContext(CockroachCloudContext);
+  return (
+    <Breadcrumbs
+      items={[
+        { link: "/databases", name: "Databases" },
+        {
+          link: isCockroachCloud
+            ? `/databases/${EncodeUriName(databaseName)}`
+            : EncodeDatabaseUri(databaseName),
+          name: "Tables",
+        },
+        {
+          link: isCockroachCloud
+            ? `/databases/${EncodeUriName(databaseName)}/${EncodeUriName(
+                schemaName,
+              )}/${EncodeUriName(tableName)}`
+            : EncodeDatabaseTableUri(databaseName, tableName),
+          name: `Table: ${tableName}`,
+        },
+      ]}
+      divider={<CaretRight className={cx("icon--xxs", "icon--primary")} />}
+    />
+  );
+};
+
+export const LastReset = ({
+  lastReset,
+}: {
+  lastReset: Moment;
+}): JSX.Element => {
+  return (
+    <span>
+      Last reset:{" "}
+      {lastReset.isSame(minDate) ? (
+        "Never"
+      ) : (
+        <Timestamp time={lastReset} format={DATE_FORMAT_24_TZ} />
+      )}
+    </span>
+  );
+};
+
+interface IndexStatProps {
+  indexStat: IndexStat;
+}
+
+export const LastUsed = ({ indexStat }: IndexStatProps): JSX.Element => {
+  // This case only occurs when we have no reads, resets, or creation time on
+  // the index.
+  if (indexStat.lastUsed.isSame(minDate)) {
+    return <>Never</>;
+  }
+  return (
+    <>
+      Last {indexStat.lastUsedType}:{" "}
+      <Timestamp time={indexStat.lastUsed} format={DATE_FORMAT} />
+    </>
+  );
+};
+
+export const IndexRecCell = ({ indexStat }: IndexStatProps): JSX.Element => {
+  const classname =
+    indexStat.indexRecommendations.length > 0
+      ? "index-recommendations-icon__exist"
+      : "index-recommendations-icon__none";
+
+  if (indexStat.indexRecommendations.length === 0) {
+    return (
+      <div>
+        <CircleFilled className={cx(classname)} />
+        <span>None</span>
+      </div>
+    );
+  }
+  // Render only the first recommendation for an index.
+  const recommendation = indexStat.indexRecommendations[0];
+  let text: string;
+  switch (recommendation.type) {
+    case "DROP_UNUSED":
+      text = "Drop unused index";
+  }
+  return (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("index-recommendations-text__tooltip-anchor")}>
+          {recommendation.reason}{" "}
+          <Anchor href={performanceTuningRecipes} target="_blank">
+            Learn more
+          </Anchor>
+        </div>
+      }
+    >
+      <CircleFilled className={cx(classname)} />
+      <span className={cx("index-recommendations-text__border")}>{text}</span>
+    </Tooltip>
+  );
+};
+
+export const ActionCell = ({
+  indexStat,
+  tableName,
+  databaseName,
+}: {
+  indexStat: IndexStat;
+  tableName: string;
+  databaseName: string;
+}): JSX.Element => {
+  const query = indexStat.indexRecommendations.map(recommendation => {
+    switch (recommendation.type) {
+      case "DROP_UNUSED":
+        return `DROP INDEX ${QuoteIdentifier(tableName)}@${QuoteIdentifier(
+          indexStat.indexName,
+        )};`;
+    }
+  });
+  if (query.length === 0) {
+    return <></>;
+  }
+
+  return (
+    <IdxRecAction
+      actionQuery={query.join(" ")}
+      actionType={"DropIndex"}
+      database={databaseName}
+    />
+  );
+};
+
+export const FormatMVCCInfo = ({
+  details,
+}: {
+  details: DatabaseTablePageDataDetails;
+}): JSX.Element => {
+  return (
+    <>
+      {format.Percentage(details.livePercentage, 1, 1)}
+      {" ("}
+      <span className={cx("bold")}>{format.Bytes(details.liveBytes)}</span> live
+      data /{" "}
+      <span className={cx("bold")}>{format.Bytes(details.totalBytes)}</span>
+      {" total)"}
+    </>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/index.ts
@@ -9,3 +9,4 @@
 // licenses/APL.txt.
 
 export * from "./databaseTablePage";
+export * from "./databaseTablePageConnected";

--- a/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
@@ -11,6 +11,7 @@
 import { DatabasesListResponse, SqlExecutionErrorMessage } from "../api";
 import { DatabasesPageDataDatabase } from "../databasesPage";
 import {
+  buildIndexStatToRecommendationsMap,
   combineLoadingErrors,
   getNodesByRegionString,
   normalizePrivileges,
@@ -19,8 +20,16 @@ import {
 import { DatabaseDetailsState } from "../store/databaseDetails";
 import { createSelector } from "@reduxjs/toolkit";
 import { TableDetailsState } from "../store/databaseTableDetails";
-import { generateTableID } from "../util";
+import { generateTableID, longToInt, TimestampToMoment } from "../util";
 import { DatabaseDetailsPageDataTable } from "src/databaseDetailsPage";
+import { DatabaseTablePageDataDetails, IndexStat } from "../databaseTablePage";
+import { IndexStatsState } from "../store/indexStats";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { RecommendationType as RecType } from "../indexDetailsPage";
+import { TableIndexStatsResponse } from "../api/indexDetailsApi";
+type IndexUsageStatistic =
+  cockroach.server.serverpb.TableIndexStatsResponse.IExtendedCollectedIndexUsageStatistics;
+const { RecommendationType } = cockroach.sql.IndexRecommendation;
 
 interface DerivedDatabaseDetailsParams {
   dbListResp: DatabasesListResponse;
@@ -160,5 +169,109 @@ const deriveDatabaseTableDetails = (
       rangeCount: results?.stats?.spanStats.range_count || 0,
       nodesByRegionString: getNodesByRegionString(nodes, nodeRegions, isTenant),
     },
+  };
+};
+
+interface DerivedTablePageDetailsParams {
+  details: TableDetailsState;
+  nodeRegions: Record<string, string>;
+  isTenant: boolean;
+}
+
+export const deriveTablePageDetailsMemoized = createSelector(
+  (params: DerivedTablePageDetailsParams) => params.details,
+  (params: DerivedTablePageDetailsParams) => params.nodeRegions,
+  (params: DerivedTablePageDetailsParams) => params.isTenant,
+  (details, nodeRegions, isTenant): DatabaseTablePageDataDetails => {
+    const results = details?.data?.results;
+    const grants = results?.grantsResp.grants || [];
+    const normalizedGrants =
+      grants.map(grant => ({
+        user: grant.user,
+        privileges: normalizePrivileges(grant.privileges),
+      })) || [];
+    const nodes = results?.stats.replicaData.nodeIDs || [];
+    return {
+      loading: !!details?.inFlight,
+      loaded: !!details?.valid,
+      lastError: details?.lastError,
+      createStatement: results?.createStmtResp.create_statement || "",
+      replicaCount: results?.stats.replicaData.replicaCount || 0,
+      indexNames: results?.schemaDetails.indexes || [],
+      grants: normalizedGrants,
+      statsLastUpdated:
+        results?.heuristicsDetails.stats_last_created_at || null,
+      totalBytes: results?.stats.spanStats.total_bytes || 0,
+      liveBytes: results?.stats.spanStats.live_bytes || 0,
+      livePercentage: results?.stats.spanStats.live_percentage || 0,
+      sizeInBytes: results?.stats.spanStats.approximate_disk_bytes || 0,
+      rangeCount: results?.stats.spanStats.range_count || 0,
+      nodesByRegionString: getNodesByRegionString(nodes, nodeRegions, isTenant),
+    };
+  },
+);
+
+interface DerivedIndexDetailsParams {
+  database: string;
+  table: string;
+  indexUsageStats: Record<string, IndexStatsState>;
+}
+
+export const deriveIndexDetailsMemoized = createSelector(
+  (params: DerivedIndexDetailsParams) => params.database,
+  (params: DerivedIndexDetailsParams) => params.table,
+  (params: DerivedIndexDetailsParams) => params.indexUsageStats,
+  (database, table, indexUsageStats): IndexStat[] => {
+    const indexStats = indexUsageStats[generateTableID(database, table)];
+    const lastReset = TimestampToMoment(indexStats?.data?.last_reset);
+    const stats = indexStats?.data?.statistics || [];
+    const recommendations = indexStats?.data?.index_recommendations || [];
+    const recsMap = buildIndexStatToRecommendationsMap(stats, recommendations);
+    return stats.map(indexStat => {
+      const indexRecs = recsMap[indexStat?.statistics.key.index_id] || [];
+      return deriveIndexDetails(indexStat, lastReset, indexRecs);
+    });
+  },
+);
+
+const deriveIndexDetails = (
+  indexStat: IndexUsageStatistic,
+  lastReset: moment.Moment,
+  recommendations: cockroach.sql.IIndexRecommendation[],
+): IndexStat => {
+  const lastRead = TimestampToMoment(indexStat.statistics?.stats?.last_read);
+  let lastUsed, lastUsedType;
+  if (indexStat.created_at !== null) {
+    lastUsed = TimestampToMoment(indexStat.created_at);
+    lastUsedType = "created";
+  } else {
+    lastUsed = lastReset;
+    lastUsedType = "reset";
+  }
+  if (lastReset.isAfter(lastUsed)) {
+    lastUsed = lastReset;
+    lastUsedType = "reset";
+  }
+  if (lastRead.isAfter(lastUsed)) {
+    lastUsed = lastRead;
+    lastUsedType = "read";
+  }
+  const indexRecommendations = recommendations.map(indexRec => {
+    let type: RecType = "Unknown";
+    switch (RecommendationType[indexRec.type].toString()) {
+      case "DROP_UNUSED":
+        type = "DROP_UNUSED";
+    }
+    return {
+      type: type,
+      reason: indexRec.reason,
+    };
+  });
+  return {
+    indexName: indexStat.index_name,
+    totalReads: longToInt(indexStat.statistics?.stats?.total_read_count),
+    lastUsed: lastUsed,
+    lastUsedType: lastUsedType,
+    indexRecommendations,
   };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
@@ -82,9 +82,7 @@ const mapStateToProps = (
   const indexName = getMatchParamByName(props.match, indexNameAttr);
 
   const stats =
-    state.adminUI?.indexStats.cachedData[
-      generateTableID(databaseName, tableName)
-    ];
+    state.adminUI?.indexStats[generateTableID(databaseName, tableName)];
   const details = stats?.data?.statistics.find(
     stat => stat.index_name === indexName, // index names must be unique for a table
   );

--- a/pkg/ui/workspaces/cluster-ui/src/store/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/clusterSettings/clusterSettings.selectors.ts
@@ -30,3 +30,12 @@ export const selectIndexRecommendationsEnabled = (state: AppState): boolean => {
   const value = settings["version"]?.value || "";
   return greaterOrEqualThanVersion(value, [22, 2, 0]);
 };
+
+export const selectIndexUsageStatsEnabled = (state: AppState): boolean => {
+  const settings = state.adminUI?.clusterSettings.data?.key_values;
+  if (!settings) {
+    return false;
+  }
+  const value = settings["version"]?.value || "";
+  return greaterOrEqualThanVersion(value, [22, 1, 0]);
+};

--- a/pkg/ui/workspaces/cluster-ui/src/store/indexStats/indexStats.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/indexStats/indexStats.reducer.ts
@@ -19,16 +19,14 @@ import {
 } from "../../api/indexDetailsApi";
 
 export type IndexStatsState = {
-  data: TableIndexStatsResponse;
-  lastError: Error;
+  data?: TableIndexStatsResponse;
+  lastError?: Error;
   valid: boolean;
   inFlight: boolean;
 };
 
 export type IndexStatsReducerState = {
-  cachedData: {
-    [id: string]: IndexStatsState;
-  };
+  [id: string]: IndexStatsState;
 };
 
 export type ResetIndexUsageStatsPayload = {
@@ -36,9 +34,7 @@ export type ResetIndexUsageStatsPayload = {
   table: string;
 };
 
-const initialState: IndexStatsReducerState = {
-  cachedData: {},
-};
+const initialState: IndexStatsReducerState = {};
 
 const indexStatsSlice = createSlice({
   name: `${DOMAIN_NAME}/indexstats`,
@@ -48,7 +44,7 @@ const indexStatsSlice = createSlice({
       state,
       action: PayloadAction<TableIndexStatsResponseWithKey>,
     ) => {
-      state.cachedData[action.payload.key] = {
+      state[action.payload.key] = {
         data: action.payload.indexStatsResponse,
         valid: true,
         lastError: null,
@@ -56,7 +52,7 @@ const indexStatsSlice = createSlice({
       };
     },
     failed: (state, action: PayloadAction<ErrorWithKey>) => {
-      state.cachedData[action.payload.key] = {
+      state[action.payload.key] = {
         data: null,
         valid: false,
         lastError: action.payload.err,
@@ -64,19 +60,19 @@ const indexStatsSlice = createSlice({
       };
     },
     invalidated: (state, action: PayloadAction<{ key: string }>) => {
-      delete state.cachedData[action.payload.key];
+      delete state[action.payload.key];
     },
     invalidateAll: state => {
       const keys = Object.keys(state);
       for (const key in keys) {
-        delete state.cachedData[key];
+        delete state[key];
       }
     },
     refresh: (state, action: PayloadAction<TableIndexStatsRequest>) => {
       const key = action?.payload
         ? generateTableID(action.payload.database, action.payload.table)
         : "";
-      state.cachedData[key] = {
+      state[key] = {
         data: null,
         valid: false,
         lastError: null,
@@ -87,7 +83,7 @@ const indexStatsSlice = createSlice({
       const key = action?.payload
         ? generateTableID(action.payload.database, action.payload.table)
         : "";
-      state.cachedData[key] = {
+      state[key] = {
         data: null,
         valid: false,
         lastError: null,
@@ -98,7 +94,7 @@ const indexStatsSlice = createSlice({
       const key = action?.payload
         ? generateTableID(action.payload.database, action.payload.table)
         : "";
-      state.cachedData[key] = {
+      state[key] = {
         data: null,
         valid: false,
         lastError: null,

--- a/pkg/ui/workspaces/cluster-ui/src/store/indexStats/indexStats.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/indexStats/indexStats.sagas.spec.ts
@@ -114,13 +114,11 @@ describe("IndexStats sagas", () => {
         )
         .withReducer(reducer)
         .hasFinalState<IndexStatsReducerState>({
-          cachedData: {
-            "test_db/test_table": {
-              data: tableIndexStatsResponse,
-              lastError: null,
-              valid: true,
-              inFlight: false,
-            },
+          "test_db/test_table": {
+            data: tableIndexStatsResponse,
+            lastError: null,
+            valid: true,
+            inFlight: false,
           },
         })
         .run();
@@ -138,13 +136,11 @@ describe("IndexStats sagas", () => {
         )
         .withReducer(reducer)
         .hasFinalState<IndexStatsReducerState>({
-          cachedData: {
-            "test_db/test_table": {
-              data: null,
-              lastError: error,
-              valid: false,
-              inFlight: false,
-            },
+          "test_db/test_table": {
+            data: null,
+            lastError: error,
+            valid: false,
+            inFlight: false,
           },
         })
         .run();
@@ -165,13 +161,11 @@ describe("IndexStats sagas", () => {
         )
         .withReducer(reducer)
         .hasFinalState<IndexStatsReducerState>({
-          cachedData: {
-            "test_db/test_table": {
-              data: null,
-              valid: false,
-              lastError: null,
-              inFlight: true,
-            },
+          "test_db/test_table": {
+            data: null,
+            valid: false,
+            lastError: null,
+            inFlight: true,
           },
         })
         .run();
@@ -189,13 +183,11 @@ describe("IndexStats sagas", () => {
         )
         .withReducer(reducer)
         .hasFinalState<IndexStatsReducerState>({
-          cachedData: {
-            "test_db/test_table": {
-              data: null,
-              lastError: err,
-              valid: false,
-              inFlight: false,
-            },
+          "test_db/test_table": {
+            data: null,
+            lastError: err,
+            valid: false,
+            inFlight: false,
           },
         })
         .run();

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -29,6 +29,7 @@ export const sessionAttr = "session";
 export const tabAttr = "tab";
 export const schemaNameAttr = "schemaName";
 export const tableNameAttr = "table_name";
+export const tableNameCCAttr = "tableName";
 export const indexNameAttr = "index_name";
 export const txnFingerprintIdAttr = "txn_fingerprint_id";
 export const unset = "(unset)";

--- a/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
@@ -14,6 +14,8 @@ import { fromNumber } from "long";
 
 type Timestamp = protos.google.protobuf.ITimestamp;
 
+export const minDate = moment.utc("0001-01-01"); // minimum value as per UTC.
+
 /**
  * NanoToMilli converts a nanoseconds value into milliseconds.
  */

--- a/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
@@ -94,3 +94,14 @@ export const selectClusterSettingVersion = createSelector(
     return settings["version"].value;
   },
 );
+
+export const selectIndexUsageStatsEnabled = createSelector(
+  selectClusterSettings,
+  (settings): boolean => {
+    if (!settings) {
+      return false;
+    }
+    const value = settings["version"]?.value || "";
+    return util.greaterOrEqualThanVersion(value, [22, 1, 0]);
+  },
+);

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -9,15 +9,7 @@
 // licenses/APL.txt.
 
 import { RouteComponentProps } from "react-router";
-import { createSelector } from "reselect";
-import _ from "lodash";
-import {
-  DatabaseTablePageData,
-  util,
-  RecommendationType as RecType,
-  getNodesByRegionString,
-  normalizePrivileges,
-} from "@cockroachlabs/cluster-ui";
+import { DatabaseTablePageData, util } from "@cockroachlabs/cluster-ui";
 
 import { cockroach } from "src/js/protos";
 import {
@@ -27,163 +19,66 @@ import {
   refreshSettings,
   refreshUserSQLRoles,
 } from "src/redux/apiReducers";
-import { selectHasAdminRole } from "src/redux/user";
+import { resetIndexUsageStatsAction } from "src/redux/indexUsageStats";
 import { AdminUIState } from "src/redux/state";
-import { databaseNameAttr, tableNameAttr } from "src/util/constants";
-import { longToInt } from "src/util/fixLong";
-import { getMatchParamByName } from "src/util/query";
 import {
   nodeRegionsByIDSelector,
   selectIsMoreThanOneNode,
 } from "src/redux/nodes";
-import { resetIndexUsageStatsAction } from "src/redux/indexUsageStats";
-import { selectAutomaticStatsCollectionEnabled } from "src/redux/clusterSettings";
+import {
+  deriveIndexDetailsMemoized,
+  deriveTablePageDetailsMemoized,
+} from "@cockroachlabs/cluster-ui";
+import { selectHasAdminRole } from "src/redux/user";
+import {
+  selectAutomaticStatsCollectionEnabled,
+  selectIndexRecommendationsEnabled,
+  selectIndexUsageStatsEnabled,
+} from "src/redux/clusterSettings";
+import { getMatchParamByName } from "src/util/query";
+import { databaseNameAttr, tableNameAttr } from "src/util/constants";
 
 const { TableIndexStatsRequest } = cockroach.server.serverpb;
-
-const { RecommendationType } = cockroach.sql.IndexRecommendation;
 
 // Hardcoded isTenant value for db-console.
 const isTenant = false;
 
-export const mapStateToProps = createSelector(
-  (_state: AdminUIState, props: RouteComponentProps): string =>
-    getMatchParamByName(props.match, databaseNameAttr),
-  (_state: AdminUIState, props: RouteComponentProps): string =>
-    getMatchParamByName(props.match, tableNameAttr),
+export const mapStateToProps = (
+  state: AdminUIState,
+  props: RouteComponentProps,
+): DatabaseTablePageData => {
+  const database = getMatchParamByName(props.match, databaseNameAttr);
+  const table = getMatchParamByName(props.match, tableNameAttr);
+  const tableDetails = state?.cachedData.tableDetails;
+  const details = tableDetails[util.generateTableID(database, table)];
+  const indexUsageStats = state?.cachedData.indexStats;
+  const indexStats = indexUsageStats[util.generateTableID(database, table)];
+  const lastReset = util.TimestampToMoment(
+    indexStats?.data?.last_reset,
+    util.minDate,
+  );
+  const nodeRegions = nodeRegionsByIDSelector(state);
 
-  state => state.cachedData.tableDetails,
-  state => state.cachedData.indexStats,
-  state => nodeRegionsByIDSelector(state),
-  state => selectIsMoreThanOneNode(state),
-  state => selectAutomaticStatsCollectionEnabled(state),
-  _ => isTenant,
-  state => selectHasAdminRole(state),
-  (
-    database,
-    table,
-    tableDetails,
-    indexUsageStats,
-    nodeRegions,
-    showNodeRegionsSection,
-    automaticStatsCollectionEnabled,
-    isTenant,
-    hasAdminRole,
-  ): DatabaseTablePageData => {
-    const details = tableDetails[util.generateTableID(database, table)];
-    const indexStats = indexUsageStats[util.generateTableID(database, table)];
-    const lastReset = util.TimestampToMoment(indexStats?.data?.last_reset);
-    const indexStatsData = _.flatMap(
-      indexStats?.data?.statistics,
-      indexStat => {
-        const lastRead = util.TimestampToMoment(
-          indexStat.statistics?.stats?.last_read,
-        );
-        let lastUsed, lastUsedType;
-        if (indexStat.created_at !== null) {
-          lastUsed = util.TimestampToMoment(indexStat.created_at);
-          lastUsedType = "created";
-        } else {
-          lastUsed = lastReset;
-          lastUsedType = "reset";
-        }
-        if (lastReset.isAfter(lastUsed)) {
-          lastUsed = lastReset;
-          lastUsedType = "reset";
-        }
-        if (lastRead.isAfter(lastUsed)) {
-          lastUsed = lastRead;
-          lastUsedType = "read";
-        }
-        const filteredIndexRecommendations =
-          indexStats?.data?.index_recommendations.filter(
-            indexRec =>
-              indexRec.index_id === indexStat?.statistics.key.index_id,
-          ) || [];
-        const indexRecommendations = filteredIndexRecommendations.map(
-          indexRec => {
-            let type: RecType = "Unknown";
-            switch (RecommendationType[indexRec.type].toString()) {
-              case "DROP_UNUSED":
-                type = "DROP_UNUSED";
-            }
-            return {
-              type: type,
-              reason: indexRec.reason,
-            };
-          },
-        );
-        return {
-          indexName: indexStat.index_name,
-          totalReads: longToInt(indexStat.statistics?.stats?.total_read_count),
-          lastUsed: lastUsed,
-          lastUsedType: lastUsedType,
-          indexRecommendations,
-        };
-      },
-    );
-
-    const userToPrivileges = new Map<string, string[]>();
-
-    details?.data?.results.grantsResp.grants.forEach(grant => {
-      if (!userToPrivileges.has(grant.user)) {
-        userToPrivileges.set(grant.user, []);
-      }
-      userToPrivileges.set(
-        grant.user,
-        userToPrivileges.get(grant.user).concat(grant.privileges),
-      );
-    });
-
-    const grants = Array.from(userToPrivileges).map(([name, value]) => ({
-      user: name,
-      privileges: normalizePrivileges(value.sort()),
-    }));
-
-    const nodes = details?.data?.results.stats.replicaData.nodeIDs || [];
-
-    return {
-      databaseName: database,
-      name: table,
-      details: {
-        loading: !!details?.inFlight,
-        loaded: !!details?.valid,
-        lastError: details?.lastError,
-        createStatement:
-          details?.data?.results.createStmtResp.create_statement || "",
-        replicaCount:
-          details?.data?.results.stats.replicaData.replicaCount || 0,
-        indexNames: _.uniq(details?.data?.results.schemaDetails.indexes),
-        grants: grants,
-        statsLastUpdated:
-          details?.data?.results.heuristicsDetails.stats_last_created_at ||
-          null,
-        totalBytes: details?.data?.results.stats.spanStats.total_bytes || 0,
-        liveBytes: details?.data?.results.stats.spanStats.live_bytes || 0,
-        livePercentage:
-          details?.data?.results.stats.spanStats.live_percentage || 0,
-        sizeInBytes:
-          details?.data?.results.stats.spanStats.approximate_disk_bytes || 0,
-        rangeCount: details?.data?.results.stats.spanStats.range_count || 0,
-        nodesByRegionString: getNodesByRegionString(
-          nodes,
-          nodeRegions,
-          isTenant,
-        ),
-      },
-      showNodeRegionsSection,
-      automaticStatsCollectionEnabled,
-      hasAdminRole,
-      indexStats: {
-        loading: !!indexStats?.inFlight,
-        loaded: !!indexStats?.valid,
-        lastError: indexStats?.lastError,
-        stats: indexStatsData,
-        lastReset: lastReset,
-      },
-    };
-  },
-);
+  return {
+    databaseName: database,
+    name: table,
+    schemaName: "",
+    details: deriveTablePageDetailsMemoized({ details, nodeRegions, isTenant }),
+    showNodeRegionsSection: selectIsMoreThanOneNode(state) && !isTenant,
+    automaticStatsCollectionEnabled:
+      selectAutomaticStatsCollectionEnabled(state) || false,
+    hasAdminRole: selectHasAdminRole(state) || false,
+    showIndexRecommendations: selectIndexRecommendationsEnabled(state),
+    indexUsageStatsEnabled: selectIndexUsageStatsEnabled(state),
+    indexStats: {
+      loading: !!indexStats?.inFlight,
+      loaded: !!indexStats?.valid,
+      lastError: indexStats?.lastError,
+      stats: deriveIndexDetailsMemoized({ database, table, indexUsageStats }),
+      lastReset: lastReset,
+    },
+  };
+};
 
 export const mapDispatchToProps = {
   refreshTableDetails: (database: string, table: string) => {

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
@@ -108,13 +108,14 @@ class TestDriver {
       ).toBe(true);
     }
     // Assert objects without moments are equal.
-    delete this.properties().details.lastRead;
+    const props = this.properties();
+    delete props.details.lastRead;
     delete expected.details.lastRead;
-    delete this.properties().details.lastReset;
+    delete props.details.lastReset;
     delete expected.details.lastReset;
-    delete this.properties().timeScale;
+    delete props.timeScale;
     delete expected.timeScale;
-    expect(this.properties()).toEqual(expected);
+    expect(props).toEqual(expected);
   }
 
   async refreshIndexStats() {
@@ -154,11 +155,11 @@ describe("Index Details Page", function () {
           loaded: false,
           createStatement: "",
           totalReads: 0,
-          lastRead: moment(),
-          lastReset: moment(),
           indexRecommendations: [],
           tableID: undefined,
           indexID: undefined,
+          lastRead: util.minDate,
+          lastReset: util.minDate,
         },
         breadcrumbItems: null,
       },

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { createSelector } from "reselect";
 import {
   IndexDetailsPageData,
   util,
@@ -40,74 +39,64 @@ import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { selectTimeScale } from "src/redux/timeScale";
 const { RecommendationType } = cockroach.sql.IndexRecommendation;
 
-export const mapStateToProps = createSelector(
-  (_state: AdminUIState, props: RouteComponentProps): string =>
-    getMatchParamByName(props.match, databaseNameAttr),
-  (_state: AdminUIState, props: RouteComponentProps): string =>
-    getMatchParamByName(props.match, tableNameAttr),
-  (_state: AdminUIState, props: RouteComponentProps): string =>
-    getMatchParamByName(props.match, indexNameAttr),
-  state => state.cachedData.indexStats,
-  state => selectHasViewActivityRedactedRole(state),
-  state => nodeRegionsByIDSelector(state),
-  state => selectHasAdminRole(state),
-  state => selectTimeScale(state),
-  (
-    database,
-    table,
-    index,
-    indexStats,
-    hasViewActivityRedactedRole,
-    nodeRegions,
-    hasAdminRole,
-    timeScale,
-  ): IndexDetailsPageData => {
-    const stats = indexStats[util.generateTableID(database, table)];
-    const details = stats?.data?.statistics.find(
-      stat => stat.index_name === index,
-    );
-    const filteredIndexRecommendations =
-      stats?.data?.index_recommendations.filter(
-        indexRec => indexRec.index_id === details?.statistics.key.index_id,
-      ) || [];
-    const indexRecommendations = filteredIndexRecommendations.map(indexRec => {
-      let type: RecType = "Unknown";
-      switch (RecommendationType[indexRec.type].toString()) {
-        case "DROP_UNUSED":
-          type = "DROP_UNUSED";
-      }
-
-      return {
-        type: type,
-        reason: indexRec.reason,
-      };
-    });
-
+export const mapStateToProps = (
+  state: AdminUIState,
+  props: RouteComponentProps,
+): IndexDetailsPageData => {
+  const database = getMatchParamByName(props.match, databaseNameAttr);
+  const table = getMatchParamByName(props.match, tableNameAttr);
+  const index = getMatchParamByName(props.match, indexNameAttr);
+  const indexStats = state.cachedData.indexStats;
+  const hasViewActivityRedactedRole = selectHasViewActivityRedactedRole(state);
+  const nodeRegions = nodeRegionsByIDSelector(state);
+  const hasAdminRole = selectHasAdminRole(state);
+  const timeScale = selectTimeScale(state);
+  const stats = indexStats[util.generateTableID(database, table)];
+  const details = stats?.data?.statistics.filter(
+    stat => stat.index_name === index, // index names must be unique for a table
+  )[0];
+  const filteredIndexRecommendations =
+    stats?.data?.index_recommendations.filter(
+      indexRec => indexRec.index_id === details?.statistics.key.index_id,
+    ) || [];
+  const indexRecommendations = filteredIndexRecommendations.map(indexRec => {
+    let type: RecType = "Unknown";
+    switch (RecommendationType[indexRec.type].toString()) {
+      case "DROP_UNUSED":
+        type = "DROP_UNUSED";
+    }
     return {
-      databaseName: database,
-      tableName: table,
-      indexName: index,
-      isTenant: false,
-      hasViewActivityRedactedRole: hasViewActivityRedactedRole,
-      hasAdminRole: hasAdminRole,
-      nodeRegions: nodeRegions,
-      timeScale: timeScale,
-      details: {
-        loading: !!stats?.inFlight,
-        loaded: !!stats?.valid,
-        createStatement: details?.create_statement || "",
-        tableID: details?.statistics.key.table_id.toString(),
-        indexID: details?.statistics.key.index_id.toString(),
-        totalReads:
-          longToInt(details?.statistics?.stats?.total_read_count) || 0,
-        lastRead: util.TimestampToMoment(details?.statistics?.stats?.last_read),
-        lastReset: util.TimestampToMoment(stats?.data?.last_reset),
-        indexRecommendations,
-      },
-      breadcrumbItems: null,
+      type: type,
+      reason: indexRec.reason,
     };
-  },
-);
+  });
+
+  return {
+    databaseName: database,
+    tableName: table,
+    indexName: index,
+    isTenant: false,
+    hasViewActivityRedactedRole: hasViewActivityRedactedRole,
+    hasAdminRole: hasAdminRole,
+    nodeRegions: nodeRegions,
+    timeScale: timeScale,
+    details: {
+      loading: !!stats?.inFlight,
+      loaded: !!stats?.valid,
+      createStatement: details?.create_statement || "",
+      tableID: details?.statistics.key.table_id.toString(),
+      indexID: details?.statistics.key.index_id.toString(),
+      totalReads: longToInt(details?.statistics?.stats?.total_read_count) || 0,
+      lastRead: util.TimestampToMoment(
+        details?.statistics?.stats?.last_read,
+        util.minDate,
+      ),
+      lastReset: util.TimestampToMoment(stats?.data?.last_reset, util.minDate),
+      indexRecommendations,
+    },
+    breadcrumbItems: null,
+  };
+};
 
 export const mapDispatchToProps = {
   refreshIndexStats: (database: string, table: string) => {


### PR DESCRIPTION
Resolves: https://github.com/cockroachdb/cockroach/issues/97885 
Related to: https://github.com/cockroachdb/cockroach/pull/103979

Consumed by: https://github.com/cockroachlabs/managed-service/pull/13237

** DEMOS **
DB: https://www.loom.com/share/9138512826bf45729c6e698fb492c6eb

This PR adds a connected component for the database table page on
cluster-ui to be used on CC console. Similar to the PR for the connected
databases page, we move some common selector/combiner logic between the
two connected components (for db/cc console) into cluster-ui for reuse.

Release note: None