### PR TITLE
build,ci: add a ci check to ensure SHA sums match

### DIFF
--- a/build/teamcity/cockroach/ci/tests/check_generated_code_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/check_generated_code_impl.sh
@@ -43,4 +43,8 @@ check_workspace_clean 'go_mod_tidy' "Run \`go mod tidy\` to automatically regene
 bazel run //pkg/cmd/generate-logictest -- -out-dir="$PWD"
 check_workspace_clean 'generate_logictest' "Run \`./dev gen testlogic\` to automatically regenerate these."
 
+# NB: If this step fails, then some checksum in the code is probably not
+# matching up to the "real" checksum for that artifact.
+bazel fetch @distdir//:archives
+
 end_check_generated_code_tests


### PR DESCRIPTION
`bazel fetch @distdir//:archives` fetches all the `distdir` files. This has the side effect of checking all SHA sums. In this way we're sure that nobody's mis-typed a SHA.

Epic: none
Release note: None