### PR TITLE
telemetry: add txn sampling option

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -458,9 +458,8 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		idxRecommendationsCache: idxrecommendations.NewIndexRecommendationsCache(cfg.Settings),
 	}
 
-	telemetryLoggingMetrics := &TelemetryLoggingMetrics{}
-
-	telemetryLoggingMetrics.Knobs = cfg.TelemetryLoggingTestingKnobs
+	telemetryLoggingMetrics := newTelemetryLoggingmetrics(cfg.TelemetryLoggingTestingKnobs, cfg.Settings)
+	telemetryLoggingMetrics.registerOnTelemetrySamplingModeChange(cfg.Settings)
 	s.TelemetryLoggingMetrics = telemetryLoggingMetrics
 
 	sqlStatsInternalExecutorMonitor := MakeInternalExecutorMemMonitor(MemoryMetrics{}, s.GetExecutorConfig().Settings)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3021,6 +3021,7 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent) {
 				transactionFingerprintID,
 			)
 		}
+
 		err = ex.recordTransactionFinish(ctx, transactionFingerprintID, ev, implicit, txnStart)
 		if err != nil {
 			if log.V(1) {
@@ -3030,6 +3031,9 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent) {
 		}
 		// If we have a commitTimestamp, we should use it.
 		ex.previousTransactionCommitTimestamp.Forward(ev.commitTimestamp)
+		if telemetryLoggingEnabled.Get(&ex.server.cfg.Settings.SV) {
+			ex.server.TelemetryLoggingMetrics.onTxnFinish(ev.txnID.String())
+		}
 	}
 }
 

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -164,7 +164,6 @@ func (p *planner) maybeLogStatementInternal(
 	slowQueryLogEnabled := slowLogThreshold != 0
 	slowInternalQueryLogEnabled := slowInternalQueryLogEnabled.Get(&p.execCfg.Settings.SV)
 	auditEventsDetected := len(p.curPlan.auditEventBuilders) != 0
-	maxEventFrequency := TelemetryMaxEventFrequency.Get(&p.execCfg.Settings.SV)
 	logConsoleQuery := telemetryInternalConsoleQueriesEnabled.Get(&p.execCfg.Settings.SV) &&
 		strings.HasPrefix(p.SessionData().ApplicationName, "$ internal-console")
 
@@ -281,23 +280,27 @@ func (p *planner) maybeLogStatementInternal(
 	if telemetryLoggingEnabled && !p.SessionData().TroubleshootingMode {
 		// We only log to the telemetry channel if enough time has elapsed from
 		// the last event emission.
-		requiredTimeElapsed := 1.0 / float64(maxEventFrequency)
 		tracingEnabled := telemetryMetrics.isTracing(p.curPlan.instrumentation.Tracing())
+
+		isStmtMode := telemetrySamplingMode.Get(&p.execCfg.Settings.SV) == telemetryModeStatement
+
 		// Always sample if one of the scenarios is true:
-		// - the current statement is not of type DML
+		// - on 'statement' sampling and the current statement is not of type DML
+		// - on 'transaction' sampling mode and the current statement is not of type DML and is not a COMMIT
 		// - tracing is enabled for this statement
 		// - this is a query emitted by our console (application_name starts with `$ internal-console`) and
 		// the cluster setting to log console queries is enabled
-		if p.stmt.AST.StatementType() != tree.TypeDML || tracingEnabled || logConsoleQuery {
-			requiredTimeElapsed = 0
-		}
-		if telemetryMetrics.maybeUpdateLastEmittedTime(telemetryMetrics.timeNow(), requiredTimeElapsed) {
-			var txnID string
-			// p.txn can be nil for COPY.
-			if p.txn != nil {
-				txnID = p.txn.ID().String()
-			}
+		forceLog := (p.stmt.AST.StatementType() != tree.TypeDML &&
+			(isStmtMode || p.stmt.AST.StatementTag() != "COMMIT")) ||
+			tracingEnabled || logConsoleQuery
 
+		var txnID string
+		// p.txn can be nil for COPY.
+		if p.txn != nil {
+			txnID = p.txn.ID().String()
+		}
+
+		if telemetryMetrics.shouldEmitLog(telemetryMetrics.timeNow(), txnID, forceLog, stmtCount) {
 			var queryLevelStats execstats.QueryLevelStats
 			if stats, ok := p.instrumentation.GetQueryLevelStats(); ok {
 				queryLevelStats = *stats

--- a/pkg/sql/telemetry_logging.go
+++ b/pkg/sql/telemetry_logging.go
@@ -11,10 +11,12 @@
 package sql
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -28,9 +30,11 @@ const defaultMaxEventFrequency = 8
 var TelemetryMaxEventFrequency = settings.RegisterIntSetting(
 	settings.TenantWritable,
 	"sql.telemetry.query_sampling.max_event_frequency",
-	"the max event frequency at which we sample queries for telemetry, "+
-		"note that this value shares a log-line limit of 10 logs per second on the "+
-		"telemetry pipeline with all other telemetry events",
+	"the max event frequency at which we sample executions for telemetry, "+
+		"note that it is recommended that this value shares a log-line limit of 10 "+
+		" logs per second on the telemetry pipeline with all other telemetry events. "+
+		"If sampling mode is set to 'transaction', all statements associated with a single "+
+		"transaction are counted as 1 unit.",
 	defaultMaxEventFrequency,
 	settings.NonNegativeInt,
 )
@@ -50,19 +54,65 @@ var telemetryInternalConsoleQueriesEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
+const (
+	telemetryModeStatement = iota
+	telemetryModeTransaction
+)
+
+var telemetrySamplingMode = settings.RegisterEnumSetting(
+	settings.TenantWritable,
+	"sql.telemetry.query_sampling.mode",
+	"the execution level used for telemetry sampling. If set to 'statement', events "+
+		"are sampled at the statement execution level. If set to 'transaction', events are "+
+		"sampled at the txn execution level, i.e. all statements for a txn will be logged "+
+		"and are counted together as one sampled event (events are still emitted one per "+
+		"statement)",
+	"statement",
+	map[int64]string{
+		telemetryModeStatement:   "statement",
+		telemetryModeTransaction: "transaction",
+	},
+)
+
+var telemetryTrackedTxnsLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"sql.telemetry.txn_mode.tracking_limit",
+	"the maximum number of transactions tracked at one time for which we will send "+
+		"all statements to telemetry",
+	10000,
+	settings.NonNegativeInt,
+)
+
 // TelemetryLoggingMetrics keeps track of the last time at which an event
 // was logged to the telemetry channel, and the number of skipped queries
 // since the last logged event.
 type TelemetryLoggingMetrics struct {
+	st *cluster.Settings
+
 	mu struct {
 		syncutil.RWMutex
 		// The timestamp of the last emitted telemetry event.
 		lastEmittedTime time.Time
+
+		// observedTxnExecutions is used to track txn executions that are currently
+		// being logged. When the sampling mode is set to txns, we must ensure we
+		// log all stmts for a txn. Txns are removed upon completing execution when
+		// all events have been captured.
+		observedTxnExecutions map[string]interface{}
 	}
+
 	Knobs *TelemetryLoggingTestingKnobs
 
 	// skippedQueryCount is used to produce the count of non-sampled queries.
 	skippedQueryCount uint64
+}
+
+func newTelemetryLoggingmetrics(
+	knobs *TelemetryLoggingTestingKnobs, st *cluster.Settings,
+) *TelemetryLoggingMetrics {
+	t := TelemetryLoggingMetrics{Knobs: knobs, st: st}
+	t.mu.observedTxnExecutions = make(map[string]interface{})
+	return &t
 }
 
 // TelemetryLoggingTestingKnobs provides hooks and knobs for unit tests.
@@ -89,6 +139,51 @@ func NewTelemetryLoggingTestingKnobs(
 	}
 }
 
+// registerOnTelemetrySamplingModeChange sets up the callback for when the
+// telemetry sampling mode is changed. When switching from txn to stmt, we
+// clear the txns we are currently tracking for logging.
+func (t *TelemetryLoggingMetrics) registerOnTelemetrySamplingModeChange(
+	settings *cluster.Settings,
+) {
+	telemetrySamplingMode.SetOnChange(&settings.SV, func(ctx context.Context) {
+		mode := telemetrySamplingMode.Get(&settings.SV)
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		if mode == telemetryModeStatement {
+			// Clear currently observed txns.
+			t.mu.observedTxnExecutions = make(map[string]interface{})
+		}
+	})
+}
+
+func (t *TelemetryLoggingMetrics) onTxnFinish(txnExecutionID string) {
+	if telemetrySamplingMode.Get(&t.st.SV) != telemetryModeTransaction {
+		return
+	}
+	//
+	// Check if txn exec id exists in the map.
+	exists := false
+	func() {
+		t.mu.RLock()
+		defer t.mu.RUnlock()
+		_, exists = t.mu.observedTxnExecutions[txnExecutionID]
+	}()
+
+	if !exists {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.mu.observedTxnExecutions, txnExecutionID)
+}
+
+func (t *TelemetryLoggingMetrics) getTrackedTxnsCount() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.mu.observedTxnExecutions)
+}
+
 // ModuleTestingKnobs implements base.ModuleTestingKnobs interface.
 func (*TelemetryLoggingTestingKnobs) ModuleTestingKnobs() {}
 
@@ -99,21 +194,67 @@ func (t *TelemetryLoggingMetrics) timeNow() time.Time {
 	return timeutil.Now()
 }
 
-// maybeUpdateLastEmittedTime updates the lastEmittedTime if the amount of time
-// elapsed between lastEmittedTime and newTime is greater than requiredSecondsElapsed.
-func (t *TelemetryLoggingMetrics) maybeUpdateLastEmittedTime(
-	newTime time.Time, requiredSecondsElapsed float64,
-) bool {
+// shouldEmitLog returns true if the stmt should be logged to telemetry. The last emitted time
+// tracked by telemetry logging metrics will be updated to the given time if any of the following
+// are met:
+//   - The telemetry mode is set to "transaction" AND the stmt is the first in
+//     the txn AND the txn is not already being tracked AND the required amount
+//     of time has elapsed.
+//   - The telemetry mode is set to "statement" AND the required amount of time has elapsed
+//   - The txn is not being tracked and the stmt is being forced to log.
+func (t *TelemetryLoggingMetrics) shouldEmitLog(
+	newTime time.Time, txnExecutionID string, force bool, stmtPosInTxn int,
+) (shouldEmit bool) {
+	maxEventFrequency := TelemetryMaxEventFrequency.Get(&t.st.SV)
+	requiredTimeElapsed := time.Second / time.Duration(maxEventFrequency)
+	isTxnMode := telemetrySamplingMode.Get(&t.st.SV) == telemetryModeTransaction
+	txnsLimit := int(telemetryTrackedTxnsLimit.Get(&t.st.SV))
+
+	if isTxnMode && txnExecutionID == "" {
+		// If we are in transaction mode, skip logging statements without txn ids
+		// since we won't be able to track the stmt's txn through its execution.
+		// This will skip statements like BEGIN which don't have an associated
+		// transaction id.
+		return false
+	}
+
+	var enoughTimeElapsed, txnIsTracked, startTrackingTxn bool
+	// Avoid taking the full lock if we don't have to.
+	func() {
+		t.mu.RLock()
+		defer t.mu.RUnlock()
+
+		enoughTimeElapsed = newTime.Sub(t.mu.lastEmittedTime) >= requiredTimeElapsed
+		startTrackingTxn = isTxnMode && txnExecutionID != "" &&
+			stmtPosInTxn == 1 && len(t.mu.observedTxnExecutions) < txnsLimit
+		_, txnIsTracked = t.mu.observedTxnExecutions[txnExecutionID]
+	}()
+
+	if txnIsTracked || (!force && (!enoughTimeElapsed || (isTxnMode && !startTrackingTxn))) {
+		// We don't want to update the last emitted time if the transaction is already tracked.
+		// We can also early exit here if we aren't forcing the log and we don't meed the required
+		// elapsed time or can't start tracking the txn due to not having received the first stmt.
+		return txnIsTracked
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	lastEmittedTime := t.mu.lastEmittedTime
-	if float64(newTime.Sub(lastEmittedTime))*1e-9 >= requiredSecondsElapsed {
-		t.mu.lastEmittedTime = newTime
-		return true
+	// The lastEmittedTime and tracked txns may have changed since releasing the Rlock.
+	// The tracked transaction count could have changed as well so we recheck these values.
+	txnLimitReached := len(t.mu.observedTxnExecutions) >= txnsLimit
+	if !force &&
+		(newTime.Sub(t.mu.lastEmittedTime) < requiredTimeElapsed || (startTrackingTxn && txnLimitReached)) {
+		return false
 	}
 
-	return false
+	// We could be forcing the log so we should only track its txn if it meets the criteria.
+	if startTrackingTxn && !txnLimitReached {
+		t.mu.observedTxnExecutions[txnExecutionID] = struct{}{}
+	}
+
+	t.mu.lastEmittedTime = newTime
+	return true
 }
 
 func (t *TelemetryLoggingMetrics) getQueryLevelStats(

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -12,9 +12,11 @@ package sql
 
 import (
 	"context"
+	gosql "database/sql"
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -22,9 +24,11 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -1598,9 +1602,10 @@ func TestTelemetryLoggingStmtPosInTxn(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	st.SetTime(timeutil.FromUnixMicros(0))
 	db.Exec(t, `SET application_name = 'telemetry-stmt=count-logging-test'`)
-
 	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.mode = "statement";`)
 
 	st.SetTime(timeutil.FromUnixMicros(int64(1e6)))
 	db.Exec(t, `BEGIN;`)
@@ -1658,6 +1663,502 @@ func TestTelemetryLoggingStmtPosInTxn(t *testing.T) {
 
 		if !found {
 			t.Errorf("did not find expected query log in log entries: %s", expected)
+		}
+	}
+}
+
+type testQuery struct {
+	query          string
+	logTime        float64
+	tracingEnabled bool
+}
+
+type expectedLog struct {
+	logMsg            string
+	skippedQueryCount int
+}
+
+// TestTelemetryLoggingTxnMode tests that when the telemetry logging is set to "transaction",
+// we sample events at the transaction level, which means that we'll emit all statements
+// for a transaction as if they were counted as 1 emitted event.
+func TestTelemetryLoggingTxnMode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := log.ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+
+	cleanup := logtestutils.InstallLogFileSink(sc, t, logpb.Channel_TELEMETRY)
+	defer cleanup()
+
+	st := logtestutils.StubTime{}
+	sts := logtestutils.StubTracingStatus{}
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			EventLog: &EventLogTestingKnobs{
+				// The sampling checks below need to have a deterministic
+				// number of statements run by internal executor.
+				SyncWrites: true,
+			},
+			TelemetryLoggingKnobs: &TelemetryLoggingTestingKnobs{
+				getTimeNow:       st.TimeNow,
+				getTracingStatus: sts.TracingStatus,
+			},
+		},
+	})
+
+	defer s.Stopper().Stop(context.Background())
+
+	queries := []testQuery{
+		{
+			query:   "BEGIN; TRUNCATE t; COMMIT",
+			logTime: 0, // Logged.
+		},
+		{
+			query:   "BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT",
+			logTime: 1, // Logged.
+		},
+		{
+			query:   "SELECT 1, 2;",
+			logTime: 1, // Skipped.
+		},
+		{
+			query:          "SELECT 1, 2;",
+			logTime:        1, // Logged. Tracing is enabled.
+			tracingEnabled: true,
+		},
+		{
+			query:   `SELECT * FROM t LIMIT 1`,
+			logTime: 1.05, // Skipped.
+		},
+		{
+			query:   `SELECT * FROM t LIMIT 1`,
+			logTime: 1.08, // Skipped.
+		},
+		{
+			query:   `SELECT * FROM t LIMIT 2`,
+			logTime: 1.1, // Logged.
+		},
+		{
+			query:   `BEGIN; SELECT * FROM t LIMIT 3; COMMIT`,
+			logTime: 1.15, // Skipped.
+		},
+		{
+			query:   `BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT`,
+			logTime: 1.2, // Logged.
+		},
+	}
+
+	expectedLogs := []expectedLog{
+		{
+			logMsg:            `TRUNCATE TABLE defaultdb.public.t`,
+			skippedQueryCount: 1, // Skipped BEGIN.
+		},
+		{
+			logMsg:            `COMMIT TRANSACTION`,
+			skippedQueryCount: 0,
+		},
+		{
+			logMsg:            `SELECT ‹1›`,
+			skippedQueryCount: 1, // BEGIN skipped.
+		},
+		{
+			logMsg:            `SELECT ‹2›`,
+			skippedQueryCount: 0,
+		},
+		{
+			logMsg:            `SELECT ‹3›`,
+			skippedQueryCount: 0,
+		},
+		{
+			logMsg:            `COMMIT TRANSACTION`,
+			skippedQueryCount: 0,
+		},
+		{
+			logMsg:            `SELECT ‹1›, ‹2›`,
+			skippedQueryCount: 1,
+		},
+		{
+			logMsg:            `SELECT * FROM ""."".t LIMIT ‹2›`,
+			skippedQueryCount: 2,
+		},
+		{
+			logMsg:            `SELECT * FROM ""."".t LIMIT ‹4›`,
+			skippedQueryCount: 4,
+		},
+		{
+			logMsg:            `SELECT * FROM ""."".t LIMIT ‹5›`,
+			skippedQueryCount: 0,
+		},
+		{
+			logMsg:            `COMMIT TRANSACTION`,
+			skippedQueryCount: 0,
+		},
+	}
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	st.SetTime(timeutil.FromUnixMicros(0))
+	db.Exec(t, `SET application_name = 'telemetry-logging-test-txn-mode'`)
+	db.Exec(t, "CREATE TABLE t();")
+	db.Exec(t, "CREATE TABLE u(x int);")
+
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.max_event_frequency = 10;`)
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.mode = "transaction";`)
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
+
+	for _, query := range queries {
+		stubTime := timeutil.FromUnixMicros(int64(query.logTime * 1e6))
+		st.SetTime(stubTime)
+		sts.SetTracingStatus(query.tracingEnabled)
+		db.Exec(t, query.query)
+	}
+
+	log.FlushFiles()
+
+	entries, err := log.FetchEntriesFromFiles(
+		0,
+		math.MaxInt64,
+		10000,
+		regexp.MustCompile(`"EventType":"sampled_query"`),
+		log.WithMarkedSensitiveData,
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) == 0 {
+		t.Fatal(errors.Newf("no entries found"))
+	}
+
+	for _, e := range entries {
+		if strings.Contains(e.Message, `"ExecMode":"`+executorTypeInternal.logLabel()) {
+			t.Errorf("unexpected telemetry event for internal statement:\n%s", e.Message)
+		}
+	}
+
+	expectedLogCount := len(expectedLogs)
+	require.GreaterOrEqualf(t, len(entries), expectedLogCount,
+		"expected at least %d log entries, got: %d\nentries:\n%v", expectedLogCount, len(entries), entries)
+
+	// FetchEntriesFromFiles delivers entries in reverse order.
+	entryIdx := len(entries) - 1
+
+	// Skip the cluster setting queries.
+	for strings.Contains(entries[entryIdx].Message, "SET CLUSTER SETTING") {
+		entryIdx--
+	}
+
+	for i := 0; i < expectedLogCount; i++ {
+		e := entries[entryIdx-i]
+
+		var sq eventpb.SampledQuery
+		err = json.Unmarshal([]byte(e.Message), &sq)
+		require.NoError(t, err)
+
+		if !strings.Contains(string(sq.Statement), expectedLogs[i].logMsg) {
+			t.Fatalf("expected log message to contain:\n%s\nbut received:\n%s\nentries:\n%v\n",
+				expectedLogs[i].logMsg, sq.Statement, entries)
+		}
+
+		expectedSkipped := expectedLogs[i].skippedQueryCount
+		if expectedSkipped == 0 {
+			require.Zerof(t, sq.SkippedQueries, "expected no skipped queries, found:\n%s", e.Message)
+		} else {
+			require.Equalf(t, uint64(expectedSkipped), sq.SkippedQueries, "expected skipped queries, found:\n%s", e.Message)
+		}
+	}
+}
+
+// TestTelemetryLoggingClearsTxns tests that when the telemetry logging is set to "statements",
+// the list of tracked txns is cleared.
+func TestTelemetryLoggingClearsTxns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := log.ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+
+	cleanup := logtestutils.InstallLogFileSink(sc, t, logpb.Channel_TELEMETRY)
+	defer cleanup()
+
+	st := logtestutils.StubTime{}
+	sts := logtestutils.StubTracingStatus{}
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			EventLog: &EventLogTestingKnobs{
+				// The sampling checks below need to have a deterministic
+				// number of statements run by internal executor.
+				SyncWrites: true,
+			},
+			TelemetryLoggingKnobs: &TelemetryLoggingTestingKnobs{
+				getTimeNow:       st.TimeNow,
+				getTracingStatus: sts.TracingStatus,
+			},
+		},
+	})
+
+	defer s.Stopper().Stop(context.Background())
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+
+	pgURL, cleanupGoDB := sqlutils.PGUrl(
+		t, s.AdvSQLAddr(), "CreateConnections" /* prefix */, url.User(username.RootUser))
+	defer cleanupGoDB()
+	sqlDB2, err := gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer sqlDB2.Close()
+	db2 := sqlutils.MakeSQLRunner(sqlDB2)
+
+	st.SetTime(timeutil.FromUnixMicros(0))
+	db.Exec(t, `SET application_name = 'telemetry-logging-test-txns-cleared'`)
+
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.max_event_frequency = 10;`)
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.mode = "transaction";`)
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
+
+	telemetryLogging := s.SQLServer().(*Server).TelemetryLoggingMetrics
+
+	require.Zero(t, telemetryLogging.getTrackedTxnsCount())
+	stubTime := timeutil.Now()
+	st.SetTime(stubTime)
+	db.Exec(t, "BEGIN; SELECT 1;")
+	require.Equal(t, 1, telemetryLogging.getTrackedTxnsCount())
+
+	// Ensure that the tracked txn cache is cleared.
+	db2.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.mode = "statement";`)
+
+	testutils.SucceedsSoon(t, func() error {
+		if telemetryLogging.getTrackedTxnsCount() != 0 {
+			return errors.Newf("expected no tracked txns")
+		}
+		return nil
+	})
+
+	db.Exec(t, "COMMIT;")
+}
+
+func TestTelemetryLoggingRespectsTxnLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := log.ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+
+	cleanup := logtestutils.InstallLogFileSink(sc, t, logpb.Channel_TELEMETRY)
+	defer cleanup()
+
+	st := logtestutils.StubTime{}
+	sts := logtestutils.StubTracingStatus{}
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			EventLog: &EventLogTestingKnobs{
+				// The sampling checks below need to have a deterministic
+				// number of statements run by internal executor.
+				SyncWrites: true,
+			},
+			TelemetryLoggingKnobs: &TelemetryLoggingTestingKnobs{
+				getTimeNow:       st.TimeNow,
+				getTracingStatus: sts.TracingStatus,
+			},
+		},
+	})
+
+	defer s.Stopper().Stop(context.Background())
+
+	// Start 2 txns. Start the second txn with enough elapsed time that would normally allow
+	// txn tracking for telemetry, however since we set the limit to 1 tracked txn, the
+	// statements in the 2nd txn will only be logged if it is non DML or tracing is on.
+
+	queries := []struct {
+		testQuery
+		txnNum int
+	}{
+		{
+			testQuery: testQuery{
+				query:   "BEGIN;",
+				logTime: 1,
+			},
+			txnNum: 1,
+		},
+		{
+			testQuery: testQuery{
+				query:   "BEGIN;",
+				logTime: 2,
+			},
+			txnNum: 2,
+		},
+		{
+			testQuery: testQuery{
+				query:   "SELECT 1;", // Logged.
+				logTime: 2,
+			},
+			txnNum: 1,
+		},
+		{
+			testQuery: testQuery{
+				query:   "SELECT 2;", // Skipped.
+				logTime: 2,
+			},
+			txnNum: 2,
+		},
+		{
+			testQuery: testQuery{
+				query:   "SELECT 1, 1;", // Logged.
+				logTime: 2,
+			},
+			txnNum: 1,
+		},
+		{
+			testQuery: testQuery{
+				query:   "SELECT 2, 2;", // Skipped.
+				logTime: 2,
+			},
+			txnNum: 2,
+		},
+		{
+			testQuery: testQuery{
+				query:   "SELECT 2, 2, 2;", // Not logged, even though enough time has elapsed.
+				logTime: 2.1,
+			},
+			txnNum: 2,
+		},
+		{
+			testQuery: testQuery{
+				query:          "SELECT 2, 2, 2, 2;", // Logged. Tracing is on.
+				logTime:        2.1,
+				tracingEnabled: true,
+			},
+			txnNum: 2,
+		},
+		{
+			testQuery: testQuery{
+				query:   "SELECT 1, 1, 1;", // Logged.
+				logTime: 2.1,
+			},
+			txnNum: 1,
+		},
+		{
+			testQuery: testQuery{
+				query:   "COMMIT;",
+				logTime: 3,
+			},
+			txnNum: 1,
+		},
+		{
+			testQuery: testQuery{
+				query:   "SELECT 2, 2, 2;", // Not logged, even though enough time has elapsed it is not the first stmt.
+				logTime: 3.5,
+			},
+			txnNum: 2,
+		},
+		{
+			testQuery: testQuery{
+				query:   "COMMIT;",
+				logTime: 3,
+			},
+			txnNum: 2,
+		},
+	}
+
+	expectedLogs := []expectedLog{
+		{
+			logMsg:            `SELECT ‹1›`,
+			skippedQueryCount: 2, // Skipped both BEGIN queries.
+		},
+		{
+			logMsg:            `SELECT ‹1›, ‹1›`,
+			skippedQueryCount: 1,
+		},
+		{
+			logMsg:            `SELECT ‹2›, ‹2›, ‹2›, ‹2›`,
+			skippedQueryCount: 2,
+		},
+		{
+			logMsg:            `SELECT ‹1›, ‹1›, ‹1›`,
+			skippedQueryCount: 0,
+		},
+	}
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+
+	pgURL, cleanupGoDB := sqlutils.PGUrl(
+		t, s.AdvSQLAddr(), "CreateConnections" /* prefix */, url.User(username.RootUser))
+	defer cleanupGoDB()
+	sqlDB2, err := gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer sqlDB2.Close()
+	db2 := sqlutils.MakeSQLRunner(sqlDB2)
+
+	st.SetTime(timeutil.FromUnixMicros(0))
+	db.Exec(t, `SET application_name = 'telemetry-logging-test-txn-limit'`)
+
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.txn_mode.tracking_limit = 1;`)
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.max_event_frequency = 10;`)
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.mode = "transaction";`)
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
+
+	for _, query := range queries {
+		stubTime := timeutil.FromUnixMicros(int64(query.logTime * 1e6))
+		st.SetTime(stubTime)
+		sts.SetTracingStatus(query.tracingEnabled)
+		if query.txnNum == 1 {
+			db.Exec(t, query.query)
+		} else {
+			db2.Exec(t, query.query)
+		}
+	}
+
+	log.FlushFiles()
+
+	entries, err := log.FetchEntriesFromFiles(
+		0,
+		math.MaxInt64,
+		10000,
+		regexp.MustCompile(`"EventType":"sampled_query"`),
+		log.WithMarkedSensitiveData,
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) == 0 {
+		t.Fatal(errors.Newf("no entries found"))
+	}
+
+	for _, e := range entries {
+		if strings.Contains(e.Message, `"ExecMode":"`+executorTypeInternal.logLabel()) {
+			t.Errorf("unexpected telemetry event for internal statement:\n%s", e.Message)
+		}
+	}
+
+	expectedLogCount := len(expectedLogs)
+	if expectedLogCount > len(entries) {
+		t.Fatalf("expected at least %d log entries, got: %d", expectedLogCount, len(entries))
+	}
+
+	// FetchEntriesFromFiles delivers entries in reverse order.
+	entryIdx := len(entries) - 1
+
+	// Skip the cluster setting queries.
+	for strings.Contains(entries[entryIdx].Message, "SET CLUSTER SETTING") {
+		entryIdx--
+	}
+
+	for i := 0; i < expectedLogCount; i++ {
+		e := entries[entryIdx-i]
+		if !strings.Contains(e.Message, expectedLogs[i].logMsg+"\"") {
+			t.Errorf("expected log message to contain:\n%s\nbut received:\n%s\n",
+				expectedLogs[i].logMsg, e.Message)
+		}
+
+		var sq eventpb.SampledQuery
+		err = json.Unmarshal([]byte(e.Message), &sq)
+		require.NoError(t, err)
+
+		expectedSkipped := expectedLogs[i].skippedQueryCount
+		if expectedSkipped == 0 {
+			require.Zerof(t, sq.SkippedQueries, "expected no skipped queries, found:\n%s", e.Message)
+		} else {
+			require.Equalf(t, uint64(expectedSkipped), sq.SkippedQueries, "expected skipped queries, found:\n%s", e.Message)
 		}
 	}
 }


