### PR TITLE
roachprod: minor fixes for snapshots

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -315,6 +315,7 @@ func (p *Provider) CreateVolumeSnapshot(
 ) (vm.VolumeSnapshot, error) {
 	args := []string{
 		"compute",
+		"--project", p.GetProject(),
 		"snapshots",
 		"create", vsco.Name,
 		"--source-disk", volume.ProviderResourceID,
@@ -336,6 +337,7 @@ func (p *Provider) CreateVolumeSnapshot(
 
 	args = []string{
 		"compute",
+		"--project", p.GetProject(),
 		"snapshots",
 		"add-labels", vsco.Name,
 		"--labels", s[:len(s)-1],
@@ -355,6 +357,7 @@ func (p *Provider) ListVolumeSnapshots(
 ) ([]vm.VolumeSnapshot, error) {
 	args := []string{
 		"compute",
+		"--project", p.GetProject(),
 		"snapshots",
 		"list",
 		"--format", "json(name,id)",
@@ -398,6 +401,7 @@ func (p *Provider) DeleteVolumeSnapshots(l *logger.Logger, snapshots ...vm.Volum
 	}
 	args := []string{
 		"compute",
+		"--project", p.GetProject(),
 		"snapshots",
 		"delete",
 	}
@@ -438,6 +442,7 @@ func (p *Provider) CreateVolume(
 	}
 	args := []string{
 		"compute",
+		"--project", p.GetProject(),
 		"disks",
 		"create", vco.Name,
 		"--size", strconv.Itoa(vco.Size),
@@ -496,6 +501,7 @@ func (p *Provider) CreateVolume(
 		s := sb.String()
 		args = []string{
 			"compute",
+			"--project", p.GetProject(),
 			"disks",
 			"add-labels", vco.Name,
 			"--labels", s[:len(s)-1],
@@ -522,6 +528,7 @@ func (p *Provider) DeleteVolume(l *logger.Logger, volume vm.Volume, vm *vm.VM) e
 	{ // Detach disks.
 		args := []string{
 			"compute",
+			"--project", p.GetProject(),
 			"instances",
 			"detach-disk", vm.Name,
 			"--disk", volume.ProviderResourceID,
@@ -535,6 +542,7 @@ func (p *Provider) DeleteVolume(l *logger.Logger, volume vm.Volume, vm *vm.VM) e
 	{ // Delete disks.
 		args := []string{
 			"compute",
+			"--project", p.GetProject(),
 			"disks",
 			"delete",
 			volume.ProviderResourceID,
@@ -646,6 +654,7 @@ func (p *Provider) AttachVolume(l *logger.Logger, volume vm.Volume, vm *vm.VM) (
 	// Volume attach.
 	args := []string{
 		"compute",
+		"--project", p.GetProject(),
 		"instances",
 		"attach-disk",
 		vm.ProviderID,
@@ -675,6 +684,7 @@ func (p *Provider) AttachVolume(l *logger.Logger, volume vm.Volume, vm *vm.VM) (
 	// Volume auto delete.
 	args = []string{
 		"compute",
+		"--project", p.GetProject(),
 		"instances",
 		"set-disk-auto-delete", vm.ProviderID,
 		"--auto-delete",


### PR DESCRIPTION
Support for disk snapshots has been recently added in [1]. This change adds minor fixes which were necessary to run in a different environment which was previously tested. Specifically, several commands were missing `--project` which resulted in (silent) failures. Error propagation from `c.Parallel` was signaling an internal error
instead of passing command's error. (Granted, the existing mechanism for error propagation is to be revisited in [2].)

[1] https://github.com/cockroachdb/cockroach/pull/103757
[2] https://github.com/cockroachdb/cockroach/issues/104312

Epic: none

Release note: None