### PR TITLE
kvflowcontrol: enable by default

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
@@ -30,7 +30,7 @@ var Enabled = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kvadmission.flow_control.enabled",
 	"determines whether we use flow control for replication traffic in KV",
-	false,
+	true,
 )
 
 // Mode determines the 'mode' of flow control we use for replication traffic in


### PR DESCRIPTION
Enable kvadmission.flow_control.enabled by default. We didn't observe noticeable performance regressions while it was disabled (single weekly run, three nightly runs). There was some minimal fallout that was since fixed (#104699). We expect performance regressions now that this commit enables it by default, and expect more fallout. We'll handle these as part of #104154.

Release note: None