### PR TITLE
storage: remove duplicated key kind constants

### DIFF
--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -138,7 +138,7 @@ func (b *appBatch) addWriteBatch(
 	if wb == nil {
 		return nil
 	}
-	if mutations, err := storage.PebbleBatchCount(wb.Data); err != nil {
+	if mutations, err := storage.BatchCount(wb.Data); err != nil {
 		log.Errorf(ctx, "unable to read header of committed WriteBatch: %+v", err)
 	} else {
 		b.numMutations += mutations

--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -12,6 +12,7 @@ package kvserver
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"strings"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble"
 	"go.etcd.io/raft/v3/raftpb"
 )
 
@@ -232,11 +234,18 @@ func tryIntent(kv storage.MVCCKeyValue) (string, error) {
 }
 
 func decodeWriteBatch(writeBatch *kvserverpb.WriteBatch) (string, error) {
+	// Ensure that we always update this function to consider any necessary
+	// updates when a new key kind is introduced. To do this, we assert
+	// pebble.KeyKindDeleteSized is the most recent key kind, ensuring that
+	// compilation will fail if it's not. Unfortunately, this doesn't protect
+	// against reusing a currently unused RocksDB key kind.
+	const _ = uint(pebble.InternalKeyKindDeleteSized - pebble.InternalKeyKindMax)
+
 	if writeBatch == nil {
 		return "<nil>\n", nil
 	}
 
-	r, err := storage.NewPebbleBatchReader(writeBatch.Data)
+	r, err := storage.NewBatchReader(writeBatch.Data)
 	if err != nil {
 		return "", err
 	}
@@ -245,32 +254,32 @@ func decodeWriteBatch(writeBatch *kvserverpb.WriteBatch) (string, error) {
 	// the caller all the info we have (in case the writebatch is corrupted).
 	var sb strings.Builder
 	for r.Next() {
-		switch r.BatchType() {
-		case storage.BatchTypeDeletion:
+		switch r.KeyKind() {
+		case pebble.InternalKeyKindDelete:
 			engineKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
 			}
 			sb.WriteString(fmt.Sprintf("Delete: %s\n", SprintEngineKey(engineKey)))
-		case storage.BatchTypeValue:
+		case pebble.InternalKeyKindSet, pebble.InternalKeyKindSetWithDelete:
 			engineKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
 			}
 			sb.WriteString(fmt.Sprintf("Put: %s\n", SprintEngineKeyValue(engineKey, r.Value())))
-		case storage.BatchTypeMerge:
+		case pebble.InternalKeyKindMerge:
 			engineKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
 			}
 			sb.WriteString(fmt.Sprintf("Merge: %s\n", SprintEngineKeyValue(engineKey, r.Value())))
-		case storage.BatchTypeSingleDeletion:
+		case pebble.InternalKeyKindSingleDelete:
 			engineKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
 			}
 			sb.WriteString(fmt.Sprintf("Single Delete: %s\n", SprintEngineKey(engineKey)))
-		case storage.BatchTypeRangeDeletion:
+		case pebble.InternalKeyKindRangeDelete:
 			engineStartKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
@@ -282,7 +291,7 @@ func decodeWriteBatch(writeBatch *kvserverpb.WriteBatch) (string, error) {
 			sb.WriteString(fmt.Sprintf(
 				"Delete Range: [%s, %s)\n", SprintEngineKey(engineStartKey), SprintEngineKey(engineEndKey),
 			))
-		case storage.BatchTypeRangeKeySet:
+		case pebble.InternalKeyKindRangeKeySet:
 			engineStartKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
@@ -301,7 +310,7 @@ func decodeWriteBatch(writeBatch *kvserverpb.WriteBatch) (string, error) {
 					"Set Range Key: %s\n", SprintEngineRangeKeyValue(span, rangeKey),
 				))
 			}
-		case storage.BatchTypeRangeKeyUnset:
+		case pebble.InternalKeyKindRangeKeyUnset:
 			engineStartKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
@@ -320,7 +329,7 @@ func decodeWriteBatch(writeBatch *kvserverpb.WriteBatch) (string, error) {
 					"Unset Range Key: %s\n", SprintEngineRangeKey(span, rangeKey.Version),
 				))
 			}
-		case storage.BatchTypeRangeKeyDelete:
+		case pebble.InternalKeyKindRangeKeyDelete:
 			engineStartKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
@@ -333,8 +342,15 @@ func decodeWriteBatch(writeBatch *kvserverpb.WriteBatch) (string, error) {
 				"Delete Range Keys: %s\n",
 				SprintKeySpan(roachpb.Span{Key: engineStartKey.Key, EndKey: engineEndKey.Key}),
 			))
