### PR TITLE
logictest: unify updating SQL testing knobs in logic tests

### DIFF
--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -48,7 +48,6 @@ go_library(
         "//pkg/sql/rowinfra",
         "//pkg/sql/schemachanger/corpus",
         "//pkg/sql/schemachanger/scexec",
-        "//pkg/sql/schemachanger/scplan",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondatapb",


### PR DESCRIPTION
This commit extracts a helper function that updates SQL testing knobs to be shared between the single-tenant and multi-tenant configs. In particular, this makes it so that 3node-tenant config correctly respects `!metamorphic-batch-sizes` logic test directive (previously, we weren't updating `ForceProductionValues` testing knob in the tenant case).

Fixes: #105121.

Release note: None