### PR TITLE
release-23.1: ui: exclude "Idle" status from active statements view

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/execTableCommon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/execTableCommon.tsx
@@ -115,7 +115,11 @@ export const executionsTableTitles: ExecutionsTableTitleType = {
           "Preparing", the ${execType} is being parsed and planned.
           If "Executing", the ${execType} is currently being
           executed. If "Waiting", the ${execType} is currently
-          experiencing contention.`}
+          experiencing contention. ${
+            execType === "transaction"
+              ? `If "Idle", the transaction is open but is not currently executing a statement.`
+              : ``
+          }`}
         </p>
       }
     >

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsPage.selectors.ts
@@ -20,7 +20,6 @@ import {
 import {
   selectRecentStatements,
   selectAppName,
-  selectExecutionStatus,
   selectClusterLocksMaxApiSizeReached,
 } from "src/selectors/recentExecutions.selectors";
 import { actions as localStorageActions } from "src/store/localStorage";
@@ -56,7 +55,6 @@ export const mapStateToRecentStatementsPageProps = (
   selectedColumns: selectColumns(state),
   sortSetting: selectSortSetting(state),
   filters: selectFilters(state),
-  executionStatus: selectExecutionStatus(),
   internalAppNamePrefix: selectAppName(state),
   isTenant: selectIsTenant(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsView.tsx
@@ -18,7 +18,11 @@ import {
 import { Loading } from "src/loading/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
 import { Search } from "src/search/search";
-import { RecentStatement, RecentStatementFilters } from "src/recentExecutions";
+import {
+  RecentStatement,
+  RecentStatementFilters,
+  ExecutionStatus,
+} from "src/recentExecutions";
 import { Filter } from "src/queryFilter";
 import LoadingError from "src/sqlActivity/errorComponent";
 import {
@@ -56,7 +60,6 @@ export type RecentStatementsViewStateProps = {
   sortSetting: SortSetting;
   sessionsError: Error | null;
   filters: RecentStatementFilters;
-  executionStatus: string[];
   internalAppNamePrefix: string;
   isTenant?: boolean;
   maxSizeApiReached?: boolean;
@@ -75,7 +78,6 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
   statements,
   sessionsError,
   filters,
-  executionStatus,
   internalAppNamePrefix,
   isTenant,
   maxSizeApiReached,
@@ -170,6 +172,10 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
   const apps = getAppsFromRecentExecutions(statements, internalAppNamePrefix);
   const countActiveFilters = calculateActiveFilters(filters);
 
+  // The "Idle" execution status does not apply to statements.
+  const executionStatuses = Object.values(ExecutionStatus).filter(
+    status => status != ExecutionStatus.Idle,
+  );
   const filteredStatements = filterRecentStatements(
     statements,
     filters,
@@ -198,7 +204,7 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
           <Filter
             activeFilters={countActiveFilters}
             onSubmitFilters={onSubmitFilters}
-            executionStatuses={executionStatus.sort()}
+            executionStatuses={executionStatuses}
             showExecutionStatus={true}
             appNames={apps}
             filters={filters}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/recentTransactionsPage.selectors.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/recentTransactionsPage.selectors.tsx
@@ -20,7 +20,6 @@ import {
 import {
   selectAppName,
   selectRecentTransactions,
-  selectExecutionStatus,
   selectClusterLocksMaxApiSizeReached,
 } from "src/selectors/recentExecutions.selectors";
 import { actions as localStorageActions } from "src/store/localStorage";
@@ -56,7 +55,6 @@ export const mapStateToRecentTransactionsPageProps = (
   selectedColumns: selectColumns(state),
   sortSetting: selectSortSetting(state),
   filters: selectFilters(state),
-  executionStatus: selectExecutionStatus(),
   internalAppNamePrefix: selectAppName(state),
   isTenant: selectIsTenant(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/recentTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/recentTransactionsView.tsx
@@ -22,6 +22,7 @@ import {
   RecentTransaction,
   RecentStatementFilters,
   RecentTransactionFilters,
+  ExecutionStatus,
 } from "src/recentExecutions";
 import LoadingError from "src/sqlActivity/errorComponent";
 import {
@@ -54,7 +55,6 @@ export type RecentTransactionsViewStateProps = {
   transactions: RecentTransaction[];
   sessionsError: Error | null;
   filters: RecentTransactionFilters;
-  executionStatus: string[];
   sortSetting: SortSetting;
   internalAppNamePrefix: string;
   isTenant?: boolean;
@@ -78,7 +78,6 @@ export const RecentTransactionsView: React.FC<RecentTransactionsViewProps> = ({
   transactions,
   sessionsError,
   filters,
-  executionStatus,
   internalAppNamePrefix,
   maxSizeApiReached,
 }: RecentTransactionsViewProps) => {
@@ -171,6 +170,7 @@ export const RecentTransactionsView: React.FC<RecentTransactionsViewProps> = ({
 
   const apps = getAppsFromRecentExecutions(transactions, internalAppNamePrefix);
   const countActiveFilters = calculateActiveFilters(filters);
+  const executionStatuses = Object.values(ExecutionStatus);
 
   const filteredTransactions = filterRecentTransactions(
     transactions,
@@ -201,7 +201,7 @@ export const RecentTransactionsView: React.FC<RecentTransactionsViewProps> = ({
           <Filter
             activeFilters={countActiveFilters}
             onSubmitFilters={onSubmitFilters}
-            executionStatuses={executionStatus.sort()}
+            executionStatuses={executionStatuses}
             showExecutionStatus={true}
             appNames={apps}
             filters={filters}

--- a/pkg/ui/workspaces/db-console/src/selectors/recentExecutionsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/selectors/recentExecutionsSelectors.ts
@@ -15,7 +15,6 @@ import {
   getRecentTransaction,
   getContentionDetailsFromLocksAndTxns,
   selectExecutionID,
-  ExecutionStatus,
 } from "@cockroachlabs/cluster-ui";
 import { createSelector } from "reselect";
 import { CachedDataReducerState } from "src/redux/apiReducers";
@@ -43,14 +42,6 @@ export const selectRecentStatements = createSelector(
   selectRecentExecutions,
   (executions: RecentExecutions) => executions.statements,
 );
-
-export const selectExecutionStatus = () => {
-  const execStatuses: string[] = [];
-  for (const execStatus in ExecutionStatus) {
-    execStatuses.push(execStatus);
-  }
-  return execStatuses;
-};
 
 export const selectRecentStatement = createSelector(
   selectRecentStatements,

--- a/pkg/ui/workspaces/db-console/src/views/statements/recentStatementsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/recentStatementsSelectors.tsx
@@ -16,7 +16,6 @@ import {
 import {
   selectRecentStatements,
   selectAppName,
-  selectExecutionStatus,
   selectClusterLocksMaxApiSizeReached,
 } from "src/selectors";
 import { refreshLiveWorkload } from "src/redux/apiReducers";
@@ -57,7 +56,6 @@ export const mapStateToRecentStatementViewProps = (state: AdminUIState) => ({
   selectedColumns: selectedColumnsLocalSetting.selectorToArray(state),
   sortSetting: sortSettingLocalSetting.selector(state),
   statements: selectRecentStatements(state),
-  executionStatus: selectExecutionStatus(),
   sessionsError: state.cachedData?.sessions.lastError,
   internalAppNamePrefix: selectAppName(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),

--- a/pkg/ui/workspaces/db-console/src/views/transactions/recentTransactionsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/recentTransactionsSelectors.tsx
@@ -17,7 +17,6 @@ import {
 import {
   selectAppName,
   selectRecentTransactions,
-  selectExecutionStatus,
   selectClusterLocksMaxApiSizeReached,
 } from "src/selectors";
 import { refreshLiveWorkload } from "src/redux/apiReducers";
@@ -58,7 +57,6 @@ export const mapStateToRecentTransactionsPageProps = (state: AdminUIState) => ({
   transactions: selectRecentTransactions(state),
   sessionsError: state.cachedData?.sessions.lastError,
   filters: filtersLocalSetting.selector(state),
-  executionStatus: selectExecutionStatus(),
   sortSetting: sortSettingLocalSetting.selector(state),
   internalAppNamePrefix: selectAppName(state),
   maxSizeApiReached: selectClusterLocksMaxApiSizeReached(state),


### PR DESCRIPTION
Backport 1/1 commits from #104428.

/cc @cockroachdb/release

---

 Part of: #100236.

Previously, #103904 added the `Idle` status to the active executions
pages which denotes txns that have began but are not currently executing
a stmt. However, a few places (the "status" tooltip, and the "status"
filter options) did not account for this change. This commit adds a
description to the tooltip for the `Idle` status only for the active
txns view. This commit also excludes the `Idle` status filter option for
the active stmts view as it only applies for txns.

**Active Statements View**
| Status Filter Options                                                                           | Tooltip                                                                                                                |
|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1037" alt="stmts-filters" src="https://github.com/cockroachdb/cockroach/assets/35943354/52d6bddb-d38e-4f56-98ef-8b8e6f6daaa5"> | <img width="1037" alt="stmts-tooltip" src="https://github.com/cockroachdb/cockroach/assets/35943354/6d7d0797-da43-4508-b201-bd26997ac391"> |

**Active Transactions View**
| Status Filter Options                                                                           | Tooltip                                                                                                                 |
|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1037" alt="txns-filters" src="https://github.com/cockroachdb/cockroach/assets/35943354/bba501d9-2efc-4af4-988b-56ebc5f7b4bd"> | <img width="1037" alt="txns-tooltip" src="https://github.com/cockroachdb/cockroach/assets/35943354/20cf662c-cf7b-4c0c-8702-c9a4b4e58d06"> |

Release note (ui change): Added description to the tooltip for the
`Idle` status only for the active txns view. Excluded `Idle` status
filter option for the active stmts view.

---

Release justification: bug fix improving UX