### PR TITLE
backupccl_test: fix bad dependency

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -352,9 +352,7 @@ stringer(
 
 genrule(
     name = "gen-backupccl-tests",
-    srcs = [
-        "//pkg/ccl/backupccl:testdata",
-    ],
+    srcs = glob(["testdata/**"]),
     outs = [
         "restore_memory_monitoring_generated_test.go",
         "data_driven_generated_test.go",


### PR DESCRIPTION
Without this we get the following error:

```
WARNING: /data/home/kena/src/go/src/github.com/cockroachdb/cockroach/pkg/ccl/backupccl/BUILD.bazel:353:8: input 'pkg/ccl/backupccl/testdata' to //pkg/ccl/backupccl:gen-backupccl-tests is a directory; dependency checking of directories is unsound
```

Epic: CRDB-17165
Release note: None