### PR TITLE
roachtest: add some shared-process multi-tenant configs

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -66,6 +66,7 @@ func registerKV(r registry.Registry) {
 		tracing                  bool // `trace.debug.enable`
 		tags                     map[string]struct{}
 		owner                    registry.Owner // defaults to KV
+		sharedProcessMT          bool
 	}
 	computeNumSplits := func(opts kvOptions) int {
 		// TODO(ajwerner): set this default to a more sane value or remove it and
@@ -131,6 +132,9 @@ func registerKV(r registry.Registry) {
 				t.Fatalf("failed to enable tracing: %v", err)
 			}
 		}
+		if opts.sharedProcessMT {
+			createInMemoryTenant(ctx, t, c, appTenantName, c.Range(1, nodes), false /* secure */)
+		}
 
 		t.Status("running workload")
 		m := c.NewMonitor(ctx, c.Range(1, nodes))
@@ -175,9 +179,13 @@ func registerKV(r registry.Registry) {
 				envFlags = " " + e
 			}
 
-			cmd := fmt.Sprintf("./workload run kv --tolerate-errors --init"+
-				histograms+concurrency+splits+duration+readPercent+batchSize+blockSize+sequential+envFlags+
-				" {pgurl:1-%d}", nodes)
+			url := fmt.Sprintf(" {pgurl:1-%d}", nodes)
+			if opts.sharedProcessMT {
+				url = fmt.Sprintf(" {pgurl:1-%d:%s}", nodes, appTenantName)
+			}
+			cmd := "./workload run kv --tolerate-errors --init" +
+				histograms + concurrency + splits + duration + readPercent +
+				batchSize + blockSize + sequential + envFlags + url
 			c.Run(ctx, c.Node(nodes+1), cmd)
 			return nil
 		})
