### PR TITLE
upgrades: deflake TestBackfillJobsInfoTable

### DIFF
--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -135,6 +135,8 @@ go_test(
     shard_count = 16,
     deps = [
         "//pkg/base",
+        "//pkg/ccl/backupccl",
+        "//pkg/ccl/changefeedccl",
         "//pkg/cloud/userfile",
         "//pkg/clusterversion",
         "//pkg/jobs",


### PR DESCRIPTION
Previously, this test created jobs that could be adopted during test execution causing the number of payload/progress updates to be variable. With this change we create startable jobs so that they are not adopted and the number of payload/progress remain constant.

Fixes: #103046
Release note: None