### PR TITLE
kvserver: clarify `kv.raft_log.disable_synchronization_unsafe`

### DIFF
--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -41,8 +41,9 @@ import (
 var disableSyncRaftLog = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.raft_log.disable_synchronization_unsafe",
-	"set to true to disable synchronization on Raft log writes to persistent storage. "+
-		"Setting to true risks data loss or data corruption on server crashes. "+
+	"disables synchronization of Raft log writes to persistent storage. "+
+		"Setting to true risks data loss or data corruption on process or OS crashes. "+
+		"This not only disables fsync, but also disables flushing writes to the OS buffer. "+
 		"The setting is meant for internal testing only and SHOULD NOT be used in production.",
 	envutil.EnvOrDefaultBool("COCKROACH_DISABLE_RAFT_LOG_SYNCHRONIZATION_UNSAFE", false),
 )


### PR DESCRIPTION
This setting not only disables fsync, it also disables flushing writes to the OS, so it will lose data even on process crashes.

Epic: none
Release note: None