### PR TITLE
kvserver: change replica range lease to use NodeVitality

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -6920,7 +6920,6 @@ func TestRaftPreVoteUnquiesceDeadLeader(t *testing.T) {
 	for i := 0; i < tc.NumServers(); i++ {
 		isLive := tc.Server(i).NodeLiveness().(*liveness.NodeLiveness).GetNodeVitalityFromCache(1).IsLive(livenesspb.LeaseCampaign)
 		require.False(t, isLive)
-		tc.GetFirstStoreFromServer(t, i).UpdateLivenessMap()
 	}
 	t.Logf("n1 not live")
 

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -125,11 +125,7 @@ func (q *consistencyQueue) shouldQueue(
 				return repl.getQueueLastProcessed(ctx, q.name)
 			},
 			isNodeAvailable: func(nodeID roachpb.NodeID) bool {
-				if repl.store.cfg.NodeLiveness != nil {
-					return repl.store.cfg.NodeLiveness.GetNodeVitalityFromCache(nodeID).IsLive(livenesspb.ConsistencyQueue)
-				}
-				// Some tests run without a NodeLiveness configured.
-				return true
+				return repl.store.cfg.NodeLiveness.GetNodeVitalityFromCache(nodeID).IsLive(livenesspb.ConsistencyQueue)
 			},
 			disableLastProcessedCheck: repl.store.cfg.TestingKnobs.DisableLastProcessedCheck,
 			interval:                  q.interval(),

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -102,10 +102,6 @@ func (s *Store) ComputeMVCCStats(reader storage.Reader) (enginepb.MVCCStats, err
 	return totalStats, err
 }
 
-func (s *Store) UpdateLivenessMap() {
-	s.updateLivenessMap()
-}
-
 // ConsistencyQueueShouldQueue invokes the shouldQueue method on the
 // store's consistency queue.
 func ConsistencyQueueShouldQueue(

--- a/pkg/kv/kvserver/liveness/cache.go
+++ b/pkg/kv/kvserver/liveness/cache.go
@@ -270,28 +270,6 @@ func (c *Cache) convertToNodeVitality(l livenesspb.Liveness) livenesspb.NodeVita
 	)
 }
 
-// getIsLiveMap returns a map of nodeID to boolean liveness status of
-// each node. This excludes nodes that were removed completely (dead +
-// decommissioned)
-func (c *Cache) getIsLiveMap() livenesspb.IsLiveMap {
-	lMap := livenesspb.IsLiveMap{}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	now := c.clock.Now()
-	for nID, l := range c.mu.nodes {
-		isLive := l.IsLive(now)
-		if l.Membership.Decommissioned() {
-			// This is a node that was completely removed. Skip over it.
-			continue
-		}
-		lMap[nID] = livenesspb.IsLiveMapEntry{
-			Liveness: l.Liveness,
-			IsLive:   isLive,
-		}
-	}
-	return lMap
-}
-
 // getAllLivenessEntries returns a copy of all the entries currently in the
 // liveness Cache. Most places should avoid calling this method and instead just
 // get the entry they need. In a few places in the code it is more efficient to

