### PR TITLE
configprofiles: deflake TestDataDriven

### DIFF
--- a/pkg/configprofiles/datadriven_test.go
+++ b/pkg/configprofiles/datadriven_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/configprofiles"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/autoconfig/acprovider"
@@ -31,6 +32,10 @@ import (
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// We need this to avoid a race condition in TestServer.
+	// See: #104500.
+	defer ccl.TestingEnableEnterprise()()
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Informs #104500.
Fixes #102408.

This test was experiencing a failure due to a race condition. The root cause is described in issue #104500 and will be addressed separately. This change ensures that the test does not encounter the code path at all.

Release note: None