### PR TITLE
release-22.2: sql: better expose non-critical errors during bundle collection

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -115,6 +115,11 @@ type diagnosticsBundle struct {
 	// Stores any error in the collection, building, or insertion of the bundle.
 	collectionErr error
 
+	// errorStrings are all non-critical errors that we ran into when collecting
+	// the bundle. "Non-critical" in this context means that most of the bundle
+	// was still collected to be useful, but some parts might be missing.
+	errorStrings []string
+
 	// diagID is the diagnostics instance ID, populated by insert().
 	diagID stmtdiagnostics.CollectedInstanceID
 }
@@ -150,9 +155,9 @@ func buildStatementBundle(
 
 	buf, err := b.finalize()
 	if err != nil {
-		return diagnosticsBundle{collectionErr: err}
+		return diagnosticsBundle{collectionErr: err, errorStrings: b.errorStrings}
 	}
-	return diagnosticsBundle{zip: buf.Bytes()}
+	return diagnosticsBundle{zip: buf.Bytes(), errorStrings: b.errorStrings}
 }
 
 // insert the bundle in statement diagnostics. Sets bundle.diagID and (in error
@@ -196,6 +201,9 @@ type stmtBundleBuilder struct {
 	trace        tracingpb.Recording
 	placeholders *tree.PlaceholderInfo
 	sv           *settings.Values
+
+	// errorStrings are non-critical errors encountered so far.
+	errorStrings []string
 
 	z memzipper.Zipper
 }
@@ -351,10 +359,19 @@ Jaeger can be started using docker with: docker run -d --name jaeger -p 16686:16
 The UI can then be accessed at http://localhost:16686/search`, b.stmt)
 	jaegerJSON, err := b.trace.ToJaegerJSON(b.stmt, comment, "")
 	if err != nil {
+		b.errorStrings = append(b.errorStrings, fmt.Sprintf("error getting jaeger trace: %v", err))
 		b.z.AddFile("trace-jaeger.txt", err.Error())
 	} else {
 		b.z.AddFile("trace-jaeger.json", jaegerJSON)
 	}
+}
+
+// printError writes the given error string into buf (with a newline appended)
+// as well as accumulates the string into b.errorStrings. The method should only
+// be used for non-critical errors.
+func (b *stmtBundleBuilder) printError(errString string, buf *bytes.Buffer) {
+	fmt.Fprintf(buf, errString+"\n")
+	b.errorStrings = append(b.errorStrings, errString)
 }
 
 func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
@@ -362,19 +379,19 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 
 	var buf bytes.Buffer
 	if err := c.PrintVersion(&buf); err != nil {
-		fmt.Fprintf(&buf, "-- error getting version: %v\n", err)
+		b.printError(fmt.Sprintf("-- error getting version: %v", err), &buf)
 	}
 	fmt.Fprintf(&buf, "\n")
 
 	// Show the values of session variables that can impact planning decisions.
 	if err := c.PrintSessionSettings(&buf, b.sv); err != nil {
-		fmt.Fprintf(&buf, "-- error getting session settings: %v\n", err)
+		b.printError(fmt.Sprintf("-- error getting session settings: %v", err), &buf)
 	}
 
 	fmt.Fprintf(&buf, "\n")
 
 	if err := c.PrintClusterSettings(&buf); err != nil {
-		fmt.Fprintf(&buf, "-- error getting cluster settings: %v\n", err)
+		b.printError(fmt.Sprintf("-- error getting cluster settings: %v", err), &buf)
 	}
 
 	b.z.AddFile("env.sql", buf.String())
@@ -398,7 +415,9 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 		return err
 	})
 	if err != nil {
-		b.z.AddFile("schema.sql", fmt.Sprintf("-- error getting data source names: %v\n", err))
+		errString := fmt.Sprintf("-- error getting data source names: %v", err)
+		b.errorStrings = append(b.errorStrings, errString)
+		b.z.AddFile("schema.sql", errString+"\n")
 		return
 	}
 
