### PR TITLE
release-22.2: sql: prevent MODIFYCLUSTERSETTING from viewing non sql.defaults settings when sql.full_modify_cluster_setting.enabled is false

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -78,7 +78,7 @@ WHERE variable IN ('sql.defaults.default_int_size')
 ----
 sql.defaults.default_int_size  4
 
-# Users with MODIFYCLUSTERSETTING cannot set non sql.default settings if sql.full_modify_cluster_setting.enabled is false.
+# Users with MODIFYCLUSTERSETTING cannot view or set non sql.default settings if sql.full_modify_cluster_setting.enabled is false.
 
 user root
 
@@ -90,7 +90,23 @@ user testuser
 statement error pq: users with the MODIFYCLUSTERSETTING privilege need the cluster setting sql.auth.modify_cluster_setting_applies_to_all.enabled to be set to true to set cluster setting 'diagnostics.reporting.enabled'
 SET CLUSTER SETTING diagnostics.reporting.enabled = false
 
+statement error pq: users with the MODIFYCLUSTERSETTING privilege need the cluster setting sql.auth.modify_cluster_setting_applies_to_all.enabled to be set to true to show cluster setting 'diagnostics.reporting.enabled'
+SHOW CLUSTER SETTING diagnostics.reporting.enabled
+
 user root
+
+statement ok
+GRANT SYSTEM VIEWCLUSTERSETTING TO testuser
+
+user testuser
+
+statement ok
+SHOW CLUSTER SETTING diagnostics.reporting.enabled
+
+user root
+
+statement ok
+REVOKE SYSTEM VIEWCLUSTERSETTING FROM testuser
 
 statement ok
 SET CLUSTER SETTING sql.auth.modify_cluster_setting_applies_to_all.enabled = true

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1215,7 +1215,7 @@ SELECT crdb_internal.unsafe_clear_gossip_info('unknown key')
 ----
 false
 
-# Verify users with VIEWCLUSTERSETTING or MODIFYCLUSTERSETTING can view non sql.defaults cluster settings.
+# Verify users with VIEWCLUSTERSETTING can view non sql.defaults cluster settings.
 
 user root
 
@@ -1237,6 +1237,30 @@ REVOKE SYSTEM VIEWCLUSTERSETTING FROM testuser
 statement ok
 GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser
 
+# Verify users with MODIFYCLUSTERSETTING can view non sql.defaults cluster setting only if sql.full_modify_cluster_setting.enabled is true.
+user testuser
+
+query T
+SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('diagnostics.reporting.enabled')
+----
+true
+
+user root
+
+statement ok
+SET CLUSTER SETTING sql.auth.modify_cluster_setting_applies_to_all.enabled = false
+
+user testuser
+
+query T
+SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('diagnostics.reporting.enabled')
+----
+
+user root
+
+statement ok
+GRANT SYSTEM VIEWCLUSTERSETTING TO testuser
+
 user testuser
 
 query T
@@ -1248,6 +1272,9 @@ user root
 
 statement ok
 REVOKE SYSTEM MODIFYCLUSTERSETTING FROM testuser
+
+statement ok
+REVOKE SYSTEM VIEWCLUSTERSETTING FROM testuser
 
 query TT
 SELECT crdb_internal.humanize_bytes(NULL), crdb_internal.humanize_bytes(102400)

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -79,7 +79,6 @@ func checkPrivilegesForSetting(ctx context.Context, p *planner, name string, act
 	if p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.SystemPrivilegesTable) {
 		if err := p.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING); err == nil {
 			hasModify = true
-			hasView = true
 		} else if pgerror.GetPGCode(err) != pgcode.InsufficientPrivilege {
 			return err
 		}
@@ -99,26 +98,6 @@ func checkPrivilegesForSetting(ctx context.Context, p *planner, name string, act
 			return err
 		}
 		hasModify = hasModify || ok