@@ -187,20 +195,28 @@ func registerKV(r registry.Registry) {
 	for _, opts := range []kvOptions{
 		// Standard configs.
 		{nodes: 1, cpus: 8, readPercent: 0},
+		{nodes: 1, cpus: 8, readPercent: 0, sharedProcessMT: true},
 		// CPU overload test, to stress admission control.
 		{nodes: 1, cpus: 8, readPercent: 50, concMultiplier: 8192},
 		// IO write overload test, to stress admission control.
 		{nodes: 1, cpus: 8, readPercent: 0, concMultiplier: 4096, blockSize: 1 << 16 /* 64 KB */},
 		{nodes: 1, cpus: 8, readPercent: 95},
+		{nodes: 1, cpus: 8, readPercent: 95, sharedProcessMT: true},
 		{nodes: 1, cpus: 32, readPercent: 0},
+		{nodes: 1, cpus: 32, readPercent: 0, sharedProcessMT: true},
 		{nodes: 1, cpus: 32, readPercent: 95},
+		{nodes: 1, cpus: 32, readPercent: 95, sharedProcessMT: true},
 		{nodes: 3, cpus: 8, readPercent: 0},
+		{nodes: 3, cpus: 8, readPercent: 0, sharedProcessMT: true},
 		{nodes: 3, cpus: 8, readPercent: 95},
+		{nodes: 3, cpus: 8, readPercent: 95, sharedProcessMT: true},
 		{nodes: 3, cpus: 8, readPercent: 95, tracing: true, owner: registry.OwnerObsInf},
 		{nodes: 3, cpus: 8, readPercent: 0, splits: -1 /* no splits */},
 		{nodes: 3, cpus: 8, readPercent: 95, splits: -1 /* no splits */},
 		{nodes: 3, cpus: 32, readPercent: 0},
+		{nodes: 3, cpus: 32, readPercent: 0, sharedProcessMT: true},
 		{nodes: 3, cpus: 32, readPercent: 95},
+		{nodes: 3, cpus: 32, readPercent: 95, sharedProcessMT: true},
 		{nodes: 3, cpus: 32, readPercent: 0, splits: -1 /* no splits */},
 		{nodes: 3, cpus: 32, readPercent: 95, splits: -1 /* no splits */},
 		{nodes: 3, cpus: 32, readPercent: 0, globalMVCCRangeTombstone: true},
@@ -304,6 +320,9 @@ func registerKV(r registry.Registry) {
 		}
 		if opts.tracing {
 			nameParts = append(nameParts, "tracing")
+		}
+		if opts.sharedProcessMT {
+			nameParts = append(nameParts, "mt-shared-process")
 		}
 		owner := registry.OwnerTestEng
 		if opts.owner != "" {

--- a/pkg/cmd/roachtest/tests/multitenant_shared_process.go
+++ b/pkg/cmd/roachtest/tests/multitenant_shared_process.go
@@ -34,7 +34,6 @@ func registerMultiTenantSharedProcess(r registry.Registry) {
 		Timeout: 1 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			var (
-				appTenantName  = "app"
 				tpccWarehouses = 500
 				crdbNodes      = c.Range(1, crdbNodeCount)
 				workloadNode   = c.Node(crdbNodeCount + 1)

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -28,7 +28,7 @@ import (
 // single-tenant deployment followed by a run of all queries in a multi-tenant
 // deployment with a single SQL instance.
 func runMultiTenantTPCH(
-	ctx context.Context, t test.Test, c cluster.Cluster, enableDirectScans bool,
+	ctx context.Context, t test.Test, c cluster.Cluster, enableDirectScans bool, sharedProcess bool,
 ) {
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(1))
@@ -91,66 +91,76 @@ func runMultiTenantTPCH(
 	}
 
 	// Now we create a tenant and run all TPCH queries within it.
-	const (
-		tenantID       = 123
-		tenantHTTPPort = 8081
-		tenantSQLPort  = 30258
-		tenantNode     = 1
-	)
-	_, err := singleTenantConn.Exec(`SELECT crdb_internal.create_tenant($1::INT)`, tenantID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tenant := createTenantNode(ctx, t, c, c.All(), tenantID, tenantNode, tenantHTTPPort, tenantSQLPort)
-	tenant.start(ctx, t, c, "./cockroach")
-	multiTenantConn, err := gosql.Open("postgres", tenant.pgURL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Allow the tenant to be able to split tables. We need to run a dummy split
-	// in order to make sure the capability is propagated before starting the
-	// test, otherwise importing tpch may fail.
-	_, err = singleTenantConn.Exec(
-		`ALTER TENANT [$1] SET CLUSTER SETTING sql.split_at.allow_for_secondary_tenant.enabled=true`, tenantID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = singleTenantConn.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_split=true`, tenantID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testutils.SucceedsSoon(t, func() error {
-		if _, err := multiTenantConn.Exec(`CREATE TABLE IF NOT EXISTS dummysplit (a INT)`); err != nil {
-			return err
+	if sharedProcess {
+		db := createInMemoryTenant(ctx, t, c, appTenantName, c.All(), true /* secure */)
+		url := fmt.Sprintf("{pgurl:1:%s}", appTenantName)
+		runTPCH(db, url, 1 /* setupIdx */)
+	} else {
+		const (
+			tenantID       = 123
+			tenantHTTPPort = 8081
+			tenantSQLPort  = 30258
+			tenantNode     = 1
+		)
+		_, err := singleTenantConn.Exec(`SELECT crdb_internal.create_tenant($1::INT)`, tenantID)
+		if err != nil {
+			t.Fatal(err)
 		}
-		_, err = multiTenantConn.Exec(`ALTER TABLE dummysplit SPLIT AT VALUES (0)`)
-		return err
-	})
-	runTPCH(multiTenantConn, "'"+tenant.secureURL()+"'", 1 /* setupIdx */)
+		tenant := createTenantNode(ctx, t, c, c.All(), tenantID, tenantNode, tenantHTTPPort, tenantSQLPort)
+		tenant.start(ctx, t, c, "./cockroach")
+		multiTenantConn, err := gosql.Open("postgres", tenant.pgURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Allow the tenant to be able to split tables. We need to run a dummy
+		// split in order to make sure the capability is propagated before
+		// starting the test, otherwise importing tpch may fail.
+		_, err = singleTenantConn.Exec(
+			`ALTER TENANT [$1] SET CLUSTER SETTING sql.split_at.allow_for_secondary_tenant.enabled=true`, tenantID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = singleTenantConn.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_split=true`, tenantID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		testutils.SucceedsSoon(t, func() error {
+			if _, err := multiTenantConn.Exec(`CREATE TABLE IF NOT EXISTS dummysplit (a INT)`); err != nil {
+				return err
+			}
+			_, err = multiTenantConn.Exec(`ALTER TABLE dummysplit SPLIT AT VALUES (0)`)
+			return err
+		})
+		runTPCH(multiTenantConn, "'"+tenant.secureURL()+"'", 1 /* setupIdx */)
+	}
 
 	// Analyze the runtimes of both setups.
 	perfHelper.compareSetups(t, numRunsPerQuery, nil /* timesCallback */)
 }
 
 func registerMultiTenantTPCH(r registry.Registry) {
-	r.Add(registry.TestSpec{
-		Name:      "multitenant/tpch",
-		Owner:     registry.OwnerSQLQueries,
-		Benchmark: true,
-		Cluster:   r.MakeClusterSpec(1 /* nodeCount */),
-		Leases:    registry.MetamorphicLeases,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runMultiTenantTPCH(ctx, t, c, false /* enableDirectScans */)
-		},
-	})
-	r.Add(registry.TestSpec{
-		Name:      "multitenant/tpch_direct_scans",
-		Owner:     registry.OwnerSQLQueries,
-		Benchmark: true,
-		Cluster:   r.MakeClusterSpec(1 /* nodeCount */),
-		Leases:    registry.MetamorphicLeases,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runMultiTenantTPCH(ctx, t, c, true /* enableDirectScans */)
-		},
-	})
+	for _, sharedProcess := range []bool{false, true} {
+		for _, enableDirectScans := range []bool{false, true} {
+			sharedProcess, enableDirectScans := sharedProcess, enableDirectScans
+			name := "multitenant/tpch"
+			if sharedProcess {
+				name += "/shared_process"
+			} else {
+				name += "/separate_process"
+			}
+			if enableDirectScans {
+				name += "/enable_direct_scans"
+			}
+			r.Add(registry.TestSpec{
+				Name:      name,
+				Owner:     registry.OwnerSQLQueries,
+				Benchmark: true,
+				Cluster:   r.MakeClusterSpec(1 /* nodeCount */),
+				Leases:    registry.MetamorphicLeases,
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runMultiTenantTPCH(ctx, t, c, enableDirectScans, sharedProcess)
+				},
+			})
+		}
+	}
 }

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -12,6 +12,7 @@ package tests
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"math"
 	"math/rand"
@@ -807,6 +808,14 @@ func registerTPCC(r registry.Registry) {
 		EstimatedMax:   gceOrAws(cloud, 750, 900),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
+		Nodes: 3,
+		CPUs:  4,
+
+		LoadWarehouses:  1000,
+		EstimatedMax:    gceOrAws(cloud, 750, 900),
+		SharedProcessMT: true,
+	})
+	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:                        3,
 		CPUs:                         4,
 		EnableDefaultScheduledBackup: true,
@@ -820,6 +829,15 @@ func registerTPCC(r registry.Registry) {
 		LoadWarehouses: gceOrAws(cloud, 3500, 3900),
 		EstimatedMax:   gceOrAws(cloud, 2900, 3500),
 		Tags:           registry.Tags(`aws`),
+	})
+	registerTPCCBenchSpec(r, tpccBenchSpec{
+		Nodes: 3,
+		CPUs:  16,
+
+		LoadWarehouses:  gceOrAws(cloud, 3500, 3900),
+		EstimatedMax:    gceOrAws(cloud, 2900, 3500),
+		Tags:            registry.Tags(`aws`),
+		SharedProcessMT: true,
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,
@@ -1009,6 +1027,9 @@ type tpccBenchSpec struct {
 	// ExpirationLeases enables use of expiration-based leases.
 	ExpirationLeases             bool
 	EnableDefaultScheduledBackup bool
+	// SharedProcessMT, if true, indicates that the cluster should run in
+	// shared-process mode of multi-tenancy.
+	SharedProcessMT bool
 }
 
 // partitions returns the number of partitions specified to the load generator.
@@ -1096,6 +1117,10 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 		nameParts = append(nameParts, "lease=expiration")
 	}
 
+	if b.SharedProcessMT {
+		nameParts = append(nameParts, "mt-shared-process")
+	}
+
 	name := strings.Join(nameParts, "/")
 
 	numNodes := b.Nodes + b.LoadConfig.numLoadNodes(b.Distribution)
@@ -1123,12 +1148,10 @@ func loadTPCCBench(
 	ctx context.Context,
 	t test.Test,
 	c cluster.Cluster,
+	db *gosql.DB,
 	b tpccBenchSpec,
 	roachNodes, loadNode option.NodeListOption,
 ) error {
-	db := c.Conn(ctx, t.L(), 1)
-	defer db.Close()
-
 	// Check if the dataset already exists and is already large enough to
 	// accommodate this benchmarking. If so, we can skip the fixture RESTORE.
 	if _, err := db.ExecContext(ctx, `USE tpcc`); err == nil {
@@ -1176,7 +1199,11 @@ func loadTPCCBench(
 	t.L().Printf("restoring tpcc fixture\n")
 	err := WaitFor3XReplication(ctx, t, db)
 	require.NoError(t, err)
-	cmd := tpccImportCmd(b.LoadWarehouses, loadArgs)
+	var pgurl string
+	if b.SharedProcessMT {
+		pgurl = fmt.Sprintf("{pgurl%s:%s}", roachNodes[:1], appTenantName)
+	}
+	cmd := tpccImportCmd(b.LoadWarehouses, loadArgs, pgurl)
 	if err = c.RunE(ctx, roachNodes[:1], cmd); err != nil {
 		return err
 	}
@@ -1197,9 +1224,13 @@ func loadTPCCBench(
 	maxRate := tpccMaxRate(b.EstimatedMax)
 	rampTime := (1 * rebalanceWait) / 4
 	loadTime := (3 * rebalanceWait) / 4
+	var tenantSuffix string
+	if b.SharedProcessMT {
+		tenantSuffix = fmt.Sprintf(":%s", appTenantName)
+	}
 	cmd = fmt.Sprintf("./cockroach workload run tpcc --warehouses=%d --workers=%d --max-rate=%d "+
-		"--wait=false --ramp=%s --duration=%s --scatter --tolerate-errors {pgurl%s}",
-		b.LoadWarehouses, b.LoadWarehouses, maxRate, rampTime, loadTime, roachNodes)
+		"--wait=false --ramp=%s --duration=%s --scatter --tolerate-errors {pgurl%s%s}",
+		b.LoadWarehouses, b.LoadWarehouses, maxRate, rampTime, loadTime, roachNodes, tenantSuffix)
 	if _, err := c.RunWithDetailsSingleNode(ctx, t.L(), loadNode, cmd); err != nil {
 		return err
 	}
@@ -1242,6 +1273,14 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 	// Don't encrypt in tpccbench tests.
 	startOpts, settings := b.startOpts()
 	c.Start(ctx, t.L(), startOpts, settings, roachNodes)
+
+	var db *gosql.DB
+	if b.SharedProcessMT {
+		db = createInMemoryTenant(ctx, t, c, appTenantName, roachNodes, false /* secure */)
+	} else {
+		db = c.Conn(ctx, t.L(), 1)
+	}
+
 	useHAProxy := b.Chaos
 	const restartWait = 15 * time.Second
 	{
@@ -1271,7 +1310,7 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 		m := c.NewMonitor(ctx, roachNodes)
 		m.Go(func(ctx context.Context) error {
 			t.Status("setting up dataset")
-			return loadTPCCBench(ctx, t, c, b, roachNodes, c.Node(loadNodes[0]))
+			return loadTPCCBench(ctx, t, c, db, b, roachNodes, c.Node(loadNodes[0]))
 		})
 		m.Wait()
 	}
@@ -1367,10 +1406,14 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 				}
 				t.Status(fmt.Sprintf("running benchmark, warehouses=%d", warehouses))
 				histogramsPath := fmt.Sprintf("%s/warehouses=%d/stats.json", t.PerfArtifactsDir(), warehouses)
+				var tenantSuffix string
+				if b.SharedProcessMT {
+					tenantSuffix = fmt.Sprintf(":%s", appTenantName)
+				}
 				cmd := fmt.Sprintf("./cockroach workload run tpcc --warehouses=%d --active-warehouses=%d "+
-					"--tolerate-errors --ramp=%s --duration=%s%s --histograms=%s {pgurl%s}",
+					"--tolerate-errors --ramp=%s --duration=%s%s --histograms=%s {pgurl%s%s}",
 					b.LoadWarehouses, warehouses, rampDur,
-					loadDur, extraFlags, histogramsPath, sqlGateways)
+					loadDur, extraFlags, histogramsPath, sqlGateways, tenantSuffix)
 				err := c.RunE(ctx, group.loadNodes, cmd)
 				loadDone <- timeutil.Now()
 				if err != nil {

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -66,6 +66,9 @@ func performClusterSetup(t test.Test, conn *gosql.DB, clusterSetup []string) {
 }
 
 type tpchVecTestCase interface {
+	// sharedProcessMT returns whether this test is running in shared-process
+	// multi-tenant mode.
+	sharedProcessMT() bool
 	// getRunConfig returns the configuration of tpchvec test run.
 	getRunConfig() tpchVecTestRunConfig
 	// preQueryRunHook is called before each tpch query is run.
@@ -81,6 +84,10 @@ type tpchVecTestCase interface {
 // tpchVecTestCaseBase is a default tpchVecTestCase implementation that can be
 // embedded and extended.
 type tpchVecTestCaseBase struct{}
+
+func (b tpchVecTestCaseBase) sharedProcessMT() bool {
+	return false
+}
 
 func (b tpchVecTestCaseBase) getRunConfig() tpchVecTestRunConfig {
 	return tpchVecTestRunConfig{
@@ -210,16 +217,24 @@ type tpchVecPerfTest struct {
 
 	settingName       string
 	slownessThreshold float64
+	sharedProcess     bool
 }
 
 var _ tpchVecTestCase = &tpchVecPerfTest{}
 
-func newTpchVecPerfTest(settingName string, slownessThreshold float64) *tpchVecPerfTest {
+func newTpchVecPerfTest(
+	settingName string, slownessThreshold float64, sharedProcessMT bool,
+) *tpchVecPerfTest {
 	return &tpchVecPerfTest{
 		tpchVecPerfHelper: newTpchVecPerfHelper([]string{"OFF", "ON"}),
 		settingName:       settingName,
 		slownessThreshold: slownessThreshold,
+		sharedProcess:     sharedProcessMT,
 	}
+}
+
+func (p tpchVecPerfTest) sharedProcessMT() bool {
+	return p.sharedProcess
 }
 
 func (p tpchVecPerfTest) getRunConfig() tpchVecTestRunConfig {
@@ -264,7 +279,7 @@ func (p *tpchVecPerfTest) postTestRunHook(
 				performClusterSetup(t, conn, setup)
 				result, err := c.RunWithDetailsSingleNode(
 					ctx, t.L(), c.Node(1),
-					getTPCHVecWorkloadCmd(runConfig.numRunsPerQuery, queryNum),
+					getTPCHVecWorkloadCmd(runConfig.numRunsPerQuery, queryNum, p.sharedProcess),
 				)
 				workloadOutput := result.Stdout + result.Stderr
 				t.L().Printf(workloadOutput)
@@ -479,13 +494,17 @@ func (d tpchVecDiskTest) getRunConfig() tpchVecTestRunConfig {
 	return runConfig
 }
 
-func getTPCHVecWorkloadCmd(numRunsPerQuery, queryNum int) string {
+func getTPCHVecWorkloadCmd(numRunsPerQuery, queryNum int, sharedProcessMT bool) string {
+	url := "{pgurl:1}"
+	if sharedProcessMT {
+		url = fmt.Sprintf("{pgurl:1:%s}", appTenantName)
+	}
 	// Note that we use --default-vectorize flag which tells tpch workload to
 	// use the current cluster setting sql.defaults.vectorize which must have
 	// been set correctly in preQueryRunHook.
 	return fmt.Sprintf("./workload run tpch --concurrency=1 --db=tpch "+
-		"--default-vectorize --max-ops=%d --queries=%d {pgurl:1} --enable-checks=true",
-		numRunsPerQuery, queryNum)
+		"--default-vectorize --max-ops=%d --queries=%d %s --enable-checks=true",
+		numRunsPerQuery, queryNum, url)
 }
 
 func baseTestRun(
@@ -497,7 +516,7 @@ func baseTestRun(
 			tc.preQueryRunHook(t, conn, setup)
 			result, err := c.RunWithDetailsSingleNode(
 				ctx, t.L(), c.Node(1),
-				getTPCHVecWorkloadCmd(runConfig.numRunsPerQuery, queryNum),
+				getTPCHVecWorkloadCmd(runConfig.numRunsPerQuery, queryNum, tc.sharedProcessMT()),
 			)
 			workloadOutput := result.Stdout + result.Stderr
 			t.L().Printf(workloadOutput)
@@ -574,10 +593,23 @@ func runTPCHVec(
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", firstNode)
 	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
 
-	conn := c.Conn(ctx, t.L(), 1)
+	var conn *gosql.DB
+	var disableMergeQueue bool
+	if testCase.sharedProcessMT() {
+		singleTenantConn := c.Conn(ctx, t.L(), 1)
+		// Disable merge queue in the system tenant.
+		if _, err := singleTenantConn.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
+			t.Fatal(err)
+		}
+		conn = createInMemoryTenant(ctx, t, c, appTenantName, c.All(), false /* secure */)
+	} else {
+		conn = c.Conn(ctx, t.L(), 1)
+		disableMergeQueue = true
+	}
+
 	t.Status("restoring TPCH dataset for Scale Factor 1")
 	if err := loadTPCHDataset(
-		ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), true, /* disableMergeQueue */
+		ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), disableMergeQueue,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -606,6 +638,7 @@ func registerTPCHVec(r registry.Registry) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(
 				"sql.defaults.vectorize", /* settingName */
 				1.5,                      /* slownessThreshold */
+				false,                    /* sharedProcessMT */
 			), baseTestRun)
 		},
 	})
@@ -638,6 +671,35 @@ func registerTPCHVec(r registry.Registry) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(
 				"sql.distsql.use_streamer.enabled", /* settingName */
 				1.5,                                /* slownessThreshold */
+				false,                              /* sharedProcessMT */
+			), baseTestRun)
+		},
+	})
+
+	r.Add(registry.TestSpec{
+		Name:      "tpchvec/direct_scans",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(tpchVecNodeCount),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCHVec(ctx, t, c, newTpchVecPerfTest(
+				"sql.distsql.direct_columnar_scans.enabled", /* settingName */
+				1.5,   /* slownessThreshold */
+				false, /* sharedProcessMT */
+			), baseTestRun)
+		},
+	})
+
+	r.Add(registry.TestSpec{
+		Name:      "tpchvec/direct_scans/mt-shared-process",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(tpchVecNodeCount),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCHVec(ctx, t, c, newTpchVecPerfTest(
+				"sql.distsql.direct_columnar_scans.enabled", /* settingName */
+				1.5,  /* slownessThreshold */
+				true, /* sharedProcessMT */
 			), baseTestRun)
 		},
 	})


### PR DESCRIPTION
This PR adds shared-process multi-tenant configs to `multitenant/tpch`, `tpchvec`, `tpccbench`, `kv0`, and `kv95` roachtests. The comparison between single-tenant and shared-process multi-tenant shows that there is no significant difference on `multitenant/tpch` and `tpchvec` but there is a perf hit of 2-8% on all other tests. See #104379 for more details.

Fixes: #104379.

Release note: None