### PR TITLE
roachpb: remove `StoreDeadReplicas`

### DIFF
--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -405,15 +405,6 @@ message StoreDescriptor {
   optional StoreProperties properties = 5 [(gogoproto.nullable) = false];
 }
 
-// StoreDeadReplicas holds a storeID and a list of dead replicas on that store.
-// Used to let the range lease holder know about corrupted or otherwise
-// destroyed replicas that should be transferred to a different store.
-message StoreDeadReplicas {
-  optional int32 store_id = 1 [(gogoproto.nullable) = false,
-      (gogoproto.customname) = "StoreID", (gogoproto.casttype) = "StoreID"];
-  repeated ReplicaIdent replicas = 2 [(gogoproto.nullable) = false];
-}
-
 // Locality is an ordered set of key value Tiers that describe a node's
 // location. The tier keys should be the same across all nodes.
 message Locality {


### PR DESCRIPTION
This doesn't seem to be in use anywhere.

Epic: none
Release note: None