### PR TITLE
loqrecovery: check meta range completeness before usage

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -191,8 +191,11 @@ type localDataView struct {
 
 // testDescriptorData yaml optimized representation of RangeDescriptor
 type testDescriptorData struct {
-	RangeID    roachpb.RangeID         `yaml:"RangeID"`
-	StartKey   string                  `yaml:"StartKey"`
+	RangeID  roachpb.RangeID `yaml:"RangeID"`
+	StartKey string          `yaml:"StartKey"`
+	// EndKey is optional, it will be filled up with next descriptor's StartKey
+	// if omitted
+	EndKey     string                  `yaml:"EndKey"`
 	Replicas   []replicaDescriptorView `yaml:"Replicas,flow"`
 	Generation roachpb.RangeGeneration `yaml:"Generation,omitempty"`
 }
@@ -535,10 +538,14 @@ func (e *quorumRecoveryEnv) handleDescriptorData(t *testing.T, d datadriven.Test
 		if gen == 0 {
 			gen = roachpb.RangeGeneration(maxReplicaID)
 		}
+		endKeyStr := testDesc.EndKey
+		if endKeyStr == "" {
+			endKeyStr = nextStartKey
+		}
 		return roachpb.RangeDescriptor{
 			RangeID:          testDesc.RangeID,
 			StartKey:         parsePrettyKey(t, testDesc.StartKey),
-			EndKey:           parsePrettyKey(t, nextStartKey),
+			EndKey:           parsePrettyKey(t, endKeyStr),
 			InternalReplicas: replicas,
 			Generation:       gen,
 			NextReplicaID:    maxReplicaID + 1,

--- a/pkg/kv/kvserver/loqrecovery/testdata/ignore_partial_meta
+++ b/pkg/kv/kvserver/loqrecovery/testdata/ignore_partial_meta
@@ -1,0 +1,54 @@
+# Test verifies that if metadata is incomplete, then it is ignored
+# To verify that, metadata contains descriptors that doesn't require any changes,
+# while replicas contain LOQ case. We expect recovery to be performed
+# regardless of meta. (Note that this can't happen in real life)
+
+replication-data
+- StoreID: 1
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Table/1
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
+  RangeAppliedIndex: 11
+  RaftCommittedIndex: 13
+- StoreID: 1
+  RangeID: 2
+  StartKey: /Table/1
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  RangeAppliedIndex: 15
+  RaftCommittedIndex: 17
+----
+ok
+
+descriptor-data
+- RangeID: 1
+  StartKey: /Min
+  EndKey: /Table/1
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+----
+ok
+
+collect-replica-info stores=(1)
+----
+ok
+
+# Range 1 replica 1 is recovered despite meta saying it doesn't need to.
+make-plan
+----
+Replica updates:
+- RangeID: 1
+  StartKey: /Min
+  OldReplicaID: 1
+  NewReplica:
+    NodeID: 1
+    StoreID: 1
+    ReplicaID: 14
+  NextReplicaID: 15
+Decommissioned nodes:
+[n2, n3]


### PR DESCRIPTION
Previously, if meta range was read incompletely, recovery plan would only include ranges from meta ignoring the rest of ranges thus making recovery incomplete.
This commit adds checks for meta completeness so that recovery planning could fall back to 'no-meta' case and deduce target state from existing replicas alone.

Fixes: #104765

Release note (bug fix): Fixes `debug recover make-plan` command to ignore partial range metadata when it can't be fully
 read from broken cluster and instead rely solely on replica info from storage to produce recovery plan.