### PR DESCRIPTION
The telemetry logging channel currently logs statement executions based on
whether or not enough time has passed between emitted query log events. We
would also like to have a sampling strategy that is able to capture all
queries in a transaction. This commit introduces the "transaction" sampling
mode for telemetry, which enables us to sample transaction executions as a
whole for telemetry. This will allow us to capture all queries for a sampled
txn.

The "transaction" mode works in the following way:
  - 'forced' stmt logging is still enabled (e.g. if the stmt is a non-DML type
    or the stmt has tracing on, it will be logged, with the added exception of
   COMMIT statements, which will not be included in the forced logging).
  - Otherwise, an entire transaction is either logged or skipped. A txn is
    tracked if when logging the first stmt in the txn, there is both enough
    capacity to track another transaction according to the cluster setting
   `sql.telemetry.txn_mode.tracking_limit`, and sufficient time has elapsed
    since the last tracked txn.

New cluster settings (not documented currently):
- sql.telemetry.query_sampling.mode: enum value of "statement" (default)
or "transaction" that controls the execution type observed for sampling
- sql.telemetry.txn_mode.tracking_limit: the maximum number of transactions
tracked at one time for which we will send all statements to telemetry

Release note: None

Part of https://github.com/cockroachdb/cockroach/issues/103518
@xinhaoz