### PR TITLE
kv: advance `txnSeqNumAllocator.readSeq` automatically when not stepping

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1355,7 +1355,7 @@ func (tc *TxnCoordSender) PrepareRetryableError(
 func (tc *TxnCoordSender) Step(ctx context.Context) error {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
-	return tc.interceptorAlloc.txnSeqNumAllocator.stepLocked(ctx)
+	return tc.interceptorAlloc.txnSeqNumAllocator.manualStepReadSeqLocked(ctx)
 }
 
 // GetReadSeqNum is part of the TxnSender interface.
@@ -1388,11 +1388,7 @@ func (tc *TxnCoordSender) ConfigureStepping(
 
 // GetSteppingMode is part of the TxnSender interface.
 func (tc *TxnCoordSender) GetSteppingMode(ctx context.Context) (curMode kv.SteppingMode) {
-	curMode = kv.SteppingDisabled
-	if tc.interceptorAlloc.txnSeqNumAllocator.steppingModeEnabled {
-		curMode = kv.SteppingEnabled
-	}
-	return curMode
+	return tc.interceptorAlloc.txnSeqNumAllocator.steppingMode
 }
 
 // DeferCommitWait is part of the TxnSender interface.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator.go
@@ -65,17 +65,18 @@ type txnSeqNumAllocator struct {
 	// write operation is encountered.
 	writeSeq enginepb.TxnSeq
 
-	// readSeq is the sequence number at which to perform read-only
-	// operations when steppingModeEnabled is set.
+	// readSeq is the sequence number at which to perform read-only operations.
 	readSeq enginepb.TxnSeq
 
-	// steppingModeEnabled indicates whether to operate in stepping mode
-	// or read-own-writes:
-	// - in read-own-writes, read-only operations read at the latest
-	//   write seqnum.
-	// - when stepping, read-only operations read at a
-	//   fixed readSeq.
-	steppingModeEnabled bool
+	// steppingMode indicates whether to operate in stepping mode or
+	// read-own-writes:
+	// - in read-own-writes, the readSeq is advanced automatically after each
+	//   write operation. All subsequent reads, even those in the same batch,
+	//   will read at the newest sequence number and observe all prior writes.
+	// - when stepping, the readSeq is only advanced when the client calls
+	//   TxnCoordSender.Step. Reads will only observe writes performed before
+	//   the last call to TxnCoordSender.Step.
+	steppingMode kv.SteppingMode
 }
 
 // SendLocked is part of the txnInterceptor interface.
@@ -89,15 +90,19 @@ func (s *txnSeqNumAllocator) SendLocked(
 		// This enables ba.IsCompleteTransaction to work properly.
 		if kvpb.IsIntentWrite(req) || req.Method() == kvpb.EndTxn {
 			s.writeSeq++
+			if err := s.maybeAutoStepReadSeqLocked(ctx); err != nil {
+				return nil, kvpb.NewError(err)
+			}
 		}
 
 		// Note: only read-only requests can operate at a past seqnum.
 		// Combined read/write requests (e.g. CPut) always read at the
 		// latest write seqnum.
 		oldHeader := req.Header()
-		oldHeader.Sequence = s.writeSeq
-		if s.steppingModeEnabled && kvpb.IsReadOnly(req) {
+		if kvpb.IsReadOnly(req) {
 			oldHeader.Sequence = s.readSeq
+		} else {
+			oldHeader.Sequence = s.writeSeq
 		}
 		req.SetHeader(oldHeader)
 	}
@@ -111,13 +116,13 @@ func (s *txnSeqNumAllocator) setWrapped(wrapped lockedSender) { s.wrapped = wrap
 // populateLeafInputState is part of the txnInterceptor interface.
 func (s *txnSeqNumAllocator) populateLeafInputState(tis *roachpb.LeafTxnInputState) {
 	tis.Txn.Sequence = s.writeSeq
-	tis.SteppingModeEnabled = s.steppingModeEnabled
+	tis.SteppingModeEnabled = bool(s.steppingMode)
 	tis.ReadSeqNum = s.readSeq
 }
 
 // initializeLeaf loads the read seqnum for a leaf transaction.
 func (s *txnSeqNumAllocator) initializeLeaf(tis *roachpb.LeafTxnInputState) {
-	s.steppingModeEnabled = tis.SteppingModeEnabled
+	s.steppingMode = kv.SteppingMode(tis.SteppingModeEnabled)
 	s.readSeq = tis.ReadSeqNum
 }
 
@@ -131,15 +136,32 @@ func (s *txnSeqNumAllocator) importLeafFinalState(
 	return nil
 }
 
-// stepLocked bumps the read seqnum to the current write seqnum.
+// manualStepReadSeqLocked bumps the read seqnum to the current write seqnum.
 // Used by the TxnCoordSender's Step() method.
-func (s *txnSeqNumAllocator) stepLocked(ctx context.Context) error {
-	if !s.steppingModeEnabled {
+func (s *txnSeqNumAllocator) manualStepReadSeqLocked(ctx context.Context) error {
+	if s.steppingMode != kv.SteppingEnabled {
 		return errors.AssertionFailedf("stepping mode is not enabled")
 	}
+	return s.stepReadSeqLocked(ctx)
+}
+
+// maybeAutoStepReadSeqLocked bumps the readSeq to the current write seqnum,
+// if manual stepping is disabled and the txnSeqNumAllocator is expected to
+// automatically step the readSeq. Otherwise, the method is a no-op.
+//
+//gcassert:inline
+func (s *txnSeqNumAllocator) maybeAutoStepReadSeqLocked(ctx context.Context) error {
+	if s.steppingMode == kv.SteppingEnabled {
+		return nil // only manual stepping allowed
+	}
+	return s.stepReadSeqLocked(ctx)
+}
+
+// stepReadSeqLocked bumps the read seqnum to the current write seqnum.
+func (s *txnSeqNumAllocator) stepReadSeqLocked(ctx context.Context) error {
 	if s.readSeq > s.writeSeq {
 		return errors.AssertionFailedf(
-			"cannot step() after mistaken initialization (%d,%d)", s.writeSeq, s.readSeq)
+			"cannot stepReadSeqLocked() after mistaken initialization (%d,%d)", s.writeSeq, s.readSeq)
 	}
 	s.readSeq = s.writeSeq
 	return nil
@@ -158,15 +180,9 @@ func (s *txnSeqNumAllocator) stepLocked(ctx context.Context) error {
 func (s *txnSeqNumAllocator) configureSteppingLocked(
 	newMode kv.SteppingMode,
 ) (prevMode kv.SteppingMode) {
-	prevEnabled := s.steppingModeEnabled
-	enabled := newMode == kv.SteppingEnabled
-	s.steppingModeEnabled = enabled
-	if !prevEnabled && enabled {
+	prevMode, s.steppingMode = s.steppingMode, newMode
+	if prevMode == kv.SteppingDisabled && newMode == kv.SteppingEnabled {
 		s.readSeq = s.writeSeq
-	}
-	prevMode = kv.SteppingDisabled
-	if prevEnabled {
-		prevMode = kv.SteppingEnabled
 	}
 	return prevMode
 }

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator_test.go
@@ -124,7 +124,7 @@ func TestSequenceNumberAllocationWithStep(t *testing.T) {
 	s.configureSteppingLocked(true /* enabled */)
 
 	for i := 1; i <= 3; i++ {
-		if err := s.stepLocked(ctx); err != nil {
+		if err := s.manualStepReadSeqLocked(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if s.writeSeq != s.readSeq {
@@ -260,7 +260,7 @@ func TestModifyReadSeqNum(t *testing.T) {
 	// 6. repeat step 4.
 
 	// First, do a mutation.
-	if err := s.stepLocked(ctx); err != nil {
+	if err := s.manualStepReadSeqLocked(ctx); err != nil {
 		t.Fatal(err)
 	}
 	ba := &kvpb.BatchRequest{}
@@ -274,7 +274,7 @@ func TestModifyReadSeqNum(t *testing.T) {
 	cursorSeqNum := s.readSeq
 
 	// Perform another mutation.
-	if err := s.stepLocked(ctx); err != nil {
+	if err := s.manualStepReadSeqLocked(ctx); err != nil {
 		t.Fatal(err)
 	}
 	ba = &kvpb.BatchRequest{}
@@ -287,7 +287,7 @@ func TestModifyReadSeqNum(t *testing.T) {
 	// Ensure that sending a read at the old seq num doesn't do anything bad and
 	// also passes through the correct seq num.
 	curReadSeq := s.readSeq
-	if err := s.stepLocked(ctx); err != nil {
+	if err := s.manualStepReadSeqLocked(ctx); err != nil {
 		t.Fatal(err)
 	}
 	s.readSeq = cursorSeqNum
@@ -304,7 +304,7 @@ func TestModifyReadSeqNum(t *testing.T) {
 
 	// Ensure that doing another read after resetting the seq num back to the
 	// newer seq num also doesn't do anything bad.
-	if err := s.stepLocked(ctx); err != nil {
+	if err := s.manualStepReadSeqLocked(ctx); err != nil {
 		t.Fatal(err)
 	}
 	ba = &kvpb.BatchRequest{}
@@ -319,7 +319,7 @@ func TestModifyReadSeqNum(t *testing.T) {
 
 	// Do another mutation after messing with the read seq nums so that we can
 	// be sure things are still groovy.
-	if err := s.stepLocked(ctx); err != nil {
+	if err := s.manualStepReadSeqLocked(ctx); err != nil {
 		t.Fatal(err)
 	}
 	ba = &kvpb.BatchRequest{}
@@ -335,7 +335,7 @@ func TestModifyReadSeqNum(t *testing.T) {
 	// Ensure that sending another read at the old seq num doesn't do anything bad
 	// and also passes through the correct seq num.
 	curReadSeq = s.readSeq
-	if err := s.stepLocked(ctx); err != nil {
+	if err := s.manualStepReadSeqLocked(ctx); err != nil {
 		t.Fatal(err)
 	}
 	s.readSeq = cursorSeqNum
@@ -352,7 +352,7 @@ func TestModifyReadSeqNum(t *testing.T) {
 
 	// Ensure that doing another read after resetting the seq num back to the
 	// newer seq num also doesn't do anything bad.
-	if err := s.stepLocked(ctx); err != nil {
+	if err := s.manualStepReadSeqLocked(ctx); err != nil {
 		t.Fatal(err)
 	}
 	ba = &kvpb.BatchRequest{}

--- a/pkg/testutils/lint/gcassert_paths.txt
+++ b/pkg/testutils/lint/gcassert_paths.txt
@@ -1,6 +1,7 @@
 col/coldata
 col/colserde
 keys
+kv/kvclient/kvcoord
 kv/kvclient/rangecache
 kv/kvpb
 kv/kvserver/intentresolver


### PR DESCRIPTION
This commit adjusts the handling of `txnSeqNumAllocator.readSeq` when the `kv.SteppingMode` is set to `kv.SteppingDisabled`. Instead of assigning the `writeSeq` to read-only requests, we now advance the readSeq automatically and always (regardless of stepping mode) assign the readSeq to read-only requests.

The commit also strongly types `txnSeqNumAllocator.steppingMode`, replacing the bool with a `kv.SteppingMode`.

This is a pure refactor and does not change behavior.

Epic: None
Release note: None