### PR TITLE
release-23.1: cluster-ui: database details page connected component with reusable combiner logic

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsConnected.ts
@@ -1,0 +1,178 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { connect } from "react-redux";
+import { withRouter, RouteComponentProps } from "react-router-dom";
+import { Dispatch } from "redux";
+import { databaseNameCCAttr } from "src/util/constants";
+import { getMatchParamByName } from "src/util/query";
+import { AppState } from "../store";
+import { actions as databaseDetailsActions } from "../store/databaseDetails";
+import {
+  actions as localStorageActions,
+  LocalStorageKeys,
+} from "../store/localStorage";
+import { actions as tableDetailsActions } from "../store/databaseTableDetails";
+import {
+  DatabaseDetailsPage,
+  DatabaseDetailsPageActions,
+  DatabaseDetailsPageData,
+  ViewMode,
+} from "./databaseDetailsPage";
+import { actions as analyticsActions } from "../store/analytics";
+import { Filters } from "../queryFilter";
+import { nodeRegionsByIDSelector } from "../store/nodes";
+import { selectIsTenant } from "../store/uiConfig";
+import {
+  selectDatabaseDetailsGrantsSortSetting,
+  selectDatabaseDetailsTablesFiltersSetting,
+  selectDatabaseDetailsTablesSearchSetting,
+  selectDatabaseDetailsTablesSortSetting,
+  selectDatabaseDetailsViewModeSetting,
+} from "../store/databaseDetails/databaseDetails.selectors";
+import { combineLoadingErrors, deriveTableDetailsMemoized } from "../databases";
+import { selectIndexRecommendationsEnabled } from "../store/clusterSettings/clusterSettings.selectors";
+
+const mapStateToProps = (
+  state: AppState,
+  props: RouteComponentProps,
+): DatabaseDetailsPageData => {
+  const database = getMatchParamByName(props.match, databaseNameCCAttr);
+  const databaseDetails = state.adminUI.databaseDetails;
+  const dbTables =
+    databaseDetails[database]?.data?.results.tablesResp.tables || [];
+  const nodeRegions = nodeRegionsByIDSelector(state);
+  const isTenant = selectIsTenant(state);
+  return {
+    loading: !!databaseDetails[database]?.inFlight,
+    loaded: !!databaseDetails[database]?.valid,
+    lastError: combineLoadingErrors(
+      databaseDetails[database]?.lastError,
+      databaseDetails[database]?.data?.maxSizeReached,
+      null,
+    ),
+    name: database,
+    showNodeRegionsColumn: Object.keys(nodeRegions).length > 1 && !isTenant,
+    viewMode: selectDatabaseDetailsViewModeSetting(state),
+    sortSettingTables: selectDatabaseDetailsTablesSortSetting(state),
+    sortSettingGrants: selectDatabaseDetailsGrantsSortSetting(state),
+    filters: selectDatabaseDetailsTablesFiltersSetting(state),
+    search: selectDatabaseDetailsTablesSearchSetting(state),
+    nodeRegions,
+    isTenant,
+    tables: deriveTableDetailsMemoized({
+      dbName: database,
+      tables: dbTables,
+      tableDetails: state.adminUI?.tableDetails,
+      nodeRegions,
+      isTenant,
+    }),
+    showIndexRecommendations: selectIndexRecommendationsEnabled(state),
+  };
+};
+
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+): DatabaseDetailsPageActions => ({
+  refreshDatabaseDetails: (database: string) => {
+    dispatch(databaseDetailsActions.refresh(database));
+  },
+  refreshTableDetails: (database: string, table: string) => {
+    dispatch(tableDetailsActions.refresh({ database, table }));
+  },
+  onViewModeChange: (viewMode: ViewMode) => {
+    dispatch(
+      analyticsActions.track({
+        name: "View Mode Clicked",
+        page: "Database Details",
+        value: ViewMode[viewMode],
+      }),
+    );
+    dispatch(
+      localStorageActions.update({
+        key: LocalStorageKeys.DB_DETAILS_VIEW_MODE,
+        value: viewMode,
+      }),
+    );
+  },
+  onSortingTablesChange: (columnName: string, ascending: boolean) => {
+    dispatch(
+      analyticsActions.track({
+        name: "Column Sorted",
+        page: "Database Details",
+        tableName: "Database Details",
+        columnName,
+      }),
+    );
+    dispatch(
+      localStorageActions.update({
+        key: LocalStorageKeys.DB_DETAILS_TABLES_PAGE_SORT,
+        value: { columnTitle: columnName, ascending: ascending },
+      }),
+    );
+  },
+  onSortingGrantsChange: (columnName: string, ascending: boolean) => {
+    dispatch(
+      analyticsActions.track({
+        name: "Column Sorted",
+        page: "Database Details",
+        tableName: "Database Details",
+        columnName,
+      }),
+    );
+    dispatch(
+      localStorageActions.update({
+        key: LocalStorageKeys.DB_DETAILS_GRANTS_PAGE_SORT,
+        value: { columnTitle: columnName, ascending: ascending },
+      }),
+    );
+  },
+  onSearchComplete: (query: string) => {
+    dispatch(
+      analyticsActions.track({
+        name: "Keyword Searched",
+        page: "Database Details",
+      }),
+    );
+    dispatch(
+      localStorageActions.update({
+        key: LocalStorageKeys.DB_DETAILS_TABLES_PAGE_SEARCH,
+        value: query,
+      }),
+    );
+  },
+  onFilterChange: (filters: Filters) => {
+    dispatch(
+      analyticsActions.track({
+        name: "Filter Clicked",
+        page: "Database Details",
+        filterName: "filters",
+        value: filters.toString(),
+      }),
+    );
+    dispatch(
+      localStorageActions.update({
+        key: LocalStorageKeys.DB_DETAILS_TABLES_PAGE_FILTERS,
+        value: filters,
+      }),
+    );
+  },
+});
+
+export const ConnectedDatabaseDetailsPage = withRouter(
+  connect<
+    DatabaseDetailsPageData,
+    DatabaseDetailsPageActions,
+    RouteComponentProps
+  >(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(DatabaseDetailsPage),
+);

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React, { useContext } from "react";
+import React from "react";
 import { Link, RouteComponentProps } from "react-router-dom";
 import { Tooltip } from "antd";
 import "antd/lib/tooltip/style";
@@ -31,13 +31,20 @@ import {
   DATE_FORMAT,
   EncodeDatabaseTableUri,
   EncodeDatabaseUri,
+  EncodeUriName,
 } from "src/util/format";
-import { mvccGarbage, syncHistory, unique } from "../util";
+import {
+  getMatchParamByName,
+  mvccGarbage,
+  schemaNameAttr,
+  syncHistory,
+  unique,
+} from "../util";
 
 import styles from "./databaseDetailsPage.module.scss";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import { baseHeadingClasses } from "src/transactionsPage/transactionsPageClasses";
-import moment, { Moment } from "moment-timezone";
+import { Moment } from "moment-timezone";
 import { Caution } from "@cockroachlabs/icons";
 import { Anchor } from "../anchor";
 import LoadingError from "../sqlActivity/errorComponent";
@@ -52,8 +59,12 @@ import {
 import { UIConfigState } from "src/store";
 import { TableStatistics } from "src/tableStatistics";
 import { Timestamp, Timezone } from "../timestamp";
-import { DatabasesPageDataDatabase } from "../databasesPage";
-import { forEach } from "lodash";
+import {
+  DbDetailsBreadcrumbs,
+  IndexRecWithIconCell,
+  MVCCInfoCell,
+  TableNameCell,
+} from "./helperComponents";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -111,6 +122,7 @@ export interface DatabaseDetailsPageData {
   isTenant?: UIConfigState["isTenant"];
   viewMode: ViewMode;
   showNodeRegionsColumn?: boolean;
+  showIndexRecommendations: boolean;
 }
 
 export interface DatabaseDetailsPageDataTable {
@@ -517,24 +529,6 @@ export class DatabaseDetailsPage extends React.Component<
     }
   }
 
-  formatMVCCInfo = (
-    details: DatabaseDetailsPageDataTableDetails,
-  ): React.ReactElement => {
-    return (
-      <>
-        <p className={cx("multiple-lines-info")}>
-          {format.Percentage(details.livePercentage, 1, 1)}
-        </p>
-        <p className={cx("multiple-lines-info")}>
-          <span className={cx("bold")}>{format.Bytes(details.liveBytes)}</span>{" "}
-          live data /{" "}
-          <span className={cx("bold")}>{format.Bytes(details.totalBytes)}</span>
-          {" total"}
-        </p>
-      </>
-    );
-  };
-
   checkInfoAvailable = (
     error: Error,
     cell: React.ReactNode,
@@ -553,15 +547,7 @@ export class DatabaseDetailsPage extends React.Component<
             Tables
           </Tooltip>
         ),
-        cell: table => (
-          <Link
-            to={EncodeDatabaseTableUri(this.props.name, table.name)}
-            className={cx("icon__container")}
-          >
-            <DatabaseIcon className={cx("icon--s", "icon--primary")} />
-            {table.name}
-          </Link>
-        ),
+        cell: table => <TableNameCell table={table} dbDetails={this.props} />,
         sort: table => table.name,
         className: cx("database-table__col-name"),
         name: "name",
@@ -624,23 +610,16 @@ export class DatabaseDetailsPage extends React.Component<
           </Tooltip>
         ),
         cell: table => {
-          let cell;
-          if (table.details.hasIndexRecommendations) {
-            cell = (
-              <div className={cx("icon__container")}>
-                <Tooltip
-                  placement="bottom"
-                  title="This table has index recommendations. Click the table name to see more details."
-                >
-                  <Caution className={cx("icon--s", "icon--warning")} />
-                </Tooltip>
-                {table.details.indexCount}
-              </div>
-            );
-          } else {
-            cell = table.details.indexCount;
-          }
-          return this.checkInfoAvailable(table.lastError, cell);
+          return table.details.hasIndexRecommendations &&
+            this.props.showIndexRecommendations
+            ? this.checkInfoAvailable(
+                table.lastError,
+                <IndexRecWithIconCell table={table} />,
+              )
+            : this.checkInfoAvailable(
+                table.lastError,
+                table.details.indexCount,
+              );
         },
         sort: table => table.details.indexCount,
         className: cx("database-table__col-index-count"),
