### PR TITLE
release-22.2: kvserverpb: mark probe requests' replicated cmds as IsTrivial

### DIFF
--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -71,6 +71,7 @@ func isTrivial(r *kvserverpb.ReplicatedEvalResult) bool {
 	allowlist.WriteTimestamp = hlc.Timestamp{}
 	allowlist.DeprecatedDelta = nil
 	allowlist.PrevLeaseProposal = nil
+	allowlist.IsProbe = false // probes are trivial, they always get refused in CheckForcedErr
 	allowlist.State = nil
 	return allowlist.IsZero()
 }


### PR DESCRIPTION
Backport 1/1 commits from #102953.

/cc @cockroachdb/release

Release justification: stability improvement

---

That way, they won't each request their own `replicaAppBatch`. They were wildly
inefficient to apply before this commit, which played a (minor) role in a recent
incident[^1].

To validate this change, I ran an experiment that set up a range with 10 million unapplied probes. This PR more than halved how long it took to apply the entries.

<details>
<summary>Without this change:</summary>

![image](https://github.com/cockroachdb/cockroach/assets/5076964/60807185-4f91-4d1a-bcdf-d4caaa2a1487)

</details>


<details>
<summary>With this change:</summary>

![image](https://github.com/cockroachdb/cockroach/assets/5076964/47fdb6a1-6b82-4a72-a9ff-cd4008de1ed0)

</details>

[^1]: https://github.com/cockroachlabs/support/issues/2287

Touches https://github.com/cockroachlabs/support/issues/2287.
Closes https://github.com/cockroachdb/cockroach/issues/103905.

Epic: none
Release note: None

