### PR TITLE
c2c: use new in memory sst on range key batcher reset

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -618,10 +618,6 @@ func TestTenantStreamingDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// TODO(casper): disabled due to error when setting a cluster setting
-	// "setting updated but timed out waiting to read new value"
-	skip.UnderStressRace(t, "disabled under stress race")
-
 	ctx := context.Background()
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, replicationtestutils.DefaultTenantStreamingClustersArgs)
 	defer cleanup()

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -105,14 +105,6 @@ type rangeKeyBatcher struct {
 	db       *kv.DB
 	settings *cluster.Settings
 
-	// Functor that creates a new range key SST writer in case
-	// we need to operate on a new batch. The created SST writer
-	// operates on the rangeKeySSTFile below.
-	// TODO(casper): replace this if SSTBatcher someday has support for
-	// adding MVCCRangeKeyValue
-	rangeKeySSTWriterMaker func() *storage.SSTWriter
-	// In-memory SST file for flushing MVCC range keys
-	rangeKeySSTFile *storage.MemObject
 	// curRangeKVBatch is the current batch of range KVs which will
 	// be ingested through 'flush' later.
 	curRangeKVBatch     mvccRangeKeyValues
@@ -133,16 +125,11 @@ func newRangeKeyBatcher(
 	ctx context.Context, cs *cluster.Settings, db *kv.DB, onFlush func(summary kvpb.BulkOpSummary),
 ) *rangeKeyBatcher {
 	batcher := &rangeKeyBatcher{
-		db:              db,
-		settings:        cs,
-		minTimestamp:    hlc.MaxTimestamp,
-		batchSummary:    kvpb.BulkOpSummary{},
-		rangeKeySSTFile: &storage.MemObject{},
-		onFlush:         onFlush,
-	}
-	batcher.rangeKeySSTWriterMaker = func() *storage.SSTWriter {
-		w := storage.MakeIngestionSSTWriter(ctx, batcher.settings, batcher.rangeKeySSTFile)
-		return &w
+		db:           db,
+		settings:     cs,
+		minTimestamp: hlc.MaxTimestamp,
+		batchSummary: kvpb.BulkOpSummary{},
+		onFlush:      onFlush,
 	}
 	return batcher
 }
@@ -833,7 +820,8 @@ func (r *rangeKeyBatcher) flush(ctx context.Context) error {
 
 	log.VInfof(ctx, 2, "flushing %d range keys", len(r.curRangeKVBatch))
 
-	sstWriter := r.rangeKeySSTWriterMaker()
+	sstFile := &storage.MemObject{}
+	sstWriter := storage.MakeIngestionSSTWriter(ctx, r.settings, sstFile)
 	defer sstWriter.Close()
 	// Sort current batch as the SST writer requires a sorted order.
 	sort.Slice(r.curRangeKVBatch, func(i, j int) bool {
@@ -864,7 +852,7 @@ func (r *rangeKeyBatcher) flush(ctx context.Context) error {
 	}
 
 	sstToFlush := &rangeKeySST{
-		data:  r.rangeKeySSTFile.Bytes(),
+		data:  sstFile.Bytes(),
 		start: start,
 		end:   end.Next(),
 	}
@@ -1078,7 +1066,6 @@ func (r *rangeKeyBatcher) reset() {
 	if len(r.curRangeKVBatch) == 0 {
 		return
 	}
-	r.rangeKeySSTFile.Reset()
 	r.minTimestamp = hlc.MaxTimestamp
 	r.batchSummary.Reset()
 	r.curRangeKVBatchSize = 0


### PR DESCRIPTION
Previously, the rangekey batcher would reuse the in-memory sst after flushing an sst to the kv layer. Unfortunately, this can cause a subsequent rangekey flush to corrupt the keys in the previous rangekey flush, as observed
 in #104203.

This patch fixes this bug by creating a new in memory sst every time we prepare to flush.

Fixes #104203

Release note: none