### PR TITLE
sql: update tenant_span builtins for consistent output

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/span_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/span_builtins
@@ -41,6 +41,20 @@ SELECT crdb_internal.tenant_span(2)
 
 subtest end
 
+subtest tenant_span_at_uint_boundary
+
+query T
+SELECT crdb_internal.pretty_key(crdb_internal.tenant_span(108)[2], 0)
+----
+/109
+
+query T
+SELECT crdb_internal.pretty_key(crdb_internal.tenant_span(109)[2], 0)
+----
+/110
+
+subtest end
+
 subtest table_span
 
 query T

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5428,19 +5428,8 @@ DO NOT USE -- USE 'CREATE TENANT' INSTEAD`,
 				if err != nil {
 					return nil, err
 				}
-				start := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(uint64(sTenID)))
-				end := start.PrefixEnd()
-
-				result := tree.NewDArray(types.Bytes)
-				if err := result.Append(tree.NewDBytes(tree.DBytes(start))); err != nil {
-					return nil, err
-				}
-
-				if err := result.Append(tree.NewDBytes(tree.DBytes(end))); err != nil {
-					return nil, err
-				}
-
-				return result, nil
+				codec := keys.MakeSQLCodec(roachpb.MustMakeTenantID(uint64(sTenID)))
+				return spanToDatum(codec.TenantSpan())
 			},
 			Info:       "This function returns the span that contains the keys for the given tenant.",
 			Volatility: volatility.Immutable,
@@ -5457,11 +5446,7 @@ DO NOT USE -- USE 'CREATE TENANT' INSTEAD`,
 				if err != nil {
 					return nil, err
 				}
-				start := keys.MakeTenantPrefix(tid)
-				return spanToDatum(roachpb.Span{
-					Key:    start,
-					EndKey: start.PrefixEnd(),
-				})
+				return spanToDatum(keys.MakeSQLCodec(tid).TenantSpan())
 			},
 			Info:       "This function returns the span that contains the keys for the given tenant.",
 			Volatility: volatility.Immutable,


### PR DESCRIPTION
The codec's TenantSpan() function was changed to avoid PrefixEnd(). Here, we update overloads of crdb_internal.tenant_span to all use TenantSpan() to avoid inconsistent output from different overloads.

Note, I don't believe that the use of PrefixEnd() in this function constituted a problem in our current usage as the only real use of this function was in calls to crdb_internal.fingerprint() or crdb_internal.scan() where the EndKey is only used as an upper-bound for iteration.

Informs #104928

Epic: none

Release note: None