--- a/pkg/kv/kvserver/liveness/cache.go
+++ b/pkg/kv/kvserver/liveness/cache.go
@@ -49,6 +49,7 @@ type Cache struct {
 	clock      *hlc.Clock
 	nodeDialer *nodedialer.Dialer
 	st         *cluster.Settings
+	isTestMode bool
 	mu         struct {
 		syncutil.RWMutex
 		// lastNodeUpdate stores timestamps of StoreDescriptor updates in Gossip.
@@ -214,6 +215,18 @@ func (c *Cache) self() (_ Record, ok bool) {
 // includes the raw, encoded value that the database has for this liveness
 // record in addition to the decoded liveness proto.
 func (c *Cache) getLiveness(nodeID roachpb.NodeID) (_ Record, ok bool) {
+	// In test mode, create a node vitality that is always live.
+	if c.isTestMode {
+		now := c.clock.Now()
+		return Record{
+			Liveness: livenesspb.Liveness{
+				NodeID:     nodeID,
+				Epoch:      1,
+				Expiration: now.AddDuration(time.Minute).ToLegacyTimestamp(),
+				Draining:   false,
+				Membership: livenesspb.MembershipStatus_ACTIVE,
+			}}, true
+	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if l, ok := c.mu.nodes[nodeID]; ok {

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -899,14 +899,6 @@ func (nl *NodeLiveness) Self() (_ livenesspb.Liveness, ok bool) {
 	return rec.Liveness, true
 }
 
-// GetIsLiveMap returns a map of nodeID to boolean liveness status of
-// each node. This excludes nodes that were removed completely (dead +
-// decommissioning).
-// TODO(baptist): Remove.
-func (nl *NodeLiveness) GetIsLiveMap() livenesspb.IsLiveMap {
-	return nl.cache.getIsLiveMap()
-}
-
 // ScanNodeVitalityFromCache returns a map of nodeID to boolean liveness status
 // of each node from the cache. This excludes nodes that were decommissioned.
 // Decommissioned nodes are kept in the KV store and the cache forever, but are

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.go
@@ -146,19 +146,6 @@ func ValidateTransition(old Liveness, newStatus MembershipStatus) (bool, error) 
 	return true, nil
 }
 
-// IsLiveMapEntry encapsulates data about current liveness for a
-// node based on the liveness range.
-// TODO(abaptist): This should only be used for epoch leases as it uses an
-// overly strict version of liveness. Once epoch leases are removed, this will
-// be also.
-type IsLiveMapEntry struct {
-	Liveness
-	IsLive bool
-}
-
-// IsLiveMap is a type alias for a map from NodeID to IsLiveMapEntry.
-type IsLiveMap map[roachpb.NodeID]IsLiveMapEntry
-
 // NodeVitality should be used any place other than epoch leases where it is
 // necessary to determine if a node is currently alive and what its health is.
 // Aliveness and deadness are concepts that refer to our best guess of the

--- a/pkg/kv/kvserver/replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker_test.go
@@ -33,9 +33,7 @@ func TestReplicaUnavailableError(t *testing.T) {
 	repls.AddReplica(roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 10, ReplicaID: 100})
 	repls.AddReplica(roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 20, ReplicaID: 200})
 	desc := roachpb.NewRangeDescriptor(10, roachpb.RKey("a"), roachpb.RKey("z"), repls)
-	lm := livenesspb.IsLiveMap{
-		1: livenesspb.IsLiveMapEntry{IsLive: true},
-	}
+	lm := livenesspb.TestCreateNodeVitality(1)
 	ts := hlc.Timestamp{WallTime: time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC).UnixNano()}
 	wrappedErr := errors.New("probe failed")
 	rs := raft.Status{}

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -149,11 +149,6 @@ func replicaIsSuspect(repl *Replica) bool {
 		return true
 	}
 
-	// NodeLiveness can be nil in tests/benchmarks.
-	if repl.store.cfg.NodeLiveness == nil {
-		return false
-	}
-
 	// If a replica doesn't have an active raft group, we should check whether
 	// or not the node is active. If not, we should consider the replica suspect
 	// because it has probably already been removed from its raft group but

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowhandle"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/leases"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1233,13 +1232,11 @@ func (rp *replicaProposer) shouldCampaignOnRedirect(
 	raftGroup proposerRaft, leaseType roachpb.LeaseType,
 ) bool {
 	r := (*Replica)(rp)
-	livenessMap, _ := r.store.livenessMap.Load().(livenesspb.IsLiveMap)
 	return shouldCampaignOnLeaseRequestRedirect(
 		raftGroup.BasicStatus(),
-		livenessMap,
+		r.store.cfg.NodeLiveness,
 		r.descRLocked(),
 		leaseType,
-		r.store.Clock().Now(),
 	)
 }
 

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -796,8 +796,7 @@ func (r *Replica) GetRangeLeaseDuration() time.Duration {
 // shouldUseExpirationLeaseRLocked. We can merge these once there are no more
 // callers: when expiration leases don't quiesce and are always eagerly renewed.
 func (r *Replica) requiresExpirationLeaseRLocked() bool {
-	return r.store.cfg.NodeLiveness == nil ||
-		r.shMu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))
+	return r.shMu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))
 }
 
 // shouldUseExpirationLeaseRLocked returns true if this range should be using an

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8145,6 +8145,9 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 	cfg := TestStoreConfig(nil)
 	// Disable ticks which would interfere with the manual ticking in this test.
 	cfg.RaftTickInterval = time.Hour
