### PR TITLE
ccl/schemachangerccl: skip TestBackupMixedVersionElements_base_drop_m…

### DIFF
--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -566,6 +566,10 @@ func cumulativeTest(
 		require.Zero(t, numTestStmts, "only one test command per-test, "+
 			"and it must be the last one.")
 		switch d.Cmd {
+		case "skip":
+			var issue int
+			d.ScanArgs(t, "issue-num", &issue)
+			skip.WithIssue(t, issue)
 		case "setup":
 			// Store setup stmts into `setup` slice (without executing them).
 			stmts, err := parser.Parse(d.Input)

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -183,6 +183,11 @@ func EndToEndSideEffects(t *testing.T, relPath string, newCluster NewClusterFunc
 			}
 		}
 		switch d.Cmd {
+		case "skip":
+			var issue int
+			d.ScanArgs(t, "issue-num", &issue)
+			skip.WithIssue(t, issue)
+			return ""
 		case "setup":
 			stmts, execStmts := parseStmts()
 			a := prettyNamespaceDump(t, tdb)

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements
@@ -3,6 +3,10 @@
 # since j and k are being dropped. We will concurrently
 # throw DML while we are mutating and dropping dependencies
 # at stage of the schema change plan.
+
+skip issue-num=103896
+----
+
 setup
 CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
 ----


### PR DESCRIPTION
…ultiple_columns_separate_statements

This skip also adds code to skip datadriven tests in `sctest`.

Refs: #103896
Reason: flaky test

Release note: None
Epic: None