### PR TITLE
release-23.1: upgrademanager: deflake TestConcurrentMigrationAttempts

### DIFF
--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -63,7 +63,6 @@ go_test(
         "//pkg/sql/isql",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/upgrade",

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
@@ -323,11 +322,10 @@ func TestConcurrentMigrationAttempts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 101021, "flaky test")
-	// We're going to be migrating from the current version to imaginary future versions.
+	// We're going to be migrating from the BinaryMinSupportedVersion to imaginary future versions.
 	current := clusterversion.TestingBinaryMinSupportedVersion
 	versions := []roachpb.Version{current}
-	for i := int32(1); i <= 5; i++ {
+	for i := int32(1); i <= 4; i++ {
 		v := current
 		v.Internal += i * 2
 		versions = append(versions, v)


### PR DESCRIPTION
Backport 1/1 commits from #104601.

/cc @cockroachdb/release

Release justification: test only change 

---

fixes https://github.com/cockroachdb/cockroach/issues/101021

This test was flaky since due to a pretty edge-casey interaction with the upgrade that adds the system.job_info table. It does not seem worth debugging that interaction further, since the purpose of this test is to test the concurrency of the upgrade framework, not any specific upgrade. In fact, the only reason this test uses "real" upgrades is due to a limitation in the `MakeTestingClusterSettingsWithVersions` function.

So instead, we'll just change the test so it doesn't run that problematic upgrade.

Release note: None
