### PR TITLE
sqlstats: fix metadata column in `system.transaction_activity`

### DIFF
--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -101,7 +102,7 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 		case <-flushDoneSignal:
 			// A flush was done. Set the timer and wait for it to complete.
 			if sqlStatsActivityFlushEnabled.Get(&settings.SV) {
-				updater := newSqlActivityUpdater(settings, execCtx.ExecCfg().InternalDB)
+				updater := newSqlActivityUpdater(settings, execCtx.ExecCfg().InternalDB, nil)
 				if err := updater.TransferStatsToActivity(ctx); err != nil {
 					log.Warningf(ctx, "error running sql activity updater job: %v", err)
 					metrics.numErrors.Inc(1)
@@ -159,16 +160,20 @@ func init() {
 }
 
 // newSqlActivityUpdater returns a new instance of sqlActivityUpdater.
-func newSqlActivityUpdater(setting *cluster.Settings, db isql.DB) *sqlActivityUpdater {
+func newSqlActivityUpdater(
+	setting *cluster.Settings, db isql.DB, testingKnobs *sqlstats.TestingKnobs,
+) *sqlActivityUpdater {
 	return &sqlActivityUpdater{
-		st: setting,
-		db: db,
+		st:           setting,
+		db:           db,
+		testingKnobs: testingKnobs,
 	}
 }
 
 type sqlActivityUpdater struct {
-	st *cluster.Settings
-	db isql.DB
+	st           *cluster.Settings
+	testingKnobs *sqlstats.TestingKnobs
+	db           isql.DB
 }
 
 func (u *sqlActivityUpdater) TransferStatsToActivity(ctx context.Context) error {
@@ -250,7 +255,7 @@ func (u *sqlActivityUpdater) transferAllStats(
                   app_name,
                   fingerprint_id,
                   agg_interval,
-                  crdb_internal.merge_stats_metadata(array_agg(metadata))      AS metadata,
+                  max(metadata) as metadata,
                   crdb_internal.merge_transaction_stats(array_agg(statistics)) AS statistics
            FROM system.public.transaction_statistics
            WHERE aggregated_ts = $2
@@ -392,7 +397,7 @@ INTO system.public.transaction_activity
                   ts.app_name,
                   ts.fingerprint_id,
                   ts.agg_interval,
-                  crdb_internal.merge_stats_metadata(array_agg(ts.metadata))    AS metadata,
+                  max(ts.metadata) AS metadata,
                   crdb_internal.merge_transaction_stats(array_agg(statistics)) AS statistics
            FROM system.public.transaction_statistics ts
                     inner join (SELECT fingerprint_id, app_name, agg_interval
@@ -575,22 +580,42 @@ func (u *sqlActivityUpdater) getAostExecutionCount(
 	totalTxnClusterExecCount int64,
 	retErr error,
 ) {
+
+	query := `
+SELECT row_count,
+       ex_sum
+FROM (SELECT count_rows():::int                     AS row_count,
+             COALESCE(sum(execution_count)::int, 0) AS ex_sum
+      FROM system.statement_statistics AS OF SYSTEM TIME follower_read_timestamp()
+      WHERE app_name not like '$ internal%' and aggregated_ts = $1
+      union all
+      SELECT
+          count_rows():::int AS row_count, COALESCE (sum(execution_count)::int, 0) AS ex_sum
+      FROM system.transaction_statistics AS OF SYSTEM TIME follower_read_timestamp()
+      WHERE app_name not like '$ internal%' and aggregated_ts = $1) AS OF SYSTEM TIME follower_read_timestamp()`
+
+	if u.testingKnobs != nil {
+		// We repeat the query in order to avoid formatting the query every time.
+		aost := u.testingKnobs.GetAOSTClause()
+		query = fmt.Sprintf(`
+SELECT row_count,
+       ex_sum
+FROM (SELECT count_rows():::int                     AS row_count,
+             COALESCE(sum(execution_count)::int, 0) AS ex_sum
+      FROM system.statement_statistics %[1]s
+      WHERE app_name not like '$ internal%%' and aggregated_ts = $1
+      union all
+      SELECT
+          count_rows():::int AS row_count, COALESCE (sum(execution_count)::int, 0) AS ex_sum
+      FROM system.transaction_statistics %[1]s
+      WHERE app_name not like '$ internal%%' and aggregated_ts = $1) %[1]s`, aost)
+	}
+
 	it, err := u.db.Executor().QueryIteratorEx(ctx,
 		"activity-flush-count",
 		nil, /* txn */
 		sessiondata.NodeUserSessionDataOverride,
-		`
-				SELECT row_count, ex_sum FROM (SELECT
-					count_rows():::int AS row_count,
-					COALESCE(sum(execution_count)::int, 0) AS ex_sum
-				FROM system.statement_statistics AS OF SYSTEM TIME follower_read_timestamp()
-				WHERE  app_name not like '$ internal%' and aggregated_ts = $1
-			union all
-				SELECT
-					count_rows():::int AS row_count,
-					COALESCE(sum(execution_count)::int, 0) AS ex_sum
-				FROM system.transaction_statistics AS OF SYSTEM TIME follower_read_timestamp()
-				WHERE app_name not like '$ internal%' and  aggregated_ts = $1) AS OF SYSTEM TIME follower_read_timestamp()`,
+		query,
 		aggTs,
 	)
 
@@ -629,12 +654,18 @@ func (u *sqlActivityUpdater) getExecutionCountFromRow(
 	return int64(tree.MustBeDInt(row[0])), int64(tree.MustBeDInt(row[1])), nil
 }
 
+func (u *sqlActivityUpdater) getTimeNow() time.Time {
+	if u.testingKnobs != nil && u.testingKnobs.StubTimeNow != nil {
+		return u.testingKnobs.StubTimeNow()
+	}
+	return timeutil.Now()
+}
+
 // ComputeAggregatedTs returns the aggregation timestamp to assign
 // in-memory SQL stats during storage or aggregation.
 func (u *sqlActivityUpdater) computeAggregatedTs(sv *settings.Values) time.Time {
 	interval := persistedsqlstats.SQLStatsAggregationInterval.Get(sv)
-
-	now := timeutil.Now()
+	now := u.getTimeNow()
 	aggTs := now.Truncate(interval)
 	return aggTs
 }
@@ -690,10 +721,11 @@ WHERE aggregated_ts not in (SELECT distinct aggregated_ts FROM system.statement_
 func (u *sqlActivityUpdater) getTableRowCount(
 	ctx context.Context, tableName string,
 ) (rowCount int64, retErr error) {
+	aost := u.testingKnobs.GetAOSTClause()
 	query := fmt.Sprintf(`
 				SELECT
 					count_rows()::int
-				FROM %s AS OF SYSTEM TIME follower_read_timestamp()`, tableName)
+				FROM %s %s`, tableName, aost)
 	datums, err := u.db.Executor().QueryRowEx(ctx,
 		"activity-total-count",
 		nil, /* txn */

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -20,13 +21,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -93,7 +97,7 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 
 	execCfg := srv.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
-	updater := newSqlActivityUpdater(st, execCfg.InternalDB)
+	updater := newSqlActivityUpdater(st, execCfg.InternalDB, nil)
 
 	// Transient failures from AOST queries: https://github.com/cockroachdb/cockroach/issues/97840
 	testutils.SucceedsWithin(t, func() error {
@@ -259,7 +263,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	updater := newSqlActivityUpdater(st, execCfg.InternalDB)
+	updater := newSqlActivityUpdater(st, execCfg.InternalDB, nil)
 
 	_, err = db.ExecContext(ctx, "SET tracing = true;")
 	require.NoError(t, err)
@@ -453,4 +457,68 @@ func TestScheduledSQLStatsCompaction(t *testing.T) {
 
 		return nil
 	}, 1*time.Minute)
+}
+
+// TestTransactionActivityMetadata verifies the metadata JSON column of system.transaction_activity are
+// what we expect it to be. This test was added to address #103618.
+func TestTransactionActivityMetadata(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "test is too slow to run under race")
+
+	ctx := context.Background()
+	stubTime := timeutil.Now().Truncate(time.Hour)
+	sqlStatsKnobs := &sqlstats.TestingKnobs{
+		StubTimeNow: func() time.Time { return stubTime },
+		AOSTClause:  "AS OF SYSTEM TIME '-1us'",
+	}
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Insecure: true,
+		Knobs: base.TestingKnobs{
+			SQLStatsKnobs: sqlStatsKnobs,
+			UpgradeManager: &upgradebase.TestingKnobs{
+				DontUseJobs:                       true,
+				SkipUpdateSQLActivityJobBootstrap: true,
+			},
+		},
+	})
+	defer s.Stopper().Stop(context.Background())
+	defer sqlDB.Close()
+
+	execCfg := s.ExecutorConfig().(ExecutorConfig)
+	st := cluster.MakeTestingClusterSettings()
+	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, "SET SESSION application_name = 'test_txn_activity_table'")
+
+	// Generate some sql stats data.
+	db.Exec(t, "SELECT 1;")
+
+	// Flush and transfer stats.
+	var metadataJSON string
+	s.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+
+	// Ensure that the metadata column contains the populated 'stmtFingerprintIDs' field.
+	var metadata struct {
+		StmtFingerprintIDs []string `json:"stmtFingerprintIDs,"`
+	}
+
+	require.NoError(t, updater.TransferStatsToActivity(ctx))
+	db.QueryRow(t, "SELECT metadata FROM system.public.transaction_activity LIMIT 1").Scan(&metadataJSON)
+	require.NoError(t, json.Unmarshal([]byte(metadataJSON), &metadata))
+	require.NotEmpty(t, metadata.StmtFingerprintIDs)
+
+	// Do the same but testing transferTopStats.
+	db.Exec(t, "SELECT crdb_internal.reset_sql_stats()")
+	db.Exec(t, "SELECT 1")
+
+	// Flush and transfer top stats.
+	s.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+	require.NoError(t, updater.transferTopStats(ctx, stubTime, 100, 100, 100))
+
+	// Ensure that the metadata column contains the populated 'stmtFingerprintIDs' field.
+	db.QueryRow(t, "SELECT metadata FROM system.public.transaction_activity LIMIT 1").Scan(&metadataJSON)
+	require.NoError(t, json.Unmarshal([]byte(metadataJSON), &metadata))
+	require.NotEmpty(t, metadata.StmtFingerprintIDs)
 }


### PR DESCRIPTION
Previously, the metadata column in `system.transaction_activity` was being incorrectly written as a the aggregated metadata type for statements. This occurs due to using `crdb_internal.merge_stats_metadata` function when this function only applies to stmt metadata. This bug meant that the UI did not have access to the txn metadata when querying from `system.transaction_activity` which contains the in-order stmt fingerprints for the txn that is used to build the txn query. Thus the txn query was showing as unavailable for all txns from this table.

As part of this change, the sql activity updater job will get its AOST clause from its newly added sqlstats testing knobs field to make testing simpler.

Fixes: #103618

Release note (bug fix): On the sql stats pages, the txn query should be available so long as the stmt fingerprints associated with the txn also exist in the payload. In other words the majority of txns should have the txn query available when selecting a recent time period.