### PR TITLE
release-22.2: roachprod: upgrade TF and add arm64 AMIs

### DIFF
--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -888,7 +888,7 @@ func (p *Provider) runInstance(
 			extraMountOpts = "nobarrier"
 		}
 	}
-	filename, err := writeStartupScript(extraMountOpts, providerOpts.UseMultipleDisks)
+	filename, err := writeStartupScript(extraMountOpts, providerOpts.UseMultipleDisks, opts.EnableFIPS)
 	if err != nil {
 		return errors.Wrapf(err, "could not write AWS startup script to temp file")
 	}
@@ -903,12 +903,16 @@ func (p *Provider) runInstance(
 		return *fl
 	}
 
+	imageID := withFlagOverride(az.region.AMI_X86_64, &providerOpts.ImageAMI)
+	if opts.EnableFIPS {
+		imageID = withFlagOverride(az.region.AMI_FIPS, &providerOpts.ImageAMI)
+	}
 	args := []string{
 		"ec2", "run-instances",
 		"--associate-public-ip-address",
 		"--count", "1",
 		"--instance-type", machineType,
-		"--image-id", withFlagOverride(az.region.AMI, &providerOpts.ImageAMI),
+		"--image-id", imageID,
 		"--key-name", keyName,
 		"--region", az.region.Name,
 		"--security-group-ids", az.region.SecurityGroup,

--- a/pkg/roachprod/vm/aws/config.go
+++ b/pkg/roachprod/vm/aws/config.go
@@ -67,7 +67,9 @@ type awsConfig struct {
 type awsRegion struct {
 	Name              string            `json:"region"`
 	SecurityGroup     string            `json:"security_group"`
-	AMI               string            `json:"ami_id"`
+	AMI_X86_64        string            `json:"ami_id"`
+	AMI_ARM64         string            `json:"ami_id_arm64"`
+	AMI_FIPS          string            `json:"ami_id_fips"`
 	AvailabilityZones availabilityZones `json:"subnets"`
 }
 

--- a/pkg/roachprod/vm/aws/config.json
+++ b/pkg/roachprod/vm/aws/config.json
@@ -1,162 +1,208 @@
 {
-    "regions": {
-        "sensitive": false,
-        "type": "list",
-        "value": [
-            {
-                "ami_id": "ami-09ff2b6ef00accc2e",
-                "region": "ap-northeast-1",
-                "security_group": "sg-0006e480d77a10104",
-                "subnets": {
-                    "ap-northeast-1a": "subnet-0d144db3c9e47edf5",
-                    "ap-northeast-1c": "subnet-02fcaaa6212fc3c1a",
-                    "ap-northeast-1d": "subnet-0e9006ef8b3bef61f"
-                }
-            },
-            {
-                "ami_id": "ami-0b329fb1f17558744",
-                "region": "ap-northeast-2",
-                "security_group": "sg-0e00c2f8f274a0fea",
-                "subnets": {
-                    "ap-northeast-2a": "subnet-0d24440b29a76b724",
-                    "ap-northeast-2b": "subnet-0b049a35364cc9d28",
-                    "ap-northeast-2c": "subnet-0261535876b726680",
-                    "ap-northeast-2d": "subnet-049feccf9cc9895f1"
-                }
-            },
-            {
-                "ami_id": "ami-01957c76cce45de38",
-                "region": "ap-south-1",
-                "security_group": "sg-03a68bb0d765c135e",
-                "subnets": {
-                    "ap-south-1a": "subnet-0286d3ac1095fc6f1",
-                    "ap-south-1b": "subnet-012666900a3627088",
-                    "ap-south-1c": "subnet-014859824b1b1365d"
-                }
-            },
-            {
-                "ami_id": "ami-048b4b1ddefe6759f",
-                "region": "ap-southeast-1",
-                "security_group": "sg-089484fc595751cf7",
-                "subnets": {
-                    "ap-southeast-1a": "subnet-0885896a131051303",
-                    "ap-southeast-1b": "subnet-000bab51dbf4e8110",
-                    "ap-southeast-1c": "subnet-066c7a79def4e9a5e"
-                }
-            },
-            {
-                "ami_id": "ami-052a251c7ca533c26",
-                "region": "ap-southeast-2",
-                "security_group": "sg-00bbe741d9d00fd3a",
-                "subnets": {
-                    "ap-southeast-2a": "subnet-02a776afc9c67cfe8",
-                    "ap-southeast-2b": "subnet-0a74fe6561a3d8763",
-                    "ap-southeast-2c": "subnet-0ac068637efd31ea7"
-                }
-            },
-            {
-                "ami_id": "ami-095509bf36d02a8e0",
-                "region": "ca-central-1",
-                "security_group": "sg-0d97f7ec3edc8f7c1",
-                "subnets": {
-                    "ca-central-1a": "subnet-02ef88f3eb706271e",
-                    "ca-central-1b": "subnet-072be60d12ab9cc6c",
-                    "ca-central-1d": "subnet-0a75f397c5f90c490"
-                }
-            },
-            {
-                "ami_id": "ami-0d3905203a039e3b0",
-                "region": "eu-central-1",
-                "security_group": "sg-05979c18ed21a6757",
-                "subnets": {
-                    "eu-central-1a": "subnet-0d8cd910b6fd633ae",
-                    "eu-central-1b": "subnet-06f3f2617af43d9e4",
-                    "eu-central-1c": "subnet-0ffb5b1d20ef5d971"
-                }
-            },
-            {
-                "ami_id": "ami-0b7fd7bc9c6fb1c78",
-                "region": "eu-west-1",
-                "security_group": "sg-033eb468bf7e3c6b5",
-                "subnets": {
-                    "eu-west-1a": "subnet-092adeba3986a0218",
-                    "eu-west-1b": "subnet-0d05781a8ca47b75c",
-                    "eu-west-1c": "subnet-063ba44da52a59451"
-                }
-            },
-            {
-                "ami_id": "ami-02ead6ecbd926d792",
-                "region": "eu-west-2",
-                "security_group": "sg-0cb561f660955a29c",
-                "subnets": {
-                    "eu-west-2a": "subnet-0436d5b881fb395cc",
-                    "eu-west-2b": "subnet-0fe8957e966a05aee",
-                    "eu-west-2c": "subnet-048129c61d1de7102"
-                }
-            },
-            {
-                "ami_id": "ami-0d7b738ade930e24a",
-                "region": "eu-west-3",
-                "security_group": "sg-032bca7008934e2ce",
-                "subnets": {
-                    "eu-west-3a": "subnet-02cf1181611f9c066",
-                    "eu-west-3b": "subnet-02cc8d4f386067c1d",
-                    "eu-west-3c": "subnet-0c5fe59cb2def6587"
-                }
-            },
-            {
-                "ami_id": "ami-03f2389c2526e67bd",
-                "region": "sa-east-1",
-                "security_group": "sg-0e7fdf92c3b1dbd11",
-                "subnets": {
-                    "sa-east-1a": "subnet-04812b53b10beee8f",
-                    "sa-east-1b": "subnet-09cc8fccd8457f85a",
-                    "sa-east-1c": "subnet-06239fca3bea45f07"
-                }
-            },
-            {
-                "ami_id": "ami-04cc2b0ad9e30a9c8",
-                "region": "us-east-1",
-                "security_group": "sg-09730a5bc7432abe7",
-                "subnets": {
-                    "us-east-1a": "subnet-0f4bc88ed9fac8d23",
-                    "us-east-1b": "subnet-070901299c800c14d",
-                    "us-east-1c": "subnet-0ae3a52e63e771bff",
-                    "us-east-1d": "subnet-0f1105fb57f950f6a",
-                    "us-east-1e": "subnet-027cccc2cccb7dde0",
-                    "us-east-1f": "subnet-0195bd208310cd301"
-                }
-            },
-            {
-                "ami_id": "ami-02fc6052104add5ae",
-                "region": "us-east-2",
-                "security_group": "sg-0319fc9c9599a6145",
-                "subnets": {
-                    "us-east-2a": "subnet-004c6ad7121a8d5a7",
-                    "us-east-2b": "subnet-0775beaa2f4c74f1c",
-                    "us-east-2c": "subnet-09065271eb9d0144d"
-                }
-            },
-            {
-                "ami_id": "ami-07be40433001d2433",
-                "region": "us-west-1",
-                "security_group": "sg-0d1ae4a3dc5d6040e",
-                "subnets": {
-                    "us-west-1a": "subnet-0fa88a6224978e522",
-                    "us-west-1c": "subnet-0a8ad0edbf8e34cfd"
-                }
-            },
-            {
-                "ami_id": "ami-0a62a78cfedc09d76",
-                "region": "us-west-2",
-                "security_group": "sg-067af4f878a9f27e3",
-                "subnets": {
-                    "us-west-2a": "subnet-04f7b1c6cb5f88766",
-                    "us-west-2b": "subnet-0ca7c2b93a469a27f",
-                    "us-west-2c": "subnet-0f69a9226c563a232",
-                    "us-west-2d": "subnet-01b72477937bc7293"
-                }
-            }
-        ]
-    }
+  "regions": {
+    "sensitive": false,
+    "type": [
+      "list",
+      [
+        "object",
+        {
+          "ami_id": "string",
+          "ami_id_arm64": "string",
+          "ami_id_fips": "string",
+          "region": "string",
+          "security_group": "string",
+          "subnets": [
+            "map",
+            "string"
+          ]
+        }
+      ]
+    ],
+    "value": [
+      {
+        "ami_id": "ami-0ba151ad81cdd97be",
+        "ami_id_arm64": "ami-0769d298068e19af3",
+        "ami_id_fips": "ami-09bfd307c31e4669c",
+        "region": "ap-northeast-1",
+        "security_group": "sg-0006e480d77a10104",
+        "subnets": {
+          "ap-northeast-1a": "subnet-0d144db3c9e47edf5",
+          "ap-northeast-1c": "subnet-02fcaaa6212fc3c1a",
+          "ap-northeast-1d": "subnet-0e9006ef8b3bef61f"
+        }
+      },
+      {
+        "ami_id": "ami-0970cc54a3aa77466",
+        "ami_id_arm64": "ami-078dacb0982ba1acd",
+        "ami_id_fips": "ami-0dd93e9ad24d01f62",
+        "region": "ap-northeast-2",
+        "security_group": "sg-0e00c2f8f274a0fea",
+        "subnets": {
+          "ap-northeast-2a": "subnet-0d24440b29a76b724",
+          "ap-northeast-2b": "subnet-0b049a35364cc9d28",
+          "ap-northeast-2c": "subnet-0261535876b726680",
+          "ap-northeast-2d": "subnet-049feccf9cc9895f1"
+        }
+      },
+      {
+        "ami_id": "ami-01e436b65d641478d",
+        "ami_id_arm64": "ami-09f75d98d6c93b280",
+        "ami_id_fips": "ami-04ea778eedaf3a8df",
+        "region": "ap-south-1",
+        "security_group": "sg-03a68bb0d765c135e",
+        "subnets": {
+          "ap-south-1a": "subnet-0286d3ac1095fc6f1",
+          "ap-south-1b": "subnet-012666900a3627088",
+          "ap-south-1c": "subnet-014859824b1b1365d"
+        }
+      },
+      {
+        "ami_id": "ami-00def9d5d68359454",
+        "ami_id_arm64": "ami-0ad955f11ef16a0b1",
+        "ami_id_fips": "ami-0145aa2d8188220bc",
+        "region": "ap-southeast-1",
+        "security_group": "sg-089484fc595751cf7",
+        "subnets": {
+          "ap-southeast-1a": "subnet-0885896a131051303",
+          "ap-southeast-1b": "subnet-000bab51dbf4e8110",
+          "ap-southeast-1c": "subnet-066c7a79def4e9a5e"
+        }
+      },
+      {
+        "ami_id": "ami-0bd8241d9d44dc95f",
+        "ami_id_arm64": "ami-08943cd23ef30fe09",
+        "ami_id_fips": "ami-066f9bd76e75011be",
+        "region": "ap-southeast-2",
+        "security_group": "sg-00bbe741d9d00fd3a",
+        "subnets": {
+          "ap-southeast-2a": "subnet-02a776afc9c67cfe8",
+          "ap-southeast-2b": "subnet-0a74fe6561a3d8763",
+          "ap-southeast-2c": "subnet-0ac068637efd31ea7"
+        }
+      },
+      {
+        "ami_id": "ami-0c0ef44e5ccbd075f",
+        "ami_id_arm64": "ami-02512a306f25c39fa",
+        "ami_id_fips": "ami-0713fd833b63915e3",
+        "region": "ca-central-1",
+        "security_group": "sg-0d97f7ec3edc8f7c1",
+        "subnets": {
+          "ca-central-1a": "subnet-02ef88f3eb706271e",
+          "ca-central-1b": "subnet-072be60d12ab9cc6c",
+          "ca-central-1d": "subnet-0a75f397c5f90c490"
+        }
+      },
+      {
+        "ami_id": "ami-05fc4b58217803cb7",
+        "ami_id_arm64": "ami-0f5a401591c7610e3",
+        "ami_id_fips": "ami-02cc4114e1c012f9c",
+        "region": "eu-central-1",
+        "security_group": "sg-05979c18ed21a6757",
+        "subnets": {
+          "eu-central-1a": "subnet-0d8cd910b6fd633ae",
+          "eu-central-1b": "subnet-06f3f2617af43d9e4",
+          "eu-central-1c": "subnet-0ffb5b1d20ef5d971"
+        }
+      },
+      {
+        "ami_id": "ami-05f1fedd8287cef0b",
+        "ami_id_arm64": "ami-0bd686ee970df20b0",
+        "ami_id_fips": "ami-014603057f9da7d50",
+        "region": "eu-west-1",
+        "security_group": "sg-033eb468bf7e3c6b5",
+        "subnets": {
+          "eu-west-1a": "subnet-092adeba3986a0218",
+          "eu-west-1b": "subnet-0d05781a8ca47b75c",
+          "eu-west-1c": "subnet-063ba44da52a59451"
+        }
+      },
+      {
+        "ami_id": "ami-015891366865ea5ca",
+        "ami_id_arm64": "ami-035941b2f8b915be7",
+        "ami_id_fips": "ami-0fcf0f89559d79e80",
+        "region": "eu-west-2",
+        "security_group": "sg-0cb561f660955a29c",
+        "subnets": {
+          "eu-west-2a": "subnet-0436d5b881fb395cc",
+          "eu-west-2b": "subnet-0fe8957e966a05aee",
+          "eu-west-2c": "subnet-048129c61d1de7102"
+        }
+      },
+      {
+        "ami_id": "ami-05262a4bcea6f9fa2",
+        "ami_id_arm64": "ami-08d47ac63ccfce6e8",
+        "ami_id_fips": "ami-03ecf0588cc1bd0f4",
+        "region": "eu-west-3",
+        "security_group": "sg-032bca7008934e2ce",
+        "subnets": {
+          "eu-west-3a": "subnet-02cf1181611f9c066",
+          "eu-west-3b": "subnet-02cc8d4f386067c1d",
+          "eu-west-3c": "subnet-0c5fe59cb2def6587"
+        }
+      },
+      {
+        "ami_id": "ami-0ac6b9321493324ee",
+        "ami_id_arm64": "ami-082d7ebf7429845d6",
+        "ami_id_fips": "ami-0977da93caf83799e",
+        "region": "sa-east-1",
+        "security_group": "sg-0e7fdf92c3b1dbd11",
+        "subnets": {
+          "sa-east-1a": "subnet-04812b53b10beee8f",
+          "sa-east-1b": "subnet-09cc8fccd8457f85a",
+          "sa-east-1c": "subnet-06239fca3bea45f07"
+        }
+      },
+      {
+        "ami_id": "ami-0481e8ba7f486bd99",
+        "ami_id_arm64": "ami-07cd31309bf4e22f9",
+        "ami_id_fips": "ami-03cf7ddd346310b5f",
+        "region": "us-east-1",
+        "security_group": "sg-09730a5bc7432abe7",
+        "subnets": {
+          "us-east-1a": "subnet-0f4bc88ed9fac8d23",
+          "us-east-1b": "subnet-070901299c800c14d",
+          "us-east-1c": "subnet-0ae3a52e63e771bff",
+          "us-east-1d": "subnet-0f1105fb57f950f6a",
+          "us-east-1e": "subnet-027cccc2cccb7dde0",
+          "us-east-1f": "subnet-0195bd208310cd301"
+        }
+      },
+      {
+        "ami_id": "ami-0a14db46282743a66",
+        "ami_id_arm64": "ami-0a929adc7bbccddfa",
+        "ami_id_fips": "ami-08692707dfc6f8b64",
+        "region": "us-east-2",
+        "security_group": "sg-0319fc9c9599a6145",
+        "subnets": {
+          "us-east-2a": "subnet-004c6ad7121a8d5a7",
+          "us-east-2b": "subnet-0775beaa2f4c74f1c",
+          "us-east-2c": "subnet-09065271eb9d0144d"
+        }
+      },
+      {
+        "ami_id": "ami-0a417a9f917183811",
+        "ami_id_arm64": "ami-0dd984c94127082f0",
+        "ami_id_fips": "ami-026c3cf51388880d6",
+        "region": "us-west-1",
+        "security_group": "sg-0d1ae4a3dc5d6040e",
+        "subnets": {
+          "us-west-1a": "subnet-0fa88a6224978e522",
+          "us-west-1c": "subnet-0a8ad0edbf8e34cfd"
+        }
+      },
+      {
+        "ami_id": "ami-088b024fca114855d",
+        "ami_id_arm64": "ami-015d5804bb67c6f5d",
+        "ami_id_fips": "ami-0dc12dcaaa9dcf99d",
+        "region": "us-west-2",
+        "security_group": "sg-067af4f878a9f27e3",
+        "subnets": {
+          "us-west-2a": "subnet-04f7b1c6cb5f88766",
+          "us-west-2b": "subnet-0ca7c2b93a469a27f",
+          "us-west-2c": "subnet-0f69a9226c563a232",
+          "us-west-2d": "subnet-01b72477937bc7293"
+        }
+      }
+    ]
+  }
 }

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -147,6 +147,10 @@ echo "kernel.core_pattern=$CORE_PATTERN" >> /etc/sysctl.conf
 
 sysctl --system  # reload sysctl settings
 
+{{ if .EnableFIPS }}
+sudo ua enable fips --assume-yes
+{{ end }}
+
 sudo touch /mnt/data1/.roachprod-initialized
 `
 
@@ -156,13 +160,14 @@ sudo touch /mnt/data1/.roachprod-initialized
 //
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
-func writeStartupScript(extraMountOpts string, useMultiple bool) (string, error) {
+func writeStartupScript(extraMountOpts string, useMultiple bool, enableFips bool) (string, error) {
 	type tmplParams struct {
 		ExtraMountOpts   string
 		UseMultipleDisks bool
+		EnableFIPS       bool
 	}
 
-	args := tmplParams{ExtraMountOpts: extraMountOpts, UseMultipleDisks: useMultiple}
+	args := tmplParams{ExtraMountOpts: extraMountOpts, UseMultipleDisks: useMultiple, EnableFIPS: enableFips}
 
 	tmpfile, err := os.CreateTemp("", "aws-startup-script")
 	if err != nil {

--- a/pkg/roachprod/vm/aws/terraform/.terraform.lock.hcl
+++ b/pkg/roachprod/vm/aws/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.66.1"
+  hashes = [
+    "h1:7GytS2hRFKZDR1GgcS/nNQlyAjaMelF09HJ5xFFWneM=",
+    "zh:001c707174b7d6bf89a96cf806f925bb852d1a285fb80b81222cbeb4743bcb79",
+    "zh:19bc6ac0a7fd1c564fd56c536f1743f71a5e7ca724e21ea51a6a79218939733d",
+    "zh:3dac5c27f40b511239e9fe6f97dc0b6c95f630ba328001820ddc764e766a5ca2",
+    "zh:49092c92e2565db4cd4c98ec6878386e6957525d3392b63f0d5df4c48a7c1913",
+    "zh:4f9e2e1d0c5365a4e6689096cc91ba88ca9c0dc7c633377ba674c1dd856b6a9f",
+    "zh:57e32bb454f2dc17d5631a9559e36188761d8ae95a452478f81f41bb568a3a42",
+    "zh:678b78ba629dd833f0705ac90630969f514a54013ab9713ce7ceda55fc5ea138",
+    "zh:8aab1d76348cf2a685f72382cb838a910b77353179e81ab5794b9c45c8fb36a3",
+    "zh:8b6791bf0948aa8b49258863992a8ad7e7332dcae1a889e86da0e5ab778dc3b6",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a36f2777452c2cebdaa8a27378416d512ead367acc078a671bb12276dd4bc9dd",
+    "zh:c492e6f685882fad6481f4793e696d9e1b01aaae419225c2db0a484b632d1cac",
+    "zh:d4418e0d1d18e321db364a91d7a768e274bb0fb46df9f3cb5b9debb2bb6917b9",
+    "zh:d5b4310ef2b2ec22ae14cf909deb1231b56bdd79dc2b51e5db4e46a05e0110c4",
+    "zh:dedfb01e26b34fb61a52b7e953b8bf5d7a69971187e91697b67221298bbed377",
+  ]
+}

--- a/pkg/roachprod/vm/aws/terraform/aws-region/ami.tf
+++ b/pkg/roachprod/vm/aws/terraform/aws-region/ami.tf
@@ -5,3 +5,17 @@ data "aws_ami" "node_ami" {
     values = ["${var.image_name}"]
   }
 }
+
+data "aws_ami" "node_ami_fips" {
+  filter {
+    name   = "name"
+    values = ["${var.image_name_fips}"]
+  }
+}
+
+data "aws_ami" "node_ami_arm64" {
+  filter {
+    name   = "name"
+    values = ["${var.image_name_arm64}"]
+  }
+}

--- a/pkg/roachprod/vm/aws/terraform/aws-region/main.tf
+++ b/pkg/roachprod/vm/aws/terraform/aws-region/main.tf
@@ -1,16 +1,33 @@
 # ---------------------------------------------------------------------------------------------------------------------
-# Single region resources for GCP.
+# Single region resources for AWS.
 # All resources are created in passed-in project name and region.
 # ---------------------------------------------------------------------------------------------------------------------
-provider "aws" {}
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.66.1"
+    }
+  }
+}
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Module variables
 # ---------------------------------------------------------------------------------------------------------------------
-variable "region"                 { description = "AWS Region name" }
-variable "image_name"             { 
-    description = "CockroachDB base image name" 
-    default = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325"
+variable "region" { description = "AWS Region name" }
+variable "image_name" {
+  description = "CockroachDB base x86_64 image name"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230502"
+}
+
+variable "image_name_arm64" {
+  description = "CockroachDB base arm64 image name"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20230502"
+}
+
+variable "image_name_fips" {
+  description = "CockroachDB base x86_64 image name"
+  default     = "ubuntu-pro-fips-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-fips-server-20221121-7bc828d1-c072-4d33-a989-fbad50380cfb"
 }
 
 variable "label" {
@@ -37,9 +54,11 @@ output "region_info" {
     "region"         = "${var.region}"
     "security_group" = "${aws_security_group.region_security_group.id}"
     "ami_id"         = "${data.aws_ami.node_ami.image_id}"
-    "subnets"        = "${zipmap(
-        "${aws_subnet.region_subnets.*.availability_zone}", 
-        "${aws_subnet.region_subnets.*.id}"
+    "ami_id_arm64"   = "${data.aws_ami.node_ami_arm64.image_id}"
+    "ami_id_fips"    = "${data.aws_ami.node_ami_fips.image_id}"
+    "subnets" = "${zipmap(
+      "${aws_subnet.region_subnets.*.availability_zone}",
+      "${aws_subnet.region_subnets.*.id}"
     )}"
   }
 }

--- a/pkg/roachprod/vm/aws/terraform/aws-region/network.tf
+++ b/pkg/roachprod/vm/aws/terraform/aws-region/network.tf
@@ -60,7 +60,7 @@ data "aws_availability_zone" "zone_detail" {
 resource "aws_vpc" "region_vpc" {
   cidr_block           = "${cidrsubnet("10.0.0.0/8", 8, local.region_number[var.region])}"
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name               = "${var.label}-vpc-${var.region}"
   }
 }
@@ -88,7 +88,7 @@ resource "aws_subnet" "region_subnets" {
   availability_zone = "${data.aws_availability_zone.zone_detail.*.name[count.index]}"
   vpc_id            = "${aws_vpc.region_vpc.id}"
   cidr_block        = "${cidrsubnet(aws_vpc.region_vpc.cidr_block, 4, local.zone_number[data.aws_availability_zone.zone_detail.*.name_suffix[count.index]])}"
-  tags {
+  tags = {
     Name        = "${var.label}-subnet-${data.aws_availability_zone.zone_detail.*.name[count.index]}"
   }
 }

--- a/pkg/roachprod/vm/aws/terraform/aws-vpc-peer/main.tf
+++ b/pkg/roachprod/vm/aws/terraform/aws-vpc-peer/main.tf
@@ -1,44 +1,57 @@
 # ---------------------------------------------------------------------------------------------------------------------
 # VPC peering connection between two regions.
 # ---------------------------------------------------------------------------------------------------------------------
-provider "aws.owner" {}
-provider "aws.peer"  {}
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 4.66.1"
+      configuration_aliases = [aws.owner, aws.peer]
+    }
+  }
+}
 
-variable "owner_vpc_info"       { type = "map", description = "VPC info for the peering owner" }
-variable "peer_vpc_info"        { type = "map", description = "VPC info for the peering accepter" }
+variable "owner_vpc_info" {
+  type        = map(string)
+  description = "VPC info for the peering owner"
+}
+variable "peer_vpc_info" {
+  type        = map(string)
+  description = "VPC info for the peering accepter"
+}
 variable "label" {}
 
 resource "aws_vpc_peering_connection" "peering_connection" {
-  provider      = "aws.owner"
-  vpc_id        = "${var.owner_vpc_info["vpc_id"]}"
-  peer_vpc_id   = "${var.peer_vpc_info["vpc_id"]}"
-  peer_region   = "${var.peer_vpc_info["region"]}"
+  provider    = aws.owner
+  vpc_id      = var.owner_vpc_info["vpc_id"]
+  peer_vpc_id = var.peer_vpc_info["vpc_id"]
+  peer_region = var.peer_vpc_info["region"]
 
-  tags {
-    Name        = "${var.label}-peering-${var.owner_vpc_info["region"]}-${var.peer_vpc_info["region"]}"
+  tags = {
+    Name = "${var.label}-peering-${var.owner_vpc_info["region"]}-${var.peer_vpc_info["region"]}"
   }
 }
 
 resource "aws_vpc_peering_connection_accepter" "peering_accepter" {
-  provider                  = "aws.peer"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peering_connection.id}"
+  provider                  = aws.peer
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering_connection.id
   auto_accept               = true
 
-  tags {
-    Name        = "${var.label}-peering-${var.owner_vpc_info["region"]}-${var.peer_vpc_info["region"]}"
+  tags = {
+    Name = "${var.label}-peering-${var.owner_vpc_info["region"]}-${var.peer_vpc_info["region"]}"
   }
 }
 
 resource "aws_route" "owner_route" {
-  provider                  = "aws.owner"
-  route_table_id            = "${var.owner_vpc_info["route_table_id"]}"
-  destination_cidr_block    = "${var.peer_vpc_info["vpc_cidr"]}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peering_connection.id}"
+  provider                  = aws.owner
+  route_table_id            = var.owner_vpc_info["route_table_id"]
+  destination_cidr_block    = var.peer_vpc_info["vpc_cidr"]
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering_connection.id
 }
 
 resource "aws_route" "peer_route" {
-  provider                  = "aws.peer"
-  route_table_id            = "${var.peer_vpc_info["route_table_id"]}"
-  destination_cidr_block    = "${var.owner_vpc_info["vpc_cidr"]}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peering_connection.id}"
+  provider                  = aws.peer
+  route_table_id            = var.peer_vpc_info["route_table_id"]
+  destination_cidr_block    = var.owner_vpc_info["vpc_cidr"]
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering_connection.id
 }

--- a/pkg/roachprod/vm/aws/terraform/main.tf
+++ b/pkg/roachprod/vm/aws/terraform/main.tf
@@ -2,7 +2,7 @@
 # TERRAFORM SETTINGS
 # ---------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.11.8"
+  required_version = ">= 0.14"
   backend "s3" {
     key            = "terraform/roachprod"
     bucket         = "roachprod-cloud-state"
@@ -25,1522 +25,1477 @@ locals {
 provider "aws" {
   alias   = "roachprod-ap-northeast-1"
   region  = "ap-northeast-1"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-ap-northeast-1" {
-  providers {
-    aws  = "aws.roachprod-ap-northeast-1"
+  providers = {
+    aws  = aws.roachprod-ap-northeast-1
   }
   region = "ap-northeast-1"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-ap-northeast-2"
   region  = "ap-northeast-2"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-ap-northeast-2" {
-  providers {
-    aws  = "aws.roachprod-ap-northeast-2"
+  providers = {
+    aws  = aws.roachprod-ap-northeast-2
   }
   region = "ap-northeast-2"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-ap-south-1"
   region  = "ap-south-1"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-ap-south-1" {
-  providers {
-    aws  = "aws.roachprod-ap-south-1"
+  providers = {
+    aws  = aws.roachprod-ap-south-1
   }
   region = "ap-south-1"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-ap-southeast-1"
   region  = "ap-southeast-1"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-ap-southeast-1" {
-  providers {
-    aws  = "aws.roachprod-ap-southeast-1"
+  providers = {
+    aws  = aws.roachprod-ap-southeast-1
   }
   region = "ap-southeast-1"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-ap-southeast-2"
   region  = "ap-southeast-2"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-ap-southeast-2" {
-  providers {
-    aws  = "aws.roachprod-ap-southeast-2"
+  providers = {
+    aws  = aws.roachprod-ap-southeast-2
   }
   region = "ap-southeast-2"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-ca-central-1"
   region  = "ca-central-1"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-ca-central-1" {
-  providers {
-    aws  = "aws.roachprod-ca-central-1"
+  providers = {
+    aws  = aws.roachprod-ca-central-1
   }
   region = "ca-central-1"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-eu-central-1"
   region  = "eu-central-1"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-eu-central-1" {
-  providers {
-    aws  = "aws.roachprod-eu-central-1"
+  providers = {
+    aws  = aws.roachprod-eu-central-1
   }
   region = "eu-central-1"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-eu-west-1"
   region  = "eu-west-1"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-eu-west-1" {
-  providers {
-    aws  = "aws.roachprod-eu-west-1"
+  providers = {
+    aws  = aws.roachprod-eu-west-1
   }
   region = "eu-west-1"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-eu-west-2"
   region  = "eu-west-2"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-eu-west-2" {
-  providers {
-    aws  = "aws.roachprod-eu-west-2"
+  providers = {
+    aws  = aws.roachprod-eu-west-2
   }
   region = "eu-west-2"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-eu-west-3"
   region  = "eu-west-3"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-eu-west-3" {
-  providers {
-    aws  = "aws.roachprod-eu-west-3"
+  providers = {
+    aws  = aws.roachprod-eu-west-3
   }
   region = "eu-west-3"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-sa-east-1"
   region  = "sa-east-1"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-sa-east-1" {
-  providers {
-    aws  = "aws.roachprod-sa-east-1"
+  providers = {
+    aws  = aws.roachprod-sa-east-1
   }
   region = "sa-east-1"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-us-east-1"
   region  = "us-east-1"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-us-east-1" {
-  providers {
-    aws  = "aws.roachprod-us-east-1"
+  providers = {
+    aws  = aws.roachprod-us-east-1
   }
   region = "us-east-1"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-us-east-2"
   region  = "us-east-2"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-us-east-2" {
-  providers {
-    aws  = "aws.roachprod-us-east-2"
+  providers = {
+    aws  = aws.roachprod-us-east-2
   }
   region = "us-east-2"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-us-west-1"
   region  = "us-west-1"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-us-west-1" {
-  providers {
-    aws  = "aws.roachprod-us-west-1"
+  providers = {
+    aws  = aws.roachprod-us-west-1
   }
   region = "us-west-1"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 provider "aws" {
   alias   = "roachprod-us-west-2"
   region  = "us-west-2"
-
-  # Fixed fields, DO NOT MODIFY.
-  version = "~> 1.41"
 }
 
 module "aws_roachprod-us-west-2" {
-  providers {
-    aws  = "aws.roachprod-us-west-2"
+  providers = {
+    aws  = aws.roachprod-us-west-2
   }
   region = "us-west-2"
-  source = "aws-region"
+  source = "./aws-region"
   label  = "roachprod"
 }
 
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-ap-northeast-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-ap-northeast-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-ap-northeast-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-ap-south-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-ap-south-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-ap-south-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ap-south-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-ap-southeast-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-ap-southeast-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-ap-southeast-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-ap-southeast-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-ap-southeast-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-ap-southeast-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-ca-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-ca-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-ca-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ca-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-eu-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-eu-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-eu-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-eu-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-eu-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-eu-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-eu-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-eu-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-eu-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-eu-west-3" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-eu-west-3"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-eu-west-3
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-3.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-sa-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-sa-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-sa-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-sa-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-1-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-1"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-1
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-ap-south-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-ap-south-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-ap-south-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ap-south-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-ap-southeast-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-ap-southeast-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-ap-southeast-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-ap-southeast-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-ap-southeast-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-ap-southeast-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-ca-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-ca-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-ca-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ca-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-eu-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-eu-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-eu-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-eu-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-eu-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-eu-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-eu-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-eu-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-eu-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-eu-west-3" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-eu-west-3"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-eu-west-3
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-3.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-sa-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-sa-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-sa-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-sa-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-northeast-2-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-northeast-2"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-northeast-2
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-northeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-ap-southeast-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-ap-southeast-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-ap-southeast-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-ap-southeast-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-ap-southeast-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-ap-southeast-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-ca-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-ca-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-ca-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ca-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-eu-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-eu-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-eu-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-eu-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-eu-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-eu-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-eu-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-eu-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-eu-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-eu-west-3" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-eu-west-3"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-eu-west-3
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-3.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-sa-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-sa-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-sa-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-sa-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-south-1-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-south-1"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-south-1
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-south-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-ap-southeast-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-ap-southeast-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-ap-southeast-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-ca-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-ca-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-ca-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ca-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-eu-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-eu-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-eu-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-eu-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-eu-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-eu-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-eu-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-eu-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-eu-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-eu-west-3" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-eu-west-3"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-eu-west-3
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-3.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-sa-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-sa-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-sa-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-sa-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-1-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-1"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-1
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-2-roachprod-ca-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-2"
-    aws.peer     = "aws.roachprod-ca-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-2
+    aws.peer     = aws.roachprod-ca-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-ca-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-2-roachprod-eu-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-2"
-    aws.peer     = "aws.roachprod-eu-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-2
+    aws.peer     = aws.roachprod-eu-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-2-roachprod-eu-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-2"
-    aws.peer     = "aws.roachprod-eu-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-2
+    aws.peer     = aws.roachprod-eu-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-2-roachprod-eu-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-2"
-    aws.peer     = "aws.roachprod-eu-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-2
+    aws.peer     = aws.roachprod-eu-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-2-roachprod-eu-west-3" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-2"
-    aws.peer     = "aws.roachprod-eu-west-3"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-2
+    aws.peer     = aws.roachprod-eu-west-3
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-3.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-2-roachprod-sa-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-2"
-    aws.peer     = "aws.roachprod-sa-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-2
+    aws.peer     = aws.roachprod-sa-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-sa-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-2-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-2"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-2
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-2-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-2"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-2
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-2-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-2"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-2
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ap-southeast-2-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ap-southeast-2"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ap-southeast-2
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ap-southeast-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ca-central-1-roachprod-eu-central-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ca-central-1"
-    aws.peer     = "aws.roachprod-eu-central-1"
+  providers = {
+    aws.owner    = aws.roachprod-ca-central-1
+    aws.peer     = aws.roachprod-eu-central-1
   }
   owner_vpc_info = "${module.aws_roachprod-ca-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-central-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ca-central-1-roachprod-eu-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ca-central-1"
-    aws.peer     = "aws.roachprod-eu-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ca-central-1
+    aws.peer     = aws.roachprod-eu-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ca-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ca-central-1-roachprod-eu-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ca-central-1"
-    aws.peer     = "aws.roachprod-eu-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ca-central-1
+    aws.peer     = aws.roachprod-eu-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ca-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ca-central-1-roachprod-eu-west-3" {
-  providers {
-    aws.owner    = "aws.roachprod-ca-central-1"
-    aws.peer     = "aws.roachprod-eu-west-3"
+  providers = {
+    aws.owner    = aws.roachprod-ca-central-1
+    aws.peer     = aws.roachprod-eu-west-3
   }
   owner_vpc_info = "${module.aws_roachprod-ca-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-3.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ca-central-1-roachprod-sa-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ca-central-1"
-    aws.peer     = "aws.roachprod-sa-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ca-central-1
+    aws.peer     = aws.roachprod-sa-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ca-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-sa-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ca-central-1-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ca-central-1"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-ca-central-1
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-ca-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ca-central-1-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ca-central-1"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-ca-central-1
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-ca-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ca-central-1-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-ca-central-1"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-ca-central-1
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-ca-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-ca-central-1-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-ca-central-1"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-ca-central-1
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-ca-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-central-1-roachprod-eu-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-central-1"
-    aws.peer     = "aws.roachprod-eu-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-central-1
+    aws.peer     = aws.roachprod-eu-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-central-1-roachprod-eu-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-central-1"
-    aws.peer     = "aws.roachprod-eu-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-eu-central-1
+    aws.peer     = aws.roachprod-eu-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-eu-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-central-1-roachprod-eu-west-3" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-central-1"
-    aws.peer     = "aws.roachprod-eu-west-3"
+  providers = {
+    aws.owner    = aws.roachprod-eu-central-1
+    aws.peer     = aws.roachprod-eu-west-3
   }
   owner_vpc_info = "${module.aws_roachprod-eu-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-3.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-central-1-roachprod-sa-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-central-1"
-    aws.peer     = "aws.roachprod-sa-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-central-1
+    aws.peer     = aws.roachprod-sa-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-sa-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-central-1-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-central-1"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-central-1
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-central-1-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-central-1"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-eu-central-1
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-eu-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-central-1-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-central-1"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-central-1
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-central-1-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-central-1"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-eu-central-1
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-eu-central-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-1-roachprod-eu-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-1"
-    aws.peer     = "aws.roachprod-eu-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-1
+    aws.peer     = aws.roachprod-eu-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-1-roachprod-eu-west-3" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-1"
-    aws.peer     = "aws.roachprod-eu-west-3"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-1
+    aws.peer     = aws.roachprod-eu-west-3
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-3.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-1-roachprod-sa-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-1"
-    aws.peer     = "aws.roachprod-sa-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-1
+    aws.peer     = aws.roachprod-sa-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-sa-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-1-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-1"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-1
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-1-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-1"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-1
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-1-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-1"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-1
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-1-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-1"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-1
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-2-roachprod-eu-west-3" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-2"
-    aws.peer     = "aws.roachprod-eu-west-3"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-2
+    aws.peer     = aws.roachprod-eu-west-3
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-eu-west-3.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-2-roachprod-sa-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-2"
-    aws.peer     = "aws.roachprod-sa-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-2
+    aws.peer     = aws.roachprod-sa-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-sa-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-2-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-2"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-2
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-2-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-2"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-2
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-2-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-2"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-2
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-2-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-2"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-2
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-3-roachprod-sa-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-3"
-    aws.peer     = "aws.roachprod-sa-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-3
+    aws.peer     = aws.roachprod-sa-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-3.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-sa-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-3-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-3"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-3
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-3.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-3-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-3"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-3
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-3.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-3-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-3"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-3
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-3.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-eu-west-3-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-eu-west-3"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-eu-west-3
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-eu-west-3.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-sa-east-1-roachprod-us-east-1" {
-  providers {
-    aws.owner    = "aws.roachprod-sa-east-1"
-    aws.peer     = "aws.roachprod-us-east-1"
+  providers = {
+    aws.owner    = aws.roachprod-sa-east-1
+    aws.peer     = aws.roachprod-us-east-1
   }
   owner_vpc_info = "${module.aws_roachprod-sa-east-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-sa-east-1-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-sa-east-1"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-sa-east-1
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-sa-east-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-sa-east-1-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-sa-east-1"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-sa-east-1
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-sa-east-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-sa-east-1-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-sa-east-1"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-sa-east-1
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-sa-east-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-us-east-1-roachprod-us-east-2" {
-  providers {
-    aws.owner    = "aws.roachprod-us-east-1"
-    aws.peer     = "aws.roachprod-us-east-2"
+  providers = {
+    aws.owner    = aws.roachprod-us-east-1
+    aws.peer     = aws.roachprod-us-east-2
   }
   owner_vpc_info = "${module.aws_roachprod-us-east-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-east-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-us-east-1-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-us-east-1"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-us-east-1
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-us-east-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-us-east-1-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-us-east-1"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-us-east-1
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-us-east-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-us-east-2-roachprod-us-west-1" {
-  providers {
-    aws.owner    = "aws.roachprod-us-east-2"
-    aws.peer     = "aws.roachprod-us-west-1"
+  providers = {
+    aws.owner    = aws.roachprod-us-east-2
+    aws.peer     = aws.roachprod-us-west-1
   }
   owner_vpc_info = "${module.aws_roachprod-us-east-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-1.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-us-east-2-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-us-east-2"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-us-east-2
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-us-east-2.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 module "vpc_peer_roachprod-us-west-1-roachprod-us-west-2" {
-  providers {
-    aws.owner    = "aws.roachprod-us-west-1"
-    aws.peer     = "aws.roachprod-us-west-2"
+  providers = {
+    aws.owner    = aws.roachprod-us-west-1
+    aws.peer     = aws.roachprod-us-west-2
   }
   owner_vpc_info = "${module.aws_roachprod-us-west-1.vpc_info}"
   peer_vpc_info  = "${module.aws_roachprod-us-west-2.vpc_info}"
 
   label          = "roachprod"
-  source         = "aws-vpc-peer"
+  source         = "./aws-vpc-peer"
 }
 
 
 output "regions" {
-  value = "${list(
+  value = "${tolist([
     "${module.aws_roachprod-ap-northeast-1.region_info}",
     "${module.aws_roachprod-ap-northeast-2.region_info}",
     "${module.aws_roachprod-ap-south-1.region_info}",
@@ -1556,6 +1511,6 @@ output "regions" {
     "${module.aws_roachprod-us-east-2.region_info}",
     "${module.aws_roachprod-us-west-1.region_info}",
     "${module.aws_roachprod-us-west-2.region_info}"
-  )}"
+  ])}"
 }
 

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -34,7 +34,11 @@ import (
 const (
 	defaultProject = "cockroach-ephemeral"
 	// ProviderName is gce.
-	ProviderName = "gce"
+	ProviderName        = "gce"
+	DefaultImage        = "ubuntu-2004-focal-v20210603"
+	FIPSImage           = "ubuntu-pro-fips-2004-focal-v20230302"
+	defaultImageProject = "ubuntu-os-cloud"
+	FIPSImageProject    = "ubuntu-os-pro-cloud"
 )
 
 // providerInstance is the instance to be registered into vm.Providers by Init.
@@ -193,7 +197,7 @@ func DefaultProviderOpts() *ProviderOpts {
 		MachineType:          "n1-standard-4",
 		MinCPUPlatform:       "",
 		Zones:                nil,
-		Image:                "ubuntu-2004-focal-v20210603",
+		Image:                DefaultImage,
 		SSDCount:             1,
 		PDVolumeType:         "pd-ssd",
 		PDVolumeSize:         500,
@@ -308,9 +312,10 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"Machine type (see https://cloud.google.com/compute/docs/machine-types)")
 	flags.StringVar(&o.MinCPUPlatform, ProviderName+"-min-cpu-platform", "",
 		"Minimum CPU platform (see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)")
-	flags.StringVar(&o.Image, ProviderName+"-image", "ubuntu-2004-focal-v20210603",
+	flags.StringVar(&o.Image, ProviderName+"-image", DefaultImage,
 		"Image to use to create the vm, "+
-			"use `gcloud compute images list --filter=\"family=ubuntu-2004-lts\"` to list available images")
+			"use `gcloud compute images list --filter=\"family=ubuntu-2004-lts\"` to list available images. "+
+			"Note: this option is ignored if --fips is passed.")
 
 	flags.IntVar(&o.SSDCount, ProviderName+"-local-ssd-count", 1,
 		"Number of local SSDs to create, only used if local-ssd=true")
