### PR TITLE
sql/pgwire: skip TestAuthenticationAndHBARules

### DIFF
--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -133,6 +133,7 @@ import (
 // alongside the "ok" or "ERROR" message.
 func TestAuthenticationAndHBARules(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 104381, "flaky test")
 	skip.UnderRace(t, "takes >1min under race")
 
 	testutils.RunTrueAndFalse(t, "insecure", func(t *testing.T, insecure bool) {


### PR DESCRIPTION
Refs: #104381

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None

Epic: None