### PR TITLE
release-22.2: sql/tests: deflake TestErrorDuringExtendedProtocolCommit

### DIFF
--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -113,7 +113,6 @@ go_test(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
-        "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/sql/tests/autocommit_extended_protocol_test.go
+++ b/pkg/sql/tests/autocommit_extended_protocol_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -26,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -157,14 +157,14 @@ func TestErrorDuringExtendedProtocolCommit(t *testing.T) {
 	var db *gosql.DB
 
 	var shouldErrorOnAutoCommit syncutil.AtomicBool
-	var traceID tracingpb.TraceID
+	var traceID atomic.Uint64
 	params, _ := CreateTestServerParams()
 	params.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
 		DisableAutoCommitDuringExec: true,
 		BeforeExecute: func(ctx context.Context, stmt string) {
 			if strings.Contains(stmt, "SELECT 'cat'") {
 				shouldErrorOnAutoCommit.Set(true)
-				traceID = tracing.SpanFromContext(ctx).TraceID()
+				traceID.Store(uint64(tracing.SpanFromContext(ctx).TraceID()))
 			}
 		},
 		BeforeAutoCommit: func(ctx context.Context, stmt string) error {
@@ -173,7 +173,7 @@ func TestErrorDuringExtendedProtocolCommit(t *testing.T) {
 				// saw when executing our test query. This is so we know that this
 				// autocommit corresponds to our test qyery rather than an internal
 				// query.
-				if traceID == tracing.SpanFromContext(ctx).TraceID() {
+				if traceID.Load() == uint64(tracing.SpanFromContext(ctx).TraceID()) {
 					shouldErrorOnAutoCommit.Set(false)
 					return errors.New("injected error")
 				}


### PR DESCRIPTION
Backport 1/2 commits from #104549.

/cc @cockroachdb/release

fixes https://github.com/cockroachdb/cockroach/issues/104664

Release justification: test only change

---

fixes https://github.com/cockroachdb/cockroach/issues/98843
fixes https://github.com/cockroachdb/cockroach/issues/103892

Release note: None
