### PR TITLE
kvserver: don't campaign when unquiescing for a Raft message

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -10587,10 +10587,10 @@ def go_deps():
         ],
         build_file_proto_mode = "default",
         importpath = "go.etcd.io/raft/v3",
-        sha256 = "c0befdb4cef60ab589f6875d541dace26b87db876f3f31f02ed0ae3cc3271f4d",
-        strip_prefix = "go.etcd.io/raft/v3@v3.0.0-20230607113044-515b14280da2",
+        sha256 = "7540ce70b9c79987eb5a09f693302931ac88e34757397451c5d44c202649adb3",
+        strip_prefix = "go.etcd.io/raft/v3@v3.0.0-20230626154957-a10cd4571633",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/go.etcd.io/raft/v3/io_etcd_go_raft_v3-v3.0.0-20230607113044-515b14280da2.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/go.etcd.io/raft/v3/io_etcd_go_raft_v3-v3.0.0-20230626154957-a10cd4571633.zip",
         ],
     )
     go_repository(

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -1024,7 +1024,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/cockroach-godeps/gomod/go.etcd.io/etcd/client/pkg/v3/io_etcd_go_etcd_client_pkg_v3-v3.5.0.zip": "c0ca209767c5734c6ed023888ba5be02aab5bd3c4d018999467f2bfa8bf65ee3",
     "https://storage.googleapis.com/cockroach-godeps/gomod/go.etcd.io/etcd/client/v2/io_etcd_go_etcd_client_v2-v2.305.0.zip": "91fcb507fe8c193844b56bfb6c8741aaeb6ffa11ee9043de2af0f141173679f3",
     "https://storage.googleapis.com/cockroach-godeps/gomod/go.etcd.io/etcd/io_etcd_go_etcd-v0.5.0-alpha.5.0.20200910180754-dd1b699fc489.zip": "d982ee501979b41b68625693bad77d15e4ae79ab9d0eae5f6028205f96a74e49",
-    "https://storage.googleapis.com/cockroach-godeps/gomod/go.etcd.io/raft/v3/io_etcd_go_raft_v3-v3.0.0-20230607113044-515b14280da2.zip": "c0befdb4cef60ab589f6875d541dace26b87db876f3f31f02ed0ae3cc3271f4d",
+    "https://storage.googleapis.com/cockroach-godeps/gomod/go.etcd.io/raft/v3/io_etcd_go_raft_v3-v3.0.0-20230626154957-a10cd4571633.zip": "7540ce70b9c79987eb5a09f693302931ac88e34757397451c5d44c202649adb3",
     "https://storage.googleapis.com/cockroach-godeps/gomod/go.mongodb.org/mongo-driver/org_mongodb_go_mongo_driver-v1.5.1.zip": "446cff132e82c64af7ffcf48e268eb16ec81f694914aa6baecb06cbbae1be0d7",
     "https://storage.googleapis.com/cockroach-godeps/gomod/go.mozilla.org/pkcs7/org_mozilla_go_pkcs7-v0.0.0-20200128120323-432b2356ecb1.zip": "3c4c1667907ff3127e371d44696326bad9e965216d4257917ae28e8b82a9e08d",
     "https://storage.googleapis.com/cockroach-godeps/gomod/go.opencensus.io/io_opencensus_go-v0.24.0.zip": "203a767d7f8e7c1ebe5588220ad168d1e15b14ae70a636de7ca9a4a88a7e0d0c",

--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/xdg-go/scram v1.1.2
 	github.com/xdg-go/stringprep v1.0.4
 	github.com/zabawaba99/go-gitignore v0.0.0-20200117185801-39e6bddfb292
-	go.etcd.io/raft/v3 v3.0.0-20230607113044-515b14280da2
+	go.etcd.io/raft/v3 v3.0.0-20230626154957-a10cd4571633
 	go.opentelemetry.io/otel v1.0.0-RC3
 	go.opentelemetry.io/otel/exporters/jaeger v1.0.0-RC3
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.0.0-RC3

--- a/go.sum
+++ b/go.sum
@@ -2320,8 +2320,8 @@ go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489/go.mod h1:yVHk9ub3C
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
-go.etcd.io/raft/v3 v3.0.0-20230607113044-515b14280da2 h1:fvy8LUxWPLFLUAjJEP+mhvBTR9LQWYLV1K5H2+1Qt80=
-go.etcd.io/raft/v3 v3.0.0-20230607113044-515b14280da2/go.mod h1:tP6U+sRzrl75ltgmFcdZg9reZVEyM3vKTxAWmwpHtB8=
+go.etcd.io/raft/v3 v3.0.0-20230626154957-a10cd4571633 h1:C6cmDqdkeGrJ6fT7OFCbnPauTEJvFY+HZSWk2N0PUvI=
+go.etcd.io/raft/v3 v3.0.0-20230626154957-a10cd4571633/go.mod h1:tP6U+sRzrl75ltgmFcdZg9reZVEyM3vKTxAWmwpHtB8=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -97,6 +97,10 @@ func (s *Store) ComputeMVCCStats() (enginepb.MVCCStats, error) {
 	return totalStats, err
 }
 
+func (s *Store) UpdateLivenessMap() {
+	s.updateLivenessMap()
+}
+
 // ConsistencyQueueShouldQueue invokes the shouldQueue method on the
 // store's consistency queue.
 func ConsistencyQueueShouldQueue(

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -26,7 +26,7 @@ import (
 )
 
 // maxRaftMsgType is the maximum value in the raft.MessageType enum.
-const maxRaftMsgType = raftpb.MsgStorageApplyResp
+const maxRaftMsgType = raftpb.MsgForgetLeader
 
 func init() {
 	for v := range raftpb.MessageType_name {

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -69,9 +69,13 @@ func (r *Replica) maybeUnquiesce(wakeLeader, mayCampaign bool) bool {
 // command anyway, or it knows the leader is awake because it received a message
 // from it.
 //
-// If mayCampaign is true, the replica may campaign if appropriate. This will
-// respect PreVote and CheckQuorum, and thus won't disrupt a current leader.
-// Should typically be true, unless the caller wants to avoid election ties.
+// If mayCampaign is true, the replica may campaign if it thinks the leader has
+// died in the meanwhile. This will respect PreVote and CheckQuorum, and thus
+// won't disrupt a current leader. Otherwise, if the leader is dead it will
+// forget about it and become a leaderless follower. Thus, if a quorum of
+// replicas independently consider the leader to be dead when unquiescing, they
+// can hold an election immediately despite PreVote+CheckQuorum. Should
+// typically be true, unless the caller wants to avoid election ties.
 func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 	if !r.canUnquiesceRLocked() {
 		return false
@@ -91,7 +95,7 @@ func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 		r.mu.lastUpdateTimes.updateOnUnquiesce(
 			r.mu.state.Desc.Replicas().Descriptors(), st.Progress, timeutil.Now())
 
-	} else if st.RaftState == raft.StateFollower && wakeLeader {
+	} else if st.RaftState == raft.StateFollower && st.Lead != raft.None && wakeLeader {
 		// Propose an empty command which will wake the leader.
 		if log.V(3) {
 			log.Infof(ctx, "waking r%d leader", r.RangeID)
@@ -106,6 +110,8 @@ func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 	// we're wrong about it being dead.
 	if mayCampaign {
 		r.maybeCampaignOnWakeLocked(ctx)
+	} else {
+		r.maybeForgetLeaderOnWakeLocked(ctx)
 	}
 
 	return true

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -811,13 +811,12 @@ func (s *Store) updateLivenessMap() {
 		// that this policy is different from the one governing the releasing of
 		// proposal quota; see comments over there.
 		//
-		// NB: This has false negatives. If a node doesn't have a conn open to it
-		// when ConnHealth is called, then ConnHealth will return
-		// rpc.ErrNotHeartbeated regardless of whether the node is up or not. That
-		// said, for the nodes that matter, we're likely talking to them via the
-		// Raft transport, so ConnHealth should usually indicate a real problem if
-		// it gives us an error back. The check can also have false positives if the
-		// node goes down after populating the map, but that matters even less.
+		// NB: This has false negatives when we haven't attempted to connect to the
+		// node yet, where it will return rpc.ErrNotHeartbeated regardless of
+		// whether the node is up or not. Once connected, the RPC circuit breakers
+		// will continually probe the connection. The check can also have false
+		// positives if the node goes down after populating the map, but that
+		// matters even less.
 		entry.IsLive = (s.cfg.NodeDialer.ConnHealth(nodeID, rpc.SystemClass) == nil)
 		nextMap[nodeID] = entry
 	}

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -817,7 +817,8 @@ func (s *Store) updateLivenessMap() {
 		// will continually probe the connection. The check can also have false
 		// positives if the node goes down after populating the map, but that
 		// matters even less.
-		entry.IsLive = (s.cfg.NodeDialer.ConnHealth(nodeID, rpc.SystemClass) == nil)
+		entry.IsLive = !s.TestingKnobs().DisableLivenessMapConnHealth &&
+			(s.cfg.NodeDialer.ConnHealth(nodeID, rpc.SystemClass) == nil)
 		nextMap[nodeID] = entry
 	}
 	s.livenessMap.Store(nextMap)

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -261,6 +261,10 @@ type StoreTestingKnobs struct {
 	RefreshReasonTicksPeriod int
 	// DisableProcessRaft disables the process raft loop.
 	DisableProcessRaft func(roachpb.StoreID) bool
+	// DisableLivenessMapConnHealth disables the ConnHealth check in
+	// updateIsLiveMap, which is useful in tests where we manipulate the node's
+	// liveness record but still keep the connection alive.
+	DisableLivenessMapConnHealth bool
 	// DisableLastProcessedCheck disables checking on replica queue last processed times.
 	DisableLastProcessedCheck bool
 	// ReplicateQueueAcceptsUnsplit allows the replication queue to


### PR DESCRIPTION
We're going to generalize this to all (pre)votes, see #105132. However, I'm merging this as-is to keep a record of the alternative, since we may want to change to this approach later, when e.g. 23.1 compatibility and epoch leases is less of a concern.

---

**DEPS: upgrade Raft to a10cd45**

Adds `ForgetLeader()`, which we need for CheckQuorum handling.

```
a10cd45 2023-06-26: Merge pull request 78 from erikgrinaker/forget-leader [Benjamin Wang]
1159466 2023-06-16: add `ForgetLeader` [Erik Grinaker]
09ea4c5 2023-06-16: rafttest: show term and leader for `raft-state` [Erik Grinaker]
26ce926 2023-06-20: rafttest: add `log-level` argument for `stabilize` [Erik Grinaker]
30e2fa4 2023-06-12: Merge pull request 70 from erikgrinaker/prevote-checkquorum-datadriven [Benjamin Wang]
a042ce3 2023-06-09: Merge pull request 75 from charles-chenzz/update-go-patch [Benjamin Wang]
dd2340f 2023-06-08: update go to patch release 1.19.10 [charles-chenzz]
27dd2c2 2023-06-02: add data-driven tests for PreVote and CheckQuorum [Erik Grinaker]
```

**kvserver: tweak updateLivenessMap comment**

**kvserver: add `Replica.forgetLeaderLocked()`**

**kvserver: don't campaign when unquiescing for a Raft message**

This patch forgets the leader when unquiescing in response to a Raft message and finding a dead leader (according to liveness). We don't campaign, because that could result in election ties, but forgetting the leader allows us to grant (pre)votes even though we've heard from the leader recently, avoiding having to wait out an election timeout.

Touches #92088.

Epic: none
Release note: None
