### PR TITLE
sql: some more inline docs for SHOW RANGES

### DIFF
--- a/pkg/sql/deprecatedshowranges/condition.go
+++ b/pkg/sql/deprecatedshowranges/condition.go
@@ -92,10 +92,15 @@ func EnableDeprecatedBehavior(
 	return useDeprecatedBehavior
 }
 
-// ShowRangesDeprecatedBehaviorSetting is the setting that controls the behavior. Exported for use in tests.
+// ShowRangesDeprecatedBehaviorSettingName is the name of the cluster
+// setting that controls the behavior.
+const ShowRangesDeprecatedBehaviorSettingName = "sql.show_ranges_deprecated_behavior.enabled"
+
+// ShowRangesDeprecatedBehaviorSetting is the setting that controls
+// the behavior. Exported for use in tests.
 var ShowRangesDeprecatedBehaviorSetting = settings.RegisterBoolSetting(
 	settings.TenantWritable,
-	`sql.show_ranges_deprecated_behavior.enabled`,
+	ShowRangesDeprecatedBehaviorSettingName,
 	"if set, SHOW RANGES and crdb_internal.ranges{_no_leases} behave with deprecated pre-v23.1 semantics."+
 		" NB: the new SHOW RANGES interface has richer WITH options "+
 		"than pre-v23.1 SHOW RANGES.",

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -8482,6 +8482,11 @@ show_range_for_row_stmt:
 //   DETAILS: add range size, leaseholder and other details
 //   KEYS:    include binary start/end keys
 //   EXPLAIN: show the SQL queries that produces the result
+//
+// Note: the availability of some of the options listed above is subject
+// to cluster configuration. See the documentation for details.
+//
+// %SeeAlso: WEBDOCS/show-ranges.html
 show_ranges_stmt:
   SHOW RANGES FROM INDEX table_index_name opt_show_ranges_options
   {


### PR DESCRIPTION
Fixes  #104985.
Epic: CRDB-28893

Prior to this patch, if a user entered e.g. `SHOW CLUSTER RANGES` (or any new 23.1 syntax) while the deprecated behavior was enabled, the error was not sufficient to clarify what was going on, for example:
```
ERROR: the deprecated syntax of SHOW RANGES only supports FROM TABLE, FROM INDEX or FROM DATABASE
```

This patch enhances the error as follows:
```
ERROR: the deprecated syntax of SHOW RANGES only supports FROM TABLE, FROM INDEX or FROM DATABASE
SQLSTATE: 42601
DETAIL: The behavior of SHOW RANGES is currently restricted by configuration to its pre-v23.1 behavior.
HINT: To access the new syntax and semantics, toggle the cluster setting sql.show_ranges_deprecated_behavior.enabled.
```

Additionally, prior to this patch the inline help (displayed when e.g. `\h SHOW RANGES` is entered) did not refer to the fact that some options are only available under configuration.

This patch fixes it by adding the following:
```
Note: the availability of some of the options listed above is subject
to cluster configuration. See the documentation for details.

See also:
  https://www.cockroachlabs.com/docs/v23.2/show-ranges.html
```

Release note (sql change): The inline documentation and error messages related to `SHOW RANGES` have been improved.