### PR TITLE
pgwire: add gauge for connections throttled by semaphore

### DIFF
--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -400,6 +400,8 @@ type AuthConn interface {
 	LogAuthFailed(ctx context.Context, reason eventpb.AuthFailReason, err error)
 	// LogAuthOK logs when the authentication handshake has completed.
 	LogAuthOK(ctx context.Context)
+	// GetTenantSpecificMetrics returns the tenant-specific metrics for the connection.
+	GetTenantSpecificMetrics() *tenantSpecificMetrics
 }
 
 // authPipe is the implementation for the authenticator and AuthConn interfaces.
@@ -555,4 +557,9 @@ func (p *authPipe) SendAuthRequest(authType int32, data []byte) error {
 	c.msgBuilder.putInt32(authType)
 	c.msgBuilder.write(data)
 	return c.msgBuilder.finishMsg(c.conn)
+}
+
+// GetTenantSpecificMetrics is part of the AuthConn interface.
+func (p *authPipe) GetTenantSpecificMetrics() *tenantSpecificMetrics {
+	return p.c.metrics
 }

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -190,9 +190,10 @@ func passwordAuthenticator(
 		// in auth.go (and report CREDENTIALS_INVALID).
 	}
 
+	metrics := c.GetTenantSpecificMetrics()
 	// Now check the cleartext password against the retrieved credentials.
 	if err := security.UserAuthPasswordHook(
-		false /*insecure*/, passwordStr, hashedPassword,
+		false, passwordStr, hashedPassword, metrics.ConnsWaitingToHash,
 	)(ctx, systemIdentity, clientConnection); err != nil {
 		if errors.HasType(err, &security.PasswordUserAuthError{}) {
 			c.LogAuthFailed(ctx, eventpb.AuthFailReason_CREDENTIALS_INVALID, err)

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -146,6 +146,12 @@ var (
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}
+	MetaConnsWaitingToHash = metric.Metadata{
+		Name:        "sql.conns_waiting_to_hash",
+		Help:        "Number of SQL connection attempts that are being throttled in order to limit password hashing concurrency",
+		Measurement: "Connections",
+		Unit:        metric.Unit_COUNT,
+	}
 	MetaBytesIn = metric.Metadata{
 		Name:        "sql.bytesin",
 		Help:        "Number of SQL bytes received",
@@ -284,6 +290,7 @@ type tenantSpecificMetrics struct {
 	BytesOutCount               *metric.Counter
 	Conns                       *metric.Gauge
 	NewConns                    *metric.Counter
+	ConnsWaitingToHash          *metric.Gauge
 	ConnLatency                 metric.IHistogram
 	ConnFailures                *metric.Counter
 	PGWireCancelTotalCount      *metric.Counter
@@ -297,10 +304,11 @@ func makeTenantSpecificMetrics(
 	sqlMemMetrics sql.MemoryMetrics, histogramWindow time.Duration,
 ) tenantSpecificMetrics {
 	return tenantSpecificMetrics{
-		BytesInCount:  metric.NewCounter(MetaBytesIn),
-		BytesOutCount: metric.NewCounter(MetaBytesOut),
-		Conns:         metric.NewGauge(MetaConns),
-		NewConns:      metric.NewCounter(MetaNewConns),
+		BytesInCount:       metric.NewCounter(MetaBytesIn),
+		BytesOutCount:      metric.NewCounter(MetaBytesOut),
+		Conns:              metric.NewGauge(MetaConns),
+		NewConns:           metric.NewCounter(MetaNewConns),
+		ConnsWaitingToHash: metric.NewGauge(MetaConnsWaitingToHash),
 		ConnLatency: metric.NewHistogram(metric.HistogramOptions{
 			Mode:     metric.HistogramModePreferHdrLatency,
 			Metadata: MetaConnLatency,


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/82900

Release note (ops change): Added a gauge metric named sql.conns_waiting_to_hash. It counts the number of connection attempts that are being throttled in order to limit the amount of concurrent password hashing operations. The throttling behavior has been present since v21.2, and was added in order to prevent password hashing from using up too much CPU. The metric is the only new addition in this change.

The metric is expected to be 0 or close to 0 in a healthy setup. If the metric is consistently high and connection latencies are high, then an operator should do one or more of the following:

- Make sure applications using the cluster have properly configured connection pools.
- Add more vCPU or more nodes to the cluster.
- Increase the password hashing concurrency using the COCKROACH_MAX_PW_HASH_COMPUTE_CONCURRENCY environment variable.