### PR TITLE
kvcoord: Release catchup reservation before re-acquire attempt

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -92,6 +92,10 @@ type rangeFeedConfig struct {
 	useMuxRangeFeed bool
 	overSystemTable bool
 	withDiff        bool
+
+	knobs struct {
+		onMuxRangefeedEvent func(event *kvpb.MuxRangeFeedEvent)
+	}
 }
 
 // RangeFeedOption configures a RangeFeed.


### PR DESCRIPTION
Release catchup scan reservation prior to attemt to re-acquire it.  Failure to do so could result in a stuck mux rangefeed when enough ranges encounter an error, such as range split, prior to receiving the first checkpoint event, that would cause additional attempts to acquire catchup scan quota.

Fixes #105058

Release note (bug fix): Fix a bug in mux rangefeed implementation that may cause mux rangefeed to become stuck if enough ranges encounter certain error concurrently.