### PR TITLE
roachtest: collect failure artifacts when restore fails

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1473,8 +1473,8 @@ COCKROACH_DEBUG_TS_IMPORT_FILE=tsdump.gob cockroach start-single-node --insecure
 }
 
 // FetchDebugZip downloads the debug zip from the cluster using `roachprod ssh`.
-// The logs will be placed in the test's artifacts dir.
-func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger) error {
+// The logs will be placed at `dest`, relative to the test's artifacts dir.
+func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger, dest string) error {
 	if c.spec.NodeCount == 0 {
 		// No nodes can happen during unit tests and implies nothing to do.
 		return nil
@@ -1486,7 +1486,7 @@ func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger) error
 	// Don't hang forever if we can't fetch the debug zip.
 	return timeutil.RunWithTimeout(ctx, "debug zip", 5*time.Minute, func(ctx context.Context) error {
 		const zipName = "debug.zip"
-		path := filepath.Join(c.t.ArtifactsDir(), zipName)
+		path := filepath.Join(c.t.ArtifactsDir(), dest)
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -134,6 +134,7 @@ type Cluster interface {
 	) error
 
 	FetchTimeseriesData(ctx context.Context, l *logger.Logger) error
+	FetchDebugZip(ctx context.Context, l *logger.Logger, dest string) error
 	RefetchCertsFromNode(ctx context.Context, node int) error
 
 	StartGrafana(ctx context.Context, l *logger.Logger, promCfg *prometheus.Config) error

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1317,7 +1317,7 @@ func (r *testRunner) collectArtifacts(
 		if err := c.FetchTimeseriesData(ctx, t.L()); err != nil {
 			t.L().Printf("failed to fetch timeseries data: %s", err)
 		}
-		if err := c.FetchDebugZip(ctx, t.L()); err != nil {
+		if err := c.FetchDebugZip(ctx, t.L(), "debug.zip"); err != nil {
 			t.L().Printf("failed to collect zip: %s", err)
 		}
 	})

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1802,7 +1802,7 @@ func (mvb *mixedVersionBackup) planAndRunBackups(
 	}
 
 	if len(tc.FromVersionNodes) > 0 {
-		const numCollections = 3
+		const numCollections = 2
 		rng.Shuffle(len(collectionSpecs), func(i, j int) {
 			collectionSpecs[i], collectionSpecs[j] = collectionSpecs[j], collectionSpecs[i]
 		})
@@ -2041,6 +2041,17 @@ func (mvb *mixedVersionBackup) verifyAllBackups(
 
 	verify(h.Context().FromVersion)
 	verify(clusterupgrade.MainVersion)
+
+	// If the context was canceled (most likely due to a test timeout),
+	// return early. In these cases, it's likely that `restoreErrors`
+	// will have a number of "restore failures" that all happened
+	// because the underlying context was canceled, so proceeding with
+	// the error reporting logic below is confusing, as it makes it look
+	// like multiple failures occurred. It also makes the actually
+	// important "timed out" message less prominent.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	if len(restoreErrors) > 0 {
 		if len(restoreErrors) == 1 {

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1694,7 +1694,10 @@ func (mvb *mixedVersionBackup) disableJobAdoption(
 			if err := retry.ForDuration(testutils.DefaultSucceedsSoonDuration, func() error {
 				db := h.Connect(node)
 				var count int
-				err := db.QueryRow(`SELECT count(*) FROM [SHOW JOBS] WHERE status = 'running'`).Scan(&count)
+				err := db.QueryRow(fmt.Sprintf(
+					`SELECT count(*) FROM [SHOW JOBS] WHERE status = 'running' AND coordinator_id = %d`,
+					node,
+				)).Scan(&count)
 				if err != nil {
 					l.Printf("node %d: error querying running jobs (%s)", node, err)
 					return err


### PR DESCRIPTION
This commit updates the `backup-restore/mixed-version` roachtest to
collect artifacts (cockroach logs and a debug.zip) when a restore
fails in the last step of the test (when all backups taken are
restored). In that step, we do not immediately fail the test when a
restore fails but instead attempt to restore every backup and return a
list of errors found when the process is done. However, restoring
cluster backups involves wiping the cluster which also deletes
existing cockroach logs up to that point. This makes debugging a
restore failure that happened prior to a cluster restore impossible.

After this commit, a restore failure in that test will cause a
`restore_failure_N` directory to be created in the artifacts
directory, including the cockroach logs collected right after the
failure, as well as a debug.zip created at the same time.

This will make issues such as #104604 more actionable.

Epic: none

Release note: None