### PR TITLE
release-22.2: ci: fix pebble nightly roachtest runs

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput_impl.sh
@@ -10,26 +10,25 @@ _dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Run the write-throughput benchmark.
 #
-# NB: We specify "true" for the --cockroach and --workload binaries to
+# NB: We specify "/usr/bin/true" for the --cockroach and --workload binaries to
 # prevent roachtest from complaining (and failing) when it can't find
 # them. The pebble roachtests don't actually use either cockroach or
 # workload.
-exit_status=0
-if ! timeout -s INT 12h bin/roachtest run \
-  --build-tag "${build_tag}" \
+timeout -s INT 12h bin/roachtest run \
+  --build-tag "${build_tag}"
   --slack-token "${SLACK_TOKEN-}" \
   --cluster-id "${TC_BUILD_ID-$(date +"%Y%m%d%H%M%S")}" \
   --cloud "gce" \
-  --cockroach "true" \
-  --workload "true" \
+  --cockroach "/usr/bin/true" \
+  --workload "/usr/bin/true" \
   --artifacts "$artifacts" \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --parallelism 2 \
   --teamcity \
   --cpu-quota=384 \
-  pebble tag:pebble_nightly_write; then
-  exit_status=$?
-fi
+  pebble tag:pebble_nightly_write
+
+exit_status=$?
 
 build_mkbench
 prepare_datadir

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh
@@ -9,26 +9,25 @@ _dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Run the YCSB benchmark.
 #
-# NB: We specify "true" for the --cockroach and --workload binaries to
+# NB: We specify "/usr/bin/true" for the --cockroach and --workload binaries to
 # prevent roachtest from complaining (and failing) when it can't find
 # them. The pebble roachtests don't actually use either cockroach or
 # workload.
-exit_status=0
-if ! timeout -s INT $((1000*60)) bin/roachtest run \
-  --build-tag "${build_tag}" \
+timeout -s INT $((1000*60)) bin/roachtest run \
+  --build-tag "${build_tag}"
   --slack-token "${SLACK_TOKEN-}" \
   --cluster-id "${TC_BUILD_ID-$(date +"%Y%m%d%H%M%S")}" \
   --cloud "aws" \
-  --cockroach "true" \
-  --workload "true" \
+  --cockroach "/usr/bin/true" \
+  --workload "/usr/bin/true" \
   --artifacts "$artifacts" \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --parallelism 3 \
   --teamcity \
   --cpu-quota=384 \
-  pebble tag:pebble_nightly_ycsb; then
-  exit_status=$?
-fi
+  pebble tag:pebble_nightly_ycsb
+
+exit_status=$?
 
 build_mkbench
 prepare_datadir

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_race_impl.sh
@@ -9,25 +9,24 @@ _dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Run the YCSB benchmark.
 #
-# NB: We specify "true" for the --cockroach and --workload binaries to
+# NB: We specify "/usr/bin/true" for the --cockroach and --workload binaries to
 # prevent roachtest from complaining (and failing) when it can't find
 # them. The pebble roachtests don't actually use either cockroach or
 # workload.
-exit_status=0
-if ! timeout -s INT $((1000*60)) bin/roachtest run \
-  --build-tag "${build_tag}" \
+timeout -s INT $((1000*60)) bin/roachtest run \
+  --build-tag "${build_tag}"
   --slack-token "${SLACK_TOKEN-}" \
   --cluster-id "${TC_BUILD_ID-$(date +"%Y%m%d%H%M%S")}" \
   --cloud "aws" \
-  --cockroach "true" \
-  --workload "true" \
+  --cockroach "/usr/bin/true" \
+  --workload "/usr/bin/true" \
   --artifacts "$artifacts" \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --parallelism 3 \
   --teamcity \
   --cpu-quota=384 \
-  pebble tag:pebble_nightly_ycsb_race; then
-  exit_status=$?
-fi
+  pebble tag:pebble_nightly_ycsb_race
+
+exit_status=$?
 
 exit "$exit_status"


### PR DESCRIPTION
Backport 1/1 commits from #104355.

/cc @cockroachdb/release

---

Previously, pebble nightly roachtest runs passed "true" to both crdb and workload binaries, both of which are required params. After a recent change [1] which introduced support for two other types of binaries (arm64 and fips), the validation was updated to require absolute paths for all user-specified binaries. The rationale is to reduce errors due to the search heuristics returning a false positive; e.g., user has multiple binaries of different arch types in the search paths.

This change updates the dummy binary paths to be absolute, i.e., "/usr/bin/true". It also fixes the wrapper scripts to correctly return the exit code which was previously negated.

[1] https://github.com/cockroachdb/cockroach/pull/103710

Epic: none
Fixes: #104324
Release note: None
Release justification: CI change