### PR TITLE
optbuilder: fix internal error in project set with column expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -1301,3 +1301,19 @@ SELECT * FROM t95615, LATERAL ROWS FROM (f95615(), f95615()) WITH ORDINALITY
 
 statement ok
 RESET testing_optimizer_disable_rule_probability
+
+# Regression test for issue #95315.
+statement ok
+CREATE TABLE t95315 (c1 INT, c2 FLOAT);
+
+statement ok
+INSERT INTO t95315 VALUES (1, 4.3), (2, 5.4), (3, 6), (4, 7);
+
+# Regression test for issue #95315.
+# A query which uses a project set involving simple column expressions does
+# not error out. Results verified on postgres.
+query IIF
+SELECT 1,c1,c2 FROM t95315 JOIN ROWS FROM (CAST(c1 AS INT), CAST(c2 AS INT)) USING (c1, c2) ORDER BY 1,2,3;
+----
+1  3  6
+1  4  7

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -1137,3 +1137,34 @@ project
       │         └── zip
       │              └── f95615()
       └── filters (true)
+
+# Regression test for issue #95315.
+exec-ddl
+CREATE TABLE t95315 (c1 INT, c2 FLOAT)
+----
+
+# Regression test for issue #95315.
+# A query which uses a project set involving simple column expressions does
+# not error out.
+build
+SELECT 1,c1,c2 FROM t95315 JOIN
+       ROWS FROM (CAST(c1 AS INT), CAST(c2 AS INT)) USING (c1, c2)
+----
+project
+ ├── columns: "?column?":8!null c1:1 c2:2
+ ├── inner-join-apply
+ │    ├── columns: t95315.c1:1 t95315.c2:2 rowid:3!null crdb_internal_mvcc_timestamp:4 tableoid:5 c1:6 c2:7
+ │    ├── scan t95315
+ │    │    └── columns: t95315.c1:1 t95315.c2:2 rowid:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    ├── project-set
+ │    │    ├── columns: c1:6 c2:7
+ │    │    ├── values
+ │    │    │    └── ()
+ │    │    └── zip
+ │    │         ├── t95315.c1:1
+ │    │         └── t95315.c2:2::INT8
+ │    └── filters
+ │         ├── t95315.c1:1 = c1:6
+ │         └── t95315.c2:2 = c2:7
+ └── projections
+      └── 1 [as="?column?":8]


### PR DESCRIPTION
This fixes rare internal errors in queries which are evaluated using
project set operations involving simple column expressions.

In the optbuilder, `buildZip` calls `buildScalar` on an input expression
and uses the resulting scalar expression as the input to a zip item.
When the `outScope` argument to `buildScalar` is non-nil, that's
interpreted as a projection operation, and if the passed-in `scalar`
expression is a `scopeColumn`, it's treated as a passthrough column
and no output scalar expression is built for it.

Since project set expressions do not have passthrough columns like
project expressions, the solution taken is to pass a nil `outScope`
argument to `buildScalar`, causing the scalar expression to be built,
then assigning the output column to a new column id to prevent an
overlap of outer columns and output columns.

Epic: none
Fixes: #95315

Release note (bug fix): This patch fixes rare internal errors which
occur when a query uses a "project set" operation involving simple
column expressions.