### PR TITLE
ui: fix Filter dropdown menu on Latency page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/filter/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/filter/index.tsx
@@ -12,6 +12,7 @@ import { Checkbox, Select } from "antd";
 import "antd/lib/checkbox/style";
 import "antd/lib/select/style";
 import Dropdown, { arrowRenderer } from "src/views/shared/components/dropdown";
+import { OutsideEventHandler } from "src/components/outsideEventHandler";
 import React from "react";
 import classNames from "classnames";
 import { NetworkFilter, NetworkSort } from "..";
@@ -141,45 +142,58 @@ export class Filter extends React.Component<IFilterProps, IFilterState> {
       width >= containerLeft + 240 ? 0 : width - (containerLeft + 240);
     return (
       <div className="Filter-latency">
-        <Dropdown
-          title="Filter"
-          options={[]}
-          selected=""
-          className={classNames(
-            { dropdown__focused: opened },
-            dropDownClassName,
-          )}
-          content={
-            <div ref={this.rangeContainer} className="Range">
-              <div
-                className="click-zone"
-                onClick={() => this.setState({ opened: !opened })}
-              />
-              {opened && (
+        <OutsideEventHandler
+          onOutsideClick={() => this.setState({ opened: false })}
+        >
+          <Dropdown
+            title="Filter"
+            options={[]}
+            selected=""
+            className={classNames(
+              {
+                dropdown__focused: opened,
+              },
+              dropDownClassName,
+            )}
+            onDropdownClick={() => this.setState({ opened: !opened })}
+            content={
+              <div ref={this.rangeContainer} className="Range">
                 <div
-                  className="trigger-container"
-                  onClick={() => this.setState({ opened: false })}
+                  className="click-zone"
+                  onClick={() => {
+                    this.setState({ opened: !opened });
+                  }}
                 />
-              )}
-              <div className="trigger-wrapper">
-                <div
-                  className={`trigger Select ${(opened && "is-open") || ""}`}
-                >
-                  <div className="Select-control">
-                    <div className="Select-arrow-zone">
-                      {arrowRenderer({ isOpen: opened })}
+                {opened && (
+                  <div
+                    className="trigger-container"
+                    onClick={() => this.setState({ opened: false })}
+                  />
+                )}
+                <div className="trigger-wrapper">
+                  <div
+                    className={`trigger Select ${(opened && "is-open") || ""}`}
+                  >
+                    <div className="Select-control">
+                      <div className="Select-arrow-zone">
+                        {arrowRenderer({ isOpen: opened })}
+                      </div>
                     </div>
                   </div>
+                  {opened && (
+                    <div
+                      className="multiple-filter__selection"
+                      style={{ left }}
+                      onClick={e => e.stopPropagation()}
+                    >
+                      {this.renderSelect()}
+                    </div>
+                  )}
                 </div>
-                {opened && (
-                  <div className="multiple-filter__selection" style={{ left }}>
-                    {this.renderSelect()}
-                  </div>
-                )}
               </div>
-            </div>
-          }
-        />
+            }
+          />
+        </OutsideEventHandler>
       </div>
     );
   }

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/dropdown/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/dropdown/index.tsx
@@ -39,6 +39,7 @@ interface DropdownOwnProps {
   // If onArrowClick exists, don't display the arrow next to the dropdown,
   // display left and right arrows to either side instead.
   onArrowClick?: (direction: ArrowDirection) => void;
+  onDropdownClick?: () => void;
   // Disable any arrows in the arrow direction array.
   disabledArrows?: ArrowDirection[];
   content?: any;
@@ -68,6 +69,11 @@ export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
   selectRef: React.RefObject<ReactSelectClass> = React.createRef();
 
   triggerSelectClick = (e: any) => {
+    this.props.onDropdownClick && this.props.onDropdownClick();
+    // Don't handle click if custom dropdown menu content is rendered.
+    if (this.props.content) {
+      return;
+    }
     const dropdownNode = this.dropdownRef.current as Node;
     const titleNode = this.titleRef.current as Node;
     const selectNode = this.selectRef.current;


### PR DESCRIPTION
Before, "Filter" dropdown menu on Latency page was broken due to changed event propagation in newer version of React. It caused that menu didn't open on click and threw errors in console.

Now, the logic of handling menu toggling with custom content is changed in a way that it relies on props event handlers instead of event propagation in DOM.
Also this change enhances behavior on outside click and closes menu when user click somewhere.

Release note: None

Resolves: #101717

https://github.com/cockroachdb/cockroach/assets/3106437/2a4a581b-1355-40de-aaba-b6479d601f08

