### PR TITLE
syncutil: add `TryLock()` for deadlock detector mutexes

### DIFF
--- a/pkg/util/syncutil/mutex_deadlock.go
+++ b/pkg/util/syncutil/mutex_deadlock.go
@@ -35,6 +35,11 @@ type Mutex struct {
 func (m *Mutex) AssertHeld() {
 }
 
+// TryLock is a no-op for deadlock mutexes.
+func (rw *Mutex) TryLock() bool {
+	return false
+}
+
 // An RWMutex is a reader/writer mutual exclusion lock.
 type RWMutex struct {
 	deadlock.RWMutex
@@ -46,4 +51,9 @@ func (rw *RWMutex) AssertHeld() {
 
 // AssertRHeld is a no-op for deadlock mutexes.
 func (rw *RWMutex) AssertRHeld() {
+}
+
+// TryLock is a no-op for deadlock mutexes.
+func (rw *RWMutex) TryLock() bool {
+	return false
 }


### PR DESCRIPTION
`TryLock()` attempts to lock a mutex, returning false if someone else is holding it. However, the deadlock detector implementation does not implement `TryLock()`. This patch adds `TryLock()` as a noop returning `false`, since that's the only non-blocking action it can take. This is equivalent to a lock holder who concurrently releases the lock.

Epic: none
Release note: None