### PR TITLE
release-22.2: sql: zero out crdb_internal.node_statement_statistics(anonymized) column

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1149,6 +1149,15 @@ func getSQLStats(
 	return p.extendedEvalCtx.statsProvider, nil
 }
 
+// legacyAnonymizedStmt is a placeholder value for the
+// crdb_internal.node_statement_statistics(anonymized) column. The column used
+// to contain the SQL statement scrubbed of all identifiers. At the time
+// of writing this comment, the column was unused for several releases. Since
+// it's expensive to compute, we no longer populate it. We keep the column in
+// the table to avoid breaking tools that scan crdb_internal tables (even though
+// we don't officially support that, this is an easy step to take).
+var legacyAnonymizedStmt = tree.NewDString("")
+
 var crdbInternalNodeStmtStatsTable = virtualSchemaTable{
 	comment: `statement statistics. ` +
 		`The contents of this table are flushed to the system.statement_statistics table at the interval set by the ` +
@@ -1218,12 +1227,6 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 
 		statementVisitor := func(_ context.Context, stats *roachpb.CollectedStatementStatistics) error {
-			anonymized := tree.DNull
-			anonStr, ok := scrubStmtStatKey(p.getVirtualTabler(), stats.Key.Query)
-			if ok {
-				anonymized = tree.NewDString(anonStr)
-			}
-
 			errString := tree.DNull
 			if stats.Stats.SensitiveInfo.LastErr != "" {
 				errString = tree.NewDString(stats.Stats.SensitiveInfo.LastErr)
@@ -1264,7 +1267,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 				tree.NewDString(flags),                                    // flags
 				tree.NewDString(strconv.FormatUint(uint64(stats.ID), 10)), // statement_id
 				tree.NewDString(stats.Key.Query),                          // key
-				anonymized,                                                // anonymized
+				legacyAnonymizedStmt,                                      // anonymized
 				tree.NewDInt(tree.DInt(stats.Stats.Count)),                // count
 				tree.NewDInt(tree.DInt(stats.Stats.FirstAttemptCount)),    // first_attempt_count
 				tree.NewDInt(tree.DInt(stats.Stats.MaxRetries)),           // max_retries

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -175,31 +175,6 @@ SET distsql = "on"                                                ·
 SHOW CLUSTER SETTING "debug.panic_on_failed_assertions"           ·
 SHOW application_name                                             ·
 
-# Check that names are anonymized properly:
-# - virtual table names are preserved, but not the db prefix (#22700)
-# - function names are preserved
-query T
-SELECT anonymized
-  FROM test.crdb_internal.node_statement_statistics
- WHERE application_name = 'valuetest' ORDER BY key
-----
-INSERT INTO _ VALUES (_, _, __more1_10__), (__more1_10__)
-SELECT (_, _, __more1_10__) FROM _ WHERE _
-SELECT _ FROM _.crdb_internal.node_statement_statistics
-SELECT sin(_)
-SELECT sqrt(_)
-SELECT _ FROM (VALUES (_, _, __more1_10__), (__more1_10__)) AS _ (_)
-SELECT _ FROM _ WHERE _ = (_ / _)
-SELECT _ FROM _ WHERE _ IN (_, _, _ + _, _, _)
-SELECT _ FROM _ WHERE _ IN (_, _, __more1_10__)
-SELECT _ FROM _ WHERE _ NOT IN (_, _, __more1_10__)
-SET CLUSTER SETTING "debug.panic_on_failed_assertions" = DEFAULT
-SET CLUSTER SETTING "debug.panic_on_failed_assertions" = _
-SET application_name = '_'
-SET distsql = _
-SHOW CLUSTER SETTING "debug.panic_on_failed_assertions"
-SHOW application_name
-
 # Check that the latency measurements looks reasonable, protecting
 # against failure to measure (#22877).
 


### PR DESCRIPTION
Backport 1/1 commits from #105114.

/cc @cockroachdb/release

Release justification: low risk performance improvement

---

This column is not used, and is expensive to compute. In the past, we
used to redact identifiers from queries for data privacy reasons, but
now we no longer have this policy. (Constants and user-supplied data are
still redacted.) To mitigate impact, we zero out the column value
instead of removing the column completely.

Epic: None
Release note: None
