### PR TITLE
rttanalysis: add benchmark for expensive ORM query

### DIFF
--- a/pkg/bench/rttanalysis/orm_queries_bench_test.go
+++ b/pkg/bench/rttanalysis/orm_queries_bench_test.go
@@ -434,5 +434,47 @@ LEFT JOIN LATERAL
     WHERE "column".attrelid = "table".oid
   ) columns ON true;`,
 		},
+
+		{
+			Name:  "column descriptions json agg",
+			Setup: "CREATE TABLE t(a INT PRIMARY KEY)",
+			Stmt: `SELECT
+	jsonb_build_object(
+		'oid', "table".oid::INT8,
+		'columns', COALESCE(columns.info, '[]')
+	)::JSONB AS info
+FROM
+	pg_catalog.pg_class AS "table"
+	JOIN pg_catalog.pg_namespace AS schema ON schema.oid = "table".relnamespace
+	-- description
+	LEFT JOIN pg_catalog.pg_description AS description ON
+			description.classoid = 'pg_catalog.pg_class'::REGCLASS
+			AND description.objoid = "table".oid
+			AND description.objsubid = 0
+	-- columns
+	LEFT JOIN LATERAL (
+			SELECT
+				jsonb_agg(
+					jsonb_build_object(
+						'description', pg_catalog.col_description("table".oid, "column".attnum)
+					)
+				)
+					AS info
+			FROM
+				pg_catalog.pg_attribute AS "column"
+				LEFT JOIN pg_catalog.pg_type AS type ON type.oid = "column".atttypid
+				LEFT JOIN pg_catalog.pg_type AS base_type ON
+						type.typtype = 'd' AND base_type.oid = type.typbasetype
+			WHERE
+				"column".attrelid = "table".oid
+				-- columns where attnum <= 0 are special, system-defined columns
+				AND "column".attnum > 0
+				-- dropped columns still exist in the system catalog as "zombie"columns, so ignore those
+				AND NOT "column".attisdropped
+		)
+			AS columns ON true
+WHERE
+	"table".relkind IN ('r')`,
+		},
 	})
 }

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -77,6 +77,7 @@ exp,benchmark
 12,ORMQueries/hasura_column_descriptions_8_tables
 5,ORMQueries/hasura_column_descriptions_modified
 4,ORMQueries/information_schema._pg_index_position
+0,ORMQueries/column_descriptions_json_agg
 134,ORMQueries/introspection_description_join
 4,ORMQueries/pg_attribute
 4,ORMQueries/pg_class


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/88891

This used to perform badly. The benchmark will help ensure we don't regress.

Release note: None