### PR TITLE
kvprober: special case node-is-decommissioned errors

### DIFF
--- a/pkg/kv/kvprober/BUILD.bazel
+++ b/pkg/kv/kvprober/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
@@ -64,5 +65,6 @@ go_test(
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//codes",
     ],
 )

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -209,6 +210,27 @@ func (p *ProberOps) Write(key roachpb.Key) func(context.Context, *kv.Txn) error 
 	}
 }
 
+// errorIsExpectedDuringNormalOperation filters out errors that may be returned
+// during normal operation of CRDB.
+//
+// One such example is the `was permanently removed from the cluster at` error
+// that is returned to the kvclient of decommissioned nodes. This error does not
+// affect user traffic, since such traffic is drained off the node by the time it
+// becomes decommissioned.
+//
+// Since such errors do not indicate a problem with CRDB, kvprober does not report
+// them as an error in its metrics.
+func errorIsExpectedDuringNormalOperation(err error) bool {
+	// Note that errors *other* than decommissioned status errors, such as
+	// `use of closed network connection`, happen *occasionally* on the kvclient
+	// of a decommissioned node. The full set of other errors is not known exactly,
+	// and the errors mostly lack structure. Since they happen rarely, and since
+	// the intended use of kvprober is to page on a sustained error rate, not a
+	// single error, we choose to only filter out errors via the
+	// kvpb.IsDecommissionedStatusErr function.
+	return kvpb.IsDecommissionedStatusErr(err)
+}
+
 // validateKey returns an error if the key is not valid for use by the kvprober.
 // This is a sanity check to ensure that the kvprober does not corrupt user data
 // in the global keyspace or other system data in the local keyspace.
@@ -351,8 +373,12 @@ func (p *Prober) readProbeImpl(ctx context.Context, ops proberOpsI, txns proberT
 		return
 	}
 	if err != nil {
-		log.Health.Errorf(ctx, "can't make a plan: %v", err)
-		p.metrics.ProbePlanFailures.Inc(1)
+		if errorIsExpectedDuringNormalOperation(err) {
+			log.Health.Warningf(ctx, "making a plan failed with expected error: %v", err)
+		} else {
+			log.Health.Errorf(ctx, "can't make a plan: %v", err)
+			p.metrics.ProbePlanFailures.Inc(1)
+		}
 		return
 	}
 
@@ -382,9 +408,13 @@ func (p *Prober) readProbeImpl(ctx context.Context, ops proberOpsI, txns proberT
 		return txns.TxnRootKV(ctx, f)
 	})
 	if err != nil {
-		// TODO(josh): Write structured events with log.Structured.
-		log.Health.Errorf(ctx, "kv.Get(%s), r=%v failed with: %v", step.Key, step.RangeID, err)
-		p.metrics.ReadProbeFailures.Inc(1)
+		if errorIsExpectedDuringNormalOperation(err) {
+			log.Health.Warningf(ctx, "kv.Get(%s), r=%v failed with expected error: %v", step.Key, step.RangeID, err)
+		} else {
+			// TODO(josh): Write structured events with log.Structured.
+			log.Health.Errorf(ctx, "kv.Get(%s), r=%v failed with: %v", step.Key, step.RangeID, err)
+			p.metrics.ReadProbeFailures.Inc(1)
+		}
 		return
 	}
 
@@ -414,8 +444,12 @@ func (p *Prober) writeProbeImpl(ctx context.Context, ops proberOpsI, txns prober
 		return
 	}
 	if err != nil {
-		log.Health.Errorf(ctx, "can't make a plan: %v", err)
-		p.metrics.ProbePlanFailures.Inc(1)
+		if errorIsExpectedDuringNormalOperation(err) {
+			log.Health.Warningf(ctx, "making a plan failed with expected error: %v", err)
+		} else {
+			log.Health.Errorf(ctx, "can't make a plan: %v", err)
+			p.metrics.ProbePlanFailures.Inc(1)
+		}
 		return
 	}
 
@@ -434,11 +468,17 @@ func (p *Prober) writeProbeImpl(ctx context.Context, ops proberOpsI, txns prober
 		return txns.TxnRootKV(ctx, f)
 	})
 	if err != nil {
-		added := p.quarantineWritePool.maybeAdd(ctx, step)
-		log.Health.Errorf(
-			ctx, "kv.Txn(Put(%s); Del(-)), r=%v failed with: %v [quarantined=%t]", step.Key, step.RangeID, err, added,
-		)
-		p.metrics.WriteProbeFailures.Inc(1)
+		if errorIsExpectedDuringNormalOperation(err) {
+			log.Health.Warningf(
+				ctx, "kv.Txn(Put(%s); Del(-)), r=%v failed with expected error: %v", step.Key, step.RangeID, err,
+			)
+		} else {
+			added := p.quarantineWritePool.maybeAdd(ctx, step)
+			log.Health.Errorf(
+				ctx, "kv.Txn(Put(%s); Del(-)), r=%v failed with: %v [quarantined=%t]", step.Key, step.RangeID, err, added,
+			)
+			p.metrics.WriteProbeFailures.Inc(1)
+		}
 		return
 	}
 	// This will no-op if not in the quarantine pool.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvprober"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
@@ -1828,6 +1829,11 @@ func (ts *TestServer) BinaryVersionOverride() roachpb.Version {
 		return roachpb.Version{}
 	}
 	return knobs.(*TestingKnobs).BinaryVersionOverride
+}
+
+// KvProber is part of the TestServerInterface.
+func (ts *TestServer) KvProber() *kvprober.Prober {
+	return ts.Server.kvProber
 }
 
 type testServerFactoryImpl struct{}

--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/config",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvprober",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/multitenant/tenantcapabilities",
         "//pkg/roachpb",

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvprober"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -317,6 +318,10 @@ type TestServerInterface interface {
 	// BinaryVersionOverride returns the value of an override if set using
 	// TestingKnobs.
 	BinaryVersionOverride() roachpb.Version
+
+	// KvProber returns a *kvprober.Prober, which is useful when asserting the
+	//correctness of the prober from integration tests.
+	KvProber() *kvprober.Prober
 }
 
 // TestServerFactory encompasses the actual implementation of the shim


### PR DESCRIPTION
**kvprober: special case node-is-decommissioned errors**

kvprober runs on decommissioned node. In CC, this is generally fine, since
automation fully takes down nodes once they reach the decommissioned state. But
there is a brief period where a node is running and in the decommissioned
state, and we see kvprober errors in metrics during this period, as in below.
This sometimes leads to false positive kvprober pages in CC production.

‹rpc error: code = PermissionDenied desc = n1 was permanently removed from...

To be clear, the errors are not wrong per say. They just are expected to
happen, once a node is decommissioned.

This commit adds special handling for errors of the kind above, by doing a
substring match on the error string. To be exact, kvprober now logs such errors
at warning level and does not increment any error counters. This way, an
operation like decommissioning a node does not cause false positive kvprober
pages in CC production.

Fixes https://github.com/cockroachdb/cockroach/issues/104367

Release note: None, since kvprober is not used by customers. (It is not
documented.)

Co-authored-by: Josh Carp <carp@cockroachlabs.com>