### PR TITLE
streamingccl: avoid deadlock in event stream close

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -308,6 +308,8 @@ func (s *eventStream) flushEvent(ctx context.Context, event *streampb.StreamEven
 		return ctx.Err()
 	case s.streamCh <- tree.Datums{tree.NewDBytes(tree.DBytes(data))}:
 		return nil
+	case <-s.doneChan:
+		return nil
 	}
 }
 


### PR DESCRIPTION
The streamCh that flushEvent is sending to is read by callers of Next(). But once we've been closed, no one is going to call Next() again.

Epic: none

Informs #104046

Release note: None