### PR TITLE
roachtest: respect context cancelation in `cdc/mixed-versions`

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -169,11 +169,13 @@ func (cmvt *cdcMixedVersionTester) waitForResolvedTimestamps() versionStep {
 		}()
 
 		var resolved int
-		for range cmvt.timestampsResolved.C {
-			resolved++
-			t.L().Printf("%d of %d timestamps resolved", resolved, resolvedTimestampsPerState)
-			if resolved == resolvedTimestampsPerState {
-				break
+		for resolved < resolvedTimestampsPerState {
+			select {
+			case <-cmvt.timestampsResolved.C:
+				resolved++
+				t.L().Printf("%d of %d timestamps resolved", resolved, resolvedTimestampsPerState)
+			case <-ctx.Done():
+				return
 			}
 		}
 


### PR DESCRIPTION
If the test's context was canceled (due to an assertion failure or timeout), the `waitForResolvedTimestamps` would block and continue waiting for resolved timestamp notifications coming from a channel.

This commit updates the test logic to stop waiting for channel messages if the context passed is canceled.

Fixes: #104313.

Release note: None