### PR TITLE
kvserver: eagerly initialize Raft groups

### DIFF
--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -112,7 +112,7 @@ func TestStoreRaftReplicaID(t *testing.T) {
 }
 
 // TestStoreLoadReplicaQuiescent tests whether replicas are initially quiescent
-// when loaded during store start, with lazy Raft group initialization. Epoch
+// when loaded during store start, with eager Raft group initialization. Epoch
 // lease ranges should be quiesced, but expiration leases shouldn't.
 func TestStoreLoadReplicaQuiescent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -173,12 +173,7 @@ func TestStoreLoadReplicaQuiescent(t *testing.T) {
 		var err error
 		repl, _, err = tc.Server(0).GetStores().(*kvserver.Stores).GetReplicaForRangeID(ctx, desc.RangeID)
 		require.NoError(t, err)
-		if expOnly {
-			require.False(t, repl.IsQuiescent())
-			require.NotNil(t, repl.RaftStatus())
-		} else {
-			require.True(t, repl.IsQuiescent())
-			require.Nil(t, repl.RaftStatus())
-		}
+		require.NotNil(t, repl.RaftStatus())
+		require.Equal(t, !expOnly, repl.IsQuiescent())
 	})
 }

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -184,7 +184,6 @@ func (fr *fakeReplica) IsDestroyed() (DestroyReason, error) { return destroyReas
 func (fr *fakeReplica) Desc() *roachpb.RangeDescriptor {
 	return &roachpb.RangeDescriptor{RangeID: fr.rangeID, EndKey: roachpb.RKey("z")}
 }
-func (fr *fakeReplica) maybeInitializeRaftGroup(context.Context) {}
 func (fr *fakeReplica) redirectOnOrAcquireLease(
 	context.Context,
 ) (kvserverpb.LeaseStatus, *kvpb.Error) {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -714,7 +714,10 @@ type Replica struct {
 		// raftMu and the entire handleRaftReady loop. Not needed if raftMu is
 		// already held.
 		applyingEntries bool
-		// The replica's Raft group "node".
+		// The replica's Raft group "node". Can be nil for destroyed replicas
+		// (destroyReasonRemoved) and in some tests, otherwise is never nil.
+		//
+		// TODO(erikgrinaker): make this never be nil.
 		internalRaftGroup *raft.RawNode
 
 		// The ID of the leader replica within the Raft group. NB: this is updated

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -366,7 +366,7 @@ func (sm *replicaStateMachine) maybeApplyConfChange(ctx context.Context, cmd *re
 		// to raft.
 		return nil
 	}
-	return sm.r.withRaftGroup(true, func(rn *raft.RawNode) (bool, error) {
+	return sm.r.withRaftGroup(func(rn *raft.RawNode) (bool, error) {
 		// NB: `etcd/raft` configuration changes diverge from the official Raft way
 		// in that a configuration change becomes active when the corresponding log
 		// entry is applied (rather than appended). This ultimately enables the way

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -100,7 +100,6 @@ func newReplicaGCQueue(store *Store, db *kv.DB) *replicaGCQueue {
 		queueConfig{
 			maxSize:                  defaultQueueMaxSize,
 			needsLease:               false,
-			needsRaftInitialized:     true,
 			needsSpanConfigs:         false,
 			acceptsUnsplitRanges:     true,
 			processDestroyedReplicas: true,

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -58,7 +58,7 @@ func loadInitializedReplicaForTesting(
 
 // newInitializedReplica creates an initialized Replica from its loaded state.
 func newInitializedReplica(store *Store, loaded kvstorage.LoadedReplicaState) (*Replica, error) {
-	r := newUninitializedReplica(store, loaded.ReplState.Desc.RangeID, loaded.ReplicaID)
+	r := newUninitializedReplicaWithoutRaftGroup(store, loaded.ReplState.Desc.RangeID, loaded.ReplicaID)
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	r.mu.Lock()
@@ -71,11 +71,31 @@ func newInitializedReplica(store *Store, loaded kvstorage.LoadedReplicaState) (*
 
 // newUninitializedReplica constructs an uninitialized Replica with the given
 // range/replica ID. The returned replica remains uninitialized until
-// Replica.loadRaftMuLockedReplicaMuLocked() is called.
+// Replica.initRaftMuLockedReplicaMuLocked() is called, but has a temporary Raft
+// group that can be used e.g. for elections or snapshot application.
 //
 // TODO(#94912): we actually have another initialization path which should be
 // refactored: Replica.initFromSnapshotLockedRaftMuLocked().
 func newUninitializedReplica(
+	store *Store, rangeID roachpb.RangeID, replicaID roachpb.ReplicaID,
+) (*Replica, error) {
+	r := newUninitializedReplicaWithoutRaftGroup(store, rangeID, replicaID)
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.initRaftGroupRaftMuLockedReplicaMuLocked(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// newUninitializedReplicaWithoutRaftGroup creates a new uninitialized replica
+// without a Raft group. Use either newInitializedReplica() or
+// newUninitializedReplica() instead. This only exists for
+// newInitializedReplica() to avoid creating the Raft group twice (once when
+// creating the uninitialized replica, and once when initializing it).
+func newUninitializedReplicaWithoutRaftGroup(
 	store *Store, rangeID roachpb.RangeID, replicaID roachpb.ReplicaID,
 ) *Replica {
 	uninitState := stateloader.UninitializedReplicaState(rangeID)
@@ -186,10 +206,6 @@ func (r *Replica) setStartKeyLocked(startKey roachpb.RKey) {
 
 // initRaftMuLockedReplicaMuLocked initializes the Replica using the state
 // loaded from storage. Must not be called more than once on a Replica.
-//
-// This method is called in:
-// - loadInitializedReplicaForTesting, to finalize creating an initialized replica;
-// - splitPostApply, to initialize a previously uninitialized replica.
 func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState) error {
 	desc := s.ReplState.Desc
 	// Ensure that the loaded state corresponds to the same replica.
@@ -206,14 +222,18 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState
 
 	r.setStartKeyLocked(desc.StartKey)
 
-	// Clear the internal raft group in case we're being reset. Since we're
-	// reloading the raft state below, it isn't safe to use the existing raft
-	// group.
-	r.mu.internalRaftGroup = nil
-
 	r.mu.state = s.ReplState
 	r.mu.lastIndexNotDurable = s.LastIndex
 	r.mu.lastTermNotDurable = invalidLastTerm
+
+	// Initialize the Raft group. This may replace a Raft group that was installed
+	// for the uninitialized replica to process Raft requests or snapshots.
+	//
+	// We do this before the call to setDescLockedRaftMuLocked(), since it flips
+	// isInitialized and we'd like the Raft group to be in place before then.
+	if err := r.initRaftGroupRaftMuLockedReplicaMuLocked(); err != nil {
+		return err
+	}
 
 	r.setDescLockedRaftMuLocked(r.AnnotateCtx(context.TODO()), desc)
 
@@ -229,6 +249,23 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState
 		r.mu.minLeaseProposedTS = r.Clock().NowAsClockTimestamp()
 	}
 
+	return nil
+}
+
+// initRaftGroupRaftMuLockedReplicaMuLocked initializes a Raft group for the
+// replica, replacing the existing Raft group if any.
+func (r *Replica) initRaftGroupRaftMuLockedReplicaMuLocked() error {
+	rg, err := raft.NewRawNode(newRaftConfig(
+		raft.Storage((*replicaRaftStorage)(r)),
+		uint64(r.replicaID),
+		r.mu.state.RaftAppliedIndex,
+		r.store.cfg,
+		&raftLogger{ctx: r.AnnotateCtx(context.Background())},
+	))
+	if err != nil {
+		return err
+	}
+	r.mu.internalRaftGroup = rg
 	return nil
 }
 
@@ -264,38 +301,6 @@ func (r *Replica) TenantID() (roachpb.TenantID, bool) {
 
 func (r *Replica) getTenantIDRLocked() (roachpb.TenantID, bool) {
 	return r.mu.tenantID, r.mu.tenantID != (roachpb.TenantID{})
-}
-
-// maybeInitializeRaftGroup check whether the internal Raft group has
-// not yet been initialized. If not, it is created and set to campaign
-// if this replica is the most recent owner of the range lease.
-func (r *Replica) maybeInitializeRaftGroup(ctx context.Context) {
-	r.mu.RLock()
-	// If this replica hasn't initialized the Raft group, create it and
-	// unquiesce and wake the leader to ensure the replica comes up to date.
-	initialized := r.mu.internalRaftGroup != nil
-	// If this replica has been removed or is in the process of being removed
-	// then it'll never handle any raft events so there's no reason to initialize
-	// it now.
-	removed := !r.mu.destroyStatus.IsAlive()
-	r.mu.RUnlock()
-	if initialized || removed {
-		return
-	}
-
-	// Acquire raftMu, but need to maintain lock ordering (raftMu then mu).
-	r.raftMu.Lock()
-	defer r.raftMu.Unlock()
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	// If we raced on checking the destroyStatus above that's fine as
-	// the below withRaftGroupLocked will no-op.
-	if err := r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
-		return true, nil
-	}); err != nil && !errors.Is(err, errRemoved) {
-		log.VErrEventf(ctx, 1, "unable to initialize raft group: %s", err)
-	}
 }
 
 // setDescRaftMuLocked atomically sets the replica's descriptor. It requires raftMu to be

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1310,7 +1310,7 @@ func (rp *replicaProposer) closedTimestampTarget() hlc.Timestamp {
 
 func (rp *replicaProposer) withGroupLocked(fn func(raftGroup proposerRaft) error) error {
 	// Pass true for mayCampaignOnWake because we're about to propose a command.
-	return (*Replica)(rp).withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
+	return (*Replica)(rp).withRaftGroupLocked(func(raftGroup *raft.RawNode) (bool, error) {
 		// We're proposing a command here so there is no need to wake the leader
 		// if we were quiesced. However, we should make sure we are unquiesced.
 		(*Replica)(rp).maybeUnquiesceLocked(false /* wakeLeader */, true /* mayCampaign */)

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -135,13 +135,10 @@ func (r *Replica) canUnquiesceRLocked() bool {
 		// then abandoned, and we don't do a good job garbage collecting them at a
 		// later point (see https://github.com/cockroachdb/cockroach/issues/73424),
 		// so it is important that they are cheap. Keeping them quiesced instead of
-		// letting them unquiesce and tick every 200ms indefinitely avoids a
+		// letting them unquiesce and tick every 500ms indefinitely avoids a
 		// meaningful amount of periodic work for each uninitialized replica.
 		r.IsInitialized() &&
-		// A replica's Raft group begins in a dormant state and is initialized
-		// lazily in response to any Raft traffic (see stepRaftGroup) or KV request
-		// traffic (see maybeInitializeRaftGroup). If it has yet to be initialized,
-		// let it remain quiesced. The Raft group will be initialized soon enough.
+		// Destroyed replicas have no Raft group, and can't unquiesce.
 		r.mu.internalRaftGroup != nil
 }
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -145,8 +145,8 @@ func (r *Replica) SendWithWriteBytes(
 	// accounting.
 	r.recordBatchRequestLoad(ctx, ba)
 
-	// If the internal Raft group is not initialized, create it and wake the leader.
-	r.maybeInitializeRaftGroup(ctx)
+	// If the internal Raft group is quiesced, wake it and the leader.
+	r.maybeUnquiesce(true /* wakeLeader */, true /* mayCampaign */)
 
 	isReadOnly := ba.IsReadOnly()
 	if err := r.checkBatchRequest(ba, isReadOnly); err != nil {

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -217,7 +217,10 @@ func (s *Store) tryGetOrCreateReplica(
 	}
 
 	// Create a new uninitialized replica and lock it for raft processing.
-	repl := newUninitializedReplica(s, rangeID, replicaID)
+	repl, err := newUninitializedReplica(s, rangeID, replicaID)
+	if err != nil {
+		return nil, false, err
+	}
 	repl.raftMu.Lock() // not unlocked
 
 	// Install the replica in the store's replica map.

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -764,7 +764,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 
 	// Verify that removal of a replica marks it as destroyed so that future raft
 	// commands on the Replica will silently be dropped.
-	err = repl1.withRaftGroup(true, func(r *raft.RawNode) (bool, error) {
+	err = repl1.withRaftGroup(func(r *raft.RawNode) (bool, error) {
 		return true, errors.Errorf("unexpectedly created a raft group")
 	})
 	require.Equal(t, errRemoved, err)
@@ -901,7 +901,7 @@ func TestMarkReplicaInitialized(t *testing.T) {
 	require.NoError(t,
 		logstore.NewStateLoader(newRangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
 
-	r := newUninitializedReplica(store, newRangeID, replicaID)
+	r, err := newUninitializedReplica(store, newRangeID, replicaID)
 	require.NoError(t, err)
 
 	store.mu.Lock()


### PR DESCRIPTION
This patch eagerly initializes Raft groups during replica construction, instead of deferring it until first use. The original motivation for lazy initialization was to avoid election storms, but since replicas start out quiesced they won't do anything until unquiesced anyway, and Raft pre-vote will prevent disturbing established leaders.

This has a minor impact on startup time: node startup time with 50.000 replicas and warm OS caches increased from 12.6 to 13.6 seconds. That seems fine, and it's likely better to do that work before joining the cluster.

This does not yet enforce the invariant that every replica has a non-nil Raft group: destroyed replicas remove their Raft group (releasing its memory for garbage collection), and many tests construct replicas without Raft groups. This may be addressed later.

Resolves #73715.

Epic: none
Release note: none