### PR TITLE
roachprod: add WithWaitOnFail() when executing sql across nodes

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -353,7 +353,7 @@ func (c *SyncedCluster) ExecSQL(
 		}
 		resultChan <- result{node: node, output: string(res.CombinedOut)}
 		return res, nil
-	}, WithDisplay(display)); err != nil {
+	}, WithDisplay(display), WithWaitOnFail()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Previously, we added fail fast behaviour when executing commands across nodes using roachtest/roachprod. There are some instances, specifically from the CLI, that should wait for all results to be returned. This PR adds `WithWaitOnFail()` to `ExecSQL()` in roachprod.

Epic: none
Fixes: #104342

Release note: None