+	// The replica timeout is computed based on a multiple of RaftTickInterval.
+	// Set this high enough to avoid tripping circuit breakers during the test.
+	replicaCircuitBreakerSlowReplicationThreshold.Override(ctx, &cfg.Settings.SV, 24*time.Hour)
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8170,7 +8170,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		ticks := r.mu.ticks
 		r.mu.Unlock()
 		for ; (ticks % reproposalTicks) != 0; ticks++ {
-			if _, err := r.tick(ctx, nil, nil); err != nil {
+			if _, err := r.tick(ctx, nil); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -8221,7 +8221,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 
 		// Tick raft.
 		iot := ioThresholdMap{m: map[roachpb.StoreID]*admissionpb.IOThreshold{}}
-		if _, err := r.tick(ctx, nil, &iot); err != nil {
+		if _, err := r.tick(ctx, &iot); err != nil {
 			t.Fatal(err)
 		}
 
@@ -9872,7 +9872,7 @@ type testQuiescer struct {
 	isDestroyed            bool
 
 	// Not used to implement quiescer, but used by tests.
-	livenessMap livenesspb.IsLiveMap
+	livenessMap livenesspb.TestNodeVitality
 	paused      map[roachpb.ReplicaID]struct{}
 }
 
@@ -9989,11 +9989,7 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 						},
 					},
 				},
-				livenessMap: livenesspb.IsLiveMap{
-					1: {IsLive: true},
-					2: {IsLive: true},
-					3: {IsLive: true},
-				},
+				livenessMap: livenesspb.TestCreateNodeVitality(1, 2, 3),
 			}
 			transform(q)
 			_, lagging, ok := shouldReplicaQuiesceRaftMuLockedReplicaMuLocked(
@@ -10003,8 +9999,8 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 				// Any non-live replicas should be in the laggingReplicaSet.
 				var expLagging laggingReplicaSet
 				for _, rep := range q.descRLocked().Replicas().Descriptors() {
-					if l, ok := q.livenessMap[rep.NodeID]; ok && !l.IsLive {
-						expLagging = append(expLagging, l.Liveness)
+					if l := q.livenessMap.GetNodeVitalityFromCache(rep.NodeID); !l.IsLive(livenesspb.RangeQuiesience) {
+						expLagging = append(expLagging, l.GetInternalLiveness())
 					}
 				}
 				slices.SortFunc(expLagging, func(a, b livenesspb.Liveness) int {
@@ -10075,24 +10071,13 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 		})
 	}
 	// Pass a nil liveness map.
-	test(true, func(q *testQuiescer) { q.livenessMap = nil })
+	test(true, func(q *testQuiescer) { q.livenessMap = livenesspb.TestCreateNodeVitality() })
 	// Verify quiesce even when replica progress doesn't match, if
 	// the replica is on a non-live node.
 	for _, i := range []raftpb.PeerID{1, 2, 3} {
 		test(true, func(q *testQuiescer) {
 			nodeID := roachpb.NodeID(i)
-			q.livenessMap[nodeID] = livenesspb.IsLiveMapEntry{
-				Liveness: livenesspb.Liveness{NodeID: nodeID},
-				IsLive:   false,
-			}
-			q.status.Progress[i] = tracker.Progress{Match: invalidIndex}
-		})
-	}
-	// Verify no quiescence when replica progress doesn't match, if
-	// given a nil liveness map.
-	for _, i := range []raftpb.PeerID{1, 2, 3} {
-		test(false, func(q *testQuiescer) {
-			q.livenessMap = nil
+			q.livenessMap.DownNode(nodeID)
 			q.status.Progress[i] = tracker.Progress{Match: invalidIndex}
 		})
 	}
@@ -10100,7 +10085,7 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 	// liveness map does not contain the lagging replica.
 	for _, i := range []raftpb.PeerID{1, 2, 3} {
 		test(false, func(q *testQuiescer) {
-			delete(q.livenessMap, roachpb.NodeID(i))
+			q.livenessMap.DeleteNode(roachpb.NodeID(i))
 			q.status.Progress[i] = tracker.Progress{Match: invalidIndex}
 		})
 	}
@@ -10153,11 +10138,7 @@ func TestFollowerQuiesceOnNotify(t *testing.T) {
 						},
 					},
 				},
