### PR TITLE
optgen: add builtin func to apply match patterns to arbitrary expressions

### DIFF
--- a/pkg/sql/opt/optgen/cmd/optfmt/main.go
+++ b/pkg/sql/opt/optgen/cmd/optfmt/main.go
@@ -410,6 +410,18 @@ func (p *pp) docOnlyExpr(e lang.Expr) pretty.Doc {
 			inner,
 			pretty.Text(")"),
 		)
+	case *lang.MatchExpr:
+		inner := pretty.Group(pretty.Fold(
+			pretty.Concat,
+			p.docExpr(e.Input),
+			pretty.Line,
+			p.docExpr(e.Match),
+		))
+		return pretty.BracketDoc(
+			pretty.Text("(Match "),
+			inner,
+			pretty.Text(")"),
+		)
 	case *lang.AnyExpr:
 		return pretty.Text("*")
 	case *lang.ListAnyExpr:

--- a/pkg/sql/opt/optgen/cmd/optfmt/testdata/test
+++ b/pkg/sql/opt/optgen/cmd/optfmt/testdata/test
@@ -88,6 +88,14 @@ define FiltersItem {
 =>
 (False)
 
+[TestMatch]
+(Select
+  $input:* & (Match $unwrapped:(Unwrap $input) (Scan) & (CheckStuff $unwrapped)) &
+    (Match $input $project:(Project))
+)
+=>
+(False)
+
 ----
 ----
 #
@@ -231,6 +239,18 @@ define FiltersItem {
             )
             $foo
         )
