### PR TITLE
sql: avoid a race condition in `sqlActivityUpdateJob`

### DIFF
--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -93,7 +93,6 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 	flushDoneSignal := make(chan struct{})
 	defer func() {
 		statsFlush.SetFlushDoneSignalCh(nil)
-		close(flushDoneSignal)
 	}()
 
 	statsFlush.SetFlushDoneSignalCh(flushDoneSignal)


### PR DESCRIPTION
Fixes #103929.

Prior to this patch, it was possible for the stats flusher to cause a go panic because the signal channel provided by `sqlActivityUpdateJob` could be closed there before the stats flusher was done with it.

There is however no particular reason why this channel should be closed. So this patch avoids the panic by simply avoiding the close.

Release note (bug fix): A bug was fixed where in rare cases a panic could occur during shutdown in relation to the SQL activity computation. This bug had been introduced in v23.1.