### PR TITLE
keyvisualizer: return error if delete query fails

### DIFF
--- a/pkg/keyvisualizer/spanstatsconsumer/span_stats_consumer.go
+++ b/pkg/keyvisualizer/spanstatsconsumer/span_stats_consumer.go
@@ -149,9 +149,5 @@ func (s *SpanStatsConsumer) decideBoundaries(ctx context.Context) ([]roachpb.Spa
 // DeleteExpiredSamples deletes historical samples older than 2 weeks.
 func (s *SpanStatsConsumer) DeleteExpiredSamples(ctx context.Context) error {
 	oneWeekAgo := timeutil.Now().AddDate(0, 0, -7)
-	if err := keyvisstorage.DeleteSamplesBeforeTime(ctx, s.ie, oneWeekAgo); err != nil {
-		panic(errors.NewAssertionErrorWithWrappedErrf(
-			err, "delete expired samples failed"))
-	}
-	return nil
+	return keyvisstorage.DeleteSamplesBeforeTime(ctx, s.ie, oneWeekAgo)
 }


### PR DESCRIPTION
This commit returns the error produced from `DeleteSamplesBeforeTime`, if any.  Before this change, an error would cause a panic, which is disruptive and unnecessary. 

The caller of this function returns errors produced to the job system, which will back off, and try again later. For more details, see [Resume](https://github.com/cockroachdb/cockroach/blob/afcd974a8ca96f9f89a3ccb2e2b75bd70830fbf6/pkg/keyvisualizer/keyvisjob/job.go#L38).

resolves #103968
Epic: none
Release note (bug fix): The keyvisualizer job no longer panics
if an error is encountered while cleaning up stale samples. Instead,
if the job encounters an error, the job will try again later.