@@ -414,12 +419,19 @@ func (p *Provider) Create(
 	}
 
 	// Fixed args.
+	image := providerOpts.Image
+	imageProject := defaultImageProject
+	if opts.EnableFIPS {
+		// NB: if FIPS is enabled, it overrides the image passed via CLI (--gce-image)
+		image = FIPSImage
+		imageProject = FIPSImageProject
+	}
 	args := []string{
 		"compute", "instances", "create",
 		"--subnet", "default",
 		"--scopes", "cloud-platform",
-		"--image", providerOpts.Image,
-		"--image-project", "ubuntu-os-cloud",
+		"--image", image,
+		"--image-project", imageProject,
 		"--boot-disk-type", "pd-ssd",
 	}
 
@@ -483,7 +495,7 @@ func (p *Provider) Create(
 	}
 
 	// Create GCE startup script file.
-	filename, err := writeStartupScript(extraMountOpts, opts.SSDOpts.FileSystem, providerOpts.UseMultipleDisks)
+	filename, err := writeStartupScript(extraMountOpts, opts.SSDOpts.FileSystem, providerOpts.UseMultipleDisks, opts.EnableFIPS)
 	if err != nil {
 		return errors.Wrapf(err, "could not write GCE startup script to temp file")
 	}

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -211,6 +211,10 @@ for service in apport.service atd.service; do
   systemctl mask $service
 done
 
