### PR TITLE
backupccl: enable tenant testing in TestBackupOnlyPublicIndexes

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8634,10 +8634,7 @@ func TestBackupOnlyPublicIndexes(t *testing.T) {
 	close(blockBackfills)
 
 	var chunkCount int32
-	// Disable running within a tenant because expected index span is not received.
-	// More investigation is necessary.
-	// https://github.com/cockroachdb/cockroach/issues/88633F
-	serverArgs := base.TestServerArgs{DefaultTestTenant: base.TestTenantDisabled}
+	serverArgs := base.TestServerArgs{}
 	serverArgs.Knobs = base.TestingKnobs{
 		// Configure knobs to block the index backfills.
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
@@ -8752,7 +8749,16 @@ func TestBackupOnlyPublicIndexes(t *testing.T) {
 		inc3Loc, fullBackup, inc1Loc, inc2Loc)
 	inc3Spans := getSpansFromManifest(ctx, t, locationToDir(inc3Loc))
 	require.Equal(t, 1, len(inc3Spans))
-	require.Regexp(t, fmt.Sprintf(".*/Table/%d/{2-3}", dataBankTableID), inc3Spans[0].String())
+	// NB: When running in a tenant, we don't add a split point
+	// for an index. As a result, we end up issuing a single
+	// export request for /Table/*/1-3 and while /Table/*/1-2 has
+	// no data in it, the start key is based on the start key of
+	// our request.
+	if tc.StartedDefaultTestTenant() {
+		require.Regexp(t, fmt.Sprintf(".*/Table/%d/{1-3}", dataBankTableID), inc3Spans[0].String())
+	} else {
+		require.Regexp(t, fmt.Sprintf(".*/Table/%d/{2-3}", dataBankTableID), inc3Spans[0].String())
+	}
 
 	// Drop the index.
 	sqlDB.Exec(t, `DROP INDEX new_balance_idx`)


### PR DESCRIPTION
This test was failing under tenant testing because manifest entries depend on range boundaries and range boundaries depend on split points and split points depend on whether you are running in a tenant or not.

Here, I update the assertion when running inside a tenant, which is a little lame. But, I think the test is still useful.

Release note: None

Fixes #88633