### PR TITLE
sql: wrong error code when failing to add a NOT NULL column

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -882,7 +882,7 @@ func newCheckViolationErr(
 func newNotNullViolationErr(
 	notNullColName string, tableColumns []catalog.Column, violatingRow tree.Datums,
 ) error {
-	return pgerror.Newf(pgcode.NotNullViolation,
+	return pgerror.Newf(pgcode.CheckViolation,
 		"validation of column %q NOT NULL failed on row: %s",
 		notNullColName, labeledRowValues(tableColumns, violatingRow))
 }


### PR DESCRIPTION
We should return 23502 (not null violation) but instead we return 23514 (check constraint violation).

Fixes #81692 / [CRDB-16032](https://cockroachlabs.atlassian.net/browse/CRDB-16032)