### PR TITLE
release-23.1: sql: fix connection stuck in scram auth

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -94,6 +94,7 @@ go_test(
     size = "medium",
     srcs = [
         "auth_test.go",
+        "authpipe_test.go",
         "conn_test.go",
         "encoding_test.go",
         "helpers_test.go",

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -413,8 +414,11 @@ type authPipe struct {
 	authMethod  string
 
 	ch chan []byte
+
+	// closeWriterDoneOnce wraps close(writerDone) to prevent a panic if
+	// noMorePwdData is called multiple times.
+	closeWriterDoneOnce sync.Once
 	// writerDone is a channel closed by noMorePwdData().
-	// Nil if noMorePwdData().
 	writerDone chan struct{}
 	readerDone chan authRes
 }
@@ -454,13 +458,13 @@ func (p *authPipe) sendPwdData(data []byte) error {
 }
 
 func (p *authPipe) noMorePwdData() {
-	if p.writerDone == nil {
-		return
-	}
-	// A reader blocked in GetPwdData() gets unblocked with an error.
-	close(p.writerDone)
-	p.writerDone = nil
+	p.closeWriterDoneOnce.Do(func() {
+		// A reader blocked in GetPwdData() gets unblocked with an error.
+		close(p.writerDone)
+	})
 }
+
+const writerDoneError = "client didn't send required auth data"
 
 // GetPwdData is part of the AuthConn interface.
 func (p *authPipe) GetPwdData() ([]byte, error) {
@@ -468,7 +472,7 @@ func (p *authPipe) GetPwdData() ([]byte, error) {
 	case data := <-p.ch:
 		return data, nil
 	case <-p.writerDone:
-		return nil, pgwirebase.NewProtocolViolationErrorf("client didn't send required auth data")
+		return nil, pgwirebase.NewProtocolViolationErrorf(writerDoneError)
 	}
 }
 

--- a/pkg/sql/pgwire/authpipe_test.go
+++ b/pkg/sql/pgwire/authpipe_test.go
@@ -1,0 +1,52 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pgwire
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func createAuthPipe() *authPipe {
+	return newAuthPipe(
+		nil,   /* c */
+		false, /* logAuthn */
+		authOptions{
+			connType: hba.ConnLocal,
+		},
+		username.SQLUsername{},
+	)
+}
+
+func TestNoMorePwdDataIdempotent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ap := createAuthPipe()
+	ap.noMorePwdData()
+	ap.noMorePwdData()
+}
+
+func TestGetPwdDataAfterNoMorePwdData(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ap := createAuthPipe()
+	ap.noMorePwdData()
+	// GetPwdData should not hang waiting for p.writerDone to close.
+	_, err := ap.GetPwdData()
+	require.ErrorContains(t, err, writerDoneError)
+}


### PR DESCRIPTION
Backport 1/1 commits from #104167.

/cc @cockroachdb/release

---

Fixes #103108

Previously `authPipe.noMorePwdData()` would set the `authPipe.writerDone` chan to nil after closing it. This means that `case <-authPipe.writerDone` will never be selected if the select is entered after `authPipe.writerDone` is nil.

For SCRAM authentication, `authPipe.GetPwdData()` is called in a loop which can result in a race between `authPipe.writerDone = nil` and `case <-authPipe.writerDone`.

This race condition is fixed by not setting `authPipe.writerDone` to nil after closing it.

Release note (bug fix): Fixed a bug that could cause goroutines to hang during SCRAM authentication.

Release justification: Stuck connection bug fix.
