### PR TITLE
distsql: don't skip JSONs and ARRAYs in some tests

### DIFF
--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -418,9 +418,7 @@ func TestDistinctAgainstProcessor(t *testing.T) {
 							ordCols    []execinfrapb.Ordering_Column
 						)
 						if rng.Float64() < randTypesProbability {
-							// If we're spilling, don't generate un-key-encodable types, since
-							// the row engine can't handle them.
-							inputTypes = generateRandomSupportedTypesWithUnencodable(rng, nCols, !spillForced)
+							inputTypes = generateRandomSupportedTypes(rng, nCols)
 							rows = randgen.RandEncDatumRowsOfTypes(rng, nRows, inputTypes)
 						} else {
 							inputTypes = intTyps[:nCols]
@@ -539,7 +537,7 @@ func TestSorterAgainstProcessor(t *testing.T) {
 						inputTypes []*types.T
 					)
 					if rng.Float64() < randTypesProbability {
-						inputTypes = generateRandomSupportedTypesWithUnencodable(rng, nCols, !spillForced)
+						inputTypes = generateRandomSupportedTypes(rng, nCols)
 						rows = randgen.RandEncDatumRowsOfTypes(rng, nRows, inputTypes)
 					} else {
 						inputTypes = intTyps[:nCols]
@@ -613,7 +611,7 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 						inputTypes []*types.T
 					)
 					if rng.Float64() < randTypesProbability {
-						inputTypes = generateRandomSupportedTypesWithUnencodable(rng, nCols, !spillForced)
+						inputTypes = generateRandomSupportedTypes(rng, nCols)
 						rows = randgen.RandEncDatumRowsOfTypes(rng, nRows, inputTypes)
 					} else {
 						inputTypes = intTyps[:nCols]
@@ -733,8 +731,7 @@ func TestHashJoinerAgainstProcessor(t *testing.T) {
 								usingRandomTypes         bool
 							)
 							if rng.Float64() < randTypesProbability {
-								// HashRowContainers can't deal with non-keyencodable types.
-								lInputTypes = generateRandomSupportedTypesWithUnencodable(rng, nCols, false /* withUnencodable */)
+								lInputTypes = generateRandomSupportedTypes(rng, nCols)
 								lEqCols = generateEqualityColumns(rng, nCols, nEqCols)
 								rInputTypes = append(rInputTypes[:0], lInputTypes...)
 								rEqCols = append(rEqCols[:0], lEqCols...)
@@ -1333,17 +1330,8 @@ func TestWindowFunctionsAgainstProcessor(t *testing.T) {
 }
 
 // generateRandomSupportedTypes generates nCols random types that are supported
-// by the vectorized engine.
+// by the vectorized engine natively (i.e. datum-backed types are skipped).
 func generateRandomSupportedTypes(rng *rand.Rand, nCols int) []*types.T {
-	return generateRandomSupportedTypesWithUnencodable(rng, nCols, true /* withUnencodable */)
-}
-
-// generateRandomSupportedTypesWithUnencodable generates nCols random types that
-// are supported by the vectorized engine. If withUnencodable is false, it won't
-// generate types that aren't key-encodable.
-func generateRandomSupportedTypesWithUnencodable(
-	rng *rand.Rand, nCols int, withUnencodable bool,
-) []*types.T {
 	typs := make([]*types.T, 0, nCols)
 	for len(typs) < nCols {
 		typ := randgen.RandType(rng)
@@ -1351,11 +1339,6 @@ func generateRandomSupportedTypesWithUnencodable(
 		if family == typeconv.DatumVecCanonicalTypeFamily {
 			// At the moment, we disallow datum-backed types.
 			// TODO(yuzefovich): remove this.
-			continue
-		}
-		if !withUnencodable && (family == types.JsonFamily || family == types.ArrayFamily) {
-			// This is so that the row engine, which has to spill using key encoding,
-			// can avoid running tests with types that don't have a key encoding.
 			continue
 		}
 		typs = append(typs, typ)


### PR DESCRIPTION
This commit removes the skipping behavior of JSONs and ARRAYs in some "against processor" tests because these types are now key-encodable. I'm a bit unsure about ARRAYs (some types could be non-key-encodable), but I ran the tests for two hours on the gceworker with no failures.

Epic: None

Release note: None