### PR TITLE
roachtest: always disable merge queue before loading TPCH

### DIFF
--- a/pkg/cmd/roachtest/tests/cancel.go
+++ b/pkg/cmd/roachtest/tests/cancel.go
@@ -52,9 +52,7 @@ func registerCancel(r registry.Registry) {
 			defer conn.Close()
 
 			t.Status("restoring TPCH dataset for Scale Factor 1")
-			if err := loadTPCHDataset(
-				ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false, /* disableMergeQueue */
-			); err != nil {
+			if err := loadTPCHDataset(ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All()); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -49,9 +49,7 @@ func runMultiTenantTPCH(
 			t.Fatal(err)
 		}
 		t.Status("restoring TPCH dataset for Scale Factor 1 in ", setupNames[setupIdx])
-		if err := loadTPCHDataset(
-			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false, /* disableMergeQueue */
-		); err != nil {
+		if err := loadTPCHDataset(ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All()); err != nil {
 			t.Fatal(err)
 		}
 		for queryNum := 1; queryNum <= tpch.NumQueries; queryNum++ {

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -31,7 +31,7 @@ import (
 // expensive dataset restore only if it doesn't.
 //
 // The function disables auto stats collection and ensures that table statistics
-// are present for all TPCH tables.
+// are present for all TPCH tables. It also disables the merge queue.
 func loadTPCHDataset(
 	ctx context.Context,
 	t test.Test,
@@ -40,7 +40,6 @@ func loadTPCHDataset(
 	sf int,
 	m cluster.Monitor,
 	roachNodes option.NodeListOption,
-	disableMergeQueue bool,
 ) (retErr error) {
 	_, err := db.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;")
 	if retErr != nil {
@@ -55,10 +54,8 @@ func loadTPCHDataset(
 			}
 		}
 	}()
-	if disableMergeQueue {
-		if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
-			t.Fatal(err)
-		}
+	if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
+		t.Fatal(err)
 	}
 
 	if _, err := db.ExecContext(ctx, `USE tpch`); err == nil {

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -44,10 +44,8 @@ func registerTPCHConcurrency(r registry.Registry) {
 			}
 		}
 
-		if err := loadTPCHDataset(
-			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx, c.Range(1, numNodes-1)),
-			c.Range(1, numNodes-1), true, /* disableMergeQueue */
-		); err != nil {
+		m := c.NewMonitor(ctx, c.Range(1, numNodes-1))
+		if err := loadTPCHDataset(ctx, t, c, conn, 1 /* sf */, m, c.Range(1, numNodes-1)); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -75,9 +75,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 		defer conn.Close()
 
 		t.Status("setting up dataset")
-		err := loadTPCHDataset(
-			ctx, t, c, conn, b.ScaleFactor, m, roachNodes, true, /* disableMergeQueue */
-		)
+		err := loadTPCHDataset(ctx, t, c, conn, b.ScaleFactor, m, roachNodes)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -576,9 +576,7 @@ func runTPCHVec(
 
 	conn := c.Conn(ctx, t.L(), 1)
 	t.Status("restoring TPCH dataset for Scale Factor 1")
-	if err := loadTPCHDataset(
-		ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), true, /* disableMergeQueue */
-	); err != nil {
+	if err := loadTPCHDataset(ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All()); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This was already done in most places, and now `cancel` and `multitenant/tpch` do that as well (I'm interested in using the latter as the benchmark, so it's better to disable the merge queue for consistency).

Epic: None

Release note: None