### PR TITLE
build,ui: install optional dependencies for `db-console`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -297,7 +297,6 @@ npm_protos_repositories()
 npm_translate_lock(
     name = "npm_db_console",
     data = ["//pkg/ui/workspaces/db-console:package.json"],
-    no_optional = True,
     npmrc = "//pkg/ui:.npmrc.pnpm",
     pnpm_lock = "//pkg/ui/workspaces/db-console:pnpm-lock.yaml",
     update_pnpm_lock = True,


### PR DESCRIPTION
Work around this error:

```
[esbuild] Failed to find package "esbuild-darwin-arm64" on the file system

This can happen if you use the "--no-optional" flag. The "optionalDependencies"
package.json feature is used by esbuild to install the correct binary executable
for your current platform. This install script will now attempt to work around
this. If that fails, you need to remove the "--no-optional" flag to use esbuild.
```

Epic: none
Release note: None