### PR TITLE
kvnemesis: add TestingKnobs.OnRangeSpanningNonTxnalBatch back

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -626,6 +626,10 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 		ds.latencyFunc = ds.rpcContext.RemoteClocks.Latency
 	}
 
+	if cfg.TestingKnobs.OnRangeSpanningNonTxnalBatch != nil {
+		ds.onRangeSpanningNonTxnalBatch = cfg.TestingKnobs.OnRangeSpanningNonTxnalBatch
+	}
+
 	if cfg.TestingKnobs.BatchRequestInterceptor != nil {
 		ds.BatchRequestInterceptor = cfg.TestingKnobs.BatchRequestInterceptor
 	}


### PR DESCRIPTION
#103963 accidentally removed a testing knob which caused #104865. 
This commit adds the testing knob back.

Fixes: https://github.com/cockroachdb/cockroach/issues/104865
Release note: none