### PR TITLE
roachtest: detect segfault using exit code in sysbench

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -13,7 +13,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -21,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/stretchr/testify/require"
 )
@@ -129,7 +129,7 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 
 		// Sysbench occasionally segfaults. When that happens, don't fail the
 		// test.
-		if strings.Contains(result.Stderr, "Segmentation fault") {
+		if result.RemoteExitStatus == errors.SegmentationFaultExitCode {
 			t.L().Printf("sysbench segfaulted; passing test anyway")
 			return nil
 		}

--- a/pkg/roachprod/errors/errors.go
+++ b/pkg/roachprod/errors/errors.go
@@ -37,6 +37,10 @@ const (
 // code of 255. This could be indicative of an SSH flake.
 var ErrSSH255 = errors.New("SSH error occurred with exit code 255")
 
+const (
+	SegmentationFaultExitCode = 139
+)
+
 // Cmd wraps errors that result from a command run against the cluster.
 type Cmd struct {
 	Err error


### PR DESCRIPTION
It seems that checking the `sysbench` stderr is not sufficient to detect segmentation fault. The "Segmentation fault" string is probably not logged in a way that ends up being captured by the roachprod infrastructure.

In this commit, the check for segfault is changed to rely on exit codes instead: a `139` exit code should indicate segmentation fault.

Fixes: #105048.

Release note: None