### PR TITLE
ui: fix storybook for db-console and make it run with bazel

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTY0NDkzMjUwNQ==
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTY0NDkzMjUwNQ==
@@ -1,6 +1,6 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm_db_console", pnpm_lock = "//pkg/ui/workspaces/db-console:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 pkg/ui/.npmrc.pnpm=1714720514
-pkg/ui/workspaces/db-console/pnpm-lock.yaml=307741782
-pkg/ui/workspaces/db-console/yarn.lock=1296929611
-pkg/ui/workspaces/db-console/package.json=-1415963323
+pkg/ui/workspaces/db-console/pnpm-lock.yaml=1591164581
+pkg/ui/workspaces/db-console/yarn.lock=861579387
+pkg/ui/workspaces/db-console/package.json=463935330

--- a/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.stories.tsx
@@ -22,7 +22,8 @@ import {
 import statementsPagePropsFixture from "src/statementsPage/statementsPage.fixture";
 import Long from "long";
 
-const { statements } = statementsPagePropsFixture;
+const statements =
+  statementsPagePropsFixture.statementsResponse.data.statements;
 
 const withinColumn =
   (width = "150px"): DecoratorFn =>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.stories.tsx
@@ -24,9 +24,7 @@ storiesOf("StatementsPage", module)
     <div style={{ backgroundColor: "#F5F7FA" }}>{storyFn()}</div>
   ))
   .add("with data", () => <StatementsPage {...statementsPagePropsFixture} />)
-  .add("without data", () => (
-    <StatementsPage {...statementsPagePropsFixture} statements={[]} />
-  ))
+  .add("without data", () => <StatementsPage {...statementsPagePropsFixture} />)
   .add("with empty search result", () => {
     const props = cloneDeep(statementsPagePropsFixture);
     const { history } = props;
@@ -37,19 +35,13 @@ storiesOf("StatementsPage", module)
       <StatementsPage
         {...props}
         {...statementsPagePropsFixture}
-        statements={[]}
         history={history}
       />
     );
   })
   .add("with error", () => {
-    return (
-      <StatementsPage
-        {...statementsPagePropsWithRequestError}
-        statements={[]}
-      />
-    );
+    return <StatementsPage {...statementsPagePropsWithRequestError} />;
   })
   .add("with loading state", () => {
-    return <StatementsPage {...statementsPagePropsFixture} statements={null} />;
+    return <StatementsPage {...statementsPagePropsFixture} />;
   });

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.stories.tsx
@@ -17,17 +17,19 @@ import {
 } from "./statementsTable";
 import statementsPagePropsFixture from "src/statementsPage/statementsPage.fixture";
 import { calculateTotalWorkload } from "src/util";
+import { convertRawStmtsToAggregateStatistics } from "../sqlActivity/util";
 
