### PR TITLE
release-23.1: sql: Limit MODIFYSQLCLUSTERSETTING to only view sql.defaults

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2065,46 +2065,38 @@ CREATE TABLE crdb_internal.cluster_settings (
   description   STRING NOT NULL
 )`,
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		if hasPriv, err := func() (bool, error) {
-			if hasAdmin, err := p.HasAdminRole(ctx); err != nil {
-				return false, err
-			} else if hasAdmin {
-				return true, nil
-			}
-			if hasModify, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING, p.User()); err != nil {
-				return false, err
-			} else if hasModify {
-				return true, nil
-			}
-			if hasSqlModify, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYSQLCLUSTERSETTING, p.User()); err != nil {
-				return false, err
-			} else if hasSqlModify {
-				return true, nil
-			}
-			if hasView, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERSETTING, p.User()); err != nil {
-				return false, err
-			} else if hasView {
-				return true, nil
-			}
-			if hasModify, err := p.HasRoleOption(ctx, roleoption.MODIFYCLUSTERSETTING); err != nil {
-				return false, err
-			} else if hasModify {
-				return true, nil
-			}
-			if hasView, err := p.HasRoleOption(ctx, roleoption.VIEWCLUSTERSETTING); err != nil {
-				return false, err
-			} else if hasView {
-				return true, nil
-			}
-			return false, nil
-		}(); err != nil {
+		hasSqlModify, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYSQLCLUSTERSETTING, p.User())
+		if err != nil {
 			return err
-		} else if !hasPriv {
+		}
+		hasModify, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING, p.User())
+		if err != nil {
+			return err
+		}
+		hasView, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERSETTING, p.User())
+		if err != nil {
+			return err
+		}
+		if !hasModify {
+			if hasModify, err = p.HasRoleOption(ctx, roleoption.MODIFYCLUSTERSETTING); err != nil {
+				return err
+			}
+		}
+		if !hasView {
+			if hasView, err = p.HasRoleOption(ctx, roleoption.VIEWCLUSTERSETTING); err != nil {
+				return err
+			}
+		}
+		if !hasModify && !hasSqlModify && !hasView {
 			return pgerror.Newf(pgcode.InsufficientPrivilege,
 				"only users with %s, %s or %s system privileges are allowed to read "+
 					"crdb_internal.cluster_settings", privilege.MODIFYCLUSTERSETTING, privilege.MODIFYSQLCLUSTERSETTING, privilege.VIEWCLUSTERSETTING)
 		}
 		for _, k := range settings.Keys(p.ExecCfg().Codec.ForSystemTenant()) {
+			// If the user has specifically MODIFYSQLCLUSTERSETTING, hide non-sql.defaults settings.
+			if !hasModify && !hasView && hasSqlModify && !strings.HasPrefix(k, "sql.defaults") {
+				continue
+			}
 			setting, _ := settings.LookupForLocalAccess(k, p.ExecCfg().Codec.ForSystemTenant())
 			strVal := setting.String(&p.ExecCfg().Settings.SV)
 			isPublic := setting.Visibility() == settings.Public

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -88,7 +88,7 @@ user testuser
 statement error only users with the MODIFYCLUSTERSETTING or MODIFYSQLCLUSTERSETTING privilege are allowed to set cluster setting 'sql.defaults.default_int_size'
 SET CLUSTER SETTING sql.defaults.default_int_size = 4
 
-# Users with MODIFYSQLCLUSTERSETTING system privilege should be able to see all cluster settings and modify only sql.defaults settings.
+# Users with MODIFYSQLCLUSTERSETTING system privilege should be able to see and modify only sql.defaults settings.
 user root
 
 statement ok
@@ -99,6 +99,11 @@ user testuser
 statement ok
 SHOW CLUSTER SETTINGS
 
+skipif config local-mixed-22.2-23.1
+statement error pq: only users with MODIFYCLUSTERSETTING or VIEWCLUSTERSETTING privileges are allowed to show cluster setting 'diagnostics.reporting.enabled'
+SHOW CLUSTER SETTING diagnostics.reporting.enabled
+
+skipif config local-mixed-22.2-23.1
 statement ok
 SET CLUSTER SETTING sql.defaults.default_int_size = 4
 
@@ -108,9 +113,6 @@ SET CLUSTER SETTING diagnostics.reporting.enabled = false
 user root
 
 statement ok
-REVOKE SYSTEM MODIFYSQLCLUSTERSETTING FROM testuser
-
-statement ok
 ALTER USER testuser NOMODIFYCLUSTERSETTING
 
 statement ok
@@ -118,10 +120,23 @@ ALTER USER testuser VIEWCLUSTERSETTING
 
 user testuser
 
-# Users with VIEWCLUSTERSETTING should be able to see non sql.defaults settings but not modify.
+# Users with VIEWCLUSTERSETTING should be able to see non sql.defaults settings but not modify regardless if they have sql modify.
 
 statement error pq: only users with the MODIFYCLUSTERSETTING privilege are allowed to set cluster setting 'diagnostics.reporting.enabled'
 SET CLUSTER SETTING diagnostics.reporting.enabled = false
+
+query B
+SHOW CLUSTER SETTING diagnostics.reporting.enabled
+----
+true
+
+user root 
+
+skipif config local-mixed-22.2-23.1
+statement ok
+REVOKE SYSTEM MODIFYSQLCLUSTERSETTING FROM testuser
+
+user testuser
 
 query B
 SHOW CLUSTER SETTING diagnostics.reporting.enabled

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1243,7 +1243,8 @@ SELECT crdb_internal.unsafe_clear_gossip_info('unknown key')
 ----
 false
 
-# Verify users with VIEWCLUSTERSETTING, MODIFYCLUSTERSETTING or MODIFYSQLCLUSTERSETTING can view non sql.defaults cluster settings.
+# Verify users with VIEWCLUSTERSETTING or MODIFYCLUSTERSETTING can view non sql.defaults cluster settings.
+# Verify users with MODIFYSQLCLUSTERSETTING can only view sql.defaults cluster settings.
 
 user root
 
@@ -1257,10 +1258,30 @@ SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('diagnostics
 ----
 true
 
+# Verify a combination of system privileges where one is restrictive will still allow users to see non sql.defaults.
+
+user root
+
+skipif config local-mixed-22.2-23.1
+statement ok
+GRANT SYSTEM MODIFYSQLCLUSTERSETTING TO testuser
+
+user testuser
+
+skipif config local-mixed-22.2-23.1
+query T
+SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('diagnostics.reporting.enabled')
+----
+true
+
 user root
 
 statement ok
 REVOKE SYSTEM VIEWCLUSTERSETTING FROM testuser
+
+skipif config local-mixed-22.2-23.1
+statement ok
+REVOKE SYSTEM MODIFYSQLCLUSTERSETTING FROM testuser
 
 statement ok
 GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser
@@ -1320,9 +1341,15 @@ GRANT SYSTEM MODIFYSQLCLUSTERSETTING TO testuser
 user testuser
 
 query T
-SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('diagnostics.reporting.enabled')
+SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('sql.defaults.zigzag_join.enabled')
 ----
 true
+
+skipif config local-mixed-22.2-23.1
+query T
+SELECT value FROM crdb_internal.cluster_settings WHERE variable IN ('diagnostics.reporting.enabled')
+----
+
 
 user root
 


### PR DESCRIPTION
This change prevents users with MODIFYSQLCLUSTERSETTING FROM viewing non sql.defaults cluster settings.

Fixes: #104156

backports: https://github.com/cockroachdb/cockroach/pull/104224
Release justification: high priority change
Release note (sql change): user with MODIFYSQLCLUSTERSETTING will no longer be able to view non sql.defaults cluster settings.