### PR TITLE
kvserver: rename RaftMessageHandler to IncomingRaftMessageHandler

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -699,9 +699,9 @@ func mergeCheckingTimestampCaches(
 				} else {
 					funcs = partitionedLeaderFuncs
 				}
-				tc.Servers[i].RaftTransport().Listen(s.StoreID(), &unreliableRaftHandler{
+				tc.Servers[i].RaftTransport().ListenIncomingRaftMessages(s.StoreID(), &unreliableRaftHandler{
 					rangeID:                    lhsDesc.GetRangeID(),
-					RaftMessageHandler:         s,
+					IncomingRaftMessageHandler: s,
 					unreliableRaftHandlerFuncs: funcs,
 				})
 			}
@@ -801,17 +801,17 @@ func mergeCheckingTimestampCaches(
 		// Remove the partition. A snapshot to the leaseholder should follow.
 		// This snapshot will inform the leaseholder about the range merge.
 		for i, s := range lhsStores {
-			var h kvserver.RaftMessageHandler
+			var h kvserver.IncomingRaftMessageHandler
 			if i == 0 {
 				h = &unreliableRaftHandler{
 					rangeID:                    lhsDesc.GetRangeID(),
-					RaftMessageHandler:         s,
+					IncomingRaftMessageHandler: s,
 					unreliableRaftHandlerFuncs: restoredLeaseholderFuncs,
 				}
 			} else {
 				h = s
 			}
-			tc.Servers[i].RaftTransport().Listen(s.StoreID(), h)
+			tc.Servers[i].RaftTransport().ListenIncomingRaftMessages(s.StoreID(), h)
 		}
 		close(filterMu.blockHBAndGCs)
 		filterMu.Lock()
@@ -2481,8 +2481,8 @@ func TestStoreReplicaGCAfterMerge(t *testing.T) {
 		nil, /* knobs */
 	)
 	errChan := errorChannelTestHandler(make(chan *kvpb.Error, 1))
-	transport.Listen(store0.StoreID(), errChan)
-	transport.Listen(store1.StoreID(), errChan)
+	transport.ListenIncomingRaftMessages(store0.StoreID(), errChan)
+	transport.ListenIncomingRaftMessages(store1.StoreID(), errChan)
 
 	sendHeartbeat := func(
 		rangeID roachpb.RangeID,
@@ -2736,9 +2736,9 @@ func TestStoreRangeMergeSlowUnabandonedFollower_WithSplit(t *testing.T) {
 
 	// Start dropping all Raft traffic to the LHS on store2 so that it won't be
 	// aware that there is a merge in progress.
-	tc.Servers[2].RaftTransport().Listen(store2.Ident.StoreID, &unreliableRaftHandler{
-		rangeID:            lhsDesc.RangeID,
-		RaftMessageHandler: store2,
+	tc.Servers[2].RaftTransport().ListenIncomingRaftMessages(store2.Ident.StoreID, &unreliableRaftHandler{
+		rangeID:                    lhsDesc.RangeID,
+		IncomingRaftMessageHandler: store2,
 		unreliableRaftHandlerFuncs: unreliableRaftHandlerFuncs{
 			dropReq: func(req *kvserverpb.RaftMessageRequest) bool {
 				return true
@@ -3017,9 +3017,9 @@ func TestStoreRangeMergeAbandonedFollowersAutomaticallyGarbageCollected(t *testi
 
 	// Start dropping all Raft traffic to the LHS replica on store2 so that it
 	// won't be aware that there is a merge in progress.
-	tc.Servers[2].RaftTransport().Listen(store2.Ident.StoreID, &unreliableRaftHandler{
-		rangeID:            lhsDesc.RangeID,
-		RaftMessageHandler: store2,
+	tc.Servers[2].RaftTransport().ListenIncomingRaftMessages(store2.Ident.StoreID, &unreliableRaftHandler{
+		rangeID:                    lhsDesc.RangeID,
+		IncomingRaftMessageHandler: store2,
 		unreliableRaftHandlerFuncs: unreliableRaftHandlerFuncs{
 			dropReq: func(*kvserverpb.RaftMessageRequest) bool {
 				return true
@@ -3219,7 +3219,7 @@ func TestStoreRangeReadoptedLHSFollower(t *testing.T) {
 type slowSnapRaftHandler struct {
 	rangeID roachpb.RangeID
 	waitCh  chan struct{}
-	kvserver.RaftMessageHandler
+	kvserver.IncomingRaftMessageHandler
 	syncutil.Mutex
 }
 
@@ -3245,7 +3245,7 @@ func (h *slowSnapRaftHandler) HandleSnapshot(
 			<-waitCh
 		}
 	}
-	return h.RaftMessageHandler.HandleSnapshot(ctx, header, respStream)
+	return h.IncomingRaftMessageHandler.HandleSnapshot(ctx, header, respStream)
 }
 
 // TestStoreRangeMergeUninitializedLHSFollower reproduces a rare bug in which a
@@ -3326,15 +3326,15 @@ func TestStoreRangeMergeUninitializedLHSFollower(t *testing.T) {
 	// of range 1 never processes the split trigger, which would create an
 	// initialized replica of A.
 	unreliableHandler := &unreliableRaftHandler{
-		rangeID:            desc.RangeID,
-		RaftMessageHandler: store2,
+		rangeID:                    desc.RangeID,
+		IncomingRaftMessageHandler: store2,
 		unreliableRaftHandlerFuncs: unreliableRaftHandlerFuncs{
 			dropReq: func(request *kvserverpb.RaftMessageRequest) bool {
 				return true
 			},
 		},
 	}
-	tc.Servers[2].RaftTransport().Listen(store2.Ident.StoreID, unreliableHandler)
+	tc.Servers[2].RaftTransport().ListenIncomingRaftMessages(store2.Ident.StoreID, unreliableHandler)
 
 	// Perform the split of A, now that store2 won't be able to initialize its
 	// replica of A.
@@ -3343,12 +3343,12 @@ func TestStoreRangeMergeUninitializedLHSFollower(t *testing.T) {
 	// Wedge a Raft snapshot that's destined for A. This allows us to capture a
 	// pre-merge Raft snapshot, which we'll let loose after the merge commits.
 	slowSnapHandler := &slowSnapRaftHandler{
-		rangeID:            aRangeID,
-		waitCh:             make(chan struct{}),
-		RaftMessageHandler: unreliableHandler,
+		rangeID:                    aRangeID,
+		waitCh:                     make(chan struct{}),
+		IncomingRaftMessageHandler: unreliableHandler,
 	}
 	defer slowSnapHandler.unblock()
-	tc.Servers[2].RaftTransport().Listen(store2.Ident.StoreID, slowSnapHandler)
+	tc.Servers[2].RaftTransport().ListenIncomingRaftMessages(store2.Ident.StoreID, slowSnapHandler)
 
 	// Remove the replica of range 1 on store2. If we were to leave it in place,
 	// store2 would refuse to GC its replica of C after the merge commits, because
@@ -4007,9 +4007,9 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 	aRepl0 := store0.LookupReplica(roachpb.RKey(keyA))
 
 	// Start dropping all Raft traffic to the first range on store2.
-	tc.Servers[2].RaftTransport().Listen(store2.Ident.StoreID, &unreliableRaftHandler{
-		rangeID:            aRepl0.RangeID,
-		RaftMessageHandler: store2,
+	tc.Servers[2].RaftTransport().ListenIncomingRaftMessages(store2.Ident.StoreID, &unreliableRaftHandler{
+		rangeID:                    aRepl0.RangeID,
+		IncomingRaftMessageHandler: store2,
 		unreliableRaftHandlerFuncs: unreliableRaftHandlerFuncs{
 			dropReq: func(request *kvserverpb.RaftMessageRequest) bool {
 				return true
@@ -4050,9 +4050,9 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 
 	// Restore Raft traffic to the LHS on store2.
 	log.Infof(ctx, "restored traffic to store 2")
-	tc.Servers[2].RaftTransport().Listen(store2.Ident.StoreID, &unreliableRaftHandler{
-		rangeID:            aRepl0.RangeID,
-		RaftMessageHandler: store2,
+	tc.Servers[2].RaftTransport().ListenIncomingRaftMessages(store2.Ident.StoreID, &unreliableRaftHandler{
+		rangeID:                    aRepl0.RangeID,
+		IncomingRaftMessageHandler: store2,
 		unreliableRaftHandlerFuncs: unreliableRaftHandlerFuncs{
 			dropReq: func(req *kvserverpb.RaftMessageRequest) bool {
 				// Make sure that even going forward no MsgApp for what we just

--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -60,7 +60,7 @@ func noopRaftHandlerFuncs() unreliableRaftHandlerFuncs {
 type unreliableRaftHandler struct {
 	name    string
 	rangeID roachpb.RangeID
-	kvserver.RaftMessageHandler
+	kvserver.IncomingRaftMessageHandler
 	unreliableRaftHandlerFuncs
 }
 
@@ -115,7 +115,7 @@ func (h *unreliableRaftHandler) HandleRaftRequest(
 			)
 		}
 	}
-	return h.RaftMessageHandler.HandleRaftRequest(ctx, req, respStream)
+	return h.IncomingRaftMessageHandler.HandleRaftRequest(ctx, req, respStream)
 }
 
 func (h *unreliableRaftHandler) filterHeartbeats(
@@ -142,7 +142,7 @@ func (h *unreliableRaftHandler) HandleRaftResponse(
 			return nil
 		}
 	}
-	return h.RaftMessageHandler.HandleRaftResponse(ctx, resp)
+	return h.IncomingRaftMessageHandler.HandleRaftResponse(ctx, resp)
 }
 
 func (h *unreliableRaftHandler) HandleSnapshot(
@@ -155,7 +155,7 @@ func (h *unreliableRaftHandler) HandleSnapshot(
 			return err
 		}
 	}
-	return h.RaftMessageHandler.HandleSnapshot(ctx, header, respStream)
+	return h.IncomingRaftMessageHandler.HandleSnapshot(ctx, header, respStream)
 }
 
 func (h *unreliableRaftHandler) HandleDelegatedSnapshot(
@@ -169,7 +169,7 @@ func (h *unreliableRaftHandler) HandleDelegatedSnapshot(
 			}
 		}
 	}
-	return h.RaftMessageHandler.HandleDelegatedSnapshot(ctx, req)
+	return h.IncomingRaftMessageHandler.HandleDelegatedSnapshot(ctx, req)
 }
 
 // testClusterStoreRaftMessageHandler exists to allows a store to be stopped and
@@ -241,7 +241,7 @@ type testClusterPartitionedRange struct {
 		partitioned         bool
 		partitionedReplicas map[roachpb.ReplicaID]bool
 	}
-	handlers []kvserver.RaftMessageHandler
+	handlers []kvserver.IncomingRaftMessageHandler
 }
 
 // setupPartitionedRange sets up an testClusterPartitionedRange for the provided
@@ -275,7 +275,7 @@ func setupPartitionedRange(
 	activated bool,
 	funcs unreliableRaftHandlerFuncs,
 ) (*testClusterPartitionedRange, error) {
-	handlers := make([]kvserver.RaftMessageHandler, 0, len(tc.Servers))
+	handlers := make([]kvserver.IncomingRaftMessageHandler, 0, len(tc.Servers))
 	for i := range tc.Servers {
 		handlers = append(handlers, &testClusterStoreRaftMessageHandler{
 			tc:       tc,
@@ -291,12 +291,12 @@ func setupPartitionedRangeWithHandlers(
 	replicaID roachpb.ReplicaID,
 	partitionedNodeIdx int,
 	activated bool,
-	handlers []kvserver.RaftMessageHandler,
+	handlers []kvserver.IncomingRaftMessageHandler,
 	funcs unreliableRaftHandlerFuncs,
 ) (*testClusterPartitionedRange, error) {
 	pr := &testClusterPartitionedRange{
 		rangeID:  rangeID,
-		handlers: make([]kvserver.RaftMessageHandler, 0, len(handlers)),
+		handlers: make([]kvserver.IncomingRaftMessageHandler, 0, len(handlers)),
 	}
 	pr.mu.partitioned = activated
 	pr.mu.partitionedNodeIdx = partitionedNodeIdx
@@ -323,7 +323,7 @@ func setupPartitionedRangeWithHandlers(
 		s := i
 		h := &unreliableRaftHandler{
 			rangeID:                    rangeID,
-			RaftMessageHandler:         handlers[s],
+			IncomingRaftMessageHandler: handlers[s],
 			unreliableRaftHandlerFuncs: funcs,
 		}
 		// Only filter messages from the partitioned store on the other
@@ -383,7 +383,7 @@ func setupPartitionedRangeWithHandlers(
 			}
 		}
 		pr.handlers = append(pr.handlers, h)
-		tc.Servers[s].RaftTransport().Listen(tc.Target(s).StoreID, h)
+		tc.Servers[s].RaftTransport().ListenIncomingRaftMessages(tc.Target(s).StoreID, h)
 	}
 	return pr, nil
 }
@@ -438,9 +438,9 @@ func dropRaftMessagesFrom(
 
 	store, err := srv.Stores().GetStore(srv.GetFirstStoreID())
 	require.NoError(t, err)
-	srv.RaftTransport().Listen(store.StoreID(), &unreliableRaftHandler{
-		rangeID:            rangeID,
-		RaftMessageHandler: store,
+	srv.RaftTransport().ListenIncomingRaftMessages(store.StoreID(), &unreliableRaftHandler{
+		rangeID:                    rangeID,
+		IncomingRaftMessageHandler: store,
 		unreliableRaftHandlerFuncs: unreliableRaftHandlerFuncs{
 			dropHB: func(hb *kvserverpb.RaftHeartbeat) bool {
 				return shouldDrop(hb.RangeID, hb.FromReplicaID)

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -868,12 +868,12 @@ func TestStoreRangeSplitMergeStats(t *testing.T) {
 	require.Equal(t, ms, msMerged, "post-merge stats differ from pre-split")
 }
 
-// RaftMessageHandlerInterceptor wraps a storage.RaftMessageHandler. It
-// delegates all methods to the underlying storage.RaftMessageHandler, except
-// that HandleSnapshot calls receiveSnapshotFilter with the snapshot request
-// header before delegating to the underlying HandleSnapshot method.
+// RaftMessageHandlerInterceptor wraps a storage.IncomingRaftMessageHandler. It
+// delegates all methods to the underlying storage.IncomingRaftMessageHandler,
+// except that HandleSnapshot calls receiveSnapshotFilter with the snapshot
+// request header before delegating to the underlying HandleSnapshot method.
 type RaftMessageHandlerInterceptor struct {
-	kvserver.RaftMessageHandler
+	kvserver.IncomingRaftMessageHandler
 	handleSnapshotFilter func(header *kvserverpb.SnapshotRequest_Header)
 }
 
@@ -883,7 +883,7 @@ func (mh RaftMessageHandlerInterceptor) HandleSnapshot(
 	respStream kvserver.SnapshotResponseStream,
 ) error {
 	mh.handleSnapshotFilter(header)
-	return mh.RaftMessageHandler.HandleSnapshot(ctx, header, respStream)
+	return mh.IncomingRaftMessageHandler.HandleSnapshot(ctx, header, respStream)
 }
 
 // TestStoreEmptyRangeSnapshotSize tests that the snapshot request header for a
@@ -923,7 +923,7 @@ func TestStoreEmptyRangeSnapshotSize(t *testing.T) {
 		headers []*kvserverpb.SnapshotRequest_Header
 	}{}
 	messageHandler := RaftMessageHandlerInterceptor{
-		RaftMessageHandler: tc.GetFirstStoreFromServer(t, 1),
+		IncomingRaftMessageHandler: tc.GetFirstStoreFromServer(t, 1),
 		handleSnapshotFilter: func(header *kvserverpb.SnapshotRequest_Header) {
 			// Each snapshot request is handled in a new goroutine, so we need
 			// synchronization.
@@ -932,7 +932,7 @@ func TestStoreEmptyRangeSnapshotSize(t *testing.T) {
 			messageRecorder.headers = append(messageRecorder.headers, header)
 		},
 	}
-	tc.Servers[1].RaftTransport().Listen(tc.GetFirstStoreFromServer(t, 1).StoreID(), messageHandler)
+	tc.Servers[1].RaftTransport().ListenIncomingRaftMessages(tc.GetFirstStoreFromServer(t, 1).StoreID(), messageHandler)
 
 	// Replicate the newly-split range to trigger a snapshot request from store 0
 	// to store 1.
@@ -3383,9 +3383,9 @@ func TestSplitTriggerMeetsUnexpectedReplicaID(t *testing.T) {
 	})
 
 	store, _ := getFirstStoreReplica(t, tc.Server(1), k)
-	tc.Servers[1].RaftTransport().Listen(store.StoreID(), &unreliableRaftHandler{
-		rangeID:            desc.RangeID,
-		RaftMessageHandler: store,
+	tc.Servers[1].RaftTransport().ListenIncomingRaftMessages(store.StoreID(), &unreliableRaftHandler{
+		rangeID:                    desc.RangeID,
+		IncomingRaftMessageHandler: store,
 	})
 
 	_, kRHS := k, k.Next()
@@ -3461,7 +3461,7 @@ func TestSplitTriggerMeetsUnexpectedReplicaID(t *testing.T) {
 
 	// Re-enable raft and wait for the lhs to catch up to the post-split
 	// descriptor. This used to panic with "raft group deleted".
-	tc.Servers[1].RaftTransport().Listen(store.StoreID(), store)
+	tc.Servers[1].RaftTransport().ListenIncomingRaftMessages(store.StoreID(), store)
 	testutils.SucceedsSoon(t, func() error {
 		repl, err := store.GetReplica(descLHS.RangeID)
 		if err != nil {

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -100,10 +100,10 @@ func TestFlowControlBasic(t *testing.T) {
 		for i := 0; i < numNodes; i++ {
 			si, err := tc.Server(i).GetStores().(*kvserver.Stores).GetStore(tc.Server(i).GetFirstStoreID())
 			require.NoError(t, err)
-			tc.Servers[i].RaftTransport().Listen(si.StoreID(),
+			tc.Servers[i].RaftTransport().ListenIncomingRaftMessages(si.StoreID(),
 				&unreliableRaftHandler{
-					rangeID:            desc.RangeID,
-					RaftMessageHandler: si,
+					rangeID:                    desc.RangeID,
+					IncomingRaftMessageHandler: si,
 					unreliableRaftHandlerFuncs: unreliableRaftHandlerFuncs{
 						dropReq: func(req *kvserverpb.RaftMessageRequest) bool {
 							// Install a raft handler to get verbose raft logging.
@@ -1907,10 +1907,10 @@ func TestFlowControlUnquiescedRange(t *testing.T) {
 	for i := 0; i < numNodes; i++ {
 		si, err := tc.Server(i).GetStores().(*kvserver.Stores).GetStore(tc.Server(i).GetFirstStoreID())
 		require.NoError(t, err)
-		tc.Servers[i].RaftTransport().Listen(si.StoreID(),
+		tc.Servers[i].RaftTransport().ListenIncomingRaftMessages(si.StoreID(),
 			&unreliableRaftHandler{
-				rangeID:            desc.RangeID,
-				RaftMessageHandler: si,
+				rangeID:                    desc.RangeID,
+				IncomingRaftMessageHandler: si,
 				unreliableRaftHandlerFuncs: unreliableRaftHandlerFuncs{
 					dropReq: func(req *kvserverpb.RaftMessageRequest) bool {
 						// Install a raft handler to get verbose raft logging.

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -105,9 +105,9 @@ type SnapshotResponseStream interface {
 	Recv() (*kvserverpb.SnapshotRequest, error)
 }
 
-// RaftMessageHandler is the interface that must be implemented by
-// arguments to RaftTransport.Listen.
-type RaftMessageHandler interface {
+// IncomingRaftMessageHandler is the interface that must be implemented by
+// arguments to RaftTransport.ListenIncomingRaftMessages.
+type IncomingRaftMessageHandler interface {
 	// HandleRaftRequest is called for each incoming Raft message. The request is
 	// always processed asynchronously and the response is sent over respStream.
 	// If an error is encountered during asynchronous processing, it will be
@@ -161,8 +161,8 @@ type RaftTransport struct {
 	// is done while holding kvflowControl.mu.
 	queues [rpc.NumConnectionClasses]syncutil.IntMap
 
-	dialer   *nodedialer.Dialer
-	handlers syncutil.IntMap // map[roachpb.StoreID]*RaftMessageHandler
+	dialer                  *nodedialer.Dialer
+	incomingMessageHandlers syncutil.IntMap // map[roachpb.StoreID]*IncomingRaftMessageHandler
 
 	kvflowControl struct {
 		// Everything nested under this struct is used to return flow tokens
@@ -372,9 +372,11 @@ func (t *RaftTransport) queueByteSize() int64 {
 	return size
 }
 
-func (t *RaftTransport) getHandler(storeID roachpb.StoreID) (RaftMessageHandler, bool) {
-	if value, ok := t.handlers.Load(int64(storeID)); ok {
-		return *(*RaftMessageHandler)(value), true
+func (t *RaftTransport) getIncomingRaftMessageHandler(
+	storeID roachpb.StoreID,
+) (IncomingRaftMessageHandler, bool) {
+	if value, ok := t.incomingMessageHandlers.Load(int64(storeID)); ok {
+		return *(*IncomingRaftMessageHandler)(value), true
 	}
 	return nil, false
 }
@@ -410,14 +412,14 @@ func (t *RaftTransport) handleRaftRequest(
 		return nil
 	}
 
-	handler, ok := t.getHandler(req.ToReplica.StoreID)
+	incomingMessageHandler, ok := t.getIncomingRaftMessageHandler(req.ToReplica.StoreID)
 	if !ok {
 		log.Warningf(ctx, "unable to accept Raft message from %+v: no handler registered for %+v",
 			req.FromReplica, req.ToReplica)
 		return kvpb.NewError(kvpb.NewStoreNotFoundError(req.ToReplica.StoreID))
 	}
 
-	return handler.HandleRaftRequest(ctx, req, respStream)
+	return incomingMessageHandler.HandleRaftRequest(ctx, req, respStream)
 }
 
 // newRaftMessageResponse constructs a RaftMessageResponse from the
@@ -537,7 +539,7 @@ func (t *RaftTransport) InternalDelegateRaftSnapshot(
 		}
 	}
 	// Get the handler of the sender store.
-	handler, ok := t.getHandler(req.DelegatedSender.StoreID)
+	incomingMessageHandler, ok := t.getIncomingRaftMessageHandler(req.DelegatedSender.StoreID)
 	if !ok {
 		log.Warningf(
 			ctx,
@@ -554,7 +556,7 @@ func (t *RaftTransport) InternalDelegateRaftSnapshot(
 	}
 
 	// Pass off the snapshot request to the sender store.
-	return handler.HandleDelegatedSnapshot(ctx, req)
+	return incomingMessageHandler.HandleDelegatedSnapshot(ctx, req)
 }
 
 // RaftSnapshot handles incoming streaming snapshot requests.
@@ -570,23 +572,25 @@ func (t *RaftTransport) RaftSnapshot(stream MultiRaft_RaftSnapshotServer) error 
 		return stream.Send(snapRespErr(err))
 	}
 	rmr := req.Header.RaftMessageRequest
-	handler, ok := t.getHandler(rmr.ToReplica.StoreID)
+	incomingMessageHandler, ok := t.getIncomingRaftMessageHandler(rmr.ToReplica.StoreID)
 	if !ok {
 		log.Warningf(ctx, "unable to accept Raft message from %+v: no handler registered for %+v",
 			rmr.FromReplica, rmr.ToReplica)
 		return kvpb.NewStoreNotFoundError(rmr.ToReplica.StoreID)
 	}
-	return handler.HandleSnapshot(ctx, req.Header, stream)
+	return incomingMessageHandler.HandleSnapshot(ctx, req.Header, stream)
 }
 
-// Listen registers a raftMessageHandler to receive proxied messages.
-func (t *RaftTransport) Listen(storeID roachpb.StoreID, handler RaftMessageHandler) {
-	t.handlers.Store(int64(storeID), unsafe.Pointer(&handler))
+// ListenIncomingRaftMessages registers a IncomingRaftMessageHandler to receive proxied messages.
+func (t *RaftTransport) ListenIncomingRaftMessages(
+	storeID roachpb.StoreID, handler IncomingRaftMessageHandler,
+) {
+	t.incomingMessageHandlers.Store(int64(storeID), unsafe.Pointer(&handler))
 }
 
-// Stop unregisters a raftMessageHandler.
-func (t *RaftTransport) Stop(storeID roachpb.StoreID) {
-	t.handlers.Delete(int64(storeID))
+// StopIncomingRaftMessages unregisters a IncomingRaftMessageHandler.
+func (t *RaftTransport) StopIncomingRaftMessages(storeID roachpb.StoreID) {
+	t.incomingMessageHandlers.Delete(int64(storeID))
 }
 
 // processQueue opens a Raft client stream and sends messages from the
@@ -611,13 +615,13 @@ func (t *RaftTransport) processQueue(
 						return err
 					}
 					t.metrics.ReverseRcvd.Inc(1)
-					handler, ok := t.getHandler(resp.ToReplica.StoreID)
+					incomingMessageHandler, ok := t.getIncomingRaftMessageHandler(resp.ToReplica.StoreID)
 					if !ok {
 						log.Warningf(ctx, "no handler found for store %s in response %s",
 							resp.ToReplica.StoreID, resp)
 						continue
 					}
-					if err := handler.HandleRaftResponse(ctx, resp); err != nil {
+					if err := incomingMessageHandler.HandleRaftResponse(ctx, resp); err != nil {
 						return err
 					}
 				}

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -220,7 +220,7 @@ func (rttc *raftTransportTestContext) ListenStore(
 	nodeID roachpb.NodeID, storeID roachpb.StoreID,
 ) channelServer {
 	ch := newChannelServer(100, 10*time.Millisecond)
-	rttc.transports[nodeID].Listen(storeID, ch)
+	rttc.transports[nodeID].ListenIncomingRaftMessages(storeID, ch)
 	return ch
 }
 
@@ -530,7 +530,7 @@ func TestRaftTransportIndependentRanges(t *testing.T) {
 	const numMessages = 50
 	channelServer := newChannelServer(numMessages*2, 10*time.Millisecond)
 	channelServer.brokenRange = 13
-	serverTransport.Listen(server.StoreID, channelServer)
+	serverTransport.ListenIncomingRaftMessages(server.StoreID, channelServer)
 
 	for i := 0; i < numMessages; i++ {
 		for _, rangeID := range []roachpb.RangeID{1, 13} {
@@ -591,7 +591,7 @@ func TestReopenConnection(t *testing.T) {
 	rttc.ListenStore(clientReplica.NodeID, clientReplica.StoreID)
 
 	// Take down the old server and start a new one at the same address.
-	serverTransport.Stop(serverReplica.StoreID)
+	serverTransport.StopIncomingRaftMessages(serverReplica.StoreID)
 	serverStopper.Stop(context.Background())
 
 	// With the old server down, nothing is listening no the address right now

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -814,9 +814,9 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 		})
 
 		// Partition the replica from the rest of its range.
-		partitionStore.Transport().Listen(partitionStore.Ident.StoreID, &unreliableRaftHandler{
-			rangeID:            rangeID,
-			RaftMessageHandler: partitionStore,
+		partitionStore.Transport().ListenIncomingRaftMessages(partitionStore.Ident.StoreID, &unreliableRaftHandler{
+			rangeID:                    rangeID,
+			IncomingRaftMessageHandler: partitionStore,
 		})
 
 		// Perform a write on the range.
@@ -849,9 +849,9 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 		}
 
 		// Remove the partition. Snapshot should follow.
-		partitionStore.Transport().Listen(partitionStore.Ident.StoreID, &unreliableRaftHandler{
-			rangeID:            rangeID,
-			RaftMessageHandler: partitionStore,
+		partitionStore.Transport().ListenIncomingRaftMessages(partitionStore.Ident.StoreID, &unreliableRaftHandler{
+			rangeID:                    rangeID,
+			IncomingRaftMessageHandler: partitionStore,
 			unreliableRaftHandlerFuncs: unreliableRaftHandlerFuncs{
 				dropReq: func(req *kvserverpb.RaftMessageRequest) bool {
 					// Make sure that even going forward no MsgApp for what we just truncated can

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1875,7 +1875,7 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 }
 
 type delayingRaftMessageHandler struct {
-	kvserver.RaftMessageHandler
+	kvserver.IncomingRaftMessageHandler
 	leaseHolderNodeID uint64
 	rangeID           roachpb.RangeID
 }
@@ -1891,11 +1891,11 @@ func (h delayingRaftMessageHandler) HandleRaftRequest(
 	respStream kvserver.RaftMessageResponseStream,
 ) *kvpb.Error {
 	if h.rangeID != req.RangeID {
-		return h.RaftMessageHandler.HandleRaftRequest(ctx, req, respStream)
+		return h.IncomingRaftMessageHandler.HandleRaftRequest(ctx, req, respStream)
 	}
 	go func() {
 		time.Sleep(raftDelay)
-		err := h.RaftMessageHandler.HandleRaftRequest(ctx, req, respStream)
+		err := h.IncomingRaftMessageHandler.HandleRaftRequest(ctx, req, respStream)
 		if err != nil {
 			log.Infof(ctx, "HandleRaftRequest returned err %s", err)
 		}
@@ -1972,7 +1972,7 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	remoteStore.Transport().Listen(
+	remoteStore.Transport().ListenIncomingRaftMessages(
 		remoteStoreID,
 		delayingRaftMessageHandler{remoteStore, leaseHolderNodeID, rangeID},
 	)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -585,18 +585,18 @@ A Replica should be thought of primarily as a State Machine applying commands
 from a replicated log (the log being replicated across the members of the
 Range). The Store's RaftTransport receives Raft messages from Replicas residing
 on other Stores and routes them to the appropriate Replicas via
-Store.HandleRaftRequest (which is part of the RaftMessageHandler interface),
-ultimately resulting in a call to Replica.handleRaftReadyRaftMuLocked, which
-houses the integration with the etcd/raft library (raft.RawNode). This may
-generate Raft messages to be sent to other Stores; these are handed to
-Replica.sendRaftMessages which ultimately hands them to the Store's
-RaftTransport.SendAsync method. Raft uses message passing (not
-request-response), and outgoing messages will use a gRPC stream that differs
-from that used for incoming messages (which makes asymmetric partitions more
-likely in case of stream-specific problems). The steady state is relatively
-straightforward but when Ranges are being reconfigured, an understanding the
-Replica Lifecycle becomes important and upholding the Store's invariants becomes
-more complex.
+Store.HandleRaftRequest (which is part of the IncomingRaftMessageHandler
+interface), ultimately resulting in a call to
+Replica.handleRaftReadyRaftMuLocked, which houses the integration with the
+etcd/raft library (raft.RawNode). This may generate Raft messages to be sent to
+other Stores; these are handed to Replica.sendRaftMessages which ultimately
+hands them to the Store's RaftTransport.SendAsync method. Raft uses message
+passing (not request-response), and outgoing messages will use a gRPC stream
+that differs from that used for incoming messages (which makes asymmetric
+partitions more likely in case of stream-specific problems). The steady state is
+relatively straightforward but when Ranges are being reconfigured, an
+understanding the Replica Lifecycle becomes important and upholding the Store's
+invariants becomes more complex.
 
 A first phenomenon to understand is that of uninitialized Replicas, which is the
 State Machine at applied index zero, i.e. has an empty state. In CockroachDB, an
@@ -2059,7 +2059,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	}
 
 	// Start Raft processing goroutines.
-	s.cfg.Transport.Listen(s.StoreID(), s)
+	s.cfg.Transport.ListenIncomingRaftMessages(s.StoreID(), s)
 	s.processRaft(ctx)
 
 	// Register a callback to unquiesce any ranges with replicas on a

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -269,9 +269,9 @@ func (s *Store) uncoalesceBeats(
 func (s *Store) HandleRaftRequest(
 	ctx context.Context, req *kvserverpb.RaftMessageRequest, respStream RaftMessageResponseStream,
 ) *kvpb.Error {
-	// NB: unlike the other two RaftMessageHandler methods implemented by Store,
-	// this one doesn't need to directly run through a Stopper task because it
-	// delegates all work through a raftScheduler, whose workers' lifetimes are
+	// NB: unlike the other two IncomingRaftMessageHandler methods implemented by
+	// Store, this one doesn't need to directly run through a Stopper task because
+	// it delegates all work through a raftScheduler, whose workers' lifetimes are
 	// already tied to the Store's Stopper.
 	if len(req.Heartbeats)+len(req.HeartbeatResps) > 0 {
 		if req.RangeID != 0 {
@@ -476,10 +476,10 @@ func (s *Store) processRaftSnapshotRequest(
 	})
 }
 
-// HandleRaftResponse implements the RaftMessageHandler interface. Per the
-// interface specification, an error is returned if and only if the underlying
-// Raft connection should be closed.
-// It requires that s.mu is not held.
+// HandleRaftResponse implements the IncomingRaftMessageHandler interface. Per
+// the interface specification, an error is returned if and only if the
+// underlying Raft connection should be closed. It requires that s.mu is not
+// held.
 func (s *Store) HandleRaftResponse(
 	ctx context.Context, resp *kvserverpb.RaftMessageResponse,
 ) error {
@@ -720,7 +720,7 @@ func (s *Store) processRaft(ctx context.Context) {
 	_ = s.stopper.RunAsyncTask(ctx, "sched-tick-loop", s.raftTickLoop)
 	_ = s.stopper.RunAsyncTask(ctx, "coalesced-hb-loop", s.coalescedHeartbeatsLoop)
 	s.stopper.AddCloser(stop.CloserFn(func() {
-		s.cfg.Transport.Stop(s.StoreID())
+		s.cfg.Transport.StopIncomingRaftMessages(s.StoreID())
 	}))
 
 	s.syncWaiter.Start(ctx, s.stopper)


### PR DESCRIPTION
The commit renames `RaftMessageHandler`, `Listen`, and `Stop` to
`IncomingRaftMessageHandler`, `ListenIncomingRaftMessages`, and
`StopIncomingRaftMessages`. Another PR is introducing a new interface
`OutgoingRaftMessageHandler`, dedicated to managing messages sent. The main
purpose of this PR is to make the future PR cleaner by handling the renaming
process. Note that this commit does not change any existing functionality.

Part of: https://github.com/cockroachdb/cockroach/issues/103983

Related: https://github.com/cockroachdb/cockroach/pull/105122

Release Note: None