### PR TITLE
roachtest: disable scheduled backups in `failover`

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -160,6 +160,7 @@ func runFailoverChaos(
 
 	// Create cluster, and set up failers for all failure modes.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
@@ -355,6 +356,7 @@ func runFailoverPartialLeaseGateway(
 
 	// Create cluster.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
@@ -508,6 +510,7 @@ func runFailoverPartialLeaseLeader(
 	// n1-n3, to precisely place system ranges, since we'll have to disable the
 	// replicate queue shortly.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_DISABLE_LEADER_FOLLOWS_LEASEHOLDER=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
@@ -663,6 +666,7 @@ func runFailoverPartialLeaseLiveness(
 
 	// Create cluster.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
@@ -806,6 +810,7 @@ func runFailoverNonSystem(
 
 	// Create cluster.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
@@ -948,6 +953,7 @@ func runFailoverLiveness(
 
 	// Create cluster. Don't schedule a backup as this roachtest reports to roachperf.
 	opts := option.DefaultStartOptsNoBackups()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
@@ -1094,6 +1100,7 @@ func runFailoverSystemNonLiveness(
 
 	// Create cluster.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication


### PR DESCRIPTION
This patch disables scheduled backup injection in the `failover` roachtests. This is particularly important for the `chaos` tests, where we're failing multiple nodes concurrently -- if we restart a node while a different node is experiencing a failure causing permanent unavailability (e.g. a deadlock), the scheduled backup injection will fail, causing the test to fail. We also disable it across the other tests, since we don't want backups to skew the results or cause additional flake.

Resolves #104260.
Resolves #104263.

Epic: none
Release note: None