### PR TITLE
roachtest: use pd-ssd as default, even when VolumeSize is set

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -183,7 +183,9 @@ func getGCEOpts(
 	}
 	opts.TerminateOnMigration = terminateOnMigration
 	opts.MinCPUPlatform = minCPUPlatform
-	opts.PDVolumeType = volumeType
+	if volumeType != "" {
+		opts.PDVolumeType = volumeType
+	}
 
 	return opts
 }


### PR DESCRIPTION
The cluster_to_cluster roachtest was setting VolumeSize, and assuming that the default pd-ssd is used, but instead the roachtest was running with standard pd (HDD). If VolumeSize is not set then roachtest is using local ssd, and if it is set then it uses whatever is in the GCEVolumeType. normally roachtest users don't set GCEVolumeType, and therefore roachtest uses an empty string for the pd type (which again means HDD).

Instead, this pr keep the default volume type unless the user asked for something else.

Epic: CRDB-25146

Release note: None