### PR TITLE
kv: support recovery from retry error with partial rollback under RC

### DIFF
--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -735,19 +737,30 @@ func TestDBDecommissionedOperations(t *testing.T) {
 }
 
 // TestGenerateForcedRetryableError verifies that GenerateForcedRetryableErr
-// returns an error with a transaction that had the epoch bumped (and not epoch 0).
+// returns an error with a transaction that had the epoch bumped (and not epoch
+// 0) for isolation levels that cannot move their read timestamp between
+// operations.
 func TestGenerateForcedRetryableError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ctx := context.Background()
-	s, db := setup(t)
-	defer s.Stopper().Stop(context.Background())
-	txn := db.NewTxn(ctx, "test: TestGenerateForcedRetryableError")
-	require.Equal(t, 0, int(txn.Epoch()))
-	err := txn.GenerateForcedRetryableErr(ctx, "testing TestGenerateForcedRetryableError")
-	var retryErr *kvpb.TransactionRetryWithProtoRefreshError
-	require.True(t, errors.As(err, &retryErr))
-	require.Equal(t, 1, int(retryErr.NextTransaction.Epoch))
+	isolation.RunEachLevel(t, func(t *testing.T, isoLevel isolation.Level) {
+		ctx := context.Background()
+		s, db := setup(t)
+		defer s.Stopper().Stop(context.Background())
+		txn := db.NewTxn(ctx, "test: TestGenerateForcedRetryableError")
+		require.NoError(t, txn.SetIsoLevel(isoLevel))
+		require.Equal(t, 0, int(txn.Epoch()))
+		err := txn.GenerateForcedRetryableErr(ctx, "testing TestGenerateForcedRetryableError")
+		var retryErr *kvpb.TransactionRetryWithProtoRefreshError
+		require.True(t, errors.As(err, &retryErr))
+		var expEpoch enginepb.TxnEpoch
+		if isoLevel == isolation.ReadCommitted {
+			expEpoch = 0 // partial retry
+		} else {
+			expEpoch = 1 // full retry
+		}
+		require.Equal(t, expEpoch, retryErr.NextTransaction.Epoch)
+	})
 }
 
 // Get a retryable error within a db.Txn transaction and verify the retry
@@ -758,77 +771,83 @@ func TestGenerateForcedRetryableError(t *testing.T) {
 func TestDB_TxnRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	isolation.RunEachLevel(t, func(t *testing.T, isoLevel isolation.Level) {
+		testutils.RunTrueAndFalse(t, "returnNil", func(t *testing.T, returnNil bool) {
+			testDBTxnRetry(t, isoLevel, returnNil)
+		})
+	})
+}
+
+func testDBTxnRetry(t *testing.T, isoLevel isolation.Level, returnNil bool) {
 	s, db := setup(t)
 	defer s.Stopper().Stop(context.Background())
+	keyA := fmt.Sprintf("a_return_nil_%t", returnNil)
+	keyB := fmt.Sprintf("b_return_nil_%t", returnNil)
+	runNumber := 0
+	err := db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
+		require.NoError(t, txn.SetIsoLevel(isoLevel))
+		require.NoError(t, txn.Put(ctx, keyA, "1"))
+		require.NoError(t, txn.Put(ctx, keyB, "1"))
 
-	testutils.RunTrueAndFalse(t, "returnNil", func(t *testing.T, returnNil bool) {
-		keyA := fmt.Sprintf("a_return_nil_%t", returnNil)
-		keyB := fmt.Sprintf("b_return_nil_%t", returnNil)
-		runNumber := 0
-		err := db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-			require.NoError(t, txn.Put(ctx, keyA, "1"))
-			require.NoError(t, txn.Put(ctx, keyB, "1"))
-
-			{
-				// High priority txn - will abort the other txn.
-				hpTxn := kv.NewTxn(ctx, db, 0)
-				require.NoError(t, hpTxn.SetUserPriority(roachpb.MaxUserPriority))
-				// Only write if we have not written before, because otherwise we will keep aborting
-				// the other txn forever.
-				r, err := hpTxn.Get(ctx, keyA)
-				require.NoError(t, err)
-				if !r.Exists() {
-					require.Zero(t, runNumber)
-					require.NoError(t, hpTxn.Put(ctx, keyA, "hp txn"))
-					require.NoError(t, hpTxn.Commit(ctx))
-				} else {
-					// We already wrote to keyA, meaning this is a retry, no need to write again.
-					require.Equal(t, 1, runNumber)
-					require.NoError(t, hpTxn.Rollback(ctx))
-				}
-			}
-
-			// Read, so that we'll get a retryable error.
-			r, err := txn.Get(ctx, keyA)
-			if runNumber == 0 {
-				// First run, we should get a retryable error.
+		{
+			// High priority txn - will abort the other txn.
+			hpTxn := kv.NewTxn(ctx, db, 0)
+			require.NoError(t, hpTxn.SetUserPriority(roachpb.MaxUserPriority))
+			// Only write if we have not written before, because otherwise we will keep aborting
+			// the other txn forever.
+			r, err := hpTxn.Get(ctx, keyA)
+			require.NoError(t, err)
+			if !r.Exists() {
 				require.Zero(t, runNumber)
-				require.IsType(t, &kvpb.TransactionRetryWithProtoRefreshError{}, err)
-				require.Equal(t, []byte(nil), r.ValueBytes())
-
-				// At this point txn is poisoned, and any op returns the same (poisoning) error.
-				r, err = txn.Get(ctx, keyB)
-				require.IsType(t, &kvpb.TransactionRetryWithProtoRefreshError{}, err)
-				require.Equal(t, []byte(nil), r.ValueBytes())
+				require.NoError(t, hpTxn.Put(ctx, keyA, "hp txn"))
+				require.NoError(t, hpTxn.Commit(ctx))
 			} else {
-				// The retry should succeed.
+				// We already wrote to keyA, meaning this is a retry, no need to write again.
 				require.Equal(t, 1, runNumber)
-				require.NoError(t, err)
-				require.Equal(t, []byte("1"), r.ValueBytes())
+				require.NoError(t, hpTxn.Rollback(ctx))
 			}
-			runNumber++
+		}
 
-			if returnNil {
-				return nil
-			}
-			// Return the retryable error.
-			return err
-		})
-		require.NoError(t, err)
-		require.Equal(t, 2, runNumber)
+		// Read, so that we'll get a retryable error.
+		r, err := txn.Get(ctx, keyA)
+		if runNumber == 0 {
+			// First run, we should get a retryable error.
+			require.Zero(t, runNumber)
+			require.IsType(t, &kvpb.TransactionRetryWithProtoRefreshError{}, err)
+			require.Equal(t, []byte(nil), r.ValueBytes())
 
-		err1 := db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-			// The high priority txn was overwritten by the successful retry.
-			kv, e1 := txn.Get(ctx, keyA)
-			require.NoError(t, e1)
-			require.Equal(t, []byte("1"), kv.ValueBytes())
-			kv, e2 := txn.Get(ctx, keyB)
-			require.NoError(t, e2)
-			require.Equal(t, []byte("1"), kv.ValueBytes())
+			// At this point txn is poisoned, and any op returns the same (poisoning) error.
+			r, err = txn.Get(ctx, keyB)
+			require.IsType(t, &kvpb.TransactionRetryWithProtoRefreshError{}, err)
+			require.Equal(t, []byte(nil), r.ValueBytes())
+		} else {
+			// The retry should succeed.
+			require.Equal(t, 1, runNumber)
+			require.NoError(t, err)
+			require.Equal(t, []byte("1"), r.ValueBytes())
+		}
+		runNumber++
+
+		if returnNil {
 			return nil
-		})
-		require.NoError(t, err1)
+		}
+		// Return the retryable error.
+		return err
 	})
