### PR TITLE
release-22.2: roachtest: revert skipping cdc tests locally on arm64

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -687,6 +688,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       1000,
@@ -705,6 +710,10 @@ func registerCDC(r registry.Registry) {
 		Tags:            []string{"manual"},
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       1000,
@@ -723,6 +732,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -741,6 +754,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -759,6 +776,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -782,6 +803,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType: ledgerWorkloadType,
 				// TODO(ssd): Range splits cause changefeed latencies to balloon
@@ -805,6 +830,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType: tpccWorkloadType,
 				// Sending data to Google Cloud Storage is a bit slower than sending to
@@ -828,6 +857,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       1,
@@ -856,6 +889,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       1,
@@ -885,6 +922,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				tpccWarehouseCount:       50,
 				workloadDuration:         "30m",
@@ -927,6 +968,10 @@ func registerCDC(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(1, spec.Arch(vm.ArchAMD64)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			runCDCKafkaAuth(ctx, t, c)
 		},
 	})
@@ -938,6 +983,10 @@ func registerCDC(r registry.Registry) {
 		RequiresLicense: true,
 		Timeout:         30 * time.Minute,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() && runtime.GOARCH == "arm64" {
+				// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
+				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/103888")
+			}
 			runCDCBank(ctx, t, c)
 		},
 	})


### PR DESCRIPTION
Backport 1/1 commits from #105014.

/cc @cockroachdb/release

---

After enabling metamorphic arm64 clusters, we used amd64 as a fallback for CDC tests, owing to [1]. However, when running _local_ roachtests on an arm64 host (e.g., graviton), amd64 emulation may not be available. Hence, we revert the original local skips until [1] is resolved.

[1] https://github.com/cockroachdb/cockroach/issues/103888

Epic: none
Fixes: #105003

Release note: None
Release justification: test/ci only change
