### PR TITLE
roachprod-microbench: export metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -303,7 +303,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/safehtml v0.0.2 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1171,7 +1171,6 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210827144239-02619b876842 h1:JCrt5MIE1fHQtdy1825HwJ45oVQaqHE6lgssRhjcg/o=
 github.com/google/pprof v0.0.0-20210827144239-02619b876842/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/safehtml v0.0.2 h1:ZOt2VXg4x24bW0m2jtzAOkhoXV0iM8vNKc0paByCZqM=
 github.com/google/safehtml v0.0.2/go.mod h1:L4KWwDsUJdECRAEpZoBn3O64bQaywRscowZjJAzjHnU=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1075,6 +1075,7 @@ GO_TARGETS = [
     "//pkg/cmd/returncheck:returncheck_lib",
     "//pkg/cmd/roachprod-microbench/cluster:cluster",
     "//pkg/cmd/roachprod-microbench/google:google",
+    "//pkg/cmd/roachprod-microbench/model:model",
     "//pkg/cmd/roachprod-microbench:roachprod-microbench",
     "//pkg/cmd/roachprod-microbench:roachprod-microbench_lib",
     "//pkg/cmd/roachprod-microbench:roachprod-microbench_test",

--- a/pkg/cmd/roachprod-microbench/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "compare.go",
         "executor.go",
+        "export.go",
         "main.go",
         "metadata.go",
         "report.go",
@@ -26,6 +27,7 @@ go_library(
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_klauspost_compress//gzip",
         "@com_github_spf13_cobra//:cobra",
+        "@org_golang_x_exp//maps",
         "@org_golang_x_perf//benchfmt",
     ],
 )
