### PR TITLE
release-22.2: pgwire: add gauge for connections throttled by semaphore

### DIFF
--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
@@ -216,7 +217,7 @@ func IsTenantCertificate(cert *x509.Certificate) bool {
 // UserAuthPasswordHook builds an authentication hook based on the security
 // mode, password, and its potentially matching hash.
 func UserAuthPasswordHook(
-	insecureMode bool, passwordStr string, hashedPassword password.PasswordHash,
+	insecureMode bool, passwordStr string, hashedPassword password.PasswordHash, gauge *metric.Gauge,
 ) UserAuthHook {
 	return func(ctx context.Context, systemIdentity username.SQLUsername, clientConnection bool) error {
 		if systemIdentity.Undefined() {
@@ -236,7 +237,7 @@ func UserAuthPasswordHook(
 			return NewErrPasswordUserAuthFailed(systemIdentity)
 		}
 		ok, err := password.CompareHashAndCleartextPassword(ctx,
-			hashedPassword, passwordStr, GetExpensiveHashComputeSem(ctx))
+			hashedPassword, passwordStr, GetExpensiveHashComputeSemWithGauge(ctx, gauge))
 		if err != nil {
 			return err
 		}

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/crypto/bcrypt"
@@ -211,8 +212,7 @@ var expensiveHashComputeSemOnce struct {
 // Otherwise, a default is computed from the configure GOMAXPROCS.
 var envMaxHashComputeConcurrency = envutil.EnvOrDefaultInt("COCKROACH_MAX_PW_HASH_COMPUTE_CONCURRENCY", 0)
 
-// GetExpensiveHashComputeSem retrieves the hashing semaphore.
-func GetExpensiveHashComputeSem(ctx context.Context) password.HashSemaphore {
+func maybeInitializeSem(ctx context.Context) {
 	expensiveHashComputeSemOnce.once.Do(func() {
 		var n int
 		if envMaxHashComputeConcurrency >= 1 {
@@ -230,7 +230,25 @@ func GetExpensiveHashComputeSem(ctx context.Context) password.HashSemaphore {
 		log.VInfof(ctx, 1, "configured maximum hashing concurrency: %d", n)
 		expensiveHashComputeSemOnce.sem = quotapool.NewIntPool("password_hashes", uint64(n))
 	})
-	return func(ctx context.Context) (func(), error) {
+}
+
+// GetExpensiveHashComputeSem retrieves the hashing semaphore.
+func GetExpensiveHashComputeSem(ctx context.Context) password.HashSemaphore {
+	return GetExpensiveHashComputeSemWithGauge(ctx, nil /* gauge */)
+}
+
+// GetExpensiveHashComputeSemWithGauge retrieves the hashing semaphore and
+// will make the callback update a gauge to track the number of goroutines
+// waiting for the semaphore.
+func GetExpensiveHashComputeSemWithGauge(
+	ctx context.Context, gauge *metric.Gauge,
+) password.HashSemaphore {
+	maybeInitializeSem(ctx)
+	return func(ctx context.Context) (cleanup func(), retErr error) {
+		if gauge != nil {
+			gauge.Inc(1)
+			defer gauge.Dec(1)
+		}
 		alloc, err := expensiveHashComputeSemOnce.sem.Acquire(ctx, 1)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -388,6 +388,8 @@ type AuthConn interface {
 	LogAuthFailed(ctx context.Context, reason eventpb.AuthFailReason, err error)
 	// LogAuthOK logs when the authentication handshake has completed.
 	LogAuthOK(ctx context.Context)
+	// GetTenantSpecificMetrics returns the tenant-specific metrics for the connection.
+	GetTenantSpecificMetrics() *ServerMetrics
 }
 
 // authPipe is the implementation for the authenticator and AuthConn interfaces.
@@ -541,4 +543,9 @@ func (p *authPipe) SendAuthRequest(authType int32, data []byte) error {
 	c.msgBuilder.putInt32(authType)
 	c.msgBuilder.write(data)
 	return c.msgBuilder.finishMsg(c.conn)
+}
+
+// GetTenantSpecificMetrics is part of the AuthConn interface.
+func (p *authPipe) GetTenantSpecificMetrics() *ServerMetrics {
+	return p.c.metrics
 }

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -190,9 +190,10 @@ func passwordAuthenticator(
 		// in auth.go (and report CREDENTIALS_INVALID).
 	}
 
+	metrics := c.GetTenantSpecificMetrics()
 	// Now check the cleartext password against the retrieved credentials.
 	err = security.UserAuthPasswordHook(
-		false /*insecure*/, passwordStr, hashedPassword,
+		false /*insecure*/, passwordStr, hashedPassword, metrics.ConnsWaitingToHash,
 	)(ctx, systemIdentity, clientConnection)
 
 	if err == nil {

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -161,6 +161,12 @@ var (
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}
+	MetaConnsWaitingToHash = metric.Metadata{
+		Name:        "sql.conns_waiting_to_hash",
+		Help:        "Number of SQL connection attempts that are being throttled in order to limit password hashing concurrency",
+		Measurement: "Connections",
+		Unit:        metric.Unit_COUNT,
+	}
 	MetaBytesIn = metric.Metadata{
 		Name:        "sql.bytesin",
 		Help:        "Number of sql bytes received",
@@ -311,6 +317,7 @@ type ServerMetrics struct {
 	BytesOutCount               *metric.Counter
 	Conns                       *metric.Gauge
 	NewConns                    *metric.Counter
+	ConnsWaitingToHash          *metric.Gauge
 	ConnLatency                 metric.IHistogram
 	ConnFailures                *metric.Counter
 	PGWireCancelTotalCount      *metric.Counter
@@ -324,10 +331,11 @@ func makeServerMetrics(
 	sqlMemMetrics sql.MemoryMetrics, histogramWindow time.Duration,
 ) ServerMetrics {
 	return ServerMetrics{
-		BytesInCount:  metric.NewCounter(MetaBytesIn),
-		BytesOutCount: metric.NewCounter(MetaBytesOut),
-		Conns:         metric.NewGauge(MetaConns),
-		NewConns:      metric.NewCounter(MetaNewConns),
+		BytesInCount:       metric.NewCounter(MetaBytesIn),
+		BytesOutCount:      metric.NewCounter(MetaBytesOut),
+		Conns:              metric.NewGauge(MetaConns),
+		NewConns:           metric.NewCounter(MetaNewConns),
+		ConnsWaitingToHash: metric.NewGauge(MetaConnsWaitingToHash),
 		ConnLatency: metric.NewHistogram(metric.HistogramOptions{
 			Mode:     metric.HistogramModePreferHdrLatency,
 			Metadata: MetaConnLatency,

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2623,6 +2623,12 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Connections Waiting to Compute Password Hash",
+				Metrics: []string{
+					"sql.conns_waiting_to_hash",
+				},
+			},
+			{
 				Title: "Connection Latency",
 				Metrics: []string{
 					"sql.conn.latency",


### PR DESCRIPTION
Backport 1/1 commits from #104235.

/cc @cockroachdb/release

Release justification: metrics only change

---

fixes https://github.com/cockroachdb/cockroach/issues/82900

Release note (ops change): Added a gauge metric named sql.conns_waiting_to_hash. It counts the number of connection attempts that are being throttled in order to limit the amount of concurrent password hashing operations. The throttling behavior has been present since v21.2, and was added in order to prevent password hashing from using up too much CPU. The metric is the only new addition in this change.

The metric is expected to be 0 or close to 0 in a healthy setup. If the metric is consistently high and connection latencies are high, then an operator should do one or more of the following:

- Make sure applications using the cluster have properly configured connection pools.
- Add more vCPU or more nodes to the cluster.
- Increase the password hashing concurrency using the COCKROACH_MAX_PW_HASH_COMPUTE_CONCURRENCY environment variable.
