### PR TITLE
democluster: deflake TestTransientClusterSimulateLatencies

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -405,6 +405,7 @@ go_test(
         "//pkg/util/log/logpb",
         "//pkg/util/protoutil",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "//pkg/util/uuid",

--- a/pkg/cli/demo_locality_test.go
+++ b/pkg/cli/demo_locality_test.go
@@ -17,13 +17,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/democluster"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-var _ = skipExample_demo_locality
-
-func skipExample_demo_locality() {
+func Example_demo_locality() {
 	c := NewCLITest(TestCLIParams{NoServer: true})
 	defer c.Cleanup()
+
+	// This is slow under deadlock as it starts a 9-node cluster which
+	// has a very high simulated latency between each node.
+	if syncutil.DeadlockEnabled {
+		return
+	}
 
 	defer democluster.TestingForceRandomizeDemoPorts()()
 

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -100,7 +100,7 @@ type transientCluster struct {
 
 // maxNodeInitTime is the maximum amount of time to wait for nodes to
 // be connected.
-const maxNodeInitTime = 30 * time.Second
+const maxNodeInitTime = 60 * time.Second
 
 // secondaryTenantID is the ID of the secondary tenant to use when
 // --multitenant=true.

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -145,11 +145,10 @@ func TestTransientClusterSimulateLatencies(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// This is slow under race as it starts a 9-node cluster which
+	// This is slow under race and deadlock as it starts a 9-node cluster which
 	// has a very high simulated latency between each node.
 	skip.UnderRace(t)
-
-	skip.WithIssue(t, 99768, "flaky test")
+	skip.UnderDeadlock(t)
 
 	demoCtx := newDemoCtx()
 	// Set up an empty 9-node cluster with simulated latencies.


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/99768
fixes https://github.com/cockroachdb/cockroach/issues/100389
fixes https://github.com/cockroachdb/cockroach/issues/99903
fixes https://github.com/cockroachdb/cockroach/issues/99426

This increases the timeout and only skips the test under deadlock, rather than entirely.

Release note: None