### PR TITLE
sql/schemachanger: avoid assertions when columns are missing

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -4150,3 +4150,14 @@ query I
 SELECT count(*) FROM child80828
 ----
 0
+
+# See #104546 which was a regression when an invalid column name was specified,
+# when adding a FK reference.
+subtest unknown_column_name
+
+statement ok
+create table t104546 (a int primary key);
+create table t104546_fk_src (a int primary key, b int);
+
+statement error pgcode 42703 column "b" does not exist
+alter table t104546 add constraint con foreign key (b) references t104546_fk_src(b);

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_not_null.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_not_null.go
@@ -22,7 +22,7 @@ func alterTableSetNotNull(
 	b BuildCtx, tn *tree.TableName, tbl *scpb.Table, t *tree.AlterTableSetNotNull,
 ) {
 	alterColumnPreChecks(b, tn, tbl, t.Column)
-	columnID := mustGetColumnIDFromColumnName(b, tbl.TableID, t.Column)
+	columnID := getColumnIDFromColumnName(b, tbl.TableID, t.Column, true /*required */)
 	if isColNotNull(b, tbl.TableID, columnID) {
 		return
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -162,7 +162,7 @@ func getprimaryIndexShardColumn(
 	if indexElem.Sharding == nil {
 		return nil
 	}
-	shardColID := getColumnIDFromColumnName(b, tableID, tree.Name(indexElem.Sharding.Name))
+	shardColID := getColumnIDFromColumnName(b, tableID, tree.Name(indexElem.Sharding.Name), false /* required */)
 	return mustRetrieveColumnElem(b, tableID, shardColID)
 }
 
@@ -181,7 +181,7 @@ func alterPKInPrimaryIndexAndItsTemp(
 		// If index is sharded, the first key column will be the new shard col.
 		if index.Sharding != nil {
 			ret = append(ret, indexColumnSpec{
-				columnID: getColumnIDFromColumnName(b, tableID, tree.Name(index.Sharding.Name)),
+				columnID: getColumnIDFromColumnName(b, tableID, tree.Name(index.Sharding.Name), false /* required */),
 				kind:     scpb.IndexColumn_KEY,
 			})
 		}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -574,10 +574,7 @@ func addColumnsForSecondaryIndex(
 				expressionTelemtryCounted = true
 			}
 		}
-		colID := getColumnIDFromColumnName(b, tableID, colName)
-		if colID == 0 {
-			panic(colinfo.NewUndefinedColumnError(string(colName)))
-		}
+		colID := getColumnIDFromColumnName(b, tableID, colName, true /* required */)
 		columnTypeElem := mustRetrieveColumnTypeElem(b, tableID, colID)
 		columnElem := mustRetrieveColumnElem(b, tableID, colID)
 		// Column should be accessible.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -349,10 +349,10 @@ func getNonDropColumns(b BuildCtx, tableID catid.DescID) (ret []*scpb.Column) {
 // getColumnIDFromColumnName looks up a column's ID by its name.
 // If no column with this name exists, 0 will be returned.
 func getColumnIDFromColumnName(
-	b BuilderState, tableID catid.DescID, columnName tree.Name,
+	b BuilderState, tableID catid.DescID, columnName tree.Name, required bool,
 ) catid.ColumnID {
 	colElems := b.ResolveColumn(tableID, columnName, ResolveParams{
-		IsExistenceOptional: true,
+		IsExistenceOptional: !required,
 		RequiredPrivilege:   privilege.CREATE,
 	})
 
@@ -373,12 +373,15 @@ func getColumnIDFromColumnName(
 func mustGetColumnIDFromColumnName(
 	b BuildCtx, tableID catid.DescID, columnName tree.Name,
 ) catid.ColumnID {
-	colID := getColumnIDFromColumnName(b, tableID, columnName)
+	colID := getColumnIDFromColumnName(b, tableID, columnName, false)
 	if colID == 0 {
-		panic(errors.AssertionFailedf("cannot find column with name %v", columnName))
+		panic(errors.AssertionFailedf("programming erorr: cannot find column with name %v", columnName))
 	}
 	return colID
 }
+
+// Currently unused.
+var _ = mustGetColumnIDFromColumnName
 
 func mustGetTableIDFromTableName(b BuildCtx, tableName tree.TableName) catid.DescID {
 	tableElems := b.ResolveTable(tableName.ToUnresolvedObjectName(), ResolveParams{
@@ -888,7 +891,7 @@ func ExtractColumnIDsInExpr(
 			return true, expr, nil
 		}
 
-		colID := getColumnIDFromColumnName(b, tableID, c.ColumnName)
+		colID := getColumnIDFromColumnName(b, tableID, c.ColumnName, false /* required */)
 		colIDs.Add(colID)
 		return false, expr, nil
 	})


### PR DESCRIPTION
Previously, the declarative schema changer, when resolving columns would assert if a column name was undefined. This is incorrect behaviour and a regression. To address this, this patch will generate the appropriate missing column error.

Fixes: #104546

Release note (bug fix): Adding a foreign key or setting a column to not null with a non-existent column produced an assertion error, instead of the proper pgcode in the declarative schema changer.