### PR TITLE
ui: add learn more to alert

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -589,7 +589,7 @@ export const upgradeNotFinalizedWarningSelector = createSelector(
     clusterVersion,
     upgradeNotFinalizedDismissed,
   ): Alert => {
-    if (upgradeNotFinalizedDismissed) {
+    if (upgradeNotFinalizedDismissed || !settings) {
       return undefined;
     }
     // Don't show this warning if nodes are on different versions, since there is
@@ -618,7 +618,9 @@ export const upgradeNotFinalizedWarningSelector = createSelector(
     return {
       level: AlertLevel.WARNING,
       title: "Upgrade not finalized.",
-      text: `All nodes are running on version ${nodesVersion}, but the cluster is on version ${clusterVersion}.`,
+      text: `All nodes are running on version ${nodesVersion}, but the cluster is on version ${clusterVersion}. 
+      Features might not be available in this state.`,
+      link: docsURL.upgradeTroubleshooting,
       dismiss: (dispatch: AppDispatch) => {
         dispatch(upgradeNotFinalizedDismissedSetting.set(true));
         return Promise.resolve();

--- a/pkg/ui/workspaces/db-console/src/util/docs.ts
+++ b/pkg/ui/workspaces/db-console/src/util/docs.ts
@@ -59,6 +59,7 @@ export let reviewOfCockroachTerminology: string;
 export let privileges: string;
 export let showSessions: string;
 export let sessionsTable: string;
+export let upgradeTroubleshooting: string;
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
 export const upgradeCockroachVersion =
@@ -132,6 +133,9 @@ export const recomputeDocsURLs = () => {
   uiDebugPages = docsURL("ui-debug-pages.html");
   readsAndWritesOverviewPage = docsURLNoVersion(
     "architecture/reads-and-writes-overview.html#important-concepts",
+  );
+  upgradeTroubleshooting = docsURL(
+    "upgrade-cockroach-version.html#troubleshooting",
   );
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/index.tsx
@@ -47,15 +47,19 @@ export class AlertBox extends React.Component<AlertBoxProps, {}> {
       </div>
     );
 
-    if (this.props.link) {
-      content = (
-        <a className="alert-box__link" href={this.props.link}>
+    const learnMore = this.props.link && (
+      <a className="" href={this.props.link}>
+        Learn More.
+      </a>
+    );
+    content = (
+      <>
+        <div className="alert-box__content">
           {content}
-        </a>
-      );
-    }
-
-    content = <div className="alert-box__content">{content}</div>;
+          {learnMore}
+        </div>
+      </>
+    );
 
     return (
       <div


### PR DESCRIPTION
Informs ##66987

Epic: None

Add Learn More link to not finalized alert.

<img width="1538" alt="Screenshot 2023-06-15 at 2 51 16 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/bf3fd501-df35-403b-aedd-866e1538521c">


Release note: None