### PR TITLE
release-23.1: c2c: allow user to pass start time as a decimal to crdb_internal.fingerprint()

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3104,6 +3104,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.encode_key"></a><code>crdb_internal.encode_key(table_id: <a href="int.html">int</a>, index_id: <a href="int.html">int</a>, row_tuple: anyelement) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Generate the key for a row on a particular table and index.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="crdb_internal.fingerprint"></a><code>crdb_internal.fingerprint(span: <a href="bytes.html">bytes</a>[], start_time: <a href="decimal.html">decimal</a>, all_revisions: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="crdb_internal.fingerprint"></a><code>crdb_internal.fingerprint(span: <a href="bytes.html">bytes</a>[], start_time: <a href="timestamp.html">timestamptz</a>, all_revisions: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="crdb_internal.fingerprint"></a><code>crdb_internal.fingerprint(span: <a href="bytes.html">bytes</a>[], stripped: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>

--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -147,7 +147,8 @@ func (c *TenantStreamingClusters) RequireDestinationFingerprintAtTimestamp(
 func FingerprintTenantAtTimestampNoHistory(
 	t sqlutils.Fataler, db *sqlutils.SQLRunner, tenantID uint64, timestamp string,
 ) string {
-	fingerprintQuery := fmt.Sprintf("SELECT * FROM crdb_internal.fingerprint(crdb_internal.tenant_span($1::INT), 0::TIMESTAMPTZ, false) AS OF SYSTEM TIME %s", timestamp)
+	fingerprintQuery := fmt.Sprintf("SELECT * FROM crdb_internal.fingerprint(crdb_internal."+
+		"tenant_span($1::INT), 0::DECIMAL, false) AS OF SYSTEM TIME %s", timestamp)
 	return db.QueryStr(t, fingerprintQuery, tenantID)[0][0]
 }
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7545,6 +7545,22 @@ expires until the statement bundle is collected`,
 		tree.Overload{
 			Types: tree.ParamTypes{
 				{Name: "span", Typ: types.BytesArray},
+				{Name: "start_time", Typ: types.Decimal},
+				{Name: "all_revisions", Typ: types.Bool},
+				// NB: The function can be called with an AOST clause that will be used
+				// as the `end_time` when issuing the ExportRequests for the purposes of
+				// fingerprinting.
+			},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return verboseFingerprint(ctx, evalCtx, args)
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: volatility.Stable,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "span", Typ: types.BytesArray},
 				{Name: "start_time", Typ: types.TimestampTZ},
 				{Name: "all_revisions", Typ: types.Bool},
 				// NB: The function can be called with an AOST clause that will be used
@@ -7553,17 +7569,7 @@ expires until the statement bundle is collected`,
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if len(args) != 3 {
-					return nil, errors.New("argument list must have three elements")
-				}
-				span, err := parseSpan(args[0])
-				if err != nil {
-					return nil, err
-				}
-				startTime := tree.MustBeDTimestampTZ(args[1]).Time
-				startTimestamp := hlc.Timestamp{WallTime: startTime.UnixNano()}
-				allRevisions := bool(tree.MustBeDBool(args[2]))
-				return fingerprint(ctx, evalCtx, span, startTimestamp, allRevisions /* stripped */, false)
+				return verboseFingerprint(ctx, evalCtx, args)
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility: volatility.Stable,

--- a/pkg/sql/sem/builtins/fingerprint_builtins.go
+++ b/pkg/sql/sem/builtins/fingerprint_builtins.go
@@ -31,6 +31,42 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+func verboseFingerprint(
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
+) (tree.Datum, error) {
+	if len(args) != 3 {
+		return nil, errors.New("argument list must have three elements")
+	}
+	span, err := parseSpan(args[0])
+	if err != nil {
+		return nil, err
+	}
+
+	var startTimestamp hlc.Timestamp
+	if parsedDecimal, ok := parseDecimal(args[1]); ok {
+		startTimestamp, err = hlc.DecimalToHLC(&parsedDecimal.Decimal)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		startTime := tree.MustBeDTimestampTZ(args[1]).Time
+		startTimestamp = hlc.Timestamp{WallTime: startTime.UnixNano()}
+	}
+
+	allRevisions := bool(tree.MustBeDBool(args[2]))
+	return fingerprint(ctx, evalCtx, span, startTimestamp, allRevisions /* stripped */, false)
+}
+
+// parseDecimal is a copy of tree.AsDDecimal() which is available on later versions
+// of cockroach.
+func parseDecimal(e tree.Expr) (*tree.DDecimal, bool) {
+	switch t := e.(type) {
+	case *tree.DDecimal:
+		return t, true
+	}
+	return nil, false
+}
+
 func fingerprint(
 	ctx context.Context,
 	evalCtx *eval.Context,

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2380,6 +2380,7 @@ var builtinOidsArray = []string{
 	2406: `crdb_internal.fingerprint(span: bytes[], stripped: bool) -> int`,
 	2407: `crdb_internal.tenant_span() -> bytes[]`,
 	2411: `to_char(date: date, format: string) -> string`,
+	2412: `crdb_internal.fingerprint(span: bytes[], start_time: decimal, all_revisions: bool) -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
Backport 1/1 commits from #104219.

/cc @cockroachdb/release

---

Previously, the user could only pass the startTime variable to crdb_internal.fingerprint() as a TimestampTZ, which only has microsecond precision. To enable nanosecond precision, this patch allows the user to pass the startTime as a decimal. This patch is consistent with the user's ability to pass and AOST timestamp as a decimal as well.

Informs #103072

Release note: None

Release justification: test infra change
