### PR TITLE
streamingccl: skip flaky tests in 22.2, those are improved in 23.1

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -322,6 +322,7 @@ func encodeSpec(
 func TestStreamPartition(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.IgnoreLint(t, "skipping in 22.2, streaming is developed in 23.1")
 	h, cleanup := streamingtest.NewReplicationHelper(t,
 		base.TestServerArgs{
 			// Test fails within a test tenant. More investigation is required.
@@ -468,6 +469,7 @@ CREATE TABLE t3(
 func TestStreamAddSSTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.IgnoreLint(t, "skipping in 22.2, streaming is developed in 23.1")
 	h, cleanup := streamingtest.NewReplicationHelper(t, base.TestServerArgs{
 		// Test hangs when run within the default test tenant. Tracked with
 		// #76378.
@@ -636,6 +638,7 @@ func sortDelRanges(receivedDelRanges []roachpb.RangeFeedDeleteRange) {
 func TestStreamDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.IgnoreLint(t, "skipping in 22.2, streaming is developed in 23.1")
 	skip.UnderStressRace(t, "disabled under stress and race")
 
 	h, cleanup := streamingtest.NewReplicationHelper(t, base.TestServerArgs{


### PR DESCRIPTION
We're working actively on streaming (physical cluster replication, aka c2c) in 23.1, no need to spend time fixing streaming bugs in 22.2 where streaming is not used.

Fixes: #104392
Fixes: #104467
Fixes: #104764

Release note: None