### PR TITLE
release-22.2: startup: retry pgerror.Code == RangeUnavailable

### DIFF
--- a/pkg/util/startup/BUILD.bazel
+++ b/pkg/util/startup/BUILD.bazel
@@ -8,6 +8,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/util",
         "//pkg/util/log",
         "//pkg/util/retry",

--- a/pkg/util/startup/retry.go
+++ b/pkg/util/startup/retry.go
@@ -60,6 +60,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -191,5 +193,8 @@ func inStartup() bool {
 
 // IsRetryableReplicaError returns true for replica availability errors.
 func IsRetryableReplicaError(err error) bool {
-	return errors.HasType(err, (*roachpb.ReplicaUnavailableError)(nil)) || errors.HasType(err, (*roachpb.AmbiguousResultError)(nil))
+	return errors.HasType(err, (*roachpb.ReplicaUnavailableError)(nil)) ||
+		errors.HasType(err, (*roachpb.AmbiguousResultError)(nil)) ||
+		// See https://github.com/cockroachdb/cockroach/issues/104016#issuecomment-1569719273.
+		pgerror.GetPGCode(err) == pgcode.RangeUnavailable
 }


### PR DESCRIPTION
Backport 1/1 commits from #104128.

/cc @cockroachdb/release

Release justification: bug fix.

---

Closes https://github.com/cockroachdb/cockroach/issues/104016.

Epic: None
Release note (bug fix): a bug was fixed due to which nodes could terminate with the following message:
    server startup failed: cockroach server exited with error:
    ‹migration-job-find-already-completed›: key range id:X is unavailable: ‹failed
    to send RPC: no replica node information available via gossip for rX›

