### PR TITLE
sql: add built-in functions for workload level index recommendations

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1436,6 +1436,14 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 <tr><td><a name="unnest"></a><code>unnest(anyelement[], anyelement[], anyelement[]...) &rarr; tuple{anyelement AS unnest, anyelement AS unnest, anyelement AS unnest}</code></td><td><span class="funcdesc"><p>Returns the input arrays as a set of rows</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="unnest"></a><code>unnest(input: anyelement[]) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="workload_index_recs"></a><code>workload_index_recs() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns set of index recommendations</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="workload_index_recs"></a><code>workload_index_recs(budget: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns set of index recommendations</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="workload_index_recs"></a><code>workload_index_recs(timestamptz: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns set of index recommendations</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="workload_index_recs"></a><code>workload_index_recs(timestamptz: <a href="timestamp.html">timestamptz</a>, budget: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns set of index recommendations</p>
 </span></td><td>Immutable</td></tr></tbody>
 </table>
 

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2432,6 +2432,13 @@ func TestTenantLogic_with(
 	runLogicTest(t, "with")
 }
 
+func TestTenantLogic_workload_indexrecs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "workload_indexrecs")
+}
+
 func TestTenantLogic_zero(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/workload_indexrecs
+++ b/pkg/sql/logictest/testdata/logic_test/workload_indexrecs
@@ -1,0 +1,32 @@
+# The returned data now is just dummy data
+# get workload index-recs
+query T nosort
+SELECT workload_index_recs();
+----
+1
+2
+3
+
+# get workload index-recs with time filter
+query T nosort
+SELECT workload_index_recs(now() - '2 weeks'::interval);
+----
+1
+2
+3
+
+# get workload index-recs with budget limit
+query T nosort
+SELECT workload_index_recs('42MB');
+----
+1
+2
+3
+
+# get workload index-recs with time filter and budget limit
+query T nosort
+SELECT workload_index_recs('2023-06-13 10:10:10-05:00', '58GiB');
+----
+1
+2
+3

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2389,6 +2389,13 @@ func TestLogic_with(
 	runLogicTest(t, "with")
 }
 
+func TestLogic_workload_indexrecs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "workload_indexrecs")
+}
+
 func TestLogic_zero(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2382,6 +2382,13 @@ func TestLogic_with(
 	runLogicTest(t, "with")
 }
 
+func TestLogic_workload_indexrecs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "workload_indexrecs")
+}
+
 func TestLogic_zero(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2410,6 +2410,13 @@ func TestLogic_with(
 	runLogicTest(t, "with")
 }
 
+func TestLogic_workload_indexrecs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "workload_indexrecs")
+}
+
 func TestLogic_zero(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2375,6 +2375,13 @@ func TestLogic_with(
 	runLogicTest(t, "with")
 }
 
+func TestLogic_workload_indexrecs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "workload_indexrecs")
+}
+
 func TestLogic_zero(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -2319,6 +2319,13 @@ func TestLogic_with(
 	runLogicTest(t, "with")
 }
 
+func TestLogic_workload_indexrecs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "workload_indexrecs")
+}
+
 func TestLogic_zero(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2403,6 +2403,13 @@ func TestLogic_with(
 	runLogicTest(t, "with")
 }
 
+func TestLogic_workload_indexrecs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "workload_indexrecs")
+}
+
 func TestLogic_zero(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2620,6 +2620,13 @@ func TestLogic_with(
 	runLogicTest(t, "with")
 }
 
+func TestLogic_workload_indexrecs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "workload_indexrecs")
+}
+
 func TestLogic_zero(
 	t *testing.T,
 ) {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2432,6 +2432,10 @@ var builtinOidsArray = []string{
 	2459: `nameconcatoid(name: string, oid: oid) -> name`,
 	2460: `pg_get_function_arg_default(func_oid: oid, arg_num: int4) -> string`,
 	2461: `crdb_internal.plpgsql_raise(severity: string, message: string, detail: string, hint: string, code: string) -> int`,
+	2462: `workload_index_recs() -> string`,
+	2463: `workload_index_recs(timestamptz: timestamptz) -> string`,
+	2464: `workload_index_recs(budget: string) -> string`,
+	2465: `workload_index_recs(timestamptz: timestamptz, budget: string) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
#### sql: add built-in functions for workload level index recommendations

This commit adds 4 generator built-in functions for workload level index
recommendations: workload_index_recs(), workload_index_recs(timestamptz:
TimestampTZ), workload_index_recs(budget: string) and
workload_index_recs(timestamptz: TimestampTZ, budget: string). The return types
of them are all a string column with multiple rows, one row for each index
recommendation.  The user can issue a command like `select
workload_index_recs(...);` and then get the index recommendations for the whole
workload.

Only those workload after the given timestamptz will be considered for the
index recommendations. If there is no timestamptz, all the workload stored in
`system.statement_statistics` will be taken into account. As for the budget, it
represents the space limit for the recommended indexes, e.g. 42GB, 580MiB.  If
it is specified, the workload index recommendation engine will prune the size
of all the indexes to satisfy the space constraint.

A method called workloadindexrec.FindWorkloadRecs() will be implemented to
return the array of indexRecs and error message for these 4 generator built-in
functions to invoke.

Release note: None

Epic: None