### PR TITLE
storage: Handle EOF correctly in externalStorageReader

### DIFF
--- a/pkg/storage/shared_storage.go
+++ b/pkg/storage/shared_storage.go
@@ -47,7 +47,10 @@ func (r *externalStorageReader) ReadAt(ctx context.Context, p []byte, offset int
 	defer reader.Close(ctx)
 	for n := 0; n < len(p); {
 		nn, err := reader.Read(ctx, p[n:])
-		if err != nil {
+		// The io.Reader interface allows for io.EOF to be returned even if we just
+		// successfully filled the buffer p and hit the end of file at the same
+		// time. Treat that case as a successful read.
+		if err != nil && !(errors.Is(err, io.EOF) && len(p) == nn+n) {
 			return err
 		}
 		n += nn


### PR DESCRIPTION
Previously, if we hit the end of file in externalSTorageWrapper's
ReadAt(), even if we were passed a buffer that ended right at EOF,
we'd return the EOF error even though we read the file's footer
successfully. This deviated from behaviour of other objstorage.Readable
implementations and from the behaviour expected by Pebble, and resulted in
`unable to read footer (invalid table): EOF` errors in testing.

Epic: none

Release note: None