### PR TITLE
release-22.2: sql: avoid using shadowed index var to get sequence id

### DIFF
--- a/pkg/sql/catalog/seqexpr/sequence.go
+++ b/pkg/sql/catalog/seqexpr/sequence.go
@@ -69,21 +69,20 @@ func GetSequenceFromFunc(funcExpr *tree.FuncExpr) (*SeqIdentifier, error) {
 
 	if hasSequenceArguments {
 		found := false
-		for i := range def.Overloads {
+		for _, overload := range def.Overloads {
 			// Find the overload that matches funcExpr.
-			if len(funcExpr.Exprs) == def.Overloads[i].Types.Length() {
-				found = true
-				argTypes, ok := def.Overloads[i].Types.(tree.ArgTypes)
+			if len(funcExpr.Exprs) == overload.Types.Length() {
+				paramTypes, ok := overload.Types.(tree.ArgTypes)
 				if !ok {
 					panic(pgerror.Newf(
 						pgcode.InvalidFunctionDefinition,
 						"%s has invalid argument types", funcExpr.Func.String(),
 					))
 				}
-				for i := 0; i < def.Overloads[i].Types.Length(); i++ {
-					// Find the sequence name arg.
-					argName := argTypes[i].Name
-					if argName == builtinconstants.SequenceNameArg {
+				found = true
+				for i := 0; i < paramTypes.Length(); i++ {
+					// Find the sequence name param.
+					if paramTypes[i].Name == builtinconstants.SequenceNameArg {
 						arg := funcExpr.Exprs[i]
 						if seqIdentifier := getSequenceIdentifier(arg); seqIdentifier != nil {
 							return seqIdentifier, nil

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2787,3 +2787,32 @@ statement ok
 USE test;
 DROP DATABASE d CASCADE;
 DROP FUNCTION fn;
+
+subtest regression_103869
+
+statement ok
+CREATE SEQUENCE sq_103869;
+
+statement ok
+CREATE FUNCTION f_103869(sq REGCLASS) RETURNS INT
+LANGUAGE SQL
+AS $$
+    SELECT setval(sq, 1);
+$$;
+
+query I
+SELECT f_103869('sq_103869'::REGCLASS);
+----
+1
+
+statement ok
+CREATE FUNCTION f_103869(sq STRING) RETURNS INT
+LANGUAGE SQL
+AS $$
+    SELECT setval(sq, 2);
+$$
+
+query I
+SELECT f_103869('sq_103869')
+----
+2


### PR DESCRIPTION
Backport 1/1 commits from #104277.

/cc @cockroachdb/release

---

Fixes: #103869

This commit fixes  a bug that shadowing index var was used featch sequence builtin function overload from a slice whose index was shadowed. This is very bad because it cause us to look at a overload accepting different number of params.

Release note (bug fix): this commit fixes a bug which would cause CREATE FUNCTION which uses `setval` builtin function to panic.

---

Release justification: low risk bug fix.