### PR TITLE
release-22.2: roachtest: update CI to enable metamorphic arm64 and fips

### DIFF
--- a/build/teamcity-roachtest-invoke.sh
+++ b/build/teamcity-roachtest-invoke.sh
@@ -6,7 +6,6 @@ set +e
 # passed by the caller, the passed one takes precedence.
 bin/roachtest run \
   --teamcity \
-  --workload="${PWD}/bin/workload" \
   --os-volume-size=32 \
   "$@"
 code=$?

--- a/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
@@ -1,26 +1,63 @@
 #!/usr/bin/env bash
 
-# Builds all bits needed for roachtests, stages them in bin/ and lib.docker_amd64/.
+# Builds all bits needed for roachtests, stages them in bin/ and lib/.
+cross_builds=(crosslinux crosslinuxarm crosslinuxfips)
 
-bazel build --config crosslinux --config ci --config with_ui -c opt --config force_build_cdeps \
-      //pkg/cmd/cockroach //pkg/cmd/workload //pkg/cmd/roachtest \
-      //c-deps:libgeos
-bazel build --config crosslinux --config ci -c opt //pkg/cmd/cockroach-short --crdb_test
-BAZEL_BIN=$(bazel info bazel-bin --config crosslinux --config ci --config with_ui -c opt)
-# Move this stuff to bin for simplicity.
+# Prepare the bin/ and lib/ directories.
 mkdir -p bin
 chmod o+rwx bin
-cp $BAZEL_BIN/pkg/cmd/cockroach/cockroach_/cockroach bin
-# Copy the binary with enabled assertions while adding "-ea" suffix (which
-# stands for "enabled assertions").
-cp $BAZEL_BIN/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short bin/cockroach-short-ea
-cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
-cp $BAZEL_BIN/pkg/cmd/workload/workload_/workload    bin
-chmod a+w bin/cockroach bin/cockroach-short-ea bin/roachtest bin/workload
-# Stage the geos libs in the appropriate spot.
-mkdir -p lib.docker_amd64
-chmod o+rwx lib.docker_amd64
-cp $BAZEL_BIN/c-deps/libgeos_foreign/lib/libgeos.so   lib.docker_amd64
-cp $BAZEL_BIN/c-deps/libgeos_foreign/lib/libgeos_c.so lib.docker_amd64
-chmod a+w lib.docker_amd64/libgeos.so lib.docker_amd64/libgeos_c.so
-ln -s lib.docker_amd64 lib
+mkdir -p lib
+chmod o+rwx lib
+
+for platform in "${cross_builds[@]}"; do
+  if [[ $platform == crosslinux ]]; then
+    os=linux
+    arch=amd64
+  elif [[ $platform == crosslinuxarm ]]; then
+    os=linux
+    arch=arm64
+  elif [[ $platform == crosslinuxfips ]]; then
+    os=linux
+    arch=amd64-fips
+  else
+    echo "unknown or unsupported platform $platform"
+    exit 1
+  fi
+
+  echo "Building $platform, os=$os, arch=$arch..."
+  # Build cockroach, workload and geos libs.
+  bazel build --config $platform --config ci --config with_ui -c opt --config force_build_cdeps \
+        //pkg/cmd/cockroach //pkg/cmd/workload \
+        //c-deps:libgeos
+  # N.B. roachtest is currently executed only on a TC agent running linux/amd64, so we build it once.
+  if [[ $os == "linux" && $arch == "amd64" ]]; then
+    bazel build --config $platform --config ci  -c opt //pkg/cmd/roachtest
+  fi
+  # Build cockroach-short with assertions enabled.
+  bazel build --config $platform --config ci -c opt //pkg/cmd/cockroach-short --crdb_test
+  # Copy the binaries.
+  BAZEL_BIN=$(bazel info bazel-bin --config $platform --config ci --config with_ui -c opt)
+  # N.B. currently, we support only one roachtest binary, so elide the suffix.
+  if [[ $os == "linux" && $arch == "amd64" ]]; then
+    cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin/roachtest
+    # Make it writable to simplify cleanup and copying (e.g., scp retry).
+    chmod a+w bin/roachtest
+  fi
+  cp $BAZEL_BIN/pkg/cmd/cockroach/cockroach_/cockroach bin/cockroach.$os-$arch
+  cp $BAZEL_BIN/pkg/cmd/workload/workload_/workload    bin/workload.$os-$arch
+  # N.B. "-ea" suffix stands for enabled-assertions.
+  cp $BAZEL_BIN/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short bin/cockroach-ea.$os-$arch
+  # Make it writable to simplify cleanup and copying (e.g., scp retry).
+  chmod a+w bin/cockroach.$os-$arch bin/workload.$os-$arch bin/cockroach-ea.$os-$arch
+
+  # Copy geos libs.
+  cp $BAZEL_BIN/c-deps/libgeos_foreign/lib/libgeos.so   lib/libgeos.$os-$arch.so
+  cp $BAZEL_BIN/c-deps/libgeos_foreign/lib/libgeos_c.so lib/libgeos_c.$os-$arch.so
+  # Make it writable to simplify cleanup and copying (e.g., scp retry).
+  chmod a+w lib/libgeos.$os-$arch.so lib/libgeos_c.$os-$arch.so
+
+done
+
+ls -l bin
+ls -l lib
+

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_aws_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_aws_impl.sh
@@ -7,7 +7,7 @@ dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 source "$dir/teamcity-support.sh"
 
 if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
