### PR TITLE
ui: hide tenant dropdown when unneeded

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
@@ -21,16 +21,32 @@ jest.mock("src/redux/cookies", () => ({
 }));
 
 describe("TenantDropdown", () => {
-  it("returns null if there are no tenants in the session cookie", () => {
+  it("returns null if there's no current tenant", () => {
     (
       selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
         typeof selectTenantsFromMultitenantSessionCookie
       >
     ).mockReturnValueOnce([]);
+    (
+      getCookieValue as jest.MockedFn<typeof getCookieValue>
+    ).mockReturnValueOnce(null);
     const wrapper = shallow(<TenantDropdown />);
     expect(wrapper.isEmptyRender());
   });
-  it("returns a dropdown list of tenant options if there are tenant in the session cookie", () => {
+  // Mutli-tenant scenarios
+  it("returns null if there are no tenants or less than 2 tenants in the session cookie", () => {
+    (
+      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
+        typeof selectTenantsFromMultitenantSessionCookie
+      >
+    ).mockReturnValueOnce(["system"]);
+    (
+      getCookieValue as jest.MockedFn<typeof getCookieValue>
+    ).mockReturnValueOnce("system");
+    const wrapper = shallow(<TenantDropdown />);
+    expect(wrapper.isEmptyRender());
+  });
+  it("returns a dropdown list of tenant options if there are multiple tenant in the session cookie", () => {
     (
       selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
         typeof selectTenantsFromMultitenantSessionCookie
@@ -40,6 +56,18 @@ describe("TenantDropdown", () => {
       getCookieValue as jest.MockedFn<typeof getCookieValue>
     ).mockReturnValueOnce("system");
     const wrapper = shallow(<TenantDropdown />);
-    expect(wrapper.find({ children: "Tenant system" }).length).toEqual(1);
+    expect(wrapper.find({ children: "Tenant: system" }).length).toEqual(1);
+  });
+  it("returns a dropdown if the there is a single tenant option but isn't system tenant", () => {
+    (
+      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
+        typeof selectTenantsFromMultitenantSessionCookie
+      >
+    ).mockReturnValueOnce(["app"]);
+    (
+      getCookieValue as jest.MockedFn<typeof getCookieValue>
+    ).mockReturnValueOnce("app");
+    const wrapper = shallow(<TenantDropdown />);
+    expect(wrapper.find({ children: "Tenant: app" }).length).toEqual(1);
   });
 });

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
@@ -16,6 +16,7 @@ import React from "react";
 import { Dropdown } from "@cockroachlabs/cluster-ui";
 import ErrorBoundary from "../errorMessage/errorBoundary";
 import "./tenantDropdown.styl";
+import { isSystemTenant } from "src/redux/tenants";
 
 const tenantIDKey = "tenant";
 
@@ -26,7 +27,7 @@ const TenantDropdown = () => {
   const createDropdownItems = () => {
     return (
       tenants?.map(tenantID => {
-        return { name: "Tenant " + tenantID, value: tenantID };
+        return { name: "Tenant: " + tenantID, value: tenantID };
       }) || []
     );
   };
@@ -38,7 +39,7 @@ const TenantDropdown = () => {
     }
   };
 
-  if (tenants.length == 0) {
+  if (!currentTenant || (tenants.length < 2 && isSystemTenant(currentTenant))) {
     return null;
   }
 
@@ -46,9 +47,9 @@ const TenantDropdown = () => {
     <ErrorBoundary>
       <Dropdown
         items={createDropdownItems()}
-        onChange={tenantID => onTenantChange(tenantID)}
+        onChange={(tenantID: string) => onTenantChange(tenantID)}
       >
-        <div className="tenant-selected">{"Tenant " + currentTenant}</div>
+        <div className="tenant-selected">{"Tenant: " + currentTenant}</div>
       </Dropdown>
     </ErrorBoundary>
   );


### PR DESCRIPTION
This change updates the tenant dropdown so that
it will not display if there are fewer than 2 tenants the user has logged in to.

Fixes: #104557

Release note (ui change): hide tenant dropdown when user has logged in to fewer than 2 tenants.