### PR TITLE
ui: add Networking metrics dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -186,39 +186,5 @@ export default function (props: GraphDashboardProps) {
         ))}
       </Axis>
     </LineGraph>,
-
-    <LineGraph
-      title="Network Bytes Received"
-      sources={nodeSources}
-      tenantSource={tenantSource}
-    >
-      <Axis units={AxisUnits.Bytes} label="bytes">
-        {nodeIDs.map(nid => (
-          <Metric
-            name="cr.node.sys.host.net.recv.bytes"
-            title={nodeDisplayName(nodeDisplayNameByID, nid)}
-            sources={[nid]}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Network Bytes Sent"
-      sources={nodeSources}
-      tenantSource={tenantSource}
-    >
-      <Axis units={AxisUnits.Bytes} label="bytes">
-        {nodeIDs.map(nid => (
-          <Metric
-            name="cr.node.sys.host.net.send.bytes"
-            title={nodeDisplayName(nodeDisplayNameByID, nid)}
-            sources={[nid]}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
   ];
 }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/networking.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/networking.tsx
@@ -1,0 +1,109 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+
+import LineGraph from "src/views/cluster/components/linegraph";
+import { Axis, Metric } from "src/views/shared/components/metricQuery";
+
+import {
+  GraphDashboardProps,
+  nodeDisplayName,
+  storeIDsForNode,
+} from "./dashboardUtils";
+import { AxisUnits } from "@cockroachlabs/cluster-ui";
+
+export default function (props: GraphDashboardProps) {
+  const { nodeIDs, nodeDisplayNameByID, storeIDsByNodeID, tenantSource } =
+    props;
+
+  return [
+    <LineGraph title="Network Bytes Received">
+      <Axis units={AxisUnits.Bytes} label="bytes">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.sys.host.net.recv.bytes"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            tenantSource={tenantSource}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Network Bytes Sent">
+      <Axis units={AxisUnits.Bytes} label="bytes">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.sys.host.net.send.bytes"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            tenantSource={tenantSource}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="RPC Heartbeat Latency: 50th percentile"
+      isKvGraph={false}
+      tooltip={`Round-trip latency for recent successful outgoing heartbeats.`}
+    >
+      <Axis units={AxisUnits.Duration} label="latency">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.round-trip-latency-p50"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            tenantSource={tenantSource}
+            downsampleMax
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="RPC Heartbeat Latency: 99th percentile"
+      isKvGraph={false}
+      tooltip={`Round-trip latency for recent successful outgoing heartbeats.`}
+    >
+      <Axis units={AxisUnits.Duration} label="latency">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.round-trip-latency-p99"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            tenantSource={tenantSource}
+            downsampleMax
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Unhealthy RPC Connections"
+      tooltip={`The number of outgoing connections on each node that are in an unhealthy state.`}
+    >
+      <Axis label="connections">
+        {nodeIDs.map(nid => (
+          <Metric
+            key={nid}
+            name="cr.node.rpc.connection.unhealthy"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            tenantSource={tenantSource}
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+  ];
+}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -70,6 +70,7 @@ import changefeedsDashboard from "./dashboards/changefeeds";
 import overloadDashboard from "./dashboards/overload";
 import ttlDashboard from "./dashboards/ttl";
 import crossClusterReplicationDashboard from "./dashboards/crossClusterReplication";
+import networkingDashboard from "./dashboards/networking";
 import { getMatchParamByName } from "src/util/query";
 import { PayloadAction } from "src/interfaces/action";
 import {
@@ -113,6 +114,11 @@ const dashboards: { [key: string]: GraphDashboard } = {
   runtime: {
     label: "Runtime",
     component: runtimeDashboard,
+    isKvDashboard: true,
+  },
+  networking: {
+    label: "Networking",
+    component: networkingDashboard,
     isKvDashboard: true,
   },
   sql: { label: "SQL", component: sqlDashboard, isKvDashboard: false },


### PR DESCRIPTION
This has #99191 as a prerequisite.

This moves a few existing network-related metrics to their own dashboard. It
also adds metrics for healthy and unhealthy connections, which are now more
functional thanks to the work on the RPC package carried out in the previous
commits.

Epic: None
Release note (ui change): the DB Console metrics dashboard now has a
"Networking" tab, and a few metrics previously displayed on the Hardware tab
have moved there.
