### PR TITLE
comprules: avoid hardcoding OIDs

### DIFF
--- a/pkg/sql/comprules/BUILD.bazel
+++ b/pkg/sql/comprules/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/sql/compengine",
         "//pkg/sql/lexbase",
         "//pkg/sql/scanner",
-        "//pkg/sql/sem/catconstants",
     ],
 )
 

--- a/pkg/sql/comprules/testdata/completion_patterns/objects
+++ b/pkg/sql/comprules/testdata/completion_patterns/objects
@@ -20,8 +20,8 @@ SELECT c.relname AS completion,
            FROM pg_catalog.pg_class c
            JOIN pg_catalog.pg_namespace n
                 ON c.relnamespace = n.oid AND n.nspname IN (TABLE unnest(current_schemas(true)))
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON c.oid = d.objoid AND d.classoid = 4294967100
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON c.oid = d.objoid AND d.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
           WHERE c.reltype != 0
             AND left(relname, length($1:::STRING)) = $1::STRING
             AND (nspname != 'pg_catalog' OR $4:::BOOL OR left($1:::STRING, 3) = 'pg_')
@@ -47,8 +47,8 @@ SELECT c.relname AS completion,
            FROM pg_catalog.pg_class c
            JOIN pg_catalog.pg_namespace n
                 ON c.relnamespace = n.oid AND n.nspname IN (TABLE unnest(current_schemas(true)))
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON c.oid = d.objoid AND d.classoid = 4294967100
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON c.oid = d.objoid AND d.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
           WHERE c.reltype != 0
             AND left(relname, length($1:::STRING)) = $1::STRING
             AND (nspname != 'pg_catalog' OR $4:::BOOL OR left($1:::STRING, 3) = 'pg_')
@@ -70,8 +70,8 @@ SELECT c.relname AS completion,
            FROM pg_catalog.pg_class c
            JOIN pg_catalog.pg_namespace n
                 ON c.relnamespace = n.oid AND n.nspname IN (TABLE unnest(current_schemas(true)))
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON c.oid = d.objoid AND d.classoid = 4294967100
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON c.oid = d.objoid AND d.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
           WHERE c.reltype != 0
             AND left(relname, length($1:::STRING)) = $1::STRING
             AND (nspname != 'pg_catalog' OR $4:::BOOL OR left($1:::STRING, 3) = 'pg_')
@@ -97,8 +97,8 @@ SELECT c.relname AS completion,
            FROM pg_catalog.pg_class c
            JOIN pg_catalog.pg_namespace n
                 ON c.relnamespace = n.oid AND n.nspname = 'a'
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON c.oid = d.objoid AND d.classoid = 4294967100
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON c.oid = d.objoid AND d.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
           WHERE c.reltype != 0
             AND left(relname, length($1:::STRING)) = $1::STRING
             AND (nspname != 'pg_catalog' OR $4:::BOOL OR left($1:::STRING, 3) = 'pg_')
@@ -120,8 +120,8 @@ SELECT c.relname AS completion,
            FROM pg_catalog.pg_class c
            JOIN pg_catalog.pg_namespace n
                 ON c.relnamespace = n.oid AND n.nspname = 'a'
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON c.oid = d.objoid AND d.classoid = 4294967100
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON c.oid = d.objoid AND d.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
           WHERE c.reltype != 0
             AND left(relname, length($1:::STRING)) = $1::STRING
             AND (nspname != 'pg_catalog' OR $4:::BOOL OR left($1:::STRING, 3) = 'pg_')
@@ -143,8 +143,8 @@ SELECT c.relname AS completion,
            FROM pg_catalog.pg_class c
            JOIN pg_catalog.pg_namespace n
                 ON c.relnamespace = n.oid AND n.nspname = 'a'
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON c.oid = d.objoid AND d.classoid = 4294967100
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON c.oid = d.objoid AND d.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
           WHERE c.reltype != 0
             AND left(relname, length($1:::STRING)) = $1::STRING
             AND (nspname != 'pg_catalog' OR $4:::BOOL OR left($1:::STRING, 3) = 'pg_')
