### PR TITLE
opt: add rule to eliminate UpsertDistinctOn

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -235,36 +235,30 @@ vectorized: true
     │ render user_id_default: user_id_default
     │ render crdb_internal_user_id_shard_16_comp: crdb_internal_user_id_shard_16_comp
     │
-    └── • distinct
+    └── • project
         │ columns: (column2, val_cast, user_id_default, crdb_internal_user_id_shard_16_comp)
-        │ estimated row count: 0 (missing stats)
-        │ distinct on: user_id_default
-        │ nulls are distinct
         │
-        └── • project
-            │ columns: (column2, val_cast, user_id_default, crdb_internal_user_id_shard_16_comp)
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+            │ equality cols are key
+            │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
             │
-            └── • lookup join (anti)
+            └── • render
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                │ equality cols are key
-                │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
+                │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
+                │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
+                │ render column2: column2
+                │ render val_cast: val_cast
+                │ render user_id_default: user_id_default
                 │
-                └── • render
-                    │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
-                    │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
-                    │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
-                    │ render column2: column2
-                    │ render val_cast: val_cast
-                    │ render user_id_default: user_id_default
-                    │
-                    └── • values
-                          columns: (column2, val_cast, user_id_default)
-                          size: 3 columns, 1 row
-                          row 0, expr 0: 'seattle'
-                          row 0, expr 1: '4321'
-                          row 0, expr 2: gen_random_uuid()
+                └── • values
+                      columns: (column2, val_cast, user_id_default)
+                      size: 3 columns, 1 row
+                      row 0, expr 0: 'seattle'
+                      row 0, expr 1: '4321'
+                      row 0, expr 2: gen_random_uuid()
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT DO NOTHING;

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -247,43 +247,37 @@ vectorized: true
     │ render crdb_region_default: crdb_region_default
     │ render crdb_internal_user_id_shard_16_comp: crdb_internal_user_id_shard_16_comp
     │
-    └── • distinct
+    └── • project
         │ columns: (val_cast, user_id_default, crdb_region_default, crdb_internal_user_id_shard_16_comp)
-        │ estimated row count: 0 (missing stats)
-        │ distinct on: user_id_default
-        │ nulls are distinct
         │
-        └── • project
-            │ columns: (val_cast, user_id_default, crdb_region_default, crdb_internal_user_id_shard_16_comp)
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+            │ equality cols are key
+            │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
-                │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
+                │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
                 │
-                └── • lookup join (anti)
+                └── • render
                     │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                    │ estimated row count: 1 (missing stats)
-                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                    │ equality cols are key
-                    │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
+                    │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
+                    │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
+                    │ render val_cast: val_cast
+                    │ render user_id_default: user_id_default
+                    │ render crdb_region_default: crdb_region_default
                     │
-                    └── • render
-                        │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                        │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
-                        │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
-                        │ render val_cast: val_cast
-                        │ render user_id_default: user_id_default
-                        │ render crdb_region_default: crdb_region_default
-                        │
-                        └── • values
-                              columns: (val_cast, user_id_default, crdb_region_default)
-                              size: 3 columns, 1 row
-                              row 0, expr 0: '4321'
-                              row 0, expr 1: gen_random_uuid()
-                              row 0, expr 2: 'ap-southeast-2'
+                    └── • values
+                          columns: (val_cast, user_id_default, crdb_region_default)
+                          size: 3 columns, 1 row
+                          row 0, expr 0: '4321'
+                          row 0, expr 1: gen_random_uuid()
+                          row 0, expr 2: 'ap-southeast-2'
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val) VALUES (4321), (8765) ON CONFLICT DO NOTHING;

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -349,49 +349,43 @@ SELECT * FROM [
 │
 └── • render
     │
-    └── • distinct
-        │ distinct on: arbiter_uniq_idx_distinct
-        │ nulls are distinct
+    └── • lookup join (anti)
+        │ table: regional_by_row_table@uniq_idx (partial index)
+        │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column4 = a)
+        │ pred: column5 > 0
         │
-        └── • render
+        └── • lookup join (anti)
+            │ table: regional_by_row_table@uniq_idx (partial index)
+            │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column4 = a)
+            │ pred: column5 > 0
             │
             └── • lookup join (anti)
-                │ table: regional_by_row_table@uniq_idx (partial index)
-                │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column4 = a)
-                │ pred: column5 > 0
+                │ table: regional_by_row_table@regional_by_row_table_b_key
+                │ equality cols are key
+                │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column5 = b)
                 │
                 └── • lookup join (anti)
-                    │ table: regional_by_row_table@uniq_idx (partial index)
-                    │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column4 = a)
-                    │ pred: column5 > 0
+                    │ table: regional_by_row_table@regional_by_row_table_b_key
+                    │ equality cols are key
+                    │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column5 = b)
                     │
