### PR TITLE
ui: adjust labels for SQL Connection Rate chart

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -54,12 +54,12 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Created SQL Connections"
+      title="SQL Connection Rate"
       isKvGraph={false}
       sources={nodeSources}
-      tooltip={`Counter of the number of SQL connections created ${tooltipSelection}`}
+      tooltip={`Rate of SQL connection attempts ${tooltipSelection}`}
     >
-      <Axis label="connections">
+      <Axis label="connections per second">
         {_.map(nodeIDs, node => (
           <Metric
             key={node}


### PR DESCRIPTION
informs https://github.com/cockroachdb/cockroach/issues/93486

This chart was recently added, but the labels did not make it clear what it was showing. Now it's a bit more precise.

Release note: None