### PR TITLE
opt: fix ambiguous column error for computed column expressions

### DIFF
--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -725,6 +725,16 @@ func (mb *mutationBuilder) addSynthesizedComputedCols(colIDs opt.OptionalColList
 			continue
 		}
 
+		// Create a new scope for resolving column references in computed column
+		// expressions. We cannot use mb.outScope because columns in that scope
+		// may be ambiguous, by design. We build a scope that contains a single
+		// column for each column in the target table, representing either an
+		// existing value (a column from mb.fetchColIDs) or a new value (a
+		// column from mb.upsertColIDs, mb.updateColIDs, or mb.insertColIDs).
+		if !pb.HasResolveScope() {
+			pb.SetResolveScope(mb.computedColumnScope())
+		}
+
 		tabColID := mb.tabID.ColumnID(i)
 		expr := mb.parseComputedExpr(tabColID)
 
@@ -909,6 +919,39 @@ func (mb *mutationBuilder) projectPartialIndexColsImpl(putScope, delScope *scope
 		mb.b.constructProjectForScope(mb.outScope, projectionScope)
 		mb.outScope = projectionScope
 	}
+}
+
+// computedColumnScope returns a new scope that can be used to build computed
+// column expressions. Columns will never be ambiguous because each column in
+// the returned scope maps to a single column in the target table.
+//
+// The columns included in the scope depend on the state of mb.upsertColIDs,
+// mb.updateColIDs, mb.fetchColIDs, and mb.insertColIDs, using the same order of
+// preference as disambiguateColumns (see mapToReturnColID). Therefore, this
+// function will return different scopes at different stages of building a
+// mutation statement. For example, when building the scan portion of an UPDATE,
+// the scope will include columns from mb.fetchColIDs, while it will include
+// columns from mb.updateColIDs or mb.fetchColIDs when building the SET portion
+// of an UPDATE.
+func (mb *mutationBuilder) computedColumnScope() *scope {
+	s := mb.b.allocScope()
+	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
+		colID := mb.mapToReturnColID(i)
+		if colID == 0 {
+			continue
+		}
+		col := mb.outScope.getColumn(colID)
+		if col == nil {
+			panic(errors.AssertionFailedf("expected to find column %d in scope", colID))
+		}
+		targetCol := mb.tab.Column(i)
+		s.cols = append(s.cols, scopeColumn{
+			name: scopeColName(targetCol.ColName()),
+			typ:  col.typ,
+			id:   col.id,
+		})
+	}
+	return s
 }
 
 // disambiguateColumns ranges over the scope and ensures that at most one column

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -365,13 +365,34 @@ func (b *Builder) finishBuildScalarRef(
 //
 // Note that this is all a cheap no-op if Add is not called.
 type projectionBuilder struct {
-	b        *Builder
-	inScope  *scope
+	b *Builder
+	// inScope is the scope of the expression to build a projection on top of.
+	inScope *scope
+	// resolveScope is the scope used to resolve column references in projection
+	// expressions. If resolveScope is nil, then inScope is used to resolve
+	// column references.
+	resolveScope *scope
+	// outScope is the scope of the resulting projection.
 	outScope *scope
 }
 
 func makeProjectionBuilder(b *Builder, inScope *scope) projectionBuilder {
 	return projectionBuilder{b: b, inScope: inScope}
+}
+
+// HasResolveScope returns true if a scope other than the inScope has been
+// provided.
+func (pb *projectionBuilder) HasResolveScope() bool {
+	return pb.resolveScope != nil
+}
+
+// SetResolveScope replaces inScope for resolving column references in
+// projection expressions.
+func (pb *projectionBuilder) SetResolveScope(resolveScope *scope) {
+	if pb.HasResolveScope() {
+		panic(errors.AssertionFailedf("expected resolveScope to be nil"))
+	}
+	pb.resolveScope = resolveScope
 }
 
 // Add a projection.
@@ -386,9 +407,13 @@ func (pb *projectionBuilder) Add(
 		pb.outScope = pb.inScope.replace()
 		pb.outScope.appendColumnsFromScope(pb.inScope)
 	}
-	typedExpr := pb.inScope.resolveType(expr, desiredType)
+	resolveScope := pb.inScope
+	if pb.HasResolveScope() {
+		resolveScope = pb.resolveScope
+	}
+	typedExpr := resolveScope.resolveType(expr, desiredType)
 	scopeCol := pb.outScope.addColumn(name, typedExpr)
-	scalar := pb.b.buildScalar(typedExpr, pb.inScope, pb.outScope, scopeCol, nil)
+	scalar := pb.b.buildScalar(typedExpr, resolveScope, pb.outScope, scopeCol, nil)
 
 	return scopeCol.id, scalar
 }

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -572,6 +572,78 @@ UPDATE SET a=5
 ----
 error (42703): column "unknown" does not exist
 
