### PR TITLE
pkg/util/syncutil: add always-false TryLock under `deadlock` build

### DIFF
--- a/pkg/util/syncutil/mutex_deadlock.go
+++ b/pkg/util/syncutil/mutex_deadlock.go
@@ -47,3 +47,8 @@ func (rw *RWMutex) AssertHeld() {
 // AssertRHeld is a no-op for deadlock mutexes.
 func (rw *RWMutex) AssertRHeld() {
 }
+
+// TryLock always fails for deadlock mutexes.
+func (rw *RWMutex) TryLock() bool {
+	return false
+}


### PR DESCRIPTION
Prior to the change in [1], `RWMutex.TryLock` was not being used anywhere else. The change broke builds under `deadlock`. This workaround adds an empty implementation of TryLock which always returns false.

[1] https://github.com/cockroachdb/cockroach/pull/103261

Epic: none

Release note: None