### PR TITLE
[dnm] release-23.1: disallow invalid splits and fall back to system tenant in DecodeTenantPrefix

### DIFF
--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -38,7 +38,8 @@ func DecodeTenantPrefix(key roachpb.Key) ([]byte, roachpb.TenantID, error) {
 	}
 	rem, tenID, err := encoding.DecodeUvarintAscending(key[1:])
 	if err != nil {
-		return nil, roachpb.TenantID{}, err
+		// NB: adding logging here tends to cause infinite recursion.
+		return nil, roachpb.SystemTenantID, nil //nolint:returnerrcheck
 	}
 	return rem, roachpb.MustMakeTenantID(tenID), nil
 }

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -235,6 +235,7 @@ go_test(
         "batch_spanset_test.go",
         "below_raft_protos_test.go",
         "client_atomic_membership_change_test.go",
+        "client_invalidsplit_test.go",
         "client_lease_test.go",
         "client_merge_test.go",
         "client_metrics_test.go",

--- a/pkg/kv/kvserver/client_invalidsplit_test.go
+++ b/pkg/kv/kvserver/client_invalidsplit_test.go
@@ -1,0 +1,74 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+var badKey = append([]byte{'\xfe'}, '\xfd')
+
+func TestInvalidSplit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	_, _, err := keys.DecodeTenantPrefix(badKey)
+	t.Log(err)
+	require.NoError(t, err) // used to error before changing DecodeTenantPrefix
+
+	ctx := context.Background()
+	stickyEngineRegistry := server.NewStickyInMemEnginesRegistry()
+	defer stickyEngineRegistry.CloseAllStickyInMemEngines()
+
+	start := func(t *testing.T) *testcluster.TestCluster {
+		serverArgs := base.TestServerArgs{
+			StoreSpecs: []base.StoreSpec{
+				{InMemory: true, StickyInMemoryEngineID: "1"},
+			},
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					StickyEngineRegistry: stickyEngineRegistry,
+				},
+			},
+		}
+
+		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+			ServerArgs: serverArgs,
+		})
+		return tc
+	}
+
+	func() {
+		tc := start(t)
+		defer tc.Stopper().Stop(ctx)
+
+		_, _, err = tc.SplitRange(badKey)
+		t.Log(err)
+	}()
+
+	func() {
+		tc := start(t)
+		defer tc.Stopper().Stop(ctx)
+		mergeKey := roachpb.Key(badKey).Prevish(5)
+		desc := tc.LookupRangeOrFatal(t, mergeKey)
+		require.EqualValues(t, badKey, desc.EndKey)
+		_, err = tc.Servers[0].MergeRanges(mergeKey)
+		require.NoError(t, err)
+	}()
+}

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -365,6 +365,9 @@ func (r *Replica) adminSplitWithDescriptor(
 		if !storage.IsValidSplitKey(foundSplitKey) {
 			return reply, errors.Errorf("cannot split range at key %s", splitKey)
 		}
+		if _, _, err := keys.DecodeTenantPrefixE(splitKey.AsRawKey()); err != nil {
+			return reply, errors.Wrapf(err, "checking for valid tenantID")
+		}
 	}
 
 	// If the range starts at the splitKey, we treat the AdminSplit


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/pull/104781 + https://github.com/cockroachdb/cockroach/pull/104802