+	require.NoError(t, err)
+	require.Equal(t, 2, runNumber)
+
+	err1 := db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
+		// The high priority txn was overwritten by the successful retry.
+		kv, e1 := txn.Get(ctx, keyA)
+		require.NoError(t, e1)
+		require.Equal(t, []byte("1"), kv.ValueBytes())
+		kv, e2 := txn.Get(ctx, keyB)
+		require.NoError(t, e2)
+		require.Equal(t, []byte("1"), kv.ValueBytes())
+		return nil
+	})
+	require.NoError(t, err1)
 }
 
 func TestPreservingSteppingOnSenderReplacement(t *testing.T) {

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -747,7 +747,7 @@ func TestGenerateForcedRetryableError(t *testing.T) {
 	err := txn.GenerateForcedRetryableErr(ctx, "testing TestGenerateForcedRetryableError")
 	var retryErr *kvpb.TransactionRetryWithProtoRefreshError
 	require.True(t, errors.As(err, &retryErr))
-	require.Equal(t, 1, int(retryErr.Transaction.Epoch))
+	require.Equal(t, 1, int(retryErr.NextTransaction.Epoch))
 }
 
 // Get a retryable error within a db.Txn transaction and verify the retry
@@ -866,16 +866,16 @@ func TestPreservingSteppingOnSenderReplacement(t *testing.T) {
 		require.IsType(t, &kvpb.TransactionRetryWithProtoRefreshError{}, err)
 		pErr := (*kvpb.TransactionRetryWithProtoRefreshError)(nil)
 		require.ErrorAs(t, err, &pErr)
-		require.Equal(t, txn.ID(), pErr.TxnID)
+		require.Equal(t, txn.ID(), pErr.PrevTxnID)
 
 		// The transaction was aborted, therefore we should have a new transaction ID.
-		require.NotEqual(t, pErr.TxnID, pErr.Transaction.ID)
+		require.NotEqual(t, pErr.PrevTxnID, pErr.NextTransaction.ID)
 
 		// Reset the handle in order to get a new sender.
 		require.NoError(t, txn.PrepareForRetry(ctx))
 
 		// Make sure we have a new txn ID.
-		require.NotEqual(t, pErr.TxnID, txn.ID())
+		require.NotEqual(t, pErr.PrevTxnID, txn.ID())
 
 		// Using ConfigureStepping() to read the current state.
 		require.Equal(t, expectedStepping, txn.ConfigureStepping(ctx, expectedStepping))

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -843,47 +843,66 @@ func (tc *TxnCoordSender) handleRetryableErrLocked(ctx context.Context, pErr *kv
 	default:
 		tc.metrics.RestartsUnknown.Inc()
 	}
-	errTxnID := pErr.GetTxn().ID
-	newTxn, assertErr := kvpb.PrepareTransactionForRetry(pErr, tc.mu.userPriority, tc.clock)
+
+	// Construct the next txn proto using the provided error.
+	prevTxn := pErr.GetTxn()
+	nextTxn, assertErr := kvpb.PrepareTransactionForRetry(pErr, tc.mu.userPriority, tc.clock)
 	if assertErr != nil {
 		return assertErr
 	}
 
-	// We'll pass a TransactionRetryWithProtoRefreshError up to the next layer.
+	// Construct the TransactionRetryWithProtoRefreshError using the next txn proto.
 	retErr := kvpb.NewTransactionRetryWithProtoRefreshError(
-		redact.Sprint(pErr),
-		errTxnID, // the id of the transaction that encountered the error
-		newTxn)
+		redact.Sprint(pErr), /* msg */
+		prevTxn.ID,          /* prevTxnID */
+		prevTxn.Epoch,       /* prevTxnEpoch */
+		nextTxn,             /* nextTxn */
+	)
 
+	// Update the TxnCoordSender's state.
+	tc.handleTransactionRetryWithProtoRefreshErrorErrLocked(ctx, retErr)
+
+	// Finally, pass a TransactionRetryWithProtoRefreshError up to the next layer.
+	return retErr
+}
+
+// handleTransactionRetryWithProtoRefreshErrorErrLocked takes a
+// TransactionRetryWithProtoRefreshError containing the transaction that needs
+// to be used by the next attempt and handles various aspects of updating the
+// TxnCoordSender's state.
+func (tc *TxnCoordSender) handleTransactionRetryWithProtoRefreshErrorErrLocked(
+	ctx context.Context, retErr *kvpb.TransactionRetryWithProtoRefreshError,
+) {
 	// Move to a retryable error state, where all Send() calls fail until the
 	// state is cleared.
 	tc.mu.txnState = txnRetryableError
 	tc.mu.storedRetryableErr = retErr
 
-	// If the ID changed, it means we had to start a new transaction and the
-	// old one is toast. This TxnCoordSender cannot be used any more - future
-	// Send() calls will be rejected; the client is supposed to create a new
-	// one.
-	if errTxnID != newTxn.ID {
+	// If the previous transaction is aborted, it means we had to start a new
+	// transaction and the old one is toast. This TxnCoordSender cannot be used
+	// any more - future Send() calls will be rejected; the client is supposed to
+	// create a new one.
+	if retErr.PrevTxnAborted() {
 		// Remember that this txn is aborted to reject future requests.
 		tc.mu.txn.Status = roachpb.ABORTED
 		// Abort the old txn. The client is not supposed to use use this
 		// TxnCoordSender any more.
 		tc.interceptorAlloc.txnHeartbeater.abortTxnAsyncLocked(ctx)
 		tc.cleanupTxnLocked(ctx)
-		return retErr
+		return
 	}
 
-	// This is where we get a new epoch.
-	tc.mu.txn.Update(&newTxn)
+	// This is where we get a new read timestamp or a new epoch.
+	tc.mu.txn.Update(&retErr.NextTransaction)
 
-	// Reset state as this is a retryable txn error that is incrementing
+	// Reset state if this is a retryable txn error that is incrementing
 	// the transaction's epoch.
-	log.VEventf(ctx, 2, "resetting epoch-based coordinator state on retry")
-	for _, reqInt := range tc.interceptorStack {
-		reqInt.epochBumpedLocked()
+	if retErr.PrevTxnEpochBumped() {
+		log.VEventf(ctx, 2, "resetting epoch-based coordinator state on retry")
+		for _, reqInt := range tc.interceptorStack {
+			reqInt.epochBumpedLocked()
+		}
 	}
-	return retErr
 }
 
 // updateStateLocked updates the transaction state in both the success and error
@@ -1162,7 +1181,7 @@ func (tc *TxnCoordSender) RequiredFrontier() hlc.Timestamp {
 
 // GenerateForcedRetryableErr is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) GenerateForcedRetryableErr(
-	ctx context.Context, ts hlc.Timestamp, msg redact.RedactableString,
+	ctx context.Context, ts hlc.Timestamp, mustRestart bool, msg redact.RedactableString,
 ) error {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
@@ -1170,24 +1189,27 @@ func (tc *TxnCoordSender) GenerateForcedRetryableErr(
 		return errors.AssertionFailedf("cannot generate retryable error, current state: %s", tc.mu.txnState)
 	}
 
-	// Invalidate any writes performed by any workers after the retry updated
-	// the txn's proto but before we synchronized (some of these writes might
-	// have been performed at the wrong epoch).
-	tc.mu.txn.Restart(tc.mu.userPriority, 0 /* upgradePriority */, ts)
-
-	pErr := kvpb.NewTransactionRetryWithProtoRefreshError(
-		msg, tc.mu.txn.ID, tc.mu.txn)
-
-	// Move to a retryable error state, where all Send() calls fail until the
-	// state is cleared.
-	tc.mu.txnState = txnRetryableError
-	tc.mu.storedRetryableErr = pErr
-
-	// Reset state as this manual restart incremented the transaction's epoch.
-	for _, reqInt := range tc.interceptorStack {
-		reqInt.epochBumpedLocked()
+	// Construct the next txn proto.
+	prevTxn := tc.mu.txn
+	nextTxn := prevTxn.Clone()
+	nextTxn.WriteTimestamp.Forward(ts)
+	// See kvpb.PrepareTransactionForRetry for an explanation of why the isolation
+	// level dictates whether we need to restart or can bump the read timestamp.
+	if !nextTxn.IsoLevel.PerStatementReadSnapshot() || mustRestart {
+		nextTxn.Restart(tc.mu.userPriority, 0 /* upgradePriority */, nextTxn.WriteTimestamp)
+	} else {
+		nextTxn.BumpReadTimestamp(nextTxn.WriteTimestamp)
 	}
-	return pErr
+
+	// Construct the TransactionRetryWithProtoRefreshError using the next txn proto.
+	retErr := kvpb.NewTransactionRetryWithProtoRefreshError(
+		msg, prevTxn.ID, prevTxn.Epoch, *nextTxn)
+
+	// Update the TxnCoordSender's state.
+	tc.handleTransactionRetryWithProtoRefreshErrorErrLocked(ctx, retErr)
+
+	// Finally, pass a TransactionRetryWithProtoRefreshError up to the next layer.
+	return retErr
 }
 
 // UpdateStateOnRemoteRetryableErr is part of the TxnSender interface.

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints.go
@@ -193,6 +193,7 @@ func (tc *TxnCoordSender) checkSavepointLocked(s *savepoint, op redact.SafeStrin
 		return kvpb.NewTransactionRetryWithProtoRefreshError(
 			redact.Sprintf("cannot %s savepoint after a transaction restart", op),
 			s.txnID,
+			s.epoch,
 			tc.mu.txn,
 		)
 	}

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -661,7 +661,7 @@ func TestTxnCoordSenderCleanupOnCommitAfterRestart(t *testing.T) {
 	}
 
 	// Restart the transaction with a new epoch.
-	require.Error(t, txn.Sender().GenerateForcedRetryableErr(ctx, s.Clock.Now(), "force retry"))
+	require.Error(t, txn.Sender().GenerateForcedRetryableErr(ctx, s.Clock.Now(), true /* mustRestart */, "force retry"))
 	txn.Sender().ClearRetryableErr(ctx)
 
 	// Now immediately commit.
@@ -727,6 +727,10 @@ func TestTxnCoordSenderGCWithAmbiguousResultErr(t *testing.T) {
 func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	isolation.RunEachLevel(t, testTxnCoordSenderTxnUpdatedOnError)
+}
+
+func testTxnCoordSenderTxnUpdatedOnError(t *testing.T, isoLevel isolation.Level) {
 	ctx := context.Background()
 	origTS := makeTS(123, 0)
 	plus10 := origTS.Add(10, 10).WithSynthetic(false)
@@ -753,8 +757,10 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			expReadTS:  origTS,
 		},
 		{
-			// On uncertainty error, new epoch begins. Timestamp moves ahead of
-			// the existing write and LocalUncertaintyLimit, if one exists.
+			// On uncertainty error, the read timestamp moves ahead of the existing
+			// write and LocalUncertaintyLimit, if one exists. Also, a new epoch
+			// begins for isolation levels that cannot move their read timestamp
+			// between operations.
 			name: "ReadWithinUncertaintyIntervalError without LocalUncertaintyLimit",
 			pErrGen: func(txn *roachpb.Transaction) *kvpb.Error {
 				pErr := kvpb.NewErrorWithTxn(
@@ -768,14 +774,21 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 					txn)
 				return pErr
 			},
-			expEpoch:   1,
+			expEpoch: func() enginepb.TxnEpoch {
+				if isoLevel == isolation.ReadCommitted {
+					return 0 // PerStatementReadSnapshot
+				}
+				return 1
+			}(),
 			expPri:     1,
 			expWriteTS: plus10.Next(),
 			expReadTS:  plus10.Next(),
 		},
 		{
-			// On uncertainty error, new epoch begins. Timestamp moves ahead of
-			// the existing write and LocalUncertaintyLimit, if one exists.
+			// On uncertainty error, the read timestamp moves ahead of the existing
+			// write and LocalUncertaintyLimit, if one exists. Also, a new epoch
+			// begins for isolation levels that cannot move their read timestamp
+			// between operations.
 			name: "ReadWithinUncertaintyIntervalError with LocalUncertaintyLimit",
 			pErrGen: func(txn *roachpb.Transaction) *kvpb.Error {
 				pErr := kvpb.NewErrorWithTxn(
@@ -789,7 +802,12 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 					txn)
 				return pErr
 			},
-			expEpoch:   1,
+			expEpoch: func() enginepb.TxnEpoch {
+				if isoLevel == isolation.ReadCommitted {
+					return 0 // PerStatementReadSnapshot
+				}
+				return 1
+			}(),
 			expPri:     1,
 			expWriteTS: plus20,
 			expReadTS:  plus20,
@@ -823,8 +841,10 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			expReadTS:           plus20,
 		},
 		{
-			// On failed push, new epoch begins just past the pushed timestamp.
-			// Additionally, priority ratchets up to just below the pusher's.
+			// On failed push, read timestamp advances just past the pushed timestamp.
+			// Additionally, priority ratchets up to just below the pusher's. Finally,
+			// a new epoch begins for isolation levels that cannot move their read
+			// timestamp between operations.
 			name: "TransactionPushError",
 			pErrGen: func(txn *roachpb.Transaction) *kvpb.Error {
 				return kvpb.NewErrorWithTxn(&kvpb.TransactionPushError{
@@ -833,23 +853,53 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 					},
 				}, txn)
 			},
-			expEpoch:   1,
+			expEpoch: func() enginepb.TxnEpoch {
+				if isoLevel == isolation.ReadCommitted {
+					return 0
+				}
+				return 1
+			}(),
 			expPri:     9,
 			expWriteTS: plus10,
 			expReadTS:  plus10,
 		},
 		{
-			// On retry, restart with new epoch, timestamp and priority.
+			// On retry, advance timestamp and priority. Also, restart with new epoch
+			// for isolation levels that cannot move their read timestamp between
+			// operations.
 			name: "TransactionRetryError",
 			pErrGen: func(txn *roachpb.Transaction) *kvpb.Error {
 				txn.WriteTimestamp = plus10
 				txn.Priority = 10
 				return kvpb.NewErrorWithTxn(&kvpb.TransactionRetryError{}, txn)
 			},
-			expEpoch:   1,
+			expEpoch: func() enginepb.TxnEpoch {
+				if isoLevel == isolation.ReadCommitted {
+					return 0
+				}
+				return 1
+			}(),
 			expPri:     10,
 			expWriteTS: plus10,
 			expReadTS:  plus10,
+		},
+		{
+			// On retry, advance timestamp and priority. Also, restart with new epoch,
+			// even for isolation levels that can move their read timestamp between
+			// operations. This is because PrepareForRetry is called instead of
+			// PrepareForPartialRetry, indicating that the client wants to promote
+			// what could be a partial retry to a full retry.
+			name: "TransactionRetryError with PrepareForRetry",
+			pErrGen: func(txn *roachpb.Transaction) *kvpb.Error {
+				txn.WriteTimestamp = plus10
+				txn.Priority = 10
+				return kvpb.NewErrorWithTxn(&kvpb.TransactionRetryError{}, txn)
+			},
+			expEpoch:            1,
+			callPrepareForRetry: true,
+			expPri:              10,
+			expWriteTS:          plus10,
+			expReadTS:           plus10,
 		},
 	}
 
@@ -890,7 +940,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			origTxnProto := roachpb.MakeTransaction(
 				"test txn",
 				key,
-				isolation.Serializable,
+				isoLevel,
 				roachpb.UserPriority(0),
 				now.ToTimestamp(),
 				clock.MaxOffset().Nanoseconds(),
@@ -907,6 +957,9 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			origTxnProto.Priority = 1
 			txn := kv.NewTxnFromProto(ctx, db, 0 /* gatewayNodeID */, now, kv.RootTxn, &origTxnProto)
 			txn.TestingSetPriority(1)
+			// Enable stepping so that Read Committed transactions don't advance their
+			// read timestamp on each operation.
+			txn.ConfigureStepping(ctx, kv.SteppingEnabled)
 
 			err := txn.Put(ctx, key, []byte("value"))
 			stopper.Stop(ctx)
@@ -2773,7 +2826,7 @@ func TestTxnCoordSenderSetFixedTimestamp(t *testing.T) {
 			before: func(t *testing.T, txn *kv.Txn) {
 				_, err := txn.Get(ctx, "k")
 				require.NoError(t, err)
-				require.Error(t, txn.Sender().GenerateForcedRetryableErr(ctx, txn.ReadTimestamp().Next(), "force retry"))
+				require.Error(t, txn.Sender().GenerateForcedRetryableErr(ctx, txn.ReadTimestamp().Next(), true /* mustRestart */, "force retry"))
 				txn.Sender().ClearRetryableErr(ctx)
 			},
 		},
@@ -2781,7 +2834,7 @@ func TestTxnCoordSenderSetFixedTimestamp(t *testing.T) {
 			name: "write before, in prior epoch",
 			before: func(t *testing.T, txn *kv.Txn) {
 				require.NoError(t, txn.Put(ctx, "k", "v"))
-				require.Error(t, txn.Sender().GenerateForcedRetryableErr(ctx, txn.ReadTimestamp().Next(), "force retry"))
+				require.Error(t, txn.Sender().GenerateForcedRetryableErr(ctx, txn.ReadTimestamp().Next(), true /* mustRestart */, "force retry"))
 				txn.Sender().ClearRetryableErr(ctx)
 			},
 		},
@@ -2791,7 +2844,7 @@ func TestTxnCoordSenderSetFixedTimestamp(t *testing.T) {
 				_, err := txn.Get(ctx, "k")
 				require.NoError(t, err)
 				require.NoError(t, txn.Put(ctx, "k", "v"))
-				require.Error(t, txn.Sender().GenerateForcedRetryableErr(ctx, txn.ReadTimestamp().Next(), "force retry"))
+				require.Error(t, txn.Sender().GenerateForcedRetryableErr(ctx, txn.ReadTimestamp().Next(), true /* mustRestart */, "force retry"))
 				txn.Sender().ClearRetryableErr(ctx)
 			},
 		},

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -338,9 +338,9 @@ func TestDB_PrepareForRetryAfterHeartbeatFailure(t *testing.T) {
 	// can read the error.
 	pErr := tc.GetRetryableErr(ctx)
 	require.NotNil(t, pErr)
-	require.Equal(t, txn.ID(), pErr.TxnID)
+	require.Equal(t, txn.ID(), pErr.PrevTxnID)
 	// The transaction was aborted, therefore we should have a new transaction ID.
-	require.NotEqual(t, pErr.TxnID, pErr.Transaction.ID)
+	require.NotEqual(t, pErr.PrevTxnID, pErr.NextTransaction.ID)
 }
 
 // getTxn fetches the requested key and returns the transaction info.

--- a/pkg/kv/kvnemesis/validator_test.go
+++ b/pkg/kv/kvnemesis/validator_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 var retryableError = kvpb.NewTransactionRetryWithProtoRefreshError(
-	``, uuid.MakeV4(), roachpb.Transaction{})
+	``, uuid.MakeV4(), 0 /* prevTxnEpoch */, roachpb.Transaction{})
 
 func withTimestamp(op Operation, ts int) Operation {
 	op.Result().OptionalTimestamp = hlc.Timestamp{WallTime: int64(ts)}

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -724,13 +724,13 @@ func (e *TransactionAbortedError) SafeFormatError(p errors.Printer) (next error)
 // to improve this: wrap `pErr.GoError()` with a barrier and then with the
 // TransactionRetryWithProtoRefreshError.
 func NewTransactionRetryWithProtoRefreshError(
-	msg redact.RedactableString, txnID uuid.UUID, txn roachpb.Transaction,
+	msg redact.RedactableString, prevTxnID uuid.UUID, nextTxn roachpb.Transaction,
 ) *TransactionRetryWithProtoRefreshError {
 	return &TransactionRetryWithProtoRefreshError{
-		Msg:           msg.StripMarkers(),
-		MsgRedactable: msg,
-		TxnID:         txnID,
-		Transaction:   txn,
+		Msg:             msg.StripMarkers(),
+		MsgRedactable:   msg,
+		PrevTxnID:       prevTxnID,
+		NextTransaction: nextTxn,
 	}
 }
 
@@ -748,7 +748,7 @@ func (e *TransactionRetryWithProtoRefreshError) SafeFormatError(p errors.Printer
 // transaction, as opposed to continuing with the existing one at a bumped
 // epoch.
 func (e *TransactionRetryWithProtoRefreshError) PrevTxnAborted() bool {
-	return !e.TxnID.Equal(e.Transaction.ID)
+	return !e.PrevTxnID.Equal(e.NextTransaction.ID)
 }
 
 // NewTransactionPushError initializes a new TransactionPushError.

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -716,20 +717,25 @@ func (e *TransactionAbortedError) SafeFormatError(p errors.Printer) (next error)
 
 // NewTransactionRetryWithProtoRefreshError initializes a new TransactionRetryWithProtoRefreshError.
 //
-// txnID is the ID of the transaction being restarted.
-// txn is the transaction that the client should use for the next attempts.
+// prevTxnID is the ID of the transaction being retried.
+// prevTxnEpoch is the epoch of the transaction being retried.
+// nextTxn is the transaction that the client should use for the next attempts.
 //
 // TODO(tbg): the message passed here is usually pErr.String(), which is a bad
 // pattern (loses structure, thus redaction). We can leverage error chaining
 // to improve this: wrap `pErr.GoError()` with a barrier and then with the
 // TransactionRetryWithProtoRefreshError.
 func NewTransactionRetryWithProtoRefreshError(
-	msg redact.RedactableString, prevTxnID uuid.UUID, nextTxn roachpb.Transaction,
+	msg redact.RedactableString,
+	prevTxnID uuid.UUID,
+	prevTxnEpoch enginepb.TxnEpoch,
+	nextTxn roachpb.Transaction,
 ) *TransactionRetryWithProtoRefreshError {
 	return &TransactionRetryWithProtoRefreshError{
 		Msg:             msg.StripMarkers(),
 		MsgRedactable:   msg,
 		PrevTxnID:       prevTxnID,
+		PrevTxnEpoch:    prevTxnEpoch,
 		NextTransaction: nextTxn,
 	}
 }
@@ -749,6 +755,27 @@ func (e *TransactionRetryWithProtoRefreshError) SafeFormatError(p errors.Printer
 // epoch.
 func (e *TransactionRetryWithProtoRefreshError) PrevTxnAborted() bool {
 	return !e.PrevTxnID.Equal(e.NextTransaction.ID)
+}
+
+// PrevTxnEpochBumped returns true if the previous transaction was not aborted
+// but its epoch was bumped. In this case, the client can continue with the
+// existing transaction, but must restart from the beginning because its writes
+// were discarded.
+//
+// NOTE: the method panics if the previous transaction was aborted and the next
+// transaction has a different identity. Callers must first check PrevTxnAborted.
+func (e *TransactionRetryWithProtoRefreshError) PrevTxnEpochBumped() bool {
+	if e.PrevTxnAborted() {
+		panic("PrevTxnEpochBumped called on aborted txn")
+	}
+	return e.PrevTxnEpoch != e.NextTransaction.Epoch
+}
+
+// TxnMustRestartFromBeginning returns true if the previous transaction's writes
+// were discarded due to the retry error, meaning that it must restart from the
+// beginning.
+func (e *TransactionRetryWithProtoRefreshError) TxnMustRestartFromBeginning() bool {
+	return e.PrevTxnAborted() || e.PrevTxnEpochBumped()
 }
 
 // NewTransactionPushError initializes a new TransactionPushError.

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -474,18 +474,47 @@ message TransactionRetryWithProtoRefreshError {
   // TODO(davidh): Remove in 23.2
   optional string msg = 1 [(gogoproto.nullable) = false];
 
-  // The ID of the transaction being restarted. The client is supposed to check
-  // this against the ID of its transaction and make sure the retryable error
-  // is meant for its level and didn't escape from some inner transaction.
+  // The ID of the transaction being retried. The client can compare this ID
+  // that of the new transaction (below) to check whether the transaction was
+  // aborted and will restart from the beginning with a new identity.
   optional bytes prev_txn_id = 2 [
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
     (gogoproto.customname) = "PrevTxnID",
     (gogoproto.nullable) = false];
 
+  // The epoch of the transaction being retried. The client can compare this
+  // epoch that of the new transaction (below) to check whether the transaction
+  // is being restarted from the beginning with all writes discarded.
+  optional int32 prev_txn_epoch = 5 [
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/storage/enginepb.TxnEpoch",
+    (gogoproto.nullable) = false];
+
   // The Transaction that should be used by next attempts. Depending on the
-  // original cause of this method, this can either be the same Transaction as
-  // before, but with an incremented epoch and timestamp, or a completely new
-  // Transaction.
+  // original cause of this method and the isolation level of the transaction,
+  // this can be:
+  //
+  // - the same Transaction as before (same ID), but with an incremented epoch
+  // and read timestamp. The transaction must start again from the beginning,
+  // with all writes discarded. This case applies to isolation levels that do
+  // not use a per-statement read snapshot, and must therefore start from the
+  // beginning if the read snapshot must be adjusted.
+  //
+  // - the same Transaction as before (same ID) with the same epoch as before,
+  // but with an incremented read timestamp. The transaction can proceed without
+  // the loss of any of its writes, although clients may employ savepoints to
+  // selectively discard the writes from the read snapshot scope (i.e. the
+  // statement) being retried. This case applies to isolation levels that use a
+  // per-statement read snapshot, and can therefore retry select portions of the
+  // transaction if the read snapshot must be adjusted, without starting from
+  // the beginning.
+  //
+  // - a completely new Transaction (different ID). The transaction must start
+  // again from the beginning with all writes discarded and with a new identity.
+  // This case applies to all isolation levels. Transaction aborts are typically
+  // associated with locking deadlocks where the previous transaction's locks
+  // were discarded to break a deadlock between transactions and also with cases
+  // where the kv layer determines that it has lost information cannot process a
+  // certain transaction.
   optional roachpb.Transaction next_transaction = 3 [(gogoproto.nullable) = false];
 
   // A user-readable message containing redaction markers.

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -477,16 +477,16 @@ message TransactionRetryWithProtoRefreshError {
   // The ID of the transaction being restarted. The client is supposed to check
   // this against the ID of its transaction and make sure the retryable error
   // is meant for its level and didn't escape from some inner transaction.
-  optional bytes txn_id = 2 [
+  optional bytes prev_txn_id = 2 [
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
-    (gogoproto.customname) = "TxnID",
+    (gogoproto.customname) = "PrevTxnID",
     (gogoproto.nullable) = false];
 
   // The Transaction that should be used by next attempts. Depending on the
   // original cause of this method, this can either be the same Transaction as
   // before, but with an incremented epoch and timestamp, or a completely new
   // Transaction.
-  optional roachpb.Transaction transaction = 3 [(gogoproto.nullable) = false];
+  optional roachpb.Transaction next_transaction = 3 [(gogoproto.nullable) = false];
 
   // A user-readable message containing redaction markers.
   optional string msg_redactable = 4 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -75,13 +75,13 @@ func TestErrPriority(t *testing.T) {
 	{
 		id1 := uuid.Must(uuid.NewV4())
 		require.Equal(t, ErrorScoreTxnRestart, ErrPriority(&TransactionRetryWithProtoRefreshError{
-			TxnID:       id1,
-			Transaction: roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: id1}},
+			PrevTxnID:       id1,
+			NextTransaction: roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: id1}},
 		}))
 		id2 := uuid.Nil
 		require.Equal(t, ErrorScoreTxnAbort, ErrPriority(&TransactionRetryWithProtoRefreshError{
-			TxnID:       id1,
-			Transaction: roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: id2}},
+			PrevTxnID:       id1,
+			NextTransaction: roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: id2}},
 		}))
 	}
 	require.Equal(t, ErrorScoreUnambiguousError, ErrPriority(&ConditionFailedError{}))

