### PR TITLE
sql: stop using deprecated catalog functions for vtables

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -613,7 +613,7 @@ func crdbInternalTablesDatabaseLookupFunc(
 	var descs nstree.Catalog
 	var err error
 	if useIndexLookupForDescriptorsInDatabase.Get(&p.EvalContext().Settings.SV) {
-		descs, err = p.Descriptors().GetAllDescriptorsForDatabase(ctx, p.Txn(), db)
+		descs, err = p.Descriptors().GetAllInDatabase(ctx, p.Txn(), db)
 	} else {
 		descs, err = p.Descriptors().GetAllDescriptors(ctx, p.Txn())
 	}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -2369,7 +2369,7 @@ func forEachTypeDesc(
 	var all nstree.Catalog
 	if dbContext != nil &&
 		useIndexLookupForDescriptorsInDatabase.Get(&p.EvalContext().Settings.SV) {
-		all, err = p.Descriptors().GetAllDescriptorsForDatabase(ctx, p.txn, dbContext)
+		all, err = p.Descriptors().GetAllInDatabase(ctx, p.txn, dbContext)
 	} else {
 		all, err = p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	}
@@ -2514,7 +2514,7 @@ func forEachTableDescWithTableLookupInternal(
 ) (err error) {
 	var all nstree.Catalog
 	if dbContext != nil && useIndexLookupForDescriptorsInDatabase.Get(&p.EvalContext().Settings.SV) {
-		all, err = p.Descriptors().GetAllDescriptorsForDatabase(ctx, p.txn, dbContext)
+		all, err = p.Descriptors().GetAllInDatabase(ctx, p.txn, dbContext)
 	} else {
 		all, err = p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	}


### PR DESCRIPTION
Epic: None
Release note: None