### PR TITLE
scrun: don't include plan details for pgerrors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -1086,3 +1086,11 @@ SELECT c0 FROM t103755 WHERE c0 < 0 OR (c0 IN (VALUES (2)) AND c1 IN (6,8,9)) OR
 ----
 -20
 -10
+
+statement ok
+CREATE TABLE t104484 (c0 VARBIT(10) AS (B'1') STORED)
+
+# We use '$' to match the end of the error text, since we want to assert
+# that the error does not include the schema plan details.
+statement error cannot create a sharded index on a computed column$
+CREATE INDEX ON t104484(c0 DESC) USING HASH

--- a/pkg/sql/schemachanger/scerrors/errors.go
+++ b/pkg/sql/schemachanger/scerrors/errors.go
@@ -178,6 +178,15 @@ func HasSchemaChangerUserError(err error) bool {
 	return errors.HasType(err, (*schemaChangerUserError)(nil))
 }
 
+// UnwrapSchemaChangerUserError returns the cause of a schemaChangerUserError,
+// or nil if the error is not a schemaChangerUserError.
+func UnwrapSchemaChangerUserError(err error) error {
+	if scUserError := (*schemaChangerUserError)(nil); errors.As(err, &scUserError) {
+		return scUserError.err
+	}
+	return nil
+}
+
 func (e *schemaChangerUserError) Error() string {
 	return fmt.Sprintf("schema change operation encountered an error: %s", e.err.Error())
 }


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/104484

Errors with a PG code are expected to occur when the user attempts to perform an invalid schema change operation. The code and the error text are sufficient to explain what the issue was, so adding the entire schema plan as well only serves to obfuscate the problem.

Release note: None