-		hasView = hasView || ok
-	}
-
-	// The "set" action requires MODIFYCLUSTERSETTING.
-	if action == "set" {
-		isSqlSetting := strings.HasPrefix(name, "sql.defaults")
-		modifyClusterSettingAll := modifyClusterSettingAppliesToAll.Get(&p.ExecCfg().Settings.SV)
-		isAdmin, err := p.HasAdminRole(ctx)
-		if err != nil {
-			return err
-		}
-		if !hasModify {
-			return pgerror.Newf(pgcode.InsufficientPrivilege,
-				"only users with the %s privilege are allowed to %s cluster setting '%s'",
-				privilege.MODIFYCLUSTERSETTING, action, name)
-		} else if !isAdmin && !modifyClusterSettingAll && !isSqlSetting {
-			return pgerror.Newf(pgcode.InsufficientPrivilege,
-				"users with the %s privilege need the cluster setting %s to be set to true to %s cluster setting '%s'",
-				privilege.MODIFYCLUSTERSETTING, modifyClusterSettingAppliesToAll.Key(), action, name)
-		}
 	}
 
 	if !hasView {
@@ -129,11 +108,45 @@ func checkPrivilegesForSetting(ctx context.Context, p *planner, name string, act
 		hasView = hasView || ok
 	}
 
-	// The "show" action requires either either MODIFYCLUSTERSETTING or VIEWCLUSTERSETTING privileges.
-	if action == "show" && !hasView {
-		return pgerror.Newf(pgcode.InsufficientPrivilege,
-			"only users with either %s or %s privileges are allowed to %s cluster setting '%s'",
-			privilege.MODIFYCLUSTERSETTING, privilege.VIEWCLUSTERSETTING, action, name)
+	modifyClusterSettingAll := modifyClusterSettingAppliesToAll.Get(&p.ExecCfg().Settings.SV)
+	isSqlSetting := strings.HasPrefix(name, "sql.defaults")
+	// If the user has admin or unrestricted modify we can early return.
+	isAdmin, err := p.HasAdminRole(ctx)
+	if err != nil {
+		return err
+	}
+	if isAdmin {
+		return nil
+	}
+	if hasModify && modifyClusterSettingAll {
+		return nil
+	}
+	// At this point for the set action, we will return an error if user doesn't have modify
+	// or has restricted modify and it's a non sql.default setting,
+	if action == "set" {
+		if !hasModify {
+			return pgerror.Newf(pgcode.InsufficientPrivilege,
+				"only users with the %s privilege are allowed to %s cluster setting '%s'",
+				privilege.MODIFYCLUSTERSETTING, action, name)
+		} else if !modifyClusterSettingAll && !isSqlSetting {
+			return pgerror.Newf(pgcode.InsufficientPrivilege,
+				"users with the %s privilege need the cluster setting %s to be set to true to %s cluster setting '%s'",
+				privilege.MODIFYCLUSTERSETTING, modifyClusterSettingAppliesToAll.Key(), action, name)
+		}
+	}
+
+	// At this point, for the show action we will return an error if the user doesn't have view or
+	// has view but also has restricted modify and it's a non sql.defaults setting.
+	if action == "show" {
+		if !hasView && !hasModify {
+			return pgerror.Newf(pgcode.InsufficientPrivilege,
+				"only users with either %s or %s privileges are allowed to %s cluster setting '%s'",
+				privilege.MODIFYCLUSTERSETTING, privilege.VIEWCLUSTERSETTING, action, name)
+		} else if hasModify && !hasView && !modifyClusterSettingAll && !isSqlSetting {
+			return pgerror.Newf(pgcode.InsufficientPrivilege,
+				"users with the %s privilege need the cluster setting %s to be set to true to %s cluster setting '%s'",
+				privilege.MODIFYCLUSTERSETTING, modifyClusterSettingAppliesToAll.Key(), action, name)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This change prevents users with MODIFYCLUSTERSETTING from viewing non sql,defaults settings when sql.full_modify_cluster_setting.enabled is false.

https://github.com/cockroachdb/cockroach/pull/104224 is not backportable to this branch, so this PR implements the same functional behavior.


Fixes: #104156

Release justification: high priority request
Release note (sql change): users with MODIFYCLUSTERSETTING will no longer be able to view non sql.defaults settings if sql.full_modify_cluster_setting.enabled is set to false.