### PR TITLE
dev: error out when the user mistypes './dev lint short'

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=72
+DEV_VERSION=73
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -44,6 +44,15 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 	timeout := mustGetFlagDuration(cmd, timeoutFlag)
 	short := mustGetFlagBool(cmd, shortFlag)
 
+	// It's quite easy to _mistype_ "dev lint short" instead of "dev lint --short". In that case, 'short'
+	// is parsed as a package name, which results in skipping a number of linters. Since 'short' is not a valid
+	// package, we bail out.
+	for _, pkg := range pkgs {
+		if pkg == "short" {
+			return fmt.Errorf("invalid package name: %q; did you mean to type '--short'?", pkg)
+		}
+	}
+
 	var args []string
 	// NOTE the --config=test here. It's very important we compile the test binary with the
 	// appropriate stuff (gotags, etc.)


### PR DESCRIPTION
A very minor UX improvement which would have saved (this) user the surprise and time. A seemingly minor typo (omitting `--`) leads to skipping a number of linters. Consequently, a number of superficial (syntax) errors end up being caught in CI instead of local dev.

This change errors out when the user mistypes `./dev lint short`, and displays the correct option (i.e., `--short`). Since `short` is not a well-formed package, we bail out.

Epic: none

Release note: None