### PR TITLE
release-23.1: sql: better expose non-critical errors during bundle collection

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -119,6 +119,11 @@ type diagnosticsBundle struct {
 	// Stores any error in the collection, building, or insertion of the bundle.
 	collectionErr error
 
+	// errorStrings are all non-critical errors that we ran into when collecting
+	// the bundle. "Non-critical" in this context means that most of the bundle
+	// was still collected to be useful, but some parts might be missing.
+	errorStrings []string
+
 	// diagID is the diagnostics instance ID, populated by insert().
 	diagID stmtdiagnostics.CollectedInstanceID
 }
@@ -155,9 +160,9 @@ func buildStatementBundle(
 
 	buf, err := b.finalize()
 	if err != nil {
-		return diagnosticsBundle{collectionErr: err}
+		return diagnosticsBundle{collectionErr: err, errorStrings: b.errorStrings}
 	}
-	return diagnosticsBundle{zip: buf.Bytes()}
+	return diagnosticsBundle{zip: buf.Bytes(), errorStrings: b.errorStrings}
 }
 
 // insert the bundle in statement diagnostics. Sets bundle.diagID and (in error
@@ -203,6 +208,9 @@ type stmtBundleBuilder struct {
 	trace        tracingpb.Recording
 	placeholders *tree.PlaceholderInfo
 	sv           *settings.Values
+
+	// errorStrings are non-critical errors encountered so far.
+	errorStrings []string
 
 	z memzipper.Zipper
 }
@@ -388,10 +396,19 @@ Jaeger can be started using docker with: docker run -d --name jaeger -p 16686:16
 The UI can then be accessed at http://localhost:16686/search`, b.stmt)
 	jaegerJSON, err := b.trace.ToJaegerJSON(b.stmt, comment, "")
 	if err != nil {
+		b.errorStrings = append(b.errorStrings, fmt.Sprintf("error getting jaeger trace: %v", err))
 		b.z.AddFile("trace-jaeger.txt", err.Error())
 	} else {
 		b.z.AddFile("trace-jaeger.json", jaegerJSON)
 	}
+}
+
+// printError writes the given error string into buf (with a newline appended)
+// as well as accumulates the string into b.errorStrings. The method should only
+// be used for non-critical errors.
+func (b *stmtBundleBuilder) printError(errString string, buf *bytes.Buffer) {
+	fmt.Fprintf(buf, errString+"\n")
+	b.errorStrings = append(b.errorStrings, errString)
 }
 
 func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
@@ -399,19 +416,19 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 
 	var buf bytes.Buffer
 	if err := c.PrintVersion(&buf); err != nil {
-		fmt.Fprintf(&buf, "-- error getting version: %v\n", err)
+		b.printError(fmt.Sprintf("-- error getting version: %v", err), &buf)
 	}
 	fmt.Fprintf(&buf, "\n")
 
 	// Show the values of session variables that can impact planning decisions.
 	if err := c.PrintSessionSettings(&buf, b.sv); err != nil {
-		fmt.Fprintf(&buf, "-- error getting session settings: %v\n", err)
+		b.printError(fmt.Sprintf("-- error getting session settings: %v", err), &buf)
 	}
 
 	fmt.Fprintf(&buf, "\n")
 
 	if err := c.PrintClusterSettings(&buf); err != nil {
-		fmt.Fprintf(&buf, "-- error getting cluster settings: %v\n", err)
+		b.printError(fmt.Sprintf("-- error getting cluster settings: %v", err), &buf)
 	}
 
 	b.z.AddFile("env.sql", buf.String())
@@ -435,7 +452,9 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 		return err
 	})
 	if err != nil {
-		b.z.AddFile("schema.sql", fmt.Sprintf("-- error getting data source names: %v\n", err))
+		errString := fmt.Sprintf("-- error getting data source names: %v", err)
+		b.errorStrings = append(b.errorStrings, errString)
+		b.z.AddFile("schema.sql", errString+"\n")
 		return
 	}
 
