### PR TITLE
lint: run `staticcheck` in bazel ci; fix stray lint failures

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -1696,7 +1696,7 @@
             "cockroach/pkg/sql/schemachanger/scplan/internal/rules/.*/.*.go$":  "schema changer rules"
         },
         "only_files": {
-            "cockroachdb_cockroach/pkg/.*$": "first-party code",
+            "cockroach/pkg/.*$": "first-party code",
             "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -69,12 +69,6 @@ var (
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}
-	metaConnectionLatency = metric.Metadata{
-		Name:        "proxy.sql.connection_latency",
-		Unit:        metric.Unit_NANOSECONDS,
-		Help:        "Latency histogram for connecting and authenticating to a tenant cluster.",
-		Measurement: "Latency",
-	}
 	metaRoutingErrCount = metric.Metadata{
 		Name:        "proxy.err.routing",
 		Help:        "Number of errors encountered when attempting to route clients",

--- a/pkg/cmd/roachprod-stress/main.go
+++ b/pkg/cmd/roachprod-stress/main.go
@@ -211,7 +211,7 @@ func run() error {
 		return errors.Wrap(err, "failed to copy testdata")
 	}
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	defer close(c)
 	signal.Notify(c, os.Interrupt)
 	signal.Notify(c, syscall.SIGHUP, syscall.SIGTERM)

--- a/pkg/cmd/roachtest/tests/rebalance_stats.go
+++ b/pkg/cmd/roachtest/tests/rebalance_stats.go
@@ -37,8 +37,6 @@ var (
 
 	rebalanceSnapshotSentStat = clusterstats.ClusterStat{
 		LabelName: "node", Query: divQuery("rate(range_snapshots_rebalancing_sent_bytes[5m])", 1<<20)}
-	rebalanceSnapshotRcvdStat = clusterstats.ClusterStat{
-		LabelName: "node", Query: divQuery("rate(range_snapshots_rebalancing_rcvd_bytes[5m])", 1<<20)}
 
 	admissionAvgWaitSecs = clusterstats.ClusterStat{
 		LabelName: "node",

--- a/pkg/kv/kvclient/kvcoord/txn_metrics.go
+++ b/pkg/kv/kvclient/kvcoord/txn_metrics.go
@@ -212,12 +212,6 @@ var (
 		Measurement: "Restarted Transactions",
 		Unit:        metric.Unit_COUNT,
 	}
-	metaRestartsPossibleReplay = metric.Metadata{
-		Name:        "txn.restarts.possiblereplay",
-		Help:        "Number of restarts due to possible replays of command batches at the storage layer",
-		Measurement: "Restarted Transactions",
-		Unit:        metric.Unit_COUNT,
-	}
 	metaRestartsAsyncWriteFailure = metric.Metadata{
 		Name:        "txn.restarts.asyncwritefailure",
 		Help:        "Number of restarts due to async consensus writes that failed to leave intents",

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -1038,7 +1038,7 @@ func (s *opTestInput) Next() coldata.Batch {
 						setColVal(vec, outputIdx, j, s.evalCtx)
 					case types.TimestampTZFamily:
 						t := timeutil.Unix(rng.Int63n(2000000000), rng.Int63n(1000000))
-						t.Round(tree.TimeFamilyPrecisionToRoundDuration(vec.Type().Precision()))
+						t = t.Round(tree.TimeFamilyPrecisionToRoundDuration(vec.Type().Precision()))
 						setColVal(vec, outputIdx, t, s.evalCtx)
 					case typeconv.DatumVecCanonicalTypeFamily:
 						switch vec.Type().Family() {

--- a/pkg/testutils/lint/BUILD.bazel
+++ b/pkg/testutils/lint/BUILD.bazel
@@ -20,7 +20,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]) + [
-        "@co_honnef_go_tools//cmd/unused",
+        "@co_honnef_go_tools//cmd/staticcheck",
         "@go_sdk//:files",
     ],
     embed = [":lint"],

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -46,7 +46,13 @@ var rawGcassertPaths string
 
 func init() {
 	if bazel.BuiltWithBazel() {
-		bazel.SetGoEnv()
+		gobin, err := bazel.Runfile("bin/go")
+		if err != nil {
+			panic(err)
+		}
+		if err := os.Setenv("PATH", fmt.Sprintf("%s%c%s", filepath.Dir(gobin), os.PathListSeparator, os.Getenv("PATH"))); err != nil {
+			panic(err)
+		}
 	}
 }
 
@@ -130,6 +136,15 @@ func TestLint(t *testing.T) {
 	}
 
 	pkgVar, pkgSpecified := os.LookupEnv("PKG")
+
+	var nogoConfig map[string]any
+	nogoJson, err := os.ReadFile(filepath.Join(crdbDir, "build", "bazelutil", "nogo_config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(nogoJson, &nogoConfig); err != nil {
+		t.Error(err)
+	}
 
 	t.Run("TestLowercaseFunctionNames", func(t *testing.T) {
 		skip.UnderShort(t)
@@ -1737,16 +1752,53 @@ func TestLint(t *testing.T) {
 	t.Run("TestStaticCheck", func(t *testing.T) {
 		// staticcheck uses 2.4GB of ram (as of 2019-05-10), so don't parallelize it.
 		skip.UnderShort(t)
+		// If run outside of Bazel, we assume this binary must be in the PATH.
+		staticcheck := "staticcheck"
 		if bazel.BuiltWithBazel() {
-			skip.IgnoreLint(t, "the staticcheck tests are run during the bazel build")
+			var err error
+			staticcheck, err = bazel.Runfile("external/co_honnef_go_tools/cmd/staticcheck/staticcheck_/staticcheck")
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 
-		cmd, stderr, filter, err := dirCmd(
-			crdbDir,
-			"staticcheck",
-			pkgScope)
+		// Determine the list of files to exclude."
+
+		cmd, stderr, filter, err := dirCmd(crdbDir, staticcheck, pkgScope)
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		staticcheckCheckNameRe := regexp.MustCompile(`^(S|SA|ST|U)[0-9][0-9][0-9][0-9]$`)
+		filters := []stream.Filter{
+			filter,
+			stream.GrepNot(`\.pb\.go`),
+			stream.GrepNot(`\.pb\.gw\.go`),
+			// NB: we define a data structure here that mirrors the shape of a stdlib
+			// data structure. This causes staticcheck to think fields in the structure
+			// are unused, when in fact the runtime uses them.
+			stream.GrepNot(`pkg/util/goschedstats/runtime_go1\.19\.go:.*\(U1000\)`),
+			// NB: Looks like false positives in this file. Maybe due to the bazel build tag.
+			// If this situation gets much worse, we can look at running staticcheck multiple
+			// times and merging the results: https://staticcheck.io/docs/running-staticcheck/cli/build-tags/
+			// This is more trouble than it's worth right now.
+			stream.GrepNot(`pkg/cmd/mirror/go/mirror.go`),
+		}
+		for analyzerName, config := range nogoConfig {
+			if !staticcheckCheckNameRe.MatchString(analyzerName) {
+				continue
+			}
+			// NB: We're not loading only_files because right now we don't need it.
+			// This could lead to disagreements between `nogo` and `lint` if things change.
+			excludeFiles := config.(map[string]any)["exclude_files"]
+			if excludeFiles == nil {
+				continue
+			}
+			for excludeRegexp := range excludeFiles.(map[string]any) {
+				excludeRegexp = strings.TrimPrefix(excludeRegexp, "cockroach/")
+				excludeRegexp = strings.TrimSuffix(excludeRegexp, "$")
+				filters = append(filters, stream.GrepNot(excludeRegexp+`:.*\(`+analyzerName+`\)$`))
+			}
 		}
 
 		if err := cmd.Start(); err != nil {
@@ -1754,109 +1806,12 @@ func TestLint(t *testing.T) {
 		}
 
 		if err := stream.ForEach(
-			stream.Sequence(
-				filter,
-				// Skip .pb.go and .pb.gw.go generated files.
-				stream.GrepNot(`pkg/.*\.pb(\.gw|)\.go:`),
-				// This file is a conditionally-compiled stub implementation that
-				// will produce fake "func is unused" errors.
-				stream.GrepNot(`pkg/build/bazel/non_bazel.go`),
-				// These binaries are Bazel-only and the unused linter gets confused
-				// about the stub implementation mentioned in
-				// pkg/build/bazel/non_bazel.go above.
-				stream.GrepNot(`pkg/cmd/mirror/go/mirror.go`),
-				stream.GrepNot(`pkg/cmd/generate-distdir/main.go`),
-				// Skip generated file.
-				stream.GrepNot(`pkg/ui/distoss/bindata.go`),
-				stream.GrepNot(`pkg/ui/distccl/bindata.go`),
-				// sql.go is the generated parser, which sets sqlDollar in all cases,
-				// even if it might not be used again.
-				stream.GrepNot(`pkg/sql/parser/sql.go:.*this value of sqlDollar is never used`),
-				// Generated file containing many unused postgres error codes.
-				stream.GrepNot(`pkg/sql/pgwire/pgcode/codes.go:.* var .* is unused`),
-				// The methods in exprgen.customFuncs are used via reflection.
-				stream.GrepNot(`pkg/sql/opt/optgen/exprgen/custom_funcs.go:.* func .* is unused`),
-				// Using deprecated method to COPY because the copyin driver does not
-				// implement StmtExecContext as of 07/06/2020.
-				stream.GrepNot(`pkg/cli/nodelocal.go:.* stmt.Exec is deprecated: .*`),
-				stream.GrepNot(`pkg/cli/userfile.go:.* stmt.Exec is deprecated: .*`),
-				// Cause is a method used by pkg/cockroachdb/errors (through an unnamed
-				// interface).
-				stream.GrepNot(`pkg/.*.go:.* func .*\.Cause is unused`),
-				// Using deprecated WireLength call.
-				stream.GrepNot(`pkg/rpc/stats_handler.go:.*v.WireLength is deprecated: This field is never set.*`),
-				// kv/kvpb/api.go needs v1 Protobuf reflection
-				stream.GrepNot(`pkg/kv/kvpb/api_test.go:.*"github.com/golang/protobuf/proto" is deprecated: Use the "google.golang.org/protobuf/proto" package instead.`),
-				// rpc/codec.go imports the same proto package that grpc-go imports (as of crdb@dd87d1145 and grpc-go@7b167fd6).
-				stream.GrepNot(`pkg/rpc/codec.go:.*"github.com/golang/protobuf/proto" is deprecated: Use the "google.golang.org/protobuf/proto" package instead.`),
-				// goschedstats contains partial copies of go runtime structures, with
-				// many fields that we're not using.
-				stream.GrepNot(`pkg/util/goschedstats/runtime.*\.go:.*is unused`),
-				// Ignore ioutil.ReadDir uses that I couldn't get rid of easily.
-				stream.GrepNot(`pkg/roachprod/.*\.go:.*"io/ioutil" has been deprecated since Go 1\.16: As of Go 1\.16`),
-				stream.GrepNot(`pkg/security/securityassets/security_assets\.go.*"io/ioutil" has been deprecated since Go 1\.16`),
-				stream.GrepNot(`pkg/security/securitytest/embedded\.go:.*"io/ioutil" has been deprecated since Go 1\.16`),
-				stream.GrepNot(`pkg/server/dumpstore.*\.go.*"io/ioutil" has been deprecated since Go 1\.16: As of Go 1\.16`),
-				stream.GrepNot(`pkg/server/profiler/profilestore_test\.go.*"io/ioutil" has been deprecated since Go 1\.16`),
-				stream.GrepNot(`pkg/util/log/file_api\.go.*"io/ioutil" has been deprecated since Go 1\.16`),
-				// TODO(yuzefovich): remove these exclusions.
-				stream.GrepNot(`pkg/sql/conn_executor.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
-				stream.GrepNot(`pkg/sql/instrumentation.go:.*SetDeprecatedContext is deprecated: .*`),
-				stream.GrepNot(`pkg/sql/planner.go:.*SetDeprecatedContext is deprecated: .*`),
-				stream.GrepNot(`pkg/sql/schema_changer.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
-				stream.GrepNot(`pkg/sql/distsql/server.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
-				stream.GrepNot(`pkg/sql/execinfra/processorsbase.go:.*SetDeprecatedContext is deprecated: .*`),
-				stream.GrepNot(`pkg/sql/importer/import_table_creation.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
-				stream.GrepNot(`pkg/sql/row/expr_walker_test.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
-				stream.GrepNot(`pkg/sql/schemachanger/scbuild/tree_context_builder.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
-				stream.GrepNot(`pkg/sql/schemachanger/scplan/internal/rules/.*/.*go:.* should not use dot imports \(ST1001\)`),
-				// TODO(yuzefovich): remove this exclusion (#100438).
-				stream.GrepNot(`pkg/util/bulk/tracing_aggregator.go:.*SetLazyTagLocked is deprecated: .*`),
-			), func(s string) {
+			stream.Sequence(filters...), func(s string) {
 				t.Errorf("\n%s", s)
 			}); err != nil {
 			t.Error(err)
 		}
 
-		if err := cmd.Wait(); err != nil {
-			if out := stderr.String(); len(out) > 0 {
-				t.Fatalf("err=%s, stderr=%s", err, out)
-			}
-		}
-	})
-
-	t.Run("TestUnused", func(t *testing.T) {
-		skip.UnderShort(t)
-		if !bazel.BuiltWithBazel() {
-			skip.IgnoreLint(t, "staticcheck takes care of U1000 in non-Bazel builds")
-		}
-		unusedBinary, err := bazel.Runfile("external/co_honnef_go_tools/cmd/unused/unused_/unused")
-		if err != nil {
-			t.Fatal(err)
-		}
-		cmd, stderr, filter, err := dirCmd(
-			crdbDir,
-			unusedBinary,
-			pkgScope,
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := cmd.Start(); err != nil {
-			t.Fatal(err)
-		}
-		if err := stream.ForEach(stream.Sequence(filter,
-			stream.Grep(crdbDir), // Only capture in-tree unused objects.
-			stream.GrepNot(`pkg/util/goschedstats/runtime_go1.19\.go`), // data structures contain "unused" fields (written/read by the runtime, but not us)
-			stream.GrepNot(`\.pb\.go`),
-			stream.GrepNot(`\.pb\.gw\.go`),
-			stream.GrepNot(`\.og\.go`),
-			stream.GrepNot(`\.eg\.go`),
-		), func(s string) {
-			t.Errorf("\n%s", s)
-		}); err != nil {
-			t.Error(err)
-		}
 		if err := cmd.Wait(); err != nil {
 			if out := stderr.String(); len(out) > 0 {
 				t.Fatalf("err=%s, stderr=%s", err, out)
@@ -2262,15 +2217,8 @@ func TestLint(t *testing.T) {
 		//    If the next-to-last argument is a string, then this may be a Printf wrapper.
 		//    Otherwise it may be a Print wrapper.
 		// Note we retrieve the list of printfuncs from nogo_config.json.
-		jsonFile, err := os.ReadFile(filepath.Join(crdbDir, "build", "bazelutil", "nogo_config.json"))
-		if err != nil {
-			t.Error(err)
-		}
-		var printSchema map[string]map[string]map[string]string
-		if err := json.Unmarshal(jsonFile, &printSchema); err != nil {
-			t.Error(err)
-		}
-		printfuncs := printSchema["printf"]["analyzer_flags"]["funcs"]
+		analyzerFlags := nogoConfig["printf"].(map[string]any)
+		printfuncs := analyzerFlags["analyzer_flags"].(map[string]any)["funcs"].(string)
 		nakedGoroutineExceptions := `(` + strings.Join([]string{
 			`pkg/.*_test\.go`,
 			`pkg/acceptance/.*\.go`,

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -1665,12 +1665,6 @@ var (
 		Measurement: "Requests",
 		Unit:        metric.Unit_COUNT,
 	}
-	waitDurationSumMeta = metric.Metadata{
-		Name:        "admission.wait_sum.",
-		Help:        "Total wait time in micros",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
-	}
 	waitDurationsMeta = metric.Metadata{
 		Name:        "admission.wait_durations.",
 		Help:        "Wait time durations for requests that waited",


### PR DESCRIPTION
We found ourselves in a position where the `make`-based `lint` job was
identifying some legitimate failures that the Bazel-based `lint` was not
catching. To fix this we're doing all of the following:

* Fix some legitimate `U1000` ("unused" variable) failures that Bazel
  CI didn't capture.
* Fix some spots where we call side effect-less functions and expect
  them not to be no-ops. `make` CI caught these where Bazel CI didn't
  because `nogo` doesn't maintain analyses of standard library functions
  in the same way that `staticcheck` does.
* `roachprod-stress` fails to build unless we buffer this channel.

At this point it becomes clear that `staticcheck` actually catches
*more* unused functions/variables than the `unused` binary does. Since
it also catches some lint failures that `nogo` can't, I update
`lint_test.go` so that it runs `staticcheck` instead of `unused`.
`staticcheck` takes a long time to run so this could be a bottleneck in
CI as well as for local developers. Unfortunately we can't do much
about this -- we'll just have to make the change and see how it pans
out.

* Also update `lint_test.go` so that we read the list of `staticcheck`
  exclusions FROM `nogo_config.json`. In this way we don't have to
  duplicate the list of exclusions in two places.

Epic: none
Release note: None