### PR TITLE
server: don't write to the test server config in `maybeStartDefaultTestTenant`

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -545,7 +545,6 @@ func (ts *TestServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 	if err := base.CheckEnterpriseEnabled(ts.st, clusterID(), "SQL servers"); err != nil {
 		// If not enterprise enabled, we won't be able to use SQL Servers so eat
 		// the error and return without creating/starting a SQL server.
-		ts.cfg.DisableDefaultTestTenant = true
 		return nil // nolint:returnerrcheck
 	}
 


### PR DESCRIPTION
Epic: CRDB-18499
Fixes #104500.

The server config can be read asynchronously by the server controller when starting servers in the background. So a write there is racy.

(If we later discover we really need to write to the server config, we'd need to introduce a mutex for that.)

Release note: None
