### PR TITLE
sql: fix sql activity job from adding too many rows

### DIFF
--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -88,7 +88,7 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 	stopper := execCtx.ExecCfg().DistSQLSrv.Stopper
 	settings := execCtx.ExecCfg().Settings
 	statsFlush := execCtx.ExecCfg().InternalDB.server.sqlStats
-	metrics := execCtx.ExecCfg().JobRegistry.MetricsStruct().JobSpecificMetrics[jobspb.TypeAutoUpdateSQLActivity].(activityUpdaterMetrics)
+	metrics := execCtx.ExecCfg().JobRegistry.MetricsStruct().JobSpecificMetrics[jobspb.TypeAutoUpdateSQLActivity].(ActivityUpdaterMetrics)
 
 	flushDoneSignal := make(chan struct{})
 	defer func() {
@@ -116,14 +116,16 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 	}
 }
 
-type activityUpdaterMetrics struct {
+// ActivityUpdaterMetrics must be public for metrics to get
+// registered
+type ActivityUpdaterMetrics struct {
 	numErrors *metric.Counter
 }
 
-func (m activityUpdaterMetrics) MetricStruct() {}
+func (m ActivityUpdaterMetrics) MetricStruct() {}
 
 func newActivityUpdaterMetrics() metric.Struct {
-	return activityUpdaterMetrics{
+	return ActivityUpdaterMetrics{
 		numErrors: metric.NewCounter(metric.Metadata{
 			Name:        "jobs.metrics.task_failed",
 			Help:        "Number of metrics sql activity updater tasks that failed",
@@ -334,16 +336,38 @@ func (u *sqlActivityUpdater) transferTopStats(
 	totalStmtClusterExecCount int64,
 	totalTxnClusterExecCount int64,
 ) (retErr error) {
-	// Select the top 500 (controlled by sql.stats.activity.top.max) for
-	// each of execution_count, total execution time, service_latency,cpu_sql_nanos,
-	// contention_time, p99_latency and insert into transaction_activity table.
-	// Up to 3000 rows (sql.stats.activity.top.max * 6) may be added to
-	// transaction_activity.
-	_, err := u.db.Executor().ExecEx(ctx,
-		"activity-flush-txn-transfer-tops",
-		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
-		`
+
+	// Deleting and inserting the activity tables needs to be done in the same
+	// transaction. A user could try to access the table during the update. If
+	// delete was done in a separate txn the user would get no results.
+	errTxn := u.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+
+		// Delete all the rows of the old data from the table for the current
+		// aggregated timestamp. This is necessary because if a customer generates
+		// a lot of fingerprints each time the upsert runs it will add all new rows
+		// instead of updating the existing one. This causes the
+		// transaction_activity to grow too large causing the UI to be slow.
+		_, err := txn.ExecEx(ctx,
+			"activity-flush-txn-transfer-tops",
+			txn.KV(), /* txn */
+			sessiondata.NodeUserSessionDataOverride,
+			`DELETE FROM system.public.transaction_activity WHERE aggregated_ts = $1;`,
+			aggTs)
+
+		if err != nil {
+			return err
+		}
+
+		// Select the top 500 (controlled by sql.stats.activity.top.max) for
+		// each of execution_count, total execution time, service_latency,cpu_sql_nanos,
+		// contention_time, p99_latency and insert into transaction_activity table.
+		// Up to 3000 rows (sql.stats.activity.top.max * 6) may be added to
+		// transaction_activity.
+		_, err = txn.ExecEx(ctx,
+			"activity-flush-txn-transfer-tops",
+			txn.KV(), /* txn */
+			sessiondata.NodeUserSessionDataOverride,
+			`
 UPSERT
 INTO system.public.transaction_activity
 (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata,
@@ -410,25 +434,46 @@ INTO system.public.transaction_activity
                     ts.fingerprint_id,
                     ts.agg_interval));
 `,
-		totalStmtClusterExecCount,
-		aggTs,
-		topLimit,
-	)
+			totalStmtClusterExecCount,
+			aggTs,
+			topLimit,
+		)
 
-	if err != nil {
 		return err
+	})
+
+	if errTxn != nil {
+		return errTxn
 	}
 
-	// Select the top 500 (controlled by sql.stats.activity.top.max) for each of
-	// execution_count, total execution time, service_latency, cpu_sql_nanos,
-	// contention_time, p99_latency. Also include all statements that are in the
-	// top N transactions. This is needed so the statement information is
-	// available for the ui so a user can see what is in the transaction.
-	_, err = u.db.Executor().ExecEx(ctx,
-		"activity-flush-stmt-transfer-tops",
-		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
-		`
+	errTxn = u.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+
+		// Delete all the rows of the old data from the table for the current
+		// aggregated timestamp. This is necessary because if a customer generates
+		// a lot of fingerprints each time the upsert runs it will add all new rows
+		// instead of updating the existing one. This causes the
+		// transaction_activity to grow too large causing the UI to be slow.
+		_, err := txn.ExecEx(ctx,
+			"activity-flush-txn-transfer-tops",
+			txn.KV(), /* txn */
+			sessiondata.NodeUserSessionDataOverride,
+			`DELETE FROM system.public.statement_activity WHERE aggregated_ts = $1;`,
+			aggTs)
+
+		if err != nil {
+			return err
+		}
+
+		// Select the top 500 (controlled by sql.stats.activity.top.max) for each of
+		// execution_count, total execution time, service_latency, cpu_sql_nanos,
+		// contention_time, p99_latency. Also include all statements that are in the
+		// top N transactions. This is needed so the statement information is
+		// available for the ui so a user can see what is in the transaction.
+		_, err = txn.ExecEx(ctx,
+			"activity-flush-stmt-transfer-tops",
+			txn.KV(), /* txn */
+			sessiondata.NodeUserSessionDataOverride,
+			`
 UPSERT
 INTO system.public.statement_activity
 (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name,
@@ -507,15 +552,18 @@ INTO system.public.statement_activity
                     ss.plan,
                     ss.index_recommendations));
 `,
-		totalTxnClusterExecCount,
-		aggTs,
-		topLimit,
-	)
+			totalTxnClusterExecCount,
+			aggTs,
+			topLimit,
+		)
 
-	return err
+		return err
+	})
+
+	return errTxn
 }
 
-// getAosExecutionCount is used to get the row counts of both the
+// getAostExecutionCount is used to get the row counts of both the
 // system.statement_statistics and system.transaction_statistics.
 // It also gets the total execution count for the specified aggregated
 // timestamp.

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -202,36 +202,29 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 	defer db.Close()
 
-	// Verify all the tables are empty initially
-	var count int
-	row := db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.transaction_activity")
-	err := row.Scan(&count)
+	_, err := db.ExecContext(ctx, "INSERT INTO system.users VALUES ('node', NULL, true, 3)")
 	require.NoError(t, err)
-	require.Equal(t, 0, count, "transaction_activity: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.statement_activity")
-	err = row.Scan(&count)
+	_, err = db.ExecContext(ctx, "GRANT node TO root")
 	require.NoError(t, err)
-	require.Equal(t, 0, count, "statement_activity: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.transaction_statistics")
-	err = row.Scan(&count)
+	// Make sure all the tables are empty initially
+	_, err = db.ExecContext(ctx, "DELETE FROM system.public.transaction_activity")
 	require.NoError(t, err)
-	require.Equal(t, 0, count, "transaction_statistics: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.statement_statistics")
-	err = row.Scan(&count)
+	_, err = db.ExecContext(ctx, "DELETE FROM system.public.statement_activity")
 	require.NoError(t, err)
-	require.Equal(t, 0, count, "statement_statistics: expect:0, actual:%d", count)
+
+	_, err = db.ExecContext(ctx, "DELETE FROM system.public.transaction_statistics")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "DELETE FROM system.public.statement_statistics")
+	require.NoError(t, err)
 
 	execCfg := srv.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
 	su := st.MakeUpdater()
-	topLimit := 5
+	const topLimit = 3
 	err = su.Set(ctx, "sql.stats.activity.top.max", settings.EncodedValue{
 		Value: settings.EncodeInt(int64(topLimit)),
 		Type:  "i",
@@ -240,76 +233,150 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 
 	updater := newSqlActivityUpdater(st, execCfg.InternalDB)
 
-	appNamePrefix := "TestSqlActivityUpdateJobLoop"
-	// Generate 100 unique rows for statistics tables
-	for i := 0; i < 100; i++ {
-		tempAppName := fmt.Sprintf("%s%d", appNamePrefix, i)
-		_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", tempAppName)
-		require.NoError(t, err)
-
-		_, err = db.ExecContext(ctx, "SELECT 1;")
-		require.NoError(t, err)
-	}
-
-	// Need to call it twice to actually cause a flush
-	srv.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
-	srv.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
-
-	_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", "randomIgnore")
+	_, err = db.ExecContext(ctx, "SET tracing = true;")
 	require.NoError(t, err)
 
-	// The check to calculate the rows uses the follower_read_timestamp which will
-	// skip the upsert because it will see there are no rows.
-	testutils.SucceedsWithin(t, func() error {
-		var txnAggTs time.Time
-		row = db.QueryRowContext(ctx, `SELECT count_rows(), aggregated_ts 
+	_, err = db.ExecContext(ctx, "set cluster setting sql.txn_stats.sample_rate  = 1;")
+	require.NoError(t, err)
+
+	const appNamePrefix = "TestSqlActivityUpdateJobLoop"
+	getAppName := func(count int) string {
+		return fmt.Sprintf("%s%d", appNamePrefix, count)
+	}
+	appIndexCount := 0
+	updateStatsCount := 0
+	for i := 1; i <= 5; i++ {
+
+		// Generate unique rows in the statistics tables
+		const numQueries = topLimit*6 /*num columns*/ + 10 /*need more rows than limit*/
+		for j := 0; j < numQueries; j++ {
+			appIndexCount++
+			_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", getAppName(appIndexCount))
+			require.NoError(t, err)
+			_, err = db.ExecContext(ctx, "SELECT 1;")
+			require.NoError(t, err)
+		}
+
+		_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", "randomIgnore")
+		require.NoError(t, err)
+
+		// Need to call it twice to actually cause a flush
+		srv.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+		srv.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+
+		// The check to calculate the rows uses the follower_read_timestamp which will
+		// skip the upsert because it will see there are no rows.
+		testutils.SucceedsWithin(t, func() error {
+			var txnAggTs time.Time
+			var count int
+			row := db.QueryRowContext(ctx, `SELECT count_rows(), aggregated_ts 
 			FROM system.public.transaction_statistics AS OF SYSTEM TIME follower_read_timestamp() 
 			WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%' 
 			GROUP BY aggregated_ts`)
-		err = row.Scan(&count, &txnAggTs)
-		if err != nil {
-			return err
-		}
-		if count < 100 {
-			return errors.New("Need to wait for row to populate with follower_read_timestamp.")
-		}
+			err = row.Scan(&count, &txnAggTs)
+			if err != nil {
+				return err
+			}
 
-		var stmtAggTs time.Time
-		row = db.QueryRowContext(ctx, `SELECT count_rows(), aggregated_ts 
+			if count < appIndexCount {
+				return errors.New("Need to wait for row to populate with follower_read_timestamp.")
+			}
+
+			var stmtAggTs time.Time
+			row = db.QueryRowContext(ctx, `SELECT count_rows(), aggregated_ts 
 			 FROM system.public.statement_statistics AS OF SYSTEM TIME follower_read_timestamp() 
 			 WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%' 
 			 GROUP BY aggregated_ts`)
-		err = row.Scan(&count, &stmtAggTs)
-		if err != nil {
-			return err
-		}
-		if count < 100 {
-			return errors.New("Need to wait for row to populate with follower_read_timestamp.")
-		}
-		require.Equal(t, stmtAggTs, txnAggTs)
-		return nil
-	}, 30*time.Second)
+			err = row.Scan(&count, &stmtAggTs)
 
-	// Run the updater to add rows to the activity tables
-	// This will use the transfer all scenarios with there only
-	// being a few rows
-	err = updater.TransferStatsToActivity(ctx)
-	require.NoError(t, err)
+			if err != nil {
+				return err
+			}
+			if count < appIndexCount {
+				return errors.New("Need to wait for row to populate with follower_read_timestamp.")
+			}
+			require.Equal(t, stmtAggTs, txnAggTs)
+			return nil
+		}, 30*time.Second)
 
-	maxRows := topLimit * 6 // Number of top columns to select from
-	row = db.QueryRowContext(ctx, `SELECT count_rows() 
+		// The max number of queries is number of top columns * max number of
+		// queries per a column (6*3=18 for this test, 6*500=3000 default). Most of
+		// the top queries are the same in this test so instead of getting 18 it's
+		// only 6 to 8 which make test unreliable. The solution is to change the
+		// values for each of the columns to make sure that it is always the max.
+		// Then run the update multiple times with new top queries each time. This
+		// is needed to simulate ORM which generates a lot of unique queries.
+		// Execution count
+		for j := 0; j < topLimit; j++ {
+			updateStatsCount++
+			_, err = db.ExecContext(ctx, `UPDATE system.public.statement_statistics
+			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
+			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
+			    WHERE app_name = $3;`, 10000+updateStatsCount, 0.0000001, getAppName(updateStatsCount))
+			require.NoError(t, err)
+		}
+
+		// Service latency time
+		for j := 0; j < topLimit; j++ {
+			updateStatsCount++
+			_, err = db.ExecContext(ctx, `UPDATE system.public.statement_statistics
+			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
+			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
+			    WHERE app_name = $3;`, 1, 1000+updateStatsCount, getAppName(updateStatsCount))
+			require.NoError(t, err)
+		}
+
+		// Total execution time. Needs to be less than individual execution count
+		// and service latency, but greater when multiplied together.
+		for j := 0; j < topLimit; j++ {
+			updateStatsCount++
+			_, err = db.ExecContext(ctx, `UPDATE system.public.statement_statistics
+			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
+			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
+			    WHERE app_name = $3;`, 500+updateStatsCount, 500+updateStatsCount, getAppName(updateStatsCount))
+			require.NoError(t, err)
+		}
+
+		// Remaining columns don't interact so a loop can be used
+		columnsToChangeValues := []string{"{execution_statistics, contentionTime, mean}", "{execution_statistics, cpu_sql_nanos, mean}", "{statistics, latencyInfo, p99}"}
+		for _, updateField := range columnsToChangeValues {
+			for j := 0; j < topLimit; j++ {
+				updateStatsCount++
+				_, err = db.ExecContext(ctx, `UPDATE system.public.statement_statistics
+			SET statistics =  jsonb_set(statistics, $1, to_jsonb($2::INT)) 
+			WHERE app_name = $3;`, updateField, 10000+updateStatsCount, getAppName(updateStatsCount))
+				require.NoError(t, err)
+			}
+		}
+
+		// Run the updater to add rows to the activity tables
+		// This will use the transfer all scenarios with there only
+		// being a few rows
+		err = updater.TransferStatsToActivity(ctx)
+		require.NoError(t, err)
+
+		maxRows := topLimit * 6 // Number of top columns to select from
+		row := db.QueryRowContext(ctx, `SELECT count_rows() 
 		FROM system.public.transaction_activity 
 		WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%'`)
-	err = row.Scan(&count)
-	require.NoError(t, err)
-	require.LessOrEqual(t, count, maxRows, "transaction_activity after transfer: actual:%d, max:%d", count, maxRows)
+		var count int
+		err = row.Scan(&count)
+		require.NoError(t, err)
+		require.LessOrEqual(t, count, maxRows, "transaction_activity after transfer: actual:%d, max:%d", count, maxRows)
 
-	row = db.QueryRowContext(ctx, `SELECT count_rows() 
+		row = db.QueryRowContext(ctx, `SELECT count_rows() 
 		FROM system.public.statement_activity 
 		WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%'`)
-	err = row.Scan(&count)
-	require.NoError(t, err)
-	require.LessOrEqual(t, count, maxRows, "statement_activity after transfer: actual:%d, max:%d", count, maxRows)
+		err = row.Scan(&count)
+		require.NoError(t, err)
+		require.LessOrEqual(t, count, maxRows, "statement_activity after transfer: actual:%d, max:%d", count, maxRows)
+
+		row = db.QueryRowContext(ctx, `SELECT count_rows() 
+		FROM system.public.transaction_activity`)
+		err = row.Scan(&count)
+		require.NoError(t, err)
+		require.LessOrEqual(t, count, maxRows, "transaction_activity after transfer: actual:%d, max:%d", count, maxRows)
+	}
 }
 
 func TestScheduledSQLStatsCompaction(t *testing.T) {


### PR DESCRIPTION
The SQL activity update job runs every 10 minutes. It always upserts the new rows into the statement_activity and transaction_activity table.

The problem is if a customer uses an ORM where it generates a lot of unique queries then the job will keep adding new rows. This causes the activity tables to grow very large. One customer had over 58k rows for a single hour. This causes the SQL Activity page to be very slow.

To prevent the table from growing the update is now done in a transaction where the first statement deletes all the rows, and the next inserts the new rows computed from the statistic table. It needs to be done in a single transaction to avoid user getting no results during the upgrade process. It also ensures that if the job fails it only deletes the older rows if inserting the new rows succeeds.

Epic: none
Fixes: #104169

Release note (sql change): Fixes the SQL Activity update job, so the
 statement_activity and transaction_activity table size is constrained
 when customer has a lot of unique queries. The prevents the SQL
 Activity page from becoming slow.