@@ -451,31 +470,31 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	}
 	blankLine()
 	if err := c.printCreateAllSchemas(&buf); err != nil {
-		fmt.Fprintf(&buf, "-- error getting all schemas: %v\n", err)
+		b.printError(fmt.Sprintf("-- error getting all schemas: %v", err), &buf)
 	}
 	for i := range sequences {
 		blankLine()
 		if err := c.PrintCreateSequence(&buf, &sequences[i]); err != nil {
-			fmt.Fprintf(&buf, "-- error getting schema for sequence %s: %v\n", sequences[i].String(), err)
+			b.printError(fmt.Sprintf("-- error getting schema for sequence %s: %v", sequences[i].String(), err), &buf)
 		}
 	}
 	if len(mem.Metadata().AllUserDefinedFunctions()) != 0 {
 		// Get all relevant user-defined functions.
 		blankLine()
-		if err := c.PrintRelevantCreateUdf(&buf, strings.ToLower(b.stmt), b.flags.RedactValues); err != nil {
-			fmt.Fprintf(&buf, "-- error getting schema for udfs: %v\n", err)
+		if err := c.PrintRelevantCreateUdf(&buf, strings.ToLower(b.stmt), b.flags.RedactValues, &b.errorStrings); err != nil {
+			b.printError(fmt.Sprintf("-- error getting schema for udfs: %v", err), &buf)
 		}
 	}
 	for i := range tables {
 		blankLine()
 		if err := c.PrintCreateTable(&buf, &tables[i], b.flags.RedactValues); err != nil {
-			fmt.Fprintf(&buf, "-- error getting schema for table %s: %v\n", tables[i].String(), err)
+			b.printError(fmt.Sprintf("-- error getting schema for table %s: %v", tables[i].String(), err), &buf)
 		}
 	}
 	for i := range views {
 		blankLine()
 		if err := c.PrintCreateView(&buf, &views[i], b.flags.RedactValues); err != nil {
-			fmt.Fprintf(&buf, "-- error getting schema for view %s: %v\n", views[i].String(), err)
+			b.printError(fmt.Sprintf("-- error getting schema for view %s: %v", views[i].String(), err), &buf)
 		}
 	}
 	if buf.Len() == 0 {
@@ -486,7 +505,7 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 		buf.Reset()
 		hideHistograms := b.flags.RedactValues
 		if err := c.PrintTableStats(&buf, &tables[i], hideHistograms); err != nil {
-			fmt.Fprintf(&buf, "-- error getting statistics for table %s: %v\n", tables[i].String(), err)
+			b.printError(fmt.Sprintf("-- error getting statistics for table %s: %v", tables[i].String(), err), &buf)
 		}
 		b.z.AddFile(fmt.Sprintf("stats-%s.sql", tables[i].String()), buf.String())
 	}
@@ -497,13 +516,16 @@ func (b *stmtBundleBuilder) addErrors(queryErr, payloadErr, commErr error) {
 		return
 	}
 
-	if queryErr == nil && payloadErr == nil && commErr == nil {
+	if queryErr == nil && payloadErr == nil && commErr == nil && len(b.errorStrings) == 0 {
 		return
 	}
 	output := fmt.Sprintf(
-		"query error:\n%v\n\npayload error:\n%v\n\ncomm error:\n%v\n",
+		"query error:\n%v\n\npayload error:\n%v\n\ncomm error:\n%v\n\n",
 		queryErr, payloadErr, commErr,
 	)
+	for _, errString := range b.errorStrings {
+		output += errString + "\n"
+	}
 	b.z.AddFile("errors.txt", output)
 }
 
@@ -804,7 +826,7 @@ func (c *stmtEnvCollector) PrintCreateSequence(w io.Writer, tn *tree.TableName) 
 }
 
 func (c *stmtEnvCollector) PrintRelevantCreateUdf(
-	w io.Writer, stmt string, redactValues bool,
+	w io.Writer, stmt string, redactValues bool, errorStrings *[]string,
 ) error {
 	// The select function_name returns a DOidWrapper,
 	// we need to cast it to string for queryRows function to process.
@@ -826,7 +848,9 @@ func (c *stmtEnvCollector) PrintRelevantCreateUdf(
 			}
 			createStatement, err := c.query(createFunctionQuery)
 			if err != nil {
-				fmt.Fprintf(w, "-- error getting user defined function %s: %s\n", name, err)
+				errString := fmt.Sprintf("-- error getting user defined function %s: %s", name, err)
+				fmt.Fprint(w, errString+"\n")
+				*errorStrings = append(*errorStrings, errString)
 				continue
 			}
 			fmt.Fprintf(w, "%s\n", createStatement)

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -416,6 +416,10 @@ func (ih *instrumentationHelper) Finish(
 				ob.BuildString(), trace, placeholders, res.Err(), payloadErr, retErr,
 				&p.extendedEvalCtx.Settings.SV,
 			)
+			// Include all non-critical errors as warnings. Note that these
+			// error strings might contain PII, but the warnings are only shown
+			// to the current user and aren't included into the bundle.
+			warnings = append(warnings, bundle.errorStrings...)
 			bundle.insert(
 				ctx, ih.fingerprint, ast, cfg.StmtDiagnosticsRecorder, ih.diagRequestID, ih.diagRequest,
 			)


### PR DESCRIPTION
Backport 1/1 commits from #105005.

/cc @cockroachdb/release

---

When we're collecting a statement bundle, we might encounter different non-critical errors (e.g. the user doesn't have the privilege to query cluster settings). These errors are benign and don't stop us from producing an incomplete but still useful bundle. This commit makes these errors more visible in two ways:
- all these errors are now included into `errors.txt` file (except when the redaction is enabled)
- all these errors are also now printed as the response to `EXPLAIN ANALYZE (DEBUG)` command in the SQL shell (i.e. they are shown as "warnings").

However, if the bundle is requested via the DB Console, then these errors are still somewhat hidden from the user. Improvement there will be addressed separately.

Addresses: #68523.
Epic: None

Release note: None

Release justification: low-risk observability improvement.