### PR TITLE
multiregionccl: reenable regional_by_table test

### DIFF
--- a/pkg/ccl/multiregionccl/testdata/regional_by_table
+++ b/pkg/ccl/multiregionccl/testdata/regional_by_table
@@ -1,6 +1,3 @@
-skip issue-num=98020
-----
-
 new-cluster localities=us-east-1,us-east-1,us-east-1,us-west-1,us-west-1,us-west-1,us-central-1,eu-central-1,eu-west-1
 ----
 


### PR DESCRIPTION
Informs: #98020

I wasn't able to repro the error mentioned in #98020 for all the 3 tests by stressing 2k runs. Assuming that something has been changed and we're fine now. But just enabling one test at a time just in case it would fail in CI for some reason.

Release note: None