### PR TITLE
kv: avoid extra key allocations in optimizePuts

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -189,6 +189,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/circuit",
         "//pkg/util/ctxgroup",
+        "//pkg/util/encoding",
         "//pkg/util/envutil",
         "//pkg/util/errorutil",
         "//pkg/util/future",


### PR DESCRIPTION
The code correctly pointed out that the lookup didn't allocate a copy,
the go compiler intelligently constructs a string on the stack pointing
directly to the byte slice. However if the string isn't in the map it
has to allocate a new string for the put. Now we avoid that.

Release note: none
Epic: none
