### PR TITLE
release-23.1: c2c: reset ingestion job retry counter if retained timestamp advanced

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/util/contextutil",
         "//pkg/util/hlc",
         "//pkg/util/protoutil",
+        "//pkg/util/retry",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
@@ -8,10 +8,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/streamingccl/streamclient",
+        "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/kv/kvpb",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",
+        "//pkg/sql/isql",
         "//pkg/storage",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -112,6 +112,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -1764,6 +1765,8 @@ type StreamingTestingKnobs struct {
 	// CutoverProgressShouldUpdate overrides the standard logic
 	// for whether the job record is updated on a progress update.
 	CutoverProgressShouldUpdate func() bool
+
+	DistSQLRetryPolicy *retry.Options
 }
 
 var _ base.ModuleTestingKnobs = &StreamingTestingKnobs{}


### PR DESCRIPTION
Previously, the replication stream would pause after 60 retryable errors bubbled up to the job coordinator. This patch changes the policy such that:
1. the coordinator resets the retry counter if the replicated timestamp advanced between two retryable errors.
2. the max number of retries without replicated timestamp progress is now 20.

Epic: None

Release note: None

Release justification: c2c only change