### PR TITLE
roachtest: make RunWithDetails pass correct "secure" argument

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2364,7 +2364,7 @@ func (c *clusterImpl) RunWithDetails(
 		testLogger.Printf("> %s\n", strings.Join(args, " "))
 	}
 
-	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, false /* secure */, args)
+	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, c.IsSecure(), args)
 	if err != nil && len(physicalFileName) > 0 {
 		l.Printf("> result: %+v", err)
 		createFailedFile(physicalFileName)


### PR DESCRIPTION
This commit makes it so that `RunWithDetails` passes the correct boolean (based on the cluster) for the "secure" argument when invoking the roachprod command.

Informs: #104379.

Epic: None

Release note: None