+exec-ddl
+CREATE TABLE t102909 (
+  id INT PRIMARY KEY,
+  a INT NULL DEFAULT 1,
+  b INT NULL,
+  c INT GENERATED ALWAYS AS (a+b) STORED
+)
+----
+
+# Regression test for #102909. The reference to column a in the computed column
+# expression should not be ambiguous when building the expression in a Project.
+build
+INSERT INTO t102909(id) VALUES (0) ON CONFLICT (id) DO UPDATE SET b = 1
+----
+upsert t102909
+ ├── arbiter indexes: t102909_pkey
+ ├── columns: <none>
+ ├── canary column: id:11
+ ├── fetch columns: id:11 a:12 b:13 c:14
+ ├── insert-mapping:
+ │    ├── column1:7 => id:1
+ │    ├── a_default:8 => a:2
+ │    ├── b_default:9 => b:3
+ │    └── c_comp:10 => c:4
+ ├── update-mapping:
+ │    ├── upsert_b:20 => b:3
+ │    └── upsert_c:21 => c:4
+ └── project
+      ├── columns: upsert_id:18 upsert_a:19 upsert_b:20 upsert_c:21 column1:7!null a_default:8!null b_default:9 c_comp:10 id:11 a:12 b:13 c:14 crdb_internal_mvcc_timestamp:15 tableoid:16 c_comp:17
+      ├── project
+      │    ├── columns: c_comp:17 column1:7!null a_default:8!null b_default:9 c_comp:10 id:11 a:12 b:13 c:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:7!null a_default:8!null b_default:9 c_comp:10 id:11 a:12 b:13 c:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    ├── ensure-upsert-distinct-on
+      │    │    │    ├── columns: column1:7!null a_default:8!null b_default:9 c_comp:10
+      │    │    │    ├── grouping columns: column1:7!null
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: c_comp:10 column1:7!null a_default:8!null b_default:9
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: a_default:8!null b_default:9 column1:7!null
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:7!null
+      │    │    │    │    │    │    └── (0,)
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         ├── 1 [as=a_default:8]
+      │    │    │    │    │         └── NULL::INT8 [as=b_default:9]
+      │    │    │    │    └── projections
+      │    │    │    │         └── a_default:8 + b_default:9 [as=c_comp:10]
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=a_default:8]
+      │    │    │         │    └── a_default:8
+      │    │    │         ├── first-agg [as=b_default:9]
+      │    │    │         │    └── b_default:9
+      │    │    │         └── first-agg [as=c_comp:10]
+      │    │    │              └── c_comp:10
+      │    │    ├── scan t102909
+      │    │    │    ├── columns: id:11!null a:12 b:13 c:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── c:14
+      │    │    │    │         └── a:12 + b:13
+      │    │    │    └── flags: disabled not visible index feature
+      │    │    └── filters
+      │    │         └── column1:7 = id:11
+      │    └── projections
+      │         └── a:12 + a_default:8 [as=c_comp:17]
+      └── projections
+           ├── CASE WHEN id:11 IS NULL THEN column1:7 ELSE id:11 END [as=upsert_id:18]
+           ├── CASE WHEN id:11 IS NULL THEN a_default:8 ELSE a:12 END [as=upsert_a:19]
+           ├── CASE WHEN id:11 IS NULL THEN b_default:9 ELSE a_default:8 END [as=upsert_b:20]
+           └── CASE WHEN id:11 IS NULL THEN c_comp:10 ELSE c_comp:17 END [as=upsert_c:21]
+
+
 # ------------------------------------------------------------------------------
 # Test DO NOTHING.
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes a rare bug that caused "ambiguous column" errors for
`INSERT .. ON CONFLICT .. DO UPDATE` statements.

Consider the schema and statement:

    CREATE TABLE t (
      id INT PRIMARY KEY,
      a INT DEFAULT 1,
      b INT,
      c INT AS (a + b) STORED
    )

    INSERT INTO t(id) VALUES (0) ON CONFLICT (id) DO UPDATE SET b = 1

In the `SET` clause, an explicit reference to `a` is ambiguous. It could
be a reference to `t.a`, the `a` of the conflicting row(s), or it could
be a reference to `excluded.a`, the `a` of the insert row(s) from the
`VALUES` clause. If the `SET` clause contained `b = a`, the result would
be an "ambiguous column" error, which is correct and matches Postgres's
behavior.

With the `SET` clause as `b = 1`, there should be no ambiguity. However,
prior to this commit, ambiguity arose when building an implicit `SET`
expression to generate the new value for the computed column `c`. When
building `a + b`, we used the same scope used to build the `b = 1`
projection: the scope of the `SET` clause. Using this scope makes `a`
ambiguous, even though it always refers to `t.a` - the `a` of the
conflicting row(s).

Normally, this ambiguity is avoided by calling
`mutationBuilder.disambiguateColumns`, which is called before computed
column expressions are built. However, it's not effective in this
specific edge case where the new value of `b` and the default value of
`a` are the same expression, `1`. In this case, we conserve column IDs
by using the same ID for both, which prevents
`mutationBuilder.disambiguateColumns` from removing the ambiguity in the
`SET` clause scope.

The bug has been fixed by creating a new scope for resolving column
references in computed column expressions. The scope contains no columns
with duplicate names, so ambiguity is impossible.

I believe the long-term fix is to avoid using scopes when building these
synthesized expressions. I attempted to do this, but there are many
tricky edge cases to iron out and the change quickly grew beyond the
size of a comfortable backport. This future work is tracked by #61298.

Fixes #102909

Release note (bug fix): A bug has been fixed that caused
`INSERT .. ON CONFLICT .. DO UPDATE` queries to incorrectly result in an
"ambiguous column" error. The bug only presented if the target table had
a computed column with an expression referencing a column with a DEFAULT
value.
