### PR TITLE
release-23.1: auditloggingccl: migrate role-based audit logging as a CCL feature

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1373,11 +1373,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	vmoduleSetting.SetOnChange(&cfg.Settings.SV, fn)
 	fn(ctx)
 
-	auditlogging.UserAuditLogConfig.SetOnChange(
-		&execCfg.Settings.SV, func(ctx context.Context) {
-			auditlogging.UpdateAuditConfigOnChange(ctx, execCfg.SessionInitCache.AuditConfig, execCfg.Settings)
-		})
-	auditlogging.UpdateAuditConfigOnChange(ctx, execCfg.SessionInitCache.AuditConfig, execCfg.Settings)
+	auditlogging.ConfigureRoleBasedAuditClusterSettings(ctx, execCfg.SessionInitCache.AuditConfig, execCfg.Settings, &execCfg.Settings.SV)
 
 	return &SQLServer{
 		ambientCtx:                     cfg.BaseConfig.AmbientCtx,

--- a/pkg/sql/auditlogging/audit_log_test.go
+++ b/pkg/sql/auditlogging/audit_log_test.go
@@ -22,11 +22,11 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	datadriven.RunTest(t, datapathutils.TestDataPath(t, "parse"),
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "Parse"),
 		func(t *testing.T, td *datadriven.TestData) string {
 			switch td.Cmd {
 			case "multiline":
-				config, err := parse(td.Input)
+				config, err := Parse(td.Input)
 				if err != nil {
 					return fmt.Sprintf("error: %v\n", err)
 				}

--- a/pkg/sql/auditlogging/parser.go
+++ b/pkg/sql/auditlogging/parser.go
@@ -20,15 +20,15 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// parse parses the provided audit logging configuration.
-func parse(input string) (*AuditConfig, error) {
+// Parse parses the provided audit logging configuration.
+func Parse(input string) (*AuditConfig, error) {
 	tokens, err := rulebasedscanner.Tokenize(input)
 	if err != nil {
 		return nil, err
 	}
 
 	config := EmptyAuditConfig()
-	config.settings = make([]AuditSetting, len(tokens.Lines))
+	config.Settings = make([]AuditSetting, len(tokens.Lines))
 	// settingsRoleMap keeps track of the roles we've already written in the config
 	settingsRoleMap := make(map[username.SQLUsername]interface{}, len(tokens.Lines))
 	for i, line := range tokens.Lines {
@@ -42,7 +42,7 @@ func parse(input string) (*AuditConfig, error) {
 			return nil, errors.Newf("duplicate role listed: %v", setting.Role)
 		}
 		settingsRoleMap[setting.Role] = i
-		config.settings[i] = setting
+		config.Settings[i] = setting
 		if setting.Role.Normalized() == allUserRole {
 			config.allRoleAuditSettingIdx = i
 		}


### PR DESCRIPTION
Backport 1/1 commits from #104383.

/cc @cockroachdb/release

---

This change moves the existing role-based audit logging logic to be consumed as a CCL (enterprise) feature.
