### PR TITLE
release-23.1: bump cluster-ui version to 23.1.3

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.1.2",
+  "version": "23.1.3",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
ui: bump cluster-ui version to 23.1.3
Version bump includes cluster-ui connected component for the databases
page, to be used on managed-service.

Epic: None
Release note: None
Release justification: low risk, high benefit changes