### PR TITLE
ui: fix columns selector being cut

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
@@ -255,4 +255,5 @@
 .table-area {
   position: relative;
   overflow-x: scroll;
+  min-height: 450px;
 }


### PR DESCRIPTION
Previously, when the number of rows on the Jobs table was smaller than 3, the height of the area was not enough to show the columns selector, making it get cut and not displayed the "Apply" button unless you scrolled.
This commit adds a min-height for that area, making sure the column selector will be displayed completely.

Fixes #104619

Before
<img width="514" alt="Screenshot 2023-06-09 at 12 09 57 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/5aaf1ee8-6040-4439-851b-3aecb8483511">


After
<img width="731" alt="Screenshot 2023-06-09 at 12 17 14 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/f62a1590-252b-41d0-9349-23b722def09e">


Release note (bug fix): The column selector on the Jobs page is no longer getting cut.