@@ -171,8 +171,8 @@ SELECT c.relname AS completion,
            FROM pg_catalog.pg_class c
            JOIN pg_catalog.pg_namespace n
                 ON c.relnamespace = n.oid AND n.nspname = 'pg_catalog'
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON c.oid = d.objoid AND d.classoid = 4294967100
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON c.oid = d.objoid AND d.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
           WHERE c.reltype != 0
             AND left(relname, length($1:::STRING)) = $1::STRING
             AND (nspname != 'pg_catalog' OR $4:::BOOL OR left($1:::STRING, 3) = 'pg_')
@@ -195,8 +195,8 @@ SELECT c.relname AS completion,
            FROM pg_catalog.pg_class c
            JOIN pg_catalog.pg_namespace n
                 ON c.relnamespace = n.oid AND n.nspname = 'PG_CATALOG'
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON c.oid = d.objoid AND d.classoid = 4294967100
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON c.oid = d.objoid AND d.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
           WHERE c.reltype != 0
             AND left(relname, length($1:::STRING)) = $1::STRING
             AND (nspname != 'pg_catalog' OR $4:::BOOL OR left($1:::STRING, 3) = 'pg_')

--- a/pkg/sql/comprules/testdata/completion_patterns/objects_other
+++ b/pkg/sql/comprules/testdata/completion_patterns/objects_other
@@ -45,8 +45,8 @@ SELECT name AS completion,
        $2:::INT AS start,
        $3:::INT AS end
   FROM t
-LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.table_id = cc.objoid AND cc.classoid = 4294967100
+LEFT OUTER JOIN "".pg_catalog.pg_description cc
+    ON t.table_id = cc.objoid AND cc.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
 --placeholders: []interface {}{"xor", 9, 12, "a", "public"}
 
 comp at=10
@@ -70,8 +70,8 @@ SELECT name AS completion,
        $2:::INT AS start,
        $3:::INT AS end
   FROM t
-LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.table_id = cc.objoid AND cc.classoid = 4294967100
+LEFT OUTER JOIN "".pg_catalog.pg_description cc
+    ON t.table_id = cc.objoid AND cc.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
 --placeholders: []interface {}{"", 10, 10, "a", "public"}
 
 comp at=9
@@ -95,8 +95,8 @@ SELECT name AS completion,
        $2:::INT AS start,
        $3:::INT AS end
   FROM t
-LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.table_id = cc.objoid AND cc.classoid = 4294967100
+LEFT OUTER JOIN "".pg_catalog.pg_description cc
+    ON t.table_id = cc.objoid AND cc.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
 --placeholders: []interface {}{"", 9, 9, "a", "public"}
 
 
@@ -125,8 +125,8 @@ SELECT name AS completion,
        $2:::INT AS start,
        $3:::INT AS end
   FROM t
-LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.table_id = cc.objoid AND cc.classoid = 4294967100
+LEFT OUTER JOIN "".pg_catalog.pg_description cc
+    ON t.table_id = cc.objoid AND cc.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
 --placeholders: []interface {}{"xor", 11, 14, "a", "b"}
 
 comp at=12
@@ -150,8 +150,8 @@ SELECT name AS completion,
        $2:::INT AS start,
        $3:::INT AS end
   FROM t
-LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.table_id = cc.objoid AND cc.classoid = 4294967100
+LEFT OUTER JOIN "".pg_catalog.pg_description cc
+    ON t.table_id = cc.objoid AND cc.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
 --placeholders: []interface {}{"", 12, 12, "a", "b"}
 
 comp at=11
@@ -175,8 +175,8 @@ SELECT name AS completion,
        $2:::INT AS start,
        $3:::INT AS end
   FROM t
-LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.table_id = cc.objoid AND cc.classoid = 4294967100
+LEFT OUTER JOIN "".pg_catalog.pg_description cc
+    ON t.table_id = cc.objoid AND cc.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
 --placeholders: []interface {}{"", 11, 11, "a", "b"}
 
 
@@ -205,8 +205,8 @@ SELECT name AS completion,
        $2:::INT AS start,
        $3:::INT AS end
   FROM t
-LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.table_id = cc.objoid AND cc.classoid = 4294967100
+LEFT OUTER JOIN "".pg_catalog.pg_description cc
+    ON t.table_id = cc.objoid AND cc.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
 --placeholders: []interface {}{"pg_", 12, 16, "mydb", "public"}
 
 # Quoted uppercase is an entire schema entirely.
@@ -231,8 +231,8 @@ SELECT name AS completion,
        $2:::INT AS start,
        $3:::INT AS end
   FROM t
-LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.table_id = cc.objoid AND cc.classoid = 4294967100
+LEFT OUTER JOIN "".pg_catalog.pg_description cc
+    ON t.table_id = cc.objoid AND cc.classoid = 'pg_catalog.pg_class'::REGCLASS::OID
 --placeholders: []interface {}{"PG_", 12, 16, "mydb", "public"}
 
 

--- a/pkg/sql/comprules/testdata/completion_patterns/schemas
+++ b/pkg/sql/comprules/testdata/completion_patterns/schemas
@@ -18,8 +18,8 @@ SELECT n.nspname AS completion,
                 $2:::INT AS start,
                 $3:::INT AS end
            FROM pg_catalog.pg_namespace n
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON n.oid = d.objoid AND d.classoid = 4294967071
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON n.oid = d.objoid AND d.classoid = 'pg_catalog.pg_namespace'::REGCLASS::OID
  WHERE left(nspname, length($1:::STRING)) = $1::STRING
 ORDER BY 1,3,4,5
 --placeholders: []interface {}{"xor", 7, 10}
@@ -38,8 +38,8 @@ SELECT n.nspname AS completion,
                 $2:::INT AS start,
                 $3:::INT AS end
            FROM pg_catalog.pg_namespace n
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON n.oid = d.objoid AND d.classoid = 4294967071
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON n.oid = d.objoid AND d.classoid = 'pg_catalog.pg_namespace'::REGCLASS::OID
  WHERE left(nspname, length($1:::STRING)) = $1::STRING
 ORDER BY 1,3,4,5
 --placeholders: []interface {}{"", 12, 12}
@@ -91,8 +91,8 @@ SELECT n.nspname AS completion,
                 $2:::INT AS start,
                 $3:::INT AS end
            FROM pg_catalog.pg_namespace n
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON n.oid = d.objoid AND d.classoid = 4294967071
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON n.oid = d.objoid AND d.classoid = 'pg_catalog.pg_namespace'::REGCLASS::OID
  WHERE left(nspname, length($1:::STRING)) = $1::STRING
 ORDER BY 1,3,4,5
 --placeholders: []interface {}{"pg_", 7, 11}
@@ -112,8 +112,8 @@ SELECT n.nspname AS completion,
                 $2:::INT AS start,
                 $3:::INT AS end
            FROM pg_catalog.pg_namespace n
-LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
-                ON n.oid = d.objoid AND d.classoid = 4294967071
+LEFT OUTER JOIN pg_catalog.pg_description d
+                ON n.oid = d.objoid AND d.classoid = 'pg_catalog.pg_namespace'::REGCLASS::OID
  WHERE left(nspname, length($1:::STRING)) = $1::STRING
 ORDER BY 1,3,4,5
 --placeholders: []interface {}{"PG_", 7, 11}


### PR DESCRIPTION
Rather than hardcoding OIDs, now the query is modified so that the OID is computed on the server-side. This improves cross-version compatibility.

This also modifies the query to use the externally-usable pg_catalog, rather than crdb_internal.

Epic: none
Release note: None