### PR TITLE
cli: capture logs from demo tests

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -405,7 +405,6 @@ go_test(
         "//pkg/util/log/logpb",
         "//pkg/util/protoutil",
         "//pkg/util/stop",
-        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "//pkg/util/uuid",

--- a/pkg/cli/demo_locality_test.go
+++ b/pkg/cli/demo_locality_test.go
@@ -8,70 +8,55 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-//go:build !race
-// +build !race
-
 package cli
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/cockroachdb/cockroach/pkg/cli/democluster"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/datadriven"
 )
 
-func Example_demo_locality() {
-	c := NewCLITest(TestCLIParams{NoServer: true})
+func TestDemoLocality(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	c := NewCLITest(TestCLIParams{T: t, NoServer: true})
 	defer c.Cleanup()
 
 	// This is slow under deadlock as it starts a 9-node cluster which
 	// has a very high simulated latency between each node.
-	if syncutil.DeadlockEnabled {
-		return
-	}
+	skip.UnderDeadlock(t)
+	skip.UnderRace(t)
 
 	defer democluster.TestingForceRandomizeDemoPorts()()
 
-	// Disable multi-tenant for this test due to the unsupported gossip commands.
-	testData := [][]string{
-		{`demo`, `--nodes`, `3`, `--multitenant=false`, `-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
-		{`demo`, `--nodes`, `9`, `--multitenant=false`, `-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
-		{`demo`, `--nodes`, `3`, `--multitenant=false`, `--demo-locality=region=us-east1:region=us-east2:region=us-east3`,
-			`-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
-	}
 	setCLIDefaultsForTests()
 	// We must reset the security asset loader here, otherwise the dummy
 	// asset loader that is set by default in tests will not be able to
 	// find the certs that demo sets up.
 	securityassets.ResetLoader()
-	for _, cmd := range testData {
-		// `demo` sets up a server and log file redirection, which asserts
-		// that the logging subsystem has not been initialized yet.  Fake
-		// this to be true.
-		log.TestingResetActive()
-		c.RunWithArgs(cmd)
-	}
 
-	// Output:
-	// demo --nodes 3 --multitenant=false -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
-	// node_id	locality
-	// 1	region=us-east1,az=b
-	// 2	region=us-east1,az=c
-	// 3	region=us-east1,az=d
-	// demo --nodes 9 --multitenant=false -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
-	// node_id	locality
-	// 1	region=us-east1,az=b
-	// 2	region=us-east1,az=c
-	// 3	region=us-east1,az=d
-	// 4	region=us-west1,az=a
-	// 5	region=us-west1,az=b
-	// 6	region=us-west1,az=c
-	// 7	region=europe-west1,az=b
-	// 8	region=europe-west1,az=c
-	// 9	region=europe-west1,az=d
-	// demo --nodes 3 --multitenant=false --demo-locality=region=us-east1:region=us-east2:region=us-east3 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
-	// node_id	locality
-	// 1	region=us-east1
-	// 2	region=us-east2
-	// 3	region=us-east3
+	// Using datadriven allows TESTFLAGS=-rewrite.
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "demo", "test_demo_locality"), func(t *testing.T, td *datadriven.TestData) string {
+		if td.Cmd != "exec" {
+			t.Fatalf("unsupported command: %s", td.Cmd)
+		}
+		cmd := strings.Split(td.Input, "\n")
+		// Disable multi-tenant for this test due to the unsupported gossip commands.
+		cmd = append(cmd, "--multitenant=false")
+		cmd = append(cmd, "--logtostderr")
+		log.TestingResetActive()
+		out, err := c.RunWithCaptureArgs(cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Skip the first line, since that just echoes the command.
+		_, afterFirstLine, _ := strings.Cut(out, "\n")
+		return afterFirstLine
+	})
 }

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -11,95 +11,46 @@
 package cli
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/cockroachdb/cockroach/pkg/cli/democluster"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
 )
 
-func Example_demo() {
-	c := NewCLITest(TestCLIParams{NoServer: true})
+func TestDemo(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	c := NewCLITest(TestCLIParams{T: t, NoServer: true})
 	defer c.Cleanup()
 
 	defer democluster.TestingForceRandomizeDemoPorts()()
 
-	// Disable multi-tenant, as it requires a CCL binary
-	testData := [][]string{
-		{`demo`, `--multitenant=false`, `-e`, `show database`},
-		{`demo`, `--multitenant=false`, `-e`, `show database`, `--no-example-database`},
-		{`demo`, `--multitenant=false`, `-e`, `show application_name`},
-		{`demo`, `--multitenant=false`, `--format=table`, `-e`, `show database`},
-		{`demo`, `--multitenant=false`, `-e`, `select 1 as "1"`, `-e`, `select 3 as "3"`},
-		{`demo`, `--multitenant=false`, `--echo-sql`, `-e`, `select 1 as "1"`},
-		{`demo`, `--multitenant=false`, `--set=errexit=0`, `-e`, `select nonexistent`, `-e`, `select 123 as "123"`},
-		{`demo`, `--multitenant=false`, `startrek`, `-e`, `SELECT database_name, owner FROM [show databases]`},
-		{`demo`, `--multitenant=false`, `startrek`, `-e`, `SELECT database_name, owner FROM [show databases]`, `--format=table`},
-		// Test that if we start with --insecure we cannot perform
-		// commands that require a secure cluster.
-		{`demo`, `--multitenant=false`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
-		{`demo`, `--multitenant=false`, `--insecure`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
-		{`demo`, `--multitenant=false`, `--geo-partitioned-replicas`, `--disable-demo-license`},
-	}
 	setCLIDefaultsForTests()
 	// We must reset the security asset loader here, otherwise the dummy
 	// asset loader that is set by default in tests will not be able to
 	// find the certs that demo sets up.
 	securityassets.ResetLoader()
-	for _, cmd := range testData {
-		// `demo` sets up a server and log file redirection, which asserts
-		// that the logging subsystem has not been initialized yet. Fake
-		// this to be true.
-		log.TestingResetActive()
-		c.RunWithArgs(cmd)
-	}
 
-	// Output:
-	// demo --multitenant=false -e show database
-	// database
-	// movr
-	// demo --multitenant=false -e show database --no-example-database
-	// database
-	// defaultdb
-	// demo --multitenant=false -e show application_name
-	// application_name
-	// $ cockroach demo
-	// demo --multitenant=false --format=table -e show database
-	//   database
-	// ------------
-	//   movr
-	// (1 row)
-	// demo --multitenant=false -e select 1 as "1" -e select 3 as "3"
-	// 1
-	// 1
-	// 3
-	// 3
-	// demo --multitenant=false --echo-sql -e select 1 as "1"
-	// > select 1 as "1"
-	// 1
-	// 1
-	// demo --multitenant=false --set=errexit=0 -e select nonexistent -e select 123 as "123"
-	// ERROR: column "nonexistent" does not exist
-	// SQLSTATE: 42703
-	// 123
-	// 123
-	// demo --multitenant=false startrek -e SELECT database_name, owner FROM [show databases]
-	// database_name	owner
-	// defaultdb	root
-	// postgres	root
-	// startrek	demo
-	// system	node
-	// demo --multitenant=false startrek -e SELECT database_name, owner FROM [show databases] --format=table
-	//   database_name | owner
-	// ----------------+--------
-	//   defaultdb     | root
-	//   postgres      | root
-	//   startrek      | demo
-	//   system        | node
-	// (4 rows)
-	// demo --multitenant=false -e CREATE USER test WITH PASSWORD 'testpass'
-	// CREATE ROLE
-	// demo --multitenant=false --insecure -e CREATE USER test WITH PASSWORD 'testpass'
-	// ERROR: setting or updating a password is not supported in insecure mode
-	// SQLSTATE: 28P01
-	// demo --multitenant=false --geo-partitioned-replicas --disable-demo-license
-	// ERROR: enterprise features are needed for this demo (--geo-partitioned-replicas)
+	// Using datadriven allows TESTFLAGS=-rewrite.
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "demo", "test_demo"), func(t *testing.T, td *datadriven.TestData) string {
+		if td.Cmd != "exec" {
+			t.Fatalf("unsupported command: %s", td.Cmd)
+		}
+		cmd := strings.Split(td.Input, "\n")
+		// Disable multi-tenant for this test due to the unsupported gossip commands.
+		cmd = append(cmd, "--multitenant=false")
+		cmd = append(cmd, "--logtostderr")
+		log.TestingResetActive()
+		out, err := c.RunWithCaptureArgs(cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Skip the first line, since that just echoes the command.
+		_, afterFirstLine, _ := strings.Cut(out, "\n")
+		return afterFirstLine
+	})
 }

--- a/pkg/cli/testdata/demo/test_demo
+++ b/pkg/cli/testdata/demo/test_demo
@@ -1,0 +1,109 @@
+exec
+demo
+--execute=show database
+----
+database
+movr
+
+exec
+demo
+--execute=show database
+--no-example-database
+----
+database
+defaultdb
+
+exec
+demo
+--execute=show application_name
+----
+application_name
+$ cockroach demo
+
+exec
+demo
+--format=table
+--execute=show database
+----
+  database
+------------
+  movr
+(1 row)
+
+exec
+demo
+--execute=select 1 as "1"
+--execute=select 3 as "3"
+----
+1
+1
+3
+3
+
+exec
+demo
+--echo-sql
+--execute=select 1 as "1"
+----
+> select 1 as "1"
+1
+1
+
+exec
+demo
+--set=errexit=0
+--execute=select nonexistent
+--execute=select 123 as "123"
+----
+ERROR: column "nonexistent" does not exist
+SQLSTATE: 42703
+123
+123
+
+exec
+demo
+startrek
+--execute=SELECT database_name, owner FROM [show databases]
+----
+database_name	owner
+defaultdb	root
+postgres	root
+startrek	demo
+system	node
+
+exec
+demo
+startrek
+--execute=SELECT database_name, owner FROM [show databases]
+--format=table
+----
+  database_name | owner
+----------------+--------
+  defaultdb     | root
+  postgres      | root
+  startrek      | demo
+  system        | node
+(4 rows)
+
+# Test that if we start with --insecure we cannot perform
+# commands that require a secure cluster.
+exec
+demo
+--execute=CREATE USER test WITH PASSWORD 'testpass'
+----
+CREATE ROLE
+
+exec
+demo
+--insecure
+--execute=CREATE USER test WITH PASSWORD 'testpass'
+----
+ERROR: setting or updating a password is not supported in insecure mode
+SQLSTATE: 28P01
+
+exec
+demo
+--geo-partitioned-replicas
+--disable-demo-license
+----
+ERROR: enterprise features are needed for this demo (--geo-partitioned-replicas)

--- a/pkg/cli/testdata/demo/test_demo_locality
+++ b/pkg/cli/testdata/demo/test_demo_locality
@@ -1,0 +1,36 @@
+exec
+demo
+--nodes=3
+--execute=select node_id, locality from crdb_internal.gossip_nodes order by node_id
+----
+node_id	locality
+1	region=us-east1,az=b
+2	region=us-east1,az=c
+3	region=us-east1,az=d
+
+exec
+demo
+--nodes=9
+--execute=select node_id, locality from crdb_internal.gossip_nodes order by node_id
+----
+node_id	locality
+1	region=us-east1,az=b
+2	region=us-east1,az=c
+3	region=us-east1,az=d
+4	region=us-west1,az=a
+5	region=us-west1,az=b
+6	region=us-west1,az=c
+7	region=europe-west1,az=b
+8	region=europe-west1,az=c
+9	region=europe-west1,az=d
+
+exec
+demo
+--nodes=3
+--demo-locality=region=us-east1:region=us-east2:region=us-east3
+--execute=select node_id, locality from crdb_internal.gossip_nodes order by node_id
+----
+node_id	locality
+1	region=us-east1
+2	region=us-east2
+3	region=us-east3


### PR DESCRIPTION
informs https://github.com/cockroachdb/cockroach/issues/104693

The CLI demo tests were previously using the go Example framework. This
was not ideal since that framework has no way of preserving logs from
demo. The reasons for that were twofold:
- demo doesn't log by default, it needs to be configured to log in a
  specified directory or to stderr.
- Once we do configure demo to log, it needs to access
  the testing.T object so that the log scopes are properly configured.
  Example-based tests can't do that.

Now these tests use the datadriven framework. This addresses the above
problem, and also is easier to use and adjust.

Release note: None