### PR TITLE
sql: mark when udfs contain mutations

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_update
+++ b/pkg/sql/logictest/testdata/logic_test/udf_update
@@ -188,3 +188,24 @@ SELECT * FROM generated_as_id_t ORDER BY a;
 7  4  2
 8  5  2
 9  6  2
+
+
+subtest repro_103693
+
+statement ok
+CREATE TABLE t1_103693(k1 PRIMARY KEY) AS SELECT 1::INT;
+CREATE TABLE t2_103693(k2 PRIMARY KEY, v2) AS SELECT 1::INT, 0::INT;
+
+statement ok
+CREATE FUNCTION f_103693(k INT, v INT) RETURNS INT AS
+$$
+  UPDATE t2_103693 SET v2 = v + 1 WHERE k2 = k2 RETURNING v2;
+$$ LANGUAGE SQL;
+
+statement ok
+SET streamer_enabled = true
+
+query I
+SELECT f_103693(k2, v2) FROM t1_103693 INNER LOOKUP JOIN t2_103693 ON k1 = k2;
+----
+1

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -936,6 +936,13 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		}
 	}
 
+	for _, s := range udf.Body {
+		if s.Relational().CanMutate {
+			b.ContainsMutation = true
+			break
+		}
+	}
+
 	// Create a tree.RoutinePlanFn that can plan the statements in the UDF body.
 	// TODO(mgartner): Add support for WITH expressions inside UDF bodies.
 	planGen := b.buildRoutinePlanGenerator(


### PR DESCRIPTION
Exec builder has a field `ContainsMutation` that helps the planner decide whether it can use a `LeafTxn` or needs to use a `RootTxn`. We now set this field when building UDFs if the UDF body contains a mutation, so that the planner will use a `RootTxn` correctly.

This bug is only present on the main branch since mutations were enabled in UDFs.

Epic: None
Fixes: #103693

Release note: None