### PR TITLE
server: start timeseries writes earlier

### DIFF
--- a/pkg/ts/BUILD.bazel
+++ b/pkg/ts/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/quotapool",
-        "//pkg/util/startup",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
For some unrelated testing, I was injecting a large raft log into
`system.settings`. This delayed the `(*SettingsWatcher).Start` call and thus
delayed the call that starts the timeseries poller by a few minutes. We should
be recording timeseries once we can. To make this possible without sacrificing
the "first write is sync" behavior that we (apparently) want, return a promise
(channel) from the method that starts the poller that is signalled on first
write. We can then start the poller earlier.

Epic: none
Release note: None