-				livenessMap: livenesspb.IsLiveMap{
-					1: {IsLive: true},
-					2: {IsLive: true},
-					3: {IsLive: true},
-				},
+				livenessMap: livenesspb.TestCreateNodeVitality(1, 2, 3),
 			}
 			req := kvserverpb.RaftMessageRequest{
 				Message: raftpb.Message{
@@ -10204,10 +10185,7 @@ func TestFollowerQuiesceOnNotify(t *testing.T) {
 			Epoch:      7,
 			Expiration: hlc.LegacyTimestamp{WallTime: 8},
 		}
-		q.livenessMap[l.NodeID] = livenesspb.IsLiveMapEntry{
-			Liveness: l,
-			IsLive:   false,
-		}
+		q.livenessMap.DownNode(l.NodeID)
 		req.LaggingFollowersOnQuiesce = []livenesspb.Liveness{l}
 		return q, req
 	})
@@ -10218,10 +10196,7 @@ func TestFollowerQuiesceOnNotify(t *testing.T) {
 			Epoch:      7,
 			Expiration: hlc.LegacyTimestamp{WallTime: 8},
 		}
-		q.livenessMap[l.NodeID] = livenesspb.IsLiveMapEntry{
-			Liveness: l,
-			IsLive:   false,
-		}
+		q.livenessMap.DownNode(l.NodeID)
 		lOld := l
 		lOld.Epoch--
 		req.LaggingFollowersOnQuiesce = []livenesspb.Liveness{lOld}
@@ -10233,10 +10208,7 @@ func TestFollowerQuiesceOnNotify(t *testing.T) {
 			Epoch:      7,
 			Expiration: hlc.LegacyTimestamp{WallTime: 8},
 		}
-		q.livenessMap[l.NodeID] = livenesspb.IsLiveMapEntry{
-			Liveness: l,
-			IsLive:   false,
-		}
+		q.livenessMap.AddDead(l.NodeID)
 		lOld := l
 		lOld.Expiration.WallTime--
 		req.LaggingFollowersOnQuiesce = []livenesspb.Liveness{lOld}
@@ -10249,10 +10221,7 @@ func TestFollowerQuiesceOnNotify(t *testing.T) {
 			Epoch:      7,
 			Expiration: hlc.LegacyTimestamp{WallTime: 8},
 		}
-		q.livenessMap[l.NodeID] = livenesspb.IsLiveMapEntry{
-			Liveness: l,
-			IsLive:   false,
-		}
+		q.livenessMap.AddDead(l.NodeID)
 		lNew := l
 		lNew.Epoch++
 		req.LaggingFollowersOnQuiesce = []livenesspb.Liveness{lNew}
@@ -10264,10 +10233,7 @@ func TestFollowerQuiesceOnNotify(t *testing.T) {
 			Epoch:      7,
 			Expiration: hlc.LegacyTimestamp{WallTime: 8},
 		}
-		q.livenessMap[l.NodeID] = livenesspb.IsLiveMapEntry{
-			Liveness: l,
-			IsLive:   false,
-		}
+		q.livenessMap.AddDead(l.NodeID)
 		lNew := l
 		lNew.Expiration.WallTime++
 		req.LaggingFollowersOnQuiesce = []livenesspb.Liveness{lNew}
