### PR TITLE
roachtest: fix tpchvec in some cases

### DIFF
--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -259,7 +259,7 @@ func (p *tpchVecPerfTest) postTestRunHook(
 
 			// Check whether we can reproduce this slowness to prevent false
 			// positives.
-			var helper tpchVecPerfHelper
+			helper := newTpchVecPerfHelper(runConfig.setupNames)
 			for setupIdx, setup := range runConfig.clusterSetups {
 				performClusterSetup(t, conn, setup)
 				result, err := c.RunWithDetailsSingleNode(


### PR DESCRIPTION
We recently introduced a minor bug in the tpchvec in c5c7eadb16f21f05f21c77a0642dffd9995b4412 where could use uninitialized helper to parse the test output, which can lead to a nil pointer when the slowness threshold is exceeded, and this is now fixed.

Epic: None

Release note: None