### PR TITLE
kvstreamer: resolve a deadlock in an edge case

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/results_buffer.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer.go
@@ -52,8 +52,8 @@ type resultsBuffer interface {
 	get(context.Context) (_ []Result, allComplete bool, _ error)
 
 	// wait blocks until there is at least one Result available to be returned
-	// to the client.
-	wait()
+	// to the client or the passed-in context is canceled.
+	wait(context.Context) error
 
 	// releaseOne decrements the number of unreleased Results by one.
 	releaseOne()
@@ -225,8 +225,13 @@ func (b *resultsBufferBase) signal() {
 	}
 }
 
-func (b *resultsBufferBase) wait() {
-	<-b.hasResults
+func (b *resultsBufferBase) wait(ctx context.Context) error {
+	select {
+	case <-b.hasResults:
+		return b.error()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (b *resultsBufferBase) numUnreleased() int {

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -728,10 +728,7 @@ func (s *Streamer) GetResults(ctx context.Context) ([]Result, error) {
 		if len(results) > 0 || allComplete || err != nil {
 			return results, err
 		}
-		s.results.wait()
-		// Check whether the Streamer has been canceled or closed while we were
-		// waiting for the results.
-		if err = ctx.Err(); err != nil {
+		if err = s.results.wait(ctx); err != nil {
 			s.results.setError(err)
 			return nil, err
 		}


### PR DESCRIPTION
This commit resolves a hypothetical deadlock that can occur when using the streamer. We've seen one case in #101823 with the following setup:
- the streamer's user goroutine is stuck waiting for any results to be produced by the streamer
- the main streamer's goroutine (workerCoordinator) is stuck waiting for more requests
- there are no requests in-flight.

I'm not quite sure how we got into this state, but it lead to a deadlock, and this commit fixes this situation by adding context cancellation to the streamer's user goroutine (the single occurrence had a statement timeout set, so we know that the ctx must have been cancelled, yet it wasn't respected). There is no regression test since I don't know how this happened, but I don't see any downside in adding this cancellation check.

Fixes: #101823.

Release note: None