### PR TITLE
release-22.2: kvserver: clarify `kv.raft_log.disable_synchronization_unsafe`

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -86,8 +86,9 @@ var testingDisableQuiescence = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_QUIES
 var disableSyncRaftLog = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.raft_log.disable_synchronization_unsafe",
-	"set to true to disable synchronization on Raft log writes to persistent storage. "+
-		"Setting to true risks data loss or data corruption on server crashes. "+
+	"disables synchronization of Raft log writes to persistent storage. "+
+		"Setting to true risks data loss or data corruption on process or OS crashes. "+
+		"This not only disables fsync, but also disables flushing writes to the OS buffer. "+
 		"The setting is meant for internal testing only and SHOULD NOT be used in production.",
 	false,
 )


### PR DESCRIPTION
Backport 1/1 commits from #104888.

/cc @cockroachdb/release

---

This setting not only disables fsync, it also disables flushing writes to the OS, so it will lose data even on process crashes.

Epic: none
Release note: None
