### PR TITLE
changefeedccl: add version gate to `SHOW CHANGEFEED JOBS`

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/changefeed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/changefeed
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local local-mixed-22.2-23.1
 
 statement ok
 CREATE TABLE t ()
@@ -49,3 +49,19 @@ user testuser
 
 statement error user testuser requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed
 CREATE CHANGEFEED FOR t INTO 'null://sink' with initial_scan='only'
+
+
+user root
+
+let $job_id
+SELECT job_id FROM [SHOW CHANGEFEED JOBS] WHERE user_name = 'testuser'
+
+query TT
+SELECT user_name, description FROM [SHOW CHANGEFEED JOB $job_id]
+----
+testuser CREATE CHANGEFEED FOR TABLE t INTO 'null://sink' WITH initial_scan = 'only'
+
+query TT
+SELECT user_name, description FROM [SHOW CHANGEFEED JOBS]
+----
+testuser CREATE CHANGEFEED FOR TABLE t INTO 'null://sink' WITH initial_scan = 'only'

--- a/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -13,7 +13,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 5,
+    shard_count = 6,
     tags = [
         "ccl_test",
         "cpu:1",

--- a/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/generated_test.go
@@ -72,6 +72,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_changefeed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "changefeed")
+}
+
 func TestCCLLogic_new_schema_changer(
 	t *testing.T,
 ) {

--- a/pkg/sql/delegate/BUILD.bazel
+++ b/pkg/sql/delegate/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/delegate",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/security/username",


### PR DESCRIPTION
On 23.1 binaries, `SHOW CHANGEFEED JOBS` queries `crdb_internal.system_jobs`, which was added in 23.1. In 22.2-23.1 mixed version clusters, this query fails.

This change adds a version gate such that before an upgrade to 23.1 is finalized, `SHOW CHANGEFEED JOBS` will query `system.jobs` instead.

This change also adds regression testing in the `changefeed` logic test, ensuring that it runs in a mixed version environment.

Release note (bug fix): `SHOW CHANGEFEED JOBS` no
longer fails on 22.2, 23.1 mixed version clusters.

Epic: None