### PR TITLE
reducesql: reduce UDFs and NULLS FIRST/LAST

### DIFF
--- a/pkg/cmd/reduce/reduce/reducesql/reducesql.go
+++ b/pkg/cmd/reduce/reduce/reducesql/reducesql.go
@@ -32,6 +32,7 @@ var SQLPasses = []reduce.Pass{
 	removeWithCTEs,
 	removeWith,
 	removeCreateDefs,
+	removeCreateFuncParams,
 	removeComputedColumn,
 	removeValuesCols,
 	removeWithSelectExprs,
@@ -755,6 +756,17 @@ var (
 			n := len(node.Defs)
 			if xfi < n {
 				node.Defs = append(node.Defs[:xfi], node.Defs[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	removeCreateFuncParams = walkSQL("remove CREATE FUNCTION parameters", func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.CreateFunction:
+			n := len(node.Params)
+			if xfi < n {
+				node.Params = append(node.Params[:xfi], node.Params[xfi+1:]...)
 			}
 			return n
 		}


### PR DESCRIPTION
#### reducesql: reduce params in CREATE FUNCTION

The `reduce` tool now attempts to remove parameters in
`CREATE FUNCTION` statements.

Release note: None

#### reducesql: walk UDF body statements

The `reduce` tool now traverses into statements inside the function body
of `CREATE FUNCTION` statements and reduces them.

Release note: None

#### reducesql: remove NULLS FIRST/LAST

The `reduce` tool now removes `NULLS FIRST` and `NULLS LAST` options in
`ORDER BY` clauses.

Epic: None

Release note: None
