### PR TITLE
sql: better expose non-critical errors during bundle collection

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -417,6 +417,10 @@ func (ih *instrumentationHelper) Finish(
 				ob.BuildString(), trace, placeholders, res.Err(), payloadErr, retErr,
 				&p.extendedEvalCtx.Settings.SV,
 			)
+			// Include all non-critical errors as warnings. Note that these
+			// error strings might contain PII, but the warnings are only shown
+			// to the current user and aren't included into the bundle.
+			warnings = append(warnings, bundle.errorStrings...)
 			bundle.insert(
 				ctx, ih.fingerprint, ast, cfg.StmtDiagnosticsRecorder, ih.diagRequestID, ih.diagRequest,
 			)


### PR DESCRIPTION
When we're collecting a statement bundle, we might encounter different non-critical errors (e.g. the user doesn't have the privilege to query cluster settings). These errors are benign and don't stop us from producing an incomplete but still useful bundle. This commit makes these errors more visible in two ways:
- all these errors are now included into `errors.txt` file (except when the redaction is enabled)
- all these errors are also now printed as the response to `EXPLAIN ANALYZE (DEBUG)` command in the SQL shell (i.e. they are shown as "warnings").

However, if the bundle is requested via the DB Console, then these errors are still somewhat hidden from the user. Improvement there will be addressed separately.

Addresses: #68523.
Epic: None

Release note: None