### PR TITLE
sql: Reduce cancel checker allocations

### DIFF
--- a/pkg/sql/flowinfra/flow_test.go
+++ b/pkg/sql/flowinfra/flow_test.go
@@ -41,11 +41,11 @@ func BenchmarkFlowSetup(b *testing.B) {
 	defer s.Stopper().Stop(ctx)
 
 	r := sqlutils.MakeSQLRunner(conn)
-	r.Exec(b, "CREATE DATABASE b; CREATE TABLE b.test (k INT);")
+	r.Exec(b, "CREATE DATABASE b; CREATE TABLE b.test (k INT); INSERT INTO b.test SELECT generate_series(1, 8192)")
 
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 	dsp := execCfg.DistSQLPlanner
-	stmt, err := parser.ParseOne("SELECT k FROM b.test WHERE k=1")
+	stmt, err := parser.ParseOne("SELECT k FROM b.test")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/util/ctxutil/BUILD.bazel
+++ b/pkg/util/ctxutil/BUILD.bazel
@@ -10,7 +10,10 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/ctxutil",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_cockroachdb_errors//:errors"],
+    deps = [
+        "//pkg/util",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
 )
 
 go_test(
@@ -23,6 +26,7 @@ go_test(
     embed = [":ctxutil"],
     deps = [
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/ctxutil/context_abi.go
+++ b/pkg/util/ctxutil/context_abi.go
@@ -14,6 +14,7 @@ package ctxutil
 
 import (
 	"context"
+	"sync/atomic"
 	_ "unsafe" // Must import unsafe to enable gross hack below.
 )
 
@@ -45,4 +46,11 @@ func context_removeChild(parent context.Context, child canceler)
 
 func (c *whenDone) cancel(removeFromParent bool, err, cause error) {
 	c.cancelWithCause(removeFromParent, err, cause)
+}
+
+func (c *FastDoneCheckerContext) cancel(removeFromParent bool, err, cause error) {
+	atomic.StoreUint32(&c.done, 1)
+	if removeFromParent {
+		context_removeChild(c.Context, c)
+	}
 }

--- a/pkg/util/ctxutil/context_abi_pre1_20.go
+++ b/pkg/util/ctxutil/context_abi_pre1_20.go
@@ -14,6 +14,7 @@ package ctxutil
 
 import (
 	"context"
+	"sync/atomic"
 	_ "unsafe" // Must import unsafe to enable gross hack below.
 )
 
@@ -35,4 +36,11 @@ func context_removeChild(parent context.Context, child canceler)
 
 func (c *whenDone) cancel(removeFromParent bool, err error) {
 	c.cancelWithCause(removeFromParent, err, nil)
+}
+
+func (c *FastDoneCheckerContext) cancel(removeFromParent bool, err error) {
+	atomic.StoreUint32(&c.done, 1)
+	if removeFromParent {
+		context_removeChild(c.Context, c)
+	}
 }

--- a/pkg/util/ctxutil/context_test.go
+++ b/pkg/util/ctxutil/context_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/logtags"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,4 +29,42 @@ func TestWhenDone(t *testing.T) {
 	case <-time.After(30 * time.Second):
 		t.Fatal("timeout")
 	}
+}
+
+func TestWhenDoneNested(t *testing.T) {
+	var val1Key, val2Key int
+	ctx := context.WithValue(context.Background(), &val1Key, 0)
+	ctx = context.WithValue(ctx, &val2Key, 0)
+	parent, cancelParent := context.WithCancel(ctx)
+	defer cancelParent()
+	ctx = logtags.AddTag(parent, "foo", "bar")
+
+	done := make(chan struct{})
+	require.NoError(t, WhenDone(ctx, func(err error) { close(done) }))
+	cancelParent()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func BenchmarkFastDoneChecker(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	b.Run("err", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = ctx.Err()
+		}
+	})
+
+	b.Run("fast", func(b *testing.B) {
+		var f FastDoneCheckerContext
+		f.Init(ctx)
+		for i := 0; i < b.N; i++ {
+			_ = f.ContextDone()
+		}
+	})
 }


### PR DESCRIPTION
Make context cancel checker a bit more efficient
by reducing allocations.

Update benchmark to execute some real workload.  Prior to this benchmark change, the query always returned 0 rows. Thus the logic of context cancellation checker showed up as something that slower, and produces more allocations. That made sense since arrange for context cancellation notification always results in an allocation (a map in the context package). However, under real workloads -- namely workloads that run under context configured with `context.WithCancel` or similar, this overhead happens anyway.  In addition, old implementation of context checker triggered (usually) once every 1024 rows, so the new implementation which checks for cancellation every row seemed to be slower.  With benchmark updated to read 8k rows, the results are below:

```
Executed 2 out of 2 tests: 2 tests pass.
INFO: Build completed successfully, 1636 total actions
name                                           old time/op    new time/op    delta
FlowSetup/vectorize=true/distribute=true-10      2.06ms ± 1%    2.05ms ± 1%    ~     (p=0.315 n=30+26)
FlowSetup/vectorize=true/distribute=false-10     2.05ms ± 0%    2.03ms ± 1%  -0.72%  (p=0.000 n=28+27)
FlowSetup/vectorize=false/distribute=true-10     2.14ms ± 2%    2.11ms ± 0%  -1.44%  (p=0.000 n=30+29)
FlowSetup/vectorize=false/distribute=false-10    2.12ms ± 2%    2.10ms ± 1%  -0.82%  (p=0.001 n=30+30)

name                                           old alloc/op   new alloc/op   delta
FlowSetup/vectorize=true/distribute=true-10       696kB ± 3%     698kB ± 3%    ~     (p=0.284 n=28+29)
FlowSetup/vectorize=true/distribute=false-10      663kB ± 9%     663kB ± 8%    ~     (p=0.877 n=28+28)
FlowSetup/vectorize=false/distribute=true-10     1.01MB ± 1%    1.01MB ± 1%  -0.12%  (p=0.042 n=26+25)
FlowSetup/vectorize=false/distribute=false-10    1.01MB ± 0%    1.01MB ± 1%    ~     (p=0.888 n=24+27)

name                                           old allocs/op  new allocs/op  delta
FlowSetup/vectorize=true/distribute=true-10         456 ±68%       459 ±67%  +0.68%  (p=0.028 n=30+30)
FlowSetup/vectorize=true/distribute=false-10        316 ±44%       325 ±51%    ~     (p=0.136 n=25+25)
FlowSetup/vectorize=false/distribute=true-10      1.32k ±13%     1.31k ±14%    ~     (p=0.120 n=27+26)
FlowSetup/vectorize=false/distribute=false-10     1.28k ± 1%     1.32k ±15%    ~     (p=0.781 n=24+27)
```

Epic: None
Release note: None