### PR TITLE
diagnostics: Fixed a crashing bug when creating diagnostics report

### DIFF
--- a/pkg/server/diagnostics/BUILD.bazel
+++ b/pkg/server/diagnostics/BUILD.bazel
@@ -55,12 +55,13 @@ go_test(
     size = "medium",
     srcs = [
         "main_test.go",
+        "reporter_test.go",
         "update_checker_test.go",
     ],
     args = ["-test.timeout=295s"],
+    embed = [":diagnostics"],
     tags = ["no-remote-exec"],
     deps = [
-        ":diagnostics",
         "//pkg/base",
         "//pkg/build",
         "//pkg/security/securityassets",
@@ -71,6 +72,7 @@ go_test(
         "//pkg/util/cloudinfo",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "@com_github_mitchellh_reflectwalk//:reflectwalk",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/diagnostics/reporter_test.go
+++ b/pkg/server/diagnostics/reporter_test.go
@@ -1,0 +1,49 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package diagnostics
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/mitchellh/reflectwalk"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStringRedactor_Primitive tests that fields of type `*string` will be
+// correctly redacted to "_", and all other field types ( including `string`)
+// will be unchanged.
+func TestStringRedactor_Primitive(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	type Foo struct {
+		A string
+		B *string
+		C map[string]string
+	}
+
+	string1 := "string 1"
+	string2 := "string 2"
+	foo := Foo{
+		A: string1,
+		B: &string2,
+		C: map[string]string{"3": "string 3"},
+	}
+
+	require.NoError(t, reflectwalk.Walk(foo, stringRedactor{}))
+	require.Equal(t, "string 1", string1)
+	require.Equal(t, "string 1", foo.A)
+	require.Equal(t, "_", string2)
+	require.Equal(t, "_", *foo.B)
+	require.Equal(t, "string 3", foo.C["3"])
+}


### PR DESCRIPTION
This commit fixed a bug where the node would sometimes crash when creating diagnostics report.

Fixes: https://github.com/cockroachdb/cockroach/issues/104172
Epic: None
Release note: None