### PR TITLE
git: don't show diffs of files in `.aspect/`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+.aspect/** -diff
 build/bazelutil/distdir_files.bzl -diff
 pkg/BUILD.bazel -diff


### PR DESCRIPTION
These files don't contain info that's interesting to most, so let's remove them from diffs.

Epic: none
Release note: None