### PR TITLE
roachtest: revert skipping cdc tests locally on arm64

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -943,6 +944,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -970,6 +975,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -997,6 +1006,10 @@ func registerCDC(r registry.Registry) {
 		Tags:            registry.Tags("manual"),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1023,6 +1036,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1045,6 +1062,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1072,6 +1093,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1104,6 +1129,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1138,6 +1167,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1167,6 +1200,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1205,6 +1242,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1240,6 +1281,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1266,6 +1311,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1311,6 +1360,10 @@ func registerCDC(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
@@ -1348,6 +1401,10 @@ func registerCDC(r registry.Registry) {
 		RequiresLicense: true,
 		Timeout:         30 * time.Minute,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			runCDCBank(ctx, t, c)
 		},
 	})


### PR DESCRIPTION
After enabling metamorphic arm64 clusters, we used amd64 as a fallback for CDC tests, owing to [1]. However, when running _local_ roachtests on an arm64 host (e.g., graviton), amd64 emulation may not be available. Hence, we revert the original local skips until [1] is resolved.

[1] https://github.com/cockroachdb/cockroach/issues/103888

Epic: none
Fixes: #105003

Release note: None