### PR TITLE
sql: fix reset_sql_stats to truncate activity tables

### DIFF
--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -186,6 +186,34 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 	err = row.Scan(&count)
 	require.NoError(t, err)
 	require.Equal(t, count, 1, "statement_activity after transfer: expect:1, actual:%d", count)
+
+	// Reset the stats and verify it's empty
+	_, err = db.ExecContext(ctx, "SELECT crdb_internal.reset_sql_stats()")
+	require.NoError(t, err)
+
+	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
+		"FROM system.public.transaction_activity")
+	err = row.Scan(&count)
+	require.NoError(t, err)
+	require.Zero(t, count, "transaction_activity after transfer: expect:0, actual:%d", count)
+
+	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
+		"FROM system.public.statement_activity")
+	err = row.Scan(&count)
+	require.NoError(t, err)
+	require.Zero(t, count, "statement_activity after transfer: expect:0, actual:%d", count)
+
+	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
+		"FROM crdb_internal.transaction_activity")
+	err = row.Scan(&count)
+	require.NoError(t, err)
+	require.Zero(t, count, "transaction_activity after transfer: expect:0, actual:%d", count)
+
+	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
+		"FROM crdb_internal.statement_activity")
+	err = row.Scan(&count)
+	require.NoError(t, err)
+	require.Zero(t, count, "statement_activity after transfer: expect:0, actual:%d", count)
 }
 
 // TestSqlActivityUpdateJob verifies that the

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/scheduledjobs",


### PR DESCRIPTION
Previously:
The reset stats on the ui and crdb_internal.reset_sql_stats() would only reset the statement_statistics and transaction_statics tables. This would leave the sql_activity table with old data. The reset stats now truncates the sql_activity table as well.

Fixes: https://github.com/cockroachdb/cockroach/issues/104321
Epic: none

Release note (sql change): Fix crdb_internal.reset_sql_stats() to
 cleanup the sql_activity table which work as a cache for the stats.