### PR TITLE
kvserver/allocator: safe format load dimensions

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/tracker"
 )
@@ -225,6 +226,9 @@ func (a AllocatorAction) String() string {
 	return allocatorActionNames[a]
 }
 
+// SafeValue implements the redact.SafeValue interface.
+func (a AllocatorAction) SafeValue()
+
 // Priority defines the priorities for various repair operations.
 //
 // NB: These priorities only influence the replicateQueue's understanding of
@@ -336,6 +340,9 @@ func (t TargetReplicaType) String() string {
 	}
 }
 
+// SafeValue implements the redact.SafeValue interface.
+func (TargetReplicaType) SafeValue()
+
 func (s ReplicaStatus) String() string {
 	switch s {
 	case Alive:
@@ -348,6 +355,9 @@ func (s ReplicaStatus) String() string {
 		panic(fmt.Sprintf("unknown replicaStatus %d", s))
 	}
 }
+
+// SafeValue implements the redact.SafeValue interface.
+func (ReplicaStatus) SafeValue()
 
 type transferDecision int
 

--- a/pkg/kv/kvserver/allocator/load/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/load/BUILD.bazel
@@ -10,7 +10,10 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/load",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/util/humanizeutil"],
+    deps = [
+        "//pkg/util/humanizeutil",
+        "@com_github_cockroachdb_redact//:redact",
+    ],
 )
 
 get_x_data(name = "get_x_data")

--- a/pkg/kv/kvserver/allocator/load/dimension.go
+++ b/pkg/kv/kvserver/allocator/load/dimension.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/redact"
 )
 
 // Dimension is a singe dimension of load that a component may track.
@@ -32,23 +33,28 @@ const (
 
 // String returns a human readable string representation of the dimension.
 func (d Dimension) String() string {
+	return redact.StringWithoutMarkers(d)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (d Dimension) SafeFormat(w redact.SafePrinter, _ rune) {
 	switch d {
 	case Queries:
-		return "queries-per-second"
+		w.Print("queries-per-second")
 	case CPU:
-		return "cpu-per-second"
+		w.Print("cpu-per-second")
 	default:
 		panic(fmt.Sprintf("cannot name: unknown dimension with ordinal %d", d))
 	}
 }
 
-// Format returns a formatted string for a value.
-func (d Dimension) Format(value float64) string {
+// FormatValue returns a formatted string for a value.
+func (d Dimension) FormatValue(value float64) redact.SafeString {
 	switch d {
 	case Queries:
-		return fmt.Sprintf("%.1f", value)
+		return redact.SafeString(fmt.Sprintf("%.1f", value))
 	case CPU:
-		return string(humanizeutil.Duration(time.Duration(int64(value))))
+		return humanizeutil.Duration(time.Duration(int64(value)))
 	default:
 		panic(fmt.Sprintf("cannot format value: unknown dimension with ordinal %d", d))
 	}

--- a/pkg/kv/kvserver/allocator/load/load.go
+++ b/pkg/kv/kvserver/allocator/load/load.go
@@ -10,12 +10,17 @@
 
 package load
 
-import "math"
+import (
+	"math"
+
+	"github.com/cockroachdb/redact"
+)
 
 // Load represents a named collection of load dimensions. It is used for
 // performing arithmetic and comparison between comparable objects which have
 // load.
 type Load interface {
+	redact.SafeFormatter
 	// Dim returns the value of the Dimension given.
 	Dim(dim Dimension) float64
 	// String returns a string representation of Load.

--- a/pkg/kv/kvserver/allocator/load/vector.go
+++ b/pkg/kv/kvserver/allocator/load/vector.go
@@ -12,7 +12,8 @@ package load
 
 import (
 	"fmt"
-	"strings"
+
+	"github.com/cockroachdb/redact"
 )
 
 // Vector is a static container which implements the Load interface.
@@ -21,25 +22,30 @@ type Vector [nDimensions]float64
 var _ Load = Vector{}
 
 // Dim returns the value of the Dimension given.
-func (s Vector) Dim(dim Dimension) float64 {
-	if int(dim) > len(s) || dim < 0 {
+func (v Vector) Dim(dim Dimension) float64 {
+	if int(dim) > len(v) || dim < 0 {
 		panic(fmt.Sprintf("Unknown load dimension access, %d", dim))
 	}
-	return s[dim]
+	return v[dim]
 }
 
 // String returns a string representation of Load.
-func (s Vector) String() string {
-	var buf strings.Builder
+func (v Vector) String() string {
+	return redact.StringWithoutMarkers(v)
+}
 
-	fmt.Fprint(&buf, "(")
-	for i, val := range s {
+// SafeFormat implements the redact.SafeFormatter interface.
+func (v Vector) SafeFormat(w redact.SafePrinter, _ rune) {
+	var buf redact.StringBuilder
+
+	buf.Print("(")
+	for i, val := range v {
 		if i > 0 {
-			fmt.Fprint(&buf, " ")
+			buf.Print(" ")
 		}
 		dim := Dimension(i)
-		fmt.Fprintf(&buf, "%s=%s", dim.String(), dim.Format(val))
+		buf.Printf("%v=%v", dim, dim.FormatValue(val))
 	}
-	fmt.Fprint(&buf, ")")
-	return buf.String()
+	buf.Print(")")
+	w.Print(buf)
 }

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -221,6 +221,10 @@ type RebalanceContext struct {
 	hottestRanges, rebalanceCandidates []CandidateReplica
 }
 
+type rebalanceSummary struct {
+  initialCapacity roachpb.StoreCapacity
+}
+
 // RebalanceMode returns the mode of the store rebalancer. See
 // LoadBasedRebalancingMode.
 func (sr *StoreRebalancer) RebalanceMode() LBRebalancingMode {


### PR DESCRIPTION
The load vector added in 23.1 did not implement `redact.SafeFormat` and only shows as redacted in redacted logging. The load vector values are useful for debugging, implement `redact.SafeFormat` to un-redact associated logging.

Part of: #102948

Release note: None