### PR TITLE
server: set sessionID during connExecutor initialization

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -756,6 +756,7 @@ func (s *Server) SetupConn(
 	clientComm ClientComm,
 	memMetrics MemoryMetrics,
 	onDefaultIntSizeChange func(newSize int32),
+	sessionID clusterunique.ID,
 ) (ConnectionHandler, error) {
 	sd := newSessionData(args)
 	sds := sessiondata.NewStack(sd)
@@ -781,8 +782,14 @@ func (s *Server) SetupConn(
 	}
 
 	ex := s.newConnExecutor(
-		ctx, sdMutIterator, stmtBuf, clientComm, memMetrics, &s.Metrics,
+		ctx,
+		sdMutIterator,
+		stmtBuf,
+		clientComm,
+		memMetrics,
+		&s.Metrics,
 		s.sqlStats.GetApplicationStats(sd.ApplicationName, false /* internal */),
+		sessionID,
 		nil, /* postSetupFn */
 	)
 	return ConnectionHandler{ex}, nil
@@ -882,11 +889,7 @@ func (h ConnectionHandler) GetQueryCancelKey() pgwirecancel.BackendKeyData {
 // connExecutor takes ownership of this memory and will close the account before
 // exiting.
 func (s *Server) ServeConn(
-	ctx context.Context,
-	h ConnectionHandler,
-	reserved *mon.BoundAccount,
-	cancel context.CancelFunc,
-	sessionID clusterunique.ID,
+	ctx context.Context, h ConnectionHandler, reserved *mon.BoundAccount, cancel context.CancelFunc,
 ) error {
 	// Make sure to close the reserved account even if closeWrapper below
 	// panics: so we do it in a defer that is guaranteed to execute. We also
@@ -897,7 +900,7 @@ func (s *Server) ServeConn(
 		r := recover()
 		h.ex.closeWrapper(ctx, r)
 	}(ctx, h)
-	return h.ex.run(ctx, s.pool, reserved, cancel, sessionID)
+	return h.ex.run(ctx, s.pool, reserved, cancel)
 }
 
 // GetLocalIndexStatistics returns a idxusage.LocalIndexUsageStats.
@@ -959,6 +962,7 @@ func (s *Server) newConnExecutor(
 	memMetrics MemoryMetrics,
 	srvMetrics *Metrics,
 	applicationStats sqlstats.ApplicationStats,
+	sessionID clusterunique.ID,
 	// postSetupFn is to override certain field of a conn executor.
 	// It is set when conn executor is init under an internal executor
 	// with a not-nil txn.
@@ -1101,6 +1105,7 @@ func (s *Server) newConnExecutor(
 	}
 
 	ex.initPlanner(ctx, &ex.planner)
+	ex.planner.extendedEvalCtx.SessionID = sessionID
 
 	return ex
 }
@@ -2060,7 +2065,6 @@ func (ex *connExecutor) run(
 	parentMon *mon.BytesMonitor,
 	reserved *mon.BoundAccount,
 	onCancel context.CancelFunc,
-	sessionID clusterunique.ID,
 ) (err error) {
 	if !ex.activated {
 		ex.activate(ctx, parentMon, reserved)
@@ -2068,8 +2072,8 @@ func (ex *connExecutor) run(
 	ex.ctxHolder.connCtx = ctx
 	ex.onCancelSession = onCancel
 
+	sessionID := ex.planner.extendedEvalCtx.SessionID
 	ex.server.cfg.SessionRegistry.register(sessionID, ex.queryCancelKey, ex)
-	ex.planner.extendedEvalCtx.SessionID = sessionID
 
 	defer func() {
 		ex.server.cfg.SessionRegistry.deregister(sessionID, ex.queryCancelKey)

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -359,7 +359,15 @@ func startConnExecutor(
 	sqlMetrics := MakeMemMetrics("test" /* endpoint */, time.Second /* histogramWindow */)
 
 	onDefaultIntSizeChange := func(int32) {}
-	conn, err := s.SetupConn(ctx, SessionArgs{}, buf, cc, sqlMetrics, onDefaultIntSizeChange)
+	conn, err := s.SetupConn(
+		ctx,
+		SessionArgs{},
+		buf,
+		cc,
+		sqlMetrics,
+		onDefaultIntSizeChange,
+		clusterunique.ID{},
+	)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -374,7 +382,6 @@ func startConnExecutor(
 			conn,
 			&mon.BoundAccount{},
 			nil, /* cancel */
-			clusterunique.ID{},
 		)
 	}()
 	return buf, syncResults, finished, stopper, resultChannel, nil
@@ -401,7 +408,15 @@ func TestSessionCloseWithPendingTempTableInTxn(t *testing.T) {
 		},
 	}
 	onDefaultIntSizeChange := func(int32) {}
-	connHandler, err := srv.SetupConn(ctx, SessionArgs{User: username.RootUserName()}, stmtBuf, clientComm, MemoryMetrics{}, onDefaultIntSizeChange)
+	connHandler, err := srv.SetupConn(
+		ctx,
+		SessionArgs{User: username.RootUserName()},
+		stmtBuf,
+		clientComm,
+		MemoryMetrics{},
+		onDefaultIntSizeChange,
+		clusterunique.ID{},
+	)
 	require.NoError(t, err)
 
 	stmts, err := parser.Parse(`
@@ -424,7 +439,6 @@ CREATE TEMPORARY TABLE foo();
 			connHandler,
 			&mon.BoundAccount{},
 			nil, /* cancel */
-			clusterunique.ID{},
 		)
 	}()
 	results := <-flushed

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -224,7 +224,6 @@ func (ie *InternalExecutor) runWithEx(
 			ie.mon,
 			&mon.BoundAccount{}, /*reserved*/
 			nil,                 /* cancel */
-			ex.server.cfg.GenerateID(),
 		); err != nil {
 			sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
 			errCallback(err)
@@ -287,6 +286,7 @@ func (ie *InternalExecutor) initConnEx(
 			ie.memMetrics,
 			&ie.s.InternalMetrics,
 			applicationStats,
+			ie.s.cfg.GenerateID(),
 			nil, /* postSetupFn */
 		)
 	} else {
@@ -363,6 +363,7 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 		ie.memMetrics,
 		&ie.s.InternalMetrics,
 		applicationStats,
+		ie.s.cfg.GenerateID(),
 		postSetupFn,
 	)
 

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -286,7 +286,7 @@ func (c *conn) processCommandsAsync(
 		}
 
 		// Inform the client of the default session settings.
-		connHandler, retErr = c.sendInitialConnData(ctx, sqlServer, onDefaultIntSizeChange)
+		connHandler, retErr = c.sendInitialConnData(ctx, sqlServer, onDefaultIntSizeChange, sessionID)
 		if retErr != nil {
 			return
 		}
@@ -312,7 +312,6 @@ func (c *conn) processCommandsAsync(
 			connHandler,
 			reserved,
 			c.cancelConn,
-			sessionID,
 		)
 	}()
 	return retCh
@@ -331,7 +330,10 @@ func (c *conn) bufferNotice(ctx context.Context, noticeErr pgnotice.Notice) erro
 }
 
 func (c *conn) sendInitialConnData(
-	ctx context.Context, sqlServer *sql.Server, onDefaultIntSizeChange func(newSize int32),
+	ctx context.Context,
+	sqlServer *sql.Server,
+	onDefaultIntSizeChange func(newSize int32),
+	sessionID clusterunique.ID,
 ) (sql.ConnectionHandler, error) {
 	connHandler, err := sqlServer.SetupConn(
 		ctx,
@@ -340,6 +342,7 @@ func (c *conn) sendInitialConnData(
 		c,
 		c.metrics.SQLMemMetrics,
 		onDefaultIntSizeChange,
+		sessionID,
 	)
 	if err != nil {
 		_ /* err */ = c.writeErr(ctx, err, c.conn)


### PR DESCRIPTION
Fixes #105178

This fixes a race between the sessionID being written and read by setting it during connExecutor initialization because the sessionID is immutable and is known at this time.

Release note: None