### PR TITLE
schemafeed: Fix initialization race in schema feed fast path

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -246,8 +246,6 @@ func (tf *schemaFeed) init() error {
 		return errors.AssertionFailedf("SchemaFeed started more than once")
 	}
 	tf.mu.started = true
-	tf.mu.allTableVersions1 = make(map[descpb.ID]descpb.DescriptorVersion)
-	tf.mu.allTableVersions2 = make(map[descpb.ID]descpb.DescriptorVersion)
 	return nil
 }
 
@@ -481,6 +479,11 @@ func (tf *schemaFeed) pauseOrResumePolling(
 	if atOrBefore.LessEq(tf.mu.highWater) {
 		// `atOrBefore` warrants a fast path already, with polling paused or not.
 		return atOrBefore, nil
+	}
+
+	if tf.mu.allTableVersions1 == nil {
+		tf.mu.allTableVersions1 = make(map[descpb.ID]descpb.DescriptorVersion)
+		tf.mu.allTableVersions2 = make(map[descpb.ID]descpb.DescriptorVersion)
 	}
 
 	// Always start with a stance to resume polling until we've proved otherwise.


### PR DESCRIPTION
Fix an initialization race introduced by https://github.com/cockroachdb/cockroach/pull/101694 where schema feed may attempt to access uninitialized maps. This race is possible since schema feed Run method (which formerly initialized those maps) runs on a separate go routine.

Fixes #104912

Release note (enterprise change): Fix an initialization race in changefeed schema feed code which may result in null pointer exception.