### PR TITLE
settings: track the origin of the current values

### DIFF
--- a/pkg/settings/common.go
+++ b/pkg/settings/common.go
@@ -74,6 +74,15 @@ func (c *common) ErrorHint() (bool, string) {
 	return false, ""
 }
 
+func (c *common) getSlot() slotIdx {
+	return c.slot
+}
+
+// ValueOrigin returns the origin of the current value of the setting.
+func (c *common) ValueOrigin(ctx context.Context, sv *Values) ValueOrigin {
+	return sv.getValueOrigin(ctx, c.slot)
+}
+
 // SetReportable indicates whether a setting's value can show up in SHOW ALL
 // CLUSTER SETTINGS and telemetry reports.
 //
@@ -113,6 +122,8 @@ type internalSetting interface {
 	init(class Class, key, description string, slot slotIdx)
 	isRetired() bool
 	setToDefault(ctx context.Context, sv *Values)
+
+	getSlot() slotIdx
 
 	// isReportable indicates whether the value of the setting can be
 	// included in user-facing reports such as that produced by SHOW ALL

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -79,6 +79,9 @@ type NonMaskedSetting interface {
 	// ErrorHint returns a hint message to be displayed to the user when there's
 	// an error.
 	ErrorHint() (bool, string)
+
+	// ValueOrigin returns the origin of the current value.
+	ValueOrigin(ctx context.Context, sv *Values) ValueOrigin
 }
 
 // Class describes the scope of a setting in multi-tenant scenarios. While all
@@ -141,4 +144,18 @@ const (
 	// customization.
 	// In short: "Go ahead but be careful."
 	Public
+)
+
+// ValueOrigin indicates the origin of the current value of a setting, e.g. if
+// it is coming from the in-code default or an explicit override.
+type ValueOrigin uint32
+
+const (
+	// OriginDefault indicates the value in use is the default value.
+	OriginDefault ValueOrigin = iota
+	// OriginExplicitlySet indicates the value is has been set explicitly.
+	OriginExplicitlySet
+	// OriginExternallySet indicates the value has been set externally, such as
+	// via a host-cluster override for this or all tenant(s).
+	OriginExternallySet
 )

--- a/pkg/settings/values.go
+++ b/pkg/settings/values.go
@@ -61,6 +61,8 @@ type valuesContainer struct {
 	// current context (i.e. it is a SystemOnly setting and the container is for a
 	// tenant). Reading or writing such a setting causes panics in test builds.
 	forbidden [numSlots]bool
+
+	hasValue [numSlots]uint32
 }
 
 func (c *valuesContainer) setGenericVal(slot slotIdx, newVal interface{}) {
@@ -152,6 +154,14 @@ func (sv *Values) setInt64(ctx context.Context, slot slotIdx, newVal int64) {
 	if sv.container.setInt64Val(slot, newVal) {
 		sv.settingChanged(ctx, slot)
 	}
+}
+
+func (sv *Values) setValueOrigin(ctx context.Context, slot slotIdx, origin ValueOrigin) {
+	atomic.StoreUint32(&sv.container.hasValue[slot], uint32(origin))
+}
+
+func (sv *Values) getValueOrigin(ctx context.Context, slot slotIdx) ValueOrigin {
+	return ValueOrigin(atomic.LoadUint32(&sv.container.hasValue[slot]))
 }
 
 // setDefaultOverride overrides the default value for the respective setting to


### PR DESCRIPTION
This adds an API to the settings package to track the origin of the current value of each setting, such as whether it is set by the the default value, an explicit override or an external override.

Release note: none.
Epic: none.