### PR TITLE
sql: fix COPY when it accesses TxnTimestamp

### DIFF
--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -100,6 +100,7 @@ func newFileUploadMachine(
 
 	// We need a planner to do the initial planning, even if a planner
 	// is not required after that.
+	c.txnOpt.initPlanner(ctx, c.p)
 	cleanup := c.p.preparePlannerForCopy(ctx, &c.txnOpt, false /* finalBatch */, c.implicitTxn)
 	defer func() {
 		retErr = cleanup(ctx, retErr)

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -297,6 +297,7 @@ func newCopyMachine(
 	}
 	// We need a planner to do the initial planning, in addition
 	// to those used for the main execution of the COPY afterwards.
+	txnOpt.initPlanner(ctx, c.p)
 	cleanup := c.p.preparePlannerForCopy(ctx, &c.txnOpt, false /* finalBatch */, c.implicitTxn)
 	defer func() {
 		retErr = cleanup(ctx, retErr)
@@ -1112,7 +1113,6 @@ func (c *copyMachine) insertRowsInternal(ctx context.Context, finalBatch bool) (
 		},
 		Returning: tree.AbsentReturningClause,
 	}
-	c.txnOpt.initPlanner(ctx, c.p)
 
 	// TODO(cucaroach): We shouldn't need to do this for every batch.
 	if err := c.p.makeOptimizerPlan(ctx); err != nil {

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -1108,3 +1108,34 @@ ReadyForQuery
 {"Type":"CopyOutResponse","ColumnFormatCodes":null}
 {"Type":"ErrorResponse","Code":"42P02","Message":"COPY (SELECT $1::INT8) TO STDOUT: no value provided for placeholder: $1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Regression test for unsetting the eval context on the COPY's planner
+# incorrectly (#104456).
+send
+Query {"String": "CREATE TABLE t104456 (i INT8, t TEXT, ts TIMESTAMP DEFAULT now())"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "COPY t104456 (i, t) FROM STDIN"}
+CopyData {"Data": "1\tblah\n"}
+CopyData {"Data": "\\.\n"}
+CopyDone
+Query {"String": "SELECT i, t FROM t104456 ORDER BY i"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"blah"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
This commit fixes a bug introduced in 888001367dee4da574386488590b9234ff0481c5 where a call to `initPlanner` was added. In particular, the problem is as follows: in the beginning of `insertRowsInternal` we set up the planner in `preparePlannerForCopy` (which correctly sets the TxnTimestamp field of the eval context), and that commit added a call to `initPlanner` which deeply-updates the eval context, without setting all of the fields (TxnTimestamp is made nil). As a result, later on if we try to evaluate one of the builtin functions that need the TxnTimestamp, then we hit a nil pointer. For example, this can happen when we have a DEFAULT expression like `now()` for one of the columns. This is now fixed by calling `initPlanner` right away, when setting up the copy machine. Additionally, this commit adds this call when creating the copy file upload machine too.

Fixes: #104456.

Release note (bug fix): CockroachDB previously could encounter `zero transaction timestamp in EvalContext` when evaluating COPY command which copies to the table that has DEFAULT expression using time-related builtins like `now()` and `localtimestamp`. The bug was introduced in 23.1.0 and is now fixed.