### PR TITLE
cluster-ui: increase payload size when retrieving statement diagnostics

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
@@ -12,6 +12,7 @@ import moment from "moment-timezone";
 import { Duration } from "src/util/format";
 import {
   executeInternalSql,
+  LARGE_RESULT_SIZE,
   SqlExecutionRequest,
   sqlResultsAreEmpty,
 } from "src/api";
@@ -47,6 +48,7 @@ export function getStatementDiagnosticsReports(): Promise<StatementDiagnosticsRe
       },
     ],
     execute: true,
+    max_result_size: LARGE_RESULT_SIZE,
   };
 
   return executeInternalSql<StatementDiagnosticsReport>(req).then(res => {


### PR DESCRIPTION
Epic: None
In response to: https://github.com/cockroachlabs/support/issues/2348

This change increases the payload size when getting statement diagnostics.

Release note: None