### PR TITLE
cli: unskip interactive tests that work in the new editor

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -277,6 +277,13 @@ func TestDockerCLI_test_log_flags(t *testing.T) {
 	runTestDockerCLI(t, "test_log_flags", "../cli/interactive_tests/test_log_flags.tcl")
 }
 
+func TestDockerCLI_test_multiline_statements(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_multiline_statements", "../cli/interactive_tests/test_multiline_statements.tcl")
+}
+
 func TestDockerCLI_test_multiline_statements_libedit(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)
@@ -303,6 +310,13 @@ func TestDockerCLI_test_password(t *testing.T) {
 	defer s.Close(t)
 
 	runTestDockerCLI(t, "test_password", "../cli/interactive_tests/test_password.tcl")
+}
+
+func TestDockerCLI_test_pretty(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_pretty", "../cli/interactive_tests/test_pretty.tcl")
 }
 
 func TestDockerCLI_test_read_only(t *testing.T) {
@@ -338,6 +352,13 @@ func TestDockerCLI_test_server_restart(t *testing.T) {
 	defer s.Close(t)
 
 	runTestDockerCLI(t, "test_server_restart", "../cli/interactive_tests/test_server_restart.tcl")
+}
+
+func TestDockerCLI_test_server_sig(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_server_sig", "../cli/interactive_tests/test_server_sig.tcl")
 }
 
 func TestDockerCLI_test_socket_name(t *testing.T) {

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -431,14 +431,6 @@ filegroup(
     name = "interactive_tests",
     srcs = glob(
         ["interactive_tests/**"],
-        # TODO(rail): The following tests fail under bazel.
-        # https://github.com/cockroachdb/cockroach/issues/71932, aka
-        # "broken_in_bazel"
-        exclude = [
-            "*/test_multiline_statements.tcl",
-            "*/test_pretty.tcl",
-            "*/test_server_sig.tcl",
-        ],
     ),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
According to https://github.com/cockroachdb/cockroach/pull/88274 the new editor might fix this.

fixes https://github.com/cockroachdb/cockroach/issues/71932

Release note: None