-                    └── • lookup join (anti)
-                        │ table: regional_by_row_table@regional_by_row_table_b_key
-                        │ equality cols are key
-                        │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column5 = b)
+                    └── • cross join (anti)
                         │
-                        └── • lookup join (anti)
-                            │ table: regional_by_row_table@regional_by_row_table_b_key
-                            │ equality cols are key
-                            │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column5 = b)
+                        ├── • values
+                        │     size: 6 columns, 1 row
+                        │
+                        └── • union all
+                            │ limit: 1
                             │
-                            └── • cross join (anti)
-                                │
-                                ├── • values
-                                │     size: 6 columns, 1 row
-                                │
-                                └── • union all
-                                    │ limit: 1
-                                    │
-                                    ├── • scan
-                                    │     missing stats
-                                    │     table: regional_by_row_table@regional_by_row_table_pkey
-                                    │     spans: [/'ap-southeast-2'/7 - /'ap-southeast-2'/7]
-                                    │
-                                    └── • scan
-                                          missing stats
-                                          table: regional_by_row_table@regional_by_row_table_pkey
-                                          spans: [/'ca-central-1'/7 - /'ca-central-1'/7] [/'us-east-1'/7 - /'us-east-1'/7]
+                            ├── • scan
+                            │     missing stats
+                            │     table: regional_by_row_table@regional_by_row_table_pkey
+                            │     spans: [/'ap-southeast-2'/7 - /'ap-southeast-2'/7]
+                            │
+                            └── • scan
+                                  missing stats
+                                  table: regional_by_row_table@regional_by_row_table_pkey
+                                  spans: [/'ca-central-1'/7 - /'ca-central-1'/7] [/'us-east-1'/7 - /'us-east-1'/7]
 
 # Tests for locality optimized search.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
@@ -752,31 +752,23 @@ vectorized: true
 │ auto commit
 │ arbiter indexes: t1_pkey, idx_v_unique_invisible
 │
-└── • distinct
-    │ distinct on: v
-    │ nulls are distinct
+└── • lookup join (anti)
+    │ table: t1@t1_pkey
+    │ equality: (k) = (k)
+    │ equality cols are key
     │
-    └── • distinct
-        │ distinct on: k
-        │ nulls are distinct
+    └── • lookup join (anti)
+        │ table: t1@idx_v_unique_invisible
+        │ equality: (v) = (v)
+        │ equality cols are key
         │
-        └── • lookup join (anti)
-            │ table: t1@t1_pkey
-            │ equality: (k) = (k)
-            │ equality cols are key
+        └── • filter
+            │ filter: v IN (1, 2)
             │
-            └── • lookup join (anti)
-                │ table: t1@idx_v_unique_invisible
-                │ equality: (v) = (v)
-                │ equality cols are key
-                │
-                └── • filter
-                    │ filter: v IN (1, 2)
-                    │
-                    └── • scan
-                          missing stats
-                          table: t1@t1_pkey
-                          spans: FULL SCAN
+            └── • scan
+                  missing stats
+                  table: t1@t1_pkey
+                  spans: FULL SCAN
 
 # UPSERT uses primary index to check uniqueness, so idx_v_unique_invisible is
 # not useful.

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -1031,86 +1031,57 @@ vectorized: true
 │ arbiter indexes: uniq_partial_pkey
 │ arbiter constraints: unique_a, unique_b
 │
-└── • project
+└── • hash join (right anti)
     │ columns: (column1, column2, column3)
+    │ estimated row count: 0 (missing stats)
+    │ equality: (b) = (column3)
+    │ right cols are key
     │
-    └── • distinct
-        │ columns: (arbiter_unique_b_distinct, column1, column2, column3)
+    ├── • filter
+    │   │ columns: (b)
+    │   │ estimated row count: 333 (missing stats)
+    │   │ filter: b > 0
+    │   │
+    │   └── • scan
+    │         columns: (b)
+    │         estimated row count: 1,000 (missing stats)
+    │         table: uniq_partial@uniq_partial_pkey
+    │         spans: FULL SCAN
+    │
+    └── • hash join (right anti)
+        │ columns: (column1, column2, column3)
         │ estimated row count: 0 (missing stats)
-        │ distinct on: arbiter_unique_b_distinct
-        │ nulls are distinct
+        │ equality: (a) = (column2)
+        │ right cols are key
+        │ pred: column3 > 0
         │
-        └── • render
-            │ columns: (arbiter_unique_b_distinct, column1, column2, column3)
-            │ render arbiter_unique_b_distinct: (column3 > 0) OR CAST(NULL AS BOOL)
-            │ render column1: column1
-            │ render column2: column2
-            │ render column3: column3
+        ├── • filter
+        │   │ columns: (a, b)
+        │   │ estimated row count: 333 (missing stats)
+        │   │ filter: b > 0
+        │   │
+        │   └── • scan
+        │         columns: (a, b)
+        │         estimated row count: 1,000 (missing stats)
+        │         table: uniq_partial@uniq_partial_pkey
+        │         spans: FULL SCAN
+        │
+        └── • cross join (anti)
+            │ columns: (column1, column2, column3)
+            │ estimated row count: 0 (missing stats)
             │