+)
+=>
+(False)
+
+[TestMatch]
+(Select
+    $input:* &
+        (Match
+            $unwrapped:(Unwrap $input)
+            (Scan) & (CheckStuff $unwrapped)
+        ) &
+        (Match $input $project:(Project))
 )
 =>
 (False)

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -225,6 +225,9 @@ func (g *newRuleGen) genMatch(match lang.Expr, context *contextDecl, noMatch boo
 	case *lang.LetExpr:
 		g.genMatchLet(t, noMatch)
 
+	case *lang.MatchExpr:
+		g.genMatchBuiltin(t, noMatch)
+
 	case *lang.AndExpr:
 		if noMatch {
 			panic("noMatch is not yet supported by the and match op")
@@ -703,6 +706,16 @@ func (g *newRuleGen) genMatchLet(let *lang.LetExpr, noMatch bool) {
 	g.genNestedExpr(let)
 
 	g.w.write(" {\n")
+}
+
+func (g *newRuleGen) genMatchBuiltin(match *lang.MatchExpr, noMatch bool) {
+	g.genBoundStatements(match.Input)
+	varName := g.uniquifier.makeUnique("_matchInput")
+	g.w.writeIndent("%s := ", varName)
+	g.genNestedExpr(match.Input)
+	g.w.newline()
+	newContext := &contextDecl{code: varName, typ: g.md.lookupType("Expr")}
+	g.genMatch(match.Match, newContext, noMatch)
 }
 
 // genNormalizeReplace generates the replace pattern code for normalization

--- a/pkg/sql/opt/optgen/lang/doc.go
+++ b/pkg/sql/opt/optgen/lang/doc.go
@@ -200,6 +200,27 @@ A let expression can also be used in a replace pattern. For example:
 	  $newFilters
 	)
 
+# Match Expression
+
+A Match expression can be used to apply an optgen match pattern to the result of
+calling a custom function. This expression consists of two elements, an input
+and a match pattern. It can only be used in a match pattern context.
+
+For example:
+
+	[RemovePassthroughProjects]
+	(Project
+	  $input:* & (Match $result:(SkipPassthroughProjects $input) (Scan))
+	  []
+	)
+	=>
+	$result
+
+The "$result:(SkipPassthroughProjects $input)" part calls a (fake) custom
+function that unwraps any pass-through Project operators from the given
+expression, then binds the result to "result". The (Scan) portion checks that
+the first part is a ScanExpr.
+
 # Matching Names
 
 In addition to simple name matching, a node matcher can match tag names. Any

--- a/pkg/sql/opt/optgen/lang/expr.og.go
+++ b/pkg/sql/opt/optgen/lang/expr.og.go
@@ -1168,6 +1168,71 @@ func (e *LetExpr) Format(buf *bytes.Buffer, level int) {
 	formatExpr(e, buf, level)
 }
 
+type MatchExpr struct {
+	Input Expr
+	Match Expr
+	Src   *SourceLoc
+	Typ   DataType
+}
+
+func (e *MatchExpr) Op() Operator {
+	return MatchOp
+}
+
+func (e *MatchExpr) ChildCount() int {
+	return 2
+}
+
+func (e *MatchExpr) Child(nth int) Expr {
+	switch nth {
+	case 0:
+		return e.Input
+	case 1:
+		return e.Match
+	}
+	panic(fmt.Sprintf("child index %d is out of range", nth))
+}
+
+func (e *MatchExpr) ChildName(nth int) string {
+	switch nth {
+	case 0:
+		return "Input"
+	case 1:
+		return "Match"
+	}
+	return ""
+}
+
+func (e *MatchExpr) Value() interface{} {
+	return nil
+}
+
+func (e *MatchExpr) Visit(visit VisitFunc) Expr {
+	children := visitChildren(e, visit)
+	if children != nil {
+		return &MatchExpr{Input: children[0], Match: children[1], Src: e.Source()}
+	}
+	return e
+}
+
+func (e *MatchExpr) Source() *SourceLoc {
+	return e.Src
+}
+
+func (e *MatchExpr) InferredType() DataType {
+	return e.Typ
+}
+
+func (e *MatchExpr) String() string {
+	var buf bytes.Buffer
+	e.Format(&buf, 0)
+	return buf.String()
+}
+
+func (e *MatchExpr) Format(buf *bytes.Buffer, level int) {
+	formatExpr(e, buf, level)
+}
+
 type RefExpr struct {
 	Label StringExpr
 	Src   *SourceLoc

--- a/pkg/sql/opt/optgen/lang/lang.opt
+++ b/pkg/sql/opt/optgen/lang/lang.opt
@@ -143,6 +143,12 @@ define Let {
 }
 
 [HasType]
+define Match {
+    Input Expr
+    Match Expr
+}
+
+[HasType]
 define Ref {
     Label String
 }

--- a/pkg/sql/opt/optgen/lang/operator.og.go
+++ b/pkg/sql/opt/optgen/lang/operator.og.go
@@ -27,6 +27,7 @@ const (
 	ListAnyOp
 	BindOp
 	LetOp
+	MatchOp
 	RefOp
 	AnyOp
 	SliceOp

--- a/pkg/sql/opt/optgen/lang/operator_string.go
+++ b/pkg/sql/opt/optgen/lang/operator_string.go
@@ -29,13 +29,14 @@ func _() {
 	_ = x[ListAnyOp-18]
 	_ = x[BindOp-19]
 	_ = x[LetOp-20]
-	_ = x[RefOp-21]
-	_ = x[AnyOp-22]
-	_ = x[SliceOp-23]
-	_ = x[StringOp-24]
-	_ = x[StringsOp-25]
-	_ = x[NumberOp-26]
-	_ = x[CustomFuncOp-27]
+	_ = x[MatchOp-21]
+	_ = x[RefOp-22]
+	_ = x[AnyOp-23]
+	_ = x[SliceOp-24]
+	_ = x[StringOp-25]
+	_ = x[StringsOp-26]
+	_ = x[NumberOp-27]
+	_ = x[CustomFuncOp-28]
 }
 
 func (i Operator) String() string {
@@ -82,6 +83,8 @@ func (i Operator) String() string {
 		return "BindOp"
 	case LetOp:
 		return "LetOp"
+	case MatchOp:
+		return "MatchOp"
 	case RefOp:
 		return "RefOp"
 	case AnyOp:

--- a/pkg/sql/opt/optgen/lang/testdata/compiler
+++ b/pkg/sql/opt/optgen/lang/testdata/compiler
@@ -854,6 +854,148 @@ define Op {
 )
 
 #
+# Test Match builtin function.
+#
+compile
+define Op {
+    Input  Expr
+    Scalar ScalarExpr
+}
+
+[Match]
+(Op
+  $input:* &
+    (Match (Func $input) (Op)) &
+    (Match $input $result:(Op *) & (Func $result)) &
+    (Match $input $matched:(Op) & (Match (Func $matched) (Op)))
+)
+=>
+(Op $input)
+----
+(Compiled
+	(Defines
+		(Define
+			Comments=(Comments)
+			Tags=(Tags)
+			Name="Op"
+			Fields=(DefineFields
+				(DefineField Comments=(Comments) Name="Input" Type="Expr" Src=<test.opt:2:5>)
+				(DefineField Comments=(Comments) Name="Scalar" Type="ScalarExpr" Src=<test.opt:3:5>)
+			)
+			Src=<test.opt:1:1>
+		)
+	)
+	(Rules
+		(Rule
+			Comments=(Comments)
+			Name="Match"
+			Tags=(Tags)
+			Match=(Func
+				Name=Op
+				Args=(Slice
+					(Bind
+						Label="input"
+						Target=(And
+							Left=(Any Typ=Expr)
+							Right=(And
+								Left=(Match
+									Input=(CustomFunc
+										Name=Func
+										Args=(Slice
+											(Ref Label="input" Src=<test.opt:9:18>)
+										)
+										Src=<test.opt:9:12>
+									)
+									Match=(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:9:26>)
+									Typ=Op
+									Src=<test.opt:9:26>
+								)
+								Right=(And
+									Left=(Match
+										Input=(Ref Label="input" Src=<test.opt:10:12>)
+										Match=(Bind
+											Label="result"
+											Target=(And
+												Left=(Func
+													Name=Op
+													Args=(Slice (Any Typ=Expr))
+													Typ=Op
+													Src=<test.opt:10:27>
+												)
+												Right=(CustomFunc
+													Name=Func
+													Args=(Slice
+														(Ref Label="result" Src=<test.opt:10:42>)
+													)
+													Typ=Expr
+													Src=<test.opt:10:36>
+												)
+												Typ=Op
+												Src=<test.opt:10:27>
+											)
+											Typ=Op
+											Src=<test.opt:10:19>
+										)
+										Typ=Op
+										Src=<test.opt:10:19>
+									)
+									Right=(Match
+										Input=(Ref Label="input" Src=<test.opt:11:12>)
+										Match=(Bind
+											Label="matched"
+											Target=(And
+												Left=(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:11:28>)
+												Right=(Match
+													Input=(CustomFunc
+														Name=Func
+														Args=(Slice
+															(Ref Label="matched" Src=<test.opt:11:48>)
+														)
+														Src=<test.opt:11:42>
+													)
+													Match=(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:11:58>)
+													Typ=Op
+													Src=<test.opt:11:58>
+												)
+												Typ=Op
+												Src=<test.opt:11:28>
+											)
+											Typ=Op
+											Src=<test.opt:11:19>
+										)
+										Typ=Op
+										Src=<test.opt:11:19>
+									)
+									Typ=Op
+									Src=<test.opt:10:5>
+								)
+								Typ=Op
+								Src=<test.opt:9:5>
+							)
+							Typ=Op
+							Src=<test.opt:8:10>
+						)
+						Typ=Op
+						Src=<test.opt:8:3>
+					)
+				)
+				Typ=Op
+				Src=<test.opt:7:1>
+			)
+			Replace=(Func
+				Name=Op
+				Args=(Slice
+					(Ref Label="input" Typ=Op Src=<test.opt:14:5>)
+				)
+				Typ=Op
+				Src=<test.opt:14:1>
+			)
+			Src=<test.opt:6:1>
+		)
+	)
+)
+
+#
 # Test type inference.
 #
 compile
@@ -1291,6 +1433,15 @@ define Op {
 
 [LetResultDeclaredOutsideLet]
 (Op $input:"foo" & (Func $a:(Func2 $input)) & (Let ($b $c):(Func3 $input) $a)) => (Op)
+
+[MatchInReplacePattern]
+(Op $input:*) => (Op (Match $input (Op)))
+
+[MatchBuiltinAtRoot]
+(Match $input:*) => (Op $input)
+
+[MatchInCustomFunc]
+(Op $input:* & (Func (Match $input (Op)))) => (Op)
 ----
 test.opt:5:1: duplicate 'Op' define statement
 test.opt:12:1: unrecognized match name 'Unknown'
@@ -1327,6 +1478,9 @@ test.opt:105:25: duplicate bind label 'input'
 test.opt:108:37: match pattern cannot use variable references
 test.opt:108:25: let target must be a custom function
 test.opt:111:75: unrecognized variable name 'a'
+test.opt:114:23: replace pattern cannot use Match builtin function
+test.opt:117:1: unrecognized match name 'Match'
+test.opt:120:23: custom match function cannot use Match builtin function
 
 # Type inference errors.
 compile

--- a/pkg/sql/opt/optgen/lang/testdata/parser
+++ b/pkg/sql/opt/optgen/lang/testdata/parser
@@ -491,6 +491,144 @@ define Op {
 )
 
 #
+# Test Match builtin function.
+#
+parse
+define Op {
+    Input  Expr
+    Scalar ScalarExpr
+}
+
+[Match]
+(Op
+  $input:* &
+    (Match (Func $input) (Op)) &
+    (Match $input $result:(Op *) & (Func $result)) &
+    (Match $input $matched:(Op) & (Match (Func $matched) (Op)))
+)
+=>
+(Op $input)
+----
+(Root
+	Defines=(DefineSet
+		(Define
+			Comments=(Comments)
+			Tags=(Tags)
+			Name="Op"
+			Fields=(DefineFields
+				(DefineField Comments=(Comments) Name="Input" Type="Expr" Src=<test.opt:2:5>)
+				(DefineField Comments=(Comments) Name="Scalar" Type="ScalarExpr" Src=<test.opt:3:5>)
+			)
+			Src=<test.opt:1:1>
+		)
+	)
+	Rules=(RuleSet
+		(Rule
+			Comments=(Comments)
+			Name="Match"
+			Tags=(Tags)
+			Match=(Func
+				Name=(Names Op)
+				Args=(Slice
+					(Bind
+						Label="input"
+						Target=(And
+							Left=(Any)
+							Right=(And
+								Left=(Match
+									Input=(Func
+										Name=(Names Func)
+										Args=(Slice
+											(Ref Label="input" Src=<test.opt:9:18>)
+										)
+										Src=<test.opt:9:12>
+									)
+									Match=(Func
+										Name=(Names Op)
+										Args=(Slice)
+										Src=<test.opt:9:26>
+									)
+									Src=<test.opt:9:6>
+								)
+								Right=(And
+									Left=(Match
+										Input=(Ref Label="input" Src=<test.opt:10:12>)
+										Match=(Bind
+											Label="result"
+											Target=(And
+												Left=(Func
+													Name=(Names Op)
+													Args=(Slice (Any))
+													Src=<test.opt:10:27>
+												)
+												Right=(Func
+													Name=(Names Func)
+													Args=(Slice
+														(Ref Label="result" Src=<test.opt:10:42>)
+													)
+													Src=<test.opt:10:36>
+												)
+												Src=<test.opt:10:27>
+											)
+											Src=<test.opt:10:19>
+										)
+										Src=<test.opt:10:6>
+									)
+									Right=(Match
+										Input=(Ref Label="input" Src=<test.opt:11:12>)
+										Match=(Bind
+											Label="matched"
+											Target=(And
+												Left=(Func
+													Name=(Names Op)
+													Args=(Slice)
+													Src=<test.opt:11:28>
+												)
+												Right=(Match
+													Input=(Func
+														Name=(Names Func)
+														Args=(Slice
+															(Ref Label="matched" Src=<test.opt:11:48>)
+														)
+														Src=<test.opt:11:42>
+													)
+													Match=(Func
+														Name=(Names Op)
+														Args=(Slice)
+														Src=<test.opt:11:58>
+													)
+													Src=<test.opt:11:36>
+												)
+												Src=<test.opt:11:28>
+											)
+											Src=<test.opt:11:19>
+										)
+										Src=<test.opt:11:6>
+									)
+									Src=<test.opt:10:5>
+								)
+								Src=<test.opt:9:5>
+							)
+							Src=<test.opt:8:10>
+						)
+						Src=<test.opt:8:3>
+					)
+				)
+				Src=<test.opt:7:1>
+			)
+			Replace=(Func
+				Name=(Names Op)
+				Args=(Slice
+					(Ref Label="input" Src=<test.opt:14:5>)
+				)
+				Src=<test.opt:14:1>
+			)
+			Src=<test.opt:6:1>
+		)
+	)
+)
+
+#
 # Match boolean expressions.
 #
 parse


### PR DESCRIPTION
This patch adds a new builtin func to optgen, `Match`, which takes two arguments. The first evaluates to an `opt.Expr`, and the second applies an optgen match pattern to that expression. See the updated documentation in this commit for more details.

This change will be useful for fast-path rules, which often only need to match an expression without modifying it. The `Match` func will allow optgen rules to match different numbers of simple `Project` operators, for example, without having to write a new optgen rule for each case.

Informs #77128

Release note: None