### PR TITLE
dev,lint: generate code before linting

### DIFF
--- a/build/teamcity/cockroach/ci/tests/lint_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/lint_impl.sh
@@ -3,7 +3,6 @@
 set -xeuo pipefail
 
 # GCAssert requirements -- start
-export PATH="$(dirname $(bazel run @go_sdk//:bin/go --run_under=realpath)):$PATH"
 bazel run //pkg/gen:code
 bazel run //pkg/cmd/generate-cgo:generate-cgo --run_under="cd $(bazel info workspace) && "
 # GCAssert requirements -- end

--- a/pkg/cmd/dev/testdata/datadriven/lint
+++ b/pkg/cmd/dev/testdata/datadriven/lint
@@ -1,6 +1,12 @@
 exec
 dev lint
 ----
+bazel run //pkg/gen:code
+bazel info workspace --color=no
+bazel run //pkg/cmd/generate-cgo:generate-cgo '--run_under=cd crdb-checkout && '
+which cc
+export CC=
+export CXX=
 bazel run --config=test //build/bazelutil:lint -- -test.v
 bazel build //pkg/cmd/cockroach-short //pkg/cmd/dev //pkg/obsservice/cmd/obsservice //pkg/cmd/roachprod //pkg/cmd/roachtest --//build/toolchains:nogo_flag
 
@@ -12,17 +18,36 @@ bazel run --config=test //build/bazelutil:lint -- -test.v -test.short -test.time
 exec
 dev lint pkg/cmd/dev
 ----
+bazel run //pkg/gen:code
+bazel info workspace --color=no
+bazel run //pkg/cmd/generate-cgo:generate-cgo '--run_under=cd crdb-checkout && '
+which cc
+export CC=
+export CXX=
 export PKG=./pkg/cmd/dev
 bazel run --config=test //build/bazelutil:lint -- -test.v
+bazel build //pkg/cmd/cockroach-short //pkg/cmd/dev //pkg/obsservice/cmd/obsservice //pkg/cmd/roachprod //pkg/cmd/roachtest --//build/toolchains:nogo_flag
 
 exec
 dev lint -f TestLowercaseFunctionNames --cpus 4
 ----
+bazel run //pkg/gen:code
+bazel info workspace --color=no
+bazel run //pkg/cmd/generate-cgo:generate-cgo '--run_under=cd crdb-checkout && '
+which cc
+export CC=
+export CXX=
 bazel run --config=test //build/bazelutil:lint --local_cpu_resources=4 -- -test.v -test.run Lint/TestLowercaseFunctionNames
 
 exec
 dev lint --cpus 4
 ----
+bazel run //pkg/gen:code
+bazel info workspace --color=no
+bazel run //pkg/cmd/generate-cgo:generate-cgo '--run_under=cd crdb-checkout && '
+which cc
+export CC=
+export CXX=
 bazel run --config=test //build/bazelutil:lint --local_cpu_resources=4 -- -test.v
 bazel build //pkg/cmd/cockroach-short //pkg/cmd/dev //pkg/obsservice/cmd/obsservice //pkg/cmd/roachprod //pkg/cmd/roachtest --//build/toolchains:nogo_flag --local_cpu_resources=4
 

--- a/pkg/testutils/lint/BUILD.bazel
+++ b/pkg/testutils/lint/BUILD.bazel
@@ -21,7 +21,7 @@ go_test(
         "nightly_lint_test.go",
     ],
     args = ["-test.timeout=295s"],
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + ["@go_sdk//:files"],
     embed = [":lint"],
     embedsrcs = ["gcassert_paths.txt"],
     gotags = ["lint"],

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -44,6 +44,12 @@ const cockroachDB = "github.com/cockroachdb/cockroach"
 //go:embed gcassert_paths.txt
 var rawGcassertPaths string
 
+func init() {
+	if bazel.BuiltWithBazel() {
+		bazel.SetGoEnv()
+	}
+}
+
 func dirCmd(
 	dir string, name string, args ...string,
 ) (*exec.Cmd, *bytes.Buffer, stream.Filter, error) {


### PR DESCRIPTION
Generated code needs to be present for `TestGCAssert`. Tell `dev` to generate code before running lints. We skip generating code if run under `--short` since `GCAssert` is skipped under `--short` anyway.

Also a small improvement to `lint` so that it pulls the `go` binary from Bazel `runfiles` instead of it needing to be injected.

Epic: none
Release note: None