### PR TITLE
changefeedccl: clear schema registry singleton upon starting tests

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1082,6 +1082,7 @@ func cdcTestNamedWithSystem(
 	t.Helper()
 	options := makeOptions(testOpts...)
 	cleanupCloudStorage := addCloudStorageOptions(t, &options)
+	TestingClearSchemaRegistrySingleton()
 
 	sinkType := randomSinkTypeWithOptions(options)
 	if sinkType == "skip" {

--- a/pkg/ccl/changefeedccl/schema_registry.go
+++ b/pkg/ccl/changefeedccl/schema_registry.go
@@ -373,3 +373,10 @@ type sharedSchemaRegistryCaches struct {
 }
 
 var schemaRegistrySingletons = &sharedSchemaRegistryCaches{cachePerEndpoint: make(map[string]*schemaRegistryCache)}
+
+// TestingClearSchemaRegistrySingleton clears out the singleton so that different tests don't pollute each other
+func TestingClearSchemaRegistrySingleton() {
+	schemaRegistrySingletons.mu.Lock()
+	defer schemaRegistrySingletons.mu.Unlock()
+	schemaRegistrySingletons.cachePerEndpoint = make(map[string]*schemaRegistryCache)
+}


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/102671
Resolves https://github.com/cockroachdb/cockroach/issues/102853
Resolves https://github.com/cockroachdb/cockroach/issues/102836
Resolves https://github.com/cockroachdb/cockroach/issues/102867
Resolves https://github.com/cockroachdb/cockroach/issues/102832

Since the schemaRegistrySingleton would persist across tests, it may be set by one test, then that test would close its server freeing up that port, then another test may get the same port and have to deal with a polluted cache.

We should still deal with this kind of case of a polluted cache in the product as well for the edge case where a user messes with their schema registry while we've cached information about it, but it feels still wrong to have all unit tests running with the unpredictable effects of other unit tests.

Release note: None