### PR TITLE
schemachanger: Fixed a crash when creating UDFs whose body casts to UDT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3566,3 +3566,19 @@ query T
 SELECT f104927()
 ----
 [{"i": 1, "s": "foo"}]
+
+subtest 104242
+
+statement ok
+CREATE TABLE t_104242 (i INT PRIMARY KEY);
+
+statement ok
+CREATE TYPE typ_104242 AS ENUM ('a', 'b', 'c');
+
+# We've only fixed issue with declarative schema changer.
+skipif config local-legacy-schema-changer
+skipif config local-mixed-22.2-23.1
+statement ok
+CREATE FUNCTION f_104242() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 FROM t_104242 WHERE NULL::typ_104242 IN () $$;
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/faketreeeval",
         "//pkg/sql/parser",
+        "//pkg/sql/parser/statements",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",


### PR DESCRIPTION
Fixes #104242

Release note (bug fix): Fixed a bug when creating UDFs whose body contains a ShortCast operator. E.g.
`CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 FROM t WHERE NULL::typ IN () $$;`