### PR TITLE
upgrades: batch the job_info backfill upgrade

### DIFF
--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -280,38 +280,38 @@ const (
 )
 
 const (
-	legacyPayloadKey  = "legacy_payload"
-	legacyProgressKey = "legacy_progress"
+	LegacyPayloadKey  = "legacy_payload"
+	LegacyProgressKey = "legacy_progress"
 )
 
 // GetLegacyPayloadKey returns the info_key whose value is the jobspb.Payload of
 // the job.
 func GetLegacyPayloadKey() string {
-	return legacyPayloadKey
+	return LegacyPayloadKey
 }
 
 // GetLegacyProgressKey returns the info_key whose value is the jobspb.Progress
 // of the job.
 func GetLegacyProgressKey() string {
-	return legacyProgressKey
+	return LegacyProgressKey
 }
 
 // GetLegacyPayload returns the job's Payload from the system.jobs_info table.
 func (i InfoStorage) GetLegacyPayload(ctx context.Context) ([]byte, bool, error) {
-	return i.Get(ctx, legacyPayloadKey)
+	return i.Get(ctx, LegacyPayloadKey)
 }
 
 // WriteLegacyPayload writes the job's Payload to the system.jobs_info table.
 func (i InfoStorage) WriteLegacyPayload(ctx context.Context, payload []byte) error {
-	return i.Write(ctx, legacyPayloadKey, payload)
+	return i.Write(ctx, LegacyPayloadKey, payload)
 }
 
 // GetLegacyProgress returns the job's Progress from the system.jobs_info table.
 func (i InfoStorage) GetLegacyProgress(ctx context.Context) ([]byte, bool, error) {
-	return i.Get(ctx, legacyProgressKey)
+	return i.Get(ctx, LegacyProgressKey)
 }
 
 // WriteLegacyProgress writes the job's Progress to the system.jobs_info table.
 func (i InfoStorage) WriteLegacyProgress(ctx context.Context, progress []byte) error {
-	return i.Write(ctx, legacyProgressKey, progress)
+	return i.Write(ctx, LegacyProgressKey, progress)
 }

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -362,7 +362,7 @@ func TestCreateJobWritesToJobInfo(t *testing.T) {
 
 		// Verify the payload in the system.job_info is the same as what we read
 		// from system.jobs.
-		require.NoError(t, infoStorage.Iterate(ctx, legacyPayloadKey, func(infoKey string, value []byte) error {
+		require.NoError(t, infoStorage.Iterate(ctx, LegacyPayloadKey, func(infoKey string, value []byte) error {
 			data, err := protoutil.Marshal(&expectedPayload)
 			if err != nil {
 				panic(err)
@@ -373,7 +373,7 @@ func TestCreateJobWritesToJobInfo(t *testing.T) {
 
 		// Verify the progress in the system.job_info is the same as what we read
 		// from system.jobs.
-		require.NoError(t, infoStorage.Iterate(ctx, legacyProgressKey, func(infoKey string, value []byte) error {
+		require.NoError(t, infoStorage.Iterate(ctx, LegacyProgressKey, func(infoKey string, value []byte) error {
 			data, err := protoutil.Marshal(&expectedProgress)
 			if err != nil {
 				panic(err)

--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -76,6 +76,7 @@ go_library(
         "//pkg/upgrade",
         "//pkg/upgrade/upgradebase",
         "//pkg/util/encoding",
+        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",


### PR DESCRIPTION
Release note (bug fix): The backfill of system.job_info upgrade migration that runs during upgrades from 22.2 now processes rows in batches to avoid cases where it could become stuck due to contention and transaction retries.
Epic: none.