### PR TITLE
sql: add system privileges to crdb_internal queries tables

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2345,7 +2345,7 @@ var crdbInternalLocalQueriesTable = virtualSchemaTable{
 		if err != nil {
 			return err
 		}
-		return populateQueriesTable(ctx, addRow, response)
+		return populateQueriesTable(ctx, p, addRow, response)
 	},
 }
 
@@ -2363,13 +2363,36 @@ var crdbInternalClusterQueriesTable = virtualSchemaTable{
 		if err != nil {
 			return err
 		}
-		return populateQueriesTable(ctx, addRow, response)
+		return populateQueriesTable(ctx, p, addRow, response)
 	},
 }
 
 func populateQueriesTable(
-	ctx context.Context, addRow func(...tree.Datum) error, response *serverpb.ListSessionsResponse,
+	ctx context.Context,
+	p *planner,
+	addRow func(...tree.Datum) error,
+	response *serverpb.ListSessionsResponse,
 ) error {
+	// Validate users have correct permission/role.
+	hasPermission, err := p.HasViewActivityOrViewActivityRedactedRole(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasPermission {
+		return noViewActivityOrViewActivityRedactedRoleError(p.User())
+	}
+	isAdmin, err := p.HasAdminRole(ctx)
+	if err != nil {
+		return err
+	}
+	// Check if we should redact the queries.
+	var shouldRedactQuery bool
+	if !isAdmin {
+		shouldRedactQuery, err = p.HasViewActivityRedacted(ctx)
+		if err != nil {
+			return err
+		}
+	}
 	for _, session := range response.Sessions {
 		sessionID := getSessionID(session)
 		for _, query := range session.ActiveQueries {
@@ -2414,6 +2437,10 @@ func populateQueriesTable(
 
 			// Interpolate placeholders into the SQL statement.
 			sql := formatActiveQuery(query)
+			// If the user does not have the correct privileges, show the query without literals or constants.
+			if shouldRedactQuery {
+				sql = query.SqlNoConstants
+			}
 			if err := addRow(
 				tree.NewDString(query.ID),
 				txnID,

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1391,3 +1391,89 @@ user root
 
 statement ok
 REVOKE SYSTEM VIEWACTIVITY FROM testuser
+
+# Test privileges for queries tables.
+user testuser
+
+statement error pq: user testuser does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege
+SELECT * FROM crdb_internal.cluster_queries
+
+statement error pq: user testuser does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege
+SELECT * FROM crdb_internal.node_queries
+
+user root
+
+# Grant VIEWACTIVITYREDACTED to testuser.
+statement ok
+GRANT SYSTEM VIEWACTIVITYREDACTED TO testuser
+
+user testuser
+
+# testuser should be able to see the queries tables.
+statement ok
+SELECT * FROM crdb_internal.cluster_queries
+
+statement ok
+SELECT * FROM crdb_internal.node_queries
+
+# Revoke VIEWACTIVITYREDACTED from testuser and grant them VIEWACTIVITY.
+user root
+
+statement ok
+REVOKE SYSTEM VIEWACTIVITYREDACTED FROM testuser
+
+statement ok
+GRANT SYSTEM VIEWACTIVITY TO testuser
+
+# testuser should be able to see the queries tables.
+statement ok
+SELECT * FROM crdb_internal.node_contention_events
+
+statement ok
+SELECT * FROM crdb_internal.transaction_contention_events
+
+# Test query redaction.
+user root
+
+statement ok
+REVOKE SYSTEM VIEWACTIVITY FROM testuser
+
+statement ok
+GRANT SYSTEM VIEWACTIVITYREDACTED TO testuser
+
+# Run a sleep query from root and verify that it is redacted.
+statement async sleepQuery count 1
+SELECT pg_sleep(3)
+
+user testuser
+
+query TT
+SELECT user_name, query FROM crdb_internal.cluster_queries WHERE user_name = 'root'
+----
+root  SELECT pg_sleep(_)
+
+user root
+
+awaitstatement sleepQuery
+
+# Grant VIEWACTIVITY to testuser and revoke VIEWACTIVITYREDACTED.
+statement ok
+REVOKE SYSTEM VIEWACTIVITYREDACTED FROM testuser
+
+statement ok
+GRANT SYSTEM VIEWACTIVITY TO testuser
+
+# Run a sleep query from root and verify that it is not redacted.
+statement async sleepQuery count 1
+SELECT pg_sleep(3)
+
+user testuser
+
+query TT
+SELECT user_name, query FROM crdb_internal.cluster_queries WHERE user_name = 'root'
+----
+root  SELECT pg_sleep(3)
+
+user root
+
+awaitstatement sleepQuery


### PR DESCRIPTION
Fixes: #103560.

This commit implements the `VIEWACTIVITY` and `VIEWACTIVITYREDACTED`
system privileges for the crdb_internal queries tables. If a user does
not have either privilege, or is not admin, an error is returned. If a
user only has `VIEWACTIVITYREDACTED`, they will see a redacted form of
the SQL queries. If they only have `VIEWACTIVITY`, they will see the
unredacted SQL queries. If they have both, `VIEWACTIVITYREDACTED` takes
precedence.

Loom: https://www.loom.com/share/64649c3377d84cc5a1d2091136344594

Release note (sql change): The `crdb_internal.cluster_queries` and
`crdb_internal.node_queries` tables redact the SQL queries if the user
has `VIEWACTIVITYREDACTED`, and not redact the SQL queries if the user
has `VIEWACTIVITY`. The `crdb_internal.cluster_queries` and
`crdb_internal.node_queries` can now only be viewed if the user has any
of `admin`, `VIEWACTIVITY`, or `VIEWACTIVITYREDACTED`.