### PR TITLE
ui: fix job details refresh when executing job

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -194,7 +194,8 @@ export class JobDetails extends React.Component<JobDetailsProps> {
   };
 
   render(): React.ReactElement {
-    const isLoading = this.props.jobRequest.inFlight;
+    const isLoading =
+      this.props.jobRequest.inFlight && !this.props.jobRequest.data;
     const error = this.props.jobRequest.error;
     const job = this.props.jobRequest.data;
     const nextRun = TimestampToMoment(job?.next_run);


### PR DESCRIPTION
Fixes: #103206

Previously, when a job was still executing, the job details page for that job would keep refreshing and the loading animation would interrupt the page, causing flickers. This commit fixes this bug to only show the loading animation when the `jobRequest` does not have data to show.

Loom: https://www.loom.com/share/498f5cfd236e4bb6aeaf9f27e9e5409b.

Release note (ui change): fix bug where the job details page would flicker between the job details and a loading animation when a job is still executing.