-            └── • distinct
-                │ columns: (arbiter_unique_a_distinct, column1, column2, column3)
-                │ estimated row count: 0 (missing stats)
-                │ distinct on: arbiter_unique_a_distinct
-                │ nulls are distinct
-                │
-                └── • render
-                    │ columns: (arbiter_unique_a_distinct, column1, column2, column3)
-                    │ render arbiter_unique_a_distinct: (column3 > 0) OR CAST(NULL AS BOOL)
-                    │ render column1: column1
-                    │ render column2: column2
-                    │ render column3: column3
-                    │
-                    └── • hash join (right anti)
-                        │ columns: (column1, column2, column3)
-                        │ estimated row count: 0 (missing stats)
-                        │ equality: (b) = (column3)
-                        │ right cols are key
-                        │
-                        ├── • filter
-                        │   │ columns: (b)
-                        │   │ estimated row count: 333 (missing stats)
-                        │   │ filter: b > 0
-                        │   │
-                        │   └── • scan
-                        │         columns: (b)
-                        │         estimated row count: 1,000 (missing stats)
-                        │         table: uniq_partial@uniq_partial_pkey
-                        │         spans: FULL SCAN
-                        │
-                        └── • hash join (right anti)
-                            │ columns: (column1, column2, column3)
-                            │ estimated row count: 0 (missing stats)
-                            │ equality: (a) = (column2)
-                            │ right cols are key
-                            │ pred: column3 > 0
-                            │
-                            ├── • filter
-                            │   │ columns: (a, b)
-                            │   │ estimated row count: 333 (missing stats)
-                            │   │ filter: b > 0
-                            │   │
-                            │   └── • scan
-                            │         columns: (a, b)
-                            │         estimated row count: 1,000 (missing stats)
-                            │         table: uniq_partial@uniq_partial_pkey
-                            │         spans: FULL SCAN
-                            │
-                            └── • cross join (anti)
-                                │ columns: (column1, column2, column3)
-                                │ estimated row count: 0 (missing stats)
-                                │
-                                ├── • values
-                                │     columns: (column1, column2, column3)
-                                │     size: 3 columns, 1 row
-                                │     row 0, expr 0: 1
-                                │     row 0, expr 1: 2
-                                │     row 0, expr 2: 3
-                                │
-                                └── • scan
-                                      columns: (k)
-                                      estimated row count: 1 (missing stats)
-                                      table: uniq_partial@uniq_partial_pkey
-                                      spans: /1/0
+            ├── • values
+            │     columns: (column1, column2, column3)
+            │     size: 3 columns, 1 row
+            │     row 0, expr 0: 1
+            │     row 0, expr 1: 2
+            │     row 0, expr 2: 3
+            │
+            └── • scan
+                  columns: (k)
+                  estimated row count: 1 (missing stats)
+                  table: uniq_partial@uniq_partial_pkey
+                  spans: /1/0
 
 # Insert with non-constant input.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -114,30 +114,23 @@ vectorized: true
     │ equality: (k) = (k)
     │ equality cols are key
     │
-    └── • distinct
+    └── • render
         │ columns: (v_default, k)
-        │ estimated row count: 2 (missing stats)
-        │ distinct on: k
-        │ nulls are distinct
-        │ error on duplicate
+        │ render v_default: CAST(NULL AS INT8)
+        │ render k: k
         │
-        └── • render
-            │ columns: (v_default, k)
-            │ render v_default: CAST(NULL AS INT8)
-            │ render k: k
+        └── • top-k
+            │ columns: (k, v)
+            │ ordering: -v
+            │ estimated row count: 2 (missing stats)
+            │ order: -v
+            │ k: 2
             │
-            └── • top-k
-                │ columns: (k, v)
-                │ ordering: -v
-                │ estimated row count: 2 (missing stats)
-                │ order: -v
-                │ k: 2
-                │
-                └── • scan
-                      columns: (k, v)
-                      estimated row count: 1,000 (missing stats)
-                      table: kv@kv_pkey
-                      spans: FULL SCAN
+            └── • scan
+                  columns: (k, v)
+                  estimated row count: 1,000 (missing stats)
+                  table: kv@kv_pkey
+                  spans: FULL SCAN
 
 # Use Upsert with indexed table, default columns, computed columns, and check
 # columns.

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -531,6 +531,14 @@ func (c *CustomFuncs) ColsAreStrictKey(cols opt.ColSet, input memo.RelExpr) bool
 	return input.Relational().FuncDeps.ColsAreStrictKey(cols)
 }
 