--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -584,7 +584,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 				} else {
 					t.Logf("retrying unexpected txn error: %v", err)
 					// Sanity check the retry error is meant for our transaction.
-					require.Equal(t, retryErr.TxnID, txn.ID())
+					require.Equal(t, retryErr.PrevTxnID, txn.ID())
 				}
 			}
 

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -462,7 +462,7 @@ func (it *erroryRangeIterator) Next(ctx context.Context) (roachpb.RangeDescripto
 
 		var err error
 		err = kvpb.NewTransactionRetryWithProtoRefreshError(
-			"injected err", uuid.Nil, roachpb.Transaction{})
+			"injected err", uuid.Nil, 0 /* prevTxnEpoch */, roachpb.Transaction{})
 		// Let's wrap the error to check the unwrapping.
 		err = errors.Wrap(err, "dummy wrapper")
 		// Feed the error to the underlying iterator to reset it.

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -985,7 +985,7 @@ func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) 
 					log.Fatalf(ctx, "unexpected UnhandledRetryableError at the txn.exec() level: %s", err)
 				}
 			} else if t := (*kvpb.TransactionRetryWithProtoRefreshError)(nil); errors.As(err, &t) {
-				if txn.ID() != t.TxnID {
+				if txn.ID() != t.PrevTxnID {
 					// Make sure the retryable error is meant for this level by checking
 					// the transaction the error was generated for. If it's not, we
 					// terminate the "retryable" character of the error. We might get a
@@ -1038,7 +1038,7 @@ func (txn *Txn) PrepareForRetry(ctx context.Context) error {
 		txn.DebugNameLocked(), retryErr)
 	txn.resetDeadlineLocked()
 
-	if txn.mu.ID != retryErr.TxnID {
+	if txn.mu.ID != retryErr.PrevTxnID {
 		// Sanity check that the retry error we're dealing with is for the current
 		// incarnation of the transaction. Aborted transactions may be retried
 		// transparently in certain cases and such incarnations come with new
@@ -1049,7 +1049,7 @@ func (txn *Txn) PrepareForRetry(ctx context.Context) error {
 			errors.NewAssertionErrorWithWrappedErrf(
 				retryErr,
 				"unexpected retryable error for old incarnation of the transaction %s; current incarnation %s",
-				retryErr.TxnID,
+				retryErr.PrevTxnID,
 				txn.mu.ID,
 			), ctx)
 	}
@@ -1115,12 +1115,12 @@ func (txn *Txn) Send(
 	}
 
 	if retryErr, ok := pErr.GetDetail().(*kvpb.TransactionRetryWithProtoRefreshError); ok {
-		if requestTxnID != retryErr.TxnID {
+		if requestTxnID != retryErr.PrevTxnID {
 			// KV should not return errors for transactions other than the one that sent
 			// the request.
 			log.Fatalf(ctx, "retryable error for the wrong txn. "+
-				"requestTxnID: %s, retryErr.TxnID: %s. retryErr: %s",
-				requestTxnID, retryErr.TxnID, retryErr)
+				"requestTxnID: %s, retryErr.PrevTxnID: %s. retryErr: %s",
+				requestTxnID, retryErr.PrevTxnID, retryErr)
 		}
 	}
 	return br, pErr
@@ -1380,7 +1380,7 @@ func (txn *Txn) handleTransactionAbortedErrorLocked(
 
 	// The transaction we had been using thus far has been aborted. The proto
 	// inside the error has been prepared for use by the next transaction attempt.
-	newTxn := &retryErr.Transaction
+	newTxn := &retryErr.NextTransaction
 	txn.mu.ID = newTxn.ID
 	// Create a new txn sender. We need to preserve the stepping mode, if any.
 	prevSteppingMode := txn.mu.sender.GetSteppingMode(ctx)

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1034,24 +1034,29 @@ func (txn *Txn) PrepareForRetry(ctx context.Context) error {
 		return errors.WithContextTags(errors.NewAssertionErrorWithWrappedErrf(
 			retryErr, "PrepareForRetry() called on leaf txn"), ctx)
 	}
+	if err := txn.checkRetryErrorTxnIDLocked(ctx, retryErr); err != nil {
+		return err
+	}
+
 	log.VEventf(ctx, 2, "retrying transaction: %s because of a retryable error: %s",
 		txn.DebugNameLocked(), retryErr)
 	txn.resetDeadlineLocked()
 
-	if txn.mu.ID != retryErr.PrevTxnID {
-		// Sanity check that the retry error we're dealing with is for the current
-		// incarnation of the transaction. Aborted transactions may be retried
-		// transparently in certain cases and such incarnations come with new
-		// txn IDs. However, at no point can both the old and new incarnation of a
-		// transaction be active at the same time -- this would constitute a
-		// programming error.
-		return errors.WithContextTags(
-			errors.NewAssertionErrorWithWrappedErrf(
-				retryErr,
-				"unexpected retryable error for old incarnation of the transaction %s; current incarnation %s",
-				retryErr.PrevTxnID,
-				txn.mu.ID,
-			), ctx)
+	if !retryErr.TxnMustRestartFromBeginning() {
+		// If the retry error does not require the transaction to restart from
+		// beginning, it will have also not caused the transaction to advance its
+		// epoch. The caller has decided that it does want to restart from the
+		// beginning, se we "promote" the partial retry error to a full retry by
+		// manually restarting the transaction.
+		const msg = "promoting partial retryable error to full transaction retry"
+		log.VEventf(ctx, 2, msg)
+		manualErr := txn.mu.sender.GenerateForcedRetryableErr(
+			ctx, retryErr.NextTransaction.WriteTimestamp, true /* mustRestart */, msg)
+		// Now replace retryErr with the error returned by ManualRestart.
+		if !errors.As(manualErr, &retryErr) {
+			return errors.WithContextTags(errors.NewAssertionErrorWithWrappedErrf(
+				manualErr, "unexpected non-retry error during manual restart"), ctx)
+		}
 	}
 
 	if !retryErr.PrevTxnAborted() {
@@ -1063,6 +1068,59 @@ func (txn *Txn) PrepareForRetry(ctx context.Context) error {
 	}
 
 	return txn.handleTransactionAbortedErrorLocked(ctx, retryErr)
+}
+
+// PrepareForPartialRetry is like PrepareForRetry, except that it expects the
+// retryable error to not require the transaction to restart from the beginning
+// (see TransactionRetryWithProtoRefreshError.TxnMustRestartFromBeginning). It
+// is called once a partial retryable error has been handled and the caller is
+// ready to continue using the transaction.
+func (txn *Txn) PrepareForPartialRetry(ctx context.Context) error {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+
+	retryErr := txn.mu.sender.GetRetryableErr(ctx)
+	if retryErr == nil {
+		return nil
+	}
+	if txn.typ != RootTxn {
+		return errors.WithContextTags(errors.NewAssertionErrorWithWrappedErrf(
+			retryErr, "PrepareForPartialRetry() called on leaf txn"), ctx)
+	}
+	if err := txn.checkRetryErrorTxnIDLocked(ctx, retryErr); err != nil {
+		return err
+	}
+	if retryErr.TxnMustRestartFromBeginning() {
+		return errors.WithContextTags(errors.NewAssertionErrorWithWrappedErrf(
+			retryErr, "unexpected retryable error that must restart from beginning"), ctx)
+	}
+
+	log.VEventf(ctx, 2, "partially retrying transaction: %s because of a retryable error: %s",
+		txn.DebugNameLocked(), retryErr)
+
+	txn.mu.sender.ClearRetryableErr(ctx)
+	return nil
+}
+
+func (txn *Txn) checkRetryErrorTxnIDLocked(
+	ctx context.Context, retryErr *kvpb.TransactionRetryWithProtoRefreshError,
+) error {
+	if txn.mu.ID == retryErr.PrevTxnID {
+		return nil
+	}
+	// Sanity check that the retry error we're dealing with is for the current
+	// incarnation of the transaction. Aborted transactions may be retried
+	// transparently in certain cases and such incarnations come with new
+	// txn IDs. However, at no point can both the old and new incarnation of a
+	// transaction be active at the same time -- this would constitute a
+	// programming error.
+	return errors.WithContextTags(
+		errors.NewAssertionErrorWithWrappedErrf(
+			retryErr,
+			"unexpected retryable error for old incarnation of the transaction %s; current incarnation %s",
+			retryErr.PrevTxnID,
+			txn.mu.ID,
+		), ctx)
 }
 
 // Send runs the specified calls synchronously in a single batch and
@@ -1427,7 +1485,7 @@ func (txn *Txn) GenerateForcedRetryableErr(ctx context.Context, msg redact.Redac
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	now := txn.db.clock.NowAsClockTimestamp()
-	return txn.mu.sender.GenerateForcedRetryableErr(ctx, now.ToTimestamp(), msg)
+	return txn.mu.sender.GenerateForcedRetryableErr(ctx, now.ToTimestamp(), false /* mustRestart */, msg)
 }
 
 const RandomTxnRetryProbability = 0.1

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -757,10 +757,10 @@ func TestUpdateStateOnRemoteRetryableErr(t *testing.T) {
 		require.Equal(t, retErr, err)
 		if tc.epochBumped {
 			require.Greater(t, txn.Epoch(), epochBefore)
-			require.Equal(t, retErr.TxnID, txnIDBefore) // transaction IDs should not have changed on us
+			require.Equal(t, retErr.PrevTxnID, txnIDBefore) // transaction IDs should not have changed on us
 		}
 		if tc.newTxn {
-			require.NotEqual(t, retErr.Transaction.ID, txnIDBefore)
+			require.NotEqual(t, retErr.NextTransaction.ID, txnIDBefore)
 			require.Equal(t, txn.Sender().TxnStatus(), roachpb.ABORTED)
 		}
 		// Lastly, ensure the TxnCoordSender was not swapped out, even if the

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -310,7 +310,7 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 								// HACK ALERT: to do without a TxnCoordSender, we jump through
 								// hoops to get the retryable error expected by db.Txn().
 								return nil, kvpb.NewError(kvpb.NewTransactionRetryWithProtoRefreshError(
-									"foo", ba.Txn.ID, *ba.Txn))
+									"foo", ba.Txn.ID, ba.Txn.Epoch, *ba.Txn))
 							}
 							return nil, pErr
 						}
@@ -464,7 +464,7 @@ func TestWrongTxnRetry(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Simulate an inner txn by generating an error with a bogus txn id.
-		return kvpb.NewTransactionRetryWithProtoRefreshError("test error", uuid.MakeV4(), roachpb.Transaction{})
+		return kvpb.NewTransactionRetryWithProtoRefreshError("test error", uuid.MakeV4(), 0, roachpb.Transaction{})
 	}
 
 	if err := db.Txn(context.Background(), txnClosure); !testutils.IsError(err, "test error") {

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -751,7 +751,7 @@ func TestRetriableErrorDuringPrepare(t *testing.T) {
 				BeforePrepare: func(ctx context.Context, stmt string, txn *kv.Txn) error {
 					if strings.Contains(stmt, uniqueString) && atomic.AddInt64(&failed, 1) <= numToFail {
 						return kvpb.NewTransactionRetryWithProtoRefreshError("boom",
-							txn.ID(), *txn.TestingCloneTxn())
+							txn.ID(), txn.Epoch(), *txn.TestingCloneTxn())
 					}
 					return nil
 				},

--- a/pkg/sql/pgwire/pgerror/flatten_test.go
+++ b/pkg/sql/pgwire/pgerror/flatten_test.go
@@ -105,6 +105,7 @@ func TestFlatten(t *testing.T) {
 				kvpb.NewTransactionRetryWithProtoRefreshError(
 					"test",
 					uuid.MakeV4(),
+					0,
 					roachpb.Transaction{},
 				),
 				"",
@@ -118,6 +119,7 @@ func TestFlatten(t *testing.T) {
 				kvpb.NewTransactionRetryWithProtoRefreshError(
 					redact.Sprint(kvpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{}, hlc.ClockTimestamp{})),
 					uuid.MakeV4(),
+					0,
 					roachpb.Transaction{},
 				),
 				"",
@@ -131,6 +133,7 @@ func TestFlatten(t *testing.T) {
 				kvpb.NewTransactionRetryWithProtoRefreshError(
 					redact.Sprint(kvpb.NewTransactionRetryError(kvpb.RETRY_SERIALIZABLE, "")),
 					uuid.MakeV4(),
+					0,
 					roachpb.Transaction{},
 				),
 				"",
@@ -144,6 +147,7 @@ func TestFlatten(t *testing.T) {
 				kvpb.NewTransactionRetryWithProtoRefreshError(
 					redact.Sprint(kvpb.NewTransactionAbortedError(kvpb.ABORT_REASON_PUSHER_ABORTED)),
 					uuid.MakeV4(),
+					0,
 					roachpb.Transaction{},
 				),
 				"",


### PR DESCRIPTION
Fixes #104233.

This commit adds support for recovering from a retry error without starting a transaction from the beginning under Read Committed isolation.

The commit does so by first adjusting how Read Committed transactions (or any isolation level that uses a per-statement read snapshot) react to retry errors. Instead of immediately advancing their epochs, they simply adjust their read snapshot to the timestamp of the retry error. The commit then introduces a new `TxnMustRestartFromBeginning` method on `TransactionRetryWithProtoRefreshError`, to inform callers whether the transaction's writes were discarded due to the retry error, meaning that it must restart from the beginning. When this method returns false, callers are permitted to employ savepoints to selectively discard the writes from the current statement and then call a new `Txn.PrepareForPartialRetry` API to escape the retryable error state and continue using the transaction.

Release note: None