### PR TITLE
roachtest: prevent post-test connection error for rust-postgres

### DIFF
--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -162,6 +162,11 @@ func registerRustPostgres(r registry.Registry) {
 		results.summarizeAll(
 			t, "rust-postgres" /* ormName */, blocklistName, expectedFailures, version, "",
 		)
+
+		// We restart the cluster with the default port again so that any post-test
+		// validation will be able to connect using the default port.
+		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.All())
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
 	}
 
 	r.Add(registry.TestSpec{


### PR DESCRIPTION
This patch prevents a connection error during the post-test validation
for rust-postgres by restarting the cluster again after the test with
the default port.

Fixes #103824

Release note: None