### PR TITLE
backupccl: add EXECUTION LOCALITY option to RESTORE

### DIFF
--- a/docs/generated/sql/bnf/restore_options.bnf
+++ b/docs/generated/sql/bnf/restore_options.bnf
@@ -19,3 +19,4 @@ restore_options ::=
 	| 'SCHEMA_ONLY'
 	| 'VERIFY_BACKUP_TABLE_DATA'
 	| 'UNSAFE_RESTORE_INCOMPATIBLE_VERSION'
+	| 'EXECUTION' 'LOCALITY' '=' string_or_placeholder

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2638,6 +2638,7 @@ restore_options ::=
 	| 'SCHEMA_ONLY'
 	| 'VERIFY_BACKUP_TABLE_DATA'
 	| 'UNSAFE_RESTORE_INCOMPATIBLE_VERSION'
+	| 'EXECUTION' 'LOCALITY' '=' string_or_placeholder
 
 scrub_option_list ::=
 	( scrub_option ) ( ( ',' scrub_option ) )*

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -412,6 +412,7 @@ func restore(
 			filter,
 			numImportSpans,
 			simpleImportSpans,
+			details.ExecutionLocality,
 			progCh,
 		)
 	}
@@ -1517,7 +1518,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	p := execCtx.(sql.JobExecContext)
 	r.execCfg = p.ExecCfg()
 
-	if err := maybeRelocateJobExecution(ctx, r.job.ID(), p, details.ExecutionLocality); err != nil {
+	if err := maybeRelocateJobExecution(ctx, r.job.ID(), p, details.ExecutionLocality, "RESTORE"); err != nil {
 		return err
 	}
 

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1517,6 +1517,10 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	p := execCtx.(sql.JobExecContext)
 	r.execCfg = p.ExecCfg()
 
+	if err := maybeRelocateJobExecution(ctx, r.job.ID(), p, details.ExecutionLocality); err != nil {
+		return err
+	}
+
 	mem := p.ExecCfg().RootMemoryMonitor.MakeBoundAccount()
 	defer mem.Close(ctx)
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1146,6 +1146,19 @@ func restorePlanHook(
 		}
 	}
 