@@ -687,7 +666,7 @@ export class DatabaseDetailsPage extends React.Component<
         cell: table =>
           this.checkInfoAvailable(
             table.lastError,
-            this.formatMVCCInfo(table.details),
+            <MVCCInfoCell details={table.details} />,
           ),
         sort: table => table.details.livePercentage,
         className: cx("database-table__col-column-count"),
@@ -842,19 +821,7 @@ export class DatabaseDetailsPage extends React.Component<
     return (
       <div className="root table-area">
         <section className={baseHeadingClasses.wrapper}>
-          <Breadcrumbs
-            items={[
-              { link: "/databases", name: "Databases" },
-              {
-                link: EncodeDatabaseUri(this.props.name),
-                name: "Tables",
-              },
-            ]}
-            divider={
-              <CaretRight className={cx("icon--xxs", "icon--primary")} />
-            }
-          />
-
+          <DbDetailsBreadcrumbs dbName={this.props.name} />
           <h3
             className={`${baseHeadingClasses.tableName} ${cx(
               "icon__container",

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/helperComponents.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/helperComponents.tsx
@@ -1,0 +1,123 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useContext } from "react";
+import {
+  EncodeDatabaseTableUri,
+  EncodeDatabaseUri,
+  EncodeUriName,
+  getMatchParamByName,
+  schemaNameAttr,
+} from "../util";
+import { Link } from "react-router-dom";
+import { DatabaseIcon } from "../icon/databaseIcon";
+import {
+  DatabaseDetailsPageDataTable,
+  DatabaseDetailsPageDataTableDetails,
+  DatabaseDetailsPageProps,
+  ViewMode,
+} from "./databaseDetailsPage";
+import classNames from "classnames/bind";
+import styles from "./databaseDetailsPage.module.scss";
+import { Tooltip } from "antd";
+import "antd/lib/tooltip/style";
+import { Caution } from "@cockroachlabs/icons";
+import * as format from "../util/format";
+import { Breadcrumbs } from "../breadcrumbs";
+import { CaretRight } from "../icon/caretRight";
+import { CockroachCloudContext } from "../contexts";
+
+const cx = classNames.bind(styles);
+
+export const TableNameCell = ({
+  table,
+  dbDetails,
+}: {
+  table: DatabaseDetailsPageDataTable;
+  dbDetails: DatabaseDetailsPageProps;
+}): JSX.Element => {
+  const isCockroachCloud = useContext(CockroachCloudContext);
+  let linkURL = "";
+  if (isCockroachCloud) {
+    linkURL = `${location.pathname}/${EncodeUriName(
+      getMatchParamByName(dbDetails.match, schemaNameAttr),
+    )}/${EncodeUriName(table.name)}`;
+    if (dbDetails.viewMode === ViewMode.Grants) {
+      linkURL += `?viewMode=${ViewMode.Grants}`;
+    }
+  } else {
+    linkURL = EncodeDatabaseTableUri(dbDetails.name, table.name);
+    if (dbDetails.viewMode === ViewMode.Grants) {
+      linkURL += `?tab=grants`;
+    }
+  }
+  return (
+    <Link to={linkURL} className={cx("icon__container")}>
+      <DatabaseIcon className={cx("icon--s", "icon--primary")} />
+      {table.name}
+    </Link>
+  );
+};
+
+export const IndexRecWithIconCell = ({
+  table,
+}: {
+  table: DatabaseDetailsPageDataTable;
+}): JSX.Element => {
+  return (
+    <div className={cx("icon__container")}>
+      <Tooltip
+        placement="bottom"
+        title="This table has index recommendations. Click the table name to see more details."
+      >
+        <Caution className={cx("icon--s", "icon--warning")} />
+      </Tooltip>
+      {table.details.indexCount}
+    </div>
+  );
+};
+
+export const MVCCInfoCell = ({
+  details,
+}: {
+  details: DatabaseDetailsPageDataTableDetails;
+}): JSX.Element => {
+  return (
+    <>
+      <p className={cx("multiple-lines-info")}>
+        {format.Percentage(details.livePercentage, 1, 1)}
+      </p>
+      <p className={cx("multiple-lines-info")}>
+        <span className={cx("bold")}>{format.Bytes(details.liveBytes)}</span>{" "}
+        live data /{" "}
+        <span className={cx("bold")}>{format.Bytes(details.totalBytes)}</span>
+        {" total"}
+      </p>
+    </>
+  );
+};
+
+export const DbDetailsBreadcrumbs = ({ dbName }: { dbName: string }) => {
+  const isCockroachCloud = useContext(CockroachCloudContext);
+  return (
+    <Breadcrumbs
+      items={[
+        { link: "/databases", name: "Databases" },
+        {
+          link: isCockroachCloud
+            ? `/databases/${EncodeUriName(dbName)}`
+            : EncodeDatabaseUri(dbName),
+          name: "Tables",
+        },
+      ]}
+      divider={<CaretRight className={cx("icon--xxs", "icon--primary")} />}
+    />
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPageConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPageConnected.ts
@@ -43,7 +43,7 @@ import {
 } from "../store/clusterSettings/clusterSettings.selectors";
 import { deriveDatabaseDetailsMemoized } from "../databases";
 
-export const mapStateToProps = (state: AppState): DatabasesPageData => {
+const mapStateToProps = (state: AppState): DatabasesPageData => {
   const databasesListState = databasesListSelector(state);
   const nodeRegions = nodeRegionsByIDSelector(state);
   const isTenant = selectIsTenant(state);
@@ -70,9 +70,7 @@ export const mapStateToProps = (state: AppState): DatabasesPageData => {
   };
 };
 
-export const mapDispatchToProps = (
-  dispatch: Dispatch,
-): DatabasesPageActions => ({
+const mapDispatchToProps = (dispatch: Dispatch): DatabasesPageActions => ({
   refreshDatabases: () => {
     dispatch(databasesListActions.refresh());
   },

--- a/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
@@ -13,6 +13,7 @@ import { DOMAIN_NAME } from "../utils";
 
 type Page =
   | "Databases"
+  | "Database Details"
   | "Index Details"
   | "Jobs"
   | "Schema Insights"
@@ -110,6 +111,12 @@ type TimeScaleChangeEvent = {
   value: string;
 };
 
+type ViewModeEvent = {
+  name: "View Mode Clicked";
+  page: Page;
+  value: string;
+};
+
 type AnalyticsEvent =
   | ApplySearchCriteriaEvent
   | BackButtonClick
@@ -124,7 +131,8 @@ type AnalyticsEvent =
   | StatementClicked
   | StatementDiagnosticEvent
   | TabChangedEvent
-  | TimeScaleChangeEvent;
+  | TimeScaleChangeEvent
+  | ViewModeEvent;
 
 const PREFIX = `${DOMAIN_NAME}/analytics`;
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.selectors.ts
@@ -1,0 +1,38 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { localStorageSelector } from "../utils/selectors";
+import { LocalStorageKeys } from "../localStorage";
+import { AppState } from "../reducers";
+
+export const selectDatabaseDetailsViewModeSetting = (state: AppState) => {
+  const localStorage = localStorageSelector(state);
+  return localStorage[LocalStorageKeys.DB_DETAILS_VIEW_MODE];
+};
+
+export const selectDatabaseDetailsTablesSortSetting = (state: AppState) => {
+  const localStorage = localStorageSelector(state);
+  return localStorage[LocalStorageKeys.DB_DETAILS_TABLES_PAGE_SORT];
+};
+
+export const selectDatabaseDetailsGrantsSortSetting = (state: AppState) => {
+  const localStorage = localStorageSelector(state);
+  return localStorage[LocalStorageKeys.DB_DETAILS_GRANTS_PAGE_SORT];
+};
+
+export const selectDatabaseDetailsTablesFiltersSetting = (state: AppState) => {
+  const localStorage = localStorageSelector(state);
+  return localStorage[LocalStorageKeys.DB_DETAILS_TABLES_PAGE_FILTERS];
+};
+
+export const selectDatabaseDetailsTablesSearchSetting = (state: AppState) => {
+  const localStorage = localStorageSelector(state);
+  return localStorage[LocalStorageKeys.DB_DETAILS_TABLES_PAGE_SEARCH];
+};

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2023 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,5 +8,5 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./databaseDetailsPage";
-export * from "./databaseDetailsConnected";
+export * from "./tableDetails.reducer";
+export * from "./tableDetails.saga";

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/tableDetails.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/tableDetails.reducer.ts
@@ -1,0 +1,79 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  ErrorWithKey,
+  SqlApiResponse,
+  TableDetailsReqParams,
+  TableDetailsResponse,
+} from "../../api";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { DOMAIN_NAME } from "../utils";
+import { generateTableID } from "../../util";
+
+type TableDetailsWithKey = {
+  tableDetailsResponse: SqlApiResponse<TableDetailsResponse>;
+  key: string;
+};
+
+export type TableDetailsState = {
+  data?: SqlApiResponse<TableDetailsResponse>;
+  // Captures thrown errors.
+  lastError?: Error;
+  valid: boolean;
+  inFlight: boolean;
+};
+
+export type KeyedTableDetailsState = {
+  [tableID: string]: TableDetailsState;
+};
+
+const initialState: KeyedTableDetailsState = {};
+
+const tableDetailsReducer = createSlice({
+  name: `${DOMAIN_NAME}/tableDetails`,
+  initialState,
+  reducers: {
+    received: (state, action: PayloadAction<TableDetailsWithKey>) => {
+      state[action.payload.key] = {
+        valid: true,
+        inFlight: false,
+        data: action.payload.tableDetailsResponse,
+        lastError: null,
+      };
+    },
+    failed: (state, action: PayloadAction<ErrorWithKey>) => {
+      state[action.payload.key] = {
+        valid: false,
+        inFlight: false,
+        data: null,
+        lastError: action.payload.err,
+      };
+    },
+    refresh: (state, action: PayloadAction<TableDetailsReqParams>) => {
+      state[generateTableID(action.payload.database, action.payload.table)] = {
+        valid: false,
+        inFlight: true,
+        data: null,
+        lastError: null,
+      };
+    },
+    request: (state, action: PayloadAction<TableDetailsReqParams>) => {
+      state[generateTableID(action.payload.database, action.payload.table)] = {
+        valid: false,
+        inFlight: true,
+        data: null,
+        lastError: null,
+      };
+    },
+  },
+});
+
+export const { reducer, actions } = tableDetailsReducer;

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/tableDetails.saga.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/tableDetails.saga.spec.ts
@@ -1,0 +1,154 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { PayloadAction } from "@reduxjs/toolkit";
+import {
+  EffectProviders,
+  StaticProvider,
+  throwError,
+} from "redux-saga-test-plan/providers";
+import * as matchers from "redux-saga-test-plan/matchers";
+import { expectSaga } from "redux-saga-test-plan";
+import ZoneConfig = cockroach.config.zonepb.ZoneConfig;
+import ZoneConfigurationLevel = cockroach.server.serverpb.ZoneConfigurationLevel;
+import {
+  TableDetailsResponse,
+  getTableDetails,
+  SqlApiResponse,
+  TableDetailsReqParams,
+} from "../../api";
+import {
+  refreshTableDetailsSaga,
+  requestTableDetailsSaga,
+} from "./tableDetails.saga";
+import {
+  actions,
+  KeyedTableDetailsState,
+  reducer,
+} from "./tableDetails.reducer";
+import moment from "moment";
+import { generateTableID } from "../../util";
+
+describe("TableDetails sagas", () => {
+  const database = "test_db";
+  const table = "test_table";
+  const key = generateTableID(database, table);
+  const requestAction: PayloadAction<TableDetailsReqParams> = {
+    payload: { database, table },
+    type: "request",
+  };
+  const tableDetailsResponse: SqlApiResponse<TableDetailsResponse> = {
+    maxSizeReached: false,
+    results: {
+      idResp: { table_id: "mock_table_id" },
+      createStmtResp: { create_statement: "CREATE TABLE test_table (num int)" },
+      grantsResp: {
+        grants: [
+          {
+            user: "test_user",
+            privileges: ["privilege1", "privilege2", "privilege3"],
+          },
+          {
+            user: "another_user",
+            privileges: ["privilege1", "privilege4", "privilege7"],
+          },
+        ],
+      },
+      schemaDetails: {
+        columns: ["col1", "col2", "col3"],
+        indexes: ["idx1", "idx2", "idx3"],
+      },
+      zoneConfigResp: {
+        configure_zone_statement: "",
+        zone_config: new ZoneConfig({
+          inherited_constraints: true,
+          inherited_lease_preferences: true,
+        }),
+        zone_config_level: ZoneConfigurationLevel.CLUSTER,
+      },
+      heuristicsDetails: { stats_last_created_at: moment() },
+      stats: {
+        spanStats: {
+          approximate_disk_bytes: 400,
+          live_bytes: 30,
+          total_bytes: 40,
+          range_count: 50,
+          live_percentage: 75,
+        },
+        replicaData: {
+          nodeIDs: [1, 2, 3],
+          nodeCount: 3,
+          replicaCount: 3,
+        },
+        indexStats: {
+          has_index_recommendations: false,
+        },
+      },
+    },
+  };
+
+  const tableDetailsAPIProvider: (EffectProviders | StaticProvider)[] = [
+    [matchers.call.fn(getTableDetails), tableDetailsResponse],
+  ];
+
+  describe("refreshTableDetailsSaga", () => {
+    it("dispatches request TableDetails action", () => {
+      return expectSaga(refreshTableDetailsSaga, requestAction)
+        .put(actions.request(requestAction.payload))
+        .run();
+    });
+  });
+
+  describe("requestTableDetailsSaga", () => {
+    it("successfully requests table details", () => {
+      return expectSaga(requestTableDetailsSaga, requestAction)
+        .provide(tableDetailsAPIProvider)
+        .put(
+          actions.received({
+            tableDetailsResponse,
+            key,
+          }),
+        )
+        .withReducer(reducer)
+        .hasFinalState<KeyedTableDetailsState>({
+          [key]: {
+            data: tableDetailsResponse,
+            lastError: null,
+            valid: true,
+            inFlight: false,
+          },
+        })
+        .run();
+    });
+
+    it("returns error on failed request", () => {
+      const error = new Error("Failed request");
+      return expectSaga(requestTableDetailsSaga, requestAction)
+        .provide([[matchers.call.fn(getTableDetails), throwError(error)]])
+        .put(
+          actions.failed({
+            err: error,
+            key,
+          }),
+        )
+        .withReducer(reducer)
+        .hasFinalState<KeyedTableDetailsState>({
+          [key]: {
+            data: null,
+            lastError: error,
+            valid: false,
+            inFlight: false,
+          },
+        })
+        .run();
+    });
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/tableDetails.saga.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/tableDetails.saga.ts
@@ -1,0 +1,50 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { all, call, put, takeLatest } from "redux-saga/effects";
+
+import { actions } from "./tableDetails.reducer";
+import { ErrorWithKey, getTableDetails, TableDetailsReqParams } from "src/api";
+import moment from "moment";
+import { PayloadAction } from "@reduxjs/toolkit";
+import { generateTableID } from "../../util";
+
+export function* refreshTableDetailsSaga(
+  action: PayloadAction<TableDetailsReqParams>,
+) {
+  yield put(actions.request(action.payload));
+}
+
+export function* requestTableDetailsSaga(
+  action: PayloadAction<TableDetailsReqParams>,
+): any {
+  const key = generateTableID(action.payload.database, action.payload.table);
+  try {
+    const result = yield call(
+      getTableDetails,
+      action.payload,
+      moment.duration(10, "m"),
+    );
+    yield put(actions.received({ key, tableDetailsResponse: result }));
+  } catch (e) {
+    const err: ErrorWithKey = {
+      err: e,
+      key,
+    };
+    yield put(actions.failed(err));
+  }
+}
+
+export function* tableDetailsSaga() {
+  yield all([
+    takeLatest(actions.refresh, refreshTableDetailsSaga),
+    takeLatest(actions.request, requestTableDetailsSaga),
+  ]);
+}

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -17,7 +17,7 @@ import {
   SqlStatsSortType,
   DEFAULT_STATS_REQ_OPTIONS,
 } from "src/api/statementsApi";
-import { ViewMode } from "../../databaseDetailsPage";
+import { ViewMode } from "src/databaseDetailsPage/databaseDetailsPage";
 
 type SortSetting = {
   ascending: boolean;
@@ -63,6 +63,8 @@ export type LocalStorageState = {
   "sortSetting/InsightsPage": SortSetting;
   "sortSetting/SchemaInsightsPage": SortSetting;
   [LocalStorageKeys.DB_SORT]: SortSetting;
+  [LocalStorageKeys.DB_DETAILS_TABLES_PAGE_SORT]: SortSetting;
+  [LocalStorageKeys.DB_DETAILS_GRANTS_PAGE_SORT]: SortSetting;
   "filters/ActiveStatementsPage": Filters;
   "filters/ActiveTransactionsPage": Filters;
   "filters/StatementsPage": Filters;
@@ -71,16 +73,14 @@ export type LocalStorageState = {
   "filters/SessionsPage": Filters;
   "filters/InsightsPage": WorkloadInsightEventFilters;
   "filters/SchemaInsightsPage": Filters;
+  [LocalStorageKeys.DB_DETAILS_TABLES_PAGE_FILTERS]: Filters;
   "search/StatementsPage": string;
   "search/TransactionsPage": string;
   [LocalStorageKeys.DB_SEARCH]: string;
+  [LocalStorageKeys.DB_DETAILS_TABLES_PAGE_SEARCH]: string;
   "typeSetting/JobsPage": number;
   "statusSetting/JobsPage": string;
   "showSetting/JobsPage": string;
-  [LocalStorageKeys.DB_DETAILS_TABLES_PAGE_SORT]: SortSetting;
-  [LocalStorageKeys.DB_DETAILS_TABLES_PAGE_FILTERS]: Filters;
-  [LocalStorageKeys.DB_DETAILS_TABLES_PAGE_SEARCH]: string;
-  [LocalStorageKeys.DB_DETAILS_GRANTS_PAGE_SORT]: SortSetting;
   [LocalStorageKeys.DB_DETAILS_VIEW_MODE]: ViewMode;
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
@@ -72,6 +72,10 @@ import {
   KeyedDatabaseDetailsState,
   reducer as databaseDetails,
 } from "./databaseDetails";
+import {
+  KeyedTableDetailsState,
+  reducer as tableDetails,
+} from "./databaseTableDetails/tableDetails.reducer";
 
 export type AdminUiState = {
   statementDiagnostics: StatementDiagnosticsState;
@@ -90,6 +94,7 @@ export type AdminUiState = {
   clusterLocks: ClusterLocksReqState;
   databasesList: DatabasesListState;
   databaseDetails: KeyedDatabaseDetailsState;
+  tableDetails: KeyedTableDetailsState;
   stmtInsights: StmtInsightsState;
   txnInsightDetails: TxnInsightDetailsCachedState;
   txnInsights: TxnInsightsState;
@@ -122,6 +127,7 @@ export const reducers = combineReducers<AdminUiState>({
   clusterLocks,
   databasesList,
   databaseDetails,
+  tableDetails,
   schemaInsights,
   statementFingerprintInsights,
   clusterSettings,

--- a/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
@@ -34,6 +34,7 @@ import { statementFingerprintInsightsSaga } from "./insights/statementFingerprin
 import { txnStatsSaga } from "./transactionStats";
 import { clusterSettingsSaga } from "./clusterSettings/clusterSettings.saga";
 import { databaseDetailsSaga } from "./databaseDetails";
+import { tableDetailsSaga } from "./databaseTableDetails";
 
 export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
   yield all([
@@ -48,6 +49,7 @@ export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
     fork(jobSaga),
     fork(databasesListSaga),
     fork(databaseDetailsSaga),
+    fork(tableDetailsSaga),
     fork(sessionsSaga),
     fork(terminateSaga),
     fork(notifificationsSaga),

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -8,8 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { duration } from "moment-timezone";
-
 export const aggregatedTsAttr = "aggregated_ts";
 export const appAttr = "app";
 export const appNamesAttr = "appNames";
@@ -19,6 +17,7 @@ export const dashQueryString = "dash";
 export const dashboardNameAttr = "dashboard_name";
 export const databaseAttr = "database";
 export const databaseNameAttr = "database_name";
+export const databaseNameCCAttr = "databaseName";
 export const fingerprintIDAttr = "fingerprint_id";
 export const implicitTxnAttr = "implicitTxn";
 export const executionIdAttr = "execution_id";

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.spec.ts
@@ -8,25 +8,21 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import {
-  generateTableID,
-  databaseRequestPayloadToID,
-  tableRequestToID,
-} from "./apiReducers";
-import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
+import { databaseRequestPayloadToID, tableRequestToID } from "./apiReducers";
+import { api as clusterUiApi, util } from "@cockroachlabs/cluster-ui";
 
 describe("table id generator", function () {
   it("generates encoded db/table id", function () {
     const db = "&a.a.a/a.a/";
     const table = "/a.a/a.a.a&";
-    expect(generateTableID(db, table)).toEqual(
+    expect(util.generateTableID(db, table)).toEqual(
       encodeURIComponent(db) + "/" + encodeURIComponent(table),
     );
     expect(
-      decodeURIComponent(generateTableID(db, table).split("/")[0]),
+      decodeURIComponent(util.generateTableID(db, table).split("/")[0]),
     ).toEqual(db);
     expect(
-      decodeURIComponent(generateTableID(db, table).split("/")[1]),
+      decodeURIComponent(util.generateTableID(db, table).split("/")[1]),
     ).toEqual(table);
   });
 });
@@ -44,7 +40,7 @@ describe("request to string functions", function () {
       table,
     };
     expect(tableRequestToID(tableRequest)).toEqual(
-      generateTableID(database, table),
+      util.generateTableID(database, table),
     );
   });
 });

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -33,7 +33,8 @@ import { INodeStatus, RollupStoreMetrics } from "src/util/proto";
 import * as protos from "src/js/protos";
 import Long from "long";
 
-const { generateStmtDetailsToID, HexStringToInt64String } = util;
+const { generateStmtDetailsToID, HexStringToInt64String, generateTableID } =
+  util;
 
 const SessionsRequest = protos.cockroach.server.serverpb.ListSessionsRequest;
 
@@ -127,12 +128,6 @@ export const hotRangesReducerObj = new PaginatedCachedDataReducer(
 export const refreshDatabaseDetails = databaseDetailsReducerObj.refresh;
 
 export const refreshHotRanges = hotRangesReducerObj.refresh;
-
-// NOTE: We encode the db and table name so we can combine them as a string.
-// TODO(maxlang): there's probably a nicer way to do this
-export function generateTableID(db: string, table: string) {
-  return `${encodeURIComponent(db)}/${encodeURIComponent(table)}`;
-}
 
 export const tableRequestToID = (
   req:

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
@@ -149,6 +149,7 @@ describe("Database Details Page", function () {
       sortSettingTables: { ascending: true, columnTitle: "name" },
       sortSettingGrants: { ascending: true, columnTitle: "name" },
       tables: [],
+      showIndexRecommendations: false,
     });
   });
 
@@ -181,6 +182,7 @@ describe("Database Details Page", function () {
       nodeRegions: {},
       isTenant: false,
       showNodeRegionsColumn: false,
+      showIndexRecommendations: false,
       viewMode: ViewMode.Tables,
       sortSettingTables: { ascending: true, columnTitle: "name" },
       sortSettingGrants: { ascending: true, columnTitle: "name" },

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -9,22 +9,17 @@
 // licenses/APL.txt.
 
 import { RouteComponentProps } from "react-router";
-import { createSelector } from "reselect";
 import { LocalSetting } from "src/redux/localsettings";
-import _ from "lodash";
 import {
   DatabaseDetailsPageData,
   defaultFilters,
   Filters,
   ViewMode,
   combineLoadingErrors,
-  getNodesByRegionString,
-  normalizePrivileges,
-  normalizeRoles,
+  deriveTableDetailsMemoized,
 } from "@cockroachlabs/cluster-ui";
 
 import {
-  generateTableID,
   refreshDatabaseDetails,
   refreshTableDetails,
 } from "src/redux/apiReducers";
@@ -35,6 +30,7 @@ import {
   nodeRegionsByIDSelector,
   selectIsMoreThanOneNode,
 } from "src/redux/nodes";
+import { selectIndexRecommendationsEnabled } from "src/redux/clusterSettings";
 
 const sortSettingTablesLocalSetting = new LocalSetting(
   "sortSetting/DatabasesDetailsTablesPage",
@@ -69,107 +65,43 @@ const searchLocalTablesSetting = new LocalSetting(
   null,
 );
 
-export const mapStateToProps = createSelector(
-  (_state: AdminUIState, props: RouteComponentProps): string =>
-    getMatchParamByName(props.match, databaseNameAttr),
-
-  state => state.cachedData.databaseDetails,
-  state => state.cachedData.tableDetails,
-  state => nodeRegionsByIDSelector(state),
-  state => selectIsMoreThanOneNode(state),
-  state => viewModeLocalSetting.selector(state),
-  state => sortSettingTablesLocalSetting.selector(state),
-  state => sortSettingGrantsLocalSetting.selector(state),
-  state => filtersLocalTablesSetting.selector(state),
-  state => searchLocalTablesSetting.selector(state),
-  (_: AdminUIState) => isTenant,
-  (
-    database,
-    databaseDetails,
-    tableDetails,
+export const mapStateToProps = (
+  state: AdminUIState,
+  props: RouteComponentProps,
+): DatabaseDetailsPageData => {
+  const database = getMatchParamByName(props.match, databaseNameAttr);
+  const databaseDetails = state?.cachedData.databaseDetails;
+  const tableDetails = state?.cachedData.tableDetails;
+  const dbTables =
+    databaseDetails[database]?.data?.results.tablesResp.tables || [];
+  const nodeRegions = nodeRegionsByIDSelector(state);
+  return {
+    loading: !!databaseDetails[database]?.inFlight,
+    loaded: !!databaseDetails[database]?.valid,
+    lastError: combineLoadingErrors(
+      databaseDetails[database]?.lastError,
+      databaseDetails[database]?.data?.maxSizeReached,
+      null,
+    ),
+    name: database,
+    showNodeRegionsColumn: selectIsMoreThanOneNode(state),
+    viewMode: viewModeLocalSetting.selector(state),
+    sortSettingTables: sortSettingTablesLocalSetting.selector(state),
+    sortSettingGrants: sortSettingGrantsLocalSetting.selector(state),
+    filters: filtersLocalTablesSetting.selector(state),
+    search: searchLocalTablesSetting.selector(state),
     nodeRegions,
-    showNodeRegionsColumn,
-    viewMode,
-    sortSettingTables,
-    sortSettingGrants,
-    filtersLocalTables,
-    searchLocalTables,
     isTenant,
-  ): DatabaseDetailsPageData => {
-    return {
-      loading: !!databaseDetails[database]?.inFlight,
-      loaded: !!databaseDetails[database]?.valid,
-      lastError: combineLoadingErrors(
-        databaseDetails[database]?.lastError,
-        databaseDetails[database]?.data?.maxSizeReached,
-        null,
-      ),
-      name: database,
-      showNodeRegionsColumn,
-      viewMode,
-      sortSettingTables,
-      sortSettingGrants,
-      filters: filtersLocalTables,
-      search: searchLocalTables,
-      nodeRegions: nodeRegions,
-      isTenant: isTenant,
-      tables: _.map(
-        databaseDetails[database]?.data?.results.tablesResp.tables,
-        table => {
-          const tableId = generateTableID(database, table);
-          const details = tableDetails[tableId];
-
-          const roles = normalizeRoles(
-            _.map(details?.data?.results.grantsResp.grants, "user"),
-          );
-          const grants = normalizePrivileges(
-            _.flatMap(details?.data?.results.grantsResp.grants, "privileges"),
-          );
-          const nodes = details?.data?.results.stats.replicaData.nodeIDs || [];
-          const numIndexes = _.uniq(
-            details?.data?.results.schemaDetails.indexes,
-          ).length;
-          return {
-            name: table,
-            loading: !!details?.inFlight,
-            loaded: !!details?.valid,
-            lastError: details?.lastError,
-            details: {
-              columnCount:
-                details?.data?.results.schemaDetails.columns?.length || 0,
-              indexCount: numIndexes,
-              userCount: roles.length,
-              roles: roles,
-              grants: grants,
-              statsLastUpdated:
-                details?.data?.results.heuristicsDetails
-                  .stats_last_created_at || null,
-              hasIndexRecommendations:
-                details?.data?.results.stats.indexStats
-                  .has_index_recommendations || false,
-              totalBytes:
-                details?.data?.results.stats.spanStats.total_bytes || 0,
-              liveBytes: details?.data?.results.stats.spanStats.live_bytes || 0,
-              livePercentage:
-                details?.data?.results.stats.spanStats.live_percentage || 0,
-              replicationSizeInBytes:
-                details?.data?.results.stats.spanStats.approximate_disk_bytes ||
-                0,
-              nodes: nodes,
-              rangeCount:
-                details?.data?.results.stats.spanStats.range_count || 0,
-              nodesByRegionString: getNodesByRegionString(
-                nodes,
-                nodeRegions,
-                isTenant,
-              ),
-            },
-          };
-        },
-      ),
-    };
-  },
-);
+    tables: deriveTableDetailsMemoized({
+      dbName: database,
+      tables: dbTables,
+      tableDetails,
+      nodeRegions,
+      isTenant,
+    }),
+    showIndexRecommendations: selectIndexRecommendationsEnabled(state),
+  };
+};
 
 export const mapDispatchToProps = {
   refreshDatabaseDetails,

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -21,7 +21,6 @@ import {
 
 import { cockroach } from "src/js/protos";
 import {
-  generateTableID,
   refreshTableDetails,
   refreshNodes,
   refreshIndexStats,
@@ -71,8 +70,8 @@ export const mapStateToProps = createSelector(
     isTenant,
     hasAdminRole,
   ): DatabaseTablePageData => {
-    const details = tableDetails[generateTableID(database, table)];
-    const indexStats = indexUsageStats[generateTableID(database, table)];
+    const details = tableDetails[util.generateTableID(database, table)];
+    const indexStats = indexUsageStats[util.generateTableID(database, table)];
     const lastReset = util.TimestampToMoment(indexStats?.data?.last_reset);
     const indexStatsData = _.flatMap(
       indexStats?.data?.statistics,

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
@@ -23,7 +23,6 @@ import {
   indexNameAttr,
 } from "src/util/constants";
 import {
-  generateTableID,
   refreshIndexStats,
   refreshNodes,
   refreshUserSQLRoles,
@@ -63,10 +62,10 @@ export const mapStateToProps = createSelector(
     hasAdminRole,
     timeScale,
   ): IndexDetailsPageData => {
-    const stats = indexStats[generateTableID(database, table)];
-    const details = stats?.data?.statistics.filter(
-      stat => stat.index_name === index, // index names must be unique for a table
-    )[0];
+    const stats = indexStats[util.generateTableID(database, table)];
+    const details = stats?.data?.statistics.find(
+      stat => stat.index_name === index,
+    );
     const filteredIndexRecommendations =
       stats?.data?.index_recommendations.filter(
         indexRec => indexRec.index_id === details?.statistics.key.index_id,


### PR DESCRIPTION
Backport 1/1 commits from #104168.

/cc @cockroachdb/release

---

Resolves: https://github.com/cockroachdb/cockroach/issues/97885 
Related to: https://github.com/cockroachdb/cockroach/pull/103979
Consumed by: https://github.com/cockroachlabs/managed-service/pull/13230

** DEMOS **
CC: https://www.loom.com/share/58af04f5fe1e42a6b89db7a2bd8054d0
DB: https://www.loom.com/share/ea344d07be804fb7a020d0c3d83f497f

This PR adds a connected component for the database details page on
cluster-ui to be used on CC console. Similar to the PR for the connected
databases page, we move some common selector/combiner logic between the
two connected components (for db/cc console) into cluster-ui for reuse.

We add the table details state as well to cluster-ui, making use of the
existing tableDetailsApi using sql-over-http.

Some notable changes with the existing database details page on CC console:
- We lose the delete and edit action modals, allowing users to edit/delete their database from the console
- We lose access to FGAC privileges
- We lose CC console feature flags such as `multiRegionServerlessEnabled` which are currently used to gate the `Regions` column (this is `Node/Regions` on DB console). In this PR, we instead gate the `Node/Regions` column if the user is a tenant (or when there is only 1 region).

Release note: None

Release justification: low risk high benefit changes