### PR TITLE
release-22.2: logictest: fix crdb_internal flake

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -853,12 +853,6 @@ SELECT start_pretty, end_pretty FROM crdb_internal.ranges
 WHERE split_enforced_until IS NOT NULL
 AND (start_pretty LIKE '/Table/112/1%' OR start_pretty LIKE '/Table/112/2%')
 ----
-/Table/112/1/1  /Table/112/1/2
-/Table/112/1/2  /Table/112/1/3
-/Table/112/1/3  /Table/112/2/1
-/Table/112/2/1  /Table/112/2/2
-/Table/112/2/2  /Table/112/2/3
-/Table/112/2/3  /Table/112/3/1
 
 statement ok
 ALTER TABLE foo SPLIT AT VALUES (1), (2), (3)


### PR DESCRIPTION
This commit fixes an incorrect change to a test that was introduced
in #104735. The test was flaky instead of consistently failing because
it uses the `retry` option.

Fixes #104952

Release justification: This is a test-only change.

Release note: None