+	var execLocality roachpb.Locality
+	if restoreStmt.Options.ExecutionLocality != nil {
+		loc, err := exprEval.String(ctx, restoreStmt.Options.ExecutionLocality)
+		if err != nil {
+			return nil, nil, nil, false, err
+		}
+		if loc != "" {
+			if err := execLocality.Set(loc); err != nil {
+				return nil, nil, nil, false, err
+			}
+		}
+	}
+
 	var newDBName string
 	if restoreStmt.Options.NewDBName != nil {
 		if restoreStmt.DescriptorCoverage == tree.AllDescriptors ||
@@ -1263,7 +1276,7 @@ func restorePlanHook(
 
 		return doRestorePlan(
 			ctx, restoreStmt, &exprEval, p, from, incStorage, pw, kms, restoreAllTenants, intoDB,
-			newDBName, newTenantID, newTenantName, endTime, resultsCh, subdir,
+			newDBName, newTenantID, newTenantName, endTime, resultsCh, subdir, execLocality,
 		)
 	}
 
@@ -1510,6 +1523,7 @@ func doRestorePlan(
 	endTime hlc.Timestamp,
 	resultsCh chan<- tree.Datums,
 	subdir string,
+	execLocality roachpb.Locality,
 ) error {
 	if len(from) == 0 || len(from[0]) == 0 {
 		return errors.New("invalid base backup specified")
@@ -2017,6 +2031,7 @@ func doRestorePlan(
 		SchemaOnly:          restoreStmt.Options.SchemaOnly,
 		VerifyData:          restoreStmt.Options.VerifyData,
 		SkipLocalitiesCheck: restoreStmt.Options.SkipLocalitiesCheck,
+		ExecutionLocality:   execLocality,
 	}
 
 	jr := jobs.Record{

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1024,6 +1024,7 @@ func restoreTypeCheck(
 			restoreStmt.Options.ForceTenantID,
 			restoreStmt.Options.AsTenant,
 			restoreStmt.Options.DebugPauseOn,
+			restoreStmt.Options.ExecutionLocality,
 		},
 	); err != nil {
 		return false, nil, err

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprofiler"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
@@ -78,6 +79,7 @@ func distRestore(
 	spanFilter spanCoveringFilter,
 	numImportSpans int,
 	useSimpleImportSpans bool,
+	execLocality roachpb.Locality,
 	progCh chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
 ) error {
 	defer close(progCh)
@@ -111,7 +113,10 @@ func distRestore(
 	memMonSSTs := memoryMonitorSSTs.Get(execCtx.ExecCfg().SV())
 	makePlan := func(ctx context.Context, dsp *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
 
-		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, execCtx.ExtendedEvalContext(), execCtx.ExecCfg())
+		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanningWithOracle(
+			ctx, execCtx.ExtendedEvalContext(), execCtx.ExecCfg(),
+			physicalplan.DefaultReplicaChooser, execLocality,
+		)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -475,7 +475,9 @@ message RestoreDetails {
   // Disables loacality checking for zone configs.
   bool SkipLocalitiesCheck = 29;
 
-  // NEXT ID: 30.
+  roachpb.Locality execution_locality = 30 [(gogoproto.nullable) = false];
+  
+  // NEXT ID: 31.
 }
 
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3818,6 +3818,11 @@ restore_options:
   {
     $$.val = &tree.RestoreOptions{UnsafeRestoreIncompatibleVersion: true}
   }
+| EXECUTION LOCALITY '=' string_or_placeholder
+  {
+    $$.val = &tree.RestoreOptions{ExecutionLocality: $4.expr()}
+  }
+
 
 virtual_cluster_opt:
   TENANT  { /* SKIP DOC */ }

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -856,12 +856,12 @@ RESTORE FROM '_' IN '_' WITH detached, include_all_virtual_clusters = $1 -- lite
 RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_virtual_clusters = $1 -- identifiers removed
 
 parse
-RESTORE FROM LATEST IN 'bar' WITH include_all_secondary_tenants = $1, detached
+RESTORE FROM LATEST IN 'bar' WITH include_all_virtual_clusters = $1, execution locality = $2, detached
 ----
-RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_virtual_clusters = $1 -- normalized!
-RESTORE FROM ('latest') IN ('bar') WITH detached, include_all_virtual_clusters = ($1) -- fully parenthesized
-RESTORE FROM '_' IN '_' WITH detached, include_all_virtual_clusters = $1 -- literals removed
-RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_virtual_clusters = $1 -- identifiers removed
+RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_virtual_clusters = $1, execution locality = $2 -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH detached, include_all_virtual_clusters = ($1), execution locality = ($2) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH detached, include_all_virtual_clusters = $1, execution locality = $1 -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_virtual_clusters = $1, execution locality = $2 -- identifiers removed
 
 parse
 RESTORE FROM LATEST IN 'bar' WITH include_all_virtual_clusters, detached
@@ -880,12 +880,12 @@ RESTORE FROM '_' IN '_' WITH detached, include_all_virtual_clusters = _ -- liter
 RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_virtual_clusters = true -- identifiers removed
 
 parse
-RESTORE FROM LATEST IN 'bar' WITH unsafe_restore_incompatible_version, detached
+RESTORE FROM LATEST IN 'bar' WITH unsafe_restore_incompatible_version, execution locality = 'abc', detached
 ----
-RESTORE FROM 'latest' IN 'bar' WITH detached, unsafe_restore_incompatible_version -- normalized!
-RESTORE FROM ('latest') IN ('bar') WITH detached, unsafe_restore_incompatible_version -- fully parenthesized
-RESTORE FROM '_' IN '_' WITH detached, unsafe_restore_incompatible_version -- literals removed
-RESTORE FROM 'latest' IN 'bar' WITH detached, unsafe_restore_incompatible_version -- identifiers removed
+RESTORE FROM 'latest' IN 'bar' WITH detached, unsafe_restore_incompatible_version, execution locality = 'abc' -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH detached, unsafe_restore_incompatible_version, execution locality = ('abc') -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH detached, unsafe_restore_incompatible_version, execution locality = '_' -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH detached, unsafe_restore_incompatible_version, execution locality = 'abc' -- identifiers removed
 
 error
 BACKUP foo TO 'bar' WITH key1, key2 = 'value'

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -145,6 +145,7 @@ type RestoreOptions struct {
 	SchemaOnly                       bool
 	VerifyData                       bool
 	UnsafeRestoreIncompatibleVersion bool
+	ExecutionLocality                Expr
 }
 
 var _ NodeFormatter = &RestoreOptions{}
@@ -492,6 +493,12 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 		maybeAddSep()
 		ctx.WriteString("unsafe_restore_incompatible_version")
 	}
+
+	if o.ExecutionLocality != nil {
+		maybeAddSep()
+		ctx.WriteString("execution locality = ")
+		ctx.FormatNode(o.ExecutionLocality)
+	}
 }
 
 // CombineWith merges other backup options into this backup options struct.
@@ -632,6 +639,12 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 		o.UnsafeRestoreIncompatibleVersion = other.UnsafeRestoreIncompatibleVersion
 	}
 
+	if o.ExecutionLocality == nil {
+		o.ExecutionLocality = other.ExecutionLocality
+	} else if other.ExecutionLocality != nil {
+		return errors.New("execution locality option specified multiple times")
+	}
+
 	return nil
 }
 
@@ -656,7 +669,8 @@ func (o RestoreOptions) IsDefault() bool {
 		o.SchemaOnly == options.SchemaOnly &&
 		o.VerifyData == options.VerifyData &&
 		o.IncludeAllSecondaryTenants == options.IncludeAllSecondaryTenants &&
-		o.UnsafeRestoreIncompatibleVersion == options.UnsafeRestoreIncompatibleVersion
+		o.UnsafeRestoreIncompatibleVersion == options.UnsafeRestoreIncompatibleVersion &&
+		o.ExecutionLocality == options.ExecutionLocality
 }
 
 // BackupTargetList represents a list of targets.

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1266,6 +1266,16 @@ func (stmt *Backup) walkStmt(v Visitor) Statement {
 		}
 	}
 
+	if stmt.Options.ExecutionLocality != nil {
+		rh, changed := WalkExpr(v, stmt.Options.ExecutionLocality)
+		if changed {
+			if ret == stmt {
+				ret = stmt.copyNode()
+			}
+			ret.Options.ExecutionLocality = rh
+		}
+	}
+
 	return ret
 }
 
@@ -1541,6 +1551,16 @@ func (stmt *Restore) walkStmt(v Visitor) Statement {
 				ret = stmt.copyNode()
 			}
 			ret.Options.IncludeAllSecondaryTenants = include
+		}
+	}
+
+	if stmt.Options.ExecutionLocality != nil {
+		include, changed := WalkExpr(v, stmt.Options.ExecutionLocality)
+		if changed {
+			if ret == stmt {
+				ret = stmt.copyNode()
+			}
+			ret.Options.ExecutionLocality = include
 		}
 	}
 


### PR DESCRIPTION
This mirrors the similar option to BACKUP and changefeeds, restricting the job coordinator and the worker processes planned by the job to executing on nodes which match the passed locality filter.

Release note (sql change): RESTORE can now be passed a WITH EXECUTION LOCALITY option similar to BACKUP, to restrict execution of the job to nodes with matching localities.

Epic: CRDB-28521