### PR TITLE
server: remove unused LivenessStatus field

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -6470,7 +6470,6 @@ The result of checking a single node's readiness for decommission.
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [int32](#cockroach.server.serverpb.DecommissionPreCheckResponse-int32) |  |  | [reserved](#support-status) |
 | decommission_readiness | [DecommissionPreCheckResponse.NodeReadiness](#cockroach.server.serverpb.DecommissionPreCheckResponse-cockroach.server.serverpb.DecommissionPreCheckResponse.NodeReadiness) |  | The node's decommission readiness status. | [reserved](#support-status) |
-| liveness_status | [cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus](#cockroach.server.serverpb.DecommissionPreCheckResponse-cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus) |  | The liveness status of the given node. | [reserved](#support-status) |
 | replica_count | [int64](#cockroach.server.serverpb.DecommissionPreCheckResponse-int64) |  | The number of total replicas on the node, computed by scanning range descriptors. | [reserved](#support-status) |
 | checked_ranges | [DecommissionPreCheckResponse.RangeCheckResult](#cockroach.server.serverpb.DecommissionPreCheckResponse-cockroach.server.serverpb.DecommissionPreCheckResponse.RangeCheckResult) | repeated | The details and recorded traces from preprocessing each range with a replica on the checked nodes that resulted in error, up to the maximum specified in the request. | [reserved](#support-status) |
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2733,13 +2733,11 @@ func (s *systemAdminServer) DecommissionPreCheck(
 			resultsByNodeID[nID] = serverpb.DecommissionPreCheckResponse_NodeCheckResult{
 				NodeID:                nID,
 				DecommissionReadiness: serverpb.DecommissionPreCheckResponse_UNKNOWN,
-				LivenessStatus:        livenessStatus,
 			}
 		} else if livenessStatus == livenesspb.NodeLivenessStatus_DECOMMISSIONED {
 			resultsByNodeID[nID] = serverpb.DecommissionPreCheckResponse_NodeCheckResult{
 				NodeID:                nID,
 				DecommissionReadiness: serverpb.DecommissionPreCheckResponse_ALREADY_DECOMMISSIONED,
-				LivenessStatus:        livenessStatus,
 			}
 		} else {
 			nodesToCheck = append(nodesToCheck, nID)
@@ -2784,7 +2782,6 @@ func (s *systemAdminServer) DecommissionPreCheck(
 		resultsByNodeID[nID] = serverpb.DecommissionPreCheckResponse_NodeCheckResult{
 			NodeID:                nID,
 			DecommissionReadiness: readiness,
-			LivenessStatus:        livenessStatusByNodeID[nID],
 			ReplicaCount:          int64(numReplicas),
 			CheckedRanges:         rangeCheckErrsByNode[nID],
 		}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -2499,7 +2499,6 @@ func checkNodeCheckResultReady(
 	require.Equal(t, serverpb.DecommissionPreCheckResponse_NodeCheckResult{
 		NodeID:                nID,
 		DecommissionReadiness: serverpb.DecommissionPreCheckResponse_READY,
-		LivenessStatus:        livenesspb.NodeLivenessStatus_LIVE,
 		ReplicaCount:          replicaCount,
 		CheckedRanges:         nil,
 	}, checkResult)
@@ -2859,7 +2858,6 @@ func TestDecommissionPreCheckInvalidNode(t *testing.T) {
 	require.Equal(t, serverpb.DecommissionPreCheckResponse_NodeCheckResult{
 		NodeID:                invalidDecommissioningNodeID,
 		DecommissionReadiness: serverpb.DecommissionPreCheckResponse_UNKNOWN,
-		LivenessStatus:        livenesspb.NodeLivenessStatus_UNKNOWN,
 		ReplicaCount:          0,
 		CheckedRanges:         nil,
 	}, resp.CheckedNodes[1])

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -532,8 +532,7 @@ message DecommissionPreCheckResponse {
     // The node's decommission readiness status.
     NodeReadiness decommission_readiness = 2;
 
-    // The liveness status of the given node.
-    kv.kvserver.liveness.livenesspb.NodeLivenessStatus liveness_status = 3;
+    reserved 3; // Previously used
 
     // The number of total replicas on the node, computed by scanning range
     // descriptors.


### PR DESCRIPTION
This field was returned in the response to a DecommissionPreCheck, but the value was never read. In a seperate PR we are attempting to remove the usage of this field, so removing it here helps.

Epic: none

Release note: None