### PR TITLE
backupccl,sqlutils: retry explicit transaction to avoid test failure

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -10,6 +10,7 @@ package backupccl
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -135,12 +136,17 @@ CREATE TABLE data2.foo (a int);
 		numUsers = 10
 	}
 
-	sqlDB.Exec(t, "BEGIN")
-	for i := 0; i < numUsers; i++ {
-		sqlDB.Exec(t, fmt.Sprintf("CREATE USER maxroach%d", i))
-		sqlDB.Exec(t, fmt.Sprintf("ALTER USER maxroach%d CREATEDB", i))
-	}
-	sqlDB.Exec(t, "COMMIT")
+	sqlDB.RunWithRetriableTxn(t, func(txn *gosql.Tx) error {
+		for i := 0; i < numUsers; i++ {
+			if _, err := txn.Exec(fmt.Sprintf("CREATE USER maxroach%d", i)); err != nil {
+				return err
+			}
+			if _, err := txn.Exec(fmt.Sprintf("ALTER USER maxroach%d CREATEDB", i)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 
 	// Populate system.zones.
 	sqlDB.Exec(t, `ALTER TABLE data.bank CONFIGURE ZONE USING gc.ttlseconds = 3600`)
@@ -624,11 +630,14 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 
 	// Setup the system systemTablesToVerify to ensure that they are copied to the new cluster.
 	// Populate system.users.
-	sqlDB.Exec(t, "BEGIN")
-	for i := 0; i < 1000; i++ {
-		sqlDB.Exec(t, fmt.Sprintf("CREATE USER maxroach%d", i))
-	}
-	sqlDB.Exec(t, "COMMIT")
+	sqlDB.RunWithRetriableTxn(t, func(txn *gosql.Tx) error {
+		for i := 0; i < 1000; i++ {
+			if _, err := txn.Exec(fmt.Sprintf("CREATE USER maxroach%d", i)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 	sqlDB.Exec(t, `BACKUP TO 'nodelocal://1/missing-ssts'`)
 
 	// Bugger the backup by removing the SST files. (Note this messes up all of

--- a/pkg/testutils/sqlutils/BUILD.bazel
+++ b/pkg/testutils/sqlutils/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
In recent CI runs, we've been seeing TestFullClusterBackup fail with:

    full_cluster_backup_restore_test.go:143: error executing 'COMMIT':
    pq: restart transaction: TransactionRetryWithProtoRefreshError:
    TransactionAbortedError(ABORT_REASON_ABORTED_RECORD_FOUND): "sql
    txn" meta={id=ec1de683 key=/Table/4/1/"maxroach0"/0
    iso=Serializable pri=0.03058324 epo=0 ts=1686254742.907452755,1
    min=1686254688.329813751,0 seq=8023} lock=true stat=ABORTED
    rts=1686254742.907452755,1 wto=false gul=1686254688.829813751,0
    int=2006

This looks to be the result of a recent change to issue all of the CREATE USER statements in a single transaction. Since explicit transactions are only automatically retried in specific circumstances, we now have to deal with the retry error.

Here, we introduce a small helper that retries anything that looks like a restart error.

Note that I haven't been able to reproduce the above locally as the test is very heavyweight and difficult to stress.

Epic: none

Release note: None