### PR TITLE
release-22.2: ui: show active txn status as 'Idle' when it is not executing a stmt

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.spec.ts
@@ -238,25 +238,6 @@ describe("test activeStatementUtils", () => {
     });
 
     it("should convert sessions response to active transactions result", () => {
-      const txns = [
-        {
-          id: new Uint8Array(),
-          start: new Timestamp({
-            seconds: Long.fromNumber(MOCK_START_TIME.unix()),
-          }),
-          num_auto_retries: 3,
-          num_statements_executed: 4,
-        },
-        {
-          id: new Uint8Array(),
-          start: new Timestamp({
-            seconds: Long.fromNumber(MOCK_START_TIME.unix()),
-          }),
-          num_auto_retries: 4,
-          num_statements_executed: 3,
-        },
-      ];
-
       const sessionsResponse: SessionsResponse = {
         sessions: [
           {
@@ -265,7 +246,14 @@ describe("test activeStatementUtils", () => {
             application_name: "application",
             client_address: "clientAddress",
             active_queries: [makeActiveQuery()],
-            active_txn: txns[0],
+            active_txn: {
+              id: new Uint8Array(),
+              start: new Timestamp({
+                seconds: Long.fromNumber(MOCK_START_TIME.unix()),
+              }),
+              num_auto_retries: 3,
+              num_statements_executed: 4,
+            },
           },
           {
             id: new Uint8Array(),
@@ -273,8 +261,32 @@ describe("test activeStatementUtils", () => {
             application_name: "application2",
             client_address: "clientAddress2",
             active_queries: [makeActiveQuery()],
-            active_txn: txns[1],
+            active_txn: {
+              id: new Uint8Array(),
+              start: new Timestamp({
+                seconds: Long.fromNumber(MOCK_START_TIME.unix()),
+              }),
+              num_auto_retries: 4,
+              num_statements_executed: 3,
+            },
           },
+          {
+            id: new Uint8Array(),
+            username: "baz",
+            application_name: "application3",
+            client_address: "clientAddress3",
+            active_queries: [],
+            active_txn: {
+              id: new Uint8Array(),
+              start: new Timestamp({
+                seconds: Long.fromNumber(MOCK_START_TIME.unix()),
+              }),
+              num_auto_retries: 2,
+              num_statements_executed: 3,
+            },
+            last_active_query: "select 1",
+          },
+          // The below txn should be filtered out.
           {
             id: new Uint8Array(),
             username: "foo",
@@ -282,7 +294,14 @@ describe("test activeStatementUtils", () => {
             application_name: "closed_application",
             client_address: "clientAddress2",
             active_queries: [makeActiveQuery()],
-            active_txn: txns[1],
+            active_txn: {
+              id: new Uint8Array(),
+              start: new Timestamp({
+                seconds: Long.fromNumber(MOCK_START_TIME.unix()),
+              }),
+              num_auto_retries: 2,
+              num_statements_executed: 3,
+            },
           },
         ],
         errors: [],
@@ -293,18 +312,26 @@ describe("test activeStatementUtils", () => {
         getActiveExecutionsFromSessions(sessionsResponse).transactions;
 
       // Should filter out the txn from closed  session.
-      expect(activeTransactions.length).toBe(2);
+      expect(activeTransactions.length).toBe(3);
 
+      let executingCnt = 0;
       activeTransactions.forEach((txn: ActiveTransaction, i) => {
         expect(txn.application).toBe(
           sessionsResponse.sessions[i].application_name,
         );
-        expect(txn.status).toBe("Executing");
         expect(txn.query).toBeTruthy();
+        if (sessionsResponse.sessions[i].active_queries.length > 0) {
+          expect(txn.status).toEqual("Executing");
+          executingCnt++;
+        } else {
+          expect(txn.status).toEqual("Idle");
+        }
         expect(txn.start.unix()).toBe(
           TimestampToMoment(defaultActiveQuery.start).unix(),
         );
       });
+
+      expect(executingCnt).toEqual(2);
     });
 
     it("should populate txn latest query when there is no active stmt for txns with at least 1 stmt", () => {

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
@@ -138,7 +138,7 @@ export function getActiveExecutionsFromSessions(
             ? session.last_active_query
             : null),
         statementID: activeStmt?.statementID,
-        status: "Executing" as ExecutionStatus,
+        status: (activeStmt != null ? "Executing" : "Idle") as ExecutionStatus,
         start: TimestampToMoment(activeTxn.start),
         elapsedTime: DurationToMomentDuration(activeTxn.elapsed_time),
         application: session.application_name,

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/statusIcon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/statusIcon.tsx
@@ -14,6 +14,7 @@ import { CircleFilled } from "src/icon";
 import { ExecutionStatus } from "./types";
 
 import styles from "./executionStatusIcon.module.scss";
+
 const cx = classNames.bind(styles);
 
 export type StatusIconProps = {
@@ -21,6 +22,6 @@ export type StatusIconProps = {
 };
 
 export const StatusIcon: React.FC<StatusIconProps> = ({ status }) => {
-  const statusClassName = status !== "Waiting" ? "executing" : "waiting";
+  const statusClassName = status === "Executing" ? "executing" : "waiting";
   return <CircleFilled className={cx("status-icon", statusClassName)} />;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
@@ -16,7 +16,9 @@ export type SessionsResponse =
   protos.cockroach.server.serverpb.ListSessionsResponse;
 export type ActiveStatementResponse =
   protos.cockroach.server.serverpb.ActiveQuery;
-export type ExecutionStatus = "Waiting" | "Executing" | "Preparing";
+
+export type ExecutionStatus = "Waiting" | "Executing" | "Preparing" | "Idle";
+
 export type ExecutionType = "statement" | "transaction";
 
 export const ActiveStatementPhase =


### PR DESCRIPTION
Backport 1/1 commits from #103904.

/cc @cockroachdb/release

---

For the active txns pages, we preivously showed txns in two different statuses: 'Executing' or 'Waiting'. This commit introduces the 'Idle' status for txns that have began but are not currently executing a stmt.

Fixes: #100236

Release note (ui change): Active Transactions pages - Transaction status will be 'Idle' if the executing txn is not currently executing a statement, instead of having an 'Executing' status.

Release justification: low-risk, high benefit change to update to existing functionality


<img width="1915" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20136951/b08d9aa8-42a3-49ee-aab1-36261e8bf8a8">
<img width="1916" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20136951/e2ecaaad-68d0-48b8-a4d7-086eee0b928d">