@@ -11482,7 +11448,7 @@ func TestReplicaShouldCampaignOnWake(t *testing.T) {
 		leaseStatus             kvserverpb.LeaseStatus
 		storeID                 roachpb.StoreID
 		raftStatus              raft.BasicStatus
-		livenessMap             livenesspb.IsLiveMap
+		livenessMap             livenesspb.TestNodeVitality
 		desc                    *roachpb.RangeDescriptor
 		requiresExpirationLease bool
 		now                     hlc.Timestamp
@@ -11516,12 +11482,10 @@ func TestReplicaShouldCampaignOnWake(t *testing.T) {
 				Lead: 2,
 			},
 		},
-		livenessMap: livenesspb.IsLiveMap{
-			1: livenesspb.IsLiveMapEntry{IsLive: true},
-			2: livenesspb.IsLiveMapEntry{IsLive: false},
-			3: livenesspb.IsLiveMapEntry{IsLive: false},
-		},
+		livenessMap: livenesspb.TestCreateNodeVitality(1),
 	}
+	base.livenessMap.AddDead(2)
+	base.livenessMap.AddDead(3)
 
 	testcases := map[string]struct {
 		expect bool
@@ -11557,43 +11521,26 @@ func TestReplicaShouldCampaignOnWake(t *testing.T) {
 			p.raftStatus.Lead = 4
 		}},
 		"leader not in liveness": {false, func(p *params) {
-			delete(p.livenessMap, 2)
+			p.livenessMap.DeleteNode(2)
 		}},
 		"leader is live": {false, func(p *params) {
-			p.livenessMap[2] = livenesspb.IsLiveMapEntry{
-				IsLive: true,
-				Liveness: livenesspb.Liveness{
-					NodeID:     2,
-					Expiration: p.now.Add(0, 1).ToLegacyTimestamp(),
-				},
-			}
+			p.livenessMap.RestartNode(2)
 		}},
 		"leader is live according to expiration": {false, func(p *params) {
-			p.livenessMap[2] = livenesspb.IsLiveMapEntry{
-				IsLive: false,
-				Liveness: livenesspb.Liveness{
-					NodeID:     2,
-					Expiration: p.now.Add(0, 1).ToLegacyTimestamp(),
-				},
-			}
+			// FIXME: This is a slightly different definition of alive.
+			p.livenessMap.RestartNode(2)
 		}},
 		"leader is dead according to expiration": {true, func(p *params) {
-			p.livenessMap[2] = livenesspb.IsLiveMapEntry{
-				IsLive: true,
-				Liveness: livenesspb.Liveness{
-					NodeID:     2,
-					Expiration: p.now.Add(0, -1).ToLegacyTimestamp(),
-				},
-			}
+			p.livenessMap.DownNode(2)
 		}},
 	}
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			p := base
-			p.livenessMap = livenesspb.IsLiveMap{}
-			for k, v := range base.livenessMap {
-				p.livenessMap[k] = v
+			p.livenessMap = livenesspb.TestCreateNodeVitality()
+			for k, v := range base.livenessMap.Entry {
+				p.livenessMap.Entry[k] = v
 			}
 			tc.modify(&p)
 			require.Equal(t, tc.expect, shouldCampaignOnWake(p.leaseStatus, p.storeID, p.raftStatus,
@@ -11608,7 +11555,7 @@ func TestReplicaShouldCampaignOnLeaseRequestRedirect(t *testing.T) {
 
 	type params struct {
 		raftStatus  raft.BasicStatus
-		livenessMap livenesspb.IsLiveMap
+		livenessMap livenesspb.TestNodeVitality
 		desc        *roachpb.RangeDescriptor
 		leaseType   roachpb.LeaseType
 		now         hlc.Timestamp
@@ -11636,14 +11583,12 @@ func TestReplicaShouldCampaignOnLeaseRequestRedirect(t *testing.T) {
 				Lead: 2,
 			},
 		},
-		livenessMap: livenesspb.IsLiveMap{
-			1: livenesspb.IsLiveMapEntry{IsLive: true},
-			2: livenesspb.IsLiveMapEntry{IsLive: false},
-			3: livenesspb.IsLiveMapEntry{IsLive: false},
-		},
-		leaseType: roachpb.LeaseEpoch,
-		now:       hlc.Timestamp{Logical: 10},
+		livenessMap: livenesspb.TestCreateNodeVitality(1),
+		leaseType:   roachpb.LeaseEpoch,
+		now:         hlc.Timestamp{Logical: 10},
 	}
+	base.livenessMap.AddDead(2)
+	base.livenessMap.AddDead(3)
 
 	testcases := map[string]struct {
 		expect bool
@@ -11675,47 +11620,30 @@ func TestReplicaShouldCampaignOnLeaseRequestRedirect(t *testing.T) {
 			p.raftStatus.Lead = 4
 		}},
 		"leader not in liveness": {false, func(p *params) {
-			delete(p.livenessMap, 2)
+			p.livenessMap.DeleteNode(2)
 		}},
 		"leader is live": {false, func(p *params) {
-			p.livenessMap[2] = livenesspb.IsLiveMapEntry{
-				IsLive: true,
-				Liveness: livenesspb.Liveness{
-					NodeID:     2,
-					Expiration: p.now.Add(0, 1).ToLegacyTimestamp(),
-				},
-			}
+			p.livenessMap.RestartNode(2)
 		}},
 		"leader is live according to expiration": {false, func(p *params) {
-			p.livenessMap[2] = livenesspb.IsLiveMapEntry{
-				IsLive: false,
-				Liveness: livenesspb.Liveness{
-					NodeID:     2,
-					Expiration: p.now.Add(0, 1).ToLegacyTimestamp(),
-				},
-			}
+			// FIXME: This is a slightly different definition of alive.
+			p.livenessMap.RestartNode(2)
 		}},
 		"leader is dead according to expiration": {true, func(p *params) {
-			p.livenessMap[2] = livenesspb.IsLiveMapEntry{
-				IsLive: true,
-				Liveness: livenesspb.Liveness{
-					NodeID:     2,
-					Expiration: p.now.Add(0, -1).ToLegacyTimestamp(),
-				},
-			}
+			p.livenessMap.DownNode(2)
 		}},
 	}
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			p := base
-			p.livenessMap = livenesspb.IsLiveMap{}
-			for k, v := range base.livenessMap {
-				p.livenessMap[k] = v
+			p.livenessMap = livenesspb.TestCreateNodeVitality()
+			for k, v := range base.livenessMap.Entry {
+				p.livenessMap.Entry[k] = v
 			}
 			tc.modify(&p)
 			require.Equal(t, tc.expect, shouldCampaignOnLeaseRequestRedirect(
-				p.raftStatus, p.livenessMap, p.desc, p.leaseType, p.now))
+				p.raftStatus, p.livenessMap, p.desc, p.leaseType))
 		})
 	}
 }
