### PR TITLE
release-23.1: roachtest: add `failover` chaos tests

### DIFF
--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -205,15 +205,15 @@ func (p clusterReusePolicyOption) apply(spec *ClusterSpec) {
 	spec.ReusePolicy = p.p
 }
 
-type preferSSDOption struct{}
+type preferLocalSSDOption bool
 
-func (*preferSSDOption) apply(spec *ClusterSpec) {
-	spec.PreferLocalSSD = true
+func (o preferLocalSSDOption) apply(spec *ClusterSpec) {
+	spec.PreferLocalSSD = bool(o)
 }
 
-// PreferSSD prefers using local SSD, when possible.
-func PreferSSD() Option {
-	return &preferSSDOption{}
+// PreferLocalSSD specifies whether to prefer using local SSD, when possible.
+func PreferLocalSSD(prefer bool) Option {
+	return preferLocalSSDOption(prefer)
 }
 
 type terminateOnMigrationOption struct{}

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -85,7 +85,7 @@ func (r *testRegistryImpl) MakeClusterSpec(nodeCount int, opts ...spec.Option) s
 	// overrides the SSD and zones settings from the registry.
 	var finalOpts []spec.Option
 	if r.preferSSD {
-		finalOpts = append(finalOpts, spec.PreferSSD())
+		finalOpts = append(finalOpts, spec.PreferLocalSSD(true))
 	}
 	if r.zones != "" {
 		finalOpts = append(finalOpts, spec.Zones(r.zones))

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -29,7 +29,8 @@ func TestMakeTestRegistry(t *testing.T) {
 		require.Equal(t, "foo", r.instanceType)
 		require.Equal(t, spec.AWS, r.cloud)
 
-		s := r.MakeClusterSpec(100, spec.Geo(), spec.Zones("zone99"), spec.CPU(12), spec.PreferSSD())
+		s := r.MakeClusterSpec(100, spec.Geo(), spec.Zones("zone99"), spec.CPU(12),
+			spec.PreferLocalSSD(true))
 		require.EqualValues(t, 100, s.NodeCount)
 		require.Equal(t, "foo", s.InstanceType)
 		require.True(t, s.Geo)

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -747,11 +747,6 @@ func runFailoverNonSystem(
 // The test runs a kv50 workload with batch size 1, using 256 concurrent workers
 // directed at n1-n3 with a rate of 2048 reqs/s. n4 fails and recovers, with 1
 // minute between each operation, for 9 cycles.
-//
-// TODO(erikgrinaker): The metrics resolution of 10 seconds isn't really good
-// enough to accurately measure the number of invalid leases, but it's what we
-// have currently. Prometheus scraping more often isn't enough, because CRDB
-// itself only samples every 10 seconds.
 func runFailoverLiveness(
 	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode, expLeases bool,
 ) {

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -35,6 +35,26 @@ func registerFailover(r registry.Registry) {
 			suffix = "/lease=expiration"
 		}
 
+		for _, readOnly := range []bool{false, true} {
+			readOnly := readOnly // pin loop variable
+			suffix := suffix
+			if readOnly {
+				suffix = "/read-only" + suffix
+			} else {
+				suffix = "/read-write" + suffix
+			}
+			r.Add(registry.TestSpec{
+				Name:                "failover/chaos" + suffix,
+				Owner:               registry.OwnerKV,
+				Timeout:             60 * time.Minute,
+				Cluster:             r.MakeClusterSpec(10, spec.CPU(4), spec.PreferLocalSSD(false)), // uses disk stalls
+				SkipPostValidations: registry.PostValidationNoDeadNodes,                             // cleanup kills nodes
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runFailoverChaos(ctx, t, c, readOnly, expirationLeases)
+				},
+			})
+		}
+
 		r.Add(registry.TestSpec{
 			Name:      "failover/partial/lease-gateway" + suffix,
 			Owner:     registry.OwnerKV,
@@ -68,14 +88,7 @@ func registerFailover(r registry.Registry) {
 			},
 		})
 
-		for _, failureMode := range []failureMode{
-			failureModeBlackhole,
-			failureModeBlackholeRecv,
-			failureModeBlackholeSend,
-			failureModeCrash,
-			failureModeDiskStall,
-			failureModePause,
-		} {
+		for _, failureMode := range allFailureModes {
 			failureMode := failureMode // pin loop variable
 
 			var usePD bool
@@ -123,6 +136,177 @@ func registerFailover(r registry.Registry) {
 			})
 		}
 	}
+}
+
+// runFailoverChaos sets up a 9-node cluster with RF=5 and randomly scattered
+// ranges and replicas, and then runs a random failure on one or two random
+// nodes for 1 minute with 1 minute recovery, for 20 cycles total. Nodes n1-n2
+// are used as SQL gateways, and are not failed to avoid disconnecting the
+// client workload.
+//
+// It runs with either a read-write or read-only KV workload, measuring the pMax
+// unavailability for graphing. The read-only workload is useful to test e.g.
+// recovering nodes stealing Raft leadership away, since this requires the
+// replica to still be up-to-date on the log.
+func runFailoverChaos(
+	ctx context.Context, t test.Test, c cluster.Cluster, readOnly, expLeases bool,
+) {
+	require.Equal(t, 10, c.Spec().NodeCount)
+
+	rng, _ := randutil.NewTestRand()
+
+	// Create cluster, and set up failers for all failure modes.
+	opts := option.DefaultStartOpts()
+	settings := install.MakeClusterSettings()
+	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
+	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
+
+	failers := []Failer{}
+	for _, failureMode := range allFailureModes {
+		failer := makeFailerWithoutLocalNoop(t, c, failureMode, opts, settings)
+		if c.IsLocal() && !failer.CanUseLocal() {
+			t.Status(fmt.Sprintf("skipping failure mode %q on local cluster", failureMode))
+			continue
+		}
+		failer.Setup(ctx)
+		defer failer.Cleanup(ctx)
+		failers = append(failers, failer)
+	}
+
+	c.Put(ctx, t.Cockroach(), "./cockroach")
+	c.Start(ctx, t.L(), opts, settings, c.Range(1, 9))
+
+	conn := c.Conn(ctx, t.L(), 1)
+	defer conn.Close()
+
+	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
+		expLeases)
+	require.NoError(t, err)
+
+	// Place 5 replicas of all ranges on n3-n9, keeping n1-n2 as SQL gateways.
+	configureAllZones(t, ctx, conn, zoneConfig{replicas: 5, onlyNodes: []int{3, 4, 5, 6, 7, 8, 9}})
+
+	// Wait for upreplication.
+	require.NoError(t, WaitForReplication(ctx, t, conn, 5 /* replicationFactor */))
+
+	// Create the kv database. If this is a read-only workload, populate it with
+	// 100.000 keys.
+	var insertCount int
+	if readOnly {
+		insertCount = 100000
+	}
+	t.Status("creating workload database")
+	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	require.NoError(t, err)
+	c.Run(ctx, c.Node(10), fmt.Sprintf(
+		`./cockroach workload init kv --splits 1000 --insert-count %d {pgurl:1}`, insertCount))
+
+	// Scatter the ranges, then relocate them off of the SQL gateways n1-n2.
+	t.Status("scattering table")
+	_, err = conn.ExecContext(ctx, `ALTER TABLE kv.kv SCATTER`)
+	require.NoError(t, err)
+	relocateRanges(t, ctx, conn, `true`, []int{1, 2}, []int{3, 4, 5, 6, 7, 8, 9})
+
+	// Wait for upreplication of the new ranges.
+	require.NoError(t, WaitForReplication(ctx, t, conn, 5 /* replicationFactor */))
+
+	// Start workload on n10 using n1-n2 as gateways.
+	t.Status("running workload")
+	m := c.NewMonitor(ctx, c.Range(1, 9))
+	m.Go(func(ctx context.Context) error {
+		readPercent := 50
+		if readOnly {
+			readPercent = 100
+		}
+		c.Run(ctx, c.Node(10), fmt.Sprintf(
+			`./cockroach workload run kv --read-percent %d --write-seq R%d `+
+				`--duration 45m --concurrency 256 --max-rate 8192 --timeout 1m --tolerate-errors `+
+				`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
+				`{pgurl:1-2}`, readPercent, insertCount))
+		return nil
+	})
+
+	// Start a worker to randomly fail random nodes for 1 minute, with 20 cycles.
+	m.Go(func(ctx context.Context) error {
+		var raftCfg base.RaftConfig
+		raftCfg.SetDefaults()
+
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+
+		for i := 0; i < 20; i++ {
+			select {
+			case <-ticker.C:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			// Pick 1 or 2 random nodes and failure modes.
+			nodeFailers := map[int]Failer{}
+			for numNodes := 1 + rng.Intn(2); len(nodeFailers) < numNodes; {
+				var node int
+				for node == 0 || nodeFailers[node] != nil {
+					node = 3 + rng.Intn(7) // n1-n2 are SQL gateways, n10 is workload runner
+				}
+				var failer Failer
+				for failer == nil {
+					failer = failers[rng.Intn(len(failers))]
+					for _, other := range nodeFailers {
+						if !other.CanRunWith(failer.Mode()) || !failer.CanRunWith(other.Mode()) {
+							failer = nil // failers aren't compatible, pick a different one
+							break
+						}
+					}
+				}
+				failer.Ready(ctx, m)
+				nodeFailers[node] = failer
+			}
+
+			randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
+
+			// Ranges may occasionally escape their constraints. Move them to where
+			// they should be.
+			relocateRanges(t, ctx, conn, `true`, []int{1, 2}, []int{3, 4, 5, 6, 7, 8, 9})
+
+			// Randomly sleep up to the lease renewal interval, to vary the time
+			// between the last lease renewal and the failure. We start the timer
+			// before the range relocation above to run them concurrently.
+			select {
+			case <-randTimer:
+			case <-ctx.Done():
+			}
+
+			for node, failer := range nodeFailers {
+				// If the failer supports partial failures (e.g. partial partitions), do
+				// one with 50% probability against a random node (including SQL
+				// gateways).
+				if partialFailer, ok := failer.(PartialFailer); ok && rng.Float64() < 0.5 {
+					var partialPeer int
+					for partialPeer == 0 || partialPeer == node {
+						partialPeer = 1 + rng.Intn(9)
+					}
+					t.Status(fmt.Sprintf("failing n%d to n%d (%s)", node, partialPeer, failer))
+					partialFailer.FailPartial(ctx, node, []int{partialPeer})
+				} else {
+					t.Status(fmt.Sprintf("failing n%d (%s)", node, failer))
+					failer.Fail(ctx, node)
+				}
+			}
+
+			select {
+			case <-ticker.C:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			for node, failer := range nodeFailers {
+				t.Status(fmt.Sprintf("recovering n%d (%s)", node, failer))
+				failer.Recover(ctx, node)
+			}
+		}
+		return nil
+	})
+	m.Wait()
 }
 
 // runFailoverPartialLeaseGateway tests a partial network partition between a
@@ -1027,6 +1211,16 @@ const (
 	failureModeNoop          failureMode = "noop"
 )
 
+var allFailureModes = []failureMode{
+	failureModeBlackhole,
+	failureModeBlackholeRecv,
+	failureModeBlackholeSend,
+	failureModeCrash,
+	failureModeDiskStall,
+	failureModePause,
+	// failureModeNoop intentionally omitted
+}
+
 // makeFailer creates a new failer for the given failureMode. It may return a
 // noopFailer on local clusters.
 func makeFailer(
@@ -1111,6 +1305,11 @@ type Failer interface {
 	// CanUseLocal returns true if the failer can be run with a local cluster.
 	CanUseLocal() bool
 
+	// CanRunWith returns true if the failer can run concurrently with another
+	// given failure mode on a different cluster node. It is not required to
+	// commute, i.e. A may not be able to run with B even though B can run with A.
+	CanRunWith(other failureMode) bool
+
 	// Setup prepares the failer. It is called before the cluster is started.
 	Setup(ctx context.Context)
 
@@ -1143,6 +1342,7 @@ type noopFailer struct{}
 func (f *noopFailer) Mode() failureMode                       { return failureModeNoop }
 func (f *noopFailer) String() string                          { return string(f.Mode()) }
 func (f *noopFailer) CanUseLocal() bool                       { return true }
+func (f *noopFailer) CanRunWith(failureMode) bool             { return true }
 func (f *noopFailer) Setup(context.Context)                   {}
 func (f *noopFailer) Ready(context.Context, cluster.Monitor)  {}
 func (f *noopFailer) Cleanup(context.Context)                 {}
@@ -1174,6 +1374,7 @@ func (f *blackholeFailer) Mode() failureMode {
 
 func (f *blackholeFailer) String() string                         { return string(f.Mode()) }
 func (f *blackholeFailer) CanUseLocal() bool                      { return false } // needs iptables
+func (f *blackholeFailer) CanRunWith(failureMode) bool            { return true }
 func (f *blackholeFailer) Setup(context.Context)                  {}
 func (f *blackholeFailer) Ready(context.Context, cluster.Monitor) {}
 
@@ -1259,6 +1460,7 @@ type crashFailer struct {
 func (f *crashFailer) Mode() failureMode                          { return failureModeCrash }
 func (f *crashFailer) String() string                             { return string(f.Mode()) }
 func (f *crashFailer) CanUseLocal() bool                          { return true }
+func (f *crashFailer) CanRunWith(failureMode) bool                { return true }
 func (f *crashFailer) Setup(_ context.Context)                    {}
 func (f *crashFailer) Ready(_ context.Context, m cluster.Monitor) { f.m = m }
 func (f *crashFailer) Cleanup(_ context.Context)                  {}
@@ -1283,9 +1485,10 @@ type diskStallFailer struct {
 	staller       diskStaller
 }
 
-func (f *diskStallFailer) Mode() failureMode { return failureModeDiskStall }
-func (f *diskStallFailer) String() string    { return string(f.Mode()) }
-func (f *diskStallFailer) CanUseLocal() bool { return false } // needs dmsetup
+func (f *diskStallFailer) Mode() failureMode           { return failureModeDiskStall }
+func (f *diskStallFailer) String() string              { return string(f.Mode()) }
+func (f *diskStallFailer) CanUseLocal() bool           { return false } // needs dmsetup
+func (f *diskStallFailer) CanRunWith(failureMode) bool { return true }
 
 func (f *diskStallFailer) Setup(ctx context.Context) {
 	f.staller.Setup(ctx)
@@ -1329,6 +1532,12 @@ func (f *pauseFailer) String() string          { return string(f.Mode()) }
 func (f *pauseFailer) CanUseLocal() bool       { return true }
 func (f *pauseFailer) Setup(context.Context)   {}
 func (f *pauseFailer) Cleanup(context.Context) {}
+
+func (f *pauseFailer) CanRunWith(other failureMode) bool {
+	// Since we disable the disk stall detector, we can't run concurrently with
+	// a disk stall on a different node.
+	return other != failureModeDiskStall
+}
 
 func (f *pauseFailer) Ready(ctx context.Context, _ cluster.Monitor) {
 	// The process pause can trip the disk stall detector, so we disable it. We

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -157,6 +157,7 @@ func runFailoverChaos(
 
 	// Create cluster, and set up failers for all failure modes.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
@@ -348,6 +349,7 @@ func runFailoverPartialLeaseGateway(
 
 	// Create cluster.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
@@ -501,6 +503,7 @@ func runFailoverPartialLeaseLeader(
 	// n1-n3, to precisely place system ranges, since we'll have to disable the
 	// replicate queue shortly.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_DISABLE_LEADER_FOLLOWS_LEASEHOLDER=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
@@ -656,6 +659,7 @@ func runFailoverPartialLeaseLiveness(
 
 	// Create cluster.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
@@ -799,6 +803,7 @@ func runFailoverNonSystem(
 
 	// Create cluster.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
@@ -940,6 +945,7 @@ func runFailoverLiveness(
 
 	// Create cluster. Don't schedule a backup as this roachtest reports to roachperf.
 	opts := option.DefaultStartOptsNoBackups()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
@@ -1085,6 +1091,7 @@ func runFailoverSystemNonLiveness(
 
 	// Create cluster.
 	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -273,7 +273,7 @@ func runFailoverPartialLeaseGateway(
 				}
 
 				for _, node := range tc.nodes {
-					t.Status(fmt.Sprintf("failing n%d (blackhole lease/gateway)", node))
+					t.Status(fmt.Sprintf("failing n%d to n%v (%s lease/gateway)", node, tc.peers, failer))
 					failer.FailPartial(ctx, node, tc.peers)
 				}
 
@@ -284,7 +284,7 @@ func runFailoverPartialLeaseGateway(
 				}
 
 				for _, node := range tc.nodes {
-					t.Status(fmt.Sprintf("recovering n%d (blackhole lease/gateway)", node))
+					t.Status(fmt.Sprintf("recovering n%d to n%v (%s lease/gateway)", node, tc.peers, failer))
 					failer.Recover(ctx, node)
 				}
 			}
@@ -426,12 +426,12 @@ func runFailoverPartialLeaseLeader(
 				case <-ctx.Done():
 				}
 
-				t.Status(fmt.Sprintf("failing n%d (blackhole lease/leader)", node))
-				nextNode := node + 1
-				if nextNode > 6 {
-					nextNode = 4
+				peer := node + 1
+				if peer > 6 {
+					peer = 4
 				}
-				failer.FailPartial(ctx, node, []int{nextNode})
+				t.Status(fmt.Sprintf("failing n%d to n%d (%s lease/leader)", node, peer, failer))
+				failer.FailPartial(ctx, node, []int{peer})
 
 				select {
 				case <-ticker.C:
@@ -439,7 +439,7 @@ func runFailoverPartialLeaseLeader(
 					return ctx.Err()
 				}
 
-				t.Status(fmt.Sprintf("recovering n%d (blackhole lease/leader)", node))
+				t.Status(fmt.Sprintf("recovering n%d to n%d (%s lease/leader)", node, peer, failer))
 				failer.Recover(ctx, node)
 			}
 		}
@@ -563,8 +563,9 @@ func runFailoverPartialLeaseLiveness(
 				case <-ctx.Done():
 				}
 
-				t.Status(fmt.Sprintf("failing n%d (blackhole lease/liveness)", node))
-				failer.FailPartial(ctx, node, []int{4})
+				peer := 4
+				t.Status(fmt.Sprintf("failing n%d to n%d (%s lease/liveness)", node, peer, failer))
+				failer.FailPartial(ctx, node, []int{peer})
 
 				select {
 				case <-ticker.C:
@@ -572,7 +573,7 @@ func runFailoverPartialLeaseLiveness(
 					return ctx.Err()
 				}
 
-				t.Status(fmt.Sprintf("recovering n%d (blackhole lease/liveness)", node))
+				t.Status(fmt.Sprintf("recovering n%d to n%d (%s lease/liveness)", node, peer, failer))
 				failer.Recover(ctx, node)
 			}
 		}
@@ -702,7 +703,7 @@ func runFailoverNonSystem(
 				case <-ctx.Done():
 				}
 
-				t.Status(fmt.Sprintf("failing n%d (%s)", node, failureMode))
+				t.Status(fmt.Sprintf("failing n%d (%s)", node, failer))
 				failer.Fail(ctx, node)
 
 				select {
@@ -711,7 +712,7 @@ func runFailoverNonSystem(
 					return ctx.Err()
 				}
 
-				t.Status(fmt.Sprintf("recovering n%d (%s)", node, failureMode))
+				t.Status(fmt.Sprintf("recovering n%d (%s)", node, failer))
 				failer.Recover(ctx, node)
 			}
 		}
@@ -847,7 +848,7 @@ func runFailoverLiveness(
 			case <-ctx.Done():
 			}
 
-			t.Status(fmt.Sprintf("failing n%d (%s)", 4, failureMode))
+			t.Status(fmt.Sprintf("failing n%d (%s)", 4, failer))
 			failer.Fail(ctx, 4)
 
 			select {
@@ -856,7 +857,7 @@ func runFailoverLiveness(
 				return ctx.Err()
 			}
 
-			t.Status(fmt.Sprintf("recovering n%d (%s)", 4, failureMode))
+			t.Status(fmt.Sprintf("recovering n%d (%s)", 4, failer))
 			failer.Recover(ctx, 4)
 			relocateLeases(t, ctx, conn, `range_id = 2`, 4)
 		}
@@ -994,7 +995,7 @@ func runFailoverSystemNonLiveness(
 				case <-ctx.Done():
 				}
 
-				t.Status(fmt.Sprintf("failing n%d (%s)", node, failureMode))
+				t.Status(fmt.Sprintf("failing n%d (%s)", node, failer))
 				failer.Fail(ctx, node)
 
 				select {
@@ -1003,7 +1004,7 @@ func runFailoverSystemNonLiveness(
 					return ctx.Err()
 				}
 
-				t.Status(fmt.Sprintf("recovering n%d (%s)", node, failureMode))
+				t.Status(fmt.Sprintf("recovering n%d (%s)", node, failer))
 				failer.Recover(ctx, node)
 			}
 		}
@@ -1022,10 +1023,29 @@ const (
 	failureModeCrash         failureMode = "crash"
 	failureModeDiskStall     failureMode = "disk-stall"
 	failureModePause         failureMode = "pause"
+	failureModeNoop          failureMode = "noop"
 )
 
-// makeFailer creates a new failer for the given failureMode.
+// makeFailer creates a new failer for the given failureMode. It may return a
+// noopFailer on local clusters.
 func makeFailer(
+	t test.Test,
+	c cluster.Cluster,
+	failureMode failureMode,
+	opts option.StartOpts,
+	settings install.ClusterSettings,
+) failer {
+	f := makeFailerWithoutLocalNoop(t, c, failureMode, opts, settings)
+	if c.IsLocal() && !f.CanUseLocal() {
+		t.Status(fmt.Sprintf(
+			`failure mode %q not supported on local clusters, using "noop" failure mode instead`,
+			failureMode))
+		f = &noopFailer{}
+	}
+	return f
+}
+
+func makeFailerWithoutLocalNoop(
 	t test.Test,
 	c cluster.Cluster,
 	failureMode failureMode,
@@ -1060,11 +1080,6 @@ func makeFailer(
 			startSettings: settings,
 		}
 	case failureModeDiskStall:
-		// TODO(baptist): This mode doesn't work on local clusters since
-		// dmsetupDiskStaller does not support local clusters. Either support could
-		// be added for it or there could be a flag to not fatal when run in local
-		// mode. The net impact is that this failure can't be simulated on local
-		// clusters today.
 		return &diskStallFailer{
 			t:             t,
 			c:             c,
@@ -1077,6 +1092,8 @@ func makeFailer(
 			t: t,
 			c: c,
 		}
+	case failureModeNoop:
+		return &noopFailer{}
 	default:
 		t.Fatalf("unknown failure mode %s", failureMode)
 		return nil
@@ -1085,6 +1102,11 @@ func makeFailer(
 
 // failer fails and recovers a given node in some particular way.
 type failer interface {
+	fmt.Stringer
+
+	// CanUseLocal returns true if the failer can be run with a local cluster.
+	CanUseLocal() bool
+
 	// Setup prepares the failer. It is called before the cluster is started.
 	Setup(ctx context.Context)
 
@@ -1110,6 +1132,18 @@ type partialFailer interface {
 	FailPartial(ctx context.Context, nodeID int, peerIDs []int)
 }
 
+// noopFailer doesn't do anything.
+type noopFailer struct{}
+
+func (f *noopFailer) String() string                          { return string(failureModeNoop) }
+func (f *noopFailer) CanUseLocal() bool                       { return true }
+func (f *noopFailer) Setup(context.Context)                   {}
+func (f *noopFailer) Ready(context.Context, cluster.Monitor)  {}
+func (f *noopFailer) Cleanup(context.Context)                 {}
+func (f *noopFailer) Fail(context.Context, int)               {}
+func (f *noopFailer) FailPartial(context.Context, int, []int) {}
+func (f *noopFailer) Recover(context.Context, int)            {}
+
 // blackholeFailer causes a network failure where TCP/IP packets to/from port
 // 26257 are dropped, causing network hangs and timeouts.
 //
@@ -1123,22 +1157,24 @@ type blackholeFailer struct {
 	output bool
 }
 
-func (f *blackholeFailer) Setup(_ context.Context)                    {}
-func (f *blackholeFailer) Ready(_ context.Context, _ cluster.Monitor) {}
+func (f *blackholeFailer) String() string {
+	if f.input && !f.output {
+		return string(failureModeBlackholeRecv)
+	} else if f.output && !f.input {
+		return string(failureModeBlackholeSend)
+	}
+	return string(failureModeBlackhole)
+}
+
+func (f *blackholeFailer) CanUseLocal() bool                      { return false } // needs iptables
+func (f *blackholeFailer) Setup(context.Context)                  {}
+func (f *blackholeFailer) Ready(context.Context, cluster.Monitor) {}
 
 func (f *blackholeFailer) Cleanup(ctx context.Context) {
-	if f.c.IsLocal() {
-		f.t.Status("skipping blackhole cleanup on local cluster")
-		return
-	}
 	f.c.Run(ctx, f.c.All(), `sudo iptables -F`)
 }
 
 func (f *blackholeFailer) Fail(ctx context.Context, nodeID int) {
-	if f.c.IsLocal() {
-		f.t.Status("skipping blackhole failure on local cluster")
-		return
-	}
 	// When dropping both input and output, make sure we drop packets in both
 	// directions for both the inbound and outbound TCP connections, such that we
 	// get a proper black hole. Only dropping one direction for both of INPUT and
@@ -1165,10 +1201,6 @@ func (f *blackholeFailer) Fail(ctx context.Context, nodeID int) {
 // FailPartial creates a partial blackhole failure between the given node and
 // peers.
 func (f *blackholeFailer) FailPartial(ctx context.Context, nodeID int, peerIDs []int) {
-	if f.c.IsLocal() {
-		f.t.Status("skipping blackhole failure on local cluster")
-		return
-	}
 	peerIPs, err := f.c.InternalIP(ctx, f.t.L(), peerIDs)
 	require.NoError(f.t, err)
 
@@ -1204,10 +1236,6 @@ func (f *blackholeFailer) FailPartial(ctx context.Context, nodeID int, peerIDs [
 }
 
 func (f *blackholeFailer) Recover(ctx context.Context, nodeID int) {
-	if f.c.IsLocal() {
-		f.t.Status("skipping blackhole recovery on local cluster")
-		return
-	}
 	f.c.Run(ctx, f.c.Node(nodeID), `sudo iptables -F`)
 }
 
@@ -1221,6 +1249,8 @@ type crashFailer struct {
 	startSettings install.ClusterSettings
 }
 
+func (f *crashFailer) String() string                             { return string(failureModeCrash) }
+func (f *crashFailer) CanUseLocal() bool                          { return true }
 func (f *crashFailer) Setup(_ context.Context)                    {}
 func (f *crashFailer) Ready(_ context.Context, m cluster.Monitor) { f.m = m }
 func (f *crashFailer) Cleanup(_ context.Context)                  {}
@@ -1244,6 +1274,9 @@ type diskStallFailer struct {
 	startSettings install.ClusterSettings
 	staller       diskStaller
 }
+
+func (f *diskStallFailer) String() string    { return string(failureModeDiskStall) }
+func (f *diskStallFailer) CanUseLocal() bool { return false } // needs dmsetup
 
 func (f *diskStallFailer) Setup(ctx context.Context) {
 	f.staller.Setup(ctx)
@@ -1282,6 +1315,8 @@ type pauseFailer struct {
 	c cluster.Cluster
 }
 
+func (f *pauseFailer) String() string              { return string(failureModePause) }
+func (f *pauseFailer) CanUseLocal() bool           { return true }
 func (f *pauseFailer) Setup(ctx context.Context)   {}
 func (f *pauseFailer) Cleanup(ctx context.Context) {}
 


### PR DESCRIPTION
Backport:
  * 2/2 commits from "roachtest: handle local clusters in `failover`" (#103262)
  * 5/5 commits from "roachtest: add `failover` chaos tests" (#103263)
  * 1/1 commits from "roachtest: disable scheduled backups in `failover`" (#104393)

Please see individual PRs for details.

The `deadlock` failover mode has not been backported, since it required adding (internal) SQL builtins, and still has some issues that we're ironing out.

/cc @cockroachdb/release
