### PR TITLE
ui: fix crash on `DurationToNumber`

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
@@ -111,7 +111,7 @@ export function DurationToNumber(
   duration?: protos.google.protobuf.IDuration,
   defaultIfNull = 0,
 ): number {
-  if (!duration) {
+  if (!duration || !duration?.seconds) {
     return defaultIfNull;
   }
   return duration.seconds.toNumber() + NanoToMilli(duration.nanos) * 1e-3;
@@ -126,7 +126,7 @@ export function DurationToMomentDuration(
   duration?: protos.google.protobuf.IDuration,
   defaultIfNullSeconds = 0,
 ): moment.Duration {
-  if (!duration) {
+  if (!duration || !duration?.seconds) {
     return moment.duration(defaultIfNullSeconds, "seconds");
   }
 


### PR DESCRIPTION
Previously, the function `DurationToNumber` was crashing when the Duration objected existed, but it was empty (`{}`). This commit fixes for this function and also for
`DurationToMomentDuration` that could have a similar problem.

Fixes #105144

Release note (bug fix): Fix crash when using `DurationToNumber` with empty duration object, causing a crash on SQL Activity tables.