@@ -41,6 +43,7 @@ go_test(
     srcs = [
         "compare_test.go",
         "executor_test.go",
+        "export_test.go",
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
@@ -48,6 +51,7 @@ go_test(
     deps = [
         "//pkg/cmd/roachprod-microbench/model",
         "//pkg/testutils/datapathutils",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//maps",

--- a/pkg/cmd/roachprod-microbench/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/BUILD.bazel
@@ -15,19 +15,18 @@ go_library(
     deps = [
         "//pkg/cmd/roachprod-microbench/cluster",
         "//pkg/cmd/roachprod-microbench/google",
+        "//pkg/cmd/roachprod-microbench/model",
         "//pkg/roachprod",
         "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/ssh",
         "//pkg/roachprod/vm",
-        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_klauspost_compress//gzip",
         "@com_github_spf13_cobra//:cobra",
-        "@org_golang_x_perf//benchstat",
-        "@org_golang_x_perf//storage/benchfmt",
+        "@org_golang_x_perf//benchfmt",
     ],
 )
 
@@ -47,10 +46,10 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":roachprod-microbench_lib"],
     deps = [
+        "//pkg/cmd/roachprod-microbench/model",
         "//pkg/testutils/datapathutils",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//maps",
-        "@org_golang_x_perf//benchstat",
     ],
 )

--- a/pkg/cmd/roachprod-microbench/compare.go
+++ b/pkg/cmd/roachprod-microbench/compare.go
@@ -16,16 +16,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/google"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/model"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
-	//lint:ignore SA1019 benchstat is deprecated
-	"golang.org/x/perf/benchstat"
-	//lint:ignore SA1019 storage/benchfmt is deprecated
-	"golang.org/x/perf/storage/benchfmt"
+	"golang.org/x/perf/benchfmt"
 )
 
 type compareConfig struct {
@@ -55,81 +51,46 @@ func newCompare(config compareConfig) (*compare, error) {
 	return &compare{compareConfig: config, service: service, packages: packages, ctx: ctx}, nil
 }
 
-func (c *compare) compareBenchmarks() (map[string][]*benchstat.Table, error) {
-	type packageResults struct {
-		old []*benchfmt.Result
-		new []*benchfmt.Result
-	}
-	combinedResults := make(map[string]*packageResults)
-	var resultMutex syncutil.Mutex
-	var wg sync.WaitGroup
-	errorsFound := false
-	wg.Add(len(c.packages))
+func (c *compare) readMetrics() (map[string]*model.MetricMap, error) {
+	builders := make(map[string]*model.Builder)
 	for _, pkg := range c.packages {
-		go func(pkg string) {
-			defer wg.Done()
-			basePackage := pkg[:strings.Index(pkg[4:]+"/", "/")+4]
-			resultMutex.Lock()
-			results, ok := combinedResults[basePackage]
-			if !ok {
-				results = &packageResults{}
-				combinedResults[basePackage] = results
-			}
-			resultMutex.Unlock()
+		basePackage := pkg[:strings.Index(pkg[4:]+"/", "/")+4]
+		results, ok := builders[basePackage]
+		if !ok {
+			results = model.NewBuilder()
+			builders[basePackage] = results
+		}
 
-			// Read the previous and current results. If either is missing, we'll just
-			// skip it. The not found error is ignored since it can be expected that
-			// some benchmarks have changed names or been removed.
-			if err := readReportFile(filepath.Join(c.oldDir, getReportLogName(reportLogName, pkg)),
-				func(result *benchfmt.Result) {
-					resultMutex.Lock()
-					results.old = append(results.old, postfixResultWithPackage(pkg, result))
-					resultMutex.Unlock()
-				}); err != nil && !oserror.IsNotExist(err) {
-				log.Printf("failed to add report for %s: %s", pkg, err)
-				errorsFound = true
-			}
-			if err := readReportFile(filepath.Join(c.newDir, getReportLogName(reportLogName, pkg)),
-				func(result *benchfmt.Result) {
-					resultMutex.Lock()
-					results.new = append(results.new, postfixResultWithPackage(pkg, result))
-					resultMutex.Unlock()
-				}); err != nil && !oserror.IsNotExist(err) {
-				log.Printf("failed to add report for %s: %s", pkg, err)
-				errorsFound = true
-			}
-		}(pkg)
-	}
-	wg.Wait()
-	if errorsFound {
-		return nil, errors.New("failed to process reports")
-	}
+		// Read the previous and current results. If either is missing, we'll just
+		// skip it.
+		if err := processReportFile(results, "old", pkg,
+			filepath.Join(c.oldDir, getReportLogName(reportLogName, pkg))); err != nil {
+			return nil, err
 
-	tableResults := make(map[string][]*benchstat.Table)
-	for pkgGroup, results := range combinedResults {
-		var c benchstat.Collection
-		c.Alpha = 0.05
-		c.Order = benchstat.Reverse(benchstat.ByDelta)
-		// Only add the results if both sets are present.
-		if len(results.old) > 0 && len(results.new) > 0 {
-			c.AddResults("old", results.old)
-			c.AddResults("new", results.new)
-			tables := prefixBenchmarkNamesWithPackage(c.Tables())
-			tableResults[pkgGroup] = tables
-		} else if len(results.old)+len(results.new) > 0 {
-			log.Printf("Only one set of results present for %s", pkgGroup)
+		}
+		if err := processReportFile(results, "new", pkg,
+			filepath.Join(c.newDir, getReportLogName(reportLogName, pkg))); err != nil {
+			log.Printf("failed to add report for %s: %s", pkg, err)
+			return nil, err
 		}
 	}
-	return tableResults, nil
+
+	// Compute the results.
+	metricMaps := make(map[string]*model.MetricMap)
+	for pkg, builder := range builders {
+		metricMap := builder.ComputeMetricMap()
+		metricMaps[pkg] = &metricMap
+	}
+	return metricMaps, nil
 }
 
-func (c *compare) publishToGoogleSheets(tableResults map[string][]*benchstat.Table) error {
-	for pkgGroup, tables := range tableResults {
+func (c *compare) publishToGoogleSheets(metricMaps map[string]*model.MetricMap) error {
+	for pkgGroup, metricMap := range metricMaps {
 		sheetName := pkgGroup + "/..."
 		if c.sheetDesc != "" {
 			sheetName += " " + c.sheetDesc
 		}
-		url, err := c.service.CreateSheet(c.ctx, sheetName, tables)
+		url, err := c.service.CreateSheet(c.ctx, sheetName, *metricMap, "old", "new")
 		if err != nil {
 			return err
 		}
@@ -138,48 +99,17 @@ func (c *compare) publishToGoogleSheets(tableResults map[string][]*benchstat.Tab
 	return nil
 }
 
-// postfixResultWithPackage appends the package name to the benchmark name
-// following a special separator. This is done to avoid prefixing the benchmark
-// name with the package name, as this would break the parsing of the benchmark
-// name by benchstat further down the line.
-func postfixResultWithPackage(pkg string, result *benchfmt.Result) *benchfmt.Result {
-	fields := strings.Fields(result.Content)
-	if !strings.HasPrefix(fields[0], "Benchmark") {
-		return result
-	}
-
-	fields[0] = fields[0] + "*" + pkg
-	return &benchfmt.Result{
-		Labels:     result.Labels,
-		NameLabels: result.NameLabels,
-		LineNum:    result.LineNum,
-		Content:    strings.Join(fields, " "),
-	}
-}
-
-// prefixBenchmarkNamesWithPackage prefixes the benchmark name with the package
-// name by using the post-fixing done in postfixResultWithPackage.
-func prefixBenchmarkNamesWithPackage(tables []*benchstat.Table) []*benchstat.Table {
-	for _, table := range tables {
-		for _, row := range table.Rows {
-			splitIndex := strings.LastIndex(row.Benchmark, "*")
-			if splitIndex == -1 {
-				continue
-			}
-			row.Benchmark = row.Benchmark[splitIndex+1:] + "/" + row.Benchmark[:splitIndex]
-		}
-	}
-	return tables
-}
-
-func readReportFile(path string, reportResults func(*benchfmt.Result)) error {
-	reader, err := os.Open(path)
+func processReportFile(builder *model.Builder, id, pkg, path string) error {
+	file, err := os.Open(path)
 	if err != nil {
+		// A not found error is ignored since it can be expected that
+		// some microbenchmarks have changed names or been removed.
+		if oserror.IsNotExist(err) {
+			return nil
+		}
 		return errors.Wrapf(err, "failed to create reader for %s", path)
 	}
-	br := benchfmt.NewReader(reader)
-	for br.Next() {
-		reportResults(br.Result())
-	}
-	return br.Err()
+	defer file.Close()
+	reader := benchfmt.NewReader(file, path)
+	return builder.AddMetrics(id, pkg+"/", reader)
 }

--- a/pkg/cmd/roachprod-microbench/export.go
+++ b/pkg/cmd/roachprod-microbench/export.go
@@ -1,0 +1,98 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/model"
+	"golang.org/x/exp/maps"
+	"golang.org/x/perf/benchfmt"
+)
+
+func exportMetrics(
+	dir string, writer io.Writer, timestamp time.Time, labels map[string]string,
+) error {
+	packages, err := getPackagesFromLogs(dir)
+	if err != nil {
+		return err
+	}
+
+	// Construct the metric map from the logs.
+	runID := "current"
+	builder := model.NewBuilder()
+	for _, pkg := range packages {
+		path := filepath.Join(dir, getReportLogName(reportLogName, pkg))
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		reader := benchfmt.NewReader(file, path)
+		err = builder.AddMetrics(runID, pkg+"/", reader)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Write metrics.
+	metricMap := builder.ComputeMetricMap()
+	labelsString := labelMapToString(labels)
+	for _, metric := range metricMap {
+		for benchmarkName, entry := range metric.BenchmarkEntries {
+			summary := entry.Summaries[runID]
+			fmt.Fprintf(writer, "%s_%s{%s} %f %d\n",
+				sanitize(benchmarkName),
+				sanitize(metric.Name),
+				labelsString,
+				summary.Center,
+				timestamp.Unix(),
+			)
+		}
+	}
+	return nil
+}
+
+func labelMapToString(labels map[string]string) string {
+	var builder strings.Builder
+	keys := maps.Keys(labels)
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := labels[key]
+		if len(builder.String()) > 0 {
+			builder.WriteString(",")
+		}
+		builder.WriteString(sanitize(key))
+		builder.WriteString("=\"")
+		builder.WriteString(sanitize(value))
+		builder.WriteString("\"")
+	}
+	return builder.String()
+}
+
+// sanitize replaces all invalid characters for metric labels with an
+// underscore. The first character must be a letter or underscore or else it
+// will also be replaced with an underscore.
+func sanitize(input string) string {
+	regex := regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	sanitized := regex.ReplaceAllString(input, "_")
+	firstCharRegex := regexp.MustCompile(`^[^a-zA-Z_]`)
+	sanitized = firstCharRegex.ReplaceAllString(sanitized, "_")
+	return sanitized
+}

--- a/pkg/cmd/roachprod-microbench/export_test.go
+++ b/pkg/cmd/roachprod-microbench/export_test.go
@@ -1,0 +1,62 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package main
+
+import (
+	"bytes"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExport(t *testing.T) {
+	testLabels := make(map[string]string)
+	testLabels["some"] = "42test"
+	testLabels["abc/def"] = "good/label?"
+	ddFilePath := path.Join(datapathutils.TestDataPath(t), "export")
+	datadriven.RunTest(t, ddFilePath, func(t *testing.T, d *datadriven.TestData) string {
+		if d.Cmd != "export" {
+			d.Fatalf(t, "unknown command %s", d.Cmd)
+		}
+		testDir := datapathutils.TestDataPath(t, "reports", d.CmdArgs[0].String())
+		writer := new(bytes.Buffer)
+		err := exportMetrics(testDir, writer, timeutil.Unix(1684920350, 0), testLabels)
+		require.NoError(t, err)
+
+		// Return the output sorted by line.
+		output := strings.Split(writer.String(), "\n")
+		sort.Strings(output)
+		return strings.Join(output, "\n")
+	})
+}
+
+func TestSanitize(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{"test", "test"},
+		{"test/sla//sh", "test_sla__sh"},
+		{"5words", "_words"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.output, sanitize(tc.input))
+		})
+	}
+}

--- a/pkg/cmd/roachprod-microbench/google/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/google/BUILD.bazel
@@ -6,11 +6,12 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/google",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/cmd/roachprod-microbench/model",
         "@com_github_cockroachdb_errors//:errors",
         "@org_golang_google_api//drive/v3:drive",
         "@org_golang_google_api//googleapi",
         "@org_golang_google_api//option",
         "@org_golang_google_api//sheets/v4:sheets",
-        "@org_golang_x_perf//benchstat",
+        "@org_golang_x_exp//maps",
     ],
 )

--- a/pkg/cmd/roachprod-microbench/main.go
+++ b/pkg/cmd/roachprod-microbench/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +47,7 @@ Typical usage:
 	// Add subcommands.
 	command.AddCommand(makeCompareCommand())
 	command.AddCommand(makeRunCommand())
+	command.AddCommand(makeExportCommand())
 
 	return command
 }
@@ -124,6 +126,28 @@ func makeCompareCommand() *cobra.Command {
 		RunE:  runCmdFunc,
 	}
 	cmd.Flags().StringVar(&config.sheetDesc, "sheet-desc", "", "append a description to the sheet title when doing a comparison")
+	return cmd
+}
+
+func makeExportCommand() *cobra.Command {
+	var (
+		labels map[string]string
+		ts     int64
+	)
+	runCmdFunc := func(cmd *cobra.Command, commandLine []string) error {
+		args, _ := splitArgsAtDash(cmd, commandLine)
+		return exportMetrics(args[0], os.Stdout, timeutil.Unix(ts, 0), labels)
+	}
+
+	cmd := &cobra.Command{
+		Use:   "export <dir>",
+		Short: "Export microbenchmark results to an open metrics format.",
+		Long:  `Export microbenchmark results to an open metrics format.`,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runCmdFunc,
+	}
+	cmd.Flags().StringToStringVar(&labels, "labels", nil, "comma-separated list of key=value pair labels to add to the metrics")
+	cmd.Flags().Int64Var(&ts, "timestamp", timeutil.Now().Unix(), "unix timestamp to use for the metrics, defaults to now")
 	return cmd
 }
 

--- a/pkg/cmd/roachprod-microbench/main.go
+++ b/pkg/cmd/roachprod-microbench/main.go
@@ -109,11 +109,11 @@ func makeCompareCommand() *cobra.Command {
 			return err
 		}
 
-		tableResults, err := c.compareBenchmarks()
+		metricMaps, err := c.readMetrics()
 		if err != nil {
 			return err
 		}
-		return c.publishToGoogleSheets(tableResults)
+		return c.publishToGoogleSheets(metricMaps)
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/roachprod-microbench/model/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/model/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//build/bazelutil/unused_checker:unused.bzl", "get_x_data")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -14,5 +13,3 @@ go_library(
         "@org_golang_x_perf//benchmath",
     ],
 )
