### PR TITLE
base: remove OptionalNodeIDErr

### DIFF
--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/util",
         "//pkg/util/envutil",
-        "//pkg/util/errorutil",
         "//pkg/util/humanizeutil",
         "//pkg/util/metric",
         "//pkg/util/mon",

--- a/pkg/base/node_id.go
+++ b/pkg/base/node_id.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -231,15 +230,6 @@ func (c *SQLIDContainer) OptionalNodeID() (roachpb.NodeID, bool) {
 		return 0, false
 	}
 	return (*NodeIDContainer)(c).Get(), true
-}
-
-// OptionalNodeIDErr is like OptionalNodeID, but returns an error (referring to
-// the optionally supplied GitHub issues) if the ID is not present.
-func (c *SQLIDContainer) OptionalNodeIDErr(issue int) (roachpb.NodeID, error) {
-	if (*NodeIDContainer)(c).standaloneSQLInstance {
-		return 0, errorutil.UnsupportedWithMultiTenancy(issue)
-	}
-	return (*NodeIDContainer)(c).Get(), nil
 }
 
 // SQLInstanceID returns the wrapped SQLInstanceID.


### PR DESCRIPTION
This method was only used in one place where we need to get the SQL instance ID of the gateway. That place has been refactored to pass that ID explicitly from the DistSQLPlanner.

Addresses: #100826.
Epic: None

Release note: None