### PR TITLE
streamingccl: avoid blocking on cutoverCh during shutdown

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -478,7 +478,10 @@ func (sip *streamIngestionProcessor) checkForCutoverSignal(
 				return err
 			}
 			if cutoverReached {
-				sip.cutoverCh <- struct{}{}
+				select {
+				case sip.cutoverCh <- struct{}{}:
+				case <-stopPoller:
+				}
 				return nil
 			}
 		}


### PR DESCRIPTION
During the shutdown process, it's possible no one is reading cutoverCh. Here, we select on the stop channel to ensure we don't block forever.

Fixes #103987

Release note: None