### PR TITLE
sql/stats: better sentry report for NumRange=0 assertion failure

### DIFF
--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -236,7 +236,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 				}
 
 				if withForecast {
-					forecasts := stats.ForecastTableStatistics(ctx, statsList)
+					forecasts := stats.ForecastTableStatistics(ctx, &p.ExtendedEvalContext().Settings.SV, statsList)
 					forecastRows := make([]tree.Datums, 0, len(forecasts))
 					// Iterate in reverse order to match the ORDER BY "columnIDs".
 					for i := len(forecasts) - 1; i >= 0; i-- {

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/cache",
         "//pkg/util/encoding",
+        "//pkg/util/errorutil",
         "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/log",

--- a/pkg/sql/stats/forecast.go
+++ b/pkg/sql/stats/forecast.go
@@ -12,14 +12,20 @@ package stats
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
 	"math"
+	"strconv"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -62,7 +68,9 @@ const minGoodnessOfFit = 0.95
 //
 // ForecastTableStatistics is deterministic: given the same observations it will
 // return the same forecasts.
-func ForecastTableStatistics(ctx context.Context, observed []*TableStatistic) []*TableStatistic {
+func ForecastTableStatistics(
+	ctx context.Context, sv *settings.Values, observed []*TableStatistic,
+) []*TableStatistic {
 	// Group observed statistics by column set, skipping over partial statistics
 	// and statistics with inverted histograms.
 	var forecastCols []string
@@ -104,7 +112,7 @@ func ForecastTableStatistics(ctx context.Context, observed []*TableStatistic) []
 		latest := observedByCols[colKey][0].CreatedAt
 		at := latest.Add(avgRefresh)
 
-		forecast, err := forecastColumnStatistics(ctx, observedByCols[colKey], at, minGoodnessOfFit)
+		forecast, err := forecastColumnStatistics(ctx, sv, observedByCols[colKey], at, minGoodnessOfFit)
 		if err != nil {
 			log.VEventf(
 				ctx, 2, "could not forecast statistics for table %v columns %s: %v",
@@ -136,7 +144,11 @@ func ForecastTableStatistics(ctx context.Context, observed []*TableStatistic) []
 // forecastColumnStatistics is deterministic: given the same observations and
 // forecast time, it will return the same forecast.
 func forecastColumnStatistics(
-	ctx context.Context, observed []*TableStatistic, at time.Time, minRequiredFit float64,
+	ctx context.Context,
+	sv *settings.Values,
+	observed []*TableStatistic,
+	at time.Time,
+	minRequiredFit float64,
 ) (forecast *TableStatistic, err error) {
 	if len(observed) < minObservationsForForecast {
 		return nil, errors.New("not enough observations to forecast statistics")
@@ -283,6 +295,61 @@ func forecastColumnStatistics(
 		}
 		forecast.HistogramData = &histData
 		forecast.setHistogramBuckets(hist)
+
+		// Verify that the first two buckets (the initial NULL bucket and the first
+		// non-NULL bucket) both have NumRange=0 and DistinctRange=0. (We must check
+		// this after calling setHistogramBuckets to account for rounding.) See
+		// #93892.
+		for _, bucket := range forecast.Histogram {
+			if bucket.NumRange != 0 || bucket.DistinctRange != 0 {
+				// Build a JSON representation of the first several buckets in each
+				// observed histogram so that we can figure out what happened.
+				const debugBucketCount = 5
+				jsonStats := make([]*JSONStatistic, 0, len(observed))
+
+				addStat := func(stat *TableStatistic) {
+					jsonStat := &JSONStatistic{
+						Name:          stat.Name,
+						CreatedAt:     stat.CreatedAt.String(),
+						Columns:       []string{strconv.FormatInt(int64(stat.ColumnIDs[0]), 10)},
+						RowCount:      stat.RowCount,
+						DistinctCount: stat.DistinctCount,
+						NullCount:     stat.NullCount,
+						AvgSize:       stat.AvgSize,
+					}
+					if err := jsonStat.SetHistogram(stat.HistogramData); err == nil &&
+						len(jsonStat.HistogramBuckets) > debugBucketCount {
+						// Limit the histogram to the first several buckets.
+						jsonStat.HistogramBuckets = jsonStat.HistogramBuckets[0:debugBucketCount]
+					}
+					// Replace UpperBounds with a hash.
+					for i := range jsonStat.HistogramBuckets {
+						hash := md5.Sum([]byte(jsonStat.HistogramBuckets[i].UpperBound))
+						jsonStat.HistogramBuckets[i].UpperBound = fmt.Sprintf("_%x", hash)
+					}
+					jsonStats = append(jsonStats, jsonStat)
+				}
+				addStat(forecast)
+				for i := range observed {
+					addStat(observed[i])
+				}
+				var debugging redact.SafeString
+				if j, err := json.Marshal(jsonStats); err == nil {
+					debugging = redact.SafeString(j)
+				}
+				err := errorutil.UnexpectedWithIssueErrorf(
+					93892,
+					"forecasted histogram had first bucket with non-zero NumRange or DistinctRange: %s",
+					debugging,
+				)
+				errorutil.SendReport(ctx, sv, err)
+				return nil, err
+			}
+			if bucket.UpperBound != tree.DNull {
+				// Stop checking after the first non-NULL bucket.
+				break
+			}
+		}
 	}
 
 	return forecast, nil

--- a/pkg/sql/stats/forecast_test.go
+++ b/pkg/sql/stats/forecast_test.go
@@ -617,7 +617,7 @@ func TestForecastColumnStatistics(t *testing.T) {
 			expected := tc.forecast.toTableStatistic(jobspb.ForecastStatsName, i, descpb.ColumnIDs{1}, fullStatID, partialStatID)
 			at := testStatTime(tc.at)
 
-			forecast, err := forecastColumnStatistics(ctx, observed, at, 1)
+			forecast, err := forecastColumnStatistics(ctx, nil /* sv */, observed, at, 1)
 			if err != nil {
 				if !tc.err {
 					t.Errorf("test case %d unexpected forecastColumnStatistics err: %v", i, err)

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -823,7 +823,7 @@ ORDER BY "createdAt" DESC, "columnIDs" DESC, "statisticID" DESC
 	statsList = append(merged, statsList...)
 
 	if forecast {
-		forecasts := ForecastTableStatistics(ctx, statsList)
+		forecasts := ForecastTableStatistics(ctx, &sc.settings.SV, statsList)
 		statsList = append(statsList, forecasts...)
 		// Some forecasts could have a CreatedAt time before or after some collected
 		// stats, so make sure the list is sorted in descending CreatedAt order.


### PR DESCRIPTION
The "first bucket should have NumRange=0" assertion failure has become hot, so add a validation step to statistics forecasting that will catch it earlier, before it causes query planning to fail. As part of this validation step, produce a better sentry report that should help us track down the problem.

Informs: #93892

Release note: None