### PR TITLE
release-22.2: jobs: avoid logging stack trace if error is not unexpected

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/protoreflect",
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -31,6 +31,8 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/lexbase",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/physicalplan",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -28,6 +28,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
@@ -126,7 +128,8 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 		// early as the delete will not work.
 		modificationTime := desc.GetModificationTime().GoTime()
 		if modificationTime.After(aost) {
-			return errors.Newf(
+			return pgerror.Newf(
+				pgcode.ObjectNotInPrerequisiteState,
 				"found a recent schema change on the table at %s, aborting",
 				modificationTime.Format(time.RFC3339),
 			)
@@ -139,7 +142,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 		rowLevelTTL = *desc.GetRowLevelTTL()
 
 		if rowLevelTTL.Pause {
-			return errors.Newf("ttl jobs on table %s are currently paused", tree.Name(desc.GetName()))
+			return pgerror.Newf(pgcode.OperatorIntervention, "ttl jobs on table %s are currently paused", tree.Name(desc.GetName()))
 		}
 
 		tn, err := descs.GetTableNameByDesc(ctx, txn, descsCol, desc)


### PR DESCRIPTION
Backport 1/1 commits from #104801.

/cc @cockroachdb/release

Release justification: logging change

---

fixes https://github.com/cockroachdb/cockroach/issues/104744
fixes https://github.com/cockroachdb/cockroach/issues/104743

This makes the logs more usable. We use a heuristic of assuming that any error with a pgcode is not an internal error, so it should not be logged with a full stack trace. For those errors, the error message is enough to explain what was wrong.

Release note: None