+{{ if .EnableFIPS }}
+sudo ua enable fips --assume-ye
+{{ end }}
+
 sudo touch /mnt/data1/.roachprod-initialized
 `
 
@@ -221,18 +225,20 @@ sudo touch /mnt/data1/.roachprod-initialized
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
 func writeStartupScript(
-	extraMountOpts string, fileSystem string, useMultiple bool,
+	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool,
 ) (string, error) {
 	type tmplParams struct {
 		ExtraMountOpts   string
 		UseMultipleDisks bool
 		Zfs              bool
+		EnableFIPS       bool
 	}
 
 	args := tmplParams{
 		ExtraMountOpts:   extraMountOpts,
 		UseMultipleDisks: useMultiple,
 		Zfs:              fileSystem == vm.Zfs,
+		EnableFIPS:       enableFIPS,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -176,6 +176,7 @@ type CreateOpts struct {
 	CustomLabels map[string]string
 
 	GeoDistributed bool
+	EnableFIPS     bool
 	VMProviders    []string
 	SSDOpts        struct {
 		UseLocalSSD bool


### PR DESCRIPTION
Backport 1/1 commits from #103236.

/cc @cockroachdb/release

---

As of [1], terraform is used in conjunction with roachprod in AWS. In addition to defining VPCs (and their pair-wise peerings), the generated TF scripts assign `ami_id` for every region. This information is made available to roachprod via config.json, generated from TF and embedded into roachprod binary.

Recently, as of [2], `ami_id_fips` was added. This PR adds `ami_id_arm64` in preparation for arm64-based nightly roachtests. Furthermore, TF is refactored to make it compatible with versions 0.14 and onwards. Both AWS resources and the resulting config.json were generated using TF 1.4.6 (latest at this time).

[1] https://github.com/cockroachdb/cockroach/pull/36418
[2] https://github.com/cockroachdb/cockroach/pull/99224

Epic: none
Release note: None
Release justification: ci/test only change