+// ColsAreLaxKey returns true if the given columns form a lax key for the given
+// input expression. A lax key considers NULL values as distinct from one
+// another, so it is allowed for two rows to have the same set of values if some
+// of the values are NULL.
+func (c *CustomFuncs) ColsAreLaxKey(cols opt.ColSet, input memo.RelExpr) bool {
+	return input.Relational().FuncDeps.ColsAreLaxKey(cols)
+}
+
 // PrimaryKeyCols returns the key columns of the primary key of the table.
 func (c *CustomFuncs) PrimaryKeyCols(table opt.TableID) opt.ColSet {
 	tabMeta := c.mem.Metadata().TableMeta(table)

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -134,6 +134,19 @@
 =>
 (Project $input [] (GroupingOutputCols $groupingPrivate $aggs))
 
+# EliminateUpsertDistinct is similar to EliminateDistinct, but it only checks if
+# the grouping columns are a lax key because UpsertDistinctOn considers NULL
+# values to be distinct from one another for the purposes of grouping.
+[EliminateUpsertDistinct, Normalize]
+(UpsertDistinctOn | EnsureUpsertDistinctOn
+    $input:*
+    $aggs:*
+    $groupingPrivate:* &
+        (ColsAreLaxKey (GroupingCols $groupingPrivate) $input)
+)
+=>
+(Project $input [] (GroupingOutputCols $groupingPrivate $aggs))
+
 # ReduceGroupingCols eliminates redundant grouping columns from the GroupBy
 # operator and replaces them by ConstAgg aggregate functions. A grouping
 # column is redundant if it is functionally determined by the other grouping

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -597,6 +597,465 @@ project
       └── xy.y:9 [as=y:12, outer=(9)]
 
 # --------------------------------------------------
+# EliminateUpsertDistinct
+# --------------------------------------------------
+
+# Case with non-null conflict column.
+norm expect=EliminateUpsertDistinct
+INSERT INTO xy VALUES (1, 2) ON CONFLICT (x) DO UPDATE SET x = 100
+----
+upsert xy
+ ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
+ ├── canary column: xy.x:7
+ ├── fetch columns: xy.x:7 y:8
+ ├── insert-mapping:
+ │    ├── column1:5 => xy.x:1
+ │    └── column2:6 => y:2
+ ├── update-mapping:
+ │    └── upsert_x:12 => xy.x:1
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── project
+ │    ├── columns: upsert_x:12!null column1:5!null column2:6!null xy.x:7 y:8
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(5-8,12)
+ │    ├── left-join (cross)
+ │    │    ├── columns: column1:5!null column2:6!null xy.x:7 y:8
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(5-8)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:5!null column2:6!null
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(5,6)
+ │    │    │    └── (1, 2)
+ │    │    ├── select
+ │    │    │    ├── columns: xy.x:7!null y:8
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(7,8)
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: xy.x:7!null y:8
+ │    │    │    │    ├── key: (7)
+ │    │    │    │    └── fd: (7)-->(8)
+ │    │    │    └── filters
+ │    │    │         └── xy.x:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── CASE WHEN xy.x:7 IS NULL THEN column1:5 ELSE 100 END [as=upsert_x:12, outer=(5,7)]
+ └── f-k-checks
+      ├── f-k-checks-item: fks(r1) -> xy(x)
+      │    └── semi-join (hash)
+      │         ├── columns: x:14
+      │         ├── cardinality: [0 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(14)
+      │         ├── except-all
+      │         │    ├── columns: x:14
+      │         │    ├── left columns: x:14
+      │         │    ├── right columns: x:15
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    ├── fd: ()-->(14)
+      │         │    ├── with-scan &1
+      │         │    │    ├── columns: x:14
+      │         │    │    ├── mapping:
+      │         │    │    │    └──  xy.x:7 => x:14
+      │         │    │    ├── cardinality: [1 - 1]
+      │         │    │    ├── key: ()
+      │         │    │    └── fd: ()-->(14)
+      │         │    └── with-scan &1
+      │         │         ├── columns: x:15!null
+      │         │         ├── mapping:
+      │         │         │    └──  upsert_x:12 => x:15
+      │         │         ├── cardinality: [1 - 1]
+      │         │         ├── key: ()
+      │         │         └── fd: ()-->(15)
+      │         ├── scan fks
+      │         │    └── columns: r1:18!null
+      │         └── filters
+      │              └── x:14 = r1:18 [outer=(14,18), constraints=(/14: (/NULL - ]; /18: (/NULL - ]), fd=(14)==(18), (18)==(14)]
+      └── f-k-checks-item: fks(r2) -> xy(x)
+           └── semi-join (hash)
+                ├── columns: x:22
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(22)
+                ├── except-all
+                │    ├── columns: x:22
+                │    ├── left columns: x:22
+                │    ├── right columns: x:23
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    ├── fd: ()-->(22)
+                │    ├── with-scan &1
+                │    │    ├── columns: x:22
+                │    │    ├── mapping:
+                │    │    │    └──  xy.x:7 => x:22
+                │    │    ├── cardinality: [1 - 1]
+                │    │    ├── key: ()
+                │    │    └── fd: ()-->(22)
+                │    └── with-scan &1
+                │         ├── columns: x:23!null
+                │         ├── mapping:
+                │         │    └──  upsert_x:12 => x:23
+                │         ├── cardinality: [1 - 1]
+                │         ├── key: ()
+                │         └── fd: ()-->(23)
+                ├── scan fks
+                │    └── columns: r2:27
+                └── filters
+                     └── x:22 = r2:27 [outer=(22,27), constraints=(/22: (/NULL - ]; /27: (/NULL - ]), fd=(22)==(27), (27)==(22)]
+
+# Case with DO NOTHING.
+norm expect=EliminateUpsertDistinct
+INSERT INTO xy VALUES (1, 2) ON CONFLICT (x) DO NOTHING
+----
+insert xy
+ ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => x:1
+ │    └── column2:6 => y:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── anti-join (cross)
+      ├── columns: column1:5!null column2:6!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(5,6)
+      ├── values
+      │    ├── columns: column1:5!null column2:6!null
+      │    ├── cardinality: [1 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(5,6)
+      │    └── (1, 2)
+      ├── select
+      │    ├── columns: x:7!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(7)
+      │    ├── scan xy
+      │    │    ├── columns: x:7!null
+      │    │    └── key: (7)
+      │    └── filters
+      │         └── x:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      └── filters (true)
+
+# Case with UPSERT.
+norm expect=EliminateUpsertDistinct
+UPSERT INTO nullablecols VALUES (1, 2, 2)
+----
+upsert nullablecols
+ ├── arbiter indexes: nullablecols_pkey
+ ├── columns: <none>
+ ├── canary column: rowid:14
+ ├── fetch columns: c1:11 c2:12 c3:13 rowid:14
+ ├── insert-mapping:
+ │    ├── column1:7 => c1:1
+ │    ├── column2:8 => c2:2
+ │    ├── column3:9 => c3:3
+ │    └── rowid_default:10 => rowid:4
+ ├── update-mapping:
+ │    ├── column1:7 => c1:1
+ │    ├── column2:8 => c2:2
+ │    └── column3:9 => c3:3
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── left-join (hash)
+      ├── columns: column1:7!null column2:8!null column3:9!null rowid_default:10 c1:11 c2:12 c3:13 rowid:14
+      ├── cardinality: [1 - 1]
+      ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      ├── volatile
+      ├── key: ()
+      ├── fd: ()-->(7-14)
+      ├── values
+      │    ├── columns: column1:7!null column2:8!null column3:9!null rowid_default:10
+      │    ├── cardinality: [1 - 1]
+      │    ├── volatile
+      │    ├── key: ()
+      │    ├── fd: ()-->(7-10)
+      │    └── (1, 2, 2, unique_rowid())
+      ├── scan nullablecols
+      │    ├── columns: c1:11 c2:12 c3:13 rowid:14!null
+      │    ├── key: (14)
+      │    └── fd: (14)-->(11-13), (11)~~>(12-14), (12,13)~~>(11,14)
+      └── filters
+           └── rowid_default:10 = rowid:14 [outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ]), fd=(10)==(14), (14)==(10)]
+
+# Case with a multi-row data source with a strict key.
+norm expect=EliminateUpsertDistinct
+INSERT INTO xy SELECT k, i FROM a ON CONFLICT (x) DO UPDATE SET x = xy.x + 100
+----
+upsert xy
+ ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
+ ├── canary column: xy.x:12
+ ├── fetch columns: xy.x:12 y:13
+ ├── insert-mapping:
+ │    ├── a.k:5 => xy.x:1
+ │    └── i:6 => y:2
+ ├── update-mapping:
+ │    └── upsert_x:17 => xy.x:1
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── project
+ │    ├── columns: upsert_x:17 a.k:5!null i:6!null xy.x:12 y:13
+ │    ├── immutable
+ │    ├── key: (5)
+ │    ├── fd: (5)-->(6,12,13,17), (12)-->(13)
+ │    ├── left-join (hash)
+ │    │    ├── columns: a.k:5!null i:6!null xy.x:12 y:13
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    ├── key: (5)
+ │    │    ├── fd: (5)-->(6,12,13), (12)-->(13)
+ │    │    ├── scan a
+ │    │    │    ├── columns: a.k:5!null i:6!null
+ │    │    │    ├── key: (5)
+ │    │    │    └── fd: (5)-->(6)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: xy.x:12!null y:13
+ │    │    │    ├── key: (12)
+ │    │    │    └── fd: (12)-->(13)
+ │    │    └── filters
+ │    │         └── a.k:5 = xy.x:12 [outer=(5,12), constraints=(/5: (/NULL - ]; /12: (/NULL - ]), fd=(5)==(12), (12)==(5)]
+ │    └── projections
+ │         └── CASE WHEN xy.x:12 IS NULL THEN a.k:5 ELSE xy.x:12 + 100 END [as=upsert_x:17, outer=(5,12), immutable]
+ └── f-k-checks
+      ├── f-k-checks-item: fks(r1) -> xy(x)
+      │    └── semi-join (hash)
+      │         ├── columns: x:19
+      │         ├── key: (19)
+      │         ├── except
+      │         │    ├── columns: x:19
+      │         │    ├── left columns: x:19
+      │         │    ├── right columns: x:20
+      │         │    ├── key: (19)
+      │         │    ├── with-scan &1
+      │         │    │    ├── columns: x:19
+      │         │    │    └── mapping:
+      │         │    │         └──  xy.x:12 => x:19
+      │         │    └── with-scan &1
+      │         │         ├── columns: x:20
+      │         │         └── mapping:
+      │         │              └──  upsert_x:17 => x:20
+      │         ├── scan fks
+      │         │    └── columns: r1:23!null
+      │         └── filters
+      │              └── x:19 = r1:23 [outer=(19,23), constraints=(/19: (/NULL - ]; /23: (/NULL - ]), fd=(19)==(23), (23)==(19)]
+      └── f-k-checks-item: fks(r2) -> xy(x)
+           └── semi-join (hash)
+                ├── columns: x:27
+                ├── key: (27)
+                ├── except
+                │    ├── columns: x:27
+                │    ├── left columns: x:27
+                │    ├── right columns: x:28
+                │    ├── key: (27)
+                │    ├── with-scan &1
+                │    │    ├── columns: x:27
+                │    │    └── mapping:
+                │    │         └──  xy.x:12 => x:27
+                │    └── with-scan &1
+                │         ├── columns: x:28
+                │         └── mapping:
+                │              └──  upsert_x:17 => x:28
+                ├── scan fks
+                │    └── columns: r2:32
+                └── filters
+                     └── x:27 = r2:32 [outer=(27,32), constraints=(/27: (/NULL - ]; /32: (/NULL - ]), fd=(27)==(32), (32)==(27)]
+
+# Case with a multi-row data source with a lax key.
+# TODO(drewk): the UpsertDistinctOn isn't removed in this case because the lax
+# key for nullablecols isn't fully simplified.
+norm
+INSERT INTO xy SELECT c1, c2 FROM nullablecols ON CONFLICT (x) DO UPDATE SET x = xy.x + 100
+----
+upsert xy
+ ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
+ ├── canary column: xy.x:11
+ ├── fetch columns: xy.x:11 y:12
+ ├── insert-mapping:
+ │    ├── c1:5 => xy.x:1
+ │    └── c2:6 => y:2
+ ├── update-mapping:
+ │    └── upsert_x:16 => xy.x:1
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── project
+ │    ├── columns: upsert_x:16 c1:5 c2:6 xy.x:11 y:12
+ │    ├── immutable
+ │    ├── lax-key: (5,11)
+ │    ├── fd: (5)~~>(6), (11)-->(12), (5,11)-->(16)
+ │    ├── left-join (hash)
+ │    │    ├── columns: c1:5 c2:6 xy.x:11 y:12
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    ├── lax-key: (5,11)
+ │    │    ├── fd: (5)~~>(6), (11)-->(12)
+ │    │    ├── ensure-upsert-distinct-on
+ │    │    │    ├── columns: c1:5 c2:6
+ │    │    │    ├── grouping columns: c1:5
+ │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
+ │    │    │    ├── lax-key: (5)
+ │    │    │    ├── fd: (5)~~>(6)
+ │    │    │    ├── scan nullablecols
+ │    │    │    │    ├── columns: c1:5 c2:6
+ │    │    │    │    ├── lax-key: (5,6)
+ │    │    │    │    └── fd: (5)~~>(6)
+ │    │    │    └── aggregations
+ │    │    │         └── first-agg [as=c2:6, outer=(6)]
+ │    │    │              └── c2:6
+ │    │    ├── scan xy
+ │    │    │    ├── columns: xy.x:11!null y:12
+ │    │    │    ├── key: (11)
+ │    │    │    └── fd: (11)-->(12)
+ │    │    └── filters
+ │    │         └── c1:5 = xy.x:11 [outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
+ │    └── projections
+ │         └── CASE WHEN xy.x:11 IS NULL THEN c1:5 ELSE xy.x:11 + 100 END [as=upsert_x:16, outer=(5,11), immutable]
+ └── f-k-checks
+      ├── f-k-checks-item: fks(r1) -> xy(x)
+      │    └── semi-join (hash)
+      │         ├── columns: x:18
+      │         ├── key: (18)
+      │         ├── except
+      │         │    ├── columns: x:18
+      │         │    ├── left columns: x:18
+      │         │    ├── right columns: x:19
+      │         │    ├── key: (18)
+      │         │    ├── with-scan &1
+      │         │    │    ├── columns: x:18
+      │         │    │    └── mapping:
+      │         │    │         └──  xy.x:11 => x:18
+      │         │    └── with-scan &1
+      │         │         ├── columns: x:19
+      │         │         └── mapping:
+      │         │              └──  upsert_x:16 => x:19
+      │         ├── scan fks
+      │         │    └── columns: r1:22!null
+      │         └── filters
+      │              └── x:18 = r1:22 [outer=(18,22), constraints=(/18: (/NULL - ]; /22: (/NULL - ]), fd=(18)==(22), (22)==(18)]
+      └── f-k-checks-item: fks(r2) -> xy(x)
+           └── semi-join (hash)
+                ├── columns: x:26
+                ├── key: (26)
+                ├── except
+                │    ├── columns: x:26
+                │    ├── left columns: x:26
+                │    ├── right columns: x:27
+                │    ├── key: (26)
+                │    ├── with-scan &1
+                │    │    ├── columns: x:26
+                │    │    └── mapping:
+                │    │         └──  xy.x:11 => x:26
+                │    └── with-scan &1
+                │         ├── columns: x:27
+                │         └── mapping:
+                │              └──  upsert_x:16 => x:27
+                ├── scan fks
+                │    └── columns: r2:31
+                └── filters
+                     └── x:26 = r2:31 [outer=(26,31), constraints=(/26: (/NULL - ]; /31: (/NULL - ]), fd=(26)==(31), (31)==(26)]
+
+# No-op because a, b is not a lax key over abc.
+norm expect-not=EliminateUpsertDistinct
+INSERT INTO xy SELECT a, b FROM abc ON CONFLICT (x) DO UPDATE SET x = xy.x + 100
+----
+upsert xy
+ ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
+ ├── canary column: xy.x:10
+ ├── fetch columns: xy.x:10 y:11
+ ├── insert-mapping:
+ │    ├── a:5 => xy.x:1
+ │    └── b:6 => y:2
+ ├── update-mapping:
+ │    └── upsert_x:15 => xy.x:1
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── project
+ │    ├── columns: upsert_x:15 a:5!null b:6!null xy.x:10 y:11
+ │    ├── immutable
+ │    ├── key: (5)
+ │    ├── fd: (5)-->(6,10,11,15), (10)-->(11)
+ │    ├── left-join (hash)
+ │    │    ├── columns: a:5!null b:6!null xy.x:10 y:11
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    ├── key: (5)
+ │    │    ├── fd: (5)-->(6,10,11), (10)-->(11)
+ │    │    ├── ensure-upsert-distinct-on
+ │    │    │    ├── columns: a:5!null b:6!null
+ │    │    │    ├── grouping columns: a:5!null
+ │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
+ │    │    │    ├── key: (5)
+ │    │    │    ├── fd: (5)-->(6)
+ │    │    │    ├── scan abc
+ │    │    │    │    └── columns: a:5!null b:6!null
+ │    │    │    └── aggregations
+ │    │    │         └── first-agg [as=b:6, outer=(6)]
+ │    │    │              └── b:6
+ │    │    ├── scan xy
+ │    │    │    ├── columns: xy.x:10!null y:11
+ │    │    │    ├── key: (10)
+ │    │    │    └── fd: (10)-->(11)
+ │    │    └── filters
+ │    │         └── a:5 = xy.x:10 [outer=(5,10), constraints=(/5: (/NULL - ]; /10: (/NULL - ]), fd=(5)==(10), (10)==(5)]
+ │    └── projections
+ │         └── CASE WHEN xy.x:10 IS NULL THEN a:5 ELSE xy.x:10 + 100 END [as=upsert_x:15, outer=(5,10), immutable]
+ └── f-k-checks
+      ├── f-k-checks-item: fks(r1) -> xy(x)
+      │    └── semi-join (hash)
+      │         ├── columns: x:17
+      │         ├── key: (17)
+      │         ├── except
+      │         │    ├── columns: x:17
+      │         │    ├── left columns: x:17
+      │         │    ├── right columns: x:18
+      │         │    ├── key: (17)
+      │         │    ├── with-scan &1
+      │         │    │    ├── columns: x:17
+      │         │    │    └── mapping:
+      │         │    │         └──  xy.x:10 => x:17
+      │         │    └── with-scan &1
+      │         │         ├── columns: x:18
+      │         │         └── mapping:
+      │         │              └──  upsert_x:15 => x:18
+      │         ├── scan fks
+      │         │    └── columns: r1:21!null
+      │         └── filters
+      │              └── x:17 = r1:21 [outer=(17,21), constraints=(/17: (/NULL - ]; /21: (/NULL - ]), fd=(17)==(21), (21)==(17)]
+      └── f-k-checks-item: fks(r2) -> xy(x)
+           └── semi-join (hash)
+                ├── columns: x:25
+                ├── key: (25)
+                ├── except
+                │    ├── columns: x:25
+                │    ├── left columns: x:25
+                │    ├── right columns: x:26
+                │    ├── key: (25)
+                │    ├── with-scan &1
+                │    │    ├── columns: x:25
+                │    │    └── mapping:
+                │    │         └──  xy.x:10 => x:25
+                │    └── with-scan &1
+                │         ├── columns: x:26
+                │         └── mapping:
+                │              └──  upsert_x:15 => x:26
+                ├── scan fks
+                │    └── columns: r2:30
+                └── filters
+                     └── x:25 = r2:30 [outer=(25,30), constraints=(/25: (/NULL - ]; /30: (/NULL - ]), fd=(25)==(30), (30)==(25)]
+
+# --------------------------------------------------
 # EliminateGroupByProject
 # --------------------------------------------------
 norm expect=EliminateGroupByProject disable=ConvertUnionToDistinctUnionAll

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -4757,30 +4757,13 @@ project
            │    ├── volatile
            │    ├── key: ()
            │    ├── fd: ()-->(11-19,23)
-           │    ├── ensure-upsert-distinct-on
+           │    ├── values
            │    │    ├── columns: column1:11!null column2:12!null column3:13!null d_default:14 rowid_default:15
-           │    │    ├── grouping columns: rowid_default:15
-           │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(11-15)
-           │    │    ├── values
-           │    │    │    ├── columns: column1:11!null column2:12!null column3:13!null d_default:14 rowid_default:15
-           │    │    │    ├── cardinality: [1 - 1]
-           │    │    │    ├── volatile
-           │    │    │    ├── key: ()
-           │    │    │    ├── fd: ()-->(11-15)
-           │    │    │    └── (1, 2, 'c', CAST(NULL AS INT8), unique_rowid())
-           │    │    └── aggregations
-           │    │         ├── first-agg [as=column1:11, outer=(11)]
-           │    │         │    └── column1:11
-           │    │         ├── first-agg [as=column2:12, outer=(12)]
-           │    │         │    └── column2:12
-           │    │         ├── first-agg [as=column3:13, outer=(13)]
-           │    │         │    └── column3:13
-           │    │         └── first-agg [as=d_default:14, outer=(14)]
-           │    │              └── d_default:14
+           │    │    └── (1, 2, 'c', CAST(NULL AS INT8), unique_rowid())
            │    ├── scan returning_test
            │    │    ├── columns: a:16 b:17 c:18 d:19 rowid:23!null
            │    │    ├── key: (23)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -2238,21 +2238,15 @@ sort
       │         │    ├── cardinality: [0 - 2]
       │         │    ├── key: (6-8)
       │         │    ├── fd: (6-8)-->(11-13)
-      │         │    ├── ensure-upsert-distinct-on
+      │         │    ├── top-k
       │         │    │    ├── columns: x:6!null y:7!null z:8!null
-      │         │    │    ├── grouping columns: x:6!null y:7!null z:8!null
-      │         │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
+      │         │    │    ├── internal-ordering: +7,+8
+      │         │    │    ├── k: 2
       │         │    │    ├── cardinality: [0 - 2]
       │         │    │    ├── key: (6-8)
-      │         │    │    └── top-k
+      │         │    │    └── scan xyz
       │         │    │         ├── columns: x:6!null y:7!null z:8!null
-      │         │    │         ├── internal-ordering: +7,+8
-      │         │    │         ├── k: 2
-      │         │    │         ├── cardinality: [0 - 2]
-      │         │    │         ├── key: (6-8)
-      │         │    │         └── scan xyz
-      │         │    │              ├── columns: x:6!null y:7!null z:8!null
-      │         │    │              └── key: (6-8)
+      │         │    │         └── key: (6-8)
       │         │    └── filters (true)
       │         └── projections
       │              ├── CASE WHEN abc.a:11 IS NULL THEN x:6 ELSE 10 END [as=upsert_a:17, outer=(6,11)]


### PR DESCRIPTION
This patch adds a new normalization rule, `EliminateUpsertDistinct`, that eliminates `UpsertDistinctOn` and `EnsureUpsertDistinctOn` expressions when the grouping columns form a lax key over the input. This may allow other rules to fire, and removes a grouping stage from the execution plan.

Fixes #105129

Release note (performance improvement): The optimizer can now avoid a grouping stage in more cases when de-duplicating the input to an `UPSERT` or `INSERT ... ON CONFLICT` statement.