### PR TITLE
test: add support for `TEST_UNDECLARED_OUTPUTS_DIR`

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -479,12 +479,14 @@ func TestLint(t *testing.T) {
 					":!testutils/data_path.go",
 					":!util/log/tracebacks.go",
 					":!util/sdnotify/sdnotify_unix.go",
-					":!util/grpcutil",                     // GRPC_GO_* variables
-					":!roachprod",                         // roachprod requires AWS environment variables
-					":!cli/env.go",                        // The CLI needs the PGHOST variable.
-					":!cli/start.go",                      // The CLI needs the GOMEMLIMIT variable.
-					":!internal/codeowners/codeowners.go", // For BAZEL_TEST.
-					":!internal/team/team.go",             // For BAZEL_TEST.
+					":!util/grpcutil",                        // GRPC_GO_* variables
+					":!roachprod",                            // roachprod requires AWS environment variables
+					":!cli/env.go",                           // The CLI needs the PGHOST variable.
+					":!cli/start.go",                         // The CLI needs the GOMEMLIMIT variable.
+					":!internal/codeowners/codeowners.go",    // For BAZEL_TEST.
+					":!internal/team/team.go",                // For BAZEL_TEST.
+					":!util/log/test_log_scope.go",           // For TEST_UNDECLARED_OUTPUT_DIR, REMOTE_EXEC
+					":!testutils/datapathutils/data_path.go", // For TEST_UNDECLARED_OUTPUT_DIR, REMOTE_EXEC
 				},
 			},
 		} {


### PR DESCRIPTION
To date, we have put temporary files from tests in $TMPDIR. We have a patch to `rules_go` that copies the value of the $TEST_TMPDIR (the variable that Bazel provides) over to $TMPDIR for use in CI. Some tests (especially those using TestLogScope) have behavior where they leave files behind after the test completes *if the test fails*, thereby allowing people to look at the left-over files for debugging.

As we transition to remote execution, this will no longer work, since the $TMPDIR is on some remote machine somewhere, and Bazel will just clean the $TMPDIR up after the test completes regardless of its exit status.

Bazel provides the variable `TEST_UNDECLARED_OUTPUTS_DIR` for the same purpose: it gives us a place to put unstructured output from tests. To prepare for remote execution, we make the following changes:

1. Update `TestLogScope` to use `TEST_UNDECLARED_OUTPUTS_DIR` where appropriate.
2. Add a new function `datapathutils.DebuggableTempDir()` which returns either `TEST_UNDECLARED_OUTPUTS_DIR` or os.TempDir() as appropriate.

Since the outputs.zip behavior is kind of awkward, we guard this behind the environment variable `REMOTE_EXEC`. We must be sure to set this variable whenever we run tests remotely.

Epic: CRDB-17165
Release note: None