### PR TITLE
sql: handle null array elements in crdb_internal.fingerprint

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -521,9 +521,6 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.revalidate_unique_constraint",
 			"crdb_internal.request_statement_bundle",
 			"crdb_internal.set_compaction_concurrency",
-			// TODO(#97097): Temporarily disable crdb_internal.fingerprint
-			// which produces internal errors for some valid inputs.
-			"crdb_internal.fingerprint",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/span_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/span_builtins
@@ -68,3 +68,13 @@ SELECT encode(crdb_internal.trim_tenant_prefix('\xfe8828a09b'), 'hex');
 fe8828a09b
 
 subtest end
+
+subtest fingerprint_handles_null_args
+
+query error StartKey cannot be NULL
+SELECT crdb_internal.fingerprint(ARRAY[NULL, NULL]::BYTES[], now(), false);
+
+query error EndKey cannot be NULL
+SELECT crdb_internal.fingerprint(ARRAY['\\x8989', NULL]::BYTES[], now(), false);
+
+subtest end

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -10572,7 +10572,16 @@ func prettyStatement(p tree.PrettyCfg, stmt string) (string, error) {
 func parseSpan(arg tree.Datum) (roachpb.Span, error) {
 	arr := tree.MustBeDArray(arg)
 	if arr.Len() != 2 {
-		return roachpb.Span{}, errors.New("expected an array of two elements")
+		return roachpb.Span{}, pgerror.New(pgcode.InvalidParameterValue,
+			"expected an array of two elements")
+	}
+	if arr.Array[0] == tree.DNull {
+		return roachpb.Span{}, pgerror.New(pgcode.InvalidParameterValue,
+			"StartKey cannot be NULL")
+	}
+	if arr.Array[1] == tree.DNull {
+		return roachpb.Span{}, pgerror.New(pgcode.InvalidParameterValue,
+			"EndKey cannot be NULL")
 	}
 	startKey := []byte(tree.MustBeDBytes(arr.Array[0]))
 	endKey := []byte(tree.MustBeDBytes(arr.Array[1]))


### PR DESCRIPTION
Previously, we failed with an internal error if either array element was NULL. Now we fail with a more sensible error.

Fixes #97097

Release note: None