### PR TITLE
cli/sql: fix virtual cluster switch via `\c` under `options=-ccluster`

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -95,6 +95,13 @@ func TestDockerCLI_test_demo_changefeeds(t *testing.T) {
 	runTestDockerCLI(t, "test_demo_changefeeds", "../cli/interactive_tests/test_demo_changefeeds.tcl")
 }
 
+func TestDockerCLI_test_demo_cli_integration(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_demo_cli_integration", "../cli/interactive_tests/test_demo_cli_integration.tcl")
+}
+
 func TestDockerCLI_test_demo_global(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -1659,6 +1659,7 @@ func (c *cliState) handleConnectInternal(cmd []string, omitConnString bool) erro
 	// Parse the arguments to \connect:
 	// it accepts newdb, user, host, port and options in that order.
 	// Each field can be marked as "-" to reuse the current defaults.
+	dbOverride := false
 	switch len(cmd) {
 	case 5:
 		if cmd[4] != "-" {
@@ -1692,6 +1693,7 @@ func (c *cliState) handleConnectInternal(cmd []string, omitConnString bool) erro
 		fallthrough
 	case 1:
 		if cmd[0] != "-" {
+			dbOverride = true
 			if err := newURL.SetOption("database", cmd[0]); err != nil {
 				return err
 			}
@@ -1706,6 +1708,41 @@ func (c *cliState) handleConnectInternal(cmd []string, omitConnString bool) erro
 
 	default:
 		return errors.Newf(`unknown syntax: \c %s`, strings.Join(cmd, " "))
+	}
+
+	// If the URL contained -ccluster=XXX to start with, but the user
+	// is overriding the DB name manually with cluster:XXX, we want
+	// to inject the new name into the `-ccluster` option.
+	if newDB := newURL.GetDatabase(); dbOverride && strings.HasPrefix(newDB, "cluster:") {
+		extraOpts := newURL.GetExtraOptions()
+		if extendedOptsS := extraOpts.Get("options"); extendedOptsS != "" {
+			extendedOpts, err := pgurl.ParseExtendedOptions(extendedOptsS)
+			// Note: we ignore the case where there is an error. In that
+			// case, the existing `options` string is preserved unchanged.
+			// We do not block the connection here, because perhaps the user
+			// is trying to use a new syntax (supported in a later version
+			// of the server) that we don't yet support in this version of
+			// the shell.
+			if err == nil {
+				parts := strings.SplitN(newDB, "/", 2)
+				logicalCluster := parts[0][len("cluster:"):]
+
+				// Override the cluster name in the -ccluster option with the
+				// new specified cluster.
+				extendedOpts.Set("cluster", logicalCluster)
+				if err := newURL.SetOption("options", pgurl.EncodeExtendedOptions(extendedOpts)); err != nil {
+					return err
+				}
+				// Set the requested db name to the remainder of the db string.
+				actualNewDB := ""
+				if len(parts) > 1 {
+					actualNewDB = parts[1]
+				}
+				if err := newURL.SetOption("database", actualNewDB); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	// If we are reconnecting to the same server with the same user, reuse

--- a/pkg/server/pgurl/pgurl_test.go
+++ b/pkg/server/pgurl/pgurl_test.go
@@ -166,3 +166,18 @@ func TestParseExtendedOptions(t *testing.T) {
 	require.Equal(t, kvs.Get("intervalstyle"), "ISO_8601")
 	require.Equal(t, kvs.Get("custom_option.custom_option"), "test2")
 }
+
+func TestEncodeExtendedOptions(t *testing.T) {
+	kvs := url.Values{}
+	kvs.Set("user", "test")
+	kvs.Set("a b", "test")
+	kvs.Set("test", "c d")
+	kvs.Set(`a\ b`, `c\d`)
+
+	opts := EncodeExtendedOptions(kvs)
+	require.Equal(t, `-ca\ b=test -ca\\\ b=c\\d -ctest=c\ d -cuser=test `, opts)
+
+	kv2, err := ParseExtendedOptions(opts)
+	require.NoError(t, err)
+	require.Equal(t, kvs, kv2)
+}


### PR DESCRIPTION
Fixes  #104496.
Epic: CRDB-26691

Prior to this patch, if `options=-ccluster=X` was present in the URL,
it was not possible to switch between virtual clusters ("tenants")
using the `\c` client-side command and a special db name, e.g. via `\c
cluster:Y - - - autocerts`.

The reason is that when both `options=-ccluster` is in the URL and a
DB name with a `cluster:` prefix is specified, the server only
considers the URL parameter as a cluster specification, and the DB
name is considered literally. This is the mechanism that guarantees
access to a database that was legitimately created with a `cluster:`
prefix, e.g. via `CREATE DATABASE "cluster:blah"`.

Meanwhile, we would like to make the UX of `\c` more convenient in the
common case of interactive use at the shell.

This commit enhances the situation as follows: if the DB name passed
via `\c` contains a `cluster:` prefix, and `options` also contains
a cluster specification, the latter is updated instead (i.e. `\c
cluster:Y/Z`will move`Y`into`options=-ccluster=Y` and keep just
`Z` as the db name).

If a user wants to really access a db named `cluster:blah` they can
use `\c cluster:app/cluster:blah ...`.
