### PR TITLE
upgrades: Zero out CompositeColumnIDs when comparing two indexes

### DIFF
--- a/pkg/upgrade/upgrades/schema_changes.go
+++ b/pkg/upgrade/upgrades/schema_changes.go
@@ -298,7 +298,6 @@ func indexDescForComparison(idx catalog.Index) *descpb.IndexDescriptor {
 
 	// Clear out the column IDs, but retain their length. Column IDs may
 	// change. Note that we retain the name slices. Those should match.
-	desc.StoreColumnIDs = nil
 	for i := range desc.StoreColumnIDs {
 		desc.StoreColumnIDs[i] = 0
 	}
@@ -307,6 +306,9 @@ func indexDescForComparison(idx catalog.Index) *descpb.IndexDescriptor {
 	}
 	for i := range desc.KeySuffixColumnIDs {
 		desc.KeySuffixColumnIDs[i] = 0
+	}
+	for i := range desc.CompositeColumnIDs {
+		desc.CompositeColumnIDs[i] = 0
 	}
 
 	desc.CreatedAtNanos = 0


### PR DESCRIPTION
Previously, if we were to add an index to a system table during an upgrade step, and such an index already exists on the table, we will zero out irrelavant fields before we can meaningfully compare it against the hard-coded one in the `systemschema/system.go` file. Irrelavant fields previously included key, keySuffix, and stored column ID but we forgot to zero out compositeColumnIDs.

Informs https://github.com/cockroachlabs/support/issues/2370
Epic: None
Release note: None