-
-get_x_data(name = "get_x_data")

--- a/pkg/cmd/roachprod-microbench/model/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/model/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//build/bazelutil/unused_checker:unused.bzl", "get_x_data")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "model",
+    srcs = [
+        "builder.go",
+        "metric.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/model",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_x_perf//benchfmt",
+        "@org_golang_x_perf//benchmath",
+    ],
+)
+
+get_x_data(name = "get_x_data")

--- a/pkg/cmd/roachprod-microbench/model/builder.go
+++ b/pkg/cmd/roachprod-microbench/model/builder.go
@@ -1,0 +1,153 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package model
+
+import (
+	"fmt"
+
+	"golang.org/x/perf/benchfmt"
+	"golang.org/x/perf/benchmath"
+)
+
+// metricUnitNames maps from unit to metric name for known built-in metrics.
+var metricUnitNames = map[string]string{
+	"ns/op": "time/op",
+	"ns/GC": "time/GC",
+	"B/op":  "alloc/op",
+	"MB/s":  "speed",
+}
+
+// Builder is used to build a MetricMap from a set of benchmark results.
+type Builder struct {
+	metricMap  MetricMap
+	thresholds *benchmath.Thresholds
+	confidence float64
+}
+
+// NewBuilder creates a new builder.
+func NewBuilder() *Builder {
+	return &Builder{
+		metricMap:  make(MetricMap),
+		thresholds: &benchmath.DefaultThresholds,
+		confidence: 0.95,
+	}
+}
+
+// AddMetrics adds microbenchmark metrics to the builder's internal model by
+// reading results from the given reader. The prefix is prepended to the
+// benchmark name for all benchmarks. The id is used to identify the source of
+// the metrics, e.g. the run the metrics came from.
+func (b *Builder) AddMetrics(id, prefix string, reader *benchfmt.Reader) error {
+	for reader.Scan() {
+		switch rec := reader.Result().(type) {
+		case *benchfmt.SyntaxError:
+			// In case the benchmark log is corrupted or contains a syntax error, we
+			// want to return an error to the caller.
+			return fmt.Errorf("syntax error: %v", rec)
+		case *benchfmt.Result:
+			benchmarkName := prefix + string(rec.Name.Full())
+			for _, value := range rec.Values {
+				metric := b.resolveMetric(&value, reader.Units())
+				entry := metric.resolveEntry(benchmarkName)
+				entry.addValue(id, value.Value)
+			}
+		}
+	}
+	return nil
+}
+
+// ComputeMetricMap computes the samples and summaries for
+// all metrics in the builder's model.
+func (b *Builder) ComputeMetricMap() MetricMap {
+	for _, metric := range b.metricMap {
+		assumption := metric.Assumption
+		for _, benchmarkEntry := range metric.BenchmarkEntries {
+			benchmarkEntry.Samples = make(map[string]*benchmath.Sample)
+			benchmarkEntry.Summaries = make(map[string]*benchmath.Summary)
+			// Compute the samples and summaries for each run.
+			for run, values := range benchmarkEntry.Values {
+				samples := benchmath.NewSample(values, b.thresholds)
+				benchmarkEntry.Samples[run] = samples
+				summary := assumption.Summary(samples, b.confidence)
+				benchmarkEntry.Summaries[run] = &summary
+			}
+
+		}
+	}
+	return b.metricMap
+}
+
+// ComputeComparison computes the Comparison between two runs of a specified
+// benchmark, each run can contain multiple iterations. The oldID and newID are
+// used to identify the source of the metrics, e.g. the runs the metrics came
+// from. Iff either run does not exist, nil is returned.
+func (m *Metric) ComputeComparison(benchmarkName, oldID, newID string) *Comparison {
+	benchmarkEntry := m.BenchmarkEntries[benchmarkName]
+	// Check that an entry for both runs exist. If not, return nil.
+	for _, run := range []string{oldID, newID} {
+		if benchmarkEntry.Samples[run] == nil || benchmarkEntry.Summaries[run] == nil {
+			return nil
+		}
+	}
+	// Compute the comparison and delta.
+	comparison := Comparison{}
+	oldSample, newSample := benchmarkEntry.Samples[oldID], benchmarkEntry.Samples[newID]
+	comparison.Distribution = m.Assumption.Compare(oldSample, newSample)
+	oldSummary, newSummary := benchmarkEntry.Summaries[oldID], benchmarkEntry.Summaries[newID]
+	comparison.FormattedDelta = comparison.Distribution.FormatDelta(oldSummary.Center, newSummary.Center)
+	if comparison.Distribution.P > comparison.Distribution.Alpha {
+		comparison.Delta = 0.0
+	} else {
+		comparison.Delta = ((newSummary.Center / oldSummary.Center) - 1.0) * 100
+	}
+	return &comparison
+}
+
+// resolveMetric returns the Metric for the given value, creating it if it does
+// not exist.
+func (b *Builder) resolveMetric(value *benchfmt.Value, units benchfmt.UnitMetadataMap) *Metric {
+	unit := value.Unit
+	if metric, ok := b.metricMap[unit]; ok {
+		return metric
+	}
+	metricName := metricUnitNames[unit]
+	if metricName == "" {
+		metricName = unit
+	}
+	metric := &Metric{
+		Name:             metricName,
+		Unit:             unit,
+		Assumption:       units.GetAssumption(unit),
+		Better:           units.GetBetter(unit),
+		BenchmarkEntries: make(map[string]*BenchmarkEntry),
+	}
+	b.metricMap[unit] = metric
+	return metric
+}
+
+// resolveEntry returns the BenchmarkEntry for the given benchmark name, creating it if
+// it does not exist.
+func (m *Metric) resolveEntry(benchmarkName string) *BenchmarkEntry {
+	if entry, ok := m.BenchmarkEntries[benchmarkName]; ok {
+		return entry
+	}
+	entry := &BenchmarkEntry{
+		Values: make(map[string][]float64),
+	}
+	m.BenchmarkEntries[benchmarkName] = entry
+	return entry
+}
+
+// addValue adds the given value to the BenchmarkEntry for the given id.
+func (e *BenchmarkEntry) addValue(id string, value float64) {
+	e.Values[id] = append(e.Values[id], value)
+}

