### PR TITLE
kvserver: maybe forget leader on (Pre)Vote requests 

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -1338,8 +1338,12 @@ func TestRequestsOnFollowerWithNonLiveLeaseholder(t *testing.T) {
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
 			Settings: st,
-			// Reduce the election timeout some to speed up the test.
-			RaftConfig: base.RaftConfig{RaftElectionTimeoutTicks: 10},
+			RaftConfig: base.RaftConfig{
+				// Reduce the election timeout some to speed up the test.
+				RaftElectionTimeoutTicks: 10,
+				// This should work with PreVote+CheckQuorum too.
+				RaftEnableCheckQuorum: true,
+			},
 			Knobs: base.TestingKnobs{
 				NodeLiveness: kvserver.NodeLivenessTestingKnobs{
 					// This test waits for an epoch-based lease to expire, so we're

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -71,11 +71,12 @@ func (r *Replica) maybeUnquiesce(wakeLeader, mayCampaign bool) bool {
 //
 // If mayCampaign is true, the replica may campaign if it thinks the leader has
 // died in the meanwhile. This will respect PreVote and CheckQuorum, and thus
-// won't disrupt a current leader. Otherwise, if the leader is dead it will
-// forget about it and become a leaderless follower. Thus, if a quorum of
-// replicas independently consider the leader to be dead when unquiescing, they
-// can hold an election immediately despite PreVote+CheckQuorum. Should
-// typically be true, unless the caller wants to avoid election ties.
+// won't disrupt a current leader. Followers that also consider the leader dead
+// will forget about it and become a leaderless follower when receiving the
+// (pre)votes. Thus, if a quorum of replicas independently consider the leader
+// to be dead when unquiescing, they can hold an election immediately despite
+// PreVote+CheckQuorum. Should typically be true, unless the caller wants to
+// avoid election ties.
 func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 	if !r.canUnquiesceRLocked() {
 		return false
@@ -110,8 +111,6 @@ func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 	// we're wrong about it being dead.
 	if mayCampaign {
 		r.maybeCampaignOnWakeLocked(ctx)
-	} else {
-		r.maybeForgetLeaderOnWakeLocked(ctx)
 	}
 
 	return true


### PR DESCRIPTION
This patch will forget the Raft leader when receiving a (Pre)Vote request and finding the leader to be dead (according to liveness) or removed. This allows a quorum of replicas to campaign despite the PreVote+CheckQuorum condition if they independently consider the leader to be dead.

A more targeted alternative was explored, where we forget the leader only when unquiescing to a dead leader. However, this had a number of drawbacks. It would have to use `TransferLeader` to steal leadership away from a Raft leader who can't heartbeat liveness during lease acquisitions, but this could cause unavailability due to races where multiple replicas request leader transfers and some are not up-to-date on the log. It would also need mixed-version logic since 23.1 nodes could otherwise be unable to obtain necessary prevotes.

We instead choose to be lenient for now, and we can consider tightening the conditions later when we're more confident in the PreVote+CheckQuorum handling and may no longer need epoch leases.

Touches https://github.com/cockroachdb/cockroach/issues/92088.

Epic: none
Release note: None