### PR TITLE
privilege: don't include NOSQLLOGIN in ALL check

### DIFF
--- a/pkg/sql/catalog/catpb/privilege.go
+++ b/pkg/sql/catalog/catpb/privilege.go
@@ -513,7 +513,10 @@ func (p PrivilegeDescriptor) CheckPrivilege(user username.SQLUsername, priv priv
 		return user.IsNodeUser()
 	}
 
-	if privilege.ALL.IsSetIn(userPriv.Privileges) {
+	if privilege.ALL.IsSetIn(userPriv.Privileges) && priv != privilege.NOSQLLOGIN {
+		// Since NOSQLLOGIN is a "negative" privilege, it's ignored for the ALL
+		// check. It's poor UX for someone with ALL privileges to not be able to
+		// log in.
 		return true
 	}
 	return priv.IsSetIn(userPriv.Privileges)

--- a/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
@@ -375,3 +375,25 @@ REVOKE node FROM root;
 DELETE FROM system.users WHERE username = 'node';
 
 subtest end
+
+# Verify that ALL privilege does not prevent SQL logins.
+
+subtest all_does_not_include_nosqllogin
+
+statement ok
+GRANT SYSTEM ALL TO testuser
+
+statement ok
+CANCEL SESSION (SELECT session_id FROM [SHOW SESSIONS] WHERE user_name = 'testuser')
+
+user testuser
+
+statement ok
+SELECT 1
+
+user root
+
+statement ok
+REVOKE SYSTEM ALL FROM testuser
+
+subtest end


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/101292

Release note (bug fix): GRANT SYSTEM ALL ... no longer causes the grantee to be unable to login. This was due to a UX oversight/bug where ALL would include the NOSQLLOGIN system privilege. Since NOSQLLOGIN is the only "negative" privilege, it is now excluded from the ALL shorthand, and must be granted explicitly in order to restrict logins.