### PR TITLE
ci: update bazel-fips builder image

### DIFF
--- a/build/.bazelbuilderversion-fips
+++ b/build/.bazelbuilderversion-fips
@@ -1,1 +1,1 @@
-cockroachdb/bazel-fips:20230303-060247
+cockroachdb/bazel-fips:20230616-060512


### PR DESCRIPTION
Release note: None
Epic: None
