### PR TITLE
release-22.2: ui: adjust labels for SQL Connection Rate chart

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -46,11 +46,11 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Created SQL Connections"
+      title="SQL Connection Rate"
       sources={nodeSources}
-      tooltip={`Counter of the number of SQL connections created ${tooltipSelection}`}
+      tooltip={`Rate of SQL connection attempts ${tooltipSelection}`}
     >
-      <Axis label="connections">
+      <Axis label="connections per second">
         {_.map(nodeIDs, node => (
           <Metric
             key={node}


### PR DESCRIPTION
Backport 1/1 commits from #104908.

/cc @cockroachdb/release

Release justification: clarify informational text

---

informs https://github.com/cockroachdb/cockroach/issues/93486

This chart was recently added, but the labels did not make it clear what it was showing. Now it's a bit more precise.

Release note: None
