### PR TITLE
kv: remove `TxnCoordSender.PrepareRetryableError`, rationalize `ManualRestart`

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1158,13 +1158,12 @@ func (tc *TxnCoordSender) RequiredFrontier() hlc.Timestamp {
 
 // ManualRestart is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) ManualRestart(
-	ctx context.Context, pri roachpb.UserPriority, ts hlc.Timestamp,
-) {
+	ctx context.Context, pri roachpb.UserPriority, ts hlc.Timestamp, msg redact.RedactableString,
+) error {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
-
-	if tc.mu.txnState == txnFinalized {
-		log.Fatalf(ctx, "ManualRestart called on finalized txn: %s", tc.mu.txn)
+	if tc.mu.txnState != txnPending && tc.mu.txnState != txnRetryableError {
+		return errors.AssertionFailedf("cannot manually restart, current state: %s", tc.mu.txnState)
 	}
 
 	// Invalidate any writes performed by any workers after the retry updated
@@ -1172,13 +1171,19 @@ func (tc *TxnCoordSender) ManualRestart(
 	// have been performed at the wrong epoch).
 	tc.mu.txn.Restart(pri, 0 /* upgradePriority */, ts)
 
+	pErr := kvpb.NewTransactionRetryWithProtoRefreshError(
+		msg, tc.mu.txn.ID, tc.mu.txn)
+
+	// Move to a retryable error state, where all Send() calls fail until the
+	// state is cleared.
+	tc.mu.txnState = txnRetryableError
+	tc.mu.storedRetryableErr = pErr
+
+	// Reset state as this manual restart incremented the transaction's epoch.
 	for _, reqInt := range tc.interceptorStack {
 		reqInt.epochBumpedLocked()
 	}
-
-	// The txn might have entered the txnError state after the epoch was bumped.
-	// Reset the state for the retry.
-	tc.mu.txnState = txnPending
+	return pErr
 }
 
 // IsSerializablePushAndRefreshNotPossible is part of the kv.TxnSender interface.
@@ -1337,22 +1342,6 @@ func (tc *TxnCoordSender) TestingCloneTxn() *roachpb.Transaction {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.mu.txn.Clone()
-}
-
-// PrepareRetryableError is part of the kv.TxnSender interface.
-func (tc *TxnCoordSender) PrepareRetryableError(
-	ctx context.Context, msg redact.RedactableString,
-) error {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-	if tc.mu.txnState != txnPending {
-		return errors.AssertionFailedf("cannot set a retryable error. current state: %s", tc.mu.txnState)
-	}
-	pErr := kvpb.NewTransactionRetryWithProtoRefreshError(
-		msg, tc.mu.txn.ID, tc.mu.txn)
-	tc.mu.storedRetryableErr = pErr
-	tc.mu.txnState = txnRetryableError
-	return pErr
 }
 
 // Step is part of the TxnSender interface.

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -145,9 +145,10 @@ func (m *MockTransactionalSender) RequiredFrontier() hlc.Timestamp {
 
 // ManualRestart is part of the TxnSender interface.
 func (m *MockTransactionalSender) ManualRestart(
-	ctx context.Context, pri roachpb.UserPriority, ts hlc.Timestamp,
-) {
+	ctx context.Context, pri roachpb.UserPriority, ts hlc.Timestamp, msg redact.RedactableString,
+) error {
 	m.txn.Restart(pri, 0 /* upgradePriority */, ts)
+	return kvpb.NewTransactionRetryWithProtoRefreshError(msg, m.txn.ID, m.txn)
 }
 
 // IsSerializablePushAndRefreshNotPossible is part of the TxnSender interface.
@@ -195,13 +196,6 @@ func (m *MockTransactionalSender) UpdateStateOnRemoteRetryableErr(
 
 // DisablePipelining is part of the kv.TxnSender interface.
 func (m *MockTransactionalSender) DisablePipelining() error { return nil }
-
-// PrepareRetryableError is part of the kv.TxnSender interface.
-func (m *MockTransactionalSender) PrepareRetryableError(
-	ctx context.Context, msg redact.RedactableString,
-) error {
-	return kvpb.NewTransactionRetryWithProtoRefreshError(msg, m.txn.ID, *m.txn.Clone())
-}
 
 // Step is part of the TxnSender interface.
 func (m *MockTransactionalSender) Step(_ context.Context) error {

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1393,23 +1393,24 @@ func (txn *Txn) SetFixedTimestamp(ctx context.Context, ts hlc.Timestamp) error {
 	return txn.mu.sender.SetFixedTimestamp(ctx, ts)
 }
 
-// GenerateForcedRetryableError returns a TransactionRetryWithProtoRefreshError that will
-// cause the txn to be retried.
+// GenerateForcedRetryableError returns a TransactionRetryWithProtoRefreshError
+// that will cause the txn to be retried.
 //
 // The transaction's epoch is bumped, simulating to an extent what the
 // TxnCoordSender does on retriable errors. The transaction's timestamp is only
 // bumped to the extent that txn.ReadTimestamp is racheted up to txn.WriteTimestamp.
 // TODO(andrei): This method should take in an up-to-date timestamp, but
 // unfortunately its callers don't currently have that handy.
+//
+// As with other transaction retry errors, the caller must call PrepareForRetry
+// before continuing to use the transaction.
 func (txn *Txn) GenerateForcedRetryableError(
 	ctx context.Context, msg redact.RedactableString,
 ) error {
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	now := txn.db.clock.NowAsClockTimestamp()
-	txn.mu.sender.ManualRestart(ctx, txn.mu.userPriority, now.ToTimestamp())
-	txn.resetDeadlineLocked()
-	return txn.mu.sender.PrepareRetryableError(ctx, msg)
+	return txn.mu.sender.ManualRestart(ctx, txn.mu.userPriority, now.ToTimestamp(), msg)
 }
 
 // IsSerializablePushAndRefreshNotPossible returns true if the transaction is


### PR DESCRIPTION
This commit cleans up the implementation of `GenerateForcedRetryableError` by removing the `TxnCoordSender.PrepareRetryableError` method and having the `TxnCoordSender.ManualRestart` return a retryable error.

The cleanup also ensures that the `TxnCoordSender` is left in a `txnRetryableError` state after a `ManualRestart`, so that `Txn.PrepareForRetry` must be called before continuing to use the transaction.

The goal with both of these changes is to close the gap between the handling of error-driven txn restarts and manual restarts. It also reworks the code to construct the retry error in the same place that "handles" the error, which is important for future changes that plan to add more context to retry errors.

Release note: None
Epic: None