@@ -11726,7 +11654,7 @@ func TestReplicaShouldForgetLeaderOnVoteRequest(t *testing.T) {
 
 	type params struct {
 		raftStatus  raft.BasicStatus
-		livenessMap livenesspb.IsLiveMap
+		livenessMap livenesspb.TestNodeVitality
 		desc        *roachpb.RangeDescriptor
 		now         hlc.Timestamp
 	}
@@ -11753,13 +11681,11 @@ func TestReplicaShouldForgetLeaderOnVoteRequest(t *testing.T) {
 				Lead: 2,
 			},
 		},
-		livenessMap: livenesspb.IsLiveMap{
-			1: livenesspb.IsLiveMapEntry{IsLive: true},
-			2: livenesspb.IsLiveMapEntry{IsLive: false},
-			3: livenesspb.IsLiveMapEntry{IsLive: false},
-		},
-		now: hlc.Timestamp{Logical: 10},
+		livenessMap: livenesspb.TestCreateNodeVitality(1),
+		now:         hlc.Timestamp{Logical: 10},
 	}
+	base.livenessMap.AddDead(2)
+	base.livenessMap.AddDead(3)
 
 	testcases := map[string]struct {
 		expect bool
@@ -11785,47 +11711,30 @@ func TestReplicaShouldForgetLeaderOnVoteRequest(t *testing.T) {
 			p.raftStatus.Lead = 4
 		}},
 		"leader not in liveness": {true, func(p *params) {
-			delete(p.livenessMap, 2)
+			p.livenessMap.DeleteNode(2)
 		}},
 		"leader is live": {false, func(p *params) {
-			p.livenessMap[2] = livenesspb.IsLiveMapEntry{
-				IsLive: true,
-				Liveness: livenesspb.Liveness{
-					NodeID:     2,
-					Expiration: p.now.Add(0, 1).ToLegacyTimestamp(),
-				},
-			}
+			p.livenessMap.RestartNode(2)
 		}},
 		"leader is live according to expiration": {false, func(p *params) {
-			p.livenessMap[2] = livenesspb.IsLiveMapEntry{
-				IsLive: false,
-				Liveness: livenesspb.Liveness{
-					NodeID:     2,
-					Expiration: p.now.Add(0, 1).ToLegacyTimestamp(),
-				},
-			}
+			// FIXME: This is a slightly different definition of alive.
+			p.livenessMap.RestartNode(2)
 		}},
 		"leader is dead according to expiration": {true, func(p *params) {
-			p.livenessMap[2] = livenesspb.IsLiveMapEntry{
-				IsLive: true,
-				Liveness: livenesspb.Liveness{
-					NodeID:     2,
-					Expiration: p.now.Add(0, -1).ToLegacyTimestamp(),
-				},
-			}
+			p.livenessMap.DownNode(2)
 		}},
 	}
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			p := base
-			p.livenessMap = livenesspb.IsLiveMap{}
-			for k, v := range base.livenessMap {
-				p.livenessMap[k] = v
+			p.livenessMap = livenesspb.TestCreateNodeVitality()
+			for k, v := range base.livenessMap.Entry {
+				p.livenessMap.Entry[k] = v
 			}
 			tc.modify(&p)
 			require.Equal(t, tc.expect, shouldForgetLeaderOnVoteRequest(
-				p.raftStatus, p.livenessMap, p.desc, p.now))
+				p.raftStatus, p.livenessMap, p.desc))
 		})
 	}
 }

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -602,11 +602,9 @@ func newReplicateQueue(store *Store, allocator allocatorimpl.Allocator) *replica
 			updateFn()
 		})
 	}
