### PR TITLE
roachtest: loosen `failover/deadlock` assertions

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -1574,7 +1574,10 @@ func (f *deadlockFailer) Fail(ctx context.Context, nodeID int) {
 			f.t.Status(fmt.Sprintf("locked r%d on n%d", rangeID, nodeID))
 		}
 	}
-	require.Len(f.t, f.locks[nodeID], f.numReplicas, "couldn't lock requested number of replicas")
+	// Some nodes may have fewer ranges than the requested numReplicas locks, and
+	// replicas may also have moved in the meanwhile. Just assert that we were able
+	// to lock at least 1 replica.
+	require.NotEmpty(f.t, f.locks[nodeID], "didn't lock any replicas")
 }
 
 func (f *deadlockFailer) Recover(ctx context.Context, nodeID int) {


### PR DESCRIPTION
The `deadlock` failer asserted that it was able to lock the requested number of replicas. However, some nodes may have fewer ranges, typically during liveness leaseholder tests where the node only has the liveness range.

Loosen the assertion to only check that we were able to lock any replica.

Resolves #104249.
Resolves #104251.

Epic: none
Release note: None