### PR TITLE
sql: fix flaky test TestSQLStatsCompactor

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -69,7 +68,6 @@ func TestSQLStatsCompactorNilTestingKnobCheck(t *testing.T) {
 func TestSQLStatsCompactor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 102750)
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -118,44 +116,45 @@ func TestSQLStatsCompactor(t *testing.T) {
 		},
 	}
 
-	kvInterceptor := kvScanInterceptor{}
-	cleanupInterceptor := cleanupInterceptor{}
-
-	server, conn, _ := serverutils.StartServer(
-		t, base.TestServerArgs{
-			Knobs: base.TestingKnobs{
-				SQLStatsKnobs: &sqlstats.TestingKnobs{
-					AOSTClause: "AS OF SYSTEM TIME '-1us'",
-					StubTimeNow: func() time.Time {
-						return timeutil.Now().Add(-2 * time.Hour)
-					},
-				},
-				Store: &kvserver.StoreTestingKnobs{
-					TestingRequestFilter: kvInterceptor.intercept,
-				},
-			},
-		},
-	)
-
-	defer server.Stopper().Stop(ctx)
-
-	sqlConn := sqlutils.MakeSQLRunner(conn)
-	internalExecutor := server.InternalExecutor().(isql.Executor)
-
-	// Disable automatic flush since the test will handle the flush manually.
-	sqlConn.Exec(t, "SET CLUSTER SETTING sql.stats.flush.interval = '24h'")
-	// Disable activity update flush which also does a scan on the stats table
-	sqlConn.Exec(t, "SET CLUSTER SETTING sql.stats.activity.flush.enabled = false")
-	// Change the automatic compaction job to avoid it running during the test.
-	// Test creates a new compactor and calls it directly.
-	sqlConn.Exec(t, "SET CLUSTER SETTING sql.stats.cleanup.recurrence = '@yearly';")
-
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("stmtCount=%d/maxPersistedRowLimit=%d/rowsDeletePerTxn=%d",
 			tc.stmtCount,
 			tc.maxPersistedRowLimit,
 			tc.rowsToDeletePerTxn,
 		), func(t *testing.T) {
+
+			kvInterceptor := kvScanInterceptor{}
+			cleanupInterceptor := cleanupInterceptor{}
+
+			server, conn, _ := serverutils.StartServer(
+				t, base.TestServerArgs{
+					Knobs: base.TestingKnobs{
+						SQLStatsKnobs: &sqlstats.TestingKnobs{
+							AOSTClause: "AS OF SYSTEM TIME '-1us'",
+							StubTimeNow: func() time.Time {
+								return timeutil.Now().Add(-2 * time.Hour)
+							},
+						},
+						Store: &kvserver.StoreTestingKnobs{
+							TestingRequestFilter: kvInterceptor.intercept,
+						},
+					},
+				},
+			)
+
+			defer server.Stopper().Stop(ctx)
+
+			sqlConn := sqlutils.MakeSQLRunner(conn)
+			internalExecutor := server.InternalExecutor().(isql.Executor)
+
+			// Disable automatic flush since the test will handle the flush manually.
+			sqlConn.Exec(t, "SET CLUSTER SETTING sql.stats.flush.interval = '24h'")
+			// Disable activity update flush which also does a scan on the stats table
+			sqlConn.Exec(t, "SET CLUSTER SETTING sql.stats.activity.flush.enabled = false")
+			// Change the automatic compaction job to avoid it running during the test.
+			// Test creates a new compactor and calls it directly.
+			sqlConn.Exec(t, "SET CLUSTER SETTING sql.stats.cleanup.recurrence = '@yearly';")
+
 			_, err := internalExecutor.ExecEx(
 				ctx,
 				"truncate-stmt-stats",


### PR DESCRIPTION
The failure does not reproduce locally. The test ran for over 30mins with no failures using the same flags and commit in the last reported test failure.

`./dev test --timeout=5m --stress --verbose pkg/sql/sqlstats/persistedsqlstats --filter=TestSQLStatsCompactor -- --define gotags=bazel,gss,deadlock --jobs 4`

The theory is the test count mistmatch is due to the test cases running in parrallel. The individual test cases are using the same shared interceptors. To fix this the interceptors and server are created as part of the test case to avoid any possible conflict.

Fixes: https://github.com/cockroachdb/cockroach/issues/102750

Epic: none
Release note: None