### PR TITLE
logictest: deflake guardrails

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/guardrails
+++ b/pkg/sql/logictest/testdata/logic_test/guardrails
@@ -1,3 +1,7 @@
+# LogicTest: !metamorphic-batch-sizes
+# We disable metamorphic batch sizes so that we read a predictable number of
+# rows in each limited scan.
+
 statement ok
 CREATE TABLE guardrails (i INT PRIMARY KEY);
 INSERT INTO guardrails SELECT generate_series(1, 100)


### PR DESCRIPTION
Add `!metamorphic-batch-sizes` to avoid flakes.

Fixes #104405

Release note: None