### PR TITLE
dev: replace `stress` with `--runs_per_test`

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=82
+DEV_VERSION=83
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -62,7 +62,7 @@ type formatter func(context.Context, failure) (issues.IssueFormatter, issues.Pos
 
 func defaultFormatter(ctx context.Context, f failure) (issues.IssueFormatter, issues.PostRequest) {
 	teams := getOwner(ctx, f.packageName, f.testName)
-	repro := fmt.Sprintf("./dev test ./pkg/%s --race --count 250 -f %s",
+	repro := fmt.Sprintf("./dev test ./pkg/%s --race --stress -f %s",
 		trimPkg(f.packageName), f.testName)
 
 	var projColID int

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -163,7 +163,7 @@ func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, goTestArgs...)
 	}
 	args = append(args, d.getGoTestEnvArgs()...)
-	args = append(args, d.getTestOutputArgs(false /* stress */, verbose, showLogs, streamOutput)...)
+	args = append(args, d.getTestOutputArgs(verbose, showLogs, streamOutput)...)
 	args = append(args, additionalBazelArgs...)
 	logCommand("bazel", args...)
 	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -108,7 +108,6 @@ var buildTargetMapping = map[string]string{
 	"smithcmp":             "//pkg/cmd/smithcmp:smithcmp",
 	"smithtest":            "//pkg/cmd/smithtest:smithtest",
 	"staticcheck":          "@co_honnef_go_tools//cmd/staticcheck:staticcheck",
-	"stress":               stressTarget,
 	"swagger":              "@com_github_go_swagger_go_swagger//cmd/swagger:swagger",
 	"tests":                "//pkg:all_tests",
 	"workload":             "//pkg/cmd/workload:workload",

--- a/pkg/cmd/dev/roachprod_stress.go
+++ b/pkg/cmd/dev/roachprod_stress.go
@@ -21,7 +21,9 @@ import (
 )
 
 const (
-	clusterFlag = "cluster"
+	clusterFlag    = "cluster"
+	stressArgsFlag = "stress-args"
+	stressTarget   = "@com_github_cockroachdb_stress//:stress"
 )
 
 func makeRoachprodStressCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -65,16 +65,6 @@ rm crdb-checkout/cockroach
 cp sandbox/pkg/cmd/cockroach/cockroach_/cockroach crdb-checkout/cockroach
 
 exec
-dev build stress
-----
-bazel build @com_github_cockroachdb_stress//:stress --//build/toolchains:nogo_disable_flag --build_event_binary_file=/tmp/path
-bazel info workspace --color=no
-mkdir crdb-checkout/bin
-bazel info bazel-bin --color=no
-rm crdb-checkout/bin/stress
-cp sandbox/external/com_github_cockroachdb_stress/stress_/stress crdb-checkout/bin/stress
-
-exec
 dev build tests
 ----
 bazel build //pkg:all_tests --config=test --build_event_binary_file=/tmp/path

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -150,3 +150,15 @@ exec
 dev test pkg/spanconfig/spanconfigstore --timeout=40s -- --test_arg '-test.timeout=0.5s'
 ----
 bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_timeout=45 --test_arg -test.timeout=40s --test_output errors --test_arg -test.timeout=0.5s --build_event_binary_file=/tmp/path
+
+exec
+dev test pkg/spanconfig/spanconfigstore --stress
+----
+getenv DEV_I_UNDERSTAND_ABOUT_STRESS
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=1000 --test_output errors --build_event_binary_file=/tmp/path
+
+exec
+dev test pkg/spanconfig/spanconfigstore --stress --count 250
+----
+getenv DEV_I_UNDERSTAND_ABOUT_STRESS
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=250 --test_output errors --build_event_binary_file=/tmp/path

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -44,7 +44,8 @@ dev testlogic base --files=auto_span_config_reconciliation --stress
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --test_env=COCKROACH_STRESS=true --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed
+getenv DEV_I_UNDERSTAND_ABOUT_STRESS
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m --cpus 8
@@ -52,7 +53,8 @@ dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=120 --test_env=COCKROACH_STRESS=true --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=1m0s -p=8' --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed
+getenv DEV_I_UNDERSTAND_ABOUT_STRESS
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_timeout=65 --test_arg -test.timeout=1m0s --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
@@ -60,7 +62,8 @@ dev testlogic base --files=auto_span_config_reconciliation --stress --stream-out
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --test_env=COCKROACH_STRESS=true --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed
+getenv DEV_I_UNDERSTAND_ABOUT_STRESS
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
@@ -68,7 +71,8 @@ dev testlogic base --files=auto_span_config_reconciliation --stress --stream-out
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --test_env=COCKROACH_STRESS=true --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed
+getenv DEV_I_UNDERSTAND_ABOUT_STRESS
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
@@ -76,4 +80,5 @@ dev testlogic base --files=auto_span_config_reconciliation --stress --stream-out
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --test_env=COCKROACH_STRESS=true --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed
+getenv DEV_I_UNDERSTAND_ABOUT_STRESS
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -60,7 +60,6 @@ func makeTestLogicCmd(runE func(cmd *cobra.Command, args []string) error) *cobra
 	testLogicCmd.Flags().Bool(noGenFlag, false, "skip generating logic test files before running logic tests")
 	testLogicCmd.Flags().Bool(streamOutputFlag, false, "stream test output during run")
 	testLogicCmd.Flags().Bool(stressFlag, false, "run tests under stress")
-	testLogicCmd.Flags().String(stressArgsFlag, "", "additional arguments to pass to stress")
 	testLogicCmd.Flags().String(testArgsFlag, "", "additional arguments to pass to go test binary")
 	testLogicCmd.Flags().Bool(showDiffFlag, false, "generate a diff for expectation mismatches when possible")
 	testLogicCmd.Flags().Bool(flexTypesFlag, false, "tolerate when a result column is produced with a different numeric type")
@@ -89,7 +88,6 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 		showSQL        = mustGetFlagBool(cmd, showSQLFlag)
 		count          = mustGetFlagInt(cmd, countFlag)
 		stress         = mustGetFlagBool(cmd, stressFlag)
-		stressCmdArgs  = mustGetFlagString(cmd, stressArgsFlag)
 		testArgs       = mustGetFlagString(cmd, testArgsFlag)
 		showDiff       = mustGetFlagBool(cmd, showDiffFlag)
 		flexTypes      = mustGetFlagBool(cmd, flexTypesFlag)
@@ -220,9 +218,6 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	if bigtest {
 		args = append(args, "--test_arg", "-bigtest")
 	}
-	if count != 1 {
-		args = append(args, "--test_arg", fmt.Sprintf("-test.count=%d", count))
-	}
 	if len(files) > 0 {
 		args = append(args, "--test_arg", "-show-sql")
 	}
@@ -248,9 +243,7 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	if showDiff {
 		args = append(args, "--test_arg", "-show-diff")
 	}
-	if timeout > 0 && !stress {
-		// If stress is specified, we'll pad the timeout differently below.
-
+	if timeout > 0 {
 		// The bazel timeout should be higher than the timeout passed to the
 		// test binary (giving it ample time to clean up, 5 seconds is probably
 		// enough).
@@ -261,10 +254,20 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 		// -- --test_arg '-test.timeout=X', that'll take precedence further
 		// below.
 	}
-
 	if stress {
-		args = append(args, "--test_sharding_strategy=disabled")
-		args = append(args, d.getStressArgs(stressCmdArgs, timeout)...)
+		if count == 1 {
+			// Default to 500 unless a different count was provided.
+			// NB: Logic tests are generally big. We use 500 instead
+			// of 1000 (the default for `dev test`).
+			count = 500
+		}
+		args = append(args,
+			"--test_env=COCKROACH_STRESS=true",
+			"--notest_keep_going",
+		)
+	}
+	if count != 1 {
+		args = append(args, fmt.Sprintf("--runs_per_test=%d", count))
 	}
 	if testArgs != "" {
 		goTestArgs, err := d.getGoTestArgs(ctx, testArgs)
@@ -279,9 +282,12 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, "--test_filter", filesRegexp+"/"+subtests)
 		args = append(args, "--test_sharding_strategy=disabled")
 	}
-	args = append(args, d.getTestOutputArgs(stress, verbose, showLogs, streamOutput)...)
+	args = append(args, d.getTestOutputArgs(verbose, showLogs, streamOutput)...)
 	args = append(args, additionalBazelArgs...)
 	logCommand("bazel", args...)
+	if stress {
+		d.warnAboutChangeInStressBehavior(timeout)
+	}
 	if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...); err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -549,7 +549,6 @@ Replaces 'make ui-lint'.`,
 			}
 
 			bazelTestArgs := d.getTestOutputArgs(
-				false, /* stream */
 				isVerbose,
 				false, /* showLogs */
 				false, /* streamOutput */
@@ -806,7 +805,6 @@ Replaces 'make ui-test' and 'make ui-test-watch'.`,
 				}
 			} else {
 				testOutputArg := d.getTestOutputArgs(
-					false, // stress
 					isVerbose,
 					false,                     // showLogs
 					isWatch || isStreamOutput, // streamOutput

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -130,14 +130,6 @@ func (d *dev) getExecutionRoot(ctx context.Context) (string, error) {
 	return d.getBazelInfo(ctx, "execution_root", []string{})
 }
 
-// getDevBin returns the path to the running dev executable.
-func (d *dev) getDevBin() string {
-	if d.knobs.devBinOverride != "" {
-		return d.knobs.devBinOverride
-	}
-	return os.Args[0]
-}
-
 // getArchivedCdepString returns a non-empty string iff the force_build_cdeps
 // config is not being used. This string is the name of the cross config used to
 // build the pre-built c-deps, minus the "cross" prefix. This can be used to
@@ -246,4 +238,14 @@ func sendBepDataToBeaverHubIfNeeded(bepFilepath string) error {
 	}
 	_ = os.Remove(bepFilepath)
 	return nil
+}
+
+func (d *dev) warnAboutChangeInStressBehavior(timeout time.Duration) {
+	if e := d.os.Getenv("DEV_I_UNDERSTAND_ABOUT_STRESS"); e == "" {
+		log.Printf("NOTE: The behavior of `dev test --stress` has changed. The new default behavior is to run the test 1,000 times in parallel (500 for logictests), stopping if any of the tests fail. The number of runs can be tweaked with the `--count` parameter to `dev`.")
+		if timeout > 0 {
+			log.Printf("WARNING: The behavior of --timeout under --stress has changed. --timeout controls the timeout of the test, not the entire `stress` invocation.")
+		}
+		log.Printf("Set DEV_I_UNDERSTAND_ABOUT_STRESS=1 to squelch this message")
+	}
 }


### PR DESCRIPTION
`--runs_per_test` does the same thing that `stress` does (runs a test
many times to weed out flakes), but better, in that:

1. Better Bazel support -- we had to hack Bazel support into `stress`
   to keep it working
2. Bazel gives us statistics and control over how the tests are
   scheduled in a way that is standardized as opposed to the ad-hoc
   arguments one can pass to `stress`
3. Bazel can collect logs and artifacts for different test runs and
   expose them to the user in a way that `stress` cannot
4. Drop-in support for remote execution when we have access to it,
   obviating the need for `roachprod-stress`

For now, the default implementation of `dev test --stress` is to
run the test 1,000 times, stopping the build if any test fails.
This is meant to replicate how people use `stress` (i.e., just start it
running and stop if there are any failures). The 1,000 figure is
arbitrary and meant to just be a "very high number" of times to run unit
tests. The default figure of 1,000 can be adjusted with `--count`. Also
update documentation with some new recipes and add extra logging to
warn about the change in behavior.

Closes https://github.com/cockroachdb/cockroach/issues/102879

Epic: none
Release note: None