### PR TITLE
allocator: log when a lease candidate is invalid

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -1967,19 +1967,50 @@ func (a *Allocator) ValidLeaseTargets(
 	replDescs := roachpb.MakeReplicaSet(existing)
 	for i := range existing {
 		if err := roachpb.CheckCanReceiveLease(existing[i], replDescs, false /* wasLastLeaseholder */); err != nil {
+			log.KvDistribution.VEventf(
+				ctx,
+				5,
+				"not considering [n%d, s%d] as a potential candidate for a lease transfer"+
+					"because %v",
+				existing[i].NodeID, existing[i].StoreID, err,
+			)
 			continue
 		}
 		// If we're not allowed to include the current replica, remove it from
 		// consideration here.
 		if existing[i].StoreID == leaseRepl.StoreID() && opts.ExcludeLeaseRepl {
+			log.KvDistribution.VEventf(
+				ctx,
+				5,
+				"not considering [n%d, s%d] as a potential candidate for a lease transfer"+
+					"because transfer options exclude current leaseholder",
+				existing[i].NodeID, existing[i].StoreID,
+			)
 			continue
 		}
 		candidates = append(candidates, existing[i])
 	}
-	candidates, _ = storePool.LiveAndDeadReplicas(
+	liveCandidates, _ := storePool.LiveAndDeadReplicas(
 		candidates, false, /* includeSuspectAndDrainingStores */
 	)
 
+	if log.ExpensiveLogEnabled(ctx, 5) {
+		// Non-live replicas contains dead, as well as draining, suspect and
+		// unknown replicas.
+		nonLiveCandidates := roachpb.MakeReplicaSet(liveCandidates).
+			Subtract(roachpb.MakeReplicaSet(candidates))
+		for i := range nonLiveCandidates {
+			log.KvDistribution.VEventf(
+				ctx,
+				5,
+				"not considering [n%d, s%d] as a potential candidate for a lease transfer"+
+					"because replica is non-live",
+				nonLiveCandidates[i].NodeID, nonLiveCandidates[i].StoreID,
+			)
+		}
+	}
+
+	candidates = liveCandidates
 	if a.knobs == nil || !a.knobs.AllowLeaseTransfersToReplicasNeedingSnapshots {
 		// Only proceed with the lease transfer if we are also the raft leader (we
 		// already know we are the leaseholder at this point), and only consider
@@ -2026,6 +2057,14 @@ func (a *Allocator) ValidLeaseTargets(
 			ctx, status, leaseRepl.GetFirstIndex(), candidates)...)
 	}
 
+	// NB: Below this point, validity is an overloaded term. When a preference
+	// can't be satisfied, we check the next preference, and so on. If no
+	// preferences are satisfied, then preferences are ignored. The valid target
+	// checks above this point are independent of other candidates, whereas below
+	// this point a candidate's validity can depend on the remaining candidates.
+	// If there is at least one candidate remaining now, we are guaranteed to
+	// return a lease transfer target.
+	//
 	// Determine which store(s) is preferred based on user-specified preferences.
 	// If any stores match, only consider those stores as candidates.
 	preferred := a.PreferredLeaseholders(storePool, conf, candidates)


### PR DESCRIPTION
It can be puzzling to figure out why a replica wasn't a potential
candidate for a lease transfer, when expected to be. This concern is
mostly relevant to debugging tests or investigations.

Log (v=5) a message when a candidate replica is not a valid transfer
target.


Epic: none

Resolves: #105066

Release note: None