### PR TITLE
db-console: rename c2c dashboard to Physical Cluster Replication

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -149,7 +149,7 @@ const dashboards: { [key: string]: GraphDashboard } = {
   },
   ttl: { label: "TTL", component: ttlDashboard, isKvDashboard: false },
   crossClusterReplication: {
-    label: "Cross-Cluster Replication",
+    label: "Physical Cluster Replication",
     component: crossClusterReplicationDashboard,
     isKvDashboard: true,
   },
@@ -396,7 +396,7 @@ export class NodeGraphs extends React.Component<
       .filter(
         option =>
           this.props.crossClusterReplicationEnabled ||
-          option.label !== "Cross-Cluster Replication",
+          option.label !== "Physical Cluster Replication",
       );
 
     return (


### PR DESCRIPTION
The recently added dashboard is called `Cross-Cluster Replication`, and this commit renames it to `Physical Cluster Replication`.

c2c is now called Physical Replication, and in contexts where it's not obvious we should be clear that this is Cluster replication and not Raft.

Epic: none

Release note: None