### PR TITLE
kvstreamer: fix invalid concurrent calls to disk buffer

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -746,11 +746,15 @@ func (s *Streamer) Close(ctx context.Context) {
 		s.mu.done = true
 		s.mu.Unlock()
 		s.requestsToServe.close()
-		s.results.close(ctx)
 		// Unblock the coordinator in case it is waiting for the budget.
 		s.budget.mu.waitForBudget.Signal()
 	}
 	s.waitGroup.Wait()
+	if s.results != nil {
+		// The results buffer can only be closed when all goroutines have
+		// exited.
+		s.results.close(ctx)
+	}
 	*s = Streamer{}
 }
 


### PR DESCRIPTION
This commit fixes a rare bug that could result in concurrent calls to the disk buffer (in the InOrder mode of the streamer) which is invalid (possibly leading to a panic). In particular, previously it was possible for the streamer's user goroutine to close the results buffer (which closes the disk buffer, flushing the pebble batch) concurrently with the worker coordinator forcing the results buffer to spill to disk in order free up some memory budget. This is now fixed by closing the results buffer only when all streamer's goroutines have exited.

I decided to omit the release note since this bug should be extremely rare in practice. Also it seems quite tedious to write a regression test for this, so there is none.

Fixes: #102092.

Release note: None