### PR TITLE
server: add missing sort option

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -371,7 +371,8 @@ func isSortOptionOnActivityTable(sort serverpb.StatsSortOptions) bool {
 		serverpb.StatsSortOptions_CPU_TIME,
 		serverpb.StatsSortOptions_EXECUTION_COUNT,
 		serverpb.StatsSortOptions_P99_STMTS_ONLY,
-		serverpb.StatsSortOptions_CONTENTION_TIME:
+		serverpb.StatsSortOptions_CONTENTION_TIME,
+		serverpb.StatsSortOptions_PCT_RUNTIME:
 		return true
 	}
 	return false


### PR DESCRIPTION
Previously, the % of runtime was not on the list
of options from the Activity tables.
This commit adds to the list.

Part Of #104605

Release note: None