### PR TITLE
backupccl: always track opened writer

### DIFF
--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -154,14 +154,14 @@ func (s *fileSSTSink) open(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	s.out = w
 	if s.conf.enc != nil {
-		var err error
-		w, err = storageccl.EncryptingWriter(w, s.conf.enc.Key)
+		e, err := storageccl.EncryptingWriter(w, s.conf.enc.Key)
 		if err != nil {
 			return err
 		}
+		s.out = e
 	}
-	s.out = w
 	s.sst = storage.MakeBackupSSTWriter(ctx, s.dest.Settings(), s.out)
 
 	return nil


### PR DESCRIPTION
Previously we would do things -- like wrap the opened writer with an encryption shim -- after opening the writer but before storing it in the sink. This could mean that if the sink opened a writer, but failed to save it, and was then closed it would fail to close the writer. This changes that, so that as soon as the writer is opened it is saved and then if it is later wrapped, saved again, to ensure that we cannot lose track of any successfully opened writer.

Fixes: #103597.

Release note: none.