### PR TITLE
roachtest: only wait for jobs claimed by same node

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -305,7 +305,7 @@ func disableJobAdoptionStep(c cluster.Cluster, nodeIDs option.NodeListOption) ve
 				defer gatewayDB.Close()
 
 				var runningJobIDs []jobspb.JobID
-				row, err := gatewayDB.Query(`SELECT job_id FROM [SHOW JOBS] WHERE status = 'running'`)
+				row, err := gatewayDB.Query(fmt.Sprintf(`SELECT job_id FROM [SHOW JOBS] WHERE status = 'running' AND coordinator_id = %d`, nodeID))
 				require.NoError(t, err)
 				for row.Next() {
 					var jobID int64


### PR DESCRIPTION
Informs: https://github.com/cockroachdb/cockroach/issues/104177 (hopefully can fix it)
Previously, when disabling job adoptions within roachtest, we simply select everything from `SHOW JOBS`. This is not adequate because `SHOW JOBS` returns jobs claimed by other nodes as well. This fails our roachtest occasionally if there were any jobs adopted by other nodes and running. This commit makes it only querying running jobs claimed by the same node.

Release note: None