@@ -414,24 +433,24 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	}
 	blankLine()
 	if err := c.printCreateAllSchemas(&buf); err != nil {
-		fmt.Fprintf(&buf, "-- error getting all schemas: %v\n", err)
+		b.printError(fmt.Sprintf("-- error getting all schemas: %v", err), &buf)
 	}
 	for i := range sequences {
 		blankLine()
 		if err := c.PrintCreateSequence(&buf, &sequences[i]); err != nil {
-			fmt.Fprintf(&buf, "-- error getting schema for sequence %s: %v\n", sequences[i].String(), err)
+			b.printError(fmt.Sprintf("-- error getting schema for sequence %s: %v", sequences[i].String(), err), &buf)
 		}
 	}
 	for i := range tables {
 		blankLine()
 		if err := c.PrintCreateTable(&buf, &tables[i]); err != nil {
-			fmt.Fprintf(&buf, "-- error getting schema for table %s: %v\n", tables[i].String(), err)
+			b.printError(fmt.Sprintf("-- error getting schema for table %s: %v", tables[i].String(), err), &buf)
 		}
 	}
 	for i := range views {
 		blankLine()
 		if err := c.PrintCreateView(&buf, &views[i]); err != nil {
-			fmt.Fprintf(&buf, "-- error getting schema for view %s: %v\n", views[i].String(), err)
+			b.printError(fmt.Sprintf("-- error getting schema for view %s: %v", views[i].String(), err), &buf)
 		}
 	}
 	if buf.Len() == 0 {
@@ -441,20 +460,23 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	for i := range tables {
 		buf.Reset()
 		if err := c.PrintTableStats(&buf, &tables[i], false /* hideHistograms */); err != nil {
-			fmt.Fprintf(&buf, "-- error getting statistics for table %s: %v\n", tables[i].String(), err)
+			b.printError(fmt.Sprintf("-- error getting statistics for table %s: %v", tables[i].String(), err), &buf)
 		}
 		b.z.AddFile(fmt.Sprintf("stats-%s.sql", tables[i].String()), buf.String())
 	}
 }
 
 func (b *stmtBundleBuilder) addErrors(queryErr, payloadErr, commErr error) {
-	if queryErr == nil && payloadErr == nil && commErr == nil {
+	if queryErr == nil && payloadErr == nil && commErr == nil && len(b.errorStrings) == 0 {
 		return
 	}
 	output := fmt.Sprintf(
-		"query error:\n%v\n\npayload error:\n%v\n\ncomm error:\n%v\n",
+		"query error:\n%v\n\npayload error:\n%v\n\ncomm error:\n%v\n\n",
 		queryErr, payloadErr, commErr,
 	)
+	for _, errString := range b.errorStrings {
+		output += errString + "\n"
+	}
 	b.z.AddFile("errors.txt", output)
 }
 

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -59,7 +59,7 @@ CREATE TABLE s.a (a INT PRIMARY KEY);`)
 	t.Run("no-table", func(t *testing.T) {
 		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT 123")
 		checkBundle(
-			t, fmt.Sprint(rows), "", nil,
+			t, fmt.Sprint(rows), "", nil, false, /* expectErrors */
 			base, plans, "distsql.html vec.txt vec-v.txt",
 		)
 	})
@@ -67,7 +67,7 @@ CREATE TABLE s.a (a INT PRIMARY KEY);`)
 	t.Run("basic", func(t *testing.T) {
 		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM abc WHERE c=1")
 		checkBundle(
-			t, fmt.Sprint(rows), "public.abc", nil,
+			t, fmt.Sprint(rows), "public.abc", nil, false, /* expectErrors */
 			base, plans, "stats-defaultdb.public.abc.sql", "distsql.html vec.txt vec-v.txt",
 		)
 	})