+		case pebble.InternalKeyKindDeleteSized:
+			engineKey, err := r.EngineKey()
+			if err != nil {
+				return sb.String(), err
+			}
+			v, _ := binary.Uvarint(r.Value())
+			sb.WriteString(fmt.Sprintf("Delete (Sized at %d): %s\n", v, SprintEngineKey(engineKey)))
 		default:
-			sb.WriteString(fmt.Sprintf("unsupported batch type: %d\n", r.BatchType()))
+			sb.WriteString(fmt.Sprintf("unsupported key kind: %d\n", r.KeyKind()))
 		}
 	}
 	return sb.String(), r.Error()

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -19,34 +19,12 @@ import (
 	"github.com/cockroachdb/pebble/rangekey"
 )
 
-// BatchType represents the type of an entry in an encoded Pebble batch.
-type BatchType byte
-
-// From github.com/cockroachdb/pebble/internal/base/internal.go.
-const (
-	BatchTypeDeletion BatchType = 0x0
-	BatchTypeValue    BatchType = 0x1
-	BatchTypeMerge    BatchType = 0x2
-	BatchTypeLogData  BatchType = 0x3
-	// BatchTypeColumnFamilyDeletion       BatchType = 0x4
-	// BatchTypeColumnFamilyValue          BatchType = 0x5
-	// BatchTypeColumnFamilyMerge          BatchType = 0x6
-	BatchTypeSingleDeletion BatchType = 0x7
-	// BatchTypeColumnFamilySingleDeletion BatchType = 0x8
-	// BatchTypeBeginPrepareXID            BatchType = 0x9
-	// BatchTypeEndPrepareXID              BatchType = 0xA
-	// BatchTypeCommitXID                  BatchType = 0xB
-	// BatchTypeRollbackXID                BatchType = 0xC
-	// BatchTypeNoop                       BatchType = 0xD
-	// BatchTypeColumnFamilyRangeDeletion  BatchType = 0xE
-	BatchTypeRangeDeletion BatchType = 0xF
-	// BatchTypeColumnFamilyBlobIndex      BatchType = 0x10
-	// BatchTypeBlobIndex                  BatchType = 0x11
-	// BatchMaxValue                       BatchType = 0x7F
-	BatchTypeRangeKeyDelete BatchType = 0x13
-	BatchTypeRangeKeyUnset  BatchType = 0x14
-	BatchTypeRangeKeySet    BatchType = 0x15
-)
+// Ensure that we always update the batch reader to consider any necessary
+// updates when a new key kind is introduced. To do this, we assert
+// InternalKeyKindMax=23, ensuring that compilation will fail if it's not.
+// Unfortunately, this doesn't protect against reusing a currently unused
+// RocksDB key kind.
+const _ = uint(pebble.InternalKeyKindDeleteSized - pebble.InternalKeyKindMax)
 
 const (
 	// The batch header is composed of an 8-byte sequence number (all zeroes) and
@@ -55,10 +33,10 @@ const (
 	countPos   int = 8
 )
 
-// decodePebbleBatchHeader decodes the header of Pebble batch repr, returning
+// decodeBatchHeader decodes the header of Pebble batch represenation, returning
 // both the count of the entries in the batch and the suffix of data remaining
 // in the batch.
-func decodePebbleBatchHeader(repr []byte) (count int, orepr pebble.BatchReader, err error) {
+func decodeBatchHeader(repr []byte) (count int, orepr pebble.BatchReader, err error) {
 	if len(repr) < headerSize {
 		return 0, nil, errors.Errorf("batch repr too small: %d < %d", len(repr), headerSize)
 	}
@@ -73,35 +51,34 @@ func decodePebbleBatchHeader(repr []byte) (count int, orepr pebble.BatchReader, 
 	return int(c), r, nil
 }
 
-// PebbleBatchReader is used to iterate the entries in a Pebble batch
+// BatchReader is used to iterate the entries in a Pebble batch
 // representation.
 //
 // Example:
-// r, err := NewPebbleBatchReader(...)
 //
+//	r, err := NewBatchReader(...)
 //	if err != nil {
 //	  return err
 //	}
-//
 //	for r.Next() {
-//		 switch r.BatchType() {
-//		 case BatchTypeDeletion:
-//		   fmt.Printf("delete(%x)", r.Key())
-//		 case BatchTypeValue:
-//		   fmt.Printf("put(%x,%x)", r.Key(), r.Value())
-//		 case BatchTypeMerge:
-//		   fmt.Printf("merge(%x,%x)", r.Key(), r.Value())
-//	  case BatchTypeSingleDeletion:
-//		   fmt.Printf("single_delete(%x)", r.Key())
-//	  case BatchTypeRangeDeletion:
-//		   fmt.Printf("delete_range(%x,%x)", r.Key(), r.Value())
+//		switch r.KeyKind() {
+//		case pebble.InternalKeyKindDelete:
+//			fmt.Printf("delete(%x)", r.Key())
+//		case pebble.InternalKeyKindSet:
+//			fmt.Printf("put(%x,%x)", r.Key(), r.Value())
+//		case pebble.InternalKeyKindMerge:
+//			fmt.Printf("merge(%x,%x)", r.Key(), r.Value())
+//		case pebble.InternalKeyKindSingleDelete:
+//			fmt.Printf("single_delete(%x)", r.Key())
+//		case pebble.InternalKeyKindRangeDelete:
+//			fmt.Printf("delete_range(%x,%x)", r.Key(), r.Value())
 //		 }
 //	}
 //
 //	if err := r.Error(); err != nil {
 //	  return err
 //	}
-type PebbleBatchReader struct {
+type BatchReader struct {
 	batchReader pebble.BatchReader
 
 	// The error encountered during iterator, if any
@@ -111,50 +88,50 @@ type PebbleBatchReader struct {
 	count int
 
 	// The following all represent the current entry and are updated by Next.
-	// `value` is not applicable for BatchTypeDeletion or BatchTypeSingleDeletion.
-	// `value` indicates the end key for BatchTypeRangeDeletion.
-	typ   BatchType
+	// `value` is not applicable for all key kinds. For RangeDelete, value
+	// indicates the end key for the range deletion.
+	kind  pebble.InternalKeyKind
 	key   []byte
 	value []byte
 }
 
-// NewPebbleBatchReader creates a PebbleBatchReader from the given batch repr
-// and verifies the header.
-func NewPebbleBatchReader(repr []byte) (*PebbleBatchReader, error) {
-	count, batchReader, err := decodePebbleBatchHeader(repr)
+// NewBatchReader creates a BatchReader from the given batch repr and
+// verifies the header.
+func NewBatchReader(repr []byte) (*BatchReader, error) {
+	count, batchReader, err := decodeBatchHeader(repr)
 	if err != nil {
 		return nil, err
 	}
-	return &PebbleBatchReader{batchReader: batchReader, count: count}, nil
+	return &BatchReader{batchReader: batchReader, count: count}, nil
 }
 
 // Count returns the declared number of entries in the batch.
-func (r *PebbleBatchReader) Count() int {
+func (r *BatchReader) Count() int {
 	return r.count
 }
 
 // Error returns the error, if any, which the iterator encountered.
-func (r *PebbleBatchReader) Error() error {
+func (r *BatchReader) Error() error {
 	return r.err
 }
 
-// BatchType returns the type of the current batch entry.
-func (r *PebbleBatchReader) BatchType() BatchType {
-	return r.typ
+// KeyKind returns the kind of the current entry.
+func (r *BatchReader) KeyKind() pebble.InternalKeyKind {
+	return r.kind
 }
 
 // Key returns the key of the current batch entry.
-func (r *PebbleBatchReader) Key() []byte {
+func (r *BatchReader) Key() []byte {
 	return r.key
 }
 
 // MVCCKey returns the MVCC key of the current batch entry.
-func (r *PebbleBatchReader) MVCCKey() (MVCCKey, error) {
+func (r *BatchReader) MVCCKey() (MVCCKey, error) {
 	return DecodeMVCCKey(r.Key())
 }
 
 // EngineKey returns the EngineKey for the current batch entry.
-func (r *PebbleBatchReader) EngineKey() (EngineKey, error) {
+func (r *BatchReader) EngineKey() (EngineKey, error) {
 	key, ok := DecodeEngineKey(r.Key())
 	if !ok {
 		return key, errors.Errorf("invalid encoded engine key: %x", r.Key())
@@ -163,10 +140,10 @@ func (r *PebbleBatchReader) EngineKey() (EngineKey, error) {
 }
 
 // Value returns the value of the current batch entry. Value panics if the
-// BatchType is a point key deletion.
-func (r *PebbleBatchReader) Value() []byte {
-	switch r.typ {
-	case BatchTypeDeletion, BatchTypeSingleDeletion:
+// kind is a point key deletion.
+func (r *BatchReader) Value() []byte {
+	switch r.kind {
+	case pebble.InternalKeyKindDelete, pebble.InternalKeyKindSingleDelete:
 		panic("cannot call Value on a deletion entry")
 	default:
 		return r.value
@@ -174,13 +151,13 @@ func (r *PebbleBatchReader) Value() []byte {
 }
 
 // EngineEndKey returns the engine end key of the current ranged batch entry.
-func (r *PebbleBatchReader) EngineEndKey() (EngineKey, error) {
+func (r *BatchReader) EngineEndKey() (EngineKey, error) {
 	var rawKey []byte
-	switch r.typ {
-	case BatchTypeRangeDeletion, BatchTypeRangeKeyDelete:
+	switch r.kind {
+	case pebble.InternalKeyKindRangeDelete:
 		rawKey = r.Value()
 
-	case BatchTypeRangeKeySet, BatchTypeRangeKeyUnset:
+	case pebble.InternalKeyKindRangeKeySet, pebble.InternalKeyKindRangeKeyUnset, pebble.InternalKeyKindRangeKeyDelete:
 		rangeKeys, err := r.rangeKeys()
 		if err != nil {
 			return EngineKey{}, err
@@ -189,7 +166,7 @@ func (r *PebbleBatchReader) EngineEndKey() (EngineKey, error) {
 
 	default:
 		return EngineKey{}, errors.AssertionFailedf(
-			"can only ask for EndKey on a ranged entry, got %v", r.typ)
+			"can only ask for EndKey on a ranged entry, got %v", r.kind)
 	}
 
 	key, ok := DecodeEngineKey(rawKey)
@@ -200,12 +177,12 @@ func (r *PebbleBatchReader) EngineEndKey() (EngineKey, error) {
 }
 
 // EngineRangeKeys returns the engine range key values at the current entry.
-func (r *PebbleBatchReader) EngineRangeKeys() ([]EngineRangeKeyValue, error) {
-	switch r.typ {
-	case BatchTypeRangeKeySet, BatchTypeRangeKeyUnset:
+func (r *BatchReader) EngineRangeKeys() ([]EngineRangeKeyValue, error) {
+	switch r.kind {
+	case pebble.InternalKeyKindRangeKeySet, pebble.InternalKeyKindRangeKeyUnset:
 	default:
 		return nil, errors.AssertionFailedf(
-			"can only ask for range keys on a range key entry, got %v", r.typ)
+			"can only ask for range keys on a range key entry, got %v", r.kind)
 	}
 	rangeKeys, err := r.rangeKeys()
 	if err != nil {
@@ -219,25 +196,21 @@ func (r *PebbleBatchReader) EngineRangeKeys() ([]EngineRangeKeyValue, error) {
 }
 
 // rangeKeys decodes and returns the current Pebble range key.
-func (r *PebbleBatchReader) rangeKeys() (rangekey.Span, error) {
-	return rangekey.Decode(pebble.InternalKey{UserKey: r.key, Trailer: uint64(r.typ)}, r.value, nil)
+func (r *BatchReader) rangeKeys() (rangekey.Span, error) {
+	return rangekey.Decode(pebble.InternalKey{UserKey: r.key, Trailer: uint64(r.kind)}, r.value, nil)
 }
 
 // Next advances to the next entry in the batch, returning false when the batch
 // is empty.
-func (r *PebbleBatchReader) Next() bool {
-	kind, ukey, value, ok := r.batchReader.Next()
-
-	r.typ = BatchType(kind)
-	r.key = ukey
-	r.value = value
-
+func (r *BatchReader) Next() bool {
+	var ok bool
+	r.kind, r.key, r.value, ok = r.batchReader.Next()
 	return ok
 }
 
-// PebbleBatchCount provides an efficient way to get the count of mutations in a
-// Pebble batch representation.
-func PebbleBatchCount(repr []byte) (int, error) {
+// BatchCount provides an efficient way to get the count of mutations in a batch
+// representation.
+func BatchCount(repr []byte) (int, error) {
 	if len(repr) < headerSize {
 		return 0, errors.Errorf("batch repr too small: %d < %d", len(repr), headerSize)
 	}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3824,7 +3824,7 @@ func buildScanIntents(data []byte) ([]roachpb.Intent, error) {
 		return nil, nil
 	}
 
-	reader, err := NewPebbleBatchReader(data)
+	reader, err := NewBatchReader(data)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit performs a small refactor of the batch reading interface exposed by the storage package. It removes 'Pebble' from a few names, removes the duplicated key kinds (Pebble exports these now), and adds assertions to ensure new key kinds trigger compilation failures. This motivated by #104539, in which I never even considered the batch reader or how it might need to change.

Epic: none
Release note: None