-	if nl := store.cfg.NodeLiveness; nl != nil { // node liveness is nil for some unittests
-		nl.RegisterCallback(func(_ livenesspb.Liveness) {
-			updateFn()
-		})
-	}
+	store.cfg.NodeLiveness.RegisterCallback(func(_ livenesspb.Liveness) {
+		updateFn()
+	})
 
 	return rq
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1100,10 +1100,6 @@ type Store struct {
 
 	scheduler *raftScheduler
 
-	// livenessMap is a map from nodeID to a bool indicating
-	// liveness. It is updated periodically in raftTickLoop()
-	// and reactively in nodeIsLiveCallback() on liveness updates.
-	livenessMap atomic.Value
 	// ioThresholds is analogous to livenessMap, but stores the *IOThresholds for
 	// the stores in the cluster . It is gossip-backed but is not updated
 	// reactively, i.e. will refresh on each tick loop iteration only.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2329,9 +2329,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 	// Register a callback to unquiesce any ranges with replicas on a
 	// node transitioning from non-live to live.
-	if s.cfg.NodeLiveness != nil {
-		s.cfg.NodeLiveness.RegisterCallback(s.nodeIsLiveCallback)
-	}
+	s.cfg.NodeLiveness.RegisterCallback(s.nodeIsLiveCallback)
 
 	// SystemConfigProvider can be nil during some tests.
 	if scp := s.cfg.SystemConfigProvider; scp != nil {

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -699,7 +699,6 @@ func (s *Store) processTick(_ context.Context, rangeID roachpb.RangeID) bool {
 		return false
 	}
 
-	livenessMap, _ := s.livenessMap.Load().(livenesspb.IsLiveMap)
 	ioThresholds := s.ioThresholds.Current()
 
 	// Record the CPU time processing the request for this replica. This is
@@ -708,7 +707,7 @@ func (s *Store) processTick(_ context.Context, rangeID roachpb.RangeID) bool {
 	start := timeutil.Now()
 	ctx := r.raftCtx
 
-	exists, err := r.tick(ctx, livenessMap, ioThresholds)
+	exists, err := r.tick(ctx, ioThresholds)
 	if err != nil {
 		log.Errorf(ctx, "%v", err)
 	}
@@ -739,14 +738,8 @@ func (s *Store) processRACv2RangeController(ctx context.Context, rangeID roachpb
 //	If a quorum of replica in a Raft group is alive and at least
 //	one of these replicas is up-to-date, the Raft group will catch
 //	up any of the live, lagging replicas.
-//
-// Note that this mechanism can race with concurrent invocations of processTick,
-// which may have a copy of the previous livenessMap where the now-live node is
-// down. Those instances should be rare, however, and we expect the newly live
-// node to eventually unquiesce the range.
 func (s *Store) nodeIsLiveCallback(l livenesspb.Liveness) {
 	ctx := context.TODO()
-	s.updateLivenessMap()
 
 	s.mu.replicasByRangeID.Range(func(_ roachpb.RangeID, r *Replica) bool {
 		r.mu.RLock()
@@ -804,8 +797,6 @@ func (s *Store) raftTickLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			// Update the liveness map.
-			s.updateLivenessMap()
 			s.updateIOThresholdMap()
 
 			s.unquiescedReplicas.Lock()
@@ -847,29 +838,6 @@ func (s *Store) updateIOThresholdMap() {
 		log.Infof(
 			s.AnnotateCtx(context.Background()), "pausable stores: %+v", cur)
 	}
-}
-
-func (s *Store) updateLivenessMap() {
-	nextMap := s.cfg.NodeLiveness.GetIsLiveMap()
-	for nodeID, entry := range nextMap {
-		if entry.IsLive {
-			continue
-		}
-		// Liveness claims that this node is down, but ConnHealth gets the last say
-		// because we'd rather quiesce a range too little than one too often. Note
-		// that this policy is different from the one governing the releasing of
-		// proposal quota; see comments over there.
-		//
-		// NB: This has false negatives when we haven't attempted to connect to the
-		// node yet, where it will return rpc.ErrNotHeartbeated regardless of
-		// whether the node is up or not. Once connected, the RPC circuit breakers
-		// will continually probe the connection. The check can also have false
-		// positives if the node goes down after populating the map, but that
-		// matters even less.
-		entry.IsLive = s.cfg.NodeDialer.ConnHealth(nodeID, rpc.SystemClass) == nil
-		nextMap[nodeID] = entry
-	}
-	s.livenessMap.Store(nextMap)
 }
 
 // Since coalesced heartbeats adds latency to heartbeat messages, it is

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -805,9 +805,7 @@ func (s *Store) raftTickLoop(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			// Update the liveness map.
-			if s.cfg.NodeLiveness != nil {
-				s.updateLivenessMap()
-			}
+			s.updateLivenessMap()
 			s.updateIOThresholdMap()
 
 			s.unquiescedReplicas.Lock()

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
@@ -273,6 +274,7 @@ func createTestStoreWithoutStart(
 	}, ds)
 	require.Nil(t, cfg.DB)
 	cfg.DB = kv.NewDB(cfg.AmbientCtx, txnCoordSenderFactory, cfg.Clock, stopper)
+	cfg.NodeLiveness = liveness.NewTestNodeLiveness(stopper, cfg.Clock, cfg.Settings)
 	store := NewStore(ctx, *cfg, eng, nodeDesc)
 	storeSender.Sender = store
 


### PR DESCRIPTION
This moves all the parts of the check into the NodeVitality interface to
simplify the conditions.

Epic: none

Release note: None