-  ssh-keygen -q -C "roachtest-nightly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
+  ssh-keygen -q -C "roachtest-weekly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
 fi
 
 source $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
@@ -16,13 +16,9 @@ artifacts=/artifacts
 source $root/build/teamcity/util/roachtest_util.sh
 
 build/teamcity-roachtest-invoke.sh \
-  --metamorphic-encryption-probability=0.5 \
+  tag:aws-weekly \
   --cloud="${CLOUD}" \
-  --count="${COUNT-1}" \
-  --parallelism="${PARALLELISM}" \
-  --cpu-quota="${CPUQUOTA}" \
-  --cluster-id="${TC_BUILD_ID}" \
+  --cluster-id "${TC_BUILD_ID}" \
   --artifacts=/artifacts \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
-  --slack-token="${SLACK_TOKEN}" \
-  "${TESTS}"
+  --slack-token="${SLACK_TOKEN}"

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -47,10 +47,8 @@ timeout -s INT $((7800*60)) bin/roachtest run \
   --build-tag "${build_tag}" \
   --cluster-id "${TC_BUILD_ID}" \
   --zones "us-central1-b,us-west1-b,europe-west2-b" \
-  --cockroach "$PWD/bin/cockroach" \
-  --workload "$PWD/bin/workload" \
-  --artifacts "/artifacts/${artifacts_subdir}" \
-  --artifacts-literal="${artifacts}" \
+  --artifacts=/artifacts \
+  --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --parallelism 5 \
   --metamorphic-encryption-probability=0.5 \
   --teamcity || exit_status=$?

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -167,11 +167,11 @@ func main() {
 		"Username to use as a cluster name prefix. "+
 			"If blank, the current OS user is detected and specified.")
 	rootCmd.PersistentFlags().StringVar(
-		&cockroachPath, "cockroach", "", "path to cockroach binary to use")
+		&cockroachPath, "cockroach", "", "absolute path to cockroach binary to use")
 	rootCmd.PersistentFlags().StringVar(
-		&cockroachShortPath, "cockroach-short", "", "path to cockroach-short binary (compiled with crdb_test build tag) to use")
+		&cockroachEAPath, "cockroach-ea", "", "absolute path to cockroach binary with enabled (runtime) assertions (i.e, compiled with crdb_test)")
 	rootCmd.PersistentFlags().StringVar(
-		&workloadPath, "workload", "", "path to workload binary to use")
+		&workloadPath, "workload", "", "absolute path to workload binary to use")
 	rootCmd.PersistentFlags().Float64Var(
 		&encryptionProbability, "metamorphic-encryption-probability", defaultEncryptionProbability,
 		"probability that clusters will be created with encryption-at-rest enabled "+

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -652,7 +652,7 @@ func (r *testRunner) runWorker(
 		t := &testImpl{
 			spec:                   &testToRun.spec,
 			cockroach:              cockroach[arch],
-			cockroachShort:         cockroachShort[arch],
+			cockroachShort:         cockroachEA[arch],
 			deprecatedWorkload:     workload[arch],
 			buildVersion:           r.buildVersion,
 			artifactsDir:           artifactsDir,

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
@@ -61,6 +62,9 @@ func registerFollowerReads(r registry.Registry) {
 				spec.Zones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b"),
 			),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				if c.Spec().Cloud == spec.GCE && c.Spec().Arch == vm.ArchARM64 {
+					t.Skip("arm64 in GCE is available only in us-central1")
+				}
 				c.Put(ctx, t.Cockroach(), "./cockroach")
 				c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
 				topology := topologySpec{


### PR DESCRIPTION
Backport 1/1 commits from #104303.

/cc @cockroachdb/release

---

Support for metamorphic arm64 and fips roachtests has been added in [1]. This change refactors the CI wrapper script to add the missing arm64 and fips builds for the required binaries and libs.

In addition, we change roachtest's CLI arg. `--cockroach-short` to `cockroach-ea` which better captures the fact that this binary is compiled with _enabled assertions_, i.e., crdb_test using crdb_test build tag. The fact that it's a "short" variant, i.e., without UI, is immaterial at this time. In future, we might explore roachtests which involve the UI, in which case `--cockroach-ea` might be replaced by the ("long") crdb binary.

[1] https://github.com/cockroachdb/cockroach/pull/103710

Epic: none

Release note: None
Release justification: ci/test only change
