### PR TITLE
pkg/server: initialize tenant version setting in settings watcher

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/redact"
@@ -59,23 +58,7 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 	const serverType redact.SafeString = "SQL server"
 
 	initConfig := func(ctx context.Context) error {
-		if err := serverCfg.InitSQLServer(ctx); err != nil {
-			return err
-		}
-
-		// We need a value in the version setting prior to the update
-		// coming from the system.settings table. This value must be valid
-		// and compatible with the state of the tenant's keyspace.
-		//
-		// Since we don't know at which binary version the tenant
-		// keyspace was initialized, we must be conservative and
-		// assume it was created a long time ago; and that we may
-		// have to run all known migrations since then. So initialize
-		// the version setting to the minimum supported version.
-		st := serverCfg.BaseConfig.Settings
-		return clusterversion.Initialize(
-			ctx, st.Version.BinaryMinSupportedVersion(), &st.SV,
-		)
+		return serverCfg.InitSQLServer(ctx)
 	}
 
 	newServerFn := func(ctx context.Context, serverCfg server.Config, stopper *stop.Stopper) (serverStartupInterface, error) {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1054,18 +1054,6 @@ func (ts *TestServer) StartTenant(
 	if st == nil {
 		st = cluster.MakeTestingClusterSettings()
 	}
-	// Verify that the settings object that was passed in has
-	// initialized the version setting. This is pretty much necessary
-	// for secondary tenants. See the comments at the beginning of
-	// `runStartSQL()` in cli/mt_start_sql.go and
-	// `makeSharedProcessTenantServerConfig()` in
-	// server_controller_new_server.go.
-	//
-	// The version is initialized in MakeTestingClusterSettings(). This
-	// assertion is there to prevent inadvertent changes to
-	// MakeTestingClusterSettings() and as a guardrail for tests that
-	// pass a custom params.Settings.
-	clusterversion.AssertInitialized(ctx, &st.SV)
 
 	// Needed for backward-compat on crdb_internal.ranges{_no_leases}.
 	// Remove in v23.2.


### PR DESCRIPTION
This code change removes the early version setting initialization
because it is not needed.

Initialization now happens in the settings watcher during the initial
scan when the tenant logical version is read from the settings table.

The setting is only initialized if it's empty / not pre-initialized
because some tests pre-initialize it.

Release note: None
Epic: CRDB-26691