### PR TITLE
release-22.2: roachtest: metamorphic ARM64 and FIPS clusters

### DIFF
--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "github.com/cockroachdb/cockroach/pkg/build.utcTime": "{BUILD_UTCTIME}",
     },
     deps = [
+        "//pkg/util/buildutil",
         "//pkg/util/envutil",
         "//pkg/util/version",
     ],

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -17,6 +17,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 )
@@ -35,11 +36,12 @@ var (
 	cgoTargetTriple string
 	platform        = fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH)
 	// Distribution is changed by the CCL init-time hook in non-APL builds.
-	Distribution  = "OSS"
-	typ           string // Type of this build: <empty>, "development", or "release"
-	channel       = "unknown"
-	envChannel    = envutil.EnvOrDefaultString("COCKROACH_CHANNEL", "unknown")
-	binaryVersion = computeVersion(tag)
+	Distribution      = "OSS"
+	typ               string // Type of this build: <empty>, "development", or "release"
+	channel           = "unknown"
+	envChannel        = envutil.EnvOrDefaultString("COCKROACH_CHANNEL", "unknown")
+	enabledAssertions = buildutil.CrdbTestBuild
+	binaryVersion     = computeVersion(tag)
 )
 
 const (
@@ -113,7 +115,8 @@ func (b Info) Long() string {
 	fmt.Fprintf(tw, "Go Version:       %s\n", b.GoVersion)
 	fmt.Fprintf(tw, "C Compiler:       %s\n", b.CgoCompiler)
 	fmt.Fprintf(tw, "Build Commit ID:  %s\n", b.Revision)
-	fmt.Fprintf(tw, "Build Type:       %s", b.Type) // No final newline: cobra prints one for us.
+	fmt.Fprintf(tw, "Build Type:       %s\n", b.Type)
+	fmt.Fprintf(tw, "Enabled Assertions: %t", b.EnabledAssertions) // No final newline: cobra prints one for us.
 	_ = tw.Flush()
 	return buf.String()
 }
@@ -139,17 +142,18 @@ func (b Info) Timestamp() (int64, error) {
 // GetInfo returns an Info struct populated with the build information.
 func GetInfo() Info {
 	return Info{
-		GoVersion:       runtime.Version(),
-		Tag:             tag,
-		Time:            utcTime,
-		Revision:        rev,
-		CgoCompiler:     cgoCompiler,
-		CgoTargetTriple: cgoTargetTriple,
-		Platform:        platform,
-		Distribution:    Distribution,
-		Type:            typ,
-		Channel:         channel,
-		EnvChannel:      envChannel,
+		GoVersion:         runtime.Version(),
+		Tag:               tag,
+		Time:              utcTime,
+		Revision:          rev,
+		CgoCompiler:       cgoCompiler,
+		CgoTargetTriple:   cgoTargetTriple,
+		Platform:          platform,
+		Distribution:      Distribution,
+		Type:              typ,
+		Channel:           channel,
+		EnvChannel:        envChannel,
+		EnabledAssertions: enabledAssertions,
 	}
 }
 

--- a/pkg/build/info.proto
+++ b/pkg/build/info.proto
@@ -38,6 +38,8 @@ message Info {
   optional string channel = 9 [(gogoproto.nullable) = false];
   // env_channel identifies the product channel as overridden by the COCKROACH_CHANNEL environment variable.
   optional string env_channel = 11 [(gogoproto.nullable) = false];
+  // enabled_assertions returns the value of 'CrdbTestBuild' (true iff compiled with 'crdb_test' tag)
+  optional bool enabled_assertions = 12 [(gogoproto.nullable) = false];
 
   // dependencies exists to allow tests that run against old clusters
   // to unmarshal JSON containing this field. The tag is unimportant,

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -40,6 +40,7 @@ var (
 	extendLifetime        time.Duration
 	wipePreserveCerts     bool
 	grafanaConfig         string
+	grafanaArch           string
 	grafanaurlOpen        bool
 	grafanaDumpDir        string
 	listDetails           bool
@@ -107,8 +108,9 @@ func initFlags() {
 			vm.AllProviderNames()))
 	createCmd.Flags().BoolVar(&createVMOpts.GeoDistributed,
 		"geo", false, "Create geo-distributed cluster")
-	createCmd.Flags().BoolVar(&createVMOpts.EnableFIPS,
-		"fips", false, "Enable FIPS mode (uses custom AMI)")
+	createCmd.Flags().StringVar(&createVMOpts.Arch, "arch", "",
+		"architecture override for VM [amd64, arm64, fips]; N.B. fips implies amd64 with openssl")
+
 	// N.B. We set "usage=roachprod" as the default, custom label for billing tracking.
 	createCmd.Flags().StringToStringVar(&createVMOpts.CustomLabels,
 		"label", map[string]string{"usage": "roachprod"},
@@ -248,6 +250,9 @@ func initFlags() {
 	// the repo, not some random URL.
 	grafanaStartCmd.Flags().StringVar(&grafanaConfig,
 		"grafana-config", "", "URL to grafana json config")
+
+	grafanaStartCmd.Flags().StringVar(&grafanaArch, "arch", "",
+		"binary architecture override [amd64, arm64]")
 
 	grafanaURLCmd.Flags().BoolVar(&grafanaurlOpen,
 		"open", false, "open the grafana dashboard url on the browser")

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -273,6 +273,7 @@ hosts file.
 					c.PrintDetails(roachprodLibraryLogger)
 				} else {
 					fmt.Fprintf(tw, "%s\t%s\t%d", c.Name, c.Clouds(), len(c.VMs))
+
 					if !c.IsLocal() {
 						fmt.Fprintf(tw, "\t(%s)", c.LifetimeRemaining().Round(time.Second))
 					} else {
@@ -904,10 +905,14 @@ var grafanaStartCmd = &cobra.Command{
 	Use:   `grafana-start <cluster>`,
 	Short: `spins up a prometheus and grafana instances on the last node in the cluster`,
 	Long: `spins up a prometheus and grafana instances on the highest numbered node in the cluster
-and will scrape from all nodes in the cluster`,
+and will scrape from all nodes in the cluster; NOTE: for arm64 clusters, use --arch arm64`,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.StartGrafana(context.Background(), roachprodLibraryLogger, args[0],
+		arch := vm.ArchAMD64
+		if grafanaArch == "arm64" {
+			arch = vm.ArchARM64
+		}
+		return roachprod.StartGrafana(context.Background(), roachprodLibraryLogger, args[0], arch,
 			grafanaConfig, nil)
 	}),
 }
@@ -954,14 +959,14 @@ func validateAndConfigure(cmd *cobra.Command, args []string) {
 
 	// Validate architecture flag, if set.
 	if archOpt := cmd.Flags().Lookup("arch"); archOpt != nil && archOpt.Changed {
-		arch := strings.ToLower(archOpt.Value.String())
+		arch := vm.CPUArch(strings.ToLower(archOpt.Value.String()))
 
-		if arch != "amd64" && arch != "arm64" && arch != "fips" {
+		if arch != vm.ArchAMD64 && arch != vm.ArchARM64 && arch != vm.ArchFIPS {
 			printErrAndExit(fmt.Errorf("unsupported architecture %q", arch))
 		}
-		if arch != archOpt.Value.String() {
+		if string(arch) != archOpt.Value.String() {
 			// Set the canonical value.
-			_ = cmd.Flags().Set("arch", arch)
+			_ = cmd.Flags().Set("arch", string(arch))
 		}
 	}
 }

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -57,13 +57,20 @@ func init() {
 }
 
 var (
-	// TODO(tbg): this is redundant with --cloud==local. Make the --local flag an
-	// alias for `--cloud=local` and remove this variable.
-	local bool
-
-	cockroach        string
-	cockroachShort   string
-	libraryFilePaths []string
+	// user-specified path to crdb binary
+	cockroachPath string
+	// maps cpuArch to the corresponding crdb binary's absolute path
+	cockroach = make(map[vm.CPUArch]string)
+	// user-specified path to short crdb binary
+	cockroachShortPath string
+	// maps cpuArch to the corresponding short crdb (i.e., without UI) binary's absolute path
+	cockroachShort = make(map[vm.CPUArch]string)
+	// user-specified path to workload binary
+	workloadPath string
+	// maps cpuArch to the corresponding workload binary's absolute path
+	workload = make(map[vm.CPUArch]string)
+	// maps cpuArch to the corresponding dynamically-linked libraries' absolute paths
+	libraryFilePaths = make(map[vm.CPUArch][]string)
 	cloud            = spec.GCE
 	// encryptionProbability controls when encryption-at-rest is enabled
 	// in a cluster for tests that have opted-in to metamorphic
@@ -73,10 +80,18 @@ var (
 	// encryption enabled by default (probability 1). In order to run
 	// them with encryption disabled (perhaps to reproduce a test
 	// failure), roachtest can be invoked with --metamorphic-encryption-probability=0
-	encryptionProbability     float64
+	encryptionProbability float64
+	// Total probability with which new ARM64 clusters are provisioned, modulo test specs. which are incompatible.
+	// N.B. if all selected tests are incompatible with ARM64, then arm64Probability is effectively 0.
+	// In other words, ClusterSpec.Arch takes precedence over the arm64Probability flag.
+	arm64Probability float64
+	// Conditional probability with which new FIPS clusters are provisioned, modulo test specs. The total probability
+	// is the product of this and 1-arm64Probability.
+	// As in the case of arm64Probability, ClusterSpec.Arch takes precedence over the fipsProbability flag.
+	fipsProbability float64
+
 	instanceType              string
 	localSSDArg               bool
-	workload                  string
 	deprecatedRoachprodBinary string
 	// overrideOpts contains vm.CreateOpts override values passed from the cli.
 	overrideOpts vm.CreateOpts
@@ -97,6 +112,9 @@ var (
 
 const (
 	defaultEncryptionProbability = 1
+	defaultFIPSProbability       = 0
+	defaultARM64Probability      = 0
+	defaultCockroachPath         = "./cockroach-default"
 )
 
 type errBinaryOrLibraryNotFound struct {
@@ -107,29 +125,59 @@ func (e errBinaryOrLibraryNotFound) Error() string {
 	return fmt.Sprintf("binary or library %q not found (or was not executable)", e.binary)
 }
 
-func filepathAbs(path string) (string, error) {
-	path, err := filepath.Abs(path)
+func validateBinaryFormat(path string, arch vm.CPUArch, checkEA bool) (string, error) {
+	abspath, err := filepath.Abs(path)
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
-	return path, nil
-}
-
-func findBinary(binary, defValue string) (abspath string, err error) {
-	if binary == "" {
-		binary = defValue
+	// Check that the binary ELF format matches the expected architecture.
+	cmd := exec.Command("file", "-b", abspath)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", errors.Wrapf(err, "error executing 'file %s'", abspath)
+	}
+	fileFormat := strings.ToLower(out.String())
+	// N.B. 'arm64' is returned on macOS, while 'aarch64' is returned on Linux;
+	// "x86_64" string is returned on macOS, while "x86-64" is returned on Linux.
+	if arch == vm.ArchARM64 && !strings.Contains(fileFormat, "arm64") && !strings.Contains(fileFormat, "aarch64") {
+		return "", errors.Newf("%s has incompatible architecture; want: %q, got: %q", abspath, arch, fileFormat)
+	} else if arch == vm.ArchAMD64 && !strings.Contains(fileFormat, "x86-64") && !strings.Contains(fileFormat, "x86_64") {
+		// Otherwise, we expect a binary that was built for amd64.
+		return "", errors.Newf("%s has incompatible architecture; want: %q, got: %q", abspath, arch, fileFormat)
+	}
+	if arch == vm.ArchFIPS && strings.HasSuffix(abspath, "cockroach") {
+		// Check that the binary is patched to use OpenSSL FIPS.
+		// N.B. only the cockroach binary is patched, so we exclude this check for dynamically-linked libraries.
+		cmd = exec.Command("bash", "-c", fmt.Sprintf("nm %s | grep golang-fips |head -1", abspath))
+		if err := cmd.Run(); err != nil {
+			return "", errors.Newf("%s is not compiled with FIPS", abspath)
+		}
+	}
+	if checkEA {
+		// Check that the binary was compiled with assertions _enabled_.
+		cmd = exec.Command("bash", "-c", fmt.Sprintf("%s version |grep \"Enabled Assertions\" |grep true", abspath))
+		if err := cmd.Run(); err != nil {
+			return "", errors.Newf("%s is not compiled with assertions enabled", abspath)
+		}
 	}
 
+	return abspath, nil
+}
+
+func findBinary(
+	name string, osName string, arch vm.CPUArch, checkEA bool,
+) (abspath string, err error) {
 	// Check to see if binary exists and is a regular file and executable.
-	if fi, err := os.Stat(binary); err == nil && fi.Mode().IsRegular() && (fi.Mode()&0111) != 0 {
-		return filepathAbs(binary)
+	if fi, err := os.Stat(name); err == nil && fi.Mode().IsRegular() && (fi.Mode()&0111) != 0 {
+		return validateBinaryFormat(name, arch, checkEA)
 	}
-	return findBinaryOrLibrary("bin", binary)
+	return findBinaryOrLibrary("bin", name, "", osName, arch, checkEA)
 }
 
-func findLibrary(libraryName string) (string, error) {
+func findLibrary(libraryName string, os string, arch vm.CPUArch) (string, error) {
 	suffix := ".so"
-	if local {
+	if cloud == spec.Local {
 		switch runtime.GOOS {
 		case "linux":
 		case "freebsd":
@@ -143,65 +191,102 @@ func findLibrary(libraryName string) (string, error) {
 			return "", errors.Newf("failed to find suffix for runtime %s", runtime.GOOS)
 		}
 	}
-	return findBinaryOrLibrary("lib", libraryName+suffix)
+
+	return findBinaryOrLibrary("lib", libraryName, suffix, os, arch, false)
 }
 
-func findBinaryOrLibrary(binOrLib string, name string) (string, error) {
+// findBinaryOrLibrary searches for a binary or library, _first_ in the $PATH, _then_ in the following hardcoded paths,
+//
+//	$GOPATH/src/github.com/cockroachdb/cockroach/
+//	$GOPATH/src/github.com/cockroachdb/artifacts/
+//	$PWD/binOrLib
+//	$GOPATH/src/github.com/cockroachdb/cockroach/binOrLib
+//
+// in the above order, unless 'name' is an absolute path, in which case the hardcoded paths are skipped.
+//
+// binOrLib is either 'bin' or 'lib'; nameSuffix is either empty, '.so', '.dll', or '.dylib'.
+// Both osName and arch are used to derive a fully qualified binary or library name by inserting the
+// corresponding arch suffix (see install.ArchInfoForOS), e.g. '.linux-arm64' or '.darwin-amd64'.
+// That is, each hardcoded path is searched for a file named 'name' or 'name.nameSuffix.archSuffix', respectively.
+//
+// If no binary or library is found, an error is returned.
+// Otherwise, if multiple binaries or libraries are located at the above paths, the first one found is returned.
+// If the found binary or library happens to be of the wrong type, e.g., architecture is different from 'arch', or
+// checkEA is true, and the binary was not compiled with runtime assertions enabled, an error is returned.
+// While we could continue the search instead of returning an error, it is assumed the user can stage the binaries
+// to avoid such ambiguity. Alternatively, the user can specify the absolute path to the binary or library,
+// e.g., via --cockroach; in this case, only the absolute path is checked and validated.
+func findBinaryOrLibrary(
+	binOrLib string, name string, nameSuffix string, osName string, arch vm.CPUArch, checkEA bool,
+) (string, error) {
 	// Find the binary to run and translate it to an absolute path. First, look
 	// for the binary in PATH.
-	path, err := exec.LookPath(name)
+	pathFromEnv, err := exec.LookPath(name)
+	if err == nil {
+		// Found it in PATH, validate and return absolute path.
+		return validateBinaryFormat(pathFromEnv, arch, checkEA)
+	}
+	if strings.HasPrefix(name, "/") {
+		// Specified name is an absolute path, but we couldn't find it; bail out.
+		return "", errors.WithStack(err)
+	}
+	// We're unable to find the name in PATH and "name" is a relative path:
+	// look in the cockroach repo.
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		gopath = filepath.Join(os.Getenv("HOME"), "go")
+	}
+
+	dirs := []string{
+		filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/"),
+		filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/artifacts/"),
+		filepath.Join(os.ExpandEnv("$PWD"), binOrLib),
+		filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach", binOrLib),
+	}
+
+	archInfo, err := install.ArchInfoForOS(osName, arch)
 	if err != nil {
-		if strings.HasPrefix(name, "/") {
-			return "", errors.WithStack(err)
-		}
+		return "", err
+	}
+	archSuffixes := []string{"." + archInfo.DebugArchitecture, "." + archInfo.ReleaseArchitecture}
 
-		// We're unable to find the name in PATH and "name" is a relative path:
-		// look in the cockroach repo.
-		gopath := os.Getenv("GOPATH")
-		if gopath == "" {
-			gopath = filepath.Join(os.Getenv("HOME"), "go")
-		}
+	for _, dir := range dirs {
+		var path string
 
-		var suffix string
-		if !local {
-			suffix = ".docker_amd64"
+		if path, err = exec.LookPath(filepath.Join(dir, name)); err == nil {
+			return validateBinaryFormat(path, arch, checkEA)
 		}
-		dirs := []string{
-			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/"),
-			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/artifacts/"),
-			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach", binOrLib+suffix),
-			filepath.Join(os.ExpandEnv("$PWD"), binOrLib+suffix),
-			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach", binOrLib),
-		}
-		for _, dir := range dirs {
-			path = filepath.Join(dir, name)
-			var err2 error
-			path, err2 = exec.LookPath(path)
-			if err2 == nil {
-				return filepathAbs(path)
+		for _, archSuffix := range archSuffixes {
+			if path, err = exec.LookPath(filepath.Join(dir, name+archSuffix+nameSuffix)); err == nil {
+				return validateBinaryFormat(path, arch, checkEA)
 			}
 		}
-		return "", errBinaryOrLibraryNotFound{name}
 	}
-	return filepathAbs(path)
+	return "", errBinaryOrLibraryNotFound{name}
 }
 
 // VerifyLibraries verifies that the required libraries, specified by name, are
 // available for the target environment.
-func VerifyLibraries(requiredLibs []string) error {
+func VerifyLibraries(requiredLibs []string, arch vm.CPUArch) error {
+	foundLibraryPaths := libraryFilePaths[arch]
+
 	for _, requiredLib := range requiredLibs {
-		if !contains(libraryFilePaths, libraryNameFromPath, requiredLib) {
-			return errors.Wrap(errors.Errorf("missing required library %s", requiredLib), "cluster.VerifyLibraries")
+		if !contains(foundLibraryPaths, libraryNameFromPath, requiredLib) {
+			return errors.Wrap(errors.Errorf("missing required library %s (arch=%q)", requiredLib, arch), "cluster.VerifyLibraries")
 		}
 	}
 	return nil
 }
 
-// libraryNameFromPath returns the name of a library without the extension, for a
+// libraryNameFromPath returns the name of a library without the extension(s), for a
 // given path.
 func libraryNameFromPath(path string) string {
 	filename := filepath.Base(path)
-	return strings.TrimSuffix(filename, filepath.Ext(filename))
+	// N.B. filename may contain multiple extensions, e.g. "libgeos.linux-amd64.fips.so".
+	for ext := filepath.Ext(filename); ext != ""; ext = filepath.Ext(filename) {
+		filename = strings.TrimSuffix(filename, ext)
+	}
+	return filename
 }
 
 func contains(list []string, transformString func(s string) string, str string) bool {
@@ -217,50 +302,128 @@ func contains(list []string, transformString func(s string) string, str string) 
 }
 
 func initBinariesAndLibraries() {
-	// If we're running against an existing "local" cluster, force the local flag
-	// to true in order to get the "local" test configurations.
-	if clusterName == "local" {
-		local = true
-	}
-	if local {
-		cloud = spec.Local
-	}
-
-	cockroachDefault := "cockroach"
-	if !local {
-		cockroachDefault = "cockroach-linux-2.6.32-gnu-amd64"
-	}
-	var err error
-	cockroach, err = findBinary(cockroach, cockroachDefault)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%+v\n", err)
-		os.Exit(1)
-	}
-
-	if cockroachShort != "" {
-		// defValue doesn't matter since cockroachShort is a non-empty string.
-		cockroachShort, err = findBinary(cockroachShort, "" /* defValue */)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%+v\n", err)
-			os.Exit(1)
+	// TODO(srosenberg): enable metamorphic local clusters; currently, spec.Local means run all tests locally.
+	// This could be revisited after we have a way to specify which clouds a given test supports,
+	//	see https://github.com/cockroachdb/cockroach/issues/104029.
+	defaultOSName := "linux"
+	defaultArch := vm.ArchAMD64
+	if cloud == spec.Local {
+		defaultOSName = runtime.GOOS
+		if arm64Probability == 1 {
+			// N.B. if arm64Probability != 1, then we're running a local cluster with both arm64 and amd64.
+			defaultArch = vm.ArchARM64
+		}
+		if string(defaultArch) != runtime.GOARCH {
+			fmt.Printf("WARN: local cluster's architecture (%q) differs from default (%q)\n", runtime.GOARCH, defaultArch)
 		}
 	}
+	fmt.Printf("Locating and verifying binaries for os=%q, arch=%q\n", defaultOSName, defaultArch)
 
-	workload, err = findBinary(workload, "workload")
-	if errors.As(err, &errBinaryOrLibraryNotFound{}) {
-		fmt.Fprintln(os.Stderr, "workload binary not provided, proceeding anyway")
-	} else if err != nil {
-		fmt.Fprintf(os.Stderr, "%+v\n", err)
-		os.Exit(1)
+	// Finds and validates a binary. If the binary 'isRequired', but not found, exit and print the error.
+	resolveBinary := func(binName string, userSpecified string, arch vm.CPUArch, isRequired bool, checkEA bool) (string, error) {
+		path := binName
+		if userSpecified != "" {
+			path = userSpecified
+		}
+		abspath, err := findBinary(path, defaultOSName, arch, checkEA)
+		if err != nil {
+			if isRequired {
+				fmt.Fprintf(os.Stderr, "ERROR: unable to find required binary %q for %q: %v\n", binName, arch, err)
+				os.Exit(1)
+			}
+			return "", err
+		}
+		if userSpecified == "" {
+			// No user-specified path, so return the found absolute path.
+			return abspath, nil
+		}
+		// Bail out if a path other than the user-specified was found.
+		userPath, err := filepath.Abs(userSpecified)
+
+		if err != nil || userPath != abspath {
+			err = errors.Wrapf(err, "ERROR: found %q at: %s instead of the user-specified path: %q\n", binName, abspath, userSpecified)
+
+			if isRequired {
+				fmt.Fprintf(os.Stderr, "%v", err)
+				os.Exit(1)
+			}
+			return "", err
+		}
+		return abspath, nil
+	}
+	// We need to verify we have at least both the cockroach and the workload binaries.
+	var err error
+
+	cockroach[defaultArch], _ = resolveBinary("cockroach", cockroachPath, defaultArch, true, false)
+	workload[defaultArch], _ = resolveBinary("workload", workloadPath, defaultArch, true, false)
+	cockroachShort[defaultArch], err = resolveBinary("cockroach-short", cockroachShortPath, defaultArch, false, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARN: unable to find %q for %q: %s\n", "cockroach-short", defaultArch, err)
+	}
+
+	if arm64Probability > 0 && defaultArch != vm.ArchARM64 {
+		fmt.Printf("Locating and verifying binaries for os=%q, arch=%q\n", defaultOSName, vm.ArchARM64)
+		// We need to verify we have all the required binaries for arm64.
+		cockroach[vm.ArchARM64], _ = resolveBinary("cockroach", cockroachPath, vm.ArchARM64, true, false)
+		workload[vm.ArchARM64], _ = resolveBinary("workload", workloadPath, vm.ArchARM64, true, false)
+		cockroachShort[vm.ArchARM64], err = resolveBinary("cockroach-short", cockroachShortPath, vm.ArchARM64, false, true)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: unable to find %q for %q: %s\n", "cockroach-short", vm.ArchARM64, err)
+		}
+	}
+	if fipsProbability > 0 && defaultArch != vm.ArchFIPS {
+		fmt.Printf("Locating and verifying binaries for os=%q, arch=%q\n", defaultOSName, vm.ArchFIPS)
+		// We need to verify we have all the required binaries for fips.
+		cockroach[vm.ArchFIPS], _ = resolveBinary("cockroach", cockroachPath, vm.ArchFIPS, true, false)
+		workload[vm.ArchFIPS], _ = resolveBinary("workload", workloadPath, vm.ArchFIPS, true, false)
+		cockroachShort[vm.ArchFIPS], err = resolveBinary("cockroach-short", cockroachShortPath, vm.ArchFIPS, false, true)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: unable to find %q for %q: %s\n", "cockroach-short", vm.ArchFIPS, err)
+		}
 	}
 
 	// In v20.2 or higher, optionally expect certain library files to exist.
 	// Since they may not be found in older versions, do not hard error if they are not found.
-	for _, libraryName := range []string{"libgeos", "libgeos_c"} {
-		if libraryFilePath, err := findLibrary(libraryName); err != nil {
-			fmt.Fprintf(os.Stderr, "error finding library %s, ignoring: %+v\n", libraryName, err)
-		} else {
-			libraryFilePaths = append(libraryFilePaths, libraryFilePath)
+	for _, arch := range []vm.CPUArch{vm.ArchAMD64, vm.ArchARM64, vm.ArchFIPS} {
+		if arm64Probability == 0 && defaultArch != vm.ArchARM64 && arch == vm.ArchARM64 {
+			// arm64 isn't used, skip finding libs for it.
+			continue
+		}
+		if fipsProbability == 0 && arch == vm.ArchFIPS {
+			// fips isn't used, skip finding libs for it.
+			continue
+		}
+		paths := []string(nil)
+
+		for _, libraryName := range []string{"libgeos", "libgeos_c"} {
+			if libraryFilePath, err := findLibrary(libraryName, defaultOSName, arch); err != nil {
+				fmt.Fprintf(os.Stderr, "WARN: unable to find library %s, ignoring: %s\n", libraryName, err)
+			} else {
+				paths = append(paths, libraryFilePath)
+			}
+		}
+		libraryFilePaths[arch] = paths
+	}
+	// Looks like we have all the binaries we'll need. Let's print them out.
+	fmt.Printf("\nFound the following binaries:\n")
+	for arch, path := range cockroach {
+		if path != "" {
+			fmt.Printf("\tcockroach %q at: %s\n", arch, path)
+		}
+	}
+	for arch, path := range workload {
+		if path != "" {
+			fmt.Printf("\tworkload %q at: %s\n", arch, path)
+		}
+	}
+	for arch, path := range cockroachShort {
+		if path != "" {
+			fmt.Printf("\tcockroach-short %q at: %s\n", arch, path)
+		}
+	}
+	for arch, paths := range libraryFilePaths {
+		if len(paths) > 0 {
+			fmt.Printf("\tlibraries %q at: %s\n", arch, strings.Join(paths, ", "))
 		}
 	}
 }
@@ -654,6 +817,8 @@ type clusterImpl struct {
 	expiration    time.Time
 	encAtRest     bool // use encryption at rest
 
+	os   string     // OS of the cluster
+	arch vm.CPUArch // CPU architecture of the cluster
 	// destroyState contains state related to the cluster's destruction.
 	destroyState destroyState
 }
@@ -737,6 +902,10 @@ type clusterConfig struct {
 	localCluster bool
 	useIOBarrier bool
 	alloc        *quotapool.IntAlloc
+	// Specifies CPU architecture which may require a custom AMI and cockroach binary.
+	arch vm.CPUArch
+	// Specifies the OS which may require a custom AMI and cockroach binary.
+	os string
 }
 
 // clusterFactory is a creator of clusters.
@@ -873,7 +1042,8 @@ func (f *clusterFactory) newCluster(
 	providerOptsContainer := vm.CreateProviderOptionsContainer()
 	// The ClusterName is set below in the retry loop to ensure
 	// that each create attempt gets a unique cluster name.
-	createVMOpts, providerOpts, err := cfg.spec.RoachprodOpts("", cfg.useIOBarrier)
+	createVMOpts, providerOpts, err := cfg.spec.RoachprodOpts("", cfg.useIOBarrier, cfg.arch)
+
 	if err != nil {
 		// We must release the allocation because cluster creation is not possible at this point.
 		cfg.alloc.Release()
@@ -909,6 +1079,8 @@ func (f *clusterFactory) newCluster(
 			spec:       cfg.spec,
 			expiration: cfg.spec.Expiration(),
 			r:          f.r,
+			arch:       cfg.arch,
+			os:         cfg.os,
 			destroyState: destroyState{
 				owned: true,
 				alloc: cfg.alloc,
@@ -1698,11 +1870,13 @@ func (c *clusterImpl) PutLibraries(
 	if err := c.RunE(ctx, c.All(), "mkdir", "-p", libraryDir); err != nil {
 		return err
 	}
-	for _, libraryFilePath := range libraryFilePaths {
-		if !contains(libraries, nil, libraryNameFromPath(libraryFilePath)) {
+
+	for _, libraryFilePath := range libraryFilePaths[c.arch] {
+		libName := libraryNameFromPath(libraryFilePath)
+		if !contains(libraries, nil, libName) {
 			continue
 		}
-		putPath := filepath.Join(libraryDir, filepath.Base(libraryFilePath))
+		putPath := filepath.Join(libraryDir, libName)
 		if err := c.PutE(
 			ctx,
 			c.l,
@@ -1728,7 +1902,7 @@ func (c *clusterImpl) Stage(
 	c.status("staging binary")
 	defer c.status("")
 	return errors.Wrap(roachprod.Stage(ctx, l, c.MakeNodes(opts...),
-		"" /* stageOS */, "" /* stageArch */, dir, application, versionOrSHA), "cluster.Stage")
+		c.os, string(c.arch), dir, application, versionOrSHA), "cluster.Stage")
 }
 
 // Get gets files from remote hosts.
@@ -2421,6 +2595,10 @@ func (c *clusterImpl) IsSecure() bool {
 	return c.localCertsDir != ""
 }
 
+func (c *clusterImpl) Architecture() vm.CPUArch {
+	return c.arch
+}
+
 // Extend extends the cluster's expiration by d.
 func (c *clusterImpl) Extend(ctx context.Context, d time.Duration, l *logger.Logger) error {
 	if ctx.Err() != nil {
@@ -2443,7 +2621,9 @@ func (c *clusterImpl) NewMonitor(ctx context.Context, opts ...option.Option) clu
 func (c *clusterImpl) StartGrafana(
 	ctx context.Context, l *logger.Logger, promCfg *prometheus.Config,
 ) error {
-	return roachprod.StartGrafana(ctx, l, c.name, "", promCfg)
+
+	return roachprod.StartGrafana(ctx, l, c.name, c.arch, "", promCfg)
+
 }
 
 func (c *clusterImpl) StopGrafana(ctx context.Context, l *logger.Logger, dumpDir string) error {

--- a/pkg/cmd/roachtest/cluster/BUILD.bazel
+++ b/pkg/cmd/roachtest/cluster/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",
+        "//pkg/roachprod/vm",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 )
 
 // Cluster is the interface through which a given roachtest interacts with the
@@ -107,7 +108,10 @@ type Cluster interface {
 	Spec() spec.ClusterSpec
 	Name() string
 	IsLocal() bool
+	// IsSecure returns true iff the cluster uses TLS.
 	IsSecure() bool
+	// Returns CPU architecture of the nodes.
+	Architecture() vm.CPUArch
 
 	// Deleting CockroachDB data and logs on nodes.
 

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -125,7 +125,10 @@ func (g *githubIssues) createPostRequest(
 		roachtestPrefix("cpu"):   fmt.Sprintf("%d", spec.Cluster.CPUs),
 		roachtestPrefix("ssd"):   fmt.Sprintf("%d", spec.Cluster.SSDs),
 	}
-
+	// Emit CPU architecture only if it was specified; otherwise, it's captured below, assuming cluster was created.
+	if spec.Cluster.Arch != "" {
+		clusterParams[roachtestPrefix("arch")] = string(spec.Cluster.Arch)
+	}
 	// These params can be probabilistically set, so we pass them here to
 	// show what their actual values are in the posted issue.
 	if g.vmCreateOpts != nil {
@@ -135,6 +138,11 @@ func (g *githubIssues) createPostRequest(
 
 	if g.cluster != nil {
 		clusterParams[roachtestPrefix("encrypted")] = fmt.Sprintf("%v", g.cluster.encAtRest)
+		if spec.Cluster.Arch == "" {
+			// N.B. when Arch is specified, it cannot differ from cluster's arch.
+			// Hence, we only emit when arch was unspecified.
+			clusterParams[roachtestPrefix("arch")] = string(g.cluster.arch)
+		}
 	}
 
 	return issues.PostRequest{

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -74,7 +74,8 @@ func TestShouldPost(t *testing.T) {
 		{false, 1, "token", "master", true},
 	}
 
-	reg := makeTestRegistry(spec.GCE, "", "", false, false)
+	reg, err := makeTestRegistry(spec.GCE, "", "", false, false)
+	require.NoError(t, err)
 
 	for _, c := range testCases {
 		t.Setenv("GITHUB_API_TOKEN", c.envGithubAPIToken)
@@ -108,34 +109,40 @@ func TestCreatePostRequest(t *testing.T) {
 		clusterCreationFailed bool
 		loadTeamsFailed       bool
 		localSSD              bool
+		arch                  vm.CPUArch
 		category              issueCategory
 		expectedPost          bool
 		expectedParams        map[string]string
 	}{
-		{true, false, false, false, otherErr, true,
+		{true, false, false, false, "", otherErr, true,
+
 			prefixAll(map[string]string{
 				"cloud":     "gce",
 				"encrypted": "false",
 				"fs":        "ext4",
 				"ssd":       "0",
 				"cpu":       "4",
+				"arch":      "amd64",
 				"localSSD":  "false",
 			}),
 		},
-		{true, false, false, true, clusterCreationErr, true,
+		{true, false, false, true, vm.ArchARM64, clusterCreationErr, true,
+
 			prefixAll(map[string]string{
 				"cloud":     "gce",
 				"encrypted": "false",
 				"fs":        "ext4",
 				"ssd":       "0",
 				"cpu":       "4",
+				"arch":      "arm64",
 				"localSSD":  "true",
 			}),
 		},
 		// Assert that release-blocker label exists when !nonReleaseBlocker
 		// Also ensure that in the event of a failed cluster creation,
 		// nil `vmOptions` and `clusterImpl` are not dereferenced
-		{false, true, false, false, sshErr, true,
+		{false, true, false, false, "", sshErr, true,
+
 			prefixAll(map[string]string{
 				"cloud": "gce",
 				"ssd":   "0",
@@ -143,17 +150,14 @@ func TestCreatePostRequest(t *testing.T) {
 			}),
 		},
 		//Simulate failure loading TEAMS.yaml
-		{true, false, true, false, otherErr, false, nil},
+		{true, false, true, false, "", otherErr, false, nil},
 	}
 
-<<<<<<< HEAD
-	reg, _ := makeTestRegistry(spec.GCE, "", "", false)
+	reg, err := makeTestRegistry(spec.GCE, "", "", false, false)
+	require.NoError(t, err)
 
-=======
-	reg := makeTestRegistry(spec.GCE, "", "", false, false)
->>>>>>> 0df3a03e781 (roachtest: require perf. tests to opt in via TestSpec.Benchmark)
 	for _, c := range testCases {
-		clusterSpec := reg.MakeClusterSpec(1)
+		clusterSpec := reg.MakeClusterSpec(1, spec.Arch(c.arch))
 
 		testSpec := &registry.TestSpec{
 			Name:              "github_test",
@@ -167,7 +171,7 @@ func TestCreatePostRequest(t *testing.T) {
 			l:    nilLogger(),
 		}
 
-		testClusterImpl := &clusterImpl{spec: clusterSpec}
+		testClusterImpl := &clusterImpl{spec: clusterSpec, arch: vm.ArchAMD64}
 		vo := vm.DefaultCreateOpts()
 		vmOpts := &vo
 

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -74,7 +74,8 @@ func TestShouldPost(t *testing.T) {
 		{false, 1, "token", "master", true},
 	}
 
-	reg, _ := makeTestRegistry(spec.GCE, "", "", false)
+	reg := makeTestRegistry(spec.GCE, "", "", false, false)
+
 	for _, c := range testCases {
 		t.Setenv("GITHUB_API_TOKEN", c.envGithubAPIToken)
 		t.Setenv("TC_BUILD_BRANCH", c.envTcBuildBranch)
@@ -145,8 +146,12 @@ func TestCreatePostRequest(t *testing.T) {
 		{true, false, true, false, otherErr, false, nil},
 	}
 
+<<<<<<< HEAD
 	reg, _ := makeTestRegistry(spec.GCE, "", "", false)
 
+=======
+	reg := makeTestRegistry(spec.GCE, "", "", false, false)
+>>>>>>> 0df3a03e781 (roachtest: require perf. tests to opt in via TestSpec.Benchmark)
 	for _, c := range testCases {
 		clusterSpec := reg.MakeClusterSpec(1)
 

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -40,6 +40,14 @@ type TestSpec struct {
 	// associated cluster expires. The timeout is always truncated to 10m before
 	// the test's cluster expires.
 	Timeout time.Duration
+	// Denotes whether the test is a roachperf benchmark. If true, the test is expected, but not required, to produce
+	// artifacts in Test.PerfArtifactsDir(), which get exported to the roachperf dashboard
+	// (see getPerfArtifacts() in test_runner.go).
+	// N.B. performance tests may choose to _assert_ on latency, throughput, or some other perf. metric, _without_
+	// exporting artifacts to the dashboard. E.g., see 'registerKVContention' and 'verifyTxnPerSecond'.
+	// N.B. performance tests may have different requirements than correctness tests, e.g., machine type/architecture.
+	// Thus, they must be opted into explicitly via this field.
+	Benchmark bool
 	// Tags is a set of tags associated with the test that allow grouping
 	// tests. If no tags are specified, the set ["default"] is automatically
 	// given.

--- a/pkg/cmd/roachtest/slack.go
+++ b/pkg/cmd/roachtest/slack.go
@@ -75,8 +75,6 @@ func postSlackReport(pass, fail, skip map[*testImpl]struct{}) {
 	switch {
 	case cloud != "":
 		prefix = strings.ToUpper(cloud)
-	case local:
-		prefix = "LOCAL"
 	default:
 		prefix = "GCE"
 	}

--- a/pkg/cmd/roachtest/spec/machine_type.go
+++ b/pkg/cmd/roachtest/spec/machine_type.go
@@ -10,15 +10,31 @@
 
 package spec
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+)
 
 // AWSMachineType selects a machine type given the desired number of CPUs.
-func AWSMachineType(cpus int, highmem bool) string {
+// Also returns the architecture of the selected machine type.
+func AWSMachineType(cpus int, highmem bool, arch vm.CPUArch) (string, vm.CPUArch) {
 	// TODO(erikgrinaker): These have significantly less RAM than
 	// their GCE counterparts. Consider harmonizing them.
 	family := "c5d" // 2 GB RAM per CPU
+	selectedArch := vm.ArchAMD64
+	if arch == vm.ArchFIPS {
+		selectedArch = vm.ArchFIPS
+	} else if arch == vm.ArchARM64 {
+		family = "c7g" // 2 GB RAM per CPU (graviton3)
+		selectedArch = vm.ArchARM64
+	}
+
 	if highmem {
 		family = "m5d" // 4 GB RAM per CPU
+		if arch == vm.ArchARM64 {
+			family = "m7g" // 4 GB RAM per CPU (graviton3)
+		}
 	}
 
 	var size string
@@ -33,36 +49,63 @@ func AWSMachineType(cpus int, highmem bool) string {
 		size = "4xlarge"
 	case cpus <= 36:
 		size = "9xlarge"
+		if family == "c7g" || family == "m7g" {
+			size = "8xlarge"
+		}
 	case cpus <= 72:
 		size = "18xlarge"
+		if family == "c7g" || family == "m7g" {
+			size = "16xlarge"
+		}
 	case cpus <= 96:
 		size = "24xlarge"
 	default:
 		panic(fmt.Sprintf("no aws machine type with %d cpus", cpus))
 	}
 
-	// There is no c5d.24xlarge.
+	// There is no m7g.24xlarge, fall back to m5d.24xlarge.
+	if family == "m7g" && size == "24xlarge" {
+		family = "m5d"
+		selectedArch = vm.ArchAMD64
+	}
+	// There is no c7g.24xlarge, fall back to c5d.24xlarge.
+	if family == "c7g" && size == "24xlarge" {
+		family = "c5d"
+		selectedArch = vm.ArchAMD64
+	}
+
+	// There is no c5d.24xlarge, fall back to m5d.24xlarge.
 	if family == "c5d" && size == "24xlarge" {
 		family = "m5d"
 	}
 
-	return fmt.Sprintf("%s.%s", family, size)
+	return fmt.Sprintf("%s.%s", family, size), selectedArch
 }
 
 // GCEMachineType selects a machine type given the desired number of CPUs.
-func GCEMachineType(cpus int, highmem bool) string {
+// Also returns the architecture of the selected machine type.
+func GCEMachineType(cpus int, highmem bool, arch vm.CPUArch) (string, vm.CPUArch) {
 	// TODO(peter): This is awkward: at or below 16 cpus, use n1-standard so that
 	// the machines have a decent amount of RAM. We could use custom machine
 	// configurations, but the rules for the amount of RAM per CPU need to be
 	// determined (you can't request any arbitrary amount of RAM).
 	series := "n1"
+	selectedArch := vm.ArchAMD64
+	if arch == vm.ArchFIPS {
+		selectedArch = vm.ArchFIPS
+	}
 	kind := "standard" // 3.75 GB RAM per CPU
 	if highmem {
 		kind = "highmem" // 6.5 GB RAM per CPU
 	} else if cpus > 16 {
 		kind = "highcpu" // 0.9 GB RAM per CPU
 	}
-	return fmt.Sprintf("%s-%s-%d", series, kind, cpus)
+	if arch == vm.ArchARM64 && !highmem && cpus <= 48 {
+		series = "t2a"
+		kind = "standard"
+		selectedArch = vm.ArchARM64
+	}
+	return fmt.Sprintf("%s-%s-%d", series, kind, cpus), selectedArch
 }
 
 // AzureMachineType selects a machine type given the desired number of CPUs.

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -10,11 +10,37 @@
 
 package spec
 
-import "time"
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+)
 
 // Option is the interface satisfied by options to MakeClusterSpec.
 type Option interface {
 	apply(spec *ClusterSpec)
+}
+
+type cloudOption string
+
+func (o cloudOption) apply(spec *ClusterSpec) {
+	spec.Cloud = string(o)
+}
+
+// Cloud controls what cloud is used to create the cluster.
+func Cloud(s string) Option {
+	return cloudOption(s)
+}
+
+type archOption string
+
+func (o archOption) apply(spec *ClusterSpec) {
+	spec.Arch = vm.CPUArch(o)
+}
+
+// Request specific CPU architecture.
+func Arch(arch vm.CPUArch) Option {
+	return archOption(arch)
 }
 
 type nodeCPUOption int

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -122,6 +122,7 @@ func (t *testImpl) BuildVersion() *version.Version {
 	return &t.buildVersion
 }
 
+// Cockroach returns the path to the cockroach binary.
 func (t *testImpl) Cockroach() string {
 	return t.cockroach
 }

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -41,5 +42,11 @@ func TestMakeTestRegistry(t *testing.T) {
 		require.Equal(t, "foo", s.InstanceType)
 		require.EqualValues(t, 4, s.CPUs)
 		require.True(t, s.TerminateOnMigration)
+
+		s = r.MakeClusterSpec(10, spec.CPU(16), spec.Arch(vm.ArchARM64))
+		require.EqualValues(t, 10, s.NodeCount)
+		require.Equal(t, "foo", s.InstanceType)
+		require.EqualValues(t, 16, s.CPUs)
+		require.EqualValues(t, vm.ArchARM64, s.Arch)
 	})
 }

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -20,8 +20,9 @@ import (
 
 func TestMakeTestRegistry(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "preferSSD", func(t *testing.T, preferSSD bool) {
-		r, err := makeTestRegistry(spec.AWS, "foo", "zone123", preferSSD)
+		r, err := makeTestRegistry(spec.AWS, "foo", "zone123", preferSSD, false)
 		require.NoError(t, err)
+
 		require.Equal(t, preferSSD, r.preferSSD)
 		require.Equal(t, "zone123", r.zones)
 		require.Equal(t, "foo", r.instanceType)
@@ -41,5 +42,4 @@ func TestMakeTestRegistry(t *testing.T) {
 		require.EqualValues(t, 4, s.CPUs)
 		require.True(t, s.TerminateOnMigration)
 	})
-
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -704,7 +704,9 @@ func (r *testRunner) runWorker(
 			}
 		} else {
 			// Upon success fetch the perf artifacts from the remote hosts.
-			getPerfArtifacts(ctx, l, c, t)
+			if t.spec.Benchmark {
+				getPerfArtifacts(ctx, l, c, t)
+			}
 		}
 	}
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -58,6 +58,8 @@ var (
 
 	// reference error used when cluster creation fails for a test
 	errClusterProvisioningFailed = fmt.Errorf("cluster could not be created")
+
+	prng, _ = randutil.NewLockedPseudoRand()
 )
 
 // testRunner runs tests.
@@ -351,11 +353,12 @@ func defaultClusterAllocator(
 	allocateCluster := func(
 		ctx context.Context,
 		t registry.TestSpec,
+		arch vm.CPUArch,
 		alloc *quotapool.IntAlloc,
 		artifactsDir string,
 		wStatus *workerStatus,
 	) (*clusterImpl, *vm.CreateOpts, error) {
-		wStatus.SetStatus("creating cluster")
+		wStatus.SetStatus(fmt.Sprintf("creating cluster (arch=%q)", arch))
 		defer wStatus.SetStatus("")
 
 		existingClusterName := clustersOpt.clusterName
@@ -372,6 +375,9 @@ func defaultClusterAllocator(
 				skipStop:       r.config.skipClusterStopOnAttach,
 				skipWipe:       r.config.skipClusterWipeOnAttach,
 			}
+			// TODO(srosenberg): we need to think about validation here. Attaching to an incompatible cluster, e.g.,
+			// using arm64 AMI with amd64 binary, would result in obscure errors. The test runner ensures compatibility
+			// during cluster reuse, whereas attachment via CLI (e.g., via roachprod) does not.
 			lopt.l.PrintfCtx(ctx, "Attaching to existing cluster %s for test %s", existingClusterName, t.Name)
 			c, err := attachToExistingCluster(ctx, existingClusterName, clusterL, t.Cluster, opt, r.cr)
 			if err == nil {
@@ -382,11 +388,11 @@ func defaultClusterAllocator(
 			}
 			// Fall through to create new cluster with name override.
 			lopt.l.PrintfCtx(
-				ctx, "Creating new cluster with custom name %q for test %s: %s",
-				clustersOpt.clusterName, t.Name, t.Cluster,
+				ctx, "Creating new cluster with custom name %q for test %s: %s (arch=%q)",
+				clustersOpt.clusterName, t.Name, t.Cluster, arch,
 			)
 		} else {
-			lopt.l.PrintfCtx(ctx, "Creating new cluster for test %s: %s", t.Name, t.Cluster)
+			lopt.l.PrintfCtx(ctx, "Creating new cluster for test %s: %s (arch=%q)", t.Name, t.Cluster, arch)
 		}
 
 		cfg := clusterConfig{
@@ -396,6 +402,7 @@ func defaultClusterAllocator(
 			username:     clustersOpt.user,
 			localCluster: clustersOpt.typ == localCluster,
 			alloc:        alloc,
+			arch:         arch,
 		}
 		return clusterFactory.newCluster(ctx, cfg, wStatus.SetStatus, lopt.tee)
 	}
@@ -405,6 +412,7 @@ func defaultClusterAllocator(
 type clusterAllocatorFn func(
 	ctx context.Context,
 	t registry.TestSpec,
+	arch vm.CPUArch,
 	alloc *quotapool.IntAlloc,
 	artifactsDir string,
 	wStatus *workerStatus,
@@ -485,8 +493,6 @@ func (r *testRunner) runWorker(
 		}
 	}()
 
-	prng, _ := randutil.NewPseudoRand()
-
 	// Loop until there's no more work in the pool, we get interrupted, or an
 	// error occurs.
 	for {
@@ -532,7 +538,7 @@ func (r *testRunner) runWorker(
 		// Attempt to reuse existing cluster.
 		if c != nil && testToRun.canReuseCluster {
 			err = func() error {
-				l.PrintfCtx(ctx, "Using existing cluster: %s. Wiping", c.name)
+				l.PrintfCtx(ctx, "Using existing cluster: %s (arch=%q). Wiping", c.name, c.arch)
 				if err := c.WipeE(ctx, l); err != nil {
 					return err
 				}
@@ -559,10 +565,48 @@ func (r *testRunner) runWorker(
 				// Let's attempt to create a fresh one.
 				testToRun.canReuseCluster = false
 			}
+			// sanity check
+			if c.spec.Cloud != spec.Local && c.spec.Arch != "" && c.arch != c.spec.Arch {
+				return errors.Newf("cluster arch %q does not match specified arch %q on cloud: %q", c.arch, c.spec.Arch, c.spec.Cloud)
+			}
+		}
+		arch := testToRun.spec.Cluster.Arch
+		// N.B. local cluster can mix different CPU architectures via emulation; e.g., mac silicon running x86.
+		if testToRun.canReuseCluster && c != nil && c.spec.Cloud != spec.Local {
+			// We're reusing a non-local cluster, so we must use the same arch.
+			arch = c.arch
+		}
+		if arch == "" {
+			// CPU architecture is unspecified, choose one according to the probability distribution.
+			arch = vm.ArchAMD64
+			if prng.Float64() < arm64Probability {
+				arch = vm.ArchARM64
+			} else if prng.Float64() < fipsProbability {
+				// N.B. branch is taken with probability (1 - arm64Probability) * fipsProbability which is P(fips | amd64).
+				// N.B. FIPS is only supported on 'amd64' at this time.
+				arch = vm.ArchFIPS
+			}
+			if testToRun.spec.Benchmark {
+				// TODO(srosenberg): enable after https://github.com/cockroachdb/cockroach/issues/104213
+				l.PrintfCtx(ctx, "Disabling randomly chosen arch=%q, %s", arch, testToRun.spec.Name)
+				arch = vm.ArchAMD64
+			}
+			l.PrintfCtx(ctx, "Using randomly chosen arch=%q, %s", arch, testToRun.spec.Name)
+		} else {
+			l.PrintfCtx(ctx, "Using specified arch=%q, %s", arch, testToRun.spec.Name)
+		}
+		// N.B. if canReuseCluster is false, then the previous cluster has been destroyed; new one will be created below.
+		if testToRun.canReuseCluster && c != nil && c.arch != arch {
+			// Non-local cluster that's being reused must have the same architecture as was ensured above.
+			if c.spec.Cloud != spec.Local {
+				return errors.New("infeasible path: non-local cluster arch mismatch")
+			}
+			// Local cluster is now reused to emulate a different CPU architecture.
+			c.arch = arch
 		}
 
 		// Verify that required native libraries are available.
-		if err = VerifyLibraries(testToRun.spec.NativeLibs); err != nil {
+		if err = VerifyLibraries(testToRun.spec.NativeLibs, arch); err != nil {
 			shout(ctx, l, stdout, "Library verification failed: %s", err)
 			return err
 		}
@@ -574,13 +618,14 @@ func (r *testRunner) runWorker(
 			// Create a new cluster if can't reuse or reuse attempt failed.
 			// N.B. non-reusable cluster would have been destroyed above.
 			wStatus.SetTest(nil /* test */, testToRun)
-			wStatus.SetStatus("creating cluster")
-			c, vmCreateOpts, clusterCreateErr = allocateCluster(ctx, testToRun.spec, testToRun.alloc, artifactsRootDir, wStatus)
+			c, vmCreateOpts, clusterCreateErr = allocateCluster(ctx, testToRun.spec, arch, testToRun.alloc, artifactsRootDir, wStatus)
 			if clusterCreateErr != nil {
 				clusterCreateErr = errors.Mark(clusterCreateErr, errClusterProvisioningFailed)
 				atomic.AddInt32(&r.numClusterErrs, 1)
 				shout(ctx, l, stdout, "Unable to create (or reuse) cluster for test %s due to: %s.",
 					testToRun.spec.Name, clusterCreateErr)
+			} else {
+				l.PrintfCtx(ctx, "Created new cluster for test %s: %s (arch=%q)", testToRun.spec.Name, c.Name(), arch)
 			}
 		}
 		// Prepare the test's logger. Always set this up with real files, using a
@@ -606,9 +651,9 @@ func (r *testRunner) runWorker(
 		}
 		t := &testImpl{
 			spec:                   &testToRun.spec,
-			cockroach:              cockroach,
-			cockroachShort:         cockroachShort,
-			deprecatedWorkload:     workload,
+			cockroach:              cockroach[arch],
+			cockroachShort:         cockroachShort[arch],
+			deprecatedWorkload:     workload[arch],
 			buildVersion:           r.buildVersion,
 			artifactsDir:           artifactsDir,
 			artifactsSpec:          artifactsSpec,
@@ -633,6 +678,9 @@ func (r *testRunner) runWorker(
 				shout(ctx, l, stdout, "failed to post issue: %s", err)
 			}
 		} else {
+			// Now run the test.
+			l.PrintfCtx(ctx, "Starting test: %s:%d on cluster=%s (arch=%q)", testToRun.spec.Name, testToRun.runNum, c.Name(), arch)
+
 			c.setTest(t)
 			err = c.PutLibraries(ctx, "./lib", t.spec.NativeLibs)
 

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -98,6 +98,7 @@ func nilLogger() *logger.Logger {
 func alwaysFailingClusterAllocator(
 	ctx context.Context,
 	t registry.TestSpec,
+	arch vm.CPUArch,
 	alloc *quotapool.IntAlloc,
 	artifactsDir string,
 	wStatus *workerStatus,

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -45,7 +45,8 @@ const defaultParallelism = 10
 
 func mkReg(t *testing.T) testRegistryImpl {
 	t.Helper()
-	r, err := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */)
+
+	r, err := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */, false /* benchOnly */)
 	require.NoError(t, err)
 	return r
 }
@@ -244,8 +245,7 @@ type runnerTest struct {
 
 func setupRunnerTest(t *testing.T, r testRegistryImpl, testFilters []string) *runnerTest {
 	ctx := context.Background()
-
-	tests := testsToRun(ctx, r, registry.NewTestFilter(testFilters))
+	tests := testsToRun(r, registry.NewTestFilter(testFilters))
 	cr := newClusterRegistry()
 
 	stopper := stop.NewStopper()
@@ -402,11 +402,12 @@ func TestRegistryPrepareSpec(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			r, err := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */)
+			r, err := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */, false /* benchOnly */)
 			if err != nil {
 				t.Fatal(err)
 			}
 			err = r.prepareSpec(&c.spec)
+
 			if !testutils.IsError(err, c.expectedErr) {
 				t.Fatalf("expected %q, but found %q", c.expectedErr, err.Error())
 			}
@@ -439,7 +440,8 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 			}
 		},
 	})
-	tests := testsToRun(ctx, r, registry.NewTestFilter(nil))
+
+	tests := testsToRun(r, registry.NewTestFilter(nil))
 	lopt := loggingOpt{
 		l:            nilLogger(),
 		tee:          logger.NoTee,

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -184,6 +184,7 @@ go_library(
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",
+        "//pkg/roachprod/vm",
         "//pkg/security/username",
         "//pkg/server",
         "//pkg/server/serverpb",

--- a/pkg/cmd/roachtest/tests/allocator.go
+++ b/pkg/cmd/roachtest/tests/allocator.go
@@ -145,27 +145,32 @@ func registerAllocator(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    `replicate/up/1to3`,
-		Owner:   registry.OwnerKV,
-		Cluster: r.MakeClusterSpec(4),
+		Name:      `replicate/up/1to3`,
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(4),
+
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAllocator(ctx, t, c, 1, 10.0)
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:    `replicate/rebalance/3to5`,
-		Owner:   registry.OwnerKV,
-		Cluster: r.MakeClusterSpec(6),
+		Name:      `replicate/rebalance/3to5`,
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(6),
+
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAllocator(ctx, t, c, 3, 42.0)
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:    `replicate/wide`,
-		Owner:   registry.OwnerKV,
-		Timeout: 10 * time.Minute,
-		Cluster: r.MakeClusterSpec(9, spec.CPU(1)),
-		Run:     runWideReplication,
+		Name:      `replicate/wide`,
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Timeout:   10 * time.Minute,
+		Cluster:   r.MakeClusterSpec(9, spec.CPU(1)),
+		Run:       runWideReplication,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/autoupgrade.go
+++ b/pkg/cmd/roachtest/tests/autoupgrade.go
@@ -260,6 +260,7 @@ func registerAutoUpgrade(r registry.Registry) {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
 			}
 			pred, err := PredecessorVersion(*t.BuildVersion())
+
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -617,6 +617,7 @@ func registerBackup(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:              fmt.Sprintf("backup/2TB/%s", backup2TBSpec),
 		Owner:             registry.OwnerDisasterRecovery,
+		Benchmark:         true,
 		Cluster:           backup2TBSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -25,7 +25,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -313,9 +313,6 @@ func cdcBasicTest(ctx context.Context, t test.Test, c cluster.Cluster, args cdcT
 }
 
 func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
-	if runtime.GOARCH == "arm64" {
-		t.Skip("Skipping cdc/bank under ARM64.")
-	}
 	// Make the logs dir on every node to work around the `roachprod get logs`
 	// spam.
 	c.Run(ctx, c.All(), `mkdir -p logs`)
@@ -683,9 +680,11 @@ func runCDCKafkaAuth(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:            "cdc/tpcc-1000",
-		Owner:           registry.OwnerCDC,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Name:      "cdc/tpcc-1000",
+		Owner:     registry.OwnerCDC,
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -698,9 +697,11 @@ func registerCDC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "cdc/tpcc-1000/sink=null",
-		Owner:           registry.OwnerCDC,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Name:      "cdc/tpcc-1000/sink=null",
+		Owner:     registry.OwnerCDC,
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		Tags:            []string{"manual"},
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -715,9 +716,11 @@ func registerCDC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "cdc/initial-scan",
-		Owner:           registry.OwnerCDC,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Name:      "cdc/initial-scan",
+		Owner:     registry.OwnerCDC,
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -731,9 +734,11 @@ func registerCDC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "cdc/sink-chaos",
-		Owner:           `cdc`,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Name:      "cdc/sink-chaos",
+		Owner:     `cdc`,
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -747,9 +752,11 @@ func registerCDC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "cdc/crdb-chaos",
-		Owner:           `cdc`,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Name:      "cdc/crdb-chaos",
+		Owner:     `cdc`,
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -770,7 +777,9 @@ func registerCDC(r registry.Registry) {
 		// TODO(mrtracy): This workload is designed to be running on a 20CPU nodes,
 		// but this cannot be allocated without some sort of configuration outside
 		// of this test. Look into it.
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -789,9 +798,11 @@ func registerCDC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "cdc/cloud-sink-gcs/rangefeed=true",
-		Owner:           `cdc`,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Name:      "cdc/cloud-sink-gcs/rangefeed=true",
+		Owner:     `cdc`,
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -810,9 +821,11 @@ func registerCDC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "cdc/pubsub-sink",
-		Owner:           `cdc`,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Name:      "cdc/pubsub-sink",
+		Owner:     `cdc`,
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -836,9 +849,11 @@ func registerCDC(r registry.Registry) {
 	// TODO(rui): Change to a shorter test as it just needs to validate
 	// permissions and shouldn't need to run a full 30m workload.
 	r.Add(registry.TestSpec{
-		Name:            "cdc/pubsub-sink/assume-role",
-		Owner:           `cdc`,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Name:      "cdc/pubsub-sink/assume-role",
+		Owner:     `cdc`,
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -863,9 +878,11 @@ func registerCDC(r registry.Registry) {
 	// TODO(rui): Change to a shorter test as it just needs to validate
 	// permissions and shouldn't need to run a full 30m workload.
 	r.Add(registry.TestSpec{
-		Name:            "cdc/cloud-sink-gcs/assume-role",
-		Owner:           `cdc`,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		Name:      "cdc/cloud-sink-gcs/assume-role",
+		Owner:     `cdc`,
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -903,18 +920,21 @@ func registerCDC(r registry.Registry) {
 		})
 	*/
 	r.Add(registry.TestSpec{
-		Name:            "cdc/kafka-auth",
-		Owner:           `cdc`,
-		Cluster:         r.MakeClusterSpec(1),
+		Name:      "cdc/kafka-auth",
+		Owner:     `cdc`,
+		Benchmark: true,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(1, spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCKafkaAuth(ctx, t, c)
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "cdc/bank",
-		Owner:           `cdc`,
-		Cluster:         r.MakeClusterSpec(4),
+		Name:  "cdc/bank",
+		Owner: `cdc`,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(4, spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Timeout:         30 * time.Minute,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -117,8 +117,9 @@ func registerConnectionLatencyTest(r registry.Registry) {
 	// Single region test.
 	numNodes := 3
 	r.Add(registry.TestSpec{
-		Name:  fmt.Sprintf("connection_latency/nodes=%d/certs", numNodes),
-		Owner: registry.OwnerSQLFoundations,
+		Name:      fmt.Sprintf("connection_latency/nodes=%d/certs", numNodes),
+		Owner:     registry.OwnerSQLFoundations,
+		Benchmark: true,
 		// Add one more node for load node.
 		Cluster: r.MakeClusterSpec(numNodes+1, spec.Zones(regionUsCentral)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -133,18 +134,20 @@ func registerConnectionLatencyTest(r registry.Registry) {
 	loadNodes := numZones
 
 	r.Add(registry.TestSpec{
-		Name:    fmt.Sprintf("connection_latency/nodes=%d/multiregion/certs", numMultiRegionNodes),
-		Owner:   registry.OwnerSQLFoundations,
-		Cluster: r.MakeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.Zones(geoZonesStr)),
+		Name:      fmt.Sprintf("connection_latency/nodes=%d/multiregion/certs", numMultiRegionNodes),
+		Owner:     registry.OwnerSQLFoundations,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.Zones(geoZonesStr)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones, false /*password*/)
 		},
 	})
 
 	r.Add(registry.TestSpec{
-		Name:    fmt.Sprintf("connection_latency/nodes=%d/multiregion/password", numMultiRegionNodes),
-		Owner:   registry.OwnerSQLFoundations,
-		Cluster: r.MakeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.Zones(geoZonesStr)),
+		Name:      fmt.Sprintf("connection_latency/nodes=%d/multiregion/password", numMultiRegionNodes),
+		Owner:     registry.OwnerSQLFoundations,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.Zones(geoZonesStr)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones, true /*password*/)
 		},

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -155,25 +155,31 @@ func registerCopyFrom(r registry.Registry) {
 	for _, tc := range testcases {
 		tc := tc
 		r.Add(registry.TestSpec{
-			Name:    fmt.Sprintf("copyfrom/crdb-atomic/sf=%d/nodes=%d", tc.sf, tc.nodes),
-			Owner:   registry.OwnerKV,
-			Cluster: r.MakeClusterSpec(tc.nodes),
+			Name:      fmt.Sprintf("copyfrom/crdb-atomic/sf=%d/nodes=%d", tc.sf, tc.nodes),
+			Owner:     registry.OwnerKV,
+			Benchmark: true,
+			Cluster:   r.MakeClusterSpec(tc.nodes),
+
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runCopyFromCRDB(ctx, t, c, tc.sf, true /*atomic*/)
 			},
 		})
 		r.Add(registry.TestSpec{
-			Name:    fmt.Sprintf("copyfrom/crdb-nonatomic/sf=%d/nodes=%d", tc.sf, tc.nodes),
-			Owner:   registry.OwnerKV,
-			Cluster: r.MakeClusterSpec(tc.nodes),
+			Name:      fmt.Sprintf("copyfrom/crdb-nonatomic/sf=%d/nodes=%d", tc.sf, tc.nodes),
+			Owner:     registry.OwnerKV,
+			Benchmark: true,
+			Cluster:   r.MakeClusterSpec(tc.nodes),
+
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runCopyFromCRDB(ctx, t, c, tc.sf, false /*atomic*/)
 			},
 		})
 		r.Add(registry.TestSpec{
-			Name:    fmt.Sprintf("copyfrom/pg/sf=%d/nodes=%d", tc.sf, tc.nodes),
-			Owner:   registry.OwnerKV,
-			Cluster: r.MakeClusterSpec(tc.nodes),
+			Name:      fmt.Sprintf("copyfrom/pg/sf=%d/nodes=%d", tc.sf, tc.nodes),
+			Owner:     registry.OwnerKV,
+			Benchmark: true,
+			Cluster:   r.MakeClusterSpec(tc.nodes),
+
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runCopyFromPG(ctx, t, c, tc.sf)
 			},

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -288,7 +288,9 @@ func registerDecommissionBenchSpec(r registry.Registry, benchSpec decommissionBe
 	r.Add(registry.TestSpec{
 		Name: fmt.Sprintf("decommissionBench/nodes=%d/cpu=%d/warehouses=%d%s",
 			benchSpec.nodes, benchSpec.cpus, benchSpec.warehouses, extraName),
-		Owner: registry.OwnerKV,
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+
 		Cluster: r.MakeClusterSpec(
 			benchSpec.nodes+addlNodeCount+1,
 			specOptions...,

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"reflect"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -100,9 +99,6 @@ func registerFollowerReads(r registry.Registry) {
 			spec.CPU(2),
 		),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if runtime.GOARCH == "arm64" {
-				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
-			}
 			runFollowerReadsMixedVersionSingleRegionTest(ctx, t, c, *t.BuildVersion())
 		},
 	})

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -162,6 +162,7 @@ func registerImportTPCC(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:              testName,
 			Owner:             registry.OwnerDisasterRecovery,
+			Benchmark:         true,
 			Cluster:           r.MakeClusterSpec(numNodes),
 			Timeout:           timeout,
 			EncryptionSupport: registry.EncryptionMetamorphic,
@@ -207,6 +208,7 @@ func registerImportTPCH(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:              fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
 			Owner:             registry.OwnerDisasterRecovery,
+			Benchmark:         true,
 			Cluster:           r.MakeClusterSpec(item.nodes),
 			Timeout:           item.timeout,
 			EncryptionSupport: registry.EncryptionMetamorphic,

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -359,6 +359,7 @@ func registerImportMixedVersion(r registry.Registry) {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
 			}
 			predV, err := PredecessorVersion(*t.BuildVersion())
+
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -31,10 +31,11 @@ import (
 func registerImportCancellation(r registry.Registry) {
 	for _, rangeTombstones := range []bool{true, false} {
 		r.Add(registry.TestSpec{
-			Name:    fmt.Sprintf(`import-cancellation/rangeTs=%t`, rangeTombstones),
-			Owner:   registry.OwnerDisasterRecovery,
-			Timeout: 4 * time.Hour,
-			Cluster: r.MakeClusterSpec(6, spec.CPU(32)),
+			Name:      fmt.Sprintf(`import-cancellation/rangeTs=%t`, rangeTombstones),
+			Owner:     registry.OwnerDisasterRecovery,
+			Benchmark: true,
+			Timeout:   4 * time.Hour,
+			Cluster:   r.MakeClusterSpec(6, spec.CPU(32)),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runImportCancellation(ctx, t, c, rangeTombstones)
 			},

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -34,9 +34,10 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 	}
 	geoZonesStr := strings.Join(geoZones, ",")
 	r.Add(registry.TestSpec{
-		Name:    fmt.Sprintf("indexes/%d/nodes=%d/multi-region", secondaryIndexes, nodes),
-		Owner:   registry.OwnerKV,
-		Cluster: r.MakeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.Zones(geoZonesStr)),
+		Name:      fmt.Sprintf("indexes/%d/nodes=%d/multi-region", secondaryIndexes, nodes),
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.Zones(geoZonesStr)),
 		// Uses CONFIGURE ZONE USING ... COPY FROM PARENT syntax.
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			firstAZ := geoZones[0]

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -140,9 +140,3 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 func registerIndexes(r registry.Registry) {
 	registerNIndexes(r, 2)
 }
-
-func registerIndexesBench(r registry.Registry) {
-	for i := 0; i <= 100; i++ {
-		registerNIndexes(r, i)
-	}
-}

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -297,10 +297,11 @@ func registerKV(r registry.Registry) {
 			skip = fmt.Sprintf("multi-store tests are not supported on cloud %s", cSpec.Cloud)
 		}
 		r.Add(registry.TestSpec{
-			Skip:    skip,
-			Name:    strings.Join(nameParts, "/"),
-			Owner:   owner,
-			Cluster: cSpec,
+			Skip:      skip,
+			Name:      strings.Join(nameParts, "/"),
+			Owner:     owner,
+			Benchmark: true,
+			Cluster:   cSpec,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runKV(ctx, t, c, opts)
 			},
@@ -313,9 +314,11 @@ func registerKV(r registry.Registry) {
 func registerKVContention(r registry.Registry) {
 	const nodes = 4
 	r.Add(registry.TestSpec{
-		Name:    fmt.Sprintf("kv/contention/nodes=%d", nodes),
-		Owner:   registry.OwnerKV,
-		Cluster: r.MakeClusterSpec(nodes + 1),
+		Name:      fmt.Sprintf("kv/contention/nodes=%d", nodes),
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(nodes + 1),
+
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))

--- a/pkg/cmd/roachtest/tests/ledger.go
+++ b/pkg/cmd/roachtest/tests/ledger.go
@@ -28,9 +28,10 @@ func registerLedger(r registry.Registry) {
 	// https://github.com/cockroachdb/cockroach/issues/66184
 	const azs = "us-central1-f,us-central1-b,us-central1-c"
 	r.Add(registry.TestSpec{
-		Name:    fmt.Sprintf("ledger/nodes=%d/multi-az", nodes),
-		Owner:   registry.OwnerKV,
-		Cluster: r.MakeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.Zones(azs)),
+		Name:      fmt.Sprintf("ledger/nodes=%d/multi-az", nodes),
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.Zones(azs)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			roachNodes := c.Range(1, nodes)
 			gatewayNodes := c.Range(1, nodes/3)

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -63,9 +63,11 @@ func registerLOQRecovery(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:              s.String(),
 			Owner:             registry.OwnerReplication,
+			Benchmark:         true,
 			Tags:              []string{`default`},
 			Cluster:           spec,
 			NonReleaseBlocker: true,
+
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runRecoverLossOfQuorum(ctx, t, c, testSpec)
 			},

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -65,9 +66,10 @@ func registerCDCMixedVersions(r registry.Registry) {
 		zones = teamcityAgentZone
 	}
 	r.Add(registry.TestSpec{
-		Name:            "cdc/mixed-versions",
-		Owner:           registry.OwnerTestEng,
-		Cluster:         r.MakeClusterSpec(5, spec.Zones(zones)),
+		Name:  "cdc/mixed-versions",
+		Owner: registry.OwnerTestEng,
+		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
+		Cluster:         r.MakeClusterSpec(5, spec.Zones(zones), spec.Arch(vm.ArchAMD64)),
 		Timeout:         timeout,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -34,6 +34,7 @@ func registerSchemaChangeMixedVersions(r registry.Registry) {
 			if runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
 			}
+
 			maxOps := 100
 			concurrency := 5
 			if c.IsLocal() {

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -15,7 +15,6 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"math/rand"
-	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -157,9 +156,6 @@ func registerRebalanceLoad(r registry.Registry) {
 			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(4), // the last node is just used to generate load
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if runtime.GOARCH == "arm64" {
-					t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
-				}
 				if c.IsLocal() {
 					concurrency = 32
 					fmt.Printf("lowering concurrency to %d in local testing\n", concurrency)

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -137,14 +137,3 @@ func RegisterTests(r registry.Registry) {
 	registerYCSB(r)
 	registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r)
 }
-
-// RegisterBenchmarks registers all benchmarks to the registry. This powers `roachtest bench`.
-//
-// TODO(tbg): it's unclear that `roachtest bench` is that useful, perhaps we make everything
-// a roachtest but use a `bench` tag to determine what tests to understand as benchmarks.
-func RegisterBenchmarks(r registry.Registry) {
-	registerIndexesBench(r)
-	registerTPCCBench(r)
-	registerKVBench(r)
-	registerTPCHBench(r)
-}

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -646,10 +646,12 @@ func registerRestore(r registry.Registry) {
 	withPauseTestName := fmt.Sprintf("restore%s/nodes=%d/with-pause", withPauseDataset.name(), 10)
 	withPauseTimeout := 3 * time.Hour
 	r.Add(registry.TestSpec{
-		Name:    withPauseTestName,
-		Owner:   registry.OwnerDisasterRecovery,
-		Cluster: r.MakeClusterSpec(10),
-		Timeout: withPauseTimeout,
+		Name:      withPauseTestName,
+		Owner:     registry.OwnerDisasterRecovery,
+		Cluster:   r.MakeClusterSpec(10),
+		Benchmark: true,
+		Timeout:   withPauseTimeout,
+
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -305,10 +305,12 @@ func makeIndexAddTpccTest(
 	spec spec.ClusterSpec, warehouses int, length time.Duration,
 ) registry.TestSpec {
 	return registry.TestSpec{
-		Name:    fmt.Sprintf("schemachange/index/tpcc/w=%d", warehouses),
-		Owner:   registry.OwnerSQLFoundations,
-		Cluster: spec,
-		Timeout: length * 3,
+		Name:      fmt.Sprintf("schemachange/index/tpcc/w=%d", warehouses),
+		Owner:     registry.OwnerSQLFoundations,
+		Benchmark: true,
+		Cluster:   spec,
+		Timeout:   length * 3,
+
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
@@ -423,10 +425,12 @@ func makeSchemaChangeDuringTPCC(
 	spec spec.ClusterSpec, warehouses int, length time.Duration,
 ) registry.TestSpec {
 	return registry.TestSpec{
-		Name:    "schemachange/during/tpcc",
-		Owner:   registry.OwnerSQLFoundations,
-		Cluster: spec,
-		Timeout: length * 3,
+		Name:      "schemachange/during/tpcc",
+		Owner:     registry.OwnerSQLFoundations,
+		Benchmark: true,
+		Cluster:   spec,
+		Timeout:   length * 3,
+
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -38,8 +38,9 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 	}
 	geoZonesStr := strings.Join(geoZones, ",")
 	r.Add(registry.TestSpec{
-		Name:  "schemachange/random-load",
-		Owner: registry.OwnerSQLFoundations,
+		Name:      "schemachange/random-load",
+		Owner:     registry.OwnerSQLFoundations,
+		Benchmark: true,
 		Cluster: r.MakeClusterSpec(
 			3,
 			spec.Geo(),
@@ -84,6 +85,7 @@ func registerRandomLoadBenchSpec(r registry.Registry, b randomLoadBenchSpec) {
 	r.Add(registry.TestSpec{
 		Name:       name,
 		Owner:      registry.OwnerSQLFoundations,
+		Benchmark:  true,
 		Cluster:    r.MakeClusterSpec(b.Nodes),
 		NativeLibs: registry.LibGEOS,
 		Skip:       "https://github.com/cockroachdb/cockroach/issues/56230",

--- a/pkg/cmd/roachtest/tests/scrub.go
+++ b/pkg/cmd/roachtest/tests/scrub.go
@@ -54,9 +54,11 @@ func makeScrubTPCCTest(
 	}
 
 	return registry.TestSpec{
-		Name:    fmt.Sprintf("scrub/%s/tpcc/w=%d", optionName, warehouses),
-		Owner:   registry.OwnerSQLQueries,
-		Cluster: r.MakeClusterSpec(numNodes),
+		Name:      fmt.Sprintf("scrub/%s/tpcc/w=%d", optionName, warehouses),
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(numNodes),
+
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses:   warehouses,

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -297,6 +297,7 @@ var tpccSupportedWarehouses = []struct {
 	// TODO(tbg): this number is copied from gce-n4cpu16. The real number should be a
 	// little higher, find out what it is.
 	{hardware: "gce-n5cpu16", v: version.MustParse(`v19.1.0-0`), warehouses: 1300},
+	{hardware: "aws-n5cpu16", v: version.MustParse(`v19.1.0-0`), warehouses: 2100},
 	// Ditto.
 	{hardware: "gce-n5cpu16", v: version.MustParse(`v2.1.0-0`), warehouses: 1300},
 }
@@ -504,6 +505,7 @@ func registerTPCC(r registry.Registry) {
 			runTPCCMixedHeadroom(ctx, t, c, cloud, 1)
 		},
 	})
+
 	r.Add(registry.TestSpec{
 		// run the same mixed-headroom test, but going back two versions
 		Name:              "tpcc/mixed-headroom/multiple-upgrades/" + mixedHeadroomSpec.String(),
@@ -1380,117 +1382,6 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 		ttycolor.Stdout(ttycolor.Green)
 		t.L().Printf("------\nMAX WAREHOUSES = %d\n------\n\n", res)
 		ttycolor.Stdout(ttycolor.Reset)
-	}
-}
-
-func registerTPCCBench(r registry.Registry) {
-	specs := []tpccBenchSpec{
-		{
-			Nodes: 3,
-			CPUs:  4,
-
-			LoadWarehouses: 1000,
-			EstimatedMax:   325,
-		},
-		{
-			Nodes: 3,
-			CPUs:  16,
-
-			LoadWarehouses: 2000,
-			EstimatedMax:   1300,
-		},
-		// objective 1, key result 1.
-		{
-			Nodes: 30,
-			CPUs:  16,
-
-			LoadWarehouses: 10000,
-			EstimatedMax:   5300,
-		},
-		// objective 1, key result 2.
-		{
-			Nodes:      18,
-			CPUs:       16,
-			LoadConfig: singlePartitionedLoadgen,
-
-			LoadWarehouses: 10000,
-			EstimatedMax:   8000,
-		},
-		// objective 2, key result 1.
-		{
-			Nodes: 7,
-			CPUs:  16,
-			Chaos: true,
-
-			LoadWarehouses: 5000,
-			EstimatedMax:   2000,
-		},
-		// objective 3, key result 1.
-		{
-			Nodes:        3,
-			CPUs:         16,
-			Distribution: multiZone,
-
-			LoadWarehouses: 2000,
-			EstimatedMax:   1000,
-		},
-		// objective 3, key result 2.
-		{
-			Nodes:        9,
-			CPUs:         16,
-			Distribution: multiRegion,
-			LoadConfig:   multiLoadgen,
-
-			LoadWarehouses: 12000,
-			EstimatedMax:   8000,
-		},
-		// objective 4, key result 2.
-		{
-			Nodes: 64,
-			CPUs:  16,
-
-			LoadWarehouses: 50000,
-			EstimatedMax:   40000,
-		},
-
-		// See https://github.com/cockroachdb/cockroach/issues/31409 for the next three specs.
-		{
-			Nodes: 6,
-			CPUs:  16,
-
-			LoadWarehouses: 5000,
-			EstimatedMax:   3000,
-			LoadConfig:     singlePartitionedLoadgen,
-		},
-		{
-			Nodes: 12,
-			CPUs:  16,
-
-			LoadWarehouses: 10000,
-			EstimatedMax:   6000,
-			LoadConfig:     singlePartitionedLoadgen,
-		},
-		{
-			Nodes: 24,
-			CPUs:  16,
-
-			LoadWarehouses: 20000,
-			EstimatedMax:   12000,
-			LoadConfig:     singlePartitionedLoadgen,
-		},
-
-		// Requested by @awoods87.
-		{
-			Nodes: 11,
-			CPUs:  32,
-
-			LoadWarehouses: 10000,
-			EstimatedMax:   8000,
-		},
-	}
-
-	for _, b := range specs {
-		registerTPCCBenchSpec(r, b)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1022,13 +1022,15 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    name,
-		Owner:   owner,
-		Cluster: nodes,
-		Tags:    b.Tags,
+		Name:      name,
+		Owner:     owner,
+		Benchmark: true,
+		Cluster:   nodes,
+		Tags:      b.Tags,
 		// NB: intentionally not enabling encryption-at-rest to produce
 		// consistent results.
 		EncryptionSupport: registry.EncryptionAlwaysDisabled,
+
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCCBench(ctx, t, c, b)
 		},

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -200,7 +200,9 @@ func registerTPCHConcurrency(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "tpch_concurrency",
 		Owner:   registry.OwnerSQLQueries,
+		Benchmark: true,
 		Cluster: r.MakeClusterSpec(numNodes),
+
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHConcurrency(ctx, t, c, true /* lowerRefreshSpansBytes */, false /* disableStreamer */)
 		},
@@ -230,9 +232,17 @@ func registerTPCHConcurrency(r registry.Registry) {
 
 	// TODO(yuzefovich): remove this once the streamer is stabilized.
 	r.Add(registry.TestSpec{
+<<<<<<< HEAD
 		Name:    "tpch_concurrency/no_streamer",
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(numNodes),
+=======
+		Name:      "tpch_concurrency/no_streamer",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Timeout:   timeout,
+		Cluster:   r.MakeClusterSpec(numNodes),
+>>>>>>> 0df3a03e781 (roachtest: require perf. tests to opt in via TestSpec.Benchmark)
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHConcurrency(ctx, t, c, true /* lowerRefreshSpansBytes */, true /* disableStreamer */)
 		},

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -198,10 +198,10 @@ func registerTPCHConcurrency(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    "tpch_concurrency",
-		Owner:   registry.OwnerSQLQueries,
+		Name:      "tpch_concurrency",
+		Owner:     registry.OwnerSQLQueries,
 		Benchmark: true,
-		Cluster: r.MakeClusterSpec(numNodes),
+		Cluster:   r.MakeClusterSpec(numNodes),
 
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHConcurrency(ctx, t, c, true /* lowerRefreshSpansBytes */, false /* disableStreamer */)
@@ -232,17 +232,11 @@ func registerTPCHConcurrency(r registry.Registry) {
 
 	// TODO(yuzefovich): remove this once the streamer is stabilized.
 	r.Add(registry.TestSpec{
-<<<<<<< HEAD
-		Name:    "tpch_concurrency/no_streamer",
-		Owner:   registry.OwnerSQLQueries,
-		Cluster: r.MakeClusterSpec(numNodes),
-=======
 		Name:      "tpch_concurrency/no_streamer",
 		Owner:     registry.OwnerSQLQueries,
 		Benchmark: true,
-		Timeout:   timeout,
 		Cluster:   r.MakeClusterSpec(numNodes),
->>>>>>> 0df3a03e781 (roachtest: require perf. tests to opt in via TestSpec.Benchmark)
+
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHConcurrency(ctx, t, c, true /* lowerRefreshSpansBytes */, true /* disableStreamer */)
 		},

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -172,9 +172,10 @@ func registerTPCHBenchSpec(r registry.Registry, b tpchBenchSpec) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    strings.Join(nameParts, "/"),
-		Owner:   registry.OwnerSQLQueries,
-		Cluster: r.MakeClusterSpec(numNodes),
+		Name:      strings.Join(nameParts, "/"),
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHBench(ctx, t, c, b)
 		},

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -102,6 +102,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// of #58489 is being addressed.
 	_ = schemaChangeStep
 	backupStep := func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+
 		// Verify that backups can be created in various configurations. This is
 		// important to test because changes in system tables might cause backups to
 		// fail in mixed-version clusters.

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -102,9 +102,10 @@ func registerYCSB(r registry.Registry) {
 			}
 			wl, cpus := wl, cpus
 			r.Add(registry.TestSpec{
-				Name:    name,
-				Owner:   registry.OwnerTestEng,
-				Cluster: r.MakeClusterSpec(4, spec.CPU(cpus)),
+				Name:      name,
+				Owner:     registry.OwnerTestEng,
+				Benchmark: true,
+				Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus)),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus, false /* rangeTombstone */)
 				},
@@ -112,9 +113,10 @@ func registerYCSB(r registry.Registry) {
 
 			if wl == "A" {
 				r.Add(registry.TestSpec{
-					Name:    fmt.Sprintf("zfs/ycsb/%s/nodes=3/cpu=%d", wl, cpus),
-					Owner:   registry.OwnerStorage,
-					Cluster: r.MakeClusterSpec(4, spec.CPU(cpus), spec.SetFileSystem(spec.Zfs)),
+					Name:      fmt.Sprintf("zfs/ycsb/%s/nodes=3/cpu=%d", wl, cpus),
+					Owner:     registry.OwnerStorage,
+					Benchmark: true,
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.SetFileSystem(spec.Zfs)),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, false /* rangeTombstone */)
 					},
@@ -123,9 +125,10 @@ func registerYCSB(r registry.Registry) {
 
 			if cpus == cpusWithGlobalMVCCRangeTombstone {
 				r.Add(registry.TestSpec{
-					Name:    fmt.Sprintf("%s/mvcc-range-keys=global", name),
-					Owner:   registry.OwnerTestEng,
-					Cluster: r.MakeClusterSpec(4, spec.CPU(cpus)),
+					Name:      fmt.Sprintf("%s/mvcc-range-keys=global", name),
+					Owner:     registry.OwnerTestEng,
+					Benchmark: true,
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus)),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, true /* rangeTombstone */)
 					},

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/ssh",
         "//pkg/roachprod/ui",
+        "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/aws",
         "//pkg/roachprod/vm/local",
         "//pkg/util",
@@ -54,6 +55,7 @@ go_test(
     embed = [":install"],
     deps = [
         "//pkg/roachprod/logger",
+        "//pkg/roachprod/vm",
         "//pkg/testutils",
         "//pkg/util/retry",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/roachprod/install/staging.go
+++ b/pkg/roachprod/install/staging.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
 )
 
@@ -98,30 +99,30 @@ var (
 )
 
 // ArchInfoForOS returns an ArchInfo for the given OS and Architecture if currently supported.
-func ArchInfoForOS(os string, arch string) (archInfo, error) {
-	if arch != "" && arch != "amd64" && arch != "arm64" && arch != "fips" {
+func ArchInfoForOS(os string, arch vm.CPUArch) (archInfo, error) {
+	if arch != "" && arch != vm.ArchAMD64 && arch != vm.ArchARM64 && arch != vm.ArchFIPS {
 		return archInfo{}, errors.Errorf("unsupported architecture %q", arch)
 	}
 
 	switch os {
 	case "linux":
-		if arch == "arm64" {
+		if arch == vm.ArchARM64 {
 			return linux_arm64_ArchInfo, nil
 		}
-		if arch == "fips" {
+		if arch == vm.ArchFIPS {
 			return linux_x86_64_fips_ArchInfo, nil
 		}
 		return linux_x86_64_ArchInfo, nil
 	case "darwin":
-		if arch == "arm64" {
+		if arch == vm.ArchARM64 {
 			return darwin_arm64_ArchInfo, nil
 		}
-		if arch == "fips" {
+		if arch == vm.ArchFIPS {
 			return archInfo{}, errors.Errorf("%q is not supported on %q", arch, os)
 		}
 		return darwin_x86_64_ArchInfo, nil
 	case "windows":
-		if arch == "fips" || arch == "arm64" {
+		if arch == vm.ArchFIPS || arch == vm.ArchARM64 {
 			return archInfo{}, errors.Errorf("%q is not supported on %q", arch, os)
 		}
 		return windowsArchInfo, nil
@@ -176,7 +177,7 @@ func StageApplication(
 	applicationName string,
 	version string,
 	os string,
-	arch string,
+	arch vm.CPUArch,
 	destDir string,
 ) error {
 	archInfo, err := ArchInfoForOS(os, arch)
@@ -226,7 +227,7 @@ func StageApplication(
 // URLsForApplication returns a slice of URLs that should be
 // downloaded for the given application.
 func URLsForApplication(
-	application string, version string, os string, arch string,
+	application string, version string, os string, arch vm.CPUArch,
 ) ([]*url.URL, error) {
 	archInfo, err := ArchInfoForOS(os, arch)
 	if err != nil {

--- a/pkg/roachprod/install/staging_test.go
+++ b/pkg/roachprod/install/staging_test.go
@@ -13,6 +13,7 @@ package install
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/stretchr/testify/require"
 )
 
@@ -322,7 +323,7 @@ func TestURLsForApplication(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := URLsForApplication(tt.args.application, tt.args.version, tt.args.os, tt.args.arch)
+			got, err := URLsForApplication(tt.args.application, tt.args.version, tt.args.os, vm.CPUArch(tt.args.arch))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("URLsForApplication() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/roachprod/prometheus/BUILD.bazel
+++ b/pkg/roachprod/prometheus/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
+        "//pkg/roachprod/vm",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_prometheus_client_golang//api/prometheus/v1:prometheus",
         "@com_github_prometheus_common//model",

--- a/pkg/roachprod/prometheus/prometheus.go
+++ b/pkg/roachprod/prometheus/prometheus.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
@@ -189,20 +190,25 @@ type Prometheus struct {
 
 // Init creates a prometheus instance on the given cluster.
 func Init(
-	ctx context.Context, l *logger.Logger, c *install.SyncedCluster, cfg Config,
+	ctx context.Context, l *logger.Logger, c *install.SyncedCluster, arch vm.CPUArch, cfg Config,
 ) (_ *Prometheus, _ error) {
+	binArch := "amd64"
+	if arch == vm.ArchARM64 {
+		binArch = "arm64"
+	}
+
 	if len(cfg.NodeExporter) > 0 {
 		// NB: when upgrading here, make sure to target a version that picks up this PR:
 		// https://github.com/prometheus/node_exporter/pull/2311
 		// At time of writing, there hasn't been a release in over half a year.
 		if err := c.RepeatRun(ctx, l, os.Stdout, os.Stderr, cfg.NodeExporter,
 			"download node exporter",
-			`
+			fmt.Sprintf(`
 (sudo systemctl stop node_exporter || true) &&
 rm -rf node_exporter && mkdir -p node_exporter && curl -fsSL \
-  https://github.com/prometheus/node_exporter/releases/download/v1.2.2/node_exporter-1.2.2.linux-amd64.tar.gz |
+  https://storage.googleapis.com/cockroach-fixtures/prometheus/node_exporter-1.2.2.linux-%s.tar.gz |
   tar zxv --strip-components 1 -C node_exporter
-`); err != nil {
+`, binArch)); err != nil {
 			return nil, err
 		}
 
@@ -235,9 +241,9 @@ sudo systemd-run --unit node_exporter --same-dir ./node_exporter`,
 		os.Stderr,
 		cfg.PrometheusNode,
 		"download prometheus",
-		`sudo rm -rf /tmp/prometheus && mkdir /tmp/prometheus && cd /tmp/prometheus &&
-			curl -fsSL https://storage.googleapis.com/cockroach-fixtures/prometheus/prometheus-2.27.1.linux-amd64.tar.gz | tar zxv --strip-components=1`,
-	); err != nil {
+		fmt.Sprintf(`sudo rm -rf /tmp/prometheus && mkdir /tmp/prometheus && cd /tmp/prometheus &&
+			curl -fsSL https://storage.googleapis.com/cockroach-fixtures/prometheus/prometheus-2.27.1.linux-%s.tar.gz | tar zxv --strip-components=1`,
+			binArch)); err != nil {
 		return nil, err
 	}
 	// create and upload prom config
@@ -279,14 +285,16 @@ sudo systemd-run --unit prometheus --same-dir \
 	if cfg.Grafana.Enabled {
 		// Install Grafana.
 		if err := c.RepeatRun(ctx, l,
-			os.Stdout,
-			os.Stderr, cfg.PrometheusNode, "install grafana",
-			`sudo apt-get install -qqy apt-transport-https &&
+			l.Stdout,
+			l.Stderr, cfg.PrometheusNode, "install grafana",
+			fmt.Sprintf(`
+sudo apt-get install -qqy apt-transport-https &&
 sudo apt-get install -qqy software-properties-common wget &&
-wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add - &&
-echo "deb https://packages.grafana.com/enterprise/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list &&
-sudo apt-get update -qqy && sudo apt-get install -qqy grafana-enterprise && sudo mkdir -p /var/lib/grafana/dashboards`,
-		); err != nil {
+sudo apt-get install -y adduser libfontconfig1 &&
+wget https://dl.grafana.com/enterprise/release/grafana-enterprise_9.2.3_%s.deb -O grafana-enterprise_9.2.3_%s.deb &&
+sudo dpkg -i grafana-enterprise_9.2.3_%s.deb &&
+sudo mkdir -p /var/lib/grafana/dashboards`,
+				binArch, binArch, binArch)); err != nil {
 			return nil, err
 		}
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -517,7 +517,7 @@ func Stage(
 		dir = stageDir
 	}
 
-	return install.StageApplication(ctx, l, c, applicationName, version, os, arch, dir)
+	return install.StageApplication(ctx, l, c, applicationName, version, os, vm.CPUArch(arch), dir)
 }
 
 // Reset resets all VMs in a cluster.
@@ -1357,7 +1357,7 @@ func StageURL(
 	if stageArch != "" {
 		arch = stageArch
 	}
-	urls, err := install.URLsForApplication(applicationName, version, os, arch)
+	urls, err := install.URLsForApplication(applicationName, version, os, vm.CPUArch(arch))
 	if err != nil {
 		return nil, err
 	}
@@ -1402,6 +1402,7 @@ func StartGrafana(
 	ctx context.Context,
 	l *logger.Logger,
 	clusterName string,
+	arch vm.CPUArch,
 	grafanaURL string,
 	promCfg *prometheus.Config, // passed iff grafanaURL is empty
 ) error {
@@ -1435,7 +1436,7 @@ func StartGrafana(
 			promCfg.WithGrafanaDashboard(grafanaURL)
 		}
 	}
-	_, err = prometheus.Init(ctx, l, c, *promCfg)
+	_, err = prometheus.Init(ctx, l, c, arch, *promCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -36,6 +36,7 @@ const (
 	// ProviderName is gce.
 	ProviderName        = "gce"
 	DefaultImage        = "ubuntu-2004-focal-v20210603"
+	ARM64Image          = "ubuntu-2004-focal-arm64-v20230523"
 	FIPSImage           = "ubuntu-pro-fips-2004-focal-v20230302"
 	defaultImageProject = "ubuntu-os-cloud"
 	FIPSImageProject    = "ubuntu-os-pro-cloud"
@@ -421,10 +422,34 @@ func (p *Provider) Create(
 	// Fixed args.
 	image := providerOpts.Image
 	imageProject := defaultImageProject
-	if opts.EnableFIPS {
+	useArmAMI := strings.HasPrefix(strings.ToLower(providerOpts.MachineType), "t2a-")
+	if useArmAMI && (opts.Arch != "" && opts.Arch != string(vm.ArchARM64)) {
+		return errors.Errorf("machine type %s is arm64, but requested arch is %s", providerOpts.MachineType, opts.Arch)
+	}
+	if useArmAMI && opts.SSDOpts.UseLocalSSD {
+		return errors.New("local SSDs are not supported with T2A instances, use --local-ssd=false")
+	}
+	if useArmAMI {
+		if len(providerOpts.Zones) == 0 {
+			zones = []string{"us-central1-a"}
+		} else {
+			for _, zone := range providerOpts.Zones {
+				if !strings.HasPrefix(zone, "us-central1-") {
+					return errors.New("T2A instances are not supported outside of us-central1")
+				}
+			}
+		}
+	}
+	//TODO(srosenberg): remove this once we have a better way to detect ARM64 machines
+	if useArmAMI {
+		image = ARM64Image
+		l.Printf("Using ARM64 AMI: %s for machine type: %s", image, providerOpts.MachineType)
+	}
+	if opts.Arch == string(vm.ArchFIPS) {
 		// NB: if FIPS is enabled, it overrides the image passed via CLI (--gce-image)
 		image = FIPSImage
 		imageProject = FIPSImageProject
+		l.Printf("Using FIPS-enabled AMI: %s for machine type: %s", image, providerOpts.MachineType)
 	}
 	args := []string{
 		"compute", "instances", "create",
@@ -495,7 +520,7 @@ func (p *Provider) Create(
 	}
 
 	// Create GCE startup script file.
-	filename, err := writeStartupScript(extraMountOpts, opts.SSDOpts.FileSystem, providerOpts.UseMultipleDisks, opts.EnableFIPS)
+	filename, err := writeStartupScript(extraMountOpts, opts.SSDOpts.FileSystem, providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS))
 	if err != nil {
 		return errors.Wrapf(err, "could not write GCE startup script to temp file")
 	}

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -34,10 +34,30 @@ const (
 	TagLifetime = "lifetime"
 	// TagRoachprod is roachprod tag const, value is true & false.
 	TagRoachprod = "roachprod"
+	// TagUsage indicates where a certain resource is used. "roachtest" is used
+	// as the key for roachtest created resources.
+	TagUsage = "usage"
+	// TagArch is the CPU architecture tag const.
+	TagArch = "arch"
+
+	ArchARM64 = CPUArch("arm64")
+	ArchAMD64 = CPUArch("amd64")
+	ArchFIPS  = CPUArch("fips")
 )
+
+type CPUArch string
 
 // GetDefaultLabelMap returns a label map for a common set of labels.
 func GetDefaultLabelMap(opts CreateOpts) map[string]string {
+	// Add architecture override tag, only if it was specified.
+	if opts.Arch != "" {
+		return map[string]string{
+			TagCluster:   opts.ClusterName,
+			TagLifetime:  opts.Lifetime.String(),
+			TagRoachprod: "true",
+			TagArch:      opts.Arch,
+		}
+	}
 	return map[string]string{
 		TagCluster:   opts.ClusterName,
 		TagLifetime:  opts.Lifetime.String(),
@@ -176,7 +196,7 @@ type CreateOpts struct {
 	CustomLabels map[string]string
 
 	GeoDistributed bool
-	EnableFIPS     bool
+	Arch           string
 	VMProviders    []string
 	SSDOpts        struct {
 		UseLocalSSD bool
@@ -197,6 +217,8 @@ func DefaultCreateOpts() CreateOpts {
 		GeoDistributed: false,
 		VMProviders:    []string{},
 		OsVolumeSize:   10,
+		// N.B. When roachprod is used via CLI, this will be overridden by {"roachprod":"true"}.
+		CustomLabels: map[string]string{"roachtest": "true"},
 	}
 	defaultCreateOpts.SSDOpts.UseLocalSSD = true
 	defaultCreateOpts.SSDOpts.NoExt4Barrier = true

--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -97,6 +97,12 @@ func NewPseudoRand() (*rand.Rand, int64) {
 	return rand.New(rand.NewSource(seed)), seed
 }
 
+// Same as NewPseudoRand, but the returned Rand is using thread safe underlying source.
+func NewLockedPseudoRand() (*rand.Rand, int64) {
+	seed := envutil.EnvOrDefaultInt64("COCKROACH_RANDOM_SEED", NewPseudoSeed())
+	return rand.New(NewLockedSource(seed)), seed
+}
+
 // NewTestRand returns an instance of math/rand.Rand seeded from rng, which is
 // seeded with the global seed. If the caller is a test with a different
 // path-qualified name than the previous caller, rng is reseeded from the global


### PR DESCRIPTION
Backport 2/2 commits from #103710.

/cc @cockroachdb/release

---

Previously, all roachtests used (cloud) machine types with the AMD64 (cpu) architecture. Recently [1], new CI infrastructure was added to run a clone of all the nightly roachtests, configured with FIPS; i.e., same AMD64 machine types, different AMI and crdb binary, patched with FIPS-certified openssl native code.

As of this PR, we add the capability to execute any roachtest in a cluster, configured with either
ARM64, FIPS, or AMD64 (default). This is controlled via the two CLI args: `metamorphic-arm64-probability` and `metamorphic-fips-probability`. The former denotes the probability (over the uniform distribution) of a new cluster provisioned using ARM64 VMs. The latter denotes the probability of a new AMD64 cluster provisioned with the FIPS-compliant (kernel) configuration.
In case a test is compatible only with AMD64, it's effectively excluded from the set; i.e., both
probabilities apply to compatible tests only.

Note, the two probabilties don't have to add up to 1. E.g., `metamorphic-arm64-probability==0.4`,
`metamorphic-fips-probability==0.2` denotes that ARM64 clusters are chosen ~40% of the time, whereas of the remaining ~60% AMD clusters, FIPS is chosen ~20%
of the time; i.e., ~12% of all clusters will use FIPS.

Note, the values '0' and '1' are absolute. Setting both 
to '0' is tantamount to the behavior before this PR.
Setting either to '1' enforces _all_ clusters 
are provisioned with either ARM64 or FIPS.
A test can specify its required architecture, in which 
case, it takes precedence over metamorphic settings.

This PR builds on [1], which enabled ARM64 provisioning for AWS in roachprod. We add ARM64 provisioning for GCE, i.e., T2A, as well as refactor 'arch' argument to
denote one of: AMD64, ARM64, FIPS, where the latter isn't formally a CPU architecture; however, it simplifies provisioning and binary staging.
We also modify roachprod.List to display CPU architecture, other than AMD64, with the machine type; this should make it easier to see which clusters are running ARM64 and FIPS configurations, as we ramp up their testing.

Epic: none
Release note: None
Release justification: ci/test only change

Resolves: https://github.com/cockroachdb/cockroach/issues/94957
Informs: https://github.com/cockroachdb/cockroach/issues/94986

[1] https://github.com/cockroachdb/cockroach/pull/99224
[2] https://github.com/cockroachdb/cockroach/pull/103243
