### PR TITLE
ui: show alert on DB Console overview when upgrade is not finalized

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -38,12 +38,16 @@ import {
 } from "./apiReducers";
 import {
   singleVersionSelector,
+  numNodesByVersionsTagSelector,
   numNodesByVersionsSelector,
 } from "src/redux/nodes";
 import { AdminUIState, AppDispatch } from "./state";
 import * as docsURL from "src/util/docs";
 import { getDataFromServer } from "../util/dataFromServer";
-import { selectClusterSettings } from "./clusterSettings";
+import {
+  selectClusterSettings,
+  selectClusterSettingVersion,
+} from "./clusterSettings";
 import { longToInt } from "src/util/fixLong";
 
 export enum AlertLevel {
@@ -141,7 +145,7 @@ export const staggeredVersionDismissedSetting = new LocalSetting(
  * This excludes decommissioned nodes.
  */
 export const staggeredVersionWarningSelector = createSelector(
-  numNodesByVersionsSelector,
+  numNodesByVersionsTagSelector,
   staggeredVersionDismissedSetting.selector,
   (versionsMap, versionMismatchDismissed): Alert => {
     if (versionMismatchDismissed) {
@@ -562,6 +566,67 @@ export const clusterPreserveDowngradeOptionOvertimeSelector = createSelector(
   },
 );
 
+////////////////////////////////////////
+// Upgrade not finalized.
+////////////////////////////////////////
+export const upgradeNotFinalizedDismissedSetting = new LocalSetting(
+  "upgrade_not_finalized_dismissed",
+  localSettingsSelector,
+  false,
+);
+
+/**
+ * Warning when all the nodes are running on the new version, but the cluster is not finalized.
+ */
+export const upgradeNotFinalizedWarningSelector = createSelector(
+  selectClusterSettings,
+  numNodesByVersionsSelector,
+  selectClusterSettingVersion,
+  upgradeNotFinalizedDismissedSetting.selector,
+  (
+    settings,
+    versionsMap,
+    clusterVersion,
+    upgradeNotFinalizedDismissed,
+  ): Alert => {
+    if (upgradeNotFinalizedDismissed) {
+      return undefined;
+    }
+    // Don't show this warning if nodes are on different versions, since there is
+    // already an alert for that (staggeredVersionWarningSelector).
+    if (!versionsMap || versionsMap.size !== 1 || !clusterVersion) {
+      return undefined;
+    }
+    // Don't show this warning if cluster.preserve_downgrade_option is set,
+    // because it's expected for the upgrade not be finalized on that case and there is
+    // an alert for that (clusterPreserveDowngradeOptionOvertimeSelector)
+    const clusterPreserveDowngradeOption =
+      settings["cluster.preserve_downgrade_option"];
+    const value = clusterPreserveDowngradeOption?.value;
+    const lastUpdated = clusterPreserveDowngradeOption?.last_updated;
+    if (value && lastUpdated) {
+      return undefined;
+    }
+
+    const nodesVersion = versionsMap.keys().next().value;
+    // Prod: node version is 23.1 and cluster version is 23.1.
+    // Dev: node version is 23.1 and cluster version is 23.1-2.
+    if (clusterVersion.startsWith(nodesVersion)) {
+      return undefined;
+    }
+
+    return {
+      level: AlertLevel.WARNING,
+      title: "Upgrade not finalized.",
+      text: `All nodes are running on version ${nodesVersion}, but the cluster is on version ${clusterVersion}.`,
+      dismiss: (dispatch: AppDispatch) => {
+        dispatch(upgradeNotFinalizedDismissedSetting.set(true));
+        return Promise.resolve();
+      },
+    };
+  },
+);
+
 /**
  * Selector which returns an array of all active alerts which should be
  * displayed in the overview list page, these should be non-critical alerts.
@@ -570,6 +635,7 @@ export const clusterPreserveDowngradeOptionOvertimeSelector = createSelector(
 export const overviewListAlertsSelector = createSelector(
   staggeredVersionWarningSelector,
   clusterPreserveDowngradeOptionOvertimeSelector,
+  upgradeNotFinalizedWarningSelector,
   (...alerts: Alert[]): Alert[] => {
     return _.without(alerts, null, undefined);
   },

--- a/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
@@ -84,3 +84,13 @@ export const selectIndexRecommendationsEnabled = createSelector(
     return util.greaterOrEqualThanVersion(value, [22, 2, 0]);
   },
 );
+
+export const selectClusterSettingVersion = createSelector(
+  selectClusterSettings,
+  (settings): string => {
+    if (!settings) {
+      return "";
+    }
+    return settings["version"].value;
+  },
+);

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.spec.ts
@@ -19,7 +19,7 @@ import {
   selectStoreIDsByNodeID,
   LivenessStatus,
   sumNodeStats,
-  numNodesByVersionsSelector,
+  numNodesByVersionsTagSelector,
 } from "./nodes";
 import { nodesReducerObj, livenessReducerObj } from "./apiReducers";
 import { createAdminUIStore } from "./state";
@@ -185,7 +185,7 @@ describe("node data selectors", function () {
     });
   });
 
-  describe("numNodesByVersionsSelector", () => {
+  describe("numNodesByVersionsTagSelector", () => {
     it("correctly returns the different binary versions and the number of associated nodes", () => {
       const data = [
         {
@@ -214,7 +214,7 @@ describe("node data selectors", function () {
         ["v22.1", 2],
         ["v21.1.7", 1],
       ]);
-      expect(numNodesByVersionsSelector(state)).toEqual(expectedResult);
+      expect(numNodesByVersionsTagSelector(state)).toEqual(expectedResult);
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -515,7 +515,7 @@ export const versionsSelector = createSelector(validateNodesSelector, nodes =>
     .value(),
 );
 
-export const numNodesByVersionsSelector = createSelector(
+export const numNodesByVersionsTagSelector = createSelector(
   validateNodesSelector,
   nodes => {
     if (!nodes) {
@@ -523,6 +523,26 @@ export const numNodesByVersionsSelector = createSelector(
     }
     return new Map(
       Object.entries(_.countBy(nodes, node => node?.build_info?.tag)),
+    );
+  },
+);
+
+export const numNodesByVersionsSelector = createSelector(
+  validateNodesSelector,
+  nodes => {
+    if (!nodes) {
+      return new Map();
+    }
+    return new Map(
+      Object.entries(
+        _.countBy(nodes, node => {
+          const serverVersion = node?.desc?.ServerVersion;
+          if (serverVersion) {
+            return `${serverVersion.major_val}.${serverVersion.minor_val}`;
+          }
+          return "";
+        }),
+      ),
     );
   },
 );


### PR DESCRIPTION
Display a warning on the DB Console overview page when all the nodes are running on the new version, but the cluster is not finalized.

Fixes #66987

<img width="1205" alt="Screenshot 2023-06-09 at 5 29 01 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/cb6f1943-91bd-4528-98f4-bc5704a7e9dc">

Example of cluster with a not finalized upgrade, and the values being used on this PR to compare:
https://www.loom.com/share/1d478f69ea0f459fbdc3d1506f5a8dfc


Release note (ui change): Add warning to DB Console overview page when all nodes are running on the new version, but the cluster upgrade is not finalized.