### PR TITLE
kv/concurrency: batch intent resolution of pushed intents from same txn

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -617,10 +617,10 @@ type lockTable interface {
 	// evaluation of this request. It adds the lock and enqueues this requester
 	// in its wait-queue. It is required that request evaluation discover such
 	// locks before acquiring its own locks, since the request needs to repeat
-	// ScanAndEnqueue. When consultFinalizedTxnCache=true, and the transaction
-	// holding the lock is finalized, the lock is not added to the lock table
-	// and instead tracked in the list of locks to resolve in the
-	// lockTableGuard.
+	// ScanAndEnqueue. When consultTxnStatusCache=true, and the transaction
+	// holding the lock is known to be pushed or finalized, the lock is not added
+	// to the lock table and instead tracked in the list of locks to resolve in
+	// the lockTableGuard.
 	//
 	// The lease sequence is used to detect lease changes between the when
 	// request that found the lock started evaluating and when the discovered
@@ -637,7 +637,7 @@ type lockTable interface {
 	// true) or whether it was ignored because the lockTable is currently
 	// disabled (false).
 	AddDiscoveredLock(
-		intent *roachpb.Intent, seq roachpb.LeaseSequence, consultFinalizedTxnCache bool,
+		intent *roachpb.Intent, seq roachpb.LeaseSequence, consultTxnStatusCache bool,
 		guard lockTableGuard) (bool, error)
 
 	// AcquireLock informs the lockTable that a new lock was acquired or an
@@ -722,11 +722,12 @@ type lockTable interface {
 	//     txn.WriteTimestamp.
 	UpdateLocks(*roachpb.LockUpdate) error
 
-	// TransactionIsFinalized informs the lock table that a transaction is
-	// finalized. This is used by the lock table in a best-effort manner to avoid
-	// waiting on locks of finalized transactions and telling the caller via
-	// lockTableGuard.ResolveBeforeEvaluation to resolve a batch of intents.
-	TransactionIsFinalized(*roachpb.Transaction)
+	// PushedTransactionUpdated informs the lock table that a transaction has been
+	// pushed and is either finalized or has been moved to a higher timestamp.
+	// This is used by the lock table in a best-effort manner to avoid waiting on
+	// locks of finalized or pushed transactions and telling the caller via
+	// lockTableGuard.ResolveBeforeScanning to resolve a batch of intents.
+	PushedTransactionUpdated(*roachpb.Transaction)
 
 	// QueryLockTableState returns detailed metadata on locks managed by the lockTable.
 	QueryLockTableState(span roachpb.Span, opts QueryLockTableOptions) ([]roachpb.LockStateInfo, QueryLockTableResumeState)

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -86,17 +86,18 @@ var MaxLockWaitQueueLength = settings.RegisterIntSetting(
 	},
 )
 
-// DiscoveredLocksThresholdToConsultFinalizedTxnCache sets a threshold as
-// mentioned in the description string. The default of 200 is somewhat
-// arbitrary but should suffice for small OLTP transactions. Given the default
+// DiscoveredLocksThresholdToConsultTxnStatusCache sets a threshold as mentioned
+// in the description string. The default of 200 is somewhat arbitrary but
+// should suffice for small OLTP transactions. Given the default
 // 10,000 lock capacity of the lock table, 200 is small enough to not matter
 // much against the capacity, which is desirable. We have seen examples with
 // discoveredCount > 100,000, caused by stats collection, where we definitely
 // want to avoid adding these locks to the lock table, if possible.
-var DiscoveredLocksThresholdToConsultFinalizedTxnCache = settings.RegisterIntSetting(
+var DiscoveredLocksThresholdToConsultTxnStatusCache = settings.RegisterIntSetting(
 	settings.SystemOnly,
+	// NOTE: the name of this setting mentions "finalized" for historical reasons.
 	"kv.lock_table.discovered_locks_threshold_for_consulting_finalized_txn_cache",
-	"the maximum number of discovered locks by a waiter, above which the finalized txn cache"+
+	"the maximum number of discovered locks by a waiter, above which the txn status cache"+
 		"is consulted and resolvable locks are not added to the lock table -- this should be a small"+
 		"fraction of the maximum number of locks in the lock table",
 	200,
@@ -465,11 +466,11 @@ func (m *managerImpl) HandleWriterIntentError(
 	//
 	// Either way, there is no possibility of the request entering an infinite
 	// loop without making progress.
-	consultFinalizedTxnCache :=
-		int64(len(t.Intents)) > DiscoveredLocksThresholdToConsultFinalizedTxnCache.Get(&m.st.SV)
+	consultTxnStatusCache :=
+		int64(len(t.Intents)) > DiscoveredLocksThresholdToConsultTxnStatusCache.Get(&m.st.SV)
 	for i := range t.Intents {
 		intent := &t.Intents[i]
-		added, err := m.lt.AddDiscoveredLock(intent, seq, consultFinalizedTxnCache, g.ltg)
+		added, err := m.lt.AddDiscoveredLock(intent, seq, consultTxnStatusCache, g.ltg)
 		if err != nil {
 			log.Fatalf(ctx, "%v", err)
 		}

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -146,7 +146,7 @@ func (c *Config) initDefaults() {
 func NewManager(cfg Config) Manager {
 	cfg.initDefaults()
 	m := new(managerImpl)
-	lt := newLockTable(cfg.MaxLockTableSize, cfg.RangeDesc.RangeID, cfg.Clock)
+	lt := newLockTable(cfg.MaxLockTableSize, cfg.RangeDesc.RangeID, cfg.Clock, cfg.Settings)
 	*m = managerImpl{
 		st: cfg.Settings,
 		// TODO(nvanbenschoten): move pkg/storage/spanlatch to a new

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -104,6 +104,19 @@ var DiscoveredLocksThresholdToConsultTxnStatusCache = settings.RegisterIntSettin
 	settings.NonNegativeInt,
 )
 
+// BatchPushedLockResolution controls whether the lock table should allow
+// non-locking readers to defer and batch the resolution of conflicting locks
+// whose holder is known to be pending and have been pushed above the reader's
+// timestamp.
+var BatchPushedLockResolution = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.lock_table.batch_pushed_lock_resolution.enabled",
+	"whether the lock table should allow non-locking readers to defer and batch the resolution of "+
+		"conflicting locks whose holder is known to be pending and have been pushed above the reader's "+
+		"timestamp",
+	true,
+)
+
 // managerImpl implements the Manager interface.
 type managerImpl struct {
 	st *cluster.Settings

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -634,13 +634,6 @@ func (m *managerImpl) TestingSetMaxLocks(maxLocks int64) {
 	m.lt.(*lockTableImpl).setMaxLocks(maxLocks)
 }
 
-func (r *Request) txnMeta() *enginepb.TxnMeta {
-	if r.Txn == nil {
-		return nil
-	}
-	return &r.Txn.TxnMeta
-}
-
 func (r *Request) isSingle(m kvpb.Method) bool {
 	if len(r.Requests) != 1 {
 		return false

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -90,6 +90,7 @@ import (
 // debug-set-clock           ts=<secs>
 // debug-advance-clock       ts=<secs>
 // debug-set-discovered-locks-threshold-to-consult-txn-status-cache n=<count>
+// debug-set-batch-pushed-lock-resolution-enabled ok=<enabled>
 // debug-set-max-locks n=<count>
 // reset
 func TestConcurrencyManagerBasic(t *testing.T) {
@@ -577,6 +578,12 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				c.setDiscoveredLocksThresholdToConsultTxnStatusCache(n)
 				return ""
 
+			case "debug-set-batch-pushed-lock-resolution-enabled":
+				var ok bool
+				d.ScanArgs(t, "ok", &ok)
+				c.setBatchPushedLockResolutionEnabled(ok)
+				return ""
+
 			case "debug-set-max-locks":
 				var n int
 				d.ScanArgs(t, "n", &n)
@@ -956,6 +963,10 @@ func (c *cluster) disableTxnPushes() {
 
 func (c *cluster) setDiscoveredLocksThresholdToConsultTxnStatusCache(n int) {
 	concurrency.DiscoveredLocksThresholdToConsultTxnStatusCache.Override(context.Background(), &c.st.SV, int64(n))
+}
+
+func (c *cluster) setBatchPushedLockResolutionEnabled(ok bool) {
+	concurrency.BatchPushedLockResolution.Override(context.Background(), &c.st.SV, ok)
 }
 
 // reset clears all request state in the cluster. This avoids portions of tests

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -89,7 +89,7 @@ import (
 // debug-disable-txn-pushes
 // debug-set-clock           ts=<secs>
 // debug-advance-clock       ts=<secs>
-// debug-set-discovered-locks-threshold-to-consult-finalized-txn-cache n=<count>
+// debug-set-discovered-locks-threshold-to-consult-txn-status-cache n=<count>
 // debug-set-max-locks n=<count>
 // reset
 func TestConcurrencyManagerBasic(t *testing.T) {
@@ -571,10 +571,10 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				c.manual.Advance(time.Duration(secs) * time.Second)
 				return ""
 
-			case "debug-set-discovered-locks-threshold-to-consult-finalized-txn-cache":
+			case "debug-set-discovered-locks-threshold-to-consult-txn-status-cache":
 				var n int
 				d.ScanArgs(t, "n", &n)
-				c.setDiscoveredLocksThresholdToConsultFinalizedTxnCache(n)
+				c.setDiscoveredLocksThresholdToConsultTxnStatusCache(n)
 				return ""
 
 			case "debug-set-max-locks":
@@ -954,8 +954,8 @@ func (c *cluster) disableTxnPushes() {
 	concurrency.LockTableDeadlockDetectionPushDelay.Override(context.Background(), &c.st.SV, time.Hour)
 }
 
-func (c *cluster) setDiscoveredLocksThresholdToConsultFinalizedTxnCache(n int) {
-	concurrency.DiscoveredLocksThresholdToConsultFinalizedTxnCache.Override(context.Background(), &c.st.SV, int64(n))
+func (c *cluster) setDiscoveredLocksThresholdToConsultTxnStatusCache(n int) {
+	concurrency.DiscoveredLocksThresholdToConsultTxnStatusCache.Override(context.Background(), &c.st.SV, int64(n))
 }
 
 // reset clears all request state in the cluster. This avoids portions of tests

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1734,7 +1734,7 @@ func (l *lockState) tryActiveWait(
 		// lockTableWaiter but difficult to coordinate through the txnStatusCache.
 		// This limitation is acceptable because the most important case here is
 		// optimizing the Export requests issued by backup.
-		if !g.hasUncertaintyInterval() {
+		if !g.hasUncertaintyInterval() && g.lt.batchPushedLockResolution() {
 			pushedTxn, ok := g.lt.txnStatusCache.pendingTxns.get(lockHolderTxn.ID)
 			if ok && g.ts.Less(pushedTxn.WriteTimestamp) {
 				up := roachpb.MakeLockUpdate(pushedTxn, roachpb.Span{Key: l.key})
@@ -2883,7 +2883,7 @@ func (t *lockTableImpl) AddDiscoveredLock(
 		// holder is known to have been pushed above the reader's timestamp. See the
 		// comment in tryActiveWait for more details, including why we include the
 		// hasUncertaintyInterval condition.
-		if str == lock.None && !g.hasUncertaintyInterval() {
+		if str == lock.None && !g.hasUncertaintyInterval() && t.batchPushedLockResolution() {
 			pushedTxn, ok := g.lt.txnStatusCache.pendingTxns.get(intent.Txn.ID)
 			if ok && g.ts.Less(pushedTxn.WriteTimestamp) {
 				g.toResolve = append(
@@ -3141,6 +3141,13 @@ func stepToNextSpan(g *lockTableGuardImpl) *roachpb.Span {
 	}
 	g.str = lock.MaxStrength
 	return nil
+}
+
+// batchPushedLockResolution returns whether non-locking readers can defer and
+// batch resolution of conflicting locks whose holder is known to be pending and
+// have been pushed above the reader's timestamp.
+func (t *lockTableImpl) batchPushedLockResolution() bool {
+	return BatchPushedLockResolution.Get(&t.settings.SV)
 }
 
 // PushedTransactionUpdated implements the lockTable interface.

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -259,16 +259,14 @@ type lockTableImpl struct {
 	// instead of clearing everything.
 	minLocks int64
 
-	// finalizedTxnCache is a small LRU cache that tracks transactions that
-	// were pushed and found to be finalized (COMMITTED or ABORTED). It is
-	// used as an optimization to avoid repeatedly pushing the transaction
-	// record when cleaning up the intents of an abandoned transaction.
+	// txnStatusCache is a small LRU cache that tracks the status of
+	// transactions that have been successfully pushed.
 	//
-	// NOTE: it probably makes sense to maintain a single finalizedTxnCache
+	// NOTE: it probably makes sense to maintain a single txnStatusCache
 	// across all Ranges on a Store instead of an individual cache per
 	// Range. For now, we don't do this because we don't share any state
 	// between separate concurrency.Manager instances.
-	finalizedTxnCache txnCache
+	txnStatusCache txnStatusCache
 
 	// clock is used to track the lock hold and lock wait start times.
 	clock *hlc.Clock
@@ -716,6 +714,10 @@ func (g *lockTableGuardImpl) txnMeta() *enginepb.TxnMeta {
 	return &g.txn.TxnMeta
 }
 
+func (g *lockTableGuardImpl) hasUncertaintyInterval() bool {
+	return g.txn != nil && g.txn.ReadTimestamp.Less(g.txn.GlobalUncertaintyLimit)
+}
+
 func (g *lockTableGuardImpl) isSameTxn(txn *enginepb.TxnMeta) bool {
 	return g.txn != nil && g.txn.ID == txn.ID
 }
@@ -748,7 +750,7 @@ func (g *lockTableGuardImpl) resumeScan(notify bool) {
 		span = &spans[g.index]
 		resumingInSameSpan = true
 	}
-	// Locks that transition to free because of the finalizedTxnCache are GC'd
+	// Locks that transition to free because of the txnStatusCache are GC'd
 	// before returning. Note that these are only unreplicated locks. Replicated
 	// locks are handled via the g.toResolve.
 	var locksToGC []*lockState
@@ -799,8 +801,20 @@ func (g *lockTableGuardImpl) resumeScan(notify bool) {
 		// we iterate over all the elements of toResolve and only keep the ones
 		// where removing the lock via the call to updateLockInternal is not a
 		// noop.
+		//
+		// For pushed transactions that are not finalized, we disable this
+		// deduplication and allow all resolution attempts to adjust the lock's
+		// timestamp to go through. This is because updating the lock ahead of
+		// resolution risks rediscovery loops where the lock is continually
+		// rediscovered at a lower timestamp than that in the lock table.
 		for i := range g.toResolve {
-			if heldByTxn := g.lt.updateLockInternal(&g.toResolve[i]); heldByTxn {
+			var doResolve bool
+			if g.toResolve[i].Status.IsFinalized() {
+				doResolve = g.lt.updateLockInternal(&g.toResolve[i])
+			} else {
+				doResolve = true
+			}
+			if doResolve {
 				g.toResolve[j] = g.toResolve[i]
 				j++
 			}
@@ -1073,8 +1087,8 @@ func (l *lockState) SafeFormat(w redact.SafePrinter, _ rune) {
 }
 
 // safeFormat is a helper for SafeFormat and String methods.
-// REQUIRES: l.mu is locked. finalizedTxnCache can be nil.
-func (l *lockState) safeFormat(sb *redact.StringBuilder, finalizedTxnCache *txnCache) {
+// REQUIRES: l.mu is locked. txnStatusCache can be nil.
+func (l *lockState) safeFormat(sb *redact.StringBuilder, txnStatusCache *txnStatusCache) {
 	sb.Printf(" lock: %s\n", l.key)
 	if l.isEmptyLock() {
 		sb.SafeString("  empty\n")
@@ -1097,8 +1111,8 @@ func (l *lockState) safeFormat(sb *redact.StringBuilder, finalizedTxnCache *txnC
 			} else {
 				sb.SafeString("unrepl ")
 			}
-			if finalizedTxnCache != nil {
-				finalizedTxn, ok := finalizedTxnCache.get(h.txn.ID)
+			if txnStatusCache != nil {
+				finalizedTxn, ok := txnStatusCache.finalizedTxns.get(h.txn.ID)
 				if ok {
 					var statusStr string
 					switch finalizedTxn.Status {
@@ -1598,11 +1612,12 @@ func (l *lockState) clearLockHolder() {
 // is notified first and the call to tryActiveWait() happens later in
 // lockTableGuard.CurState().
 //
-// It uses the finalizedTxnCache to decide that the caller does not need to
-// wait on a lock of a transaction that is already finalized.
+// It uses the txnStatusCache to decide that the caller does not need to wait on
+// a lock of a transaction that is already finalized or is pending but pushed
+// above the request's read timestamp (for non-locking readers).
 //
-//   - For unreplicated locks, this method will silently remove the lock and
-//     proceed as normal.
+//   - For unreplicated locks, this method will silently remove (or update) the
+//     lock and proceed as normal.
 //
 //   - For replicated locks the behavior is more complicated since we need to
 //     resolve the intent. We desire:
@@ -1675,12 +1690,13 @@ func (l *lockState) tryActiveWait(
 
 	var replicatedLockFinalizedTxn *roachpb.Transaction
 	if lockHolderTxn != nil {
-		finalizedTxn, ok := g.lt.finalizedTxnCache.get(lockHolderTxn.ID)
+		finalizedTxn, ok := g.lt.txnStatusCache.finalizedTxns.get(lockHolderTxn.ID)
 		if ok {
 			if l.holder.holder[lock.Replicated].txn == nil {
 				// Only held unreplicated. Release immediately.
-				l.clearLockHolder()
-				if l.lockIsFree() {
+				up := roachpb.MakeLockUpdate(finalizedTxn, roachpb.Span{Key: l.key})
+				_, gc := l.tryUpdateLockLocked(up)
+				if gc {
 					// Empty lock.
 					return false, true
 				}
@@ -1704,6 +1720,40 @@ func (l *lockState) tryActiveWait(
 		if g.ts.Less(lockHolderTS) {
 			return false, false
 		}
+
+		// If the non-locking reader is reading at a higher timestamp than the lock
+		// holder, but it knows that the lock holder has been pushed above its read
+		// timestamp, it can proceed after rewriting the lock at its transaction's
+		// pushed timestamp. Intent resolution can be deferred to maximize batching
+		// opportunities.
+		//
+		// This fast-path is only enabled for readers without uncertainty intervals,
+		// as readers with uncertainty intervals must contend with the possibility
+		// of pushing a conflicting intent up into their uncertainty interval and
+		// causing more work for themselves, which is avoided with care by the
+		// lockTableWaiter but difficult to coordinate through the txnStatusCache.
+		// This limitation is acceptable because the most important case here is
+		// optimizing the Export requests issued by backup.
+		if !g.hasUncertaintyInterval() {
+			pushedTxn, ok := g.lt.txnStatusCache.pendingTxns.get(lockHolderTxn.ID)
+			if ok && g.ts.Less(pushedTxn.WriteTimestamp) {
+				up := roachpb.MakeLockUpdate(pushedTxn, roachpb.Span{Key: l.key})
+				if l.holder.holder[lock.Replicated].txn == nil {
+					// Only held unreplicated. Update lock directly in case other
+					// waiting readers can benefit from the pushed timestamp.
+					//
+					// TODO(arul): this case is only possible while non-locking reads
+					// block on Exclusive locks. Once non-locking reads start only
+					// blocking on intents, it can be removed and asserted against.
+					_, _ = l.tryUpdateLockLocked(up)
+				} else {
+					// Resolve to push the replicated intent.
+					g.toResolve = append(g.toResolve, up)
+				}
+				return false, false
+			}
+		}
+
 		g.mu.Lock()
 		_, alsoLocksWithHigherStrength := g.mu.locks[l]
 		g.mu.Unlock()
@@ -1915,7 +1965,7 @@ func (l *lockState) isNonConflictingLock(g *lockTableGuardImpl, str lock.Strengt
 		// Already locked by this txn.
 		return true
 	}
-	// NB: We do not look at the finalizedTxnCache in this optimistic evaluation
+	// NB: We do not look at the txnStatusCache in this optimistic evaluation
 	// path. A conflict with a finalized txn will be noticed when retrying
 	// pessimistically.
 
@@ -2296,9 +2346,14 @@ func removeIgnored(
 func (l *lockState) tryUpdateLock(up *roachpb.LockUpdate) (heldByTxn, gc bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	return l.tryUpdateLockLocked(*up)
+}
+
+// REQUIRES: l.mu is locked.
+func (l *lockState) tryUpdateLockLocked(up roachpb.LockUpdate) (heldByTxn, gc bool) {
 	if l.isEmptyLock() {
 		// Already free. This can happen when an unreplicated lock is removed in
-		// tryActiveWait due to the txn being in the finalizedTxnCache.
+		// tryActiveWait due to the txn being in the txnStatusCache.
 		return false, true
 	}
 	if !l.isLockedBy(up.Txn.ID) {
@@ -2769,13 +2824,13 @@ func (t *lockTableImpl) Dequeue(guard lockTableGuard) {
 //
 // We discussed in
 // https://github.com/cockroachdb/cockroach/issues/62470#issuecomment-818374388
-// the possibility of consulting the finalizedTxnCache in AddDiscoveredLock,
+// the possibility of consulting the txnStatusCache in AddDiscoveredLock,
 // and not adding the lock if the txn is already finalized, and instead
 // telling the caller to do batched intent resolution before calling
 // ScanAndEnqueue.
 // This reduces memory pressure on the lockTableImpl in the extreme case of
 // huge numbers of discovered locks. Note that when there isn't memory
-// pressure, the consultation of the finalizedTxnCache in the ScanAndEnqueue
+// pressure, the consultation of the txnStatusCache in the ScanAndEnqueue
 // achieves the same batched intent resolution. Additionally, adding the lock
 // to the lock table allows it to coordinate the population of
 // lockTableGuardImpl.toResolve for different requests that encounter the same
@@ -2787,11 +2842,11 @@ func (t *lockTableImpl) Dequeue(guard lockTableGuard) {
 // For now we adopt the following heuristic: the caller calls DiscoveredLocks
 // with the count of locks discovered, prior to calling AddDiscoveredLock for
 // each of the locks. At that point a decision is made whether to consult the
-// finalizedTxnCache eagerly when adding discovered locks.
+// txnStatusCache eagerly when adding discovered locks.
 func (t *lockTableImpl) AddDiscoveredLock(
 	intent *roachpb.Intent,
 	seq roachpb.LeaseSequence,
-	consultFinalizedTxnCache bool,
+	consultTxnStatusCache bool,
 	guard lockTableGuard,
 ) (added bool, _ error) {
 	t.enabledMu.RLock()
@@ -2816,12 +2871,25 @@ func (t *lockTableImpl) AddDiscoveredLock(
 	if err != nil {
 		return false, err
 	}
-	if consultFinalizedTxnCache {
-		finalizedTxn, ok := t.finalizedTxnCache.get(intent.Txn.ID)
+	if consultTxnStatusCache {
+		finalizedTxn, ok := t.txnStatusCache.finalizedTxns.get(intent.Txn.ID)
 		if ok {
 			g.toResolve = append(
 				g.toResolve, roachpb.MakeLockUpdate(finalizedTxn, roachpb.Span{Key: key}))
 			return true, nil
+		}
+
+		// If the discoverer is a non-locking read, also check whether the lock's
+		// holder is known to have been pushed above the reader's timestamp. See the
+		// comment in tryActiveWait for more details, including why we include the
+		// hasUncertaintyInterval condition.
+		if str == lock.None && !g.hasUncertaintyInterval() {
+			pushedTxn, ok := g.lt.txnStatusCache.pendingTxns.get(intent.Txn.ID)
+			if ok && g.ts.Less(pushedTxn.WriteTimestamp) {
+				g.toResolve = append(
+					g.toResolve, roachpb.MakeLockUpdate(pushedTxn, roachpb.Span{Key: key}))
+				return true, nil
+			}
 		}
 	}
 	var l *lockState
@@ -3075,14 +3143,14 @@ func stepToNextSpan(g *lockTableGuardImpl) *roachpb.Span {
 	return nil
 }
 
-// TransactionIsFinalized implements the lockTable interface.
-func (t *lockTableImpl) TransactionIsFinalized(txn *roachpb.Transaction) {
+// PushedTransactionUpdated implements the lockTable interface.
+func (t *lockTableImpl) PushedTransactionUpdated(txn *roachpb.Transaction) {
 	// TODO(sumeer): We don't take any action for requests that are already
 	// waiting on locks held by txn. They need to take some action, like
 	// pushing, and resume their scan, to notice the change to this txn. We
 	// could be more proactive if we knew which locks in lockTableImpl were held
 	// by txn.
-	t.finalizedTxnCache.add(txn)
+	t.txnStatusCache.add(txn)
 }
 
 // Enable implements the lockTable interface.
@@ -3113,9 +3181,9 @@ func (t *lockTableImpl) Clear(disable bool) {
 	}
 	// The numToClear=0 is arbitrary since it is unused when force=true.
 	t.tryClearLocks(true /* force */, 0)
-	// Also clear the finalized txn cache, since it won't be needed any time
+	// Also clear the txn status cache, since it won't be needed any time
 	// soon and consumes memory.
-	t.finalizedTxnCache.clear()
+	t.txnStatusCache.clear()
 }
 
 // QueryLockTableState implements the lockTable interface.
@@ -3210,7 +3278,7 @@ func (t *lockTableImpl) String() string {
 	for iter.First(); iter.Valid(); iter.Next() {
 		l := iter.Cur()
 		l.mu.Lock()
-		l.safeFormat(&sb, &t.finalizedTxnCache)
+		l.safeFormat(&sb, &t.txnStatusCache)
 		l.mu.Unlock()
 	}
 	t.locks.mu.RUnlock()

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -377,7 +377,7 @@ type lockTableGuardImpl struct {
 	lt     *lockTableImpl
 
 	// Information about this request.
-	txn                *enginepb.TxnMeta
+	txn                *roachpb.Transaction
 	ts                 hlc.Timestamp
 	spans              *lockspanset.LockSpanSet
 	waitPolicy         lock.WaitPolicy
@@ -707,6 +707,13 @@ func (g *lockTableGuardImpl) notify() {
 func (g *lockTableGuardImpl) doneActivelyWaitingAtLock() {
 	g.mu.mustComputeWaitingState = true
 	g.notify()
+}
+
+func (g *lockTableGuardImpl) txnMeta() *enginepb.TxnMeta {
+	if g.txn == nil {
+		return nil
+	}
+	return &g.txn.TxnMeta
 }
 
 func (g *lockTableGuardImpl) isSameTxn(txn *enginepb.TxnMeta) bool {
@@ -1203,7 +1210,7 @@ func (l *lockState) lockStateInfo(now time.Time) roachpb.LockStateInfo {
 		readerGuard := e.Value.(*lockTableGuardImpl)
 		readerGuard.mu.Lock()
 		lockWaiters = append(lockWaiters, lock.Waiter{
-			WaitingTxn:   readerGuard.txn,
+			WaitingTxn:   readerGuard.txnMeta(),
 			ActiveWaiter: true, // readers always actively wait at a lock
 			Strength:     lock.None,
 			WaitDuration: now.Sub(readerGuard.mu.curLockWaitStart),
@@ -1217,7 +1224,7 @@ func (l *lockState) lockStateInfo(now time.Time) roachpb.LockStateInfo {
 		writerGuard := qg.guard
 		writerGuard.mu.Lock()
 		lockWaiters = append(lockWaiters, lock.Waiter{
-			WaitingTxn:   writerGuard.txn,
+			WaitingTxn:   writerGuard.txnMeta(),
 			ActiveWaiter: qg.active,
 			Strength:     lock.Exclusive,
 			WaitDuration: now.Sub(writerGuard.mu.curLockWaitStart),
@@ -1393,9 +1400,9 @@ func (l *lockState) claimantTxn() (_ *enginepb.TxnMeta, held bool) {
 		// refactored, and we no longer call into this method before readjusting
 		// the queued of writers to make the first one inactive.
 		//panic("first queued writer should be transactional and inactive")
-		return qg.guard.txn, false
+		return qg.guard.txnMeta(), false
 	}
-	return qg.guard.txn, false
+	return qg.guard.txnMeta(), false
 }
 
 // releaseWritersFromTxn removes all waiting writers for the lockState that are
@@ -2708,7 +2715,7 @@ func (t *lockTableImpl) newGuardForReq(req Request) *lockTableGuardImpl {
 	g := newLockTableGuardImpl()
 	g.seqNum = atomic.AddUint64(&t.seqNum, 1)
 	g.lt = t
-	g.txn = req.txnMeta()
+	g.txn = req.Txn
 	g.ts = req.Timestamp
 	g.spans = req.LockSpans
 	g.waitPolicy = req.WaitPolicy

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -271,14 +272,20 @@ type lockTableImpl struct {
 
 	// clock is used to track the lock hold and lock wait start times.
 	clock *hlc.Clock
+
+	// settings provides a handle to cluster settings.
+	settings *cluster.Settings
 }
 
 var _ lockTable = &lockTableImpl{}
 
-func newLockTable(maxLocks int64, rangeID roachpb.RangeID, clock *hlc.Clock) *lockTableImpl {
+func newLockTable(
+	maxLocks int64, rangeID roachpb.RangeID, clock *hlc.Clock, settings *cluster.Settings,
+) *lockTableImpl {
 	lt := &lockTableImpl{
-		rID:   rangeID,
-		clock: clock,
+		rID:      rangeID,
+		clock:    clock,
+		settings: settings,
 	}
 	lt.setMaxLocks(maxLocks)
 	return lt

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -103,12 +103,12 @@ update txn=<name> ts=<int>[,<int>] epoch=<int> span=<start>[,<end>] [ignored-seq
 
  Updates locks for the named transaction.
 
-txn-finalized txn=<name> status=committed|aborted
+pushed-txn-updated txn=<name> status=committed|aborted|pending [ts=<ts>]
 ----
 
  Informs the lock table that the named transaction is finalized.
 
-add-discovered r=<name> k=<key> txn=<name> [lease-seq=<seq>] [consult-finalized-txn-cache=<bool>]
+add-discovered r=<name> k=<key> txn=<name> [lease-seq=<seq>] [consult-txn-status-cache=<bool>]
 ----
 <error string>
 
@@ -262,7 +262,7 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				return ""
 
-			case "txn-finalized":
+			case "pushed-txn-updated":
 				var txnName string
 				d.ScanArgs(t, "txn", &txnName)
 				txnMeta, ok := txnsByName[txnName]
@@ -279,10 +279,16 @@ func TestLockTableBasic(t *testing.T) {
 					txn.Status = roachpb.COMMITTED
 				case "aborted":
 					txn.Status = roachpb.ABORTED
+				case "pending":
+					txn.Status = roachpb.PENDING
 				default:
 					return fmt.Sprintf("unknown txn status %s", statusStr)
 				}
-				lt.TransactionIsFinalized(txn)
+				if d.HasArg("ts") {
+					ts := scanTimestamp(t, d)
+					txn.WriteTimestamp.Forward(ts)
+				}
+				lt.PushedTransactionUpdated(txn)
 				return ""
 
 			case "new-request":
@@ -452,13 +458,13 @@ func TestLockTableBasic(t *testing.T) {
 				if d.HasArg("lease-seq") {
 					d.ScanArgs(t, "lease-seq", &seq)
 				}
-				consultFinalizedTxnCache := false
-				if d.HasArg("consult-finalized-txn-cache") {
-					d.ScanArgs(t, "consult-finalized-txn-cache", &consultFinalizedTxnCache)
+				consultTxnStatusCache := false
+				if d.HasArg("consult-txn-status-cache") {
+					d.ScanArgs(t, "consult-txn-status-cache", &consultTxnStatusCache)
 				}
 				leaseSeq := roachpb.LeaseSequence(seq)
 				if _, err := lt.AddDiscoveredLock(
-					&intent, leaseSeq, consultFinalizedTxnCache, g); err != nil {
+					&intent, leaseSeq, consultTxnStatusCache, g); err != nil {
 					return err.Error()
 				}
 				return lt.String()

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanlatch"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -197,7 +198,9 @@ func TestLockTableBasic(t *testing.T) {
 			case "new-lock-table":
 				var maxLocks int
 				d.ScanArgs(t, "maxlocks", &maxLocks)
-				ltImpl := newLockTable(int64(maxLocks), roachpb.RangeID(3), clock)
+				ltImpl := newLockTable(
+					int64(maxLocks), roachpb.RangeID(3), clock, cluster.MakeTestingClusterSettings(),
+				)
 				ltImpl.enabled = true
 				ltImpl.enabledSeq = 1
 				ltImpl.minLocks = 0
@@ -776,7 +779,9 @@ func intentsToResolveToStr(toResolve []roachpb.LockUpdate, startOnNewLine bool) 
 }
 
 func TestLockTableMaxLocks(t *testing.T) {
-	lt := newLockTable(5, roachpb.RangeID(3), hlc.NewClockForTesting(nil))
+	lt := newLockTable(
+		5, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(),
+	)
 	lt.minLocks = 0
 	lt.enabled = true
 	var keys []roachpb.Key
@@ -905,7 +910,9 @@ func TestLockTableMaxLocks(t *testing.T) {
 // TestLockTableMaxLocksWithMultipleNotRemovableRefs tests the notRemovable
 // ref counting.
 func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
-	lt := newLockTable(2, roachpb.RangeID(3), hlc.NewClockForTesting(nil))
+	lt := newLockTable(
+		2, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(),
+	)
 	lt.minLocks = 0
 	lt.enabled = true
 	var keys []roachpb.Key
@@ -1143,7 +1150,9 @@ type workloadExecutor struct {
 
 func newWorkLoadExecutor(items []workloadItem, concurrency int) *workloadExecutor {
 	const maxLocks = 100000
-	lt := newLockTable(maxLocks, roachpb.RangeID(3), hlc.NewClockForTesting(nil))
+	lt := newLockTable(
+		maxLocks, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(),
+	)
 	lt.enabled = true
 	return &workloadExecutor{
 		lm:           spanlatch.Manager{},
@@ -1724,7 +1733,12 @@ func BenchmarkLockTable(b *testing.B) {
 						var numRequestsWaited uint64
 						var numScanCalls uint64
 						const maxLocks = 100000
-						lt := newLockTable(maxLocks, roachpb.RangeID(3), hlc.NewClockForTesting(nil))
+						lt := newLockTable(
+							maxLocks,
+							roachpb.RangeID(3),
+							hlc.NewClockForTesting(nil),
+							cluster.MakeTestingClusterSettings(),
+						)
 						lt.enabled = true
 						env := benchEnv{
 							lm:                &spanlatch.Manager{},
@@ -1764,7 +1778,12 @@ func BenchmarkLockTableMetrics(b *testing.B) {
 	for _, locks := range []int{0, 1 << 0, 1 << 4, 1 << 8, 1 << 12} {
 		b.Run(fmt.Sprintf("locks=%d", locks), func(b *testing.B) {
 			const maxLocks = 100000
-			lt := newLockTable(maxLocks, roachpb.RangeID(3), hlc.NewClockForTesting(nil))
+			lt := newLockTable(
+				maxLocks,
+				roachpb.RangeID(3),
+				hlc.NewClockForTesting(nil),
+				cluster.MakeTestingClusterSettings(),
+			)
 			lt.enabled = true
 
 			txn := &roachpb.Transaction{

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -57,7 +57,7 @@ var LockTableLivenessPushDelay = settings.RegisterDurationSetting(
 	// - a per-store cache of recently detected abandoned transaction IDs
 	// - a per-range reverse index from transaction ID to locked keys
 	//
-	// EDIT: The finalizedTxnCache gets us part of the way here. It allows us to
+	// EDIT: The txnStatusCache gets us part of the way here. It allows us to
 	// pay the liveness push delay cost once per abandoned transaction per range
 	// instead of once per each of an abandoned transaction's locks. This helped
 	// us to feel comfortable increasing the default delay from the original
@@ -527,12 +527,10 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 		return err
 	}
 
-	// If the transaction is finalized, add it to the finalizedTxnCache. This
-	// avoids needing to push it again if we find another one of its locks and
-	// allows for batching of intent resolution.
-	if pusheeTxn.Status.IsFinalized() {
-		w.lt.TransactionIsFinalized(pusheeTxn)
-	}
+	// If the transaction was pushed, add it to the txnStatusCache. This avoids
+	// needing to push it again if we find another one of its locks and allows for
+	// batching of intent resolution.
+	w.lt.PushedTransactionUpdated(pusheeTxn)
 
 	// If the push succeeded then the lock holder transaction must have
 	// experienced a state transition such that it no longer conflicts with
@@ -901,6 +899,40 @@ func watchForNotifications(ctx context.Context, cancel func(), newStateC chan st
 	}
 }
 
+// txnStatusCache is a small LRU cache that tracks the status of transactions
+// have been successfully pushed. The caches are partitioned into finalized and
+// pending transactions. Users are responsible for accessing the partition that
+// interests them.
+//
+// The zero value of this struct is ready for use.
+type txnStatusCache struct {
+	// finalizedTxns is a small LRU cache that tracks transactions that were
+	// pushed and found to be finalized (COMMITTED or ABORTED). It is used as an
+	// optimization to avoid repeatedly pushing the transaction record when
+	// cleaning up the intents of an abandoned transaction.
+	finalizedTxns txnCache
+
+	// pendingTxns is a small LRU cache that tracks transactions whose minimum
+	// commit timestamp was pushed but whose final status is not yet known. It is
+	// used an an optimization to avoid repeatedly pushing the transaction record
+	// when transaction priorities allow a pusher to move many intents of a
+	// lower-priority transaction.
+	pendingTxns txnCache
+}
+
+func (c *txnStatusCache) add(txn *roachpb.Transaction) {
+	if txn.Status.IsFinalized() {
+		c.finalizedTxns.add(txn)
+	} else {
+		c.pendingTxns.add(txn)
+	}
+}
+
+func (c *txnStatusCache) clear() {
+	c.finalizedTxns.clear()
+	c.pendingTxns.clear()
+}
+
 // txnCache is a small LRU cache that holds Transaction objects.
 //
 // The zero value of this struct is ready for use.
@@ -924,6 +956,9 @@ func (c *txnCache) add(txn *roachpb.Transaction) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if idx := c.getIdxLocked(txn.ID); idx >= 0 {
+		if !txn.Status.IsFinalized() {
+			txn.Update(c.txns[idx])
+		}
 		c.moveFrontLocked(txn, idx)
 	} else {
 		c.insertFrontLocked(txn)

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -101,7 +101,7 @@ type mockLockTable struct {
 	txnFinalizedFn func(txn *roachpb.Transaction)
 }
 
-func (lt *mockLockTable) TransactionIsFinalized(txn *roachpb.Transaction) {
+func (lt *mockLockTable) TransactionUpdated(txn *roachpb.Transaction) {
 	lt.txnFinalizedFn(txn)
 }
 
@@ -924,6 +924,33 @@ func TestTxnCache(t *testing.T) {
 	for i, txnInCache := range c.txns {
 		require.Equal(t, &txns[i+overflow], txnInCache)
 	}
+}
+
+func TestTxnCacheUpdatesTxn(t *testing.T) {
+	var c txnCache
+
+	// Add txn to cache.
+	txnOrig := makeTxnProto("txn")
+	c.add(txnOrig.Clone())
+	txnInCache, ok := c.get(txnOrig.ID)
+	require.True(t, ok)
+	require.Equal(t, txnOrig.WriteTimestamp, txnInCache.WriteTimestamp)
+
+	// Add pushed txn with higher write timestamp.
+	txnPushed := txnOrig.Clone()
+	txnPushed.WriteTimestamp.Forward(txnPushed.WriteTimestamp.Add(1, 0))
+	c.add(txnPushed)
+	txnInCache, ok = c.get(txnOrig.ID)
+	require.True(t, ok)
+	require.NotEqual(t, txnOrig.WriteTimestamp, txnInCache.WriteTimestamp)
+	require.Equal(t, txnPushed.WriteTimestamp, txnInCache.WriteTimestamp)
+
+	// Re-add txn with lower timestamp. Timestamp should not regress.
+	c.add(txnOrig.Clone())
+	txnInCache, ok = c.get(txnOrig.ID)
+	require.True(t, ok)
+	require.NotEqual(t, txnOrig.WriteTimestamp, txnInCache.WriteTimestamp)
+	require.Equal(t, txnPushed.WriteTimestamp, txnInCache.WriteTimestamp)
 }
 
 func BenchmarkTxnCache(b *testing.B) {

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -99,7 +99,7 @@ debug-advance-clock ts=123
 ----
 
 # txn1 is the distinguished waiter on key "a". It will push txn2, notice that it
-# is aborted, and then resolve key "a". Once txn2 is in the finalizedTxnCache,
+# is aborted, and then resolve key "a". Once txn2 is in the txnStatusCache,
 # txn1 will create a batch to resolve all other keys together.
 on-txn-updated txn=txn2 status=aborted
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -3,9 +3,9 @@
 # the lock table, and get resolved.
 # -------------------------------------------------------------------------
 
-# This setting causes the finalized txn cache to be consulted when discovered
+# This setting causes the txn status cache to be consulted when discovered
 # locks > 1.
-debug-set-discovered-locks-threshold-to-consult-finalized-txn-cache n=1
+debug-set-discovered-locks-threshold-to-consult-txn-status-cache n=1
 ----
 
 new-txn name=txn1 ts=10,1 epoch=0
@@ -60,7 +60,7 @@ debug-advance-clock ts=123
 ----
 
 # txn1 is the distinguished waiter on key "a". It will push txn2, notice that it
-# is aborted, and then resolve key "a". This places txn2 in the finalizedTxnCache.
+# is aborted, and then resolve key "a". This places txn2 in the txnStatusCache.
 on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -1,0 +1,321 @@
+# -------------------------------------------------------------
+# A scan finds 10 intents that it can push from same txn.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0 priority=high
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-txn name=txn3 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  scan key=a endkey=z
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 lease-seq=1
+  intent txn=txn2 key=a
+  intent txn=txn2 key=b
+  intent txn=txn2 key=c
+  intent txn=txn2 key=d
+  intent txn=txn2 key=e
+  intent txn=txn2 key=f
+  intent txn=txn2 key=g
+  intent txn=txn2 key=h
+  intent txn=txn2 key=i
+  intent txn=txn2 key=j
+----
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+
+debug-lock-table
+----
+num=10
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "f"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "g"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "h"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "i"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "j"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+# Before re-scanning and pushing, add a waiter on a single key to demonstrate
+# that uncontended, replicated keys are released when pushed, while contended,
+# replicated keys are not.
+new-request name=req2 txn=txn3 ts=10,1
+  put key=c value=val
+----
+
+sequence req=req2
+----
+[3] sequence req2: sequencing request
+[3] sequence req2: acquiring latches
+[3] sequence req2: scanning lock table for conflicting locks
+[3] sequence req2: waiting in lock wait-queues
+[3] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
+[3] sequence req2: pushing txn 00000002 to abort
+[3] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# Now re-scan with the high-priority reader.
+sequence req=req1
+----
+[4] sequence req1: re-sequencing request
+[4] sequence req1: acquiring latches
+[4] sequence req1: scanning lock table for conflicting locks
+[4] sequence req1: waiting in lock wait-queues
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: pusher pushed pushee to 10.000000000,2
+[4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
+[4] sequence req1: lock wait-queue event: done waiting
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req1: resolving a batch of 9 intent(s)
+[4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status
+[4] sequence req1: resolving intent ‹"c"› for txn 00000002 with PENDING status
+[4] sequence req1: resolving intent ‹"d"› for txn 00000002 with PENDING status
+[4] sequence req1: resolving intent ‹"e"› for txn 00000002 with PENDING status
+[4] sequence req1: resolving intent ‹"f"› for txn 00000002 with PENDING status
+[4] sequence req1: resolving intent ‹"g"› for txn 00000002 with PENDING status
+[4] sequence req1: resolving intent ‹"h"› for txn 00000002 with PENDING status
+[4] sequence req1: resolving intent ‹"i"› for txn 00000002 with PENDING status
+[4] sequence req1: resolving intent ‹"j"› for txn 00000002 with PENDING status
+[4] sequence req1: acquiring latches
+[4] sequence req1: scanning lock table for conflicting locks
+[4] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+# Only the contended lock remains.
+debug-lock-table
+----
+num=1
+ lock: "c"
+   queued writers:
+    active: false req: 2, txn: 00000003-0000-0000-0000-000000000000
+
+on-txn-updated txn=txn2 status=aborted
+----
+[-] update txn: aborting txn2
+[3] sequence req2: resolving intent ‹"c"› for txn 00000002 with ABORTED status
+[3] sequence req2: lock wait-queue event: done waiting
+[3] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[3] sequence req2: acquiring latches
+[3] sequence req2: scanning lock table for conflicting locks
+[3] sequence req2: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+reset namespace
+----
+
+# ---------------------------------------------------------------------------
+# A scan finds 2 intents and 2 unreplicated locks from the same txn. When the
+# txn is pushed, only the 2 intents need to be resolved, since it is sufficient
+# to advance the timestamp of the unreplicated locks in the lock table directly.
+# ---------------------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0 priority=high
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  scan key=a endkey=z
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 lease-seq=1
+  intent txn=txn2 key=a
+  intent txn=txn2 key=b
+----
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, released latches
+
+debug-lock-table
+----
+num=2
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+new-request name=req2 txn=txn2 ts=10,1
+  put key=g value=v1
+  put key=h value=v2
+----
+
+sequence req=req2
+----
+[3] sequence req2: sequencing request
+[3] sequence req2: acquiring latches
+[3] sequence req2: scanning lock table for conflicting locks
+[3] sequence req2: sequencing complete, returned guard
+
+on-lock-acquired req=req2 key=g dur=u
+----
+[-] acquire lock: txn 00000002 @ ‹g›
+
+on-lock-acquired req=req2 key=h dur=u
+----
+[-] acquire lock: txn 00000002 @ ‹h›
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+debug-lock-table
+----
+num=4
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "g"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "h"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+
+sequence req=req1
+----
+[4] sequence req1: re-sequencing request
+[4] sequence req1: acquiring latches
+[4] sequence req1: scanning lock table for conflicting locks
+[4] sequence req1: waiting in lock wait-queues
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: pusher pushed pushee to 10.000000000,2
+[4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,4}
+[4] sequence req1: lock wait-queue event: done waiting
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req1: resolving a batch of 1 intent(s)
+[4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status
+[4] sequence req1: acquiring latches
+[4] sequence req1: scanning lock table for conflicting locks
+[4] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+debug-lock-table
+----
+num=2
+ lock: "g"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "h"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# A scan with an uncertainty interval does not defer resolution
+# of pushed intents. Instead, it pushes and resolves intents one
+# by one. This is a limitation.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0 priority=high uncertainty-limit=11,1
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  scan key=a endkey=z
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 lease-seq=1
+  intent txn=txn2 key=a
+  intent txn=txn2 key=b
+  intent txn=txn2 key=c
+----
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, released latches
+
+debug-lock-table
+----
+num=3
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[3] sequence req1: pushing timestamp of txn 00000002 above 11.000000000,1
+[3] sequence req1: pusher pushed pushee to 11.000000000,2
+[3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,6}
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[3] sequence req1: pushing timestamp of txn 00000002 above 11.000000000,1
+[3] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,8}
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[3] sequence req1: pushing timestamp of txn 00000002 above 11.000000000,1
+[3] sequence req1: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,10}
+[3] sequence req1: lock wait-queue event: done waiting
+[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+debug-lock-table
+----
+num=0
+
+reset namespace
+----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -319,3 +319,182 @@ num=0
 
 reset namespace
 ----
+
+# -------------------------------------------------------------------------
+# The kv.lock_table.batch_pushed_lock_resolution.enabled cluster setting can
+# be used to disable deferred lock resolution of pushed intents.
+# -------------------------------------------------------------------------
+
+debug-set-batch-pushed-lock-resolution-enabled ok=false
+----
+
+new-txn name=txn1 ts=10,1 epoch=0 priority=high
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-txn name=txn3 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  scan key=a endkey=z
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 lease-seq=1
+  intent txn=txn2 key=a
+  intent txn=txn2 key=b
+  intent txn=txn2 key=c
+  intent txn=txn2 key=d
+  intent txn=txn2 key=e
+  intent txn=txn2 key=f
+  intent txn=txn2 key=g
+  intent txn=txn2 key=h
+  intent txn=txn2 key=i
+  intent txn=txn2 key=j
+----
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+
+debug-lock-table
+----
+num=10
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "f"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "g"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "h"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "i"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "j"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+# Before re-scanning and pushing, add a waiter on a single key to demonstrate
+# that uncontended, replicated keys are released when pushed, while contended,
+# replicated keys are not.
+new-request name=req2 txn=txn3 ts=10,1
+  put key=c value=val
+----
+
+sequence req=req2
+----
+[3] sequence req2: sequencing request
+[3] sequence req2: acquiring latches
+[3] sequence req2: scanning lock table for conflicting locks
+[3] sequence req2: waiting in lock wait-queues
+[3] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
+[3] sequence req2: pushing txn 00000002 to abort
+[3] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# Now re-scan with the high-priority reader.
+sequence req=req1
+----
+[4] sequence req1: re-sequencing request
+[4] sequence req1: acquiring latches
+[4] sequence req1: scanning lock table for conflicting locks
+[4] sequence req1: waiting in lock wait-queues
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: pusher pushed pushee to 10.000000000,2
+[4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,13}
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,15}
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedWriters: 1, queuedReaders: 1)
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[4] sequence req1: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,17}
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"d"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,19}
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"e"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,21}
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"f"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"e"› for 0.000s
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,23}
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"g"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"f"› for 0.000s
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,25}
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"h"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"g"› for 0.000s
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,27}
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"i"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"h"› for 0.000s
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,29}
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"j"› (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"i"› for 0.000s
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[4] sequence req1: resolving intent ‹"j"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,31}
+[4] sequence req1: lock wait-queue event: done waiting
+[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"j"› for 0.000s
+[4] sequence req1: acquiring latches
+[4] sequence req1: scanning lock table for conflicting locks
+[4] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+# Only the contended lock remains.
+debug-lock-table
+----
+num=1
+ lock: "c"
+   queued writers:
+    active: false req: 7, txn: 00000003-0000-0000-0000-000000000000
+
+on-txn-updated txn=txn2 status=aborted
+----
+[-] update txn: aborting txn2
+[3] sequence req2: resolving intent ‹"c"› for txn 00000002 with ABORTED status
+[3] sequence req2: lock wait-queue event: done waiting
+[3] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[3] sequence req2: acquiring latches
+[3] sequence req2: scanning lock table for conflicting locks
+[3] sequence req2: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+reset namespace
+----
+
+debug-set-batch-pushed-lock-resolution-enabled ok=true
+----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -1,0 +1,284 @@
+# -------------------------------------------------------------------------
+# A scan finds many pushed intents from same txn that don't get added to
+# the lock table, and get resolved.
+# -------------------------------------------------------------------------
+
+# This setting causes the txn status cache to be consulted when discovered
+# locks > 1.
+debug-set-discovered-locks-threshold-to-consult-txn-status-cache n=1
+----
+
+new-txn name=txn1 ts=10,1 epoch=0 priority=high
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  scan key=a endkey=b
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 lease-seq=1
+  intent txn=txn2 key=a
+----
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, released latches
+
+debug-lock-table
+----
+num=1
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[3] sequence req1: pusher pushed pushee to 10.000000000,2
+[3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[3] sequence req1: lock wait-queue event: done waiting
+[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+debug-lock-table
+----
+num=0
+
+new-request name=req2 txn=txn1 ts=10,1
+  scan key=b endkey=z
+----
+
+sequence req=req2
+----
+[4] sequence req2: sequencing request
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: sequencing complete, returned guard
+
+# The intents get resolved instead of being added to the lock table.
+handle-write-intent-error req=req2 lease-seq=1
+  intent txn=txn2 key=b
+  intent txn=txn2 key=c
+  intent txn=txn2 key=d
+  intent txn=txn2 key=e
+  intent txn=txn2 key=f
+  intent txn=txn2 key=g
+  intent txn=txn2 key=h
+  intent txn=txn2 key=i
+  intent txn=txn2 key=j
+----
+[5] handle write intent error req2: resolving a batch of 9 intent(s)
+[5] handle write intent error req2: resolving intent ‹"b"› for txn 00000002 with PENDING status
+[5] handle write intent error req2: resolving intent ‹"c"› for txn 00000002 with PENDING status
+[5] handle write intent error req2: resolving intent ‹"d"› for txn 00000002 with PENDING status
+[5] handle write intent error req2: resolving intent ‹"e"› for txn 00000002 with PENDING status
+[5] handle write intent error req2: resolving intent ‹"f"› for txn 00000002 with PENDING status
+[5] handle write intent error req2: resolving intent ‹"g"› for txn 00000002 with PENDING status
+[5] handle write intent error req2: resolving intent ‹"h"› for txn 00000002 with PENDING status
+[5] handle write intent error req2: resolving intent ‹"i"› for txn 00000002 with PENDING status
+[5] handle write intent error req2: resolving intent ‹"j"› for txn 00000002 with PENDING status
+[5] handle write intent error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+
+debug-lock-table
+----
+num=0
+
+sequence req=req2
+----
+[6] sequence req2: re-sequencing request
+[6] sequence req2: acquiring latches
+[6] sequence req2: scanning lock table for conflicting locks
+[6] sequence req2: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+reset namespace
+----
+
+# -------------------------------------------------------------------------
+# A scan with an uncertainty interval does not consult the txn status cache, so
+# it will always add the intents to the lock table before pushing and resolving.
+# This is a limitation.
+# -------------------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0 priority=high uncertainty-limit=11,1
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  scan key=a endkey=b
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 lease-seq=1
+  intent txn=txn2 key=a
+----
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, released latches
+
+debug-lock-table
+----
+num=1
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[3] sequence req1: pushing timestamp of txn 00000002 above 11.000000000,1
+[3] sequence req1: pusher pushed pushee to 11.000000000,2
+[3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,3}
+[3] sequence req1: lock wait-queue event: done waiting
+[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+debug-lock-table
+----
+num=0
+
+new-request name=req2 txn=txn1 ts=10,1
+  scan key=b endkey=z
+----
+
+sequence req=req2
+----
+[4] sequence req2: sequencing request
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: sequencing complete, returned guard
+
+# The intents get resolved instead of being added to the lock table.
+handle-write-intent-error req=req2 lease-seq=1
+  intent txn=txn2 key=b
+  intent txn=txn2 key=c
+  intent txn=txn2 key=d
+  intent txn=txn2 key=e
+  intent txn=txn2 key=f
+  intent txn=txn2 key=g
+  intent txn=txn2 key=h
+  intent txn=txn2 key=i
+  intent txn=txn2 key=j
+----
+[5] handle write intent error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+
+debug-lock-table
+----
+num=9
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "f"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "g"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "h"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "i"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "j"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+sequence req=req2
+----
+[6] sequence req2: re-sequencing request
+[6] sequence req2: acquiring latches
+[6] sequence req2: scanning lock table for conflicting locks
+[6] sequence req2: waiting in lock wait-queues
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
+[6] sequence req2: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,5}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
+[6] sequence req2: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,7}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"d"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
+[6] sequence req2: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,9}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"e"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
+[6] sequence req2: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,11}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"f"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"e"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
+[6] sequence req2: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,13}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"g"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"f"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
+[6] sequence req2: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,15}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"h"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"g"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
+[6] sequence req2: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,17}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"i"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"h"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
+[6] sequence req2: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,19}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"j"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"i"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
+[6] sequence req2: resolving intent ‹"j"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,21}
+[6] sequence req2: lock wait-queue event: done waiting
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"j"› for 0.000s
+[6] sequence req2: acquiring latches
+[6] sequence req2: scanning lock table for conflicting locks
+[6] sequence req2: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+reset namespace
+----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -282,3 +282,177 @@ finish req=req2
 
 reset namespace
 ----
+
+# -------------------------------------------------------------------------
+# The kv.lock_table.batch_pushed_lock_resolution.enabled cluster setting can
+# be used to disable eager lock resolution of pushed locks during discovery.
+# -------------------------------------------------------------------------
+
+debug-set-batch-pushed-lock-resolution-enabled ok=false
+----
+
+new-txn name=txn1 ts=10,1 epoch=0 priority=high
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  scan key=a endkey=b
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 lease-seq=1
+  intent txn=txn2 key=a
+----
+[2] handle write intent error req1: handled conflicting intents on ‹"a"›, released latches
+
+debug-lock-table
+----
+num=1
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[3] sequence req1: pusher pushed pushee to 10.000000000,2
+[3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,23}
+[3] sequence req1: lock wait-queue event: done waiting
+[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+debug-lock-table
+----
+num=0
+
+new-request name=req2 txn=txn1 ts=10,1
+  scan key=b endkey=z
+----
+
+sequence req=req2
+----
+[4] sequence req2: sequencing request
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: sequencing complete, returned guard
+
+# The intents get resolved instead of being added to the lock table.
+handle-write-intent-error req=req2 lease-seq=1
+  intent txn=txn2 key=b
+  intent txn=txn2 key=c
+  intent txn=txn2 key=d
+  intent txn=txn2 key=e
+  intent txn=txn2 key=f
+  intent txn=txn2 key=g
+  intent txn=txn2 key=h
+  intent txn=txn2 key=i
+  intent txn=txn2 key=j
+----
+[5] handle write intent error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+
+debug-lock-table
+----
+num=9
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "f"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "g"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "h"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "i"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "j"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+sequence req=req2
+----
+[6] sequence req2: re-sequencing request
+[6] sequence req2: acquiring latches
+[6] sequence req2: scanning lock table for conflicting locks
+[6] sequence req2: waiting in lock wait-queues
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
+[6] sequence req2: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,25}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
+[6] sequence req2: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,27}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"d"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
+[6] sequence req2: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,29}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"e"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
+[6] sequence req2: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,31}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"f"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"e"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
+[6] sequence req2: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,33}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"g"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"f"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
+[6] sequence req2: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,35}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"h"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"g"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
+[6] sequence req2: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,37}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"i"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"h"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
+[6] sequence req2: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,39}
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"j"› (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"i"› for 0.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true
+[6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
+[6] sequence req2: resolving intent ‹"j"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,41}
+[6] sequence req2: lock wait-queue event: done waiting
+[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"j"› for 0.000s
+[6] sequence req2: acquiring latches
+[6] sequence req2: scanning lock table for conflicting locks
+[6] sequence req2: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+reset namespace
+----
+
+debug-set-batch-pushed-lock-resolution-enabled ok=true
+----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -162,7 +162,7 @@ num=5
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
-txn-finalized txn=txn2 status=aborted
+pushed-txn-updated txn=txn2 status=aborted
 ----
 
 scan r=req1
@@ -199,7 +199,7 @@ num=5
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
-txn-finalized txn=txn3 status=committed
+pushed-txn-updated txn=txn3 status=committed
 ----
 
 release txn=txn4 span=c
@@ -331,7 +331,7 @@ num=3
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
 
-txn-finalized txn=txn2 status=aborted
+pushed-txn-updated txn=txn2 status=aborted
 ----
 
 scan r=req3
@@ -416,7 +416,7 @@ num=2
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
 
-txn-finalized txn=txn2 status=aborted
+pushed-txn-updated txn=txn2 status=aborted
 ----
 
 scan r=req6
@@ -552,7 +552,7 @@ num=2
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
 
-txn-finalized txn=txn2 status=aborted
+pushed-txn-updated txn=txn2 status=aborted
 ----
 
 scan r=req8
@@ -644,7 +644,7 @@ num=4
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: repl epoch: 0, seqs: [0]
 
-txn-finalized txn=txn3 status=aborted
+pushed-txn-updated txn=txn3 status=aborted
 ----
 
 scan r=req9
@@ -681,7 +681,7 @@ Intents to resolve:
  key="a" txn=00000000 status=ABORTED
  key="b" txn=00000000 status=ABORTED
 
-txn-finalized txn=txn4 status=aborted
+pushed-txn-updated txn=txn4 status=aborted
 ----
 
 release txn=txn4 span=c
@@ -722,7 +722,7 @@ num=1
    queued writers:
     active: false req: 11, txn: none
 
-txn-finalized txn=txn2 status=aborted
+pushed-txn-updated txn=txn2 status=aborted
 ----
 
 scan r=req11
@@ -765,7 +765,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 12.000000000,1, info: repl epoch: 0, seqs: [0]
 
-txn-finalized txn=txn2 status=aborted
+pushed-txn-updated txn=txn2 status=aborted
 ----
 
 scan r=req12

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -14,6 +14,17 @@ new-txn txn=txn3 ts=10 epoch=0
 new-txn txn=txn4 ts=10 epoch=0
 ----
 
+new-txn txn=txn5 ts=10 epoch=0
+----
+
+new-txn txn=txn6 ts=10 epoch=0
+----
+
+new-txn txn=txn7 ts=10 epoch=0
+----
+
+# req1 is a writer that must wait for discovered intents to be finalized.
+
 new-request r=req1 txn=txn1 ts=10 spans=intent@a,e
 ----
 
@@ -21,11 +32,11 @@ scan r=req1
 ----
 start-waiting: false
 
-txn-finalized txn=txn2 status=aborted
+pushed-txn-updated txn=txn2 status=aborted
 ----
 
-# Don't consult finalizedTxnCache.
-add-discovered r=req1 k=a txn=txn2 consult-finalized-txn-cache=false
+# Don't consult txnStatusCache.
+add-discovered r=req1 k=a txn=txn2 consult-txn-status-cache=false
 ----
 num=1
  lock: "a"
@@ -59,27 +70,27 @@ scan r=req1
 ----
 start-waiting: false
 
-txn-finalized txn=txn3 status=aborted
+pushed-txn-updated txn=txn3 status=aborted
 ----
 
-# Txn is finalized and finalizedTxnCache is consulted.
-add-discovered r=req1 k=b txn=txn3 consult-finalized-txn-cache=true
-----
-num=1
- lock: "a"
-   queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
-
-# Txn is finalized and finalizedTxnCache is consulted.
-add-discovered r=req1 k=c txn=txn3 consult-finalized-txn-cache=true
+# Txn is finalized and txnStatusCache is consulted.
+add-discovered r=req1 k=b txn=txn3 consult-txn-status-cache=true
 ----
 num=1
  lock: "a"
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
-# Txn is not finalized and finalizedTxnCache is consulted.
-add-discovered r=req1 k=d txn=txn4 consult-finalized-txn-cache=true
+# Txn is finalized and txnStatusCache is consulted.
+add-discovered r=req1 k=c txn=txn3 consult-txn-status-cache=true
+----
+num=1
+ lock: "a"
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+
+# Txn is not finalized and txnStatusCache is consulted.
+add-discovered r=req1 k=d txn=txn4 consult-txn-status-cache=true
 ----
 num=2
  lock: "a"
@@ -110,3 +121,95 @@ dequeue r=req1
 num=1
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000004, ts: 10.000000000,0, info: repl epoch: 0, seqs: [0]
+
+clear
+----
+num=0
+
+# req2 is a reader that must wait for discovered intents to be finalized or
+# pushed.
+
+new-request r=req2 txn=txn1 ts=10 spans=none@e,i
+----
+
+scan r=req2
+----
+start-waiting: false
+
+pushed-txn-updated txn=txn5 status=pending ts=11,0
+----
+
+# Don't consult txnStatusCache.
+add-discovered r=req2 k=e txn=txn5 consult-txn-status-cache=false
+----
+num=1
+ lock: "e"
+  holder: txn: 00000000-0000-0000-0000-000000000005, ts: 10.000000000,0, info: repl epoch: 0, seqs: [0]
+
+# Nothing to resolve yet.
+resolve-before-scanning r=req2
+----
+
+scan r=req2
+----
+start-waiting: true
+
+# The scan picks up the intent to resolve.
+guard-state r=req2
+----
+new: state=doneWaiting
+Intents to resolve:
+ key="e" txn=00000000 status=PENDING
+
+update txn=txn5 ts=11,1 epoch=0 span=e
+----
+num=0
+
+scan r=req2
+----
+start-waiting: false
+
+pushed-txn-updated txn=txn6 status=aborted
+----
+
+# Txn is pushed and txnStatusCache is consulted.
+add-discovered r=req2 k=f txn=txn5 consult-txn-status-cache=true
+----
+num=0
+
+# Txn is finalized and txnStatusCache is consulted.
+add-discovered r=req2 k=g txn=txn6 consult-txn-status-cache=true
+----
+num=0
+
+# Txn is not pushed or finalized and txnStatusCache is consulted.
+add-discovered r=req2 k=g txn=txn7 consult-txn-status-cache=true
+----
+num=1
+ lock: "g"
+  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 10.000000000,0, info: repl epoch: 0, seqs: [0]
+
+# Locks for f and g were not added to lock table.
+resolve-before-scanning r=req2
+----
+Intents to resolve:
+ key="f" txn=00000000 status=PENDING
+ key="g" txn=00000000 status=ABORTED
+
+scan r=req2
+----
+start-waiting: true
+
+guard-state r=req2
+----
+new: state=waitForDistinguished txn=txn7 key="g" held=true guard-strength=None
+
+dequeue r=req2
+----
+num=1
+ lock: "g"
+  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 10.000000000,0, info: repl epoch: 0, seqs: [0]
+
+clear
+----
+num=0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
@@ -1,0 +1,190 @@
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10,1 epoch=0
+----
+
+new-txn txn=txn2 ts=10,1 epoch=0
+----
+
+# -----------------------------------------------------------------------------
+# req1 waits for an unreplicated lock held on key a.
+# req2 waits for a replicated lock held on key b.
+# req3 waits for a replicated and unreplicated lock held on key c.
+# req4 scans all three keys and notices that the lock holder has been pushed.
+# It immediately updates the unreplicated-only lock and performs deferred
+# resolution on the other locks.
+# -----------------------------------------------------------------------------
+
+new-request r=req1 txn=txn1 ts=10,1 spans=none@a
+----
+
+new-request r=req2 txn=txn1 ts=10,1 spans=none@b
+----
+
+new-request r=req3 txn=txn1 ts=10,1 spans=none@c
+----
+
+new-request r=req4 txn=txn1 ts=10,1 spans=none@a,d
+----
+
+scan r=req4
+----
+start-waiting: false
+
+add-discovered r=req4 k=b txn=txn2
+----
+num=1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+add-discovered r=req4 k=c txn=txn2
+----
+num=2
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+new-request r=reqLock txn=txn2 ts=10,1 spans=intent@a+intent@b+intent@c+intent@d
+----
+
+scan r=reqLock
+----
+start-waiting: false
+
+acquire r=reqLock k=a durability=u
+----
+num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+acquire r=reqLock k=b durability=u
+----
+num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+dequeue r=reqLock
+----
+num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+
+scan r=req1
+----
+start-waiting: true
+
+scan r=req2
+----
+start-waiting: true
+
+scan r=req3
+----
+start-waiting: true
+
+print
+----
+num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 3, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 3
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 4, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 4
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 5, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 5
+
+pushed-txn-updated txn=txn2 status=pending ts=11,1
+----
+
+scan r=req4
+----
+start-waiting: true
+
+print
+----
+num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 4, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 4
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 5, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 5
+
+guard-state r=req1
+----
+new: state=doneWaiting
+
+guard-state r=req2
+----
+new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=None
+
+guard-state r=req3
+----
+new: state=waitForDistinguished txn=txn2 key="c" held=true guard-strength=None
+
+guard-state r=req4
+----
+new: state=doneWaiting
+Intents to resolve:
+ key="b" txn=00000000 status=PENDING
+ key="c" txn=00000000 status=PENDING
+
+update txn=txn2 ts=11,1 epoch=0 span=b
+----
+num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 5, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 5
+
+update txn=txn2 ts=11,1 epoch=0 span=c
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+
+guard-state r=req2
+----
+new: state=doneWaiting
+
+guard-state r=req3
+----
+new: state=doneWaiting
+
+clear
+----
+num=0


### PR DESCRIPTION
Fixes #103126.

This commit extends the infrastructure introduced in #49218 for transaction timestamp pushes. It avoids redundant txn pushes of PENDING transactions and batches the resolution of PENDING intents. This breaks the O(num_intents) work performed by high-priority scans (e.g. backups) over intent-heavy keyspaces into something closer to O(num_ranges) work.

The commit accomplishes its goals by adding a second per-Range LRU cache of transactions that are PENDING and are known to have been pushed to higher timestamps. We use this cache for two purposes:

1. when we are a non-locking read and we see a lock at a conflicting timestamp who is held by a pushed txn above our read timestamp, we neither wait out the kv.lock_table.coordinator_liveness_push_delay (50 ms) nor push the transactions record (RPC to leaseholder of pushee's txn record range).
2. we use the existence of a transaction in the cache as an indication that it may have written multiple intents, so we begin deferring intent resolution to enable batching.

Together, these two changes make us much more effective at pushing transactions with a large number of intents. The following example (from #103126) demonstrates this:
```sql
-- SETUP: run in a 3-node GCP roachprod cluster

--- session 1 - write 100k intents
CREATE TABLE keys (k BIGINT NOT NULL PRIMARY KEY);
BEGIN; INSERT INTO keys SELECT generate_series(1, 100000);

--- session 2 - push intents with high-priority txn without uncertainty interval
BEGIN PRIORITY HIGH AS OF SYSTEM TIME '-1ms';
SELECT count(*) FROM keys;

--- BEFORE this PR and before #103265 (i.e. v23.1.2): takes ~7.1ms per intent
Time: 714.441s total

--- BEFORE this PR: takes ~1.5ms per intent
Time: 151.880s total

--- AFTER this PR: takes ~24μs per intent
Time: 2.405s
```

The change does have an unfortunate limitation. Deferred intent resolution is only currently enabled for non-locking readers without uncertainty intervals. Readers with uncertainty intervals must contend with the possibility of pushing a conflicting intent up into their uncertainty interval and causing more work for themselves, which is avoided with care by the lockTableWaiter but difficult to coordinate through the txnStatusCache. This limitation is acceptable because the most important case here is optimizing the Export requests issued by backup.

This limitation also hints at the long-term plan for this interaction, which is that non-locking readers can ignore known pending intents without the need to even resolve those intents (see #94730). This will require a request-scoped cache of pending, pushed transactions, which does not have the same problems with uncertainty intervals.

Release note (performance improvement): Backups no longer perform work proportional to the number of pending intents that they encounter, so they are over 100x faster when encountering long-running, bulk writing transactions.