### PR TITLE
mma: add cluster state mutators & accessors 

### DIFF
--- a/pkg/kv/kvserver/allocator/mma/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mma/BUILD.bazel
@@ -16,13 +16,16 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 
 go_test(
     name = "mma_test",
     srcs = [
+        "cluster_state_test.go",
         "constraint_matcher_test.go",
         "constraint_test.go",
         "load_test.go",
@@ -32,6 +35,9 @@ go_test(
     embed = [":mma"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/testutils/datapathutils",
+        "//pkg/util/hlc",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/allocator/mma/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mma/allocator_state.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 type allocatorState struct {
@@ -27,9 +28,9 @@ type allocatorState struct {
 	changeRangeLimiter *storeChangeRateLimiter
 }
 
-func newAllocatorState() *allocatorState {
+func newAllocatorState(clock hlc.WallClock) *allocatorState {
 	interner := newStringInterner()
-	cs := newClusterState(interner)
+	cs := newClusterState(clock, interner)
 	return &allocatorState{
 		cs:                     cs,
 		rangesNeedingAttention: map[roachpb.RangeID]struct{}{},

--- a/pkg/kv/kvserver/allocator/mma/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mma/cluster_state.go
@@ -6,10 +6,15 @@
 package mma
 
 import (
+	"fmt"
 	"slices"
+	"sort"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // These values can sometimes be used in replicaType, replicaIDAndType,
@@ -34,6 +39,56 @@ type replicaIDAndType struct {
 	replicaType
 }
 
+// SafeFormat implements the redact.SafeFormatter interface.
+func (rt replicaIDAndType) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Print("replica-id=")
+	switch rt.ReplicaID {
+	case unknownReplicaID:
+		w.Print("unknown")
+	case noReplicaID:
+		w.Print("none")
+	default:
+		w.Print(rt.ReplicaID)
+	}
+	w.Printf(" lease=%v type=%v", rt.isLeaseholder, rt.replicaType.replicaType)
+}
+
+func (rt replicaIDAndType) String() string {
+	return redact.StringWithoutMarkers(rt)
+}
+
+// prev is the state before the proposed change and next is the state after
+// the proposed change. rit is the current observed state.
+func (rit replicaIDAndType) subsumesChange(prev replicaIDAndType, next replicaIDAndType) bool {
+	if rit.ReplicaID == noReplicaID && next.ReplicaID == noReplicaID {
+		// Removal has happened.
+		return true
+	}
+	notSubsumed := (rit.ReplicaID == noReplicaID && next.ReplicaID != noReplicaID) ||
+		(rit.ReplicaID != noReplicaID && next.ReplicaID == noReplicaID)
+	if notSubsumed {
+		return false
+	}
+	// Both rit and next have replicaIDs != noReplicaID. We don't actually care
+	// about the replicaID's since we don't control them. If the replicaTypes
+	// are as expected, and if we were either not trying to change the
+	// leaseholder, or that leaseholder change has happened, then the change has
+	// been subsumed.
+	switch rit.replicaType.replicaType {
+	case roachpb.VOTER_INCOMING:
+		// Already seeing the load, so consider the change done.
+		rit.replicaType.replicaType = roachpb.VOTER_FULL
+	}
+	// rit.replicaId equal to LEARNER, VOTER_DEMOTING* are left as-is. If next
+	// is trying to remove a replica, this store is still seeing some of the
+	// load.
+	if rit.replicaType == next.replicaType && (prev.isLeaseholder == next.isLeaseholder ||
+		rit.isLeaseholder == next.isLeaseholder) {
+		return true
+	}
+	return false
+}
+
 type replicaState struct {
 	replicaIDAndType
 	// voterIsLagging can be set for a VOTER_FULL replica that has fallen behind
@@ -45,27 +100,11 @@ type replicaState struct {
 	replicationPaused bool
 }
 
-// Unique ID, in the context of this data-structure and when receiving updates
-// about enactment having happened or having been rejected (by the component
-// responsible for change enactment).
-type changeID uint64
-
-// pendingReplicaChange is a proposed change to a single replica. Some
-// external entity (the leaseholder of the range) may choose to enact this
-// change. It may not be enacted if it will cause some invariant (like the
-// number of replicas, or having a leaseholder) to be violated. If not
-// enacted, the allocator will either be told about the lack of enactment, or
-// will eventually expire from the allocator's state after
-// pendingChangeExpiryDuration. Such expiration without enactment should be
-// rare. pendingReplicaChanges can be paired, when a range is being moved from
-// one store to another -- that pairing is not captured here, and captured in
-// the changes suggested by the allocator to the external entity.
-type pendingReplicaChange struct {
-	changeID
-
+type replicaChange struct {
 	// The load this change adds to a store. The values will be negative if the
 	// load is being removed.
-	loadDelta loadVector
+	loadDelta          loadVector
+	secondaryLoadDelta secondaryLoadVector
 
 	storeID roachpb.StoreID
 	rangeID roachpb.RangeID
@@ -88,6 +127,171 @@ type pendingReplicaChange struct {
 	//   NON_VOTER.
 	prev replicaState
 	next replicaIDAndType
+}
+
+func (rc replicaChange) isRemoval() bool {
+	return rc.prev.ReplicaID >= 0 && rc.next.ReplicaID == noReplicaID
+}
+
+func (rc replicaChange) isAddition() bool {
+	return rc.prev.ReplicaID == noReplicaID && rc.next.ReplicaID == unknownReplicaID
+}
+
+func (rc replicaChange) isUpdate() bool {
+	return rc.prev.ReplicaID >= 0 && rc.next.ReplicaID >= 0
+}
+
+func makeLeaseTransferChanges(
+	rLoad rangeLoad, rState *rangeState, addStoreID, removeStoreID roachpb.StoreID,
+) [2]replicaChange {
+	addIdx, removeIdx := -1, -1
+	for i, replica := range rState.replicas {
+		if replica.StoreID == addStoreID {
+			addIdx = i
+		}
+		if replica.StoreID == removeStoreID {
+			removeIdx = i
+		}
+	}
+	if removeIdx == -1 {
+		panic(fmt.Sprintf(
+			"existing leaseholder replica doesn't exist on store %v", removeIdx))
+	}
+	if addIdx == -1 {
+		panic(fmt.Sprintf(
+			"new leaseholder replica doesn't exist on store %v", addStoreID))
+	}
+	remove := rState.replicas[removeIdx]
+	add := rState.replicas[addIdx]
+
+	removeLease := replicaChange{
+		storeID: removeStoreID,
+		rangeID: rLoad.RangeID,
+		prev:    remove.replicaState,
+		next:    remove.replicaIDAndType,
+	}
+	addLease := replicaChange{
+		storeID: addStoreID,
+		rangeID: rLoad.RangeID,
+		prev:    add.replicaState,
+		next:    add.replicaIDAndType,
+	}
+	addLease.next.isLeaseholder = true
+	removeLease.next.isLeaseholder = false
+
+	// Only account for the leaseholder CPU, all other primary load dimensions
+	// are ignored. Byte size and write bytes are not impacted by having a range
+	// lease.
+	nonRaftCPU := rLoad.load[cpu] - rLoad.raftCPU
+	removeLease.loadDelta[cpu] -= nonRaftCPU
+	addLease.loadDelta[cpu] += nonRaftCPU
+	// Also account for the lease count.
+	removeLease.secondaryLoadDelta[leaseCount] = -1
+	addLease.secondaryLoadDelta[leaseCount] = 1
+	return [2]replicaChange{removeLease, addLease}
+}
+
+// makeAddReplicaChange creates a replica change which adds the replica type
+// to the store addStoreID. The load impact of adding the replica does not
+// account for whether the replica is becoming the leaseholder or not.
+//
+// TODO(kvoli,sumeerbhola): Add promotion/demotion changes.
+func makeAddReplicaChange(
+	rLoad rangeLoad, addStoreID roachpb.StoreID, rType roachpb.ReplicaType,
+) replicaChange {
+	addReplica := replicaChange{
+		storeID: addStoreID,
+		rangeID: rLoad.RangeID,
+		prev: replicaState{
+			replicaIDAndType: replicaIDAndType{
+				ReplicaID: noReplicaID,
+			},
+		},
+		next: replicaIDAndType{
+			ReplicaID: unknownReplicaID,
+			replicaType: replicaType{
+				replicaType: rType,
+			},
+		},
+	}
+
+	addReplica.loadDelta.add(rLoad.load)
+	// Set the load delta for CPU to be just the raft CPU. The non-raft CPU we
+	// assume is associated with the lease.
+	addReplica.loadDelta[cpu] = rLoad.raftCPU
+	return addReplica
+}
+
+// makeRemoveReplicaChange creates a replica change which removes the replica
+// given. The load impact of removing the replica does not account for whether
+// the replica was the previous leaseholder or not.
+func makeRemoveReplicaChange(rLoad rangeLoad, remove storeIDAndReplicaState) replicaChange {
+	removeReplica := replicaChange{
+		storeID: remove.StoreID,
+		rangeID: rLoad.RangeID,
+		prev:    remove.replicaState,
+		next: replicaIDAndType{
+			ReplicaID: noReplicaID,
+		},
+	}
+	removeReplica.loadDelta.sub(rLoad.load)
+	// Set the load delta for CPU to be just the raft CPU. The non-raft CPU we
+	// assume is associated with the lease.
+	removeReplica.loadDelta[cpu] = -rLoad.raftCPU
+	return removeReplica
+}
+
+// makeRebalanceReplicaChanges creates to replica changes, adding a replica and
+// removing another. If the replica being rebalanced is the current
+// leaseholder, the impact of the rebalance also includes the lease load.
+//
+// TODO(kvoli,sumeerbhola): If the leaseholder is being rebalanced, we need to
+// ensure the incoming replica is eligible to take the lease.
+func makeRebalanceReplicaChanges(
+	rLoad rangeLoad, rState *rangeState, addStoreID, removeStoreID roachpb.StoreID,
+) [2]replicaChange {
+	var remove storeIDAndReplicaState
+	for _, replica := range rState.replicas {
+		if replica.StoreID == removeStoreID {
+			remove = replica
+		}
+	}
+
+	addReplicaChange := makeAddReplicaChange(rLoad, addStoreID, remove.replicaType.replicaType)
+	removeReplicaChange := makeRemoveReplicaChange(rLoad, remove)
+	if remove.isLeaseholder {
+		// The existing leaseholder is being removed. The incoming replica will
+		// take the lease load, in addition to the replica load.
+		addReplicaChange.next.isLeaseholder = true
+		addReplicaChange.loadDelta = loadVector{}
+		removeReplicaChange.loadDelta = loadVector{}
+		addReplicaChange.loadDelta.add(rLoad.load)
+		removeReplicaChange.loadDelta.sub(rLoad.load)
+		addReplicaChange.secondaryLoadDelta[leaseCount] = 1
+		addReplicaChange.secondaryLoadDelta[leaseCount] = -1
+	}
+
+	return [2]replicaChange{addReplicaChange, removeReplicaChange}
+}
+
+// Unique ID, in the context of this data-structure and when receiving updates
+// about enactment having happened or having been rejected (by the component
+// responsible for change enactment).
+type changeID uint64
+
+// pendingReplicaChange is a proposed change to a single replica. Some
+// external entity (the leaseholder of the range) may choose to enact this
+// change. It may not be enacted if it will cause some invariant (like the
+// number of replicas, or having a leaseholder) to be violated. If not
+// enacted, the allocator will either be told about the lack of enactment, or
+// will eventually expire from the allocator's state after
+// pendingChangeExpiryDuration. Such expiration without enactment should be
+// rare. pendingReplicaChanges can be paired, when a range is being moved from
+// one store to another -- that pairing is not captured here, and captured in
+// the changes suggested by the allocator to the external entity.
+type pendingReplicaChange struct {
+	changeID
+	replicaChange
 
 	// The wall time at which this pending change was initiated. Used for
 	// expiry.
@@ -108,6 +312,18 @@ func (p *pendingChangesOldestFirst) removeChangeAtIndex(index int) {
 	*p = (*p)[:n-1]
 }
 
+func (p *pendingChangesOldestFirst) Len() int {
+	return len(*p)
+}
+
+func (p *pendingChangesOldestFirst) Less(i, j int) bool {
+	return (*p)[i].startTime.Before((*p)[j].startTime)
+}
+
+func (p *pendingChangesOldestFirst) Swap(i, j int) {
+	(*p)[i], (*p)[j] = (*p)[j], (*p)[i]
+}
+
 type storeInitState int8
 
 const (
@@ -123,6 +339,24 @@ const (
 	// there are no ranges referencing it.
 	removed
 )
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (sis storeInitState) SafeFormat(w redact.SafePrinter, _ rune) {
+	switch sis {
+	case partialInit:
+		w.Print("partial")
+	case fullyInit:
+		w.Print("full")
+	case removed:
+		w.Print("removed")
+	default:
+		w.Print("unknown")
+	}
+}
+
+func (sis storeInitState) String() string {
+	return redact.StringWithoutMarkers(sis)
+}
 
 // storeChangeRateLimiter and helpers.
 //
@@ -202,8 +436,8 @@ func (h *storeEnactedHistory) gcHistory(now time.Time, gcThreshold time.Duration
 	for ; i < len(h.changes); i++ {
 		c := h.changes[i]
 		if now.Sub(c.enactedAtTime) > gcThreshold {
-			h.totalDelta.subtract(c.loadDelta)
-			h.totalSecondary.subtract(c.secondaryDelta)
+			h.totalDelta.sub(c.loadDelta)
+			h.totalSecondary.sub(c.secondaryDelta)
 		} else {
 			break
 		}
@@ -383,6 +617,35 @@ func (ss *storeState) computePendingChangesReflectedInLatestLoad(
 	return changes
 }
 
+func newStoreState(storeID roachpb.StoreID, nodeID roachpb.NodeID) *storeState {
+	ss := &storeState{
+		storeLoad: storeLoad{
+			StoreID:    storeID,
+			NodeID:     nodeID,
+			topKRanges: []rangeLoad{},
+		},
+	}
+	ss.adjusted.loadReplicas = map[roachpb.RangeID]replicaType{}
+	ss.adjusted.loadPendingChanges = map[changeID]*pendingReplicaChange{}
+	ss.adjusted.replicas = map[roachpb.RangeID]replicaState{}
+	return ss
+}
+
+// applyChangeLoadDelta adds the change load delta to the store's adjusted load.
+func (ss *storeState) applyChangeLoadDelta(change replicaChange) {
+	ss.adjusted.load.add(change.loadDelta)
+	ss.adjusted.secondaryLoad.add(change.secondaryLoadDelta)
+	ss.loadSeqNum++
+}
+
+// undoChangeLoadDelta subtracts the change load delta from the store's
+// adjusted load.
+func (ss *storeState) undoChangeLoadDelta(change replicaChange) {
+	ss.adjusted.load.sub(change.loadDelta)
+	ss.adjusted.secondaryLoad.sub(change.secondaryLoadDelta)
+	ss.loadSeqNum++
+}
+
 // failureDetectionSummary is provided by an external entity and never
 // computed inside the allocator.
 type failureDetectionSummary uint8
@@ -400,6 +663,33 @@ const (
 	fdDead
 )
 
+// SafeFormat implements the redact.SafeFormatter interface.
+func (fds failureDetectionSummary) SafeFormat(w redact.SafePrinter, _ rune) {
+	switch fds {
+	case fdOK:
+		w.Print("ok")
+	case fdSuspect:
+		w.Print("suspect")
+	case fdDrain:
+		w.Print("drain")
+	case fdDead:
+		w.Print("dead")
+	}
+}
+
+func (fds failureDetectionSummary) String() string {
+	return redact.StringWithoutMarkers(fds)
+}
+
+func newNodeState(nodeID roachpb.NodeID) *nodeState {
+	return &nodeState{
+		stores: []roachpb.StoreID{},
+		nodeLoad: nodeLoad{
+			nodeID: nodeID,
+		},
+	}
+}
+
 type nodeState struct {
 	stores []roachpb.StoreID
 	nodeLoad
@@ -411,13 +701,31 @@ type nodeState struct {
 	fdSummary   failureDetectionSummary
 }
 
+// applyChangeLoadDelta adds the change load delta to the node's adjusted load.
+func (ns *nodeState) applyChangeLoadDelta(change replicaChange) {
+	ns.adjustedCPU += change.loadDelta[cpu]
+}
+
+// undoChangeLoadDelta subtracts the change load delta from the node's adjusted
+// load.
+func (ns *nodeState) undoChangeLoadDelta(change replicaChange) {
+	ns.adjustedCPU -= change.loadDelta[cpu]
+}
+
 type storeIDAndReplicaState struct {
 	roachpb.StoreID
 	// Only valid ReplicaTypes are used here.
 	replicaState
 }
 
-// rangeState is periodically updated based on reporting by the leaseholder.
+func newRangeState() *rangeState {
+	return &rangeState{
+		replicas:       []storeIDAndReplicaState{},
+		pendingChanges: []*pendingReplicaChange{},
+	}
+}
+
+// rangeState is periodically updated based in reporting by the leaseholder.
 type rangeState struct {
 	// replicas is the adjusted replicas. It is always consistent with
 	// the storeState.adjusted.replicas in the corresponding stores.
@@ -445,6 +753,41 @@ type rangeState struct {
 	lastHeardTime time.Time
 }
 
+func (rs *rangeState) removePendingChangeTracking(cid changeID) {
+	i := 0
+	n := len(rs.pendingChanges)
+	for ; i < n; i++ {
+		if rs.pendingChanges[i].changeID == cid {
+			rs.pendingChanges[i], rs.pendingChanges[n-1] = rs.pendingChanges[n-1], rs.pendingChanges[i]
+			rs.pendingChanges = rs.pendingChanges[:n-1]
+			break
+		}
+	}
+	rs.constraints = nil
+}
+
+func (rs *rangeState) setReplica(repl storeIDAndReplicaState) {
+	for i := range rs.replicas {
+		if rs.replicas[i].StoreID == repl.StoreID {
+			rs.replicas[i].replicaState = repl.replicaState
+			return
+		}
+	}
+	rs.replicas = append(rs.replicas, repl)
+}
+
+func (rs *rangeState) removeReplica(storeID roachpb.StoreID) {
+	var i, n int
+	n = len(rs.replicas)
+	for ; i < n; i++ {
+		if rs.replicas[i].StoreID == storeID {
+			rs.replicas[i], rs.replicas[n-1] = rs.replicas[n-1], rs.replicas[i]
+			rs.replicas = rs.replicas[:n-1]
+			break
+		}
+	}
+}
+
 // clusterState is the state of the cluster known to the allocator, including
 // adjustments based on pending changes. It does not include additional
 // indexing needed for constraint matching, or for tracking ranges that may
@@ -454,25 +797,31 @@ type clusterState struct {
 	stores map[roachpb.StoreID]*storeState
 	ranges map[roachpb.RangeID]*rangeState
 	// Added to when a change is proposed. Will also add to corresponding
-	// rangeState.pendingChanges and to the effected storeStates.
+	// rangeState.pendingChanges and to the affected storeStates.
 	//
 	// Removed from based on rangeMsg, explicit rejection by enacting module, or
 	// time-based GC. There is no explicit acceptance by enacting module since
 	// the single source of truth of a rangeState is the leaseholder.
-	pendingChanges map[changeID]*pendingReplicaChange
+	pendingChanges    map[changeID]*pendingReplicaChange
+	pendingChangeList []*pendingReplicaChange
+	changeSeqGen      changeID
 
 	*constraintMatcher
 	*localityTierInterner
+
+	clock hlc.WallClock
 }
 
-func newClusterState(interner *stringInterner) *clusterState {
+func newClusterState(clock hlc.WallClock, interner *stringInterner) *clusterState {
 	return &clusterState{
 		nodes:                map[roachpb.NodeID]*nodeState{},
 		stores:               map[roachpb.StoreID]*storeState{},
 		ranges:               map[roachpb.RangeID]*rangeState{},
 		pendingChanges:       map[changeID]*pendingReplicaChange{},
+		pendingChangeList:    []*pendingReplicaChange{},
 		constraintMatcher:    newConstraintMatcher(interner),
 		localityTierInterner: newLocalityTierInterner(interner),
+		clock:                clock,
 	}
 }
 
@@ -480,50 +829,525 @@ func newClusterState(interner *stringInterner) *clusterState {
 // clusterState mutators
 //======================================================================
 
-func (cs *clusterState) processNodeLoadResponse(resp *nodeLoadResponse) {
-	// TODO(sumeer):
+func (cs *clusterState) processNodeLoadResponse(resp *nodeLoadResponse) error {
+	if resp.lastLoadSeqNum != fullUpdateLoadSeqNum {
+		// TODO(kvoli,sumeerbhola): Handle delta responses.
+		panic("unimplemented")
+	}
+
+	now := cs.clock.Now()
+	cs.gcPendingChanges(now)
+
+	// Ensure that the stores and node being reported are known to the allocator.
+	// If they are not, return an error and don't process the load message.
+	ns, ok := cs.nodes[resp.nodeID]
+	if !ok {
+		return errors.Errorf(
+			"node %v doesn't exist", resp.nodeID)
+	}
+	for _, msg := range resp.stores {
+		if _, ok := cs.stores[msg.StoreID]; !ok {
+			return errors.Errorf(
+				"store %v doesn't exist", msg.StoreID)
+		}
+	}
+
+	// Handle the leaseholder store messages first. These have do not affect load
+	// delta adjustments but will mark pending changes as enacted.
+	for _, leaseMsg := range resp.leaseholderStores {
+		for _, rangeMsg := range leaseMsg.ranges {
+			rs, ok := cs.ranges[rangeMsg.RangeID]
+			if !ok {
+				rs = newRangeState()
+				cs.ranges[rangeMsg.RangeID] = rs
+			}
+
+			// Unilaterally remove the existing range state replicas. Then add back
+			// the replicas reported by the range message.
+			//
+			// TODO(kvoli,sumeerbhola): Use a set difference with rangeMsg.replicas
+			// and rs.replicas instead.
+			for _, replica := range rs.replicas {
+				delete(cs.stores[replica.StoreID].adjusted.replicas, rangeMsg.RangeID)
+			}
+			// Set the range state replicas to be equal to the range leaseholder
+			// replicas. The pending changes which aren't enacted in the range
+			// message are hanled and added back below.
+			rs.replicas = rangeMsg.replicas
+			for _, replica := range rangeMsg.replicas {
+				cs.stores[replica.StoreID].adjusted.replicas[rangeMsg.RangeID] = replica.replicaState
+			}
+
+			// Find any pending changes which are now enacted, according to the
+			// leaseholder's authoritative view.
+			var remainingChanges, enactedChanges []*pendingReplicaChange
+			for _, change := range rs.pendingChanges {
+				ss := cs.stores[change.storeID]
+				replIdAndType, ok := ss.adjusted.replicas[rangeMsg.RangeID]
+				if !ok {
+					replIdAndType.ReplicaID = noReplicaID
+				}
+				// The change has been enacted according to the leaseholder.
+				if replIdAndType.subsumesChange(change.prev.replicaIDAndType, change.next) {
+					enactedChanges = append(enactedChanges, change)
+				} else {
+					remainingChanges = append(remainingChanges, change)
+				}
+			}
+
+			for _, change := range enactedChanges {
+				// Mark the change as enacted. Enacting a change does not remove the
+				// corresponding load adjustments. The store load message will do that,
+				// or GC, indiciating that the change has been reflected in the store
+				// load.
+				cs.markPendingChangeEnacted(change.changeID, now)
+			}
+			// Re-apply the remaining changes. These do not update the load state,
+			// only the authoritative replica tracking in store state and range
+			// state.
+			for _, change := range remainingChanges {
+				cs.applyReplicaChange(change.replicaChange, changeEffectTypeReplicas)
+			}
+
+			rs.lastHeardTime = now
+			normSpanConfig, err := makeNormalizedSpanConfig(&rangeMsg.conf, cs.constraintMatcher.interner)
+			if err != nil {
+				return err
+			}
+			rs.conf = normSpanConfig
+		}
+	}
+
+	// Handle the node load, updating the reported load and set the adjusted load
+	// to be equal to the reported load initially. Any remaining pending changes
+	// will be re-applied to the reported load.
+	ns.reportedCPU = resp.reportedCPU
+	ns.adjustedCPU = resp.reportedCPU
+	ns.nodeLoad = resp.nodeLoad
+	for _, msg := range resp.stores {
+		// NB: The store must exist, we checked it above.
+		ss := cs.stores[msg.StoreID]
+		// The store's load seqeunce number is incremented on each load change. The
+		// store's load is updated below.
+		ss.loadSeqNum++
+		newLoadReplicas := map[roachpb.RangeID]replicaType{}
+		oldLoadReplicas := ss.adjusted.loadReplicas
+		for _, r := range msg.storeRanges {
+			// Update the last heard from time for the range, creating a new range state
+			// if we have never heard about this range before.
+			rs, ok := cs.ranges[r.RangeID]
+			if !ok {
+				rs = newRangeState()
+				cs.ranges[r.RangeID] = rs
+			}
+			rs.lastHeardTime = now
+			newLoadReplicas[r.RangeID] = r.replicaType
+		}
+		// Update the store reported load. The reported load ignores any
+		// adjustments.
+		ss.storeLoad.reportedLoad = msg.load
+		ss.storeLoad.capacity = msg.capacity
+		ss.storeLoad.reportedSecondaryLoad = msg.secondaryLoad
+		ss.storeLoad.meanNonTopKRangeLoad = msg.meanNonTopKRangeLoad
+		ss.storeLoad.topKRanges = msg.topKRanges
+		// Reset the adjusted load to be the reported load. We will re-apply any
+		// remaining pending change deltas to the updated adjusted load.
+		ss.adjusted.load = ss.storeLoad.reportedLoad
+		ss.adjusted.secondaryLoad = msg.secondaryLoad
+		// Find any pending changes for the range which involve this store. These
+		// pending changes can now be removed from the loadPendingChanges. We don't
+		// need to un-do the corresponding delta adjustment as the reported load
+		// already contains the effect.
+		for _, change := range ss.adjusted.loadPendingChanges {
+			newRepl, inNew := newLoadReplicas[change.rangeID]
+			_, inOld := oldLoadReplicas[change.rangeID]
+			var replIdAndType replicaIDAndType
+			if inNew {
+				replIdAndType.replicaType = newRepl
+				// We don't know the actual replica ID in the new state, only that it
+				// exists. Use the placeholder unknownReplicaID, so that
+				// subsumesChange(...) recognizes that a replica exists.
+				replIdAndType.ReplicaID = unknownReplicaID
+			} else {
+				replIdAndType.ReplicaID = noReplicaID
+			}
+			// Consider the change included in the store's load when (a) the change
+			// is subsumed by the replica state or (b) the change was enacted more
+			// than enactedPendingChangeGCDuration duration ago.
+			considerIncluded := replIdAndType.subsumesChange(change.prev.replicaIDAndType, change.next) ||
+				(change.enactedAtTime != time.Time{} &&
+					now.Sub(change.enactedAtTime) > enactedPendingChangeGCDuration)
+			if considerIncluded {
+				delete(ss.adjusted.loadPendingChanges, change.changeID)
+			} else {
+				// The pending change hasn't been reported as done, re-apply the load
+				// delta to the adjusted load and include it in the new adjusted load
+				// replicas.
+				cs.applyChangeLoadDelta(change.replicaChange)
+				if inOld {
+					// If the pending change is to remove a replica, we don't set it in
+					// the load replicas. Otherwise, update the load replicas to be the
+					// change's next replica state.
+					newLoadReplicas[change.rangeID] = change.next.replicaType
+				}
+			}
+		}
+		ss.adjusted.loadReplicas = newLoadReplicas
+	}
+	return nil
 }
 
-func (cs *clusterState) addNodeID(nodeID roachpb.NodeID) {
-	// TODO(sumeer):
+func (cs *clusterState) setStore(store roachpb.StoreDescriptor) error {
+	var ns *nodeState
+	var ss *storeState
+	var exists bool
+	if ns, exists = cs.nodes[store.Node.NodeID]; !exists {
+		ns = newNodeState(store.Node.NodeID)
+		cs.nodes[store.Node.NodeID] = ns
+	}
+	if ss, exists = cs.stores[store.StoreID]; exists {
+		switch ss.storeInitState {
+		case partialInit, fullyInit:
+			// When in partialInit, the adjusted.replicas have been initialized on
+			// this store. This can occur if the leaseholder sends information prior to
+			// the allocator learning of the store.
+		case removed:
+			// TODO(kvoli,sumeerbhola): Should we allow setting the store after it
+			// has been tombstoned?
+			return errors.Errorf("setting store %d already removed", store.StoreID)
+		}
+	} else {
+		ss = newStoreState(store.StoreID, store.Node.NodeID)
+		cs.stores[store.StoreID] = ss
+		ns.stores = append(ns.stores, store.StoreID)
+	}
+	// Mark the store as fully initialized any time it is set.
+	ss.storeInitState = fullyInit
+	ss.storeLoad.StoreDescriptor = store
+	ss.localityTiers = cs.localityTierInterner.intern(store.Locality())
+	cs.constraintMatcher.setStore(store)
+	// NB: If the locality has changed, it implies any other stores on the same
+	// node also have had their locality changed. We don't proactively update the
+	// locality of other stores here as we expect setStore to be called for each
+	// store on the same node quickly. Any inconsistenty should be short lived
+	// and transient.
+	return nil
 }
 
-func (cs *clusterState) addStore(store roachpb.StoreDescriptor) {
-	// TODO(sumeer):
-}
-
-func (cs *clusterState) changeStore(store roachpb.StoreDescriptor) {
-	// TODO(sumeer):
-}
-
-func (cs *clusterState) removeNodeAndStores(nodeID roachpb.NodeID) {
-	// TODO(sumeer):
+func (cs *clusterState) removeNodeAndStores(nodeID roachpb.NodeID) error {
+	var ns *nodeState
+	var exists bool
+	if ns, exists = cs.nodes[nodeID]; !exists {
+		return errors.Errorf(
+			"removing node %d doesn't exist", nodeID)
+	}
+	for _, storeID := range ns.stores {
+		// NB: Ranges and pending changes may still reference this store. The
+		// changes will be GC'd later and the left over replicas removed when the
+		// leaseholder providides an update.
+		ss := cs.stores[storeID]
+		ss.storeInitState = removed
+		cs.constraintMatcher.removeStore(storeID)
+	}
+	delete(cs.nodes, nodeID)
+	return nil
 }
 
 // If the pending change does not happen within this GC duration, we
 // forget it in the data-structure.
 const pendingChangeGCDuration = 5 * time.Minute
 
+// if an enacted pending change is not reflected in a store's reported load
+// after this GC duration, we forget it in the data-structure.
+const enactedPendingChangeGCDuration = 15 * time.Second
+
 // Called periodically by allocator.
-func (cs *clusterState) gcPendingChanges() {
-	// TODO(sumeer):
+func (cs *clusterState) gcPendingChanges(now time.Time) {
+	gcBeforeTime := now.Add(-pendingChangeGCDuration)
+	oldestFirst := pendingChangesOldestFirst(cs.pendingChangeList)
+	sort.Sort(&oldestFirst)
+	var removeChangeIds []changeID
+	var i, n int
+	n = len(cs.pendingChangeList)
+	for ; i < n; i++ {
+		change := cs.pendingChangeList[i]
+		// GC the change If either the start time of the pending change is too
+		// old.
+		if !change.startTime.After(gcBeforeTime) {
+			removeChangeIds = append(removeChangeIds, change.changeID)
+		}
+	}
+	for _, rmChange := range removeChangeIds {
+		cs.undoPendingChange(rmChange)
+	}
 }
 
 // Called by enacting module.
-func (cs *clusterState) pendingChangesRejected(
-	rangeID roachpb.RangeID, changes []pendingReplicaChange,
-) {
-	// TODO(sumeer):
+func (cs *clusterState) pendingChangesRejected(changes []changeID) {
+	// Wipe rejected changes, including load adjustments, tracking and replica
+	// changes.
+	//
+	// NB: This doesn't handle rejecting changes which have been reported as
+	// complete by the store load, but not reported by the leaseholder. These
+	// will be GC'd eventually regardless.
+	for _, changeID := range changes {
+		cs.undoPendingChange(changeID)
+	}
 }
 
-func (cs *clusterState) addPendingChanges(rangeID roachpb.RangeID, changes []pendingReplicaChange) {
-	// TODO(sumeer):
+// makePendingChanges takes a set of changes for a range and applies the
+// changes as pending. The application updates the adjusted load, tracked
+// pending changes and changeID to reflect the pending application.
+func (cs *clusterState) makePendingChanges(
+	rangeID roachpb.RangeID, changes []replicaChange,
+) []*pendingReplicaChange {
+	now := cs.clock.Now()
+	var pendingChanges []*pendingReplicaChange
+	for _, change := range changes {
+		pendingChange := cs.makePendingChange(now, change)
+		pendingChanges = append(pendingChanges, pendingChange)
+	}
+	return pendingChanges
+}
+
+func (cs *clusterState) makePendingChange(
+	now time.Time, change replicaChange,
+) *pendingReplicaChange {
+	// Apply the load and replica change to state.
+	cs.applyReplicaChange(change, changeEffectTypeAll)
+	// Grab the next change ID, then add the pending change to the pending change
+	// trackers on the range, store and cluster state.
+	cs.changeSeqGen++
+	cid := cs.changeSeqGen
+	pendingChange := &pendingReplicaChange{
+		changeID:      cid,
+		replicaChange: change,
+		startTime:     now,
+		enactedAtTime: time.Time{},
+	}
+	storeState := cs.stores[change.storeID]
+	rangeState := cs.ranges[change.rangeID]
+	cs.pendingChanges[cid] = pendingChange
+	cs.pendingChangeList = append(cs.pendingChangeList, pendingChange)
+	storeState.adjusted.loadPendingChanges[cid] = pendingChange
+	rangeState.pendingChanges = append(rangeState.pendingChanges, pendingChange)
+	return pendingChange
+}
+
+func (cs *clusterState) applyReplicaChange(change replicaChange, effectType changeEffectType) {
+	storeState := cs.stores[change.storeID]
+	rangeState := cs.ranges[change.rangeID]
+	if change.isRemoval() {
+		// The change is to remove a replica.
+		if effectType == changeEffectTypeReplicas || effectType == changeEffectTypeAll {
+			delete(storeState.adjusted.replicas, change.rangeID)
+		}
+		if effectType == changeEffectTypeLoad || effectType == changeEffectTypeAll {
+			delete(storeState.adjusted.loadReplicas, change.rangeID)
+		}
+		rangeState.removeReplica(change.storeID)
+	} else if change.isAddition() {
+		// The change is to add a new replica.
+		pendingRepl := storeIDAndReplicaState{
+			StoreID: change.storeID,
+			replicaState: replicaState{
+				replicaIDAndType: change.next,
+			},
+		}
+		if effectType == changeEffectTypeReplicas || effectType == changeEffectTypeAll {
+			storeState.adjusted.replicas[change.rangeID] = pendingRepl.replicaState
+			rangeState.setReplica(pendingRepl)
+		}
+		if effectType == changeEffectTypeLoad || effectType == changeEffectTypeAll {
+			storeState.adjusted.loadReplicas[change.rangeID] = pendingRepl.replicaType
+		}
+	} else if change.isUpdate() {
+		// The change is to update an existing replica.
+		replState := storeState.adjusted.replicas[change.rangeID]
+		replState.replicaIDAndType = change.next
+		if effectType == changeEffectTypeReplicas || effectType == changeEffectTypeAll {
+			storeState.adjusted.replicas[change.rangeID] = replState
+			rangeState.setReplica(storeIDAndReplicaState{
+				StoreID:      change.storeID,
+				replicaState: replState,
+			})
+		}
+		if effectType == changeEffectTypeLoad || effectType == changeEffectTypeAll {
+			storeState.adjusted.loadReplicas[change.rangeID] = replState.replicaType
+		}
+	} else {
+		panic(fmt.Sprintf("unknown replica change %+v", change))
+	}
+
+	if effectType == changeEffectTypeLoad || effectType == changeEffectTypeAll {
+		cs.applyChangeLoadDelta(change)
+	}
+}
+
+func (cs *clusterState) markPendingChangeEnacted(cid changeID, enactedAt time.Time) {
+	change := cs.pendingChanges[cid]
+	change.enactedAtTime = enactedAt
+	cs.removePendingChangeTracking(change.changeID)
+}
+
+// There are two categories of pending change data-structures:
+//
+// - load adjusting: storeState.adjusted.loadPendingChanges
+// - authoritative: clusterState.pendingChanges, rangeState.pendingChanges
+//
+// Load adjusting pending changes are removed when one of these conditions is
+// true: (1) a store reports the change as complete via its store load; or (2)
+// the pending change was reported as enacted by the leaseholder and more than
+// enactedPendingChangeGCDuration duration has elapsed; or (3) the pending
+// change was started more than pendingChangeGCDuration duration ago.
+//
+// Load adjusting pending changes apply a load impact on the store/node when
+// not removed (storeState.adjusted.load, storeState.adjusted.secondaryLoad,
+// nodeState.adjustedCPU) and additionally affect the replicas in
+// storeState.adjusted.loadReplicas.
+//
+// Authoritative pending changes are removed when one of these conditions is
+// true: (1) a leaseholder reports the change as enacted; or (2) the pending
+// change was started more than pendingChangeGCDuration ago.
+//
+// Authoritative pending changes do not apply a load impact on the associated
+// store/node. Authoritative pending changes update rangeState.replicas and
+// storeState.adjusted.replicas to be the state of the range if the change were
+// applied.
+
+// changeEffectType is provided when applying or undoing a replica change. The
+// effect type describes what parts of the clusterState should be adjusted.
+type changeEffectType uint8
+
+const (
+	// changeEffectTypeReplicas affects the authoritative replicas, tracked in
+	// rangeState.replicas and storeState.adjusted.replicas.
+	changeEffectTypeReplicas = iota
+	// changeEffectTypeLoad affects the adjusted load tracked in
+	// storeState.adjusted.load and nodeState.adjustedCPU. The adjusted load
+	// replicas (storeState.adjusted.loadReplicas) is also affected.
+	changeEffectTypeLoad
+	// changeEffectTypeAll is the union of the two above changeEffectTypes.
+	changeEffectTypeAll
+)
+
+// undoPendingChange reverses the change with ID cid, if it exists.
+func (cs *clusterState) undoPendingChange(cid changeID) {
+	change, ok := cs.pendingChanges[cid]
+	if !ok {
+		// The pending change doesn't exist.
+		return
+	}
+	// Undo the change effects, including changes to the range replicas and load.
+	cs.undoReplicaChange(change.replicaChange, changeEffectTypeAll)
+	// Remove the change from tracking all tracking.
+	cs.removePendingChangeTracking(cid)
+	delete(cs.stores[change.storeID].adjusted.loadPendingChanges, change.changeID)
+}
+
+func (cs *clusterState) undoReplicaChange(change replicaChange, effectType changeEffectType) {
+	rangeState := cs.ranges[change.rangeID]
+	storeState := cs.stores[change.storeID]
+	if change.isRemoval() {
+		// The change was to remove a replica. Add the replica back using the prev
+		// state stored in the replica change.
+		prevRepl := storeIDAndReplicaState{
+			StoreID:      change.storeID,
+			replicaState: change.prev,
+		}
+
+		if effectType == changeEffectTypeReplicas || effectType == changeEffectTypeAll {
+			storeState.adjusted.loadReplicas[change.rangeID] = prevRepl.replicaType
+		}
+		if effectType == changeEffectTypeLoad || effectType == changeEffectTypeAll {
+			rangeState.setReplica(prevRepl)
+			storeState.adjusted.replicas[change.rangeID] = prevRepl.replicaState
+		}
+	} else if change.isAddition() {
+		// The change was to add a new replica.
+		if effectType == changeEffectTypeReplicas || effectType == changeEffectTypeAll {
+			delete(storeState.adjusted.replicas, change.rangeID)
+			rangeState.removeReplica(change.storeID)
+		}
+		if effectType == changeEffectTypeLoad || effectType == changeEffectTypeAll {
+			delete(storeState.adjusted.loadReplicas, change.rangeID)
+		}
+	} else if change.isUpdate() {
+		// The change was to update an existing replica.
+		replState := change.prev
+		if effectType == changeEffectTypeReplicas || effectType == changeEffectTypeAll {
+			rangeState.setReplica(storeIDAndReplicaState{
+				StoreID:      change.storeID,
+				replicaState: replState,
+			})
+			storeState.adjusted.replicas[change.rangeID] = replState
+		}
+		if effectType == changeEffectTypeLoad || effectType == changeEffectTypeAll {
+			storeState.adjusted.loadReplicas[change.rangeID] = replState.replicaType
+		}
+	} else {
+		panic(fmt.Sprintf("unknown replica change %+v", change))
+	}
+
+	if effectType == changeEffectTypeLoad || effectType == changeEffectTypeAll {
+		// Undo the load adjustments that were applied for this change.
+		cs.undoChangeLoadDelta(change)
+	}
+}
+
+// TODO(kvoli,sumeerbhola): The load of the store and node can become negative
+// when applying or undoing load adjustments. For load adjustments to be
+// reversible quickly, we aren't able to zero out the value when negative. We
+// should handle the negative values when using them.
+
+// applyChangeLoadDelta adds the change load delta to the adjusted load of the
+// store and node affected.
+func (cs *clusterState) applyChangeLoadDelta(change replicaChange) {
+	ss := cs.stores[change.storeID]
+	ns := cs.nodes[ss.NodeID]
+	ss.applyChangeLoadDelta(change)
+	ns.applyChangeLoadDelta(change)
+}
+
+// undoChangeLoadDelta subtracts the change load delta from the adjusted load
+// of the store and node affected.
+func (cs *clusterState) undoChangeLoadDelta(change replicaChange) {
+	ss := cs.stores[change.storeID]
+	ns := cs.nodes[ss.NodeID]
+	ss.undoChangeLoadDelta(change)
+	ns.undoChangeLoadDelta(change)
+}
+
+// removePendingChangeTracking removes the given change from the cluster and
+// range pending change tracking. If the change doesn't exist, this is a no-op.
+// Note the change's effects aren't removed, it is no longer tracked.
+func (cs *clusterState) removePendingChangeTracking(cid changeID) {
+	change, ok := cs.pendingChanges[cid]
+	if !ok {
+		// Nothing to do.
+		return
+	}
+	cs.ranges[change.rangeID].removePendingChangeTracking(change.changeID)
+	delete(cs.pendingChanges, change.changeID)
+	i := 0
+	n := len(cs.pendingChangeList)
+	for ; i < n; i++ {
+		if cs.pendingChangeList[i].changeID == cid {
+			cs.pendingChangeList[i], cs.pendingChangeList[n-1] = cs.pendingChangeList[n-1], cs.pendingChangeList[i]
+			cs.pendingChangeList = cs.pendingChangeList[:n-1]
+			break
+		}
+	}
 }
 
 func (cs *clusterState) updateFailureDetectionSummary(
 	nodeID roachpb.NodeID, fd failureDetectionSummary,
-) {
-	// TODO(sumeer):
+) error {
+	if ns, ok := cs.nodes[nodeID]; ok {
+		ns.fdSummary = fd
+		return nil
+	}
+	return errors.Errorf("node %d doesn't exist", nodeID)
 }
 
 //======================================================================
@@ -535,13 +1359,17 @@ func (cs *clusterState) updateFailureDetectionSummary(
 // For meansMemo.
 var _ loadInfoProvider = &clusterState{}
 
-func (cs *clusterState) getStoreReportedLoad(roachpb.StoreID) *storeLoad {
-	// TODO(sumeer):
+func (cs *clusterState) getStoreReportedLoad(storeID roachpb.StoreID) *storeLoad {
+	if storeState, ok := cs.stores[storeID]; ok {
+		return &storeState.storeLoad
+	}
 	return nil
 }
 
-func (cs *clusterState) getNodeReportedLoad(roachpb.NodeID) *nodeLoad {
-	// TODO(sumeer):
+func (cs *clusterState) getNodeReportedLoad(nodeID roachpb.NodeID) *nodeLoad {
+	if nodeState, ok := cs.nodes[nodeID]; ok {
+		return &nodeState.nodeLoad
+	}
 	return nil
 }
 
@@ -560,6 +1388,7 @@ func (cs *clusterState) computeLoadSummary(
 	ns := cs.nodes[ss.NodeID]
 	sls := loadLow
 	for i := range msl.load {
+		// TODO(kvoli,sumeerbhola): Handle negative adjusted store/node loads.
 		ls := loadSummaryForDimension(ss.adjusted.load[i], ss.capacity[i], msl.load[i], msl.util[i])
 		if ls < sls {
 			sls = ls
@@ -575,72 +1404,13 @@ func (cs *clusterState) computeLoadSummary(
 }
 
 // Avoid unused lint errors.
-
 var _ = (&pendingChangesOldestFirst{}).removeChangeAtIndex
-var _ = (&clusterState{}).processNodeLoadResponse
-var _ = (&clusterState{}).addNodeID
-var _ = (&clusterState{}).addStore
-var _ = (&clusterState{}).changeStore
-var _ = (&clusterState{}).removeNodeAndStores
-var _ = (&clusterState{}).gcPendingChanges
-var _ = (&clusterState{}).pendingChangesRejected
-var _ = (&clusterState{}).addPendingChanges
-var _ = (&clusterState{}).updateFailureDetectionSummary
-var _ = (&clusterState{}).getStoreReportedLoad
-var _ = (&clusterState{}).getNodeReportedLoad
 var _ = (&clusterState{}).canAddLoad
-var _ = (&clusterState{}).computeLoadSummary
-var _ = unknownReplicaID
-var _ = noReplicaID
-var _ = fdSuspect
-var _ = fdDrain
-var _ = fdDead
-var _ = partialInit
-var _ = fullyInit
-var _ = removed
-var _ = pendingChangeGCDuration
-var _ = replicaType{}.replicaType
-var _ = replicaType{}.isLeaseholder
-var _ = replicaIDAndType{}.ReplicaID
-var _ = replicaIDAndType{}.replicaType
-var _ = replicaState{}.replicaIDAndType
 var _ = replicaState{}.voterIsLagging
 var _ = replicaState{}.replicationPaused
-var _ = pendingReplicaChange{}.changeID
-var _ = pendingReplicaChange{}.loadDelta
-var _ = pendingReplicaChange{}.storeID
-var _ = pendingReplicaChange{}.rangeID
-var _ = pendingReplicaChange{}.prev
-var _ = pendingReplicaChange{}.next
-var _ = pendingReplicaChange{}.startTime
-var _ = pendingReplicaChange{}.enactedAtTime
-var _ = storeState{}.storeInitState
-var _ = storeState{}.storeLoad
-var _ = storeState{}.adjusted.loadReplicas
-var _ = storeState{}.adjusted.loadPendingChanges
-var _ = storeState{}.adjusted.secondaryLoad
-var _ = storeState{}.adjusted.replicas
 var _ = storeState{}.maxFractionPending
-var _ = storeState{}.localityTiers
-var _ = nodeState{}.stores
-var _ = nodeState{}.nodeLoad
-var _ = nodeState{}.adjustedCPU
 var _ = nodeState{}.loadSummary
-var _ = nodeState{}.fdSummary
-var _ = storeIDAndReplicaState{}.StoreID
-var _ = storeIDAndReplicaState{}.replicaState
-var _ = rangeState{}.replicas
-var _ = rangeState{}.conf
-var _ = rangeState{}.pendingChanges
-var _ = rangeState{}.constraints
 var _ = rangeState{}.diversityIncreaseLastFailedAttempt
-var _ = rangeState{}.lastHeardTime
-var _ = clusterState{}.nodes
-var _ = clusterState{}.stores
-var _ = clusterState{}.ranges
-var _ = clusterState{}.pendingChanges
-var _ = clusterState{}.constraintMatcher
-var _ = clusterState{}.localityTierInterner
 var _ = (&storeChangeRateLimiter{}).initForRebalancePass
 var _ = (&storeChangeRateLimiter{}).updateForRebalancePass
 var _ = newStoreChangeRateLimiter

--- a/pkg/kv/kvserver/allocator/mma/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mma/cluster_state_test.go
@@ -1,0 +1,509 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mma
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+func parseBool(t *testing.T, in string) bool {
+	b, err := strconv.ParseBool(in)
+	require.NoError(t, err)
+	return b
+}
+
+func parseInt(t *testing.T, in string) int {
+	i, err := strconv.Atoi(in)
+	require.NoError(t, err)
+	return i
+}
+
+func parseInts(t *testing.T, in string) []int {
+	parts := strings.Split(in, ",")
+	ints := make([]int, 0, len(parts))
+	for _, i := range strings.Split(in, ",") {
+		ints = append(ints, parseInt(t, i))
+	}
+	return ints
+}
+
+func stripParens(t *testing.T, in string) string {
+	rTrim := strings.TrimSuffix(in, ")")
+	lrTrim := strings.TrimPrefix(rTrim, "(")
+	return lrTrim
+}
+
+func parseLoadVector(t *testing.T, in string) loadVector {
+	var vec loadVector
+	parts := strings.Split(stripParens(t, in), ",")
+	require.Len(t, parts, int(numLoadDimensions))
+	for dim := range vec {
+		vec[dim] = loadValue(parseInt(t, parts[dim]))
+	}
+	return vec
+}
+
+func parseSecondaryLoadVector(t *testing.T, in string) secondaryLoadVector {
+	var vec secondaryLoadVector
+	parts := strings.Split(stripParens(t, in), ",")
+	require.Len(t, parts, int(numSecondaryLoadDimensions))
+	for dim := range vec {
+		vec[dim] = loadValue(parseInt(t, parts[dim]))
+	}
+	return vec
+}
+
+func parseStoreLoad(t *testing.T, in string) storeLoad {
+	var sl storeLoad
+	for _, v := range strings.Fields(in) {
+		parts := strings.Split(v, "=")
+		require.Len(t, parts, 2)
+		switch parts[0] {
+		case "store-id":
+			sl.StoreID = roachpb.StoreID(parseInt(t, parts[1]))
+		case "node-id":
+			sl.NodeID = roachpb.NodeID(parseInt(t, parts[1]))
+		case "load":
+			sl.reportedLoad = parseLoadVector(t, parts[1])
+		case "capacity":
+			sl.capacity = parseLoadVector(t, parts[1])
+			for i := range sl.capacity {
+				if sl.capacity[i] < 0 {
+					sl.capacity[i] = parentCapacity
+				}
+			}
+		case "secondary-load":
+			sl.reportedSecondaryLoad = parseSecondaryLoadVector(t, parts[1])
+		default:
+			t.Fatalf("Unknown argument: %s", parts[0])
+		}
+	}
+	return sl
+}
+
+func parseNodeLoad(t *testing.T, in string) nodeLoad {
+	var nl nodeLoad
+	for _, part := range strings.Fields(in) {
+		parts := strings.Split(part, "=")
+		require.Len(t, parts, 2)
+		switch parts[0] {
+		case "node-id":
+			nl.nodeID = roachpb.NodeID(parseInt(t, parts[1]))
+		case "cpu-load":
+			nl.reportedCPU = loadValue(parseInt(t, parts[1]))
+		case "cpu-capacity":
+			nl.capacityCPU = loadValue(parseInt(t, parts[1]))
+		default:
+			t.Fatalf("Unknown argument: %s", parts[0])
+		}
+	}
+	return nl
+}
+
+func parseStoreRange(t *testing.T, in string) storeRange {
+	var sr storeRange
+	for _, v := range strings.Fields(in) {
+		parts := strings.Split(v, "=")
+		require.Len(t, parts, 2)
+		switch parts[0] {
+		case "range-id":
+			sr.RangeID = roachpb.RangeID(parseInt(t, parts[1]))
+		case "lease":
+			sr.isLeaseholder = parseBool(t, parts[1])
+		case "type":
+			rType, err := parseReplicaType(parts[1])
+			require.NoError(t, err)
+			sr.replicaType.replicaType = rType
+		}
+	}
+	return sr
+}
+
+func parseChangeAddRemove(
+	t *testing.T, in string,
+) (add, remove roachpb.StoreID, replType roachpb.ReplicaType, rangeLoad rangeLoad) {
+	// Note that remove or add will 0 if not found in this string.
+	for _, v := range strings.Fields(in) {
+		parts := strings.Split(v, "=")
+		require.Len(t, parts, 2)
+		switch parts[0] {
+		case "add-store":
+			add = roachpb.StoreID(parseInt(t, parts[1]))
+		case "remove-store":
+			remove = roachpb.StoreID(parseInt(t, parts[1]))
+		case "type":
+			var err error
+			replType, err = parseReplicaType(parts[1])
+			require.NoError(t, err)
+		case "load":
+			rangeLoad.load = parseLoadVector(t, parts[1])
+		case "cpu-raft":
+			rangeLoad.raftCPU = loadValue(parseInt(t, parts[1]))
+		}
+	}
+	return add, remove, replType, rangeLoad
+}
+
+func parseRangeMsgReplica(t *testing.T, in string) storeIDAndReplicaState {
+	var repl storeIDAndReplicaState
+	for _, v := range strings.Fields(in) {
+		parts := strings.Split(v, "=")
+		require.Len(t, parts, 2)
+		switch parts[0] {
+		case "store-id":
+			repl.StoreID = roachpb.StoreID(parseInt(t, parts[1]))
+		case "replica-id":
+			repl.ReplicaID = roachpb.ReplicaID(parseInt(t, parts[1]))
+		case "lease":
+			repl.isLeaseholder = parseBool(t, parts[1])
+		case "type":
+			replType, err := parseReplicaType(parts[1])
+			require.NoError(t, err)
+			repl.replicaType.replicaType = replType
+		}
+	}
+	return repl
+}
+
+// TODO(kvoli,sumeerbhola): Convert string functions into SafeFormat functions
+// on relevant structs to use in logging.
+func printNodeListMeta(cs *clusterState) string {
+	nodeList := []int{}
+	for nodeID := range cs.nodes {
+		nodeList = append(nodeList, int(nodeID))
+	}
+	sort.Ints(nodeList)
+	var buf strings.Builder
+	for _, nodeID := range nodeList {
+		ns := cs.nodes[roachpb.NodeID(nodeID)]
+		fmt.Fprintf(&buf, "node-id=%s failure-summary=%s locality-tiers=%s\n",
+			ns.nodeID, ns.fdSummary, cs.stores[ns.stores[0]].StoreDescriptor.Locality())
+		for _, storeID := range ns.stores {
+			ss := cs.stores[storeID]
+			fmt.Fprintf(&buf, "  store-id=%v init=%s attrs=%s locality-code=%s\n",
+				ss.StoreID, ss.storeInitState, ss.Attrs, ss.localityTiers.str)
+		}
+	}
+	return buf.String()
+}
+
+func printPendingChanges(changes []*pendingReplicaChange) string {
+	oldestFirst := pendingChangesOldestFirst(changes)
+	sort.Sort(&oldestFirst)
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "pending(%d)", len(oldestFirst))
+	for _, change := range oldestFirst {
+		fmt.Fprintf(&buf, "\nchange-id=%d start=%ds store-id=%v range-id=%v delta=%v",
+			change.changeID, change.startTime.Unix(), change.storeID,
+			change.rangeID, change.loadDelta,
+		)
+		if !(change.enactedAtTime == time.Time{}) {
+			fmt.Fprintf(&buf, " enacted=%ds", change.enactedAtTime.Unix())
+		}
+		fmt.Fprintf(&buf, "\n  prev=(%v)\n  next=(%v)", change.prev, change.next)
+	}
+	return buf.String()
+}
+
+// testingGetStoreList returns the IDs of stores in the cluster state. Two
+// lists of storeIDs are returned, containing the non-removed and removed
+// stores respectively. Both lists are sorted. This testing helper method is
+// intended to be used in order to ensure determinism.
+func testingGetStoreList(cs *clusterState) (nonRemovedList, removedList storeIDPostingList) {
+	for storeID, ss := range cs.stores {
+		if ss.storeInitState == removed {
+			removedList.insert(storeID)
+		} else {
+			nonRemovedList.insert(storeID)
+		}
+	}
+	return nonRemovedList, removedList
+}
+
+func testingGetPendingChanges(cs *clusterState) []*pendingReplicaChange {
+	pendingChangeSet := map[changeID]struct{}{}
+	var pendingChangeList []*pendingReplicaChange
+	maybeAddChange := func(change *pendingReplicaChange) {
+		if _, ok := pendingChangeSet[change.changeID]; ok {
+			return
+		}
+		pendingChangeList = append(pendingChangeList, change)
+		pendingChangeSet[change.changeID] = struct{}{}
+	}
+
+	for _, change := range cs.pendingChangeList {
+		maybeAddChange(change)
+	}
+
+	// Use the sorted store list to ensure deterministic iteration order.
+	storeList, _ := testingGetStoreList(cs)
+	for _, storeID := range storeList {
+		for _, change := range cs.stores[storeID].adjusted.loadPendingChanges {
+			maybeAddChange(change)
+		}
+	}
+	return pendingChangeList
+}
+
+// manualTestClock implements the hlc.WallClock interface.
+type manualTestClock struct {
+	nanos int64
+}
+
+var _ hlc.WallClock = &manualTestClock{}
+
+// Now returns the current time.
+func (m *manualTestClock) Now() time.Time {
+	return timeutil.Unix(0, m.nanos)
+}
+
+// Set sets the wall time to the supplied timestamp.
+func (m *manualTestClock) Set(tsNanos int64) {
+	m.nanos = tsNanos
+}
+
+func TestClusterState(t *testing.T) {
+	dir := datapathutils.TestDataPath(t, "clusterstate")
+	datadriven.Walk(t, dir, func(t *testing.T, path string) {
+		manualClock := &manualTestClock{}
+		cs := newClusterState(manualClock, newStringInterner())
+		datadriven.RunTest(t, path,
+			func(t *testing.T, d *datadriven.TestData) string {
+				switch d.Cmd {
+				case "ranges":
+					var rangeIDs []int
+					for rangeID := range cs.ranges {
+						rangeIDs = append(rangeIDs, int(rangeID))
+					}
+					// Sort the range IDs before printing, iterating over a map would lead
+					// to non-determinism.
+					sort.Ints(rangeIDs)
+					var buf strings.Builder
+					for _, rangeID := range rangeIDs {
+						rs := cs.ranges[roachpb.RangeID(rangeID)]
+						fmt.Fprintf(&buf, "range-id=%v\n", rangeID)
+						for _, repl := range rs.replicas {
+							fmt.Fprintf(&buf, "  store-id=%v %v\n",
+								repl.StoreID, repl.replicaIDAndType,
+							)
+						}
+					}
+					return buf.String()
+
+				case "get-load-info":
+					var buf strings.Builder
+					storeList, _ := testingGetStoreList(cs)
+					for _, storeID := range storeList {
+						ss := cs.stores[storeID]
+						if ss.storeInitState == removed {
+							continue
+						}
+						ns := cs.nodes[ss.NodeID]
+						fmt.Fprintf(&buf,
+							"store-id=%v reported=%v adjusted=%v node-reported-cpu=%v node-adjusted-cpu=%v seq=%d\n",
+							ss.StoreID, ss.reportedLoad, ss.adjusted.load, ns.reportedCPU, ns.adjustedCPU, ss.loadSeqNum,
+						)
+					}
+					return buf.String()
+
+				case "get-pending-changes":
+					return printPendingChanges(testingGetPendingChanges(cs))
+
+				case "set-store":
+					for _, next := range strings.Split(d.Input, "\n") {
+						desc := parseStoreDescriptor(t, strings.TrimSpace(next))
+						require.NoError(t, cs.setStore(desc))
+					}
+					return printNodeListMeta(cs)
+				case "remove-node":
+					var nodeID int
+
+					d.ScanArgs(t, "node-id", &nodeID)
+					require.NoError(t, cs.removeNodeAndStores(roachpb.NodeID(nodeID)))
+
+					var buf strings.Builder
+					nonRemovedStores, removedStores := testingGetStoreList(cs)
+					buf.WriteString("non-removed store-ids: ")
+					printPostingList(&buf, nonRemovedStores)
+					buf.WriteString("\nremoved store-ids: ")
+					printPostingList(&buf, removedStores)
+					return buf.String()
+				case "update-failure-detection":
+					var nodeID int
+					var failureDetectionString string
+					d.ScanArgs(t, "node-id", &nodeID)
+					d.ScanArgs(t, "summary", &failureDetectionString)
+					var fd failureDetectionSummary
+					for i := fdOK; i < fdDead+1; i++ {
+						if i.String() == failureDetectionString {
+							fd = i
+							break
+						}
+					}
+					require.NoError(t, cs.updateFailureDetectionSummary(roachpb.NodeID(nodeID), fd))
+					return printNodeListMeta(cs)
+
+				case "msg":
+					var lastSeqNum, curSeqNum int64
+					var storeIdx, rangeIdx int
+					var storeLeaseMsgs []storeLeaseholderMsg
+					var storeLoadMsgs []storeLoadMsg
+
+					d.ScanArgs(t, "last-seq", &lastSeqNum)
+					d.ScanArgs(t, "cur-seq", &curSeqNum)
+					lines := strings.Split(d.Input, "\n")
+					// The node load should be specified first.
+					nl := parseNodeLoad(t, lines[0])
+					storeIdx, rangeIdx = -1, -1
+					for _, next := range lines[1:] {
+						line := strings.TrimSpace(next)
+						if len(line) < 2 {
+							continue
+						}
+						parts := strings.Split(line, ":")
+						k, v := parts[0], parts[1]
+						switch k {
+						case "store":
+							sl := parseStoreLoad(t, v)
+							storeLoadMsgs = append(storeLoadMsgs, storeLoadMsg{
+								StoreID:       sl.StoreID,
+								load:          sl.reportedLoad,
+								capacity:      sl.capacity,
+								secondaryLoad: sl.reportedSecondaryLoad,
+							})
+							storeLeaseMsgs = append(
+								storeLeaseMsgs,
+								storeLeaseholderMsg{StoreID: sl.StoreID},
+							)
+							rangeIdx = -1
+							storeIdx++
+						case "range":
+							storeRange := parseStoreRange(t, v)
+							storeLoadMsgs[storeIdx].storeRanges = append(
+								storeLoadMsgs[storeIdx].storeRanges,
+								storeRange,
+							)
+							// If the store has a lease for the range, also create a store
+							// lease message which will be populated with any replicas lower
+							// down.
+							if storeRange.isLeaseholder {
+								storeLeaseMsgs[storeIdx].ranges = append(
+									storeLeaseMsgs[storeIdx].ranges,
+									rangeMsg{RangeID: storeRange.RangeID},
+								)
+								rangeIdx++
+							}
+						case "replica":
+							replMsg := parseRangeMsgReplica(t, v)
+							if replMsg.StoreID == storeLoadMsgs[storeIdx].StoreID {
+								replMsg.isLeaseholder = true
+							}
+							rng := &storeLeaseMsgs[storeIdx].ranges[rangeIdx]
+							rng.replicas = append(rng.replicas, replMsg)
+						}
+					}
+					if err := cs.processNodeLoadResponse(&nodeLoadResponse{
+						lastLoadSeqNum:    lastSeqNum,
+						curLoadSeqNum:     curSeqNum,
+						nodeLoad:          nl,
+						stores:            storeLoadMsgs,
+						leaseholderStores: storeLeaseMsgs,
+					}); err != nil {
+						return fmt.Sprintf("err=%v", err.Error())
+					}
+					return "OK"
+
+				case "make-pending-changes":
+					var rid int
+					var changes []replicaChange
+
+					d.ScanArgs(t, "range-id", &rid)
+					rangeID := roachpb.RangeID(rid)
+					rState := cs.ranges[rangeID]
+					lines := strings.Split(d.Input, "\n")
+					for _, next := range lines {
+						line := strings.TrimSpace(next)
+						if len(line) < 2 {
+							continue
+						}
+						parts := strings.Split(line, ":")
+						k, v := parts[0], parts[1]
+						switch k {
+						case "transfer-lease":
+							add, remove, _, load := parseChangeAddRemove(t, v)
+							load.RangeID = rangeID
+							transferChanges := makeLeaseTransferChanges(load, rState, add, remove)
+							changes = append(changes, transferChanges[:]...)
+						case "add-replica":
+							add, _, replType, load := parseChangeAddRemove(t, v)
+							load.RangeID = rangeID
+							addChanges := makeAddReplicaChange(load, add, replType)
+							changes = append(changes, addChanges)
+						case "remove-replica":
+							_, remove, _, load := parseChangeAddRemove(t, v)
+							load.RangeID = rangeID
+							var removeRepl storeIDAndReplicaState
+							for _, replica := range rState.replicas {
+								if replica.StoreID == remove {
+									removeRepl = replica
+								}
+							}
+							changes = append(changes, makeRemoveReplicaChange(load, removeRepl))
+						case "rebalance-replica":
+							add, remove, _, load := parseChangeAddRemove(t, v)
+							load.RangeID = rangeID
+							rebalanceChanges := makeRebalanceReplicaChanges(load, rState, add, remove)
+							changes = append(changes, rebalanceChanges[:]...)
+						}
+					}
+					cs.makePendingChanges(rangeID, changes)
+					return printPendingChanges(testingGetPendingChanges(cs))
+
+				case "gc-pending-changes":
+					cs.gcPendingChanges(cs.clock.Now())
+					return printPendingChanges(testingGetPendingChanges(cs))
+
+				case "reject-pending-changes":
+					lines := strings.Split(d.Input, "\n")
+					// The node load should be specified first.
+					require.Len(t, lines, 1)
+					line := lines[0]
+					parts := strings.Split(line, "=")
+					require.Len(t, parts, 2)
+					changeIDInts := parseInts(t, stripParens(t, parts[1]))
+					changeIDs := make([]changeID, len(changeIDInts))
+					for i := range changeIDInts {
+						changeIDs = append(changeIDs, changeID(changeIDInts[i]))
+					}
+					cs.pendingChangesRejected(changeIDs)
+					return printPendingChanges(testingGetPendingChanges(cs))
+
+				case "tick":
+					var seconds int
+					d.ScanArgs(t, "seconds", &seconds)
+					manualClock.Set(manualClock.Now().Add(time.Second * time.Duration(seconds)).UnixNano())
+					curSeconds := cs.clock.Now().UnixNano() / int64(time.Second)
+					return fmt.Sprintf("clock=%ds", curSeconds)
+
+				default:
+					return fmt.Sprintf("unknown command: %s", d.Cmd)
+				}
+			},
+		)
+	})
+}

--- a/pkg/kv/kvserver/allocator/mma/constraint_matcher_test.go
+++ b/pkg/kv/kvserver/allocator/mma/constraint_matcher_test.go
@@ -16,30 +16,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func parseStoreDescriptor(t *testing.T, d *datadriven.TestData) roachpb.StoreDescriptor {
+func parseStoreDescriptor(t *testing.T, in string) roachpb.StoreDescriptor {
 	var desc roachpb.StoreDescriptor
-	var storeID int
-	d.ScanArgs(t, "store-id", &storeID)
-	desc.StoreID = roachpb.StoreID(storeID)
-	var nodeID int
-	if d.HasArg("node-id") {
-		d.ScanArgs(t, "node-id", &nodeID)
-		desc.Node.NodeID = roachpb.NodeID(nodeID)
-	}
-	var attrs string
-	d.ScanArgs(t, "attrs", &attrs)
-	for _, v := range strings.Split(attrs, ",") {
-		v = strings.TrimSpace(v)
-		desc.Attrs.Attrs = append(desc.Attrs.Attrs, v)
-	}
-	var lts string
-	d.ScanArgs(t, "locality-tiers", &lts)
-	for _, v := range strings.Split(lts, ",") {
-		v = strings.TrimSpace(v)
-		kv := strings.Split(v, "=")
-		require.Equal(t, 2, len(kv))
-		desc.Node.Locality.Tiers = append(
-			desc.Node.Locality.Tiers, roachpb.Tier{Key: kv[0], Value: kv[1]})
+	for _, v := range strings.Split(in, " ") {
+		parts := strings.SplitN(v, "=", 2)
+		switch parts[0] {
+		case "store-id":
+			desc.StoreID = roachpb.StoreID(parseInt(t, parts[1]))
+		case "node-id":
+			desc.Node.NodeID = roachpb.NodeID(parseInt(t, parts[1]))
+		case "attrs":
+			desc.Attrs.Attrs = append(
+				desc.Attrs.Attrs,
+				strings.Split(parts[1], ",")...,
+			)
+		case "locality-tiers":
+			for _, lt := range strings.Split(parts[1], ",") {
+				kv := strings.Split(lt, "=")
+				require.Equal(t, 2, len(kv))
+				desc.Node.Locality.Tiers = append(
+					desc.Node.Locality.Tiers, roachpb.Tier{Key: kv[0], Value: kv[1]})
+			}
+		}
 	}
 	return desc
 }
@@ -84,8 +82,10 @@ func TestConstraintMatcher(t *testing.T) {
 
 			switch d.Cmd {
 			case "store":
-				desc := parseStoreDescriptor(t, d)
-				cm.setStore(desc)
+				for _, next := range strings.Split(d.Input, "\n") {
+					desc := parseStoreDescriptor(t, strings.TrimSpace(next))
+					cm.setStore(desc)
+				}
 				var b strings.Builder
 				printMatcher(&b)
 				return b.String()

--- a/pkg/kv/kvserver/allocator/mma/constraint_test.go
+++ b/pkg/kv/kvserver/allocator/mma/constraint_test.go
@@ -339,7 +339,6 @@ func testingAnalyzeFn(
 	return toRemove, toAdd, err
 }
 
-// TODO(sumeer): testing of query methods.
 func TestRangeAnalyzedConstraints(t *testing.T) {
 	interner := newStringInterner()
 	cm := newConstraintMatcher(interner)
@@ -352,9 +351,11 @@ func TestRangeAnalyzedConstraints(t *testing.T) {
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "store":
-				desc := parseStoreDescriptor(t, d)
-				cm.setStore(desc)
-				stores[desc.StoreID] = desc
+				for _, next := range strings.Split(d.Input, "\n") {
+					desc := parseStoreDescriptor(t, strings.TrimSpace(next))
+					cm.setStore(desc)
+					stores[desc.StoreID] = desc
+				}
 				return ""
 
 			case "span-config":

--- a/pkg/kv/kvserver/allocator/mma/load.go
+++ b/pkg/kv/kvserver/allocator/mma/load.go
@@ -37,15 +37,15 @@ type loadValue int64
 // dimension.
 type loadVector [numLoadDimensions]loadValue
 
-func (lv *loadVector) add(other loadVector) {
-	for i := range other {
-		(*lv)[i] += other[i]
+func (lv *loadVector) sub(other loadVector) {
+	for i := 0; i < int(numLoadDimensions); i++ {
+		lv[i] -= other[i]
 	}
 }
 
-func (lv *loadVector) subtract(other loadVector) {
-	for i := range other {
-		(*lv)[i] -= other[i]
+func (lv *loadVector) add(other loadVector) {
+	for i := 0; i < int(numLoadDimensions); i++ {
+		lv[i] += other[i]
 	}
 }
 
@@ -83,19 +83,20 @@ const (
 
 type secondaryLoadVector [numSecondaryLoadDimensions]loadValue
 
-func (lv *secondaryLoadVector) add(other secondaryLoadVector) {
-	for i := range other {
-		(*lv)[i] += other[i]
+func (slv *secondaryLoadVector) add(other secondaryLoadVector) {
+	for i := 0; i < int(numSecondaryLoadDimensions); i++ {
+		slv[i] += other[i]
 	}
 }
 
-func (lv *secondaryLoadVector) subtract(other secondaryLoadVector) {
-	for i := range other {
-		(*lv)[i] -= other[i]
+func (slv *secondaryLoadVector) sub(other secondaryLoadVector) {
+	for i := 0; i < int(numSecondaryLoadDimensions); i++ {
+		slv[i] -= other[i]
 	}
 }
 
 type rangeLoad struct {
+	roachpb.RangeID
 	load loadVector
 	// Nanos per second. raftCPU <= load[cpu]. Handling this as a special case,
 	// rather than trying to (over) generalize, since currently this is the only
@@ -144,10 +145,17 @@ type storeLoad struct {
 	// decision on what ranges to shed for an overloaded node -- it simply tries
 	// to find new homes for the ranges in this top-k. We decentralize this
 	// decision to reduce the time complexity of rebalancing.
-	topKRanges map[roachpb.RangeID]rangeLoad
+	topKRanges []rangeLoad
 	// Mean load for the non-top-k ranges. This is used to estimate the load
 	// change for transferring them.
 	meanNonTopKRangeLoad rangeLoad
+}
+
+func newStoreLoad(storeID roachpb.StoreID, nodeID roachpb.NodeID) storeLoad {
+	return storeLoad{
+		StoreID: storeID,
+		NodeID:  nodeID,
+	}
 }
 
 // nodeLoad is the load information for a node. Roughly, this is the
@@ -463,6 +471,7 @@ var _ = meansForStoreSetSlicePoolImpl{}.newEntry
 var _ = meansForStoreSetSlicePoolImpl{}.releaseEntry
 var _ = meansForStoreSetAllocator{}.ensureNonNilMapEntry
 var _ = (&meansMemo{}).clear
+var _ = newStoreLoad
 var _ = rangeLoad{}.load
 var _ = rangeLoad{}.raftCPU
 var _ = storeLoad{}.StoreID

--- a/pkg/kv/kvserver/allocator/mma/load_test.go
+++ b/pkg/kv/kvserver/allocator/mma/load_test.go
@@ -59,52 +59,29 @@ func TestMeansMemo(t *testing.T) {
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "store":
-				desc := parseStoreDescriptor(t, d)
-				cm.setStore(desc)
-				storeMap[desc.StoreID] = desc
+				for _, next := range strings.Split(d.Input, "\n") {
+					desc := parseStoreDescriptor(t, strings.TrimSpace(next))
+					cm.setStore(desc)
+					storeMap[desc.StoreID] = desc
+				}
 				return ""
 
 			case "store-load":
-				var storeID int
-				d.ScanArgs(t, "store-id", &storeID)
-				desc, ok := storeMap[roachpb.StoreID(storeID)]
-				require.True(t, ok)
-				var cpuLoad, wbLoad, bsLoad int64
-				d.ScanArgs(t, "load", &cpuLoad, &wbLoad, &bsLoad)
-				var cpuCapacity, wbCapacity, bsCapacity int64
-				d.ScanArgs(t, "capacity", &cpuCapacity, &wbCapacity, &bsCapacity)
-				var leaseCountLoad int64
-				d.ScanArgs(t, "secondary-load", &leaseCountLoad)
-				sLoad := &storeLoad{
-					StoreID:         desc.StoreID,
-					StoreDescriptor: desc,
-					NodeID:          desc.Node.NodeID,
-					reportedLoad:    loadVector{loadValue(cpuLoad), loadValue(wbLoad), loadValue(bsLoad)},
-					capacity: loadVector{
-						loadValue(cpuCapacity), loadValue(wbCapacity), loadValue(bsCapacity)},
-					reportedSecondaryLoad: secondaryLoadVector{loadValue(leaseCountLoad)},
+				for _, next := range strings.Split(d.Input, "\n") {
+					sLoad := parseStoreLoad(t, next)
+					desc, ok := storeMap[sLoad.StoreID]
+					require.True(t, ok)
+					sLoad.StoreDescriptor = desc
+					sLoad.NodeID = desc.Node.NodeID
+					loadProvider.sloads[sLoad.StoreID] = &sLoad
 				}
-				for i := range sLoad.capacity {
-					if sLoad.capacity[i] < 0 {
-						sLoad.capacity[i] = parentCapacity
-					}
-				}
-				loadProvider.sloads[roachpb.StoreID(storeID)] = sLoad
-
 				return ""
 
 			case "node-load":
-				var nodeID int
-				d.ScanArgs(t, "node-id", &nodeID)
-				var cpuLoad, cpuCapacity int64
-				d.ScanArgs(t, "cpu-load", &cpuLoad)
-				d.ScanArgs(t, "cpu-capacity", &cpuCapacity)
-				nLoad := &nodeLoad{
-					nodeID:      roachpb.NodeID(nodeID),
-					reportedCPU: loadValue(cpuLoad),
-					capacityCPU: loadValue(cpuCapacity),
+				for _, next := range strings.Split(d.Input, "\n") {
+					nLoad := parseNodeLoad(t, next)
+					loadProvider.nloads[nLoad.nodeID] = &nLoad
 				}
-				loadProvider.nloads[nLoad.nodeID] = nLoad
 				return ""
 
 			case "get-means":

--- a/pkg/kv/kvserver/allocator/mma/messages.go
+++ b/pkg/kv/kvserver/allocator/mma/messages.go
@@ -22,12 +22,9 @@ type storeLoadMsg struct {
 	// adjustments for pending changes. This is *all* the ranges at the store.
 	storeRanges []storeRange
 
-	capacity      loadVector
-	secondaryLoad secondaryLoadVector
-	topKRanges    []struct {
-		roachpb.RangeID
-		rangeLoad
-	}
+	capacity             loadVector
+	secondaryLoad        secondaryLoadVector
+	topKRanges           []rangeLoad
 	meanNonTopKRangeLoad rangeLoad
 }
 
@@ -73,6 +70,14 @@ type rangeMsg struct {
 func (rm *rangeMsg) isDeletedRange() bool {
 	return len(rm.replicas) == 0
 }
+
+const (
+	// fullUpdateLoadSeqNum is a load sequence number when nodeLoadResponse is
+	// not a diff.
+	//
+	// TODO(kvoli,sumeerbhola): Handle sequence numbers.
+	fullUpdateLoadSeqNum int64 = -1
+)
 
 // nodeLoadResponse is sent periodically in response to polling by the
 // allocator. It is the top-level message containing all the previous structs

--- a/pkg/kv/kvserver/allocator/mma/testdata/clusterstate/multi_store_no_changes
+++ b/pkg/kv/kvserver/allocator/mma/testdata/clusterstate/multi_store_no_changes
@@ -1,0 +1,80 @@
+set-store
+store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
+store-id=2 node-id=1 attrs=yellow locality-tiers=region=us-west-1,zone=us-west-1a
+----
+node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 init=full attrs=purple locality-code=1:2:3:
+  store-id=2 init=full attrs=yellow locality-code=1:2:3:
+
+set-store
+store-id=3 node-id=2 attrs=green  locality-tiers=region=us-west-1,zone=us-west-1b
+store-id=4 node-id=2 attrs=orange locality-tiers=region=us-west-1,zone=us-west-1b
+store-id=5 node-id=3 attrs=blue   locality-tiers=region=us-west-1,zone=us-west-1c
+store-id=6 node-id=3 attrs=red    locality-tiers=region=us-west-1,zone=us-west-1c
+store-id=7 node-id=4 attrs=purple locality-tiers=region=us-east-1,zone=us-east-1a
+store-id=8 node-id=4 attrs=teal   locality-tiers=region=us-east-1,zone=us-east-1a
+----
+node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 init=full attrs=purple locality-code=1:2:3:
+  store-id=2 init=full attrs=yellow locality-code=1:2:3:
+node-id=2 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1b,node=2
+  store-id=3 init=full attrs=green locality-code=1:4:5:
+  store-id=4 init=full attrs=orange locality-code=1:4:5:
+node-id=3 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1c,node=3
+  store-id=5 init=full attrs=blue locality-code=1:6:7:
+  store-id=6 init=full attrs=red locality-code=1:6:7:
+node-id=4 failure-summary=ok locality-tiers=region=us-east-1,zone=us-east-1a,node=4
+  store-id=7 init=full attrs=purple locality-code=8:9:10:
+  store-id=8 init=full attrs=teal locality-code=8:9:10:
+
+remove-node node-id=4
+----
+non-removed store-ids: 1, 2, 3, 4, 5, 6
+removed store-ids: 7, 8
+
+update-failure-detection node-id=2 summary=suspect
+----
+node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 init=full attrs=purple locality-code=1:2:3:
+  store-id=2 init=full attrs=yellow locality-code=1:2:3:
+node-id=2 failure-summary=suspect locality-tiers=region=us-west-1,zone=us-west-1b,node=2
+  store-id=3 init=full attrs=green locality-code=1:4:5:
+  store-id=4 init=full attrs=orange locality-code=1:4:5:
+node-id=3 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1c,node=3
+  store-id=5 init=full attrs=blue locality-code=1:6:7:
+  store-id=6 init=full attrs=red locality-code=1:6:7:
+
+msg last-seq=-1 cur-seq=-1
+node-id=1 cpu-load=60 cpu-capacity=100
+  store: store-id=1 load=(20,15,10) capacity=(-1,100,100) secondary-load=25
+    range: range-id=1 lease=true type=VOTER_FULL
+      replica: store-id=1 replica-id=1 type=VOTER_FULL
+      replica: store-id=3 replica-id=2 type=VOTER_FULL
+      replica: store-id=5 replica-id=3 type=VOTER_FULL
+  store: store-id=2 load=(40,30,20) capacity=(-1,200,200) secondary-load=50
+    range: range-id=2 lease=true type=VOTER_FULL
+      replica: store-id=2 replica-id=1 type=VOTER_FULL
+      replica: store-id=4 replica-id=2 type=VOTER_FULL
+      replica: store-id=6 replica-id=3 type=VOTER_FULL
+----
+OK
+
+ranges
+----
+range-id=1
+  store-id=1 replica-id=1 lease=true type=VOTER_FULL
+  store-id=3 replica-id=2 lease=false type=VOTER_FULL
+  store-id=5 replica-id=3 lease=false type=VOTER_FULL
+range-id=2
+  store-id=2 replica-id=1 lease=true type=VOTER_FULL
+  store-id=4 replica-id=2 lease=false type=VOTER_FULL
+  store-id=6 replica-id=3 lease=false type=VOTER_FULL
+
+get-load-info
+----
+store-id=1 reported=[20 15 10] adjusted=[20 15 10] node-reported-cpu=60 node-adjusted-cpu=60 seq=1
+store-id=2 reported=[40 30 20] adjusted=[40 30 20] node-reported-cpu=60 node-adjusted-cpu=60 seq=1
+store-id=3 reported=[0 0 0] adjusted=[0 0 0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=4 reported=[0 0 0] adjusted=[0 0 0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=5 reported=[0 0 0] adjusted=[0 0 0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=6 reported=[0 0 0] adjusted=[0 0 0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0

--- a/pkg/kv/kvserver/allocator/mma/testdata/clusterstate/pending_changes
+++ b/pkg/kv/kvserver/allocator/mma/testdata/clusterstate/pending_changes
@@ -1,0 +1,338 @@
+set-store
+store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
+store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
+----
+node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 init=full attrs=purple locality-code=1:2:3:
+node-id=2 failure-summary=ok locality-tiers=region=us-east-1,zone=us-east-1a,node=2
+  store-id=2 init=full attrs=yellow locality-code=4:5:6:
+
+msg last-seq=-1 cur-seq=-1
+node-id=1 cpu-load=80 cpu-capacity=100
+  store: store-id=1 load=(80,80,80) capacity=(-1,100,100) secondary-load=1
+    range: range-id=1 lease=true type=VOTER_FULL
+      replica: store-id=1 replica-id=1 type=VOTER_FULL
+----
+OK
+
+msg last-seq=-1 cur-seq=-1
+node-id=2 cpu-load=0 cpu-capacity=100
+  store: store-id=2 load=(0,0,0) capacity=(-1,100,100) secondary-load=0
+----
+OK
+
+make-pending-changes range-id=1
+add-replica: add-store=2 load=(80,80,80) cpu-raft=40
+----
+pending(1)
+change-id=1 start=0s store-id=2 range-id=1 delta=[40 80 80]
+  prev=(replica-id=none lease=false type=VOTER_FULL)
+  next=(replica-id=unknown lease=false type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 reported=[0 0 0] adjusted=[40 80 80] node-reported-cpu=0 node-adjusted-cpu=40 seq=2
+
+tick seconds=10
+----
+clock=10s
+
+msg last-seq=-1 cur-seq=-1
+node-id=1 cpu-load=80 cpu-capacity=100
+  store: store-id=1 load=(80,80,80) capacity=(-1,100,100) secondary-load=1
+    range: range-id=1 lease=true type=VOTER_FULL
+      replica: store-id=1 replica-id=1 type=VOTER_FULL
+      replica: store-id=2 replica-id=2 type=VOTER_FULL
+----
+OK
+
+# Check the pending changes on each store, we expect there to be an enacted
+# change on store 2. The change should also have been removed from the cluster
+# and range tracking.
+get-pending-changes
+----
+pending(1)
+change-id=1 start=0s store-id=2 range-id=1 delta=[40 80 80] enacted=10s
+  prev=(replica-id=none lease=false type=VOTER_FULL)
+  next=(replica-id=unknown lease=false type=VOTER_FULL)
+
+# The load deltas should still be applied to the adjusted store and node state
+# for s2. Enacting a change should not undo its adjustments.
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
+store-id=2 reported=[0 0 0] adjusted=[40 80 80] node-reported-cpu=0 node-adjusted-cpu=40 seq=2
+
+# Now send the load update from s2 which reports the change as complete.
+msg last-seq=-1 cur-seq=-1
+node-id=2 cpu-load=40 cpu-capacity=100
+  store: store-id=2 load=(40,80,80) capacity=(-1,100,100) secondary-load=0
+    range: range-id=1 lease=false type=VOTER_FULL
+----
+OK
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
+store-id=2 reported=[40 80 80] adjusted=[40 80 80] node-reported-cpu=40 node-adjusted-cpu=40 seq=3
+
+# Expect no changes tracked in either the store or cluster tracker.
+get-pending-changes
+----
+pending(0)
+
+# Next enqueue a lease transfer with the same range load as the replica add.
+make-pending-changes range-id=1
+transfer-lease: remove-store=1 add-store=2 load=(80,80,80) cpu-raft=40
+----
+pending(2)
+change-id=2 start=10s store-id=1 range-id=1 delta=[-40 0 0]
+  prev=(replica-id=1 lease=true type=VOTER_FULL)
+  next=(replica-id=1 lease=false type=VOTER_FULL)
+change-id=3 start=10s store-id=2 range-id=1 delta=[40 0 0]
+  prev=(replica-id=2 lease=false type=VOTER_FULL)
+  next=(replica-id=2 lease=true type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[40 80 80] node-reported-cpu=80 node-adjusted-cpu=40 seq=3
+store-id=2 reported=[40 80 80] adjusted=[80 80 80] node-reported-cpu=40 node-adjusted-cpu=80 seq=4
+
+# Bump the clock with the GC duration. The pending changes should be GC'd and
+# the reported load equal to the adjusted load.
+tick seconds=300
+----
+clock=310s
+
+gc-pending-changes
+----
+pending(0)
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=4
+store-id=2 reported=[40 80 80] adjusted=[40 80 80] node-reported-cpu=40 node-adjusted-cpu=40 seq=5
+
+# Perform a replica removal without GC'ing. This time, instead of first
+# sending a lease store message to mark the change as enacted; send a load
+# message which should drop the load adjustments but leave the change as
+# pending in the cluster and range state.
+make-pending-changes range-id=1
+remove-replica: remove-store=2 load=(80,80,80) cpu-raft=40
+----
+pending(1)
+change-id=4 start=310s store-id=2 range-id=1 delta=[-40 -80 -80]
+  prev=(replica-id=2 lease=false type=VOTER_FULL)
+  next=(replica-id=none lease=false type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=4
+store-id=2 reported=[40 80 80] adjusted=[0 0 0] node-reported-cpu=40 node-adjusted-cpu=0 seq=6
+
+msg last-seq=-1 cur-seq=-1
+node-id=2 cpu-load=0 cpu-capacity=100
+  store: store-id=2 load=(0,0,0) capacity=(-1,100,100) secondary-load=0
+----
+OK
+
+get-pending-changes
+----
+pending(1)
+change-id=4 start=310s store-id=2 range-id=1 delta=[-40 -80 -80]
+  prev=(replica-id=2 lease=false type=VOTER_FULL)
+  next=(replica-id=none lease=false type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=4
+store-id=2 reported=[0 0 0] adjusted=[0 0 0] node-reported-cpu=0 node-adjusted-cpu=0 seq=7
+
+# Send a lease message to mark the change as enacted and clean it up from the
+# cluster tracking.
+msg last-seq=-1 cur-seq=-1
+node-id=1 cpu-load=80 cpu-capacity=100
+  store: store-id=1 load=(80,80,80) capacity=(-1,100,100) secondary-load=1
+    range: range-id=1 lease=true type=VOTER_FULL
+      replica: store-id=1 replica-id=1 type=VOTER_FULL
+----
+OK
+
+get-pending-changes
+----
+pending(0)
+
+# Add a new store (s3) and send a leaseholder message from the store indicating
+# it is the new leaseholder for r1.
+set-store
+store-id=3 node-id=3 attrs=green  locality-tiers=region=us-west-1,zone=us-west-1a
+----
+node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 init=full attrs=purple locality-code=1:2:3:
+node-id=2 failure-summary=ok locality-tiers=region=us-east-1,zone=us-east-1a,node=2
+  store-id=2 init=full attrs=yellow locality-code=4:5:6:
+node-id=3 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=3
+  store-id=3 init=full attrs=green locality-code=1:2:7:
+
+msg last-seq=-1 cur-seq=-1
+node-id=3 cpu-load=80 cpu-capacity=100
+  store: store-id=3 load=(80,80,80) capacity=(-1,100,100) secondary-load=1
+    range: range-id=1 lease=true type=VOTER_FULL
+      replica: store-id=1 replica-id=1 type=VOTER_FULL
+      replica: store-id=3 replica-id=3 type=VOTER_FULL
+----
+OK
+
+ranges
+----
+range-id=1
+  store-id=1 replica-id=1 lease=false type=VOTER_FULL
+  store-id=3 replica-id=3 lease=true type=VOTER_FULL
+
+# Make a pending change to rebalance the replica from s1 to s3.
+make-pending-changes range-id=1
+rebalance-replica: add-store=2 remove-store=1 load=(80,80,80) cpu-raft=40
+----
+pending(2)
+change-id=5 start=310s store-id=2 range-id=1 delta=[40 80 80]
+  prev=(replica-id=none lease=false type=VOTER_FULL)
+  next=(replica-id=unknown lease=false type=VOTER_FULL)
+change-id=6 start=310s store-id=1 range-id=1 delta=[-40 -80 -80]
+  prev=(replica-id=1 lease=false type=VOTER_FULL)
+  next=(replica-id=none lease=false type=VOTER_FULL)
+
+ranges
+----
+range-id=1
+  store-id=2 replica-id=unknown lease=false type=VOTER_FULL
+  store-id=3 replica-id=3 lease=true type=VOTER_FULL
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[40 0 0] node-reported-cpu=80 node-adjusted-cpu=40 seq=6
+store-id=2 reported=[0 0 0] adjusted=[40 80 80] node-reported-cpu=0 node-adjusted-cpu=40 seq=8
+store-id=3 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+
+# Mark the change as enacted by sending a lease range update from s3.
+msg last-seq=-1 cur-seq=-1
+node-id=3 cpu-load=80 cpu-capacity=100
+  store: store-id=3 load=(80,80,80) capacity=(-1,100,100) secondary-load=1
+    range: range-id=1 lease=true type=VOTER_FULL
+      replica: store-id=2 replica-id=2 type=VOTER_FULL
+      replica: store-id=3 replica-id=3 type=VOTER_FULL
+----
+OK
+
+# The change should still be present on each store for load adjustments.
+get-pending-changes
+----
+pending(2)
+change-id=6 start=310s store-id=1 range-id=1 delta=[-40 -80 -80] enacted=310s
+  prev=(replica-id=1 lease=false type=VOTER_FULL)
+  next=(replica-id=none lease=false type=VOTER_FULL)
+change-id=5 start=310s store-id=2 range-id=1 delta=[40 80 80] enacted=310s
+  prev=(replica-id=none lease=false type=VOTER_FULL)
+  next=(replica-id=unknown lease=false type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[40 0 0] node-reported-cpu=80 node-adjusted-cpu=40 seq=6
+store-id=2 reported=[0 0 0] adjusted=[40 80 80] node-reported-cpu=0 node-adjusted-cpu=40 seq=8
+store-id=3 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
+
+# Bump the clock forward to GC the enacted changes. The involved stores (s1,s2) haven't
+# had any load updates to remove these yet - so the adjustments are still
+# applied, shown above.
+tick seconds=15
+----
+clock=325s
+
+gc-pending-changes
+----
+pending(2)
+change-id=6 start=310s store-id=1 range-id=1 delta=[-40 -80 -80] enacted=310s
+  prev=(replica-id=1 lease=false type=VOTER_FULL)
+  next=(replica-id=none lease=false type=VOTER_FULL)
+change-id=5 start=310s store-id=2 range-id=1 delta=[40 80 80] enacted=310s
+  prev=(replica-id=none lease=false type=VOTER_FULL)
+  next=(replica-id=unknown lease=false type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[40 0 0] node-reported-cpu=80 node-adjusted-cpu=40 seq=6
+store-id=2 reported=[0 0 0] adjusted=[40 80 80] node-reported-cpu=0 node-adjusted-cpu=40 seq=8
+store-id=3 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
+
+ranges
+----
+range-id=1
+  store-id=2 replica-id=2 lease=false type=VOTER_FULL
+  store-id=3 replica-id=3 lease=true type=VOTER_FULL
+
+# Add a change which we then mark as rejected by the enacting module, the
+# change should be wiped.
+make-pending-changes range-id=1
+rebalance-replica: add-store=1 remove-store=2 load=(80,80,80) cpu-raft=40
+----
+pending(4)
+change-id=6 start=310s store-id=1 range-id=1 delta=[-40 -80 -80] enacted=310s
+  prev=(replica-id=1 lease=false type=VOTER_FULL)
+  next=(replica-id=none lease=false type=VOTER_FULL)
+change-id=5 start=310s store-id=2 range-id=1 delta=[40 80 80] enacted=310s
+  prev=(replica-id=none lease=false type=VOTER_FULL)
+  next=(replica-id=unknown lease=false type=VOTER_FULL)
+change-id=7 start=325s store-id=1 range-id=1 delta=[40 80 80]
+  prev=(replica-id=none lease=false type=VOTER_FULL)
+  next=(replica-id=unknown lease=false type=VOTER_FULL)
+change-id=8 start=325s store-id=2 range-id=1 delta=[-40 -80 -80]
+  prev=(replica-id=2 lease=false type=VOTER_FULL)
+  next=(replica-id=none lease=false type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=7
+store-id=2 reported=[0 0 0] adjusted=[0 0 0] node-reported-cpu=0 node-adjusted-cpu=0 seq=9
+store-id=3 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
+
+reject-pending-changes
+change-ids=(7,8)
+----
+pending(2)
+change-id=6 start=310s store-id=1 range-id=1 delta=[-40 -80 -80] enacted=310s
+  prev=(replica-id=1 lease=false type=VOTER_FULL)
+  next=(replica-id=none lease=false type=VOTER_FULL)
+change-id=5 start=310s store-id=2 range-id=1 delta=[40 80 80] enacted=310s
+  prev=(replica-id=none lease=false type=VOTER_FULL)
+  next=(replica-id=unknown lease=false type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[40 0 0] node-reported-cpu=80 node-adjusted-cpu=40 seq=8
+store-id=2 reported=[0 0 0] adjusted=[40 80 80] node-reported-cpu=0 node-adjusted-cpu=40 seq=10
+store-id=3 reported=[80 80 80] adjusted=[80 80 80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
+
+# Rebalance the leaseholder replica from store 3 to store 1. The load
+# adjustment should include the full load of the range.
+make-pending-changes range-id=1
+rebalance-replica: add-store=1 remove-store=3 load=(80,80,80) cpu-raft=40
+----
+pending(4)
+change-id=6 start=310s store-id=1 range-id=1 delta=[-40 -80 -80] enacted=310s
+  prev=(replica-id=1 lease=false type=VOTER_FULL)
+  next=(replica-id=none lease=false type=VOTER_FULL)
+change-id=5 start=310s store-id=2 range-id=1 delta=[40 80 80] enacted=310s
+  prev=(replica-id=none lease=false type=VOTER_FULL)
+  next=(replica-id=unknown lease=false type=VOTER_FULL)
+change-id=9 start=325s store-id=1 range-id=1 delta=[80 80 80]
+  prev=(replica-id=none lease=false type=VOTER_FULL)
+  next=(replica-id=unknown lease=true type=VOTER_FULL)
+change-id=10 start=325s store-id=3 range-id=1 delta=[-80 -80 -80]
+  prev=(replica-id=3 lease=true type=VOTER_FULL)
+  next=(replica-id=none lease=false type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 reported=[80 80 80] adjusted=[120 80 80] node-reported-cpu=80 node-adjusted-cpu=120 seq=9
+store-id=2 reported=[0 0 0] adjusted=[40 80 80] node-reported-cpu=0 node-adjusted-cpu=40 seq=10
+store-id=3 reported=[80 80 80] adjusted=[0 0 0] node-reported-cpu=80 node-adjusted-cpu=0 seq=3

--- a/pkg/kv/kvserver/allocator/mma/testdata/constraint_matcher
+++ b/pkg/kv/kvserver/allocator/mma/testdata/constraint_matcher
@@ -1,4 +1,5 @@
-store store-id=5 attrs=ssd,green locality-tiers=region=us-west
+store
+store-id=5 attrs=ssd,green locality-tiers=region=us-west
 ----
 
 remove-store store-id=2
@@ -34,7 +35,8 @@ print
 +blue:
 +region=us-west: 5
 
-store store-id=2 attrs=slow-disk,purple locality-tiers=continent=na,region=us-west
+store 
+store-id=2 attrs=slow-disk,purple locality-tiers=continent=na,region=us-west
 ----
 +ssd: 5
 +green: 5
@@ -57,7 +59,8 @@ print
 +region=us-west: 2, 5
 +continent=na: 2
 
-store store-id=4 attrs=slow-disk,blue locality-tiers=continent=na,region=us-east
+store 
+store-id=4 attrs=slow-disk,blue locality-tiers=continent=na,region=us-east
 ----
 +ssd: 5
 +green: 5
@@ -114,7 +117,8 @@ print
 +continent=na: 2, 4
 -slow-disk: 5
 
-store store-id=5 attrs=slow-disk,green locality-tiers=region=us-east
+store 
+store-id=5 attrs=slow-disk,green locality-tiers=region=us-east
 ----
 +ssd:
 +green: 5

--- a/pkg/kv/kvserver/allocator/mma/testdata/means_memo
+++ b/pkg/kv/kvserver/allocator/mma/testdata/means_memo
@@ -1,22 +1,18 @@
 # Two stores at different nodes.
-
-store store-id=1 node-id=1 attrs=green locality-tiers=region=us-west
-----
-
-store store-id=2 node-id=2 attrs=green locality-tiers=region=us-east
+store
+store-id=1 node-id=1 attrs=green locality-tiers=region=us-west
+store-id=2 node-id=2 attrs=green locality-tiers=region=us-east
 ----
 
 # -1 is parentCapacity.
-store-load store-id=1 load=(10,100,1000) capacity=(-1,400,8000) secondary-load=80
+store-load
+store-id=1 load=(10,100,1000) capacity=(-1,400,8000) secondary-load=80
+store-id=2 load=(20,200,4000) capacity=(-1,500,4000) secondary-load=100
 ----
 
-store-load store-id=2 load=(20,200,4000) capacity=(-1,500,4000) secondary-load=100
-----
-
-node-load node-id=1 cpu-load=200 cpu-capacity=1000
-----
-
-node-load node-id=2 cpu-load=250 cpu-capacity=500
+node-load
+node-id=1 cpu-load=200 cpu-capacity=1000
+node-id=2 cpu-load=250 cpu-capacity=500
 ----
 
 get-means
@@ -49,10 +45,12 @@ get-store-summary store-id=2 load-seq-num=0
 called computeLoadSummary: returning seqnum 0
 
 # Add another store that is on the same node as store 1.
-store store-id=3 node-id=1 attrs=green locality-tiers=region=us-west
+store
+store-id=3 node-id=1 attrs=green locality-tiers=region=us-west
 ----
 
-store-load store-id=3 load=(100,200,400) capacity=(-1,800,1600) secondary-load=120
+store-load
+store-id=3 load=(100,200,400) capacity=(-1,800,1600) secondary-load=120
 ----
 
 # Mean is unchanged since cached.

--- a/pkg/kv/kvserver/allocator/mma/testdata/range_analyzed_constraints
+++ b/pkg/kv/kvserver/allocator/mma/testdata/range_analyzed_constraints
@@ -1,4 +1,5 @@
-store store-id=2 attrs=ssd locality-tiers=region=b,zone=b1 node-id=1
+store 
+store-id=2 attrs=ssd locality-tiers=region=b,zone=b1 node-id=1
 ----
 
 span-config name=multi-region1 num-replicas=5 num-voters=3
@@ -47,7 +48,8 @@ voter-constraints:
     non-voters:
 diversity: voter 1.000000, all 1.000000
 
-store store-id=3 attrs=disk locality-tiers=region=b,zone=b1 node-id=1
+store
+store-id=3 attrs=disk locality-tiers=region=b,zone=b1 node-id=1
 ----
 
 analyze-constraints config-name=multi-region1
@@ -100,13 +102,10 @@ replaceVoterRebalance replace=2
 replaceVoterRebalance replace=3
 	err: expected enough voters and non-voters but have 2/3 voters and 0/2 non-voters
 
-store store-id=5 attrs=ssd locality-tiers=region=d,zone=d2 node-id=2
-----
-
-store store-id=6 attrs=disk locality-tiers=region=a,zone=a1 node-id=3
-----
-
-store store-id=7 attrs=disk locality-tiers=region=a,zone=a1 node-id=4
+store 
+store-id=5 attrs=ssd locality-tiers=region=d,zone=d2 node-id=2
+store-id=6 attrs=disk locality-tiers=region=a,zone=a1 node-id=3
+store-id=7 attrs=disk locality-tiers=region=a,zone=a1 node-id=4
 ----
 
 # Stores 3, 6, 7 are not ssd.
@@ -171,13 +170,10 @@ replaceNonVoterRebalance replace=5
 replaceNonVoterRebalance replace=6
 	err: expected enough voters and non-voters but have 2/3 voters and 2/2 non-voters
 
-store store-id=8 attrs=tape locality-tiers=region=d,zone=d2 node-id=5
-----
-
-store store-id=9 attrs=tape locality-tiers=region=d node-id=6
-----
-
-store store-id=10 attrs=tape locality-tiers=region=a,zone=a3 node-id=7
+store 
+store-id=8 attrs=tape locality-tiers=region=d,zone=d2 node-id=5
+store-id=9 attrs=tape locality-tiers=region=d node-id=6
+store-id=10 attrs=tape locality-tiers=region=a,zone=a3 node-id=7
 ----
 
 # Stores 3, 6, 7, 8, 9, 10 are not ssd.
@@ -252,7 +248,8 @@ replaceNonVoterRebalance replace=6
 replaceNonVoterRebalance replace=8
 	err: expected only matched constraints but found under=1 match=0 over=2
 
-store store-id=11 attrs=flash locality-tiers=region=c,zone=c2 node-id=8
+store 
+store-id=11 attrs=flash locality-tiers=region=c,zone=c2 node-id=8
 ----
 
 # The constraints are all matched and there is the correct number of voters and


### PR DESCRIPTION
This patch adds support for processing non-delta node load responses, as
well as other inputs such as rejecting pending changes, updating failure
detection and a store's descriptor.

When the allocator receives a node load response, it checks whether any
tracked pending changes have been enacted or reported in the store's
load.

A pending change is marked as enacted when the range's leaseholder store
reports the range's replicas, and the replica location and type indicate
the change completed. When a change is marked as enacted, the allocator
stops tracking the pending change, except in the store state. The store
state retains the pending change until it is either GC'd or reported in
the store's load. The change's load adjustment still applies.

When a change is reported as complete, evident by the store's ranges,
the load adjustment and store state tracking are removed. The pending
change is still tracked on the cluster state / range pending changes.

This patch also adds additional data-driven test helpers to parse test
file input. The intention is to also use these for testing candidate
selection and rebalancing

Informs: https://github.com/cockroachdb/cockroach/issues/103320

Epic: CRDB-25222

Release note: None