### PR TITLE
kv: rename `Transaction.Refresh` to `Transaction.BumpReadTimestamp`, add testing

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -299,7 +299,7 @@ func (sr *txnSpanRefresher) maybeRefreshAndRetrySend(
 	}
 	refreshFrom := txn.ReadTimestamp
 	refreshToTxn := txn.Clone()
-	refreshToTxn.Refresh(refreshTS)
+	refreshToTxn.BumpReadTimestamp(refreshTS)
 	switch refreshToTxn.Status {
 	case roachpb.PENDING:
 	case roachpb.STAGING:
@@ -502,7 +502,7 @@ func (sr *txnSpanRefresher) maybeRefreshPreemptively(
 
 	refreshFrom := ba.Txn.ReadTimestamp
 	refreshToTxn := ba.Txn.Clone()
-	refreshToTxn.Refresh(ba.Txn.WriteTimestamp)
+	refreshToTxn.BumpReadTimestamp(ba.Txn.WriteTimestamp)
 	log.VEventf(ctx, 2, "preemptively refreshing to timestamp %s before issuing %s",
 		refreshToTxn.ReadTimestamp, ba)
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
@@ -1215,7 +1215,7 @@ func TestTxnSpanRefresherAssignsCanForwardReadTimestamp(t *testing.T) {
 
 		br := ba.CreateReply()
 		br.Txn = ba.Txn.Clone()
-		br.Txn.Refresh(refreshTS1) // server-side refresh
+		br.Txn.BumpReadTimestamp(refreshTS1) // server-side refresh
 		return br, nil
 	})
 
@@ -1273,7 +1273,7 @@ func TestTxnSpanRefresherAssignsCanForwardReadTimestamp(t *testing.T) {
 
 		br = ba.CreateReply()
 		br.Txn = ba.Txn.Clone()
-		br.Txn.Refresh(refreshTS2) // server-side refresh
+		br.Txn.BumpReadTimestamp(refreshTS2) // server-side refresh
 		return br, nil
 	})
 
@@ -1348,7 +1348,7 @@ func TestTxnSpanRefresherAssignsCanForwardReadTimestamp(t *testing.T) {
 
 		// Return an error that contains a server-side refreshed transaction.
 		txn := ba.Txn.Clone()
-		txn.Refresh(refreshTS3) // server-side refresh
+		txn.BumpReadTimestamp(refreshTS3) // server-side refresh
 		pErr := kvpb.NewErrorWithTxn(&kvpb.ConditionFailedError{}, txn)
 		return nil, pErr
 	})

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -99,8 +99,8 @@ const (
 	// allow RollbackToSavepoint() to be called after such errors. In particular,
 	// this is useful for SQL which wants to allow rolling back to a savepoint
 	// after ConditionFailedErrors (uniqueness violations) and WriteIntentError
-	// (lock not available errors). With continuing after errors its important for
-	// the coordinator to track the timestamp at which intents might have been
+	// (lock not available errors). With continuing after errors it's important
+	// for the coordinator to track the timestamp at which intents might have been
 	// written.
 	//
 	// Note that all the lower scores also are unambiguous in this sense, so this

--- a/pkg/kv/kvserver/replica_batch_updates.go
+++ b/pkg/kv/kvserver/replica_batch_updates.go
@@ -240,7 +240,7 @@ func tryBumpBatchTimestamp(
 	log.VEventf(ctx, 2, "bumping batch timestamp to: %s from read: %s, write: %s",
 		ts, ba.Txn.ReadTimestamp, ba.Txn.WriteTimestamp)
 	ba.Txn = ba.Txn.Clone()
-	ba.Txn.Refresh(ts)
+	ba.Txn.BumpReadTimestamp(ts)
 	ba.Timestamp = ba.Txn.ReadTimestamp // Refresh just updated ReadTimestamp
 	return true
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8616,7 +8616,7 @@ func TestRefreshFromBelowGCThreshold(t *testing.T) {
 			}
 		}
 		txn := roachpb.MakeTransaction("test", keyA, 0, 0, ts2, 0, 0)
-		txn.Refresh(ts4)
+		txn.BumpReadTimestamp(ts4)
 
 		for _, testCase := range []struct {
 			gc     hlc.Timestamp

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -2867,7 +2867,7 @@ func TestMVCCMultiplePutOldTimestamp(t *testing.T) {
 
 	// Put again after advancing the txn's timestamp to the WriteTooOld error's
 	// timestamp and verify no WriteTooOldError.
-	txn.Refresh(wtoErr.ActualTimestamp)
+	txn.BumpReadTimestamp(wtoErr.ActualTimestamp)
 	txn.Sequence++
 	err = MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn)
 	require.NoError(t, err)


### PR DESCRIPTION
This commit renames the `Transaction.Refresh` method to `Transaction.BumpReadTimestamp`. It also adds commentary to the function, adds a unit test, and stops having the function assume that the provided timestamp is >= the transaction's write timestamp.

Epic: None
Release note: None