@@ -76,7 +76,7 @@ CREATE TABLE s.a (a INT PRIMARY KEY);`)
 	t.Run("subqueries", func(t *testing.T) {
 		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT EXISTS (SELECT * FROM abc WHERE c=1)")
 		checkBundle(
-			t, fmt.Sprint(rows), "public.abc", nil,
+			t, fmt.Sprint(rows), "public.abc", nil, false, /* expectErrors */
 			base, plans, "stats-defaultdb.public.abc.sql", "distsql-2-main-query.html distsql-1-subquery.html vec-1-subquery-v.txt vec-1-subquery.txt vec-2-main-query-v.txt vec-2-main-query.txt",
 		)
 	})
@@ -84,7 +84,7 @@ CREATE TABLE s.a (a INT PRIMARY KEY);`)
 	t.Run("user-defined schema", func(t *testing.T) {
 		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM s.a WHERE a=1")
 		checkBundle(
-			t, fmt.Sprint(rows), "s.a", nil,
+			t, fmt.Sprint(rows), "s.a", nil, false, /* expectErrors */
 			base, plans, "stats-defaultdb.s.a.sql", "distsql.html vec.txt vec-v.txt",
 		)
 	})
@@ -98,7 +98,7 @@ CREATE TABLE s.a (a INT PRIMARY KEY);`)
 		// The bundle url is inside the error detail.
 		var pqErr *pq.Error
 		_ = errors.As(err, &pqErr)
-		checkBundle(t, fmt.Sprintf("%+v", pqErr.Detail), "", nil, base, plans, "distsql.html errors.txt")
+		checkBundle(t, fmt.Sprintf("%+v", pqErr.Detail), "", nil, false /* expectErrors */, base, plans, "distsql.html errors.txt")
 	})
 
 	// #92920 Make sure schema and opt files are created.
@@ -111,7 +111,7 @@ CREATE TABLE s.a (a INT PRIMARY KEY);`)
 				}
 			}
 			return nil
-		}, base, plans, "distsql.html vec.txt vec-v.txt")
+		}, false /* expectErrors */, base, plans, "distsql.html vec.txt vec-v.txt")
 	})
 
 	// Verify that we can issue the statement with prepare (which can happen
@@ -136,7 +136,7 @@ CREATE TABLE s.a (a INT PRIMARY KEY);`)
 			rowsBuf.WriteByte('\n')
 		}
 		checkBundle(
-			t, rowsBuf.String(), "public.abc", nil,
+			t, rowsBuf.String(), "public.abc", nil, false, /* expectErrors */
 			base, plans, "stats-defaultdb.public.abc.sql", "distsql.html vec.txt vec-v.txt",
 		)
 	})
@@ -155,7 +155,7 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 `)
 		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) INSERT INTO users (promo_id) VALUES (642606224929619969);")
 		checkBundle(
-			t, fmt.Sprint(rows), "public.users", nil, base, plans,
+			t, fmt.Sprint(rows), "public.users", nil, false /* expectErrors */, base, plans,
 			"stats-defaultdb.public.users.sql", "stats-defaultdb.public.promos.sql",
 			"distsql-1-main-query.html distsql-2-postquery.html vec-1-main-query-v.txt vec-1-main-query.txt vec-2-postquery-v.txt vec-2-postquery.txt",
 		)
@@ -167,7 +167,7 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 		defer r.Exec(t, "SET CLUSTER SETTING sql.trace.txn.enable_threshold='0ms';")
 		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM abc WHERE c=1")
 		checkBundle(
-			t, fmt.Sprint(rows), "public.abc", nil,
+			t, fmt.Sprint(rows), "public.abc", nil, false, /* expectErrors */
 			base, plans, "stats-defaultdb.public.abc.sql", "distsql.html vec.txt vec-v.txt",
 		)
 	})
@@ -225,7 +225,7 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 							}
 						}
 						return nil
