### PR TITLE
rangefeed/changefeed: Enable mux rangefeeds by default.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -233,7 +233,7 @@ var UseMuxRangeFeed = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"changefeed.mux_rangefeed.enabled",
 	"if true, changefeed uses multiplexing rangefeed RPC",
-	util.ConstantWithMetamorphicTestBool("changefeed.mux_rangefeed.enabled", false),
+	util.ConstantWithMetamorphicTestBool("changefeed.mux_rangefeed.enabled", true),
 )
 
 // EventConsumerWorkers specifies the maximum number of workers to use when

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -267,7 +267,7 @@ func (f *RangeFeed) Close() {
 // will be reset.
 const resetThreshold = 30 * time.Second
 
-var useMuxRangeFeed = util.ConstantWithMetamorphicTestBool("use-mux-rangefeed", false)
+var useMuxRangeFeed = util.ConstantWithMetamorphicTestBool("use-mux-rangefeed", true)
 
 // run will run the RangeFeed until the context is canceled or if the client
 // indicates that an initial scan error is non-recoverable.


### PR DESCRIPTION
Make mux range feeds default implementation for rangefeeds. This is done in preparation for mux range feeds becoming default from release 23.2.

Release note (performance improvement): mux range feeds reuse connection and workers across multiple range feeds. This mode is now enabled by default.

Jira-Issue: [CRDB-28547](https://cockroachlabs.atlassian.net/browse/CRDB-28547)