### PR TITLE
roachtest: unskip index-backfill tests in CI

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -44,7 +44,6 @@ func registerDatabaseDrop(r registry.Registry) {
 		Timeout:   10 * time.Hour,
 		Owner:     registry.OwnerAdmissionControl,
 		Benchmark: true,
-		Skip:      "TC builder agents need new GCE permissions",
 		// TODO(irfansharif): Reduce to weekly cadence once stabilized.
 		// Tags:            registry.Tags(`weekly`),
 		Cluster:         clusterSpec,
@@ -228,7 +227,10 @@ func registerDatabaseDrop(r registry.Registry) {
 			// heavy and in the short spurt where we there's a burst of
 			// compactions, we're not using disk bandwidth sufficiently to need
 			// something like disk bandwidth tokens. Find a more appropriate
-			// foreground load to run and refresh this test.
+			// foreground load to run and refresh this test. Look at the
+			// clearrange tests -- it seems more appropriate and there's already
+			// sustained IO token exhaustion, so perhaps just cargocult that
+			// test and use disk snapshots?
 			runTPCE(ctx, t, c, tpceOptions{
 				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					c.Put(ctx, t.Cockroach(), "./cockroach", c.All())

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -47,7 +47,6 @@ func registerIndexBackfill(r registry.Registry) {
 		Timeout:   6 * time.Hour,
 		Owner:     registry.OwnerAdmissionControl,
 		Benchmark: true,
-		Skip:      "TC builder agents need new GCE permissions",
 		// TODO(irfansharif): Reduce to weekly cadence once stabilized.
 		// Tags:            registry.Tags(`weekly`),
 		Cluster:         clusterSpec,

--- a/pkg/cmd/roachtest/tests/prune_dangling_snapshots_and_disks.go
+++ b/pkg/cmd/roachtest/tests/prune_dangling_snapshots_and_disks.go
@@ -35,7 +35,6 @@ func registerPruneDanglingSnapshotsAndDisks(r registry.Registry) {
 		Name:            "prune-dangling",
 		Owner:           registry.OwnerTestEng,
 		Cluster:         clusterSpec,
-		Skip:            "TC builder agents need new GCE permissions",
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{


### PR DESCRIPTION
They were skipped due to gcloud permissions our test runners are instantiated with, which was allegedly fixed (DEVINF-768).

Release note: None