--- a/pkg/cmd/roachprod-microbench/model/metric.go
+++ b/pkg/cmd/roachprod-microbench/model/metric.go
@@ -1,0 +1,50 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package model
+
+import "golang.org/x/perf/benchmath"
+
+// MetricMap is a map from metric name to metric.
+type MetricMap map[string]*Metric
+
+// Metric contains the details of a metric and all benchmark entries associated
+// with it.
+type Metric struct {
+	// Name is the name of the metric (e.g. "time/op").
+	// This is usually the same as the unit, but not always.
+	Name string
+	// Unit is the unit of the metric (e.g. "ns/op").
+	Unit string
+	// Assumption is the statistical assumption to make about distributions of
+	// values in this metric.
+	Assumption benchmath.Assumption
+	// Better is the direction of improvement for this metric.
+	Better int
+	// BenchmarkEntries is a map from full benchmark name to BenchmarkEntry.
+	BenchmarkEntries map[string]*BenchmarkEntry
+}
+
+// BenchmarkEntry contains the samples and summaries for microbenchmark(s).
+// The samples and summaries are keyed by the id of the source of the
+// microbenchmark(s), e.g. the run the microbenchmark(s) came from.
+type BenchmarkEntry struct {
+	Values    map[string][]float64
+	Samples   map[string]*benchmath.Sample
+	Summaries map[string]*benchmath.Summary
+}
+
+// Comparison contains the results of comparing two microbenchmarks.
+type Comparison struct {
+	Distribution   benchmath.Comparison
+	Delta          float64
+	FormattedDelta string
+}

