### PR TITLE
roachtest: run `failover` tests with 2 CPUs

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -80,7 +80,7 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Benchmark:           true,
 				Timeout:             60 * time.Minute,
-				Cluster:             r.MakeClusterSpec(10, spec.CPU(4), spec.PreferLocalSSD(false)), // uses disk stalls
+				Cluster:             r.MakeClusterSpec(10, spec.CPU(2), spec.PreferLocalSSD(false)), // uses disk stalls
 				Leases:              leases,
 				SkipPostValidations: registry.PostValidationNoDeadNodes, // cleanup kills nodes
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -94,7 +94,7 @@ func registerFailover(r registry.Registry) {
 			Owner:     registry.OwnerKV,
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
-			Cluster:   r.MakeClusterSpec(8, spec.CPU(4)),
+			Cluster:   r.MakeClusterSpec(8, spec.CPU(2)),
 			Leases:    leases,
 			Run:       runFailoverPartialLeaseGateway,
 		})
@@ -104,7 +104,7 @@ func registerFailover(r registry.Registry) {
 			Owner:     registry.OwnerKV,
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
-			Cluster:   r.MakeClusterSpec(7, spec.CPU(4)),
+			Cluster:   r.MakeClusterSpec(7, spec.CPU(2)),
 			Leases:    leases,
 			Run:       runFailoverPartialLeaseLeader,
 		})
@@ -114,7 +114,7 @@ func registerFailover(r registry.Registry) {
 			Owner:     registry.OwnerKV,
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
-			Cluster:   r.MakeClusterSpec(8, spec.CPU(4)),
+			Cluster:   r.MakeClusterSpec(8, spec.CPU(2)),
 			Leases:    leases,
 			Run:       runFailoverPartialLeaseLiveness,
 		})
@@ -136,7 +136,7 @@ func registerFailover(r registry.Registry) {
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
 				SkipPostValidations: postValidation,
-				Cluster:             r.MakeClusterSpec(7, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Cluster:             r.MakeClusterSpec(7, spec.CPU(2), spec.PreferLocalSSD(!usePD)),
 				Leases:              leases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runFailoverNonSystem(ctx, t, c, failureMode)
@@ -148,7 +148,7 @@ func registerFailover(r registry.Registry) {
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
 				SkipPostValidations: postValidation,
-				Cluster:             r.MakeClusterSpec(5, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Cluster:             r.MakeClusterSpec(5, spec.CPU(2), spec.PreferLocalSSD(!usePD)),
 				Leases:              leases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runFailoverLiveness(ctx, t, c, failureMode)
@@ -160,7 +160,7 @@ func registerFailover(r registry.Registry) {
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
 				SkipPostValidations: postValidation,
-				Cluster:             r.MakeClusterSpec(7, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Cluster:             r.MakeClusterSpec(7, spec.CPU(2), spec.PreferLocalSSD(!usePD)),
 				Leases:              leases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runFailoverSystemNonLiveness(ctx, t, c, failureMode)
@@ -247,7 +247,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 		}
 		err := c.RunE(ctx, c.Node(10), fmt.Sprintf(
 			`./cockroach workload run kv --read-percent %d --write-seq R%d `+
-				`--concurrency 256 --max-rate 8192 --timeout 1m --tolerate-errors `+
+				`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
 				`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-2}`,
 			readPercent, insertCount))
 		if ctx.Err() != nil {


### PR DESCRIPTION
These tests don't need a lot of CPU: the workload is gentle, and we're measuring availability. Downgrading the nodes to 2 CPUs saves us some money, considering the number of tests we run.

Epic: none
Release note: None

The CPU graphs for `failover/chaos/read-write/lease=expiration` and `failover/non-system/crash/lease=expiration` respectively show that we have sufficient headroom with 2 CPUs:

<img width="960" alt="Screenshot 2023-06-07 at 11 08 09" src="https://github.com/cockroachdb/cockroach/assets/644420/b3e07717-753f-4134-9a41-d2538aa4443f">

<img width="956" alt="Screenshot 2023-06-07 at 11 21 03" src="https://github.com/cockroachdb/cockroach/assets/644420/813458ce-f1ca-4dcd-bbbb-a45689e87f39">
