### PR TITLE
ui: exclude "Idle" status from active statements view

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/execTableCommon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/execTableCommon.tsx
@@ -115,7 +115,11 @@ export const executionsTableTitles: ExecutionsTableTitleType = {
           "Preparing", the ${execType} is being parsed and planned.
           If "Executing", the ${execType} is currently being
           executed. If "Waiting", the ${execType} is currently
-          experiencing contention.`}
+          experiencing contention. ${
+            execType === "transaction"
+              ? `If "Idle", the transaction is open but is not currently executing a statement.`
+              : ``
+          }`}
         </p>
       }
     >

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutions.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutions.selectors.ts
@@ -13,6 +13,7 @@ import {
   ActiveExecutions,
   ActiveTransaction,
   ExecutionStatus,
+  ExecutionType,
 } from "src/activeExecutions/types";
 import { AppState } from "src/store";
 import { selectActiveExecutionsCombiner } from "src/selectors/activeExecutionsCommon.selectors";
@@ -45,14 +46,6 @@ export const selectActiveStatements = createSelector(
   selectActiveExecutions,
   (executions: ActiveExecutions) => executions.statements,
 );
-
-export const selectExecutionStatus = () => {
-  const execStatuses: string[] = [];
-  for (const execStatus in ExecutionStatus) {
-    execStatuses.push(execStatus);
-  }
-  return execStatuses;
-};
 
 export const selecteActiveStatement = createSelector(
   selectActiveStatements,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsPage.selectors.ts
@@ -20,7 +20,6 @@ import {
 import {
   selectActiveStatements,
   selectAppName,
-  selectExecutionStatus,
   selectClusterLocksMaxApiSizeReached,
 } from "src/selectors/activeExecutions.selectors";
 import { actions as localStorageActions } from "src/store/localStorage";
@@ -56,7 +55,6 @@ export const mapStateToActiveStatementsPageProps = (
   selectedColumns: selectColumns(state),
   sortSetting: selectSortSetting(state),
   filters: selectFilters(state),
-  executionStatus: selectExecutionStatus(),
   internalAppNamePrefix: selectAppName(state),
   isTenant: selectIsTenant(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -18,7 +18,11 @@ import {
 import { Loading } from "src/loading/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
 import { Search } from "src/search/search";
-import { ActiveStatement, ActiveStatementFilters } from "src/activeExecutions";
+import {
+  ActiveStatement,
+  ActiveStatementFilters,
+  ExecutionStatus,
+} from "src/activeExecutions";
 import { Filter } from "src/queryFilter";
 import LoadingError from "src/sqlActivity/errorComponent";
 import {
@@ -56,7 +60,6 @@ export type ActiveStatementsViewStateProps = {
   sortSetting: SortSetting;
   sessionsError: Error | null;
   filters: ActiveStatementFilters;
-  executionStatus: string[];
   internalAppNamePrefix: string;
   isTenant?: boolean;
   maxSizeApiReached?: boolean;
@@ -75,7 +78,6 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
   statements,
   sessionsError,
   filters,
-  executionStatus,
   internalAppNamePrefix,
   isTenant,
   maxSizeApiReached,
@@ -169,7 +171,10 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
 
   const apps = getAppsFromActiveExecutions(statements, internalAppNamePrefix);
   const countActiveFilters = calculateActiveFilters(filters);
-
+  // The "Idle" execution status does not apply to statements.
+  const executionStatuses = Object.values(ExecutionStatus).filter(
+    status => status != ExecutionStatus.Idle,
+  );
   const filteredStatements = filterActiveStatements(
     statements,
     filters,
@@ -198,7 +203,7 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
           <Filter
             activeFilters={countActiveFilters}
             onSubmitFilters={onSubmitFilters}
-            executionStatuses={executionStatus.sort()}
+            executionStatuses={executionStatuses}
             showExecutionStatus={true}
             appNames={apps}
             filters={filters}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
@@ -20,7 +20,6 @@ import {
 import {
   selectAppName,
   selectActiveTransactions,
-  selectExecutionStatus,
   selectClusterLocksMaxApiSizeReached,
 } from "src/selectors/activeExecutions.selectors";
 import { actions as localStorageActions } from "src/store/localStorage";
@@ -56,7 +55,6 @@ export const mapStateToActiveTransactionsPageProps = (
   selectedColumns: selectColumns(state),
   sortSetting: selectSortSetting(state),
   filters: selectFilters(state),
-  executionStatus: selectExecutionStatus(),
   internalAppNamePrefix: selectAppName(state),
   isTenant: selectIsTenant(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
@@ -22,6 +22,7 @@ import {
   ActiveTransaction,
   ActiveStatementFilters,
   ActiveTransactionFilters,
+  ExecutionStatus,
 } from "src/activeExecutions";
 import LoadingError from "src/sqlActivity/errorComponent";
 import {
@@ -54,7 +55,6 @@ export type ActiveTransactionsViewStateProps = {
   transactions: ActiveTransaction[];
   sessionsError: Error | null;
   filters: ActiveTransactionFilters;
-  executionStatus: string[];
   sortSetting: SortSetting;
   internalAppNamePrefix: string;
   isTenant?: boolean;
@@ -78,7 +78,6 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
   transactions,
   sessionsError,
   filters,
-  executionStatus,
   internalAppNamePrefix,
   maxSizeApiReached,
 }: ActiveTransactionsViewProps) => {
@@ -171,6 +170,7 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
 
   const apps = getAppsFromActiveExecutions(transactions, internalAppNamePrefix);
   const countActiveFilters = calculateActiveFilters(filters);
+  const executionStatuses = Object.values(ExecutionStatus);
 
   const filteredTransactions = filterActiveTransactions(
     transactions,
@@ -201,7 +201,7 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
           <Filter
             activeFilters={countActiveFilters}
             onSubmitFilters={onSubmitFilters}
-            executionStatuses={executionStatus.sort()}
+            executionStatuses={executionStatuses}
             showExecutionStatus={true}
             appNames={apps}
             filters={filters}

--- a/pkg/ui/workspaces/db-console/src/selectors/activeExecutionsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/selectors/activeExecutionsSelectors.ts
@@ -15,7 +15,6 @@ import {
   getActiveTransaction,
   getContentionDetailsFromLocksAndTxns,
   selectExecutionID,
-  ExecutionStatus,
 } from "@cockroachlabs/cluster-ui";
 import { createSelector } from "reselect";
 import { CachedDataReducerState } from "src/redux/apiReducers";
@@ -43,14 +42,6 @@ export const selectActiveStatements = createSelector(
   selectActiveExecutions,
   (executions: ActiveExecutions) => executions.statements,
 );
-
-export const selectExecutionStatus = () => {
-  const execStatuses: string[] = [];
-  for (const execStatus in ExecutionStatus) {
-    execStatuses.push(execStatus);
-  }
-  return execStatuses;
-};
 
 export const selectActiveStatement = createSelector(
   selectActiveStatements,

--- a/pkg/ui/workspaces/db-console/src/views/statements/activeStatementsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/activeStatementsSelectors.tsx
@@ -16,7 +16,6 @@ import {
 import {
   selectActiveStatements,
   selectAppName,
-  selectExecutionStatus,
   selectClusterLocksMaxApiSizeReached,
 } from "src/selectors";
 import { refreshLiveWorkload } from "src/redux/apiReducers";
@@ -57,7 +56,6 @@ export const mapStateToActiveStatementViewProps = (state: AdminUIState) => ({
   selectedColumns: selectedColumnsLocalSetting.selectorToArray(state),
   sortSetting: sortSettingLocalSetting.selector(state),
   statements: selectActiveStatements(state),
-  executionStatus: selectExecutionStatus(),
   sessionsError: state.cachedData?.sessions.lastError,
   internalAppNamePrefix: selectAppName(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),

--- a/pkg/ui/workspaces/db-console/src/views/transactions/activeTransactionsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/activeTransactionsSelectors.tsx
@@ -17,7 +17,6 @@ import {
 import {
   selectAppName,
   selectActiveTransactions,
-  selectExecutionStatus,
   selectClusterLocksMaxApiSizeReached,
 } from "src/selectors";
 import { refreshLiveWorkload } from "src/redux/apiReducers";
@@ -58,7 +57,6 @@ export const mapStateToActiveTransactionsPageProps = (state: AdminUIState) => ({
   transactions: selectActiveTransactions(state),
   sessionsError: state.cachedData?.sessions.lastError,
   filters: filtersLocalSetting.selector(state),
-  executionStatus: selectExecutionStatus(),
   sortSetting: sortSettingLocalSetting.selector(state),
   internalAppNamePrefix: selectAppName(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),


### PR DESCRIPTION
 Part of: #100236.

Previously, #103904 added the `Idle` status to the active executions
pages which denotes txns that have began but are not currently executing
a stmt. However, a few places (the "status" tooltip, and the "status"
filter options) did not account for this change. This commit adds a
description to the tooltip for the `Idle` status only for the active
txns view. This commit also excludes the `Idle` status filter option for
the active stmts view as it only applies for txns.

**Active Statements View**
| Status Filter Options                                                                           | Tooltip                                                                                                                |
|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1037" alt="stmts-filters" src="https://github.com/cockroachdb/cockroach/assets/35943354/52d6bddb-d38e-4f56-98ef-8b8e6f6daaa5"> | <img width="1037" alt="stmts-tooltip" src="https://github.com/cockroachdb/cockroach/assets/35943354/6d7d0797-da43-4508-b201-bd26997ac391"> |

**Active Transactions View**
| Status Filter Options                                                                           | Tooltip                                                                                                                 |
|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1037" alt="txns-filters" src="https://github.com/cockroachdb/cockroach/assets/35943354/bba501d9-2efc-4af4-988b-56ebc5f7b4bd"> | <img width="1037" alt="txns-tooltip" src="https://github.com/cockroachdb/cockroach/assets/35943354/20cf662c-cf7b-4c0c-8702-c9a4b4e58d06"> |

Release note (ui change): Added description to the tooltip for the
`Idle` status only for the active txns view. Excluded `Idle` status
filter option for the active stmts view.