### PR TITLE
sql: Limit MODIFYSQLCLUSTERSETTING to only view sql.defaults

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -88,7 +88,7 @@ user testuser
 statement error only users with the MODIFYCLUSTERSETTING or MODIFYSQLCLUSTERSETTING privilege are allowed to set cluster setting 'sql.defaults.default_int_size'
 SET CLUSTER SETTING sql.defaults.default_int_size = 4
 
-# Users with MODIFYSQLCLUSTERSETTING system privilege should be able to see all cluster settings and modify only sql.defaults settings.
+# Users with MODIFYSQLCLUSTERSETTING system privilege should be able to see and modify only sql.defaults settings.
 user root
 
 skipif config local-mixed-22.2-23.1
@@ -102,6 +102,10 @@ statement ok
 SHOW CLUSTER SETTINGS
 
 skipif config local-mixed-22.2-23.1
+statement error pq: only users with MODIFYCLUSTERSETTING or VIEWCLUSTERSETTING privileges are allowed to show cluster setting 'diagnostics.reporting.enabled'
+SHOW CLUSTER SETTING diagnostics.reporting.enabled
+
+skipif config local-mixed-22.2-23.1
 statement ok
 SET CLUSTER SETTING sql.defaults.default_int_size = 4
 
@@ -109,10 +113,6 @@ statement error pq: only users with the MODIFYCLUSTERSETTING privilege are allow
 SET CLUSTER SETTING diagnostics.reporting.enabled = false
 
 user root
-
-skipif config local-mixed-22.2-23.1
-statement ok
-REVOKE SYSTEM MODIFYSQLCLUSTERSETTING FROM testuser
 
 statement ok
 ALTER USER testuser NOMODIFYCLUSTERSETTING
@@ -122,10 +122,23 @@ ALTER USER testuser VIEWCLUSTERSETTING
 
 user testuser
 
-# Users with VIEWCLUSTERSETTING should be able to see non sql.defaults settings but not modify.
+# Users with VIEWCLUSTERSETTING should be able to see non sql.defaults settings but not modify regardless if they have sql modify.
 
 statement error pq: only users with the MODIFYCLUSTERSETTING privilege are allowed to set cluster setting 'diagnostics.reporting.enabled'
 SET CLUSTER SETTING diagnostics.reporting.enabled = false
+
+query B
+SHOW CLUSTER SETTING diagnostics.reporting.enabled
+----
+true
+
+user root 
+
+skipif config local-mixed-22.2-23.1
+statement ok
+REVOKE SYSTEM MODIFYSQLCLUSTERSETTING FROM testuser
+
+user testuser
 
 query B
 SHOW CLUSTER SETTING diagnostics.reporting.enabled

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1244,7 +1244,8 @@ SELECT crdb_internal.unsafe_clear_gossip_info('unknown key')
 ----
 false
 
-# Verify users with VIEWCLUSTERSETTING, MODIFYCLUSTERSETTING or MODIFYSQLCLUSTERSETTING can view non sql.defaults cluster settings.
+# Verify users with VIEWCLUSTERSETTING or MODIFYCLUSTERSETTING can view non sql.defaults cluster settings.
+# Verify users with MODIFYSQLCLUSTERSETTING can only view sql.defaults cluster settings.
 
 user root
 
@@ -1258,10 +1259,30 @@ SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('diagnostics
 ----
 true
 
+# Verify a combination of system privileges where one is restrictive will still allow users to see non sql.defaults.
+
+user root
+
+skipif config local-mixed-22.2-23.1
+statement ok
+GRANT SYSTEM MODIFYSQLCLUSTERSETTING TO testuser
+
+user testuser
+
+skipif config local-mixed-22.2-23.1
+query T
+SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('diagnostics.reporting.enabled')
+----
+true
+
 user root
 
 statement ok
 REVOKE SYSTEM VIEWCLUSTERSETTING FROM testuser
+
+skipif config local-mixed-22.2-23.1
+statement ok
+REVOKE SYSTEM MODIFYSQLCLUSTERSETTING FROM testuser
 
 statement ok
 GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser
@@ -1323,9 +1344,15 @@ user testuser
 
 skipif config local-mixed-22.2-23.1
 query T
-SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('diagnostics.reporting.enabled')
+SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('sql.defaults.zigzag_join.enabled')
 ----
 true
+
+skipif config local-mixed-22.2-23.1
+query T
+SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('diagnostics.reporting.enabled')
+----
+
 
 user root
 


### PR DESCRIPTION
This change prevents users with MODIFYSQLCLUSTERSETTING FROM viewing non sql.defaults cluster settings.

Fixes: #104156

Release note (sql change): user with MODIFYSQLCLUSTERSETTING will no longer be able to view non sql.defaults cluster settings.