### PR TITLE
roachtest: fix `failover` workload cancellation

### DIFF
--- a/pkg/cmd/roachtest/cluster/monitor_interface.go
+++ b/pkg/cmd/roachtest/cluster/monitor_interface.go
@@ -25,6 +25,7 @@ type Monitor interface {
 	ExpectDeaths(count int32)
 	ResetDeaths()
 	Go(fn func(context.Context) error)
+	GoWithCancel(fn func(context.Context) error) func()
 	WaitE() error
 	Wait()
 }

--- a/pkg/cmd/roachtest/monitor.go
+++ b/pkg/cmd/roachtest/monitor.go
@@ -106,6 +106,16 @@ func (m *monitorImpl) Go(fn func(context.Context) error) {
 	})
 }
 
+// GoWithCancel is like Go, but returns a function that can be used to cancel
+// the goroutine.
+func (m *monitorImpl) GoWithCancel(fn func(context.Context) error) func() {
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.Go(func(_ context.Context) error {
+		return fn(ctx)
+	})
+	return cancel
+}
+
 func (m *monitorImpl) WaitE() error {
 	if m.t.Failed() {
 		// If the test has failed, don't try to limp along.

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -557,7 +557,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
 		err := c.RunE(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
 			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
 		if ctx.Err() != nil {
 			return nil // test requested workload shutdown
@@ -853,8 +853,8 @@ func runFailoverLiveness(
 	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
-	// Create cluster. Don't schedule a backup as this roachtest reports to roachperf.
-	opts := option.DefaultStartOptsNoBackups()
+	// Create cluster.
+	opts := option.DefaultStartOpts()
 	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
@@ -896,7 +896,7 @@ func runFailoverLiveness(
 	// We also make sure the lease is located on n4.
 	relocateLeases(t, ctx, conn, `range_id = 2`, 4)
 
-	// Run workload on n7 via n1-n3 gateways until test ends (context cancels).
+	// Run workload on n5 via n1-n3 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
 		err := c.RunE(ctx, c.Node(5), `./cockroach workload run kv --read-percent 50 `+
@@ -1601,8 +1601,8 @@ func waitForUpreplication(
 //
 //  2. We need to know when the replicate queue is done placing both replicas and
 //     leases in accordance with the zone configurations, so that we can wait for
-//     it. SpanConfigConformance should provide this, but current doesn't have a
-//     public API, and doesn't handle lease preferences.
+//     it. SpanConfigConformance should provide this, but currently doesn't have
+//     a public API, and doesn't handle lease preferences.
 //
 //  3. The replicate queue must guarantee that replicas and leases won't escape
 //     their constraints after the initial setup. We see them do so currently.


### PR DESCRIPTION
The `failover` tests use context cancellation to cancel the workload once all failures have completed. However, previously the main test context would be cancelled, and this would cause test cleanup to fail since it was using this context.

This patch adds and uses `Monitor.GoWithCancel()`, which allows cancelling a goroutine spawned by `Monitor`, instead of using the main test context.

Resolves #104462.
Resolves #104474.
Resolves #104475.
Resolves #104482.
Resolves #104485.
Resolves #104486.
Resolves #104409.
Resolves #104491.
Resolves #104492.
Resolves #104493.
Resolves #104494.
Resolves #104495.
Resolves #104502.
Resolves #104510.
Resolves #104509.
Resolves #104507.
Resolves #104504.
Resolves #104511.
Resolves #104513.
Resolves #104514.
Resolves #104516.
Resolves #104517.
Resolves #104518.
Resolves #104519.
Resolves #104520.
Resolves #104521.
Resolves #104522.
Resolves #104524.
Resolves #104525.
Resolves #104526.
Resolves #104527.
Resolves #104529.
Resolves #104530.
Resolves #104532.

Epic: none
Release note: None