### PR TITLE
sql: disable histogram usage for internal executor

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -72,6 +72,12 @@ func NewInternalSessionData(
 
 	sdMutIterator.applyOnEachMutator(func(m sessionDataMutator) {
 		for varName, v := range varGen {
+			if varName == "optimizer_use_histograms" {
+				// Do not use histograms when optimizing internal executor
+				// queries. This causes a significant performance regression.
+				// TODO(#102954): Diagnose and fix this.
+				continue
+			}
 			if v.Set != nil {
 				hasDefault, defVal := getSessionVarDefaultString(varName, v, m.sessionDataMutatorBase)
 				if hasDefault {


### PR DESCRIPTION
Since #101486, the internal executor has used global defaults for
session settings. This effectively enabled `optimizer_use_histograms`
for the internal executor, which was disabled before. This caused a
huge performance regression. The root cause of the regression is not yet
understood. This commit disables `optimizer_use_histograms` as a
temporary solution for the performance regression.

Informs #102954

Epic: None

Release note: None