### PR TITLE
backupccl: break dependency on gossip

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -55,7 +55,6 @@ go_library(
         "//pkg/cloud/cloudprivilege",
         "//pkg/clusterversion",
         "//pkg/featureflag",
-        "//pkg/gossip",
         "//pkg/jobs",
         "//pkg/jobs/joberror",
         "//pkg/jobs/jobspb",

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -76,7 +76,6 @@ func distRestore(
 	uris []string,
 	backupLocalityInfo []jobspb.RestoreDetails_BackupLocalityInfo,
 	spanFilter spanCoveringFilter,
-	numNodes int,
 	numImportSpans int,
 	useSimpleImportSpans bool,
 	progCh chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
@@ -117,6 +116,7 @@ func distRestore(
 			return nil, nil, err
 		}
 
+		numNodes := len(sqlInstanceIDs)
 		p := planCtx.NewPhysicalPlan()
 
 		restoreDataSpec := execinfrapb.RestoreDataSpec{


### PR DESCRIPTION
This commit removes the dependency of the backup / restore on gossip. Previously, gossip was used to count the number of nodes in the cluster, and this information is used for telemetry reporting as well as for chunking up the working spans. However, that seems unnecessary and in some cases incorrect.

In particular, for backup telemetry we computed speed per node via dividing by the cluster node count, but we might have used less SQL instances, so we should actually be dividing by the number of SQL instances used in the backup plan. In restore we use all available SQL instances, and we now calculate that number right before using it for telemetry calculation. It's possible that we used different number of instances in the restore operations (which there appear to be three) when the instances went up or down, but it's probably not that important.

Addresses: #54252.
Epic: None.

Release note: None