### PR TITLE
roachprod: add aws AZ override for c6id.24xlarge

### DIFF
--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -279,8 +279,9 @@ var defaultCreateZones = []string{
 // not specifying an Availability Zone in your request or choosing us-east-2b, us-east-2c."
 // N.B. we implicitly specify AZ to select an AMI in that zone, hence we fall back to instance-specific overrides.
 var overrideDefaultCreateZones = map[string][]string{
-	"c6id.4xlarge": {"us-east-2c", "us-west-2b", "eu-west-2b"},
-	"c6id.8xlarge": {"us-east-2c", "us-west-2b", "eu-west-2b"},
+	"c6id.4xlarge":  {"us-east-2c", "us-west-2b", "eu-west-2b"},
+	"c6id.8xlarge":  {"us-east-2c", "us-west-2b", "eu-west-2b"},
+	"c6id.24xlarge": {"us-east-2b", "us-west-2b", "eu-west-2b"},
 }
 
 type Tag struct {


### PR DESCRIPTION
Since the bump to new instance types in GCE and AWS [1], we are still experiencing occasional cluster creation issues owing to "insufficient capacity". GCE quota has already been bumped, with `asia-northeast1` being the latest, and hopefully last.

The most recent cluster creation in AWS is owing to "insufficient capacity" of `c6id.24xlarge` in us-east-2a. As a workaround, we extend the existing zone override to place `c6id.24xlarge` into us-east-2b, which
allegedly has sufficient capacity.

Note, the long-term fix is to rework how cluster creation retry currently operates, by effectively trying other AZs.

[1] https://github.com/cockroachdb/cockroach/pull/104419

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/78601#issuecomment-1598353824

Release note: None