### PR TITLE
logictest: fix recently introduced flake

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1936,7 +1936,7 @@ test           sc_test_show_grants  100205       f_test_show_grants(int8)  root 
 test           sc_test_show_grants  100205       f_test_show_grants(int8)  u_test_show_grants  EXECUTE         false
 
 query TTTTTTB colnames
-SELECT * FROM [SHOW GRANTS ON FUNCTION f_test_show_grants(INT, string, OID)] ORDER BY function_signature
+SELECT * FROM [SHOW GRANTS ON FUNCTION f_test_show_grants(INT, string, OID)] ORDER BY grantee
 ----
 database_name  schema_name          function_id  function_signature                   grantee             privilege_type  is_grantable
 test           sc_test_show_grants  100206       f_test_show_grants(int8, text, oid)  root                EXECUTE         true


### PR DESCRIPTION
We were ordering by the column that has equal values in both rows. Seen [here](https://teamcity.cockroachdb.com/viewLog.html?buildId=10610049&buildTypeId=Cockroach_BazelEssentialCi).

Epic: None

Release note: None