--- a/pkg/cmd/roachprod-microbench/report.go
+++ b/pkg/cmd/roachprod-microbench/report.go
@@ -32,18 +32,6 @@ type report struct {
 	path            string
 }
 
-// TODO: move this
-func initLogger(path string) *logger.Logger {
-	loggerCfg := logger.Config{Stdout: os.Stdout, Stderr: os.Stderr}
-	var loggerError error
-	l, loggerError := loggerCfg.NewLogger(path)
-	if loggerError != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "unable to configure logger: %s\n", loggerError)
-		os.Exit(1)
-	}
-	return l
-}
-
 func getReportLogName(name string, pkg string) string {
 	pkgFormatted := strings.ReplaceAll(pkg, "/", "_")
 	return fmt.Sprintf("%s-%s.log", pkgFormatted, name)

--- a/pkg/cmd/roachprod-microbench/testdata/compare
+++ b/pkg/cmd/roachprod-microbench/testdata/compare
@@ -1,72 +1,58 @@
 # Compare reports containing benchmarks with the same name, but different packages
 compare name-conflict-a name-conflict-b
-
 ----
-----
-Sheet: pkg/parent
-name                             old time/op    new time/op    delta
-pkg/parent/WithNameConflict         100ns ± 0%     100ns ± 0%   ~     (all equal)
-pkg/parent/sub/WithNameConflict    2.00µs ± 0%    2.00µs ± 0%   ~     (all equal)
-
-name                             old alloc/op   new alloc/op   delta
-pkg/parent/WithNameConflict          100B ± 0%      100B ± 0%   ~     (all equal)
-pkg/parent/sub/WithNameConflict    2.00kB ± 0%    2.00kB ± 0%   ~     (all equal)
-
-name                             old allocs/op  new allocs/op  delta
-pkg/parent/WithNameConflict           100 ± 0%       100 ± 0%   ~     (all equal)
-pkg/parent/sub/WithNameConflict     2.00k ± 0%     2.00k ± 0%   ~     (all equal)
-----
-----
+Package pkg/parent
+Metric B/op
+BenchmarkEntry pkg/parent/WithNameConflict +18.45% [122 103] p=0.008 n=5
+BenchmarkEntry pkg/parent/sub/WithNameConflict ~ [2200 2000] p=1.000 n=1
+Metric allocs/op
+BenchmarkEntry pkg/parent/WithNameConflict +18.45% [122 103] p=0.008 n=5
+BenchmarkEntry pkg/parent/sub/WithNameConflict ~ [2200 2000] p=1.000 n=1
+Metric sec/op
+BenchmarkEntry pkg/parent/WithNameConflict +18.45% [1.22e-07 1.0300000000000001e-07] p=0.008 n=5
+BenchmarkEntry pkg/parent/sub/WithNameConflict ~ [2.2e-06 2.0000000000000003e-06] p=1.000 n=1
 
 # Compare reports with the same set of benchmarks
 compare set-a set-b
 ----
-----
-Sheet: pkg/server
-name                                            old time/op    new time/op    delta
-pkg/server/AdminAPIDataDistribution-8              558ms ± 2%     811ms ± 2%  +45.39%  (p=0.000 n=10+10)
-pkg/server/SetupSpanForIncomingRPC/grpcMeta-8     63.8µs ± 2%     0.9µs ± 2%  -98.58%  (p=0.000 n=10+10)
-pkg/server/SetupSpanForIncomingRPC/no_parent-8    62.3µs ± 2%     0.9µs ± 3%  -98.57%  (p=0.000 n=10+10)
-pkg/server/SetupSpanForIncomingRPC/traceInfo-8    62.3µs ± 1%     0.9µs ± 3%  -98.58%  (p=0.000 n=10+10)
-
-name                                            old alloc/op   new alloc/op   delta
-pkg/server/AdminAPIDataDistribution-8             88.0MB ± 1%   102.4MB ± 0%  +16.39%  (p=0.000 n=10+9)
-pkg/server/SetupSpanForIncomingRPC/grpcMeta-8     62.6kB ± 0%     0.3kB ± 0%  -99.49%  (p=0.002 n=8+10)
-pkg/server/SetupSpanForIncomingRPC/no_parent-8    62.0kB ± 0%     0.3kB ± 0%  -99.48%  (p=0.000 n=10+10)
-pkg/server/SetupSpanForIncomingRPC/traceInfo-8    62.0kB ± 0%     0.3kB ± 0%  -99.48%  (p=0.000 n=10+10)
-
-name                                            old allocs/op  new allocs/op  delta
-pkg/server/AdminAPIDataDistribution-8               620k ± 0%      787k ± 0%  +26.92%  (p=0.000 n=10+10)
-pkg/server/SetupSpanForIncomingRPC/grpcMeta-8       27.0 ± 0%       3.0 ± 0%  -88.89%  (p=0.000 n=10+10)
-pkg/server/SetupSpanForIncomingRPC/no_parent-8      21.0 ± 0%       3.0 ± 0%  -85.71%  (p=0.000 n=10+10)
-pkg/server/SetupSpanForIncomingRPC/traceInfo-8      21.0 ± 0%       3.0 ± 0%  -85.71%  (p=0.000 n=10+10)
-
-Sheet: pkg/util
-name                                      old time/op    new time/op    delta
-pkg/util/hlc/DecimalToHLC-8                  391ns ± 1%     395ns ± 1%  +1.24%  (p=0.000 n=9+10)
-pkg/util/hlc/TimestampIsEmpty/all-8         1.41ns ± 3%    1.39ns ± 3%    ~     (p=0.148 n=10+10)
-pkg/util/hlc/TimestampIsEmpty/empty-8       0.88ns ± 2%    0.89ns ± 2%    ~     (p=0.436 n=10+10)
-pkg/util/hlc/TimestampIsEmpty/walltime-8    1.40ns ± 3%    1.39ns ± 3%    ~     (p=0.404 n=10+10)
-pkg/util/hlc/TimestampString-8              69.2ns ± 0%    70.4ns ± 0%  +1.77%  (p=0.000 n=9+8)
-pkg/util/hlc/TimestampStringSynthetic-8     69.6ns ± 1%    69.9ns ± 0%    ~     (p=0.112 n=8+7)
-pkg/util/hlc/Update-8                       67.6ms ± 2%    69.0ms ± 5%    ~     (p=0.143 n=10+10)
-
-name                                      old alloc/op   new alloc/op   delta
-pkg/util/hlc/DecimalToHLC-8                  0.00B          0.00B         ~     (all equal)
-pkg/util/hlc/TimestampIsEmpty/all-8          0.00B          0.00B         ~     (all equal)
-pkg/util/hlc/TimestampIsEmpty/empty-8        0.00B          0.00B         ~     (all equal)
-pkg/util/hlc/TimestampIsEmpty/walltime-8     0.00B          0.00B         ~     (all equal)
-pkg/util/hlc/TimestampString-8               24.0B ± 0%     24.0B ± 0%    ~     (all equal)
-pkg/util/hlc/TimestampStringSynthetic-8      24.0B ± 0%     24.0B ± 0%    ~     (all equal)
-pkg/util/hlc/Update-8                       6.19kB ±28%    6.04kB ±16%    ~     (p=0.965 n=10+8)
-
-name                                      old allocs/op  new allocs/op  delta
-pkg/util/hlc/DecimalToHLC-8                   0.00           0.00         ~     (all equal)
-pkg/util/hlc/TimestampIsEmpty/all-8           0.00           0.00         ~     (all equal)
-pkg/util/hlc/TimestampIsEmpty/empty-8         0.00           0.00         ~     (all equal)
-pkg/util/hlc/TimestampIsEmpty/walltime-8      0.00           0.00         ~     (all equal)
-pkg/util/hlc/TimestampString-8                1.00 ± 0%      1.00 ± 0%    ~     (all equal)
-pkg/util/hlc/TimestampStringSynthetic-8       1.00 ± 0%      1.00 ± 0%    ~     (all equal)
-pkg/util/hlc/Update-8                         46.8 ± 9%      46.4 ± 7%    ~     (p=0.909 n=10+8)
-----
-----
+Package pkg/server
+Metric B/op
+BenchmarkEntry pkg/server/AdminAPIDataDistribution-8 -14.38% [8.7777966e+07 1.02515994e+08] p=0.000 n=10
+BenchmarkEntry pkg/server/SetupSpanForIncomingRPC/grpcMeta-8 +19456.56% [62581 320] p=0.000 n=10
+BenchmarkEntry pkg/server/SetupSpanForIncomingRPC/no_parent-8 +19286.25% [62036 320] p=0.000 n=10
+BenchmarkEntry pkg/server/SetupSpanForIncomingRPC/traceInfo-8 +19286.25% [62036 320] p=0.000 n=10
+Metric allocs/op
+BenchmarkEntry pkg/server/AdminAPIDataDistribution-8 -21.18% [619796.5 786333] p=0.000 n=10
+BenchmarkEntry pkg/server/SetupSpanForIncomingRPC/grpcMeta-8 +800.00% [27 3] p=0.000 n=10
+BenchmarkEntry pkg/server/SetupSpanForIncomingRPC/no_parent-8 +600.00% [21 3] p=0.000 n=10
+BenchmarkEntry pkg/server/SetupSpanForIncomingRPC/traceInfo-8 +600.00% [21 3] p=0.000 n=10
+Metric sec/op
+BenchmarkEntry pkg/server/AdminAPIDataDistribution-8 -31.53% [0.5577142265000001 0.8145041255000001] p=0.000 n=10
+BenchmarkEntry pkg/server/SetupSpanForIncomingRPC/grpcMeta-8 +6950.33% [6.387600000000001e-05 9.060000000000001e-07] p=0.000 n=10
+BenchmarkEntry pkg/server/SetupSpanForIncomingRPC/no_parent-8 +6886.35% [6.217850000000001e-05 8.900000000000001e-07] p=0.000 n=10
+BenchmarkEntry pkg/server/SetupSpanForIncomingRPC/traceInfo-8 +6916.60% [6.256e-05 8.916000000000001e-07] p=0.000 n=10
+Package pkg/util
+Metric B/op
+BenchmarkEntry pkg/util/hlc/DecimalToHLC-8 ~ [0 0] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampIsEmpty/all-8 ~ [0 0] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampIsEmpty/empty-8 ~ [0 0] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampIsEmpty/walltime-8 ~ [0 0] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampString-8 ~ [24 24] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampStringSynthetic-8 ~ [24 24] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/Update-8 ~ [6074.5 6066] p=0.971 n=10
+Metric allocs/op
+BenchmarkEntry pkg/util/hlc/DecimalToHLC-8 ~ [0 0] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampIsEmpty/all-8 ~ [0 0] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampIsEmpty/empty-8 ~ [0 0] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampIsEmpty/walltime-8 ~ [0 0] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampString-8 ~ [1 1] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampStringSynthetic-8 ~ [1 1] p=1.000 n=10
+BenchmarkEntry pkg/util/hlc/Update-8 ~ [46.5 47] p=0.926 n=10
+Metric sec/op
+BenchmarkEntry pkg/util/hlc/DecimalToHLC-8 -1.09% [3.912e-07 3.955e-07] p=0.001 n=10
+BenchmarkEntry pkg/util/hlc/TimestampIsEmpty/all-8 ~ [1.4155000000000001e-09 1.3935e-09] p=0.148 n=10
+BenchmarkEntry pkg/util/hlc/TimestampIsEmpty/empty-8 ~ [8.8595e-10 8.8665e-10] p=0.436 n=10
+BenchmarkEntry pkg/util/hlc/TimestampIsEmpty/walltime-8 ~ [1.4000000000000001e-09 1.393e-09] p=0.404 n=10
+BenchmarkEntry pkg/util/hlc/TimestampString-8 -1.73% [6.920000000000001e-08 7.041500000000001e-08] p=0.000 n=10
+BenchmarkEntry pkg/util/hlc/TimestampStringSynthetic-8 ~ [6.9535e-08 6.9835e-08] p=0.159 n=10
+BenchmarkEntry pkg/util/hlc/Update-8 ~ [0.067674381 0.06884473399999999] p=0.143 n=10

--- a/pkg/cmd/roachprod-microbench/testdata/export
+++ b/pkg/cmd/roachprod-microbench/testdata/export
@@ -1,0 +1,40 @@
+# Export reports to open metrics format
+export set-a
+----
+----
+
+pkg_server_AdminAPIDataDistribution_8_alloc_op{abc_def="good_label_",some="_2test"} 102515994.000000 1684920350
+pkg_server_AdminAPIDataDistribution_8_allocs_op{abc_def="good_label_",some="_2test"} 786333.000000 1684920350
+pkg_server_AdminAPIDataDistribution_8_sec_op{abc_def="good_label_",some="_2test"} 0.814504 1684920350
+pkg_server_SetupSpanForIncomingRPC_grpcMeta_8_alloc_op{abc_def="good_label_",some="_2test"} 320.000000 1684920350
+pkg_server_SetupSpanForIncomingRPC_grpcMeta_8_allocs_op{abc_def="good_label_",some="_2test"} 3.000000 1684920350
+pkg_server_SetupSpanForIncomingRPC_grpcMeta_8_sec_op{abc_def="good_label_",some="_2test"} 0.000001 1684920350
+pkg_server_SetupSpanForIncomingRPC_no_parent_8_alloc_op{abc_def="good_label_",some="_2test"} 320.000000 1684920350
+pkg_server_SetupSpanForIncomingRPC_no_parent_8_allocs_op{abc_def="good_label_",some="_2test"} 3.000000 1684920350
+pkg_server_SetupSpanForIncomingRPC_no_parent_8_sec_op{abc_def="good_label_",some="_2test"} 0.000001 1684920350
+pkg_server_SetupSpanForIncomingRPC_traceInfo_8_alloc_op{abc_def="good_label_",some="_2test"} 320.000000 1684920350
+pkg_server_SetupSpanForIncomingRPC_traceInfo_8_allocs_op{abc_def="good_label_",some="_2test"} 3.000000 1684920350
+pkg_server_SetupSpanForIncomingRPC_traceInfo_8_sec_op{abc_def="good_label_",some="_2test"} 0.000001 1684920350
+pkg_util_hlc_DecimalToHLC_8_alloc_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_DecimalToHLC_8_allocs_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_DecimalToHLC_8_sec_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampIsEmpty_all_8_alloc_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampIsEmpty_all_8_allocs_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampIsEmpty_all_8_sec_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampIsEmpty_empty_8_alloc_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampIsEmpty_empty_8_allocs_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampIsEmpty_empty_8_sec_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampIsEmpty_walltime_8_alloc_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampIsEmpty_walltime_8_allocs_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampIsEmpty_walltime_8_sec_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampStringSynthetic_8_alloc_op{abc_def="good_label_",some="_2test"} 24.000000 1684920350
+pkg_util_hlc_TimestampStringSynthetic_8_allocs_op{abc_def="good_label_",some="_2test"} 1.000000 1684920350
+pkg_util_hlc_TimestampStringSynthetic_8_sec_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_TimestampString_8_alloc_op{abc_def="good_label_",some="_2test"} 24.000000 1684920350
+pkg_util_hlc_TimestampString_8_allocs_op{abc_def="good_label_",some="_2test"} 1.000000 1684920350
+pkg_util_hlc_TimestampString_8_sec_op{abc_def="good_label_",some="_2test"} 0.000000 1684920350
+pkg_util_hlc_Update_8_alloc_op{abc_def="good_label_",some="_2test"} 6066.000000 1684920350
+pkg_util_hlc_Update_8_allocs_op{abc_def="good_label_",some="_2test"} 47.000000 1684920350
+pkg_util_hlc_Update_8_sec_op{abc_def="good_label_",some="_2test"} 0.068845 1684920350
+----
+----

--- a/pkg/cmd/roachprod-microbench/testdata/reports/name-conflict-a/pkg_parent-report.log
+++ b/pkg/cmd/roachprod-microbench/testdata/reports/name-conflict-a/pkg_parent-report.log
@@ -1,1 +1,5 @@
-BenchmarkWithNameConflict 100 100 ns/op 100 B/op 100 allocs/op
+BenchmarkWithNameConflict 101 101 ns/op 101 B/op 101 allocs/op
+BenchmarkWithNameConflict 102 102 ns/op 102 B/op 102 allocs/op
+BenchmarkWithNameConflict 103 103 ns/op 103 B/op 103 allocs/op
+BenchmarkWithNameConflict 104 104 ns/op 104 B/op 104 allocs/op
+BenchmarkWithNameConflict 105 105 ns/op 105 B/op 105 allocs/op

--- a/pkg/cmd/roachprod-microbench/testdata/reports/name-conflict-b/pkg_parent-report.log
+++ b/pkg/cmd/roachprod-microbench/testdata/reports/name-conflict-b/pkg_parent-report.log
@@ -1,1 +1,5 @@
-BenchmarkWithNameConflict 100 100 ns/op 100 B/op 100 allocs/op
+BenchmarkWithNameConflict 120 120 ns/op 120 B/op 120 allocs/op
+BenchmarkWithNameConflict 121 121 ns/op 121 B/op 121 allocs/op
+BenchmarkWithNameConflict 122 122 ns/op 122 B/op 122 allocs/op
+BenchmarkWithNameConflict 123 123 ns/op 123 B/op 123 allocs/op
+BenchmarkWithNameConflict 124 124 ns/op 124 B/op 124 allocs/op

--- a/pkg/cmd/roachprod-microbench/testdata/reports/name-conflict-b/pkg_parent_sub-report.log
+++ b/pkg/cmd/roachprod-microbench/testdata/reports/name-conflict-b/pkg_parent_sub-report.log
@@ -1,1 +1,1 @@
-BenchmarkWithNameConflict 2000 2000 ns/op 2000 B/op 2000 allocs/op
+BenchmarkWithNameConflict 2200 2200 ns/op 2200 B/op 2200 allocs/op

--- a/pkg/cmd/roachprod-microbench/util.go
+++ b/pkg/cmd/roachprod-microbench/util.go
@@ -85,3 +85,14 @@ func initRoachprod(l *logger.Logger) error {
 func roachprodRun(clusterName string, l *logger.Logger, cmdArray []string) error {
 	return roachprod.Run(context.Background(), l, clusterName, "", "", false, os.Stdout, os.Stderr, cmdArray)
 }
+
+func initLogger(path string) *logger.Logger {
+	loggerCfg := logger.Config{Stdout: os.Stdout, Stderr: os.Stderr}
+	var loggerError error
+	l, loggerError := loggerCfg.NewLogger(path)
+	if loggerError != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "unable to configure logger: %s\n", loggerError)
+		os.Exit(1)
+	}
+	return l
+}


### PR DESCRIPTION
This PR contains a few commits related to adding support for exporting metrics in open metrics format.
The first two commits replace deprecated golang perf dependencies, and the final commit introduces the export command.

Epic: [CRDB-20903](https://cockroachlabs.atlassian.net/browse/CRDB-20903)
Release note: None