### PR TITLE
sql: disable strict gc ttl enforcement in schema changer test

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -619,6 +619,8 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		t.Fatal(err)
 	}
 	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
+	// Disable strict GC TTL enforcement so that we can use AddImmediateGCZoneConfig.
+	defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
 	// Add a zone config for the table so that garbage collection happens rapidly.
 	if _, err := sqltestutils.AddImmediateGCZoneConfig(sqlDB, tableDesc.GetID()); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Before this change, the TestRaceWithBackfill test would add a zone config to force garbage collection to happen frequently, however this could cause a race between batch timestamps and garbage collection thresholds. This change adds a call to `DisableGCTTLStrictEnforcement`, which is supposed to be called before updating the zone config with `AddImmediateGCZoneConfig` for testing purposes.

Epic: None
Fixes: #104655

Release note: None