-const { statements } = statementsPagePropsFixture;
+const statements =
+  statementsPagePropsFixture.statementsResponse.data.statements;
 
 storiesOf("StatementsSortedTable", module)
   .addDecorator(storyFn => <MemoryRouter>{storyFn()}</MemoryRouter>)
   .add("with data", () => (
     <StatementsSortedTable
       className="statements-table"
-      data={statements}
+      data={convertRawStmtsToAggregateStatistics(statements)}
       columns={makeStatementsColumns(
-        statements,
+        convertRawStmtsToAggregateStatistics(statements),
         ["$ internal"],
         calculateTotalWorkload(statements),
         "statement",
@@ -49,9 +51,9 @@ storiesOf("StatementsSortedTable", module)
   .add("with data and VIEWACTIVITYREDACTED role", () => (
     <StatementsSortedTable
       className="statements-table"
-      data={statements}
+      data={convertRawStmtsToAggregateStatistics(statements)}
       columns={makeStatementsColumns(
-        statements,
+        convertRawStmtsToAggregateStatistics(statements),
         ["$ internal"],
         calculateTotalWorkload(statements),
         "statement",

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -13,11 +13,9 @@ import { storiesOf } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
 import { noop } from "lodash";
 import {
-  error,
   nodeRegions,
   routeProps,
   timeScale,
-  transaction,
   transactionDetailsData,
   transactionFingerprintId,
 } from "./transactionDetails.fixture";
@@ -37,9 +35,6 @@ storiesOf("Transactions Details", module)
       {...routeProps}
       timeScale={timeScale}
       transactionFingerprintId={transactionFingerprintId.toString()}
-      transaction={transaction}
-      isLoading={false}
-      statements={transactionDetailsData.statements}
       nodeRegions={nodeRegions}
       isTenant={false}
       hasViewActivityRedactedRole={false}
@@ -48,11 +43,16 @@ storiesOf("Transactions Details", module)
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
       refreshNodes={noop}
-      lastUpdated={moment("0001-01-01T00:00:00Z")}
       refreshTransactionInsights={noop}
       limit={100}
       reqSortSetting={StatsSortOptions.SERVICE_LAT}
-      isDataValid={true}
+      txnStatsResp={{
+        lastUpdated: moment(),
+        error: null,
+        inFlight: false,
+        valid: true,
+        data: transactionDetailsData,
+      }}
     />
   ))
   .add("with loading indicator", () => (
@@ -60,9 +60,6 @@ storiesOf("Transactions Details", module)
       {...routeProps}
       timeScale={timeScale}
       transactionFingerprintId={transactionFingerprintId.toString()}
-      transaction={null}
-      isLoading={true}
-      statements={undefined}
       nodeRegions={nodeRegions}
       isTenant={false}
       hasViewActivityRedactedRole={false}
@@ -71,11 +68,16 @@ storiesOf("Transactions Details", module)
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
       refreshNodes={noop}
-      lastUpdated={moment("0001-01-01T00:00:00Z")}
       refreshTransactionInsights={noop}
       limit={100}
       reqSortSetting={StatsSortOptions.SERVICE_LAT}
-      isDataValid={true}
+      txnStatsResp={{
+        lastUpdated: moment(),
+        error: null,
+        inFlight: false,
+        valid: true,
+        data: transactionDetailsData,
+      }}
     />
   ))
   .add("with error alert", () => (
@@ -83,11 +85,7 @@ storiesOf("Transactions Details", module)
       {...routeProps}
       timeScale={timeScale}
       transactionFingerprintId={undefined}
-      transaction={undefined}
-      isLoading={false}
-      statements={undefined}
       nodeRegions={nodeRegions}
-      error={error}
       isTenant={false}
       hasViewActivityRedactedRole={false}
       transactionInsights={undefined}
@@ -95,11 +93,16 @@ storiesOf("Transactions Details", module)
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
       refreshNodes={noop}
-      lastUpdated={moment("0001-01-01T00:00:00Z")}
       refreshTransactionInsights={noop}
       limit={100}
       reqSortSetting={StatsSortOptions.SERVICE_LAT}
-      isDataValid={true}
+      txnStatsResp={{
+        lastUpdated: moment(),
+        error: null,
+        inFlight: false,
+        valid: true,
+        data: transactionDetailsData,
+      }}
     />
   ))
   .add("No data for this time frame; no cached transaction text", () => {
@@ -108,9 +111,6 @@ storiesOf("Transactions Details", module)
         {...routeProps}
         timeScale={timeScale}
         transactionFingerprintId={transactionFingerprintId.toString()}
-        transaction={undefined}
-        isLoading={false}
-        statements={transactionDetailsData.statements}
         nodeRegions={nodeRegions}
         isTenant={false}
         hasViewActivityRedactedRole={false}
@@ -119,11 +119,16 @@ storiesOf("Transactions Details", module)
         refreshUserSQLRoles={noop}
         onTimeScaleChange={noop}
         refreshNodes={noop}
-        lastUpdated={moment("0001-01-01T00:00:00Z")}
         refreshTransactionInsights={noop}
         limit={100}
         reqSortSetting={StatsSortOptions.SERVICE_LAT}
-        isDataValid={true}
+        txnStatsResp={{
+          lastUpdated: moment(),
+          error: null,
+          inFlight: false,
+          valid: true,
+          data: transactionDetailsData,
+        }}
       />
     );
   });

--- a/pkg/ui/workspaces/db-console/.storybook/webpack.config.js
+++ b/pkg/ui/workspaces/db-console/.storybook/webpack.config.js
@@ -8,7 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-const custom = require("../webpack.app.js");
+const custom = require("../webpack.config");
+const path = require("path");
 
 const appConfig = custom({dist: "ccl"}, {mode: "development"});
 
@@ -17,8 +18,13 @@ module.exports = async ({ config, mode }) => {
     ...config,
     resolve: {
       ...config.resolve,
-      modules: appConfig.resolve.modules,
+      modules: [
+        path.resolve(__dirname, "..", "ccl"),
+        path.resolve(__dirname, ".."),
+        "node_modules",
+      ],
       extensions: appConfig.resolve.extensions,
+      alias: appConfig.resolve.alias,
     },
     module: {
       rules: [

--- a/pkg/ui/workspaces/db-console/package.json
+++ b/pkg/ui/workspaces/db-console/package.json
@@ -119,6 +119,7 @@
     "chai": "^4.1.0",
     "chalk": "^1.1.3",
     "copy-webpack-plugin": "^4.5.1",
+    "core-js": "^3.0.1",
     "css-loader": "^3.4.0",
     "d3": "<4.0.0",
     "d3-geo-projection": "^2.5.0",

--- a/pkg/ui/workspaces/db-console/pnpm-lock.yaml
+++ b/pkg/ui/workspaces/db-console/pnpm-lock.yaml
@@ -62,7 +62,7 @@ dependencies:
     version: 5.1.15
   '@typescript-eslint/utils':
     specifier: ^5.26.0
-    version: 5.26.0(eslint@7.29.0)(typescript@4.2.4)
+    version: 5.59.8(eslint@7.29.0)(typescript@4.2.4)
   analytics-node:
     specifier: ^3.5.0
     version: 3.5.0
@@ -349,6 +349,9 @@ devDependencies:
   copy-webpack-plugin:
     specifier: ^4.5.1
     version: 4.6.0
+  core-js:
+    specifier: ^2.6.12
+    version: 2.6.12
   css-loader:
     specifier: ^3.4.0
     version: 3.6.0(webpack@4.46.0)
@@ -3107,6 +3110,16 @@ packages:
     resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
     dev: true
 
+  /@eslint-community/eslint-utils@4.4.0(eslint@7.29.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 7.29.0
+      eslint-visitor-keys: 3.4.1
+    dev: false
+
   /@eslint/eslintrc@0.4.2:
     resolution: {integrity: sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4907,6 +4920,10 @@ packages:
   /@types/scheduler@0.16.1:
     resolution: {integrity: sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==}
 
+  /@types/semver@7.5.0:
+    resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+    dev: false
+
   /@types/sinon@7.5.2:
     resolution: {integrity: sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==}
     dev: true
@@ -5054,12 +5071,12 @@ packages:
       '@typescript-eslint/visitor-keys': 4.29.1
     dev: true
 
-  /@typescript-eslint/scope-manager@5.26.0:
-    resolution: {integrity: sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==}
+  /@typescript-eslint/scope-manager@5.59.8:
+    resolution: {integrity: sha512-/w08ndCYI8gxGf+9zKf1vtx/16y8MHrZs5/tnjHhMLNSixuNcJavSX4wAiPf4aS5x41Es9YPCn44MIe4cxIlig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.26.0
-      '@typescript-eslint/visitor-keys': 5.26.0
+      '@typescript-eslint/types': 5.59.8
+      '@typescript-eslint/visitor-keys': 5.59.8
     dev: false
 
   /@typescript-eslint/types@4.29.1:
@@ -5067,8 +5084,8 @@ packages:
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dev: true
 
-  /@typescript-eslint/types@5.26.0:
-    resolution: {integrity: sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==}
+  /@typescript-eslint/types@5.59.8:
+    resolution: {integrity: sha512-+uWuOhBTj/L6awoWIg0BlWy0u9TyFpCHrAuQ5bNfxDaZ1Ppb3mx6tUigc74LHcbHpOHuOTOJrBoAnhdHdaea1w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
@@ -5093,8 +5110,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.26.0(typescript@4.2.4):
-    resolution: {integrity: sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==}
+  /@typescript-eslint/typescript-estree@5.59.8(typescript@4.2.4):
+    resolution: {integrity: sha512-Jy/lPSDJGNow14vYu6IrW790p7HIf/SOV1Bb6lZ7NUkLc2iB2Z9elESmsaUtLw8kVqogSbtLH9tut5GCX1RLDg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -5102,8 +5119,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.26.0
-      '@typescript-eslint/visitor-keys': 5.26.0
+      '@typescript-eslint/types': 5.59.8
+      '@typescript-eslint/visitor-keys': 5.59.8
       debug: 4.3.4(supports-color@6.1.0)
       globby: 11.1.0
       is-glob: 4.0.3
@@ -5114,19 +5131,21 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.26.0(eslint@7.29.0)(typescript@4.2.4):
-    resolution: {integrity: sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==}
+  /@typescript-eslint/utils@5.59.8(eslint@7.29.0)(typescript@4.2.4):
+    resolution: {integrity: sha512-Tr65630KysnNn9f9G7ROF3w1b5/7f6QVCJ+WK9nhIocWmx9F+TmCAcglF26Vm7z8KCTwoKcNEBZrhlklla3CKg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@7.29.0)
       '@types/json-schema': 7.0.12
-      '@typescript-eslint/scope-manager': 5.26.0
-      '@typescript-eslint/types': 5.26.0
-      '@typescript-eslint/typescript-estree': 5.26.0(typescript@4.2.4)
+      '@types/semver': 7.5.0
+      '@typescript-eslint/scope-manager': 5.59.8
+      '@typescript-eslint/types': 5.59.8
+      '@typescript-eslint/typescript-estree': 5.59.8(typescript@4.2.4)
       eslint: 7.29.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@7.29.0)
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5140,11 +5159,11 @@ packages:
       eslint-visitor-keys: 2.1.0
     dev: true
 
-  /@typescript-eslint/visitor-keys@5.26.0:
-    resolution: {integrity: sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==}
+  /@typescript-eslint/visitor-keys@5.59.8:
+    resolution: {integrity: sha512-pJhi2ms0x0xgloT7xYabil3SGGlojNNKjK/q6dB3Ey0uJLMjK2UDGJvHieiyJVW/7C3KI+Z4Q3pEHkm4ejA+xQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.26.0
+      '@typescript-eslint/types': 5.59.8
       eslint-visitor-keys: 3.4.1
     dev: false
 
@@ -8699,6 +8718,7 @@ packages:
     dependencies:
       eslint: 7.29.0
       eslint-visitor-keys: 2.1.0
+    dev: true
 
   /eslint-visitor-keys@1.3.0:
     resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}

--- a/pkg/ui/workspaces/db-console/yarn.lock
+++ b/pkg/ui/workspaces/db-console/yarn.lock
@@ -7528,6 +7528,11 @@ core-js@^2.6.12:
   resolved "https://storage.googleapis.com/cockroach-npm-deps/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
+core-js@^3.0.1:
+  version "3.31.1"
+  resolved "https://storage.googleapis.com/cockroach-npm-deps/core-js/-/core-js-3.31.1.tgz#f2b0eea9be9da0def2c5fece71064a7e5d687653"
+  integrity sha512-2sKLtfq1eFST7l7v62zaqXacPc7uG8ZAya8ogijLhTtaKNcpzpB4TMoTw2Si+8GYKRwFPMMtUT0263QFWFfqyQ==
+
 core-js@^3.0.4:
   version "2.6.12"
   resolved "https://storage.googleapis.com/cockroach-npm-deps/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
@@ -17741,6 +17746,22 @@ react-router@5.2.0:
   integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
   dependencies:
     "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.3.1:
+  version "5.3.1"
+  resolved "https://storage.googleapis.com/cockroach-npm-deps/react-router/-/react-router-5.3.1.tgz#b13e84a016c79b9e80dde123ca4112c4f117e3cf"
+  integrity sha512-v+zwjqb7bakqgF+wMVKlAPTca/cEmPOvQ9zt7gpSNyPXau1+0qvuYZ5BWzzNDP1y6s15zDwgb9rPN63+SIniRQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
     history "^4.9.0"
     hoist-non-react-statics "^3.1.0"
     loose-envify "^1.3.1"


### PR DESCRIPTION
This change includes several changes that enables better experience for developers to build visual components with Storybook, now it is possible to run Storybook with `dev` ie:
```
dev ui storybook --project cluster-ui --port 9009
or
dev ui storybook # db-console project is default one
```

- fixed storybook configuration for Db Console project. It required to install `core-js` package to resolve following issues: https://github.com/storybookjs/storybook/blob/main/MIGRATION.md#core-js-dependency-errors
- updated fixtures for cluster UI storybook that wasn't adjusted to changes in components they rely on.
- Added new `dev ui storybook` subcommand that allows run storybooks for Db Console or Cluster UI projects

Release note: None

Epic: None