### PR TITLE
release-22.2: sql: fix connection stuck in scram auth

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -90,6 +90,7 @@ go_test(
     size = "medium",
     srcs = [
         "auth_test.go",
+        "authpipe_test.go",
         "conn_test.go",
         "encoding_test.go",
         "helpers_test.go",

--- a/pkg/sql/pgwire/authpipe_test.go
+++ b/pkg/sql/pgwire/authpipe_test.go
@@ -1,0 +1,52 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pgwire
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func createAuthPipe() *authPipe {
+	return newAuthPipe(
+		nil,   /* c */
+		false, /* logAuthn */
+		authOptions{
+			connType: hba.ConnLocal,
+		},
+		username.SQLUsername{},
+	)
+}
+
+func TestNoMorePwdDataIdempotent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ap := createAuthPipe()
+	ap.noMorePwdData()
+	ap.noMorePwdData()
+}
+
+func TestGetPwdDataAfterNoMorePwdData(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ap := createAuthPipe()
+	ap.noMorePwdData()
+	// GetPwdData should not hang waiting for p.writerDone to close.
+	_, err := ap.GetPwdData()
+	require.ErrorContains(t, err, writerDoneError)
+}


### PR DESCRIPTION
Backport 1/1 commits from #104167.

/cc @cockroachdb/release

---

Fixes #103108

Previously `authPipe.noMorePwdData()` would set the `authPipe.writerDone` chan to nil after closing it. This means that `case <-authPipe.writerDone` will never be selected if the select is entered after `authPipe.writerDone` is nil.

For SCRAM authentication, `authPipe.GetPwdData()` is called in a loop which can result in a race between `authPipe.writerDone = nil` and `case <-authPipe.writerDone`.

This race condition is fixed by not setting `authPipe.writerDone` to nil after closing it.

Release note (bug fix): Fixed a bug that could cause goroutines to hang during SCRAM authentication.

Release justification: Stuck connection bug fix.