-					},
+					}, false, /* expectErrors */
 					base, plans, "stats-defaultdb.public.abc.sql", "distsql.html vec.txt vec-v.txt",
 				)
 			})
@@ -277,9 +277,32 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 					}
 				}
 				return nil
-			},
+			}, false, /* expectErrors */
 			base, plans, "stats-defaultdb.public.parent.sql", "stats-defaultdb.public.child.sql",
 			"distsql.html vec.txt vec-v.txt",
+		)
+	})
+
+	t.Run("permission error", func(t *testing.T) {
+		r.Exec(t, "CREATE USER test")
+		r.Exec(t, "SET ROLE test")
+		defer r.Exec(t, "SET ROLE root")
+		r.Exec(t, "CREATE TABLE permissions (k PRIMARY KEY) AS SELECT 1")
+		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM permissions")
+		// Check that we see an error about missing privileges for the cluster
+		// settings as a warning.
+		var numErrors int
+		for _, row := range rows {
+			if strings.HasPrefix(row[0], "-- error") {
+				numErrors++
+			}
+		}
+		if numErrors != 1 {
+			t.Fatalf("didn't see 1 error in %v", rows)
+		}
+		checkBundle(
+			t, fmt.Sprint(rows), "permission" /* tableName */, nil /* contentCheck */, true, /* expectErrors */
+			base, plans, "distsql.html errors.txt stats-defaultdb.public.permissions.sql vec.txt vec-v.txt",
 		)
 	})
 }
@@ -288,10 +311,13 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 // bundle contains the expected files. The expected files are passed as an
 // arbitrary number of strings; each string contains one or more filenames
 // separated by a space.
+// - expectErrors, if set, indicates that non-critical errors might have
+// occurred during the bundle collection and shouldn't fail the test.
 func checkBundle(
 	t *testing.T,
 	text, tableName string,
 	contentCheck func(name, contents string) error,
+	expectErrors bool,
 	expectedFiles ...string,
 ) {
 	httpClient := httputil.NewClientWithTimeout(30 * time.Second)
@@ -338,7 +364,7 @@ func checkBundle(
 		}
 		contents := string(bytes)
 
-		if strings.Contains(contents, "-- error") {
+		if !expectErrors && strings.Contains(contents, "-- error") {
 			t.Errorf(
 				"expected no errors in %s, file contents:\n%s",
 				f.Name, contents,

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -400,6 +400,10 @@ func (ih *instrumentationHelper) Finish(
 				ih.origCtx, cfg.DB, ie.(*InternalExecutor), stmtRawSQL, &p.curPlan, ob.BuildString(), trace,
 				placeholders, res.Err(), payloadErr, retErr, &p.extendedEvalCtx.Settings.SV,
 			)
+			// Include all non-critical errors as warnings. Note that these
+			// error strings might contain PII, but the warnings are only shown
+			// to the current user and aren't included into the bundle.
+			warnings = append(warnings, bundle.errorStrings...)
 			bundle.insert(
 				ctx, ih.fingerprint, ast, cfg.StmtDiagnosticsRecorder, ih.diagRequestID, ih.diagRequest,
 			)


### PR DESCRIPTION
Backport 1/1 commits from #105005.

/cc @cockroachdb/release

---

When we're collecting a statement bundle, we might encounter different non-critical errors (e.g. the user doesn't have the privilege to query cluster settings). These errors are benign and don't stop us from producing an incomplete but still useful bundle. This commit makes these errors more visible in two ways:
- all these errors are now included into `errors.txt` file (except when the redaction is enabled)
- all these errors are also now printed as the response to `EXPLAIN ANALYZE (DEBUG)` command in the SQL shell (i.e. they are shown as "warnings").

However, if the bundle is requested via the DB Console, then these errors are still somewhat hidden from the user. Improvement there will be addressed separately.

Addresses: #68523.
Epic: None

Release note: None

Release justification: low-risk observability improvement.