### PR TITLE
kvnemesis,kvserver: add coverage for illegal lease applied index and reproposal errors

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -31,7 +31,8 @@ import (
 // The degree of the inFlightWrites btree.
 const txnPipelinerBtreeDegree = 32
 
-var pipelinedWritesEnabled = settings.RegisterBoolSetting(
+// PipelinedWritesEnabled is the kv.transaction.write_pipelining_enabled cluster setting.
+var PipelinedWritesEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.transaction.write_pipelining_enabled",
 	"if enabled, transactional writes are pipelined through Raft consensus",
@@ -432,7 +433,7 @@ func (tp *txnPipeliner) canUseAsyncConsensus(ctx context.Context, ba *kvpb.Batch
 		return false
 	}
 
-	if !pipelinedWritesEnabled.Get(&tp.st.SV) || tp.disabled {
+	if !PipelinedWritesEnabled.Get(&tp.st.SV) || tp.disabled {
 		return false
 	}
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
@@ -858,7 +858,7 @@ func TestTxnPipelinerEnableDisableMixTxn(t *testing.T) {
 	tp, mockSender := makeMockTxnPipeliner(nil /* iter */)
 
 	// Start with pipelining disabled. Should NOT use async consensus.
-	pipelinedWritesEnabled.Override(ctx, &tp.st.SV, false)
+	PipelinedWritesEnabled.Override(ctx, &tp.st.SV, false)
 
 	txn := makeTxnProto()
 	keyA, keyC := roachpb.Key("a"), roachpb.Key("c")
@@ -885,7 +885,7 @@ func TestTxnPipelinerEnableDisableMixTxn(t *testing.T) {
 	require.Equal(t, 0, tp.ifWrites.len())
 
 	// Enable pipelining. Should use async consensus.
-	pipelinedWritesEnabled.Override(ctx, &tp.st.SV, true)
+	PipelinedWritesEnabled.Override(ctx, &tp.st.SV, true)
 
 	ba.Requests = nil
 	putArgs2 := kvpb.PutRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}}
@@ -913,7 +913,7 @@ func TestTxnPipelinerEnableDisableMixTxn(t *testing.T) {
 
 	// Disable pipelining again. Should NOT use async consensus but should still
 	// make sure to chain on to any overlapping in-flight writes.
-	pipelinedWritesEnabled.Override(ctx, &tp.st.SV, false)
+	PipelinedWritesEnabled.Override(ctx, &tp.st.SV, false)
 
 	ba.Requests = nil
 	putArgs4 := kvpb.PutRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}}

--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -97,6 +97,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "//pkg/util/syncutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",

--- a/pkg/kv/kvnemesis/generator.go
+++ b/pkg/kv/kvnemesis/generator.go
@@ -925,16 +925,32 @@ func makeClosureTxn(
 // fk stands for "from key", i.e. decode the uint64 the key represents.
 // Panics on error.
 func fk(k string) uint64 {
+	i, err := fkE(k)
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
+// fkE is like fk, but returns an error instead of panicking.
+func fkE(k string) (uint64, error) {
+	l := len(GeneratorDataSpan().Key)
+	if len(k) < l {
+		return 0, errors.New("key too short")
+	}
 	k = k[len(GeneratorDataSpan().Key):]
 	_, s, err := encoding.DecodeUnsafeStringAscendingDeepCopy([]byte(k), nil)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 	sl, err := hex.DecodeString(s)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
-	return binary.BigEndian.Uint64(sl)
+	if len(sl) < 8 {
+		return 0, errors.New("slice too short")
+	}
+	return binary.BigEndian.Uint64(sl), nil
 }
 
 // tk stands for toKey, i.e. encode the uint64 into its key representation.

--- a/pkg/kv/kvnemesis/generator.go
+++ b/pkg/kv/kvnemesis/generator.go
@@ -934,11 +934,11 @@ func fk(k string) uint64 {
 
 // fkE is like fk, but returns an error instead of panicking.
 func fkE(k string) (uint64, error) {
-	l := len(GeneratorDataSpan().Key)
-	if len(k) < l {
+	span := GeneratorDataSpan()
+	if !span.ContainsKey(roachpb.Key(k)) {
 		return 0, errors.New("key too short")
 	}
-	k = k[len(GeneratorDataSpan().Key):]
+	k = k[len(span.Key):]
 	_, s, err := encoding.DecodeUnsafeStringAscendingDeepCopy([]byte(k), nil)
 	if err != nil {
 		return 0, err

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -34,12 +34,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
 var defaultNumSteps = envutil.EnvOrDefaultInt("COCKROACH_KVNEMESIS_STEPS", 50)
 
-func testClusterArgs(tr *SeqTracker) base.TestClusterArgs {
+func (cfg kvnemesisTestCfg) testClusterArgs(tr *SeqTracker) base.TestClusterArgs {
 	storeKnobs := &kvserver.StoreTestingKnobs{
 		// Drop the clock MaxOffset to reduce commit-wait time for
 		// transactions that write to global_read ranges.
@@ -52,6 +54,77 @@ func testClusterArgs(tr *SeqTracker) base.TestClusterArgs {
 				tr.Add(key, endKey, ts, seq)
 			}
 		},
+	}
+
+	isOurCommand := func(ba *kvpb.BatchRequest) (string, uint64, bool) {
+		key := ba.Requests[0].GetInner().Header().Key
+		n, err := fkE(string(key))
+		if err != nil {
+			return "", 0, false
+		}
+		return string(key), n, true
+	}
+
+	shouldInject := func(baseProb float64, key uint64, attempt int) bool {
+		// Example: baseProb = 0.8
+		// On attempt 1, 0.8/1 = 80% chance of catching retry.
+		// On attempt 2, 0.8/2 = 40%.
+		// On attempt 3, 0.8/3 = 27%.
+		// And so on.
+		thresh := baseProb / float64(attempt)
+		// NB: it's important to include "attempt" in here so that a write to a key
+		// that is unlucky enough to map to, say, 1E-9, eventually gets to
+		// successfully go through.
+		return rand.New(rand.NewSource(int64(attempt)+int64(key))).Float64() < thresh
+	}
+
+	storeKnobs.LeaseIndexFilter = nil
+	storeKnobs.InjectReproposalError = nil
+
+	if p := cfg.injectReproposalErrorProb; p > 0 {
+		var mu syncutil.Mutex
+		seen := map[string]int{}
+		storeKnobs.InjectReproposalError = func(pd *kvserver.ProposalData) error {
+			key, n, ok := isOurCommand(pd.Request)
+			if !ok {
+				return nil
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			seen[key]++
+			if !shouldInject(p, n, seen[key]) {
+				return nil
+			}
+			log.Infof(context.Background(), "inserting reproposal error for %s (seen %d times)", roachpb.Key(key), seen[key])
+			err := errInjected // special error that kvnemesis accepts
+			return errors.Wrapf(err, "on %s at %s", pd.Request.Summary(), roachpb.Key(key))
+		}
+	}
+
+	if p := cfg.injectReproposalErrorProb; p > 0 {
+		var mu syncutil.Mutex
+		seen := map[string]int{}
+		storeKnobs.LeaseIndexFilter = func(pd *kvserver.ProposalData) kvpb.LeaseAppliedIndex {
+			key, n, ok := isOurCommand(pd.Request)
+			if !ok {
+				return 0
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			seen[key]++
+			if !shouldInject(p, n, seen[key]) {
+				return 0
+			}
+			log.Infof(context.Background(), "inserting illegal lease index for %s (seen %d times)", roachpb.Key(key), seen[key])
+			// LAI 1 is always going to fail because the LAI is initialized when the lease
+			// comes into existence. (It's important that we pick one here that reliably
+			// fails because otherwise we may accidentally regress the closed timestamp[^1].
+			//
+			// [^1]: https://github.com/cockroachdb/cockroach/issues/70894#issuecomment-1433244880
+			return 1
+		}
 	}
 
 	return base.TestClusterArgs{
@@ -139,6 +212,18 @@ type kvnemesisTestCfg struct {
 	numSteps     int
 	concurrency  int
 	seedOverride int64
+	// The two knobs below inject illegal lease index errors and, for the
+	// resulting reproposals, reproposal errors. The injection is stateful and
+	// remembers the keys on which the commands operated, and, per key, the
+	// probability is scaled down linearly based on the number of times we've
+	// injected an error. In other words, this can be set to 1.0 and some amount
+	// of progress would still be made.
+	//
+	// NB: to at least directionally preserve determinism, the rand for each dice
+	// roll is seeded from the uint64 represented by the key, so this shouldn't be
+	// considered truly random, but is random enough for the desired purpose.
+	invalidLeaseAppliedIndexProb float64 // [0,1)
+	injectReproposalErrorProb    float64 // [0,1)
 }
 
 func TestKVNemesisSingleNode(t *testing.T) {
@@ -146,10 +231,26 @@ func TestKVNemesisSingleNode(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testKVNemesisImpl(t, kvnemesisTestCfg{
-		numNodes:     1,
-		numSteps:     defaultNumSteps,
-		concurrency:  5,
-		seedOverride: 0,
+		numNodes:                     1,
+		numSteps:                     defaultNumSteps,
+		concurrency:                  5,
+		seedOverride:                 0,
+		invalidLeaseAppliedIndexProb: 0.1,
+		injectReproposalErrorProb:    0.1,
+	})
+}
+
+func TestKVNemesisSingleNode_ReproposalChaos(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testKVNemesisImpl(t, kvnemesisTestCfg{
+		numNodes:                     1,
+		numSteps:                     defaultNumSteps,
+		concurrency:                  5,
+		seedOverride:                 0,
+		invalidLeaseAppliedIndexProb: 0.9,
+		injectReproposalErrorProb:    0.5,
 	})
 }
 
@@ -158,10 +259,12 @@ func TestKVNemesisMultiNode(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testKVNemesisImpl(t, kvnemesisTestCfg{
-		numNodes:     4,
-		numSteps:     defaultNumSteps,
-		concurrency:  5,
-		seedOverride: 0,
+		numNodes:                     4,
+		numSteps:                     defaultNumSteps,
+		concurrency:                  5,
+		seedOverride:                 0,
+		invalidLeaseAppliedIndexProb: 0.1,
+		injectReproposalErrorProb:    0.1,
 	})
 }
 
@@ -182,7 +285,7 @@ func testKVNemesisImpl(t *testing.T, cfg kvnemesisTestCfg) {
 	// 4 nodes so we have somewhere to move 3x replicated ranges to.
 	ctx := context.Background()
 	tr := &SeqTracker{}
-	tc := testcluster.StartTestCluster(t, cfg.numNodes, testClusterArgs(tr))
+	tc := testcluster.StartTestCluster(t, cfg.numNodes, cfg.testClusterArgs(tr))
 	defer tc.Stopper().Stop(ctx)
 	dbs, sqlDBs := make([]*kv.DB, cfg.numNodes), make([]*gosql.DB, cfg.numNodes)
 	for i := 0; i < cfg.numNodes; i++ {

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -1232,6 +1232,16 @@ func (v *validator) failIfError(
 ) (ambiguous, hasError bool) {
 	exceptions = append(exceptions[:len(exceptions):len(exceptions)], func(err error) bool {
 		return errors.Is(err, errInjected)
+	}, func(err error) bool {
+		// Work-around for [1].
+		//
+		// TODO(arul): find out why we (as of [2]) sometimes leaking
+		// *TransactionPushError (wrapped in `UnhandledRetryableError`) from
+		// `db.Get`, `db.Scan`, etc.
+		//
+		// [1]: https://github.com/cockroachdb/cockroach/issues/105330
+		// [2]: https://github.com/cockroachdb/cockroach/pull/97779
+		return errors.HasType(err, (*kvpb.UnhandledRetryableError)(nil))
 	})
 	switch r.Type {
 	case ResultType_Unknown:

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -1230,6 +1230,9 @@ func (v *validator) checkNonAmbError(
 func (v *validator) failIfError(
 	op Operation, r Result, exceptions ...func(err error) bool,
 ) (ambiguous, hasError bool) {
+	exceptions = append(exceptions[:len(exceptions):len(exceptions)], func(err error) bool {
+		return errors.Is(err, errInjected)
+	})
 	switch r.Type {
 	case ResultType_Unknown:
 		err := errors.AssertionFailedf(`unknown result %s`, op)

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -465,6 +465,7 @@ go_test(
         "//pkg/util",
         "//pkg/util/admission",
         "//pkg/util/admission/admissionpb",
+        "//pkg/util/allstacks",
         "//pkg/util/caller",
         "//pkg/util/circuit",
         "//pkg/util/ctxgroup",

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -113,6 +113,7 @@ func newUninitializedReplica(
 	r.mu.proposalBuf.testing.allowLeaseProposalWhenNotLeader = store.cfg.TestingKnobs.AllowLeaseRequestProposalsWhenNotLeader
 	r.mu.proposalBuf.testing.dontCloseTimestamps = store.cfg.TestingKnobs.DontCloseTimestamps
 	r.mu.proposalBuf.testing.submitProposalFilter = store.cfg.TestingKnobs.TestingProposalSubmitFilter
+	r.mu.proposalBuf.testing.leaseIndexFilter = store.cfg.TestingKnobs.LeaseIndexFilter
 
 	if leaseHistoryMaxEntries > 0 {
 		r.leaseHistory = newLeaseHistory(leaseHistoryMaxEntries)

--- a/pkg/kv/kvserver/replica_raft_test.go
+++ b/pkg/kv/kvserver/replica_raft_test.go
@@ -11,21 +11,38 @@
 package kvserver
 
 import (
+	"context"
+	"fmt"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.etcd.io/raft/v3/tracker"
 )
 
@@ -123,4 +140,244 @@ func Test_handleRaftReadyStats_SafeFormat(t *testing.T) {
 
 	echotest.Require(t, string(redact.Sprint(stats)),
 		filepath.Join(datapathutils.TestDataPath(t, "handle_raft_ready_stats.txt")))
+}
+
+// TestProposalsWithInjectedLeaseIndexAndReproposalError runs a number of
+// increment operations whose proposals are randomly subjected to invalid
+// LeaseAppliedIndex assignments, and for which reproposals randomly fail with
+// an injected error. The test verifies that increments that "went through" are
+// actually present (and not duplicated) and that operations that failed with an
+// unambiguous error did not apply.
+func TestProposalsWithInjectedLeaseIndexAndReproposalError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunTrueAndFalse(t, "pipelined", testProposalsWithInjectedLeaseIndexAndReproposalError)
+}
+
+func testProposalsWithInjectedLeaseIndexAndReproposalError(t *testing.T, pipelined bool) {
+	stopper := stop.NewStopper()
+	ctx := context.Background()
+
+	tc := testContext{}
+
+	isOurCommand := func(ba *kvpb.BatchRequest) (_ string, ok bool) {
+		if ba == nil {
+			return "", false // not local proposal
+		}
+		inc := ba.Requests[0].GetIncrement()
+		if inc == nil {
+			return "", false
+		}
+		key := string(inc.Key)
+		if !strings.HasSuffix(key, "-testing") {
+			return "", false
+		}
+		return key, true
+	}
+
+	rnd, seed := randutil.NewPseudoRand()
+	t.Logf("seed: %d", seed)
+
+	shouldInject := func(baseProb float64, attempt int) bool { // start at attempt one
+		// Example: baseProb = 0.8
+		// On attempt 1, 80% chance of catching retry.
+		// On attempt 2, 40%.
+		// On attempt 3, 27%.
+		// And so on.
+		thresh := baseProb / float64(attempt)
+		return rnd.Float64() < thresh
+	}
+
+	cfg := TestStoreConfig(hlc.NewClockForTesting(nil))
+
+	var injectedReproposalErrors atomic.Int32
+	{
+		var mu syncutil.Mutex
+		seen := map[string]int{} // access from proposal buffer under raftMu
+		cfg.TestingKnobs.InjectReproposalError = func(p *ProposalData) error {
+			key, ok := isOurCommand(p.Request)
+			if !ok {
+				return nil
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			seen[key]++
+			if !shouldInject(0.2, seen[key]) {
+				return nil
+			}
+			t.Logf("inserting reproposal error for %s (seen %d times)", key, seen[key])
+			return errors.Errorf("injected error")
+		}
+	}
+
+	var insertedIllegalLeaseIndex atomic.Int32
+	{
+		var mu syncutil.Mutex
+		seen := map[string]int{}
+		cfg.TestingKnobs.LeaseIndexFilter = func(p *ProposalData) kvpb.LeaseAppliedIndex {
+			key, ok := isOurCommand(p.Request)
+			if !ok {
+				return 0
+			}
+			mu.Lock()
+			seen[key]++
+			defer mu.Unlock()
+			if !shouldInject(0.8, seen[key]) { // very frequent reproposals
+				return 0
+			}
+			insertedIllegalLeaseIndex.Add(1)
+			// LAI 1 is always going to fail because the LAI is initialized when the lease
+			// comes into existence. (It's important that we pick one here that reliably
+			// fails because otherwise we may accidentally regress the closed timestamp[^1].
+			//
+			// [^1]: https://github.com/cockroachdb/cockroach/issues/70894#issuecomment-1433244880
+			return 1
+		}
+	}
+
+	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
+
+	defer checkNoLeakedTraceSpans(t, tc.store)
+	defer stopper.Stop(ctx)
+
+	tc.store.cfg.Tracer().SetActiveSpansRegistryEnabled(true)
+	tc.store.cfg.Tracer().PanicOnUseAfterFinish()
+
+	kvcoord.PipelinedWritesEnabled.Override(ctx, &tc.store.ClusterSettings().SV, pipelined)
+
+	k := func(idx int) roachpb.Key {
+		var key roachpb.Key
+		key = append(key, tc.repl.Desc().StartKey...)
+		key = append(key, fmt.Sprintf("%05d", idx)...)
+		key = append(key, "-testing"...)
+		return key
+	}
+	var observedAsyncWriteFailures atomic.Int32
+	var observedReproposalErrors atomic.Int32
+	const iters = 300
+	expectations := map[string]int{}
+	for i := 0; i < iters; i++ {
+		key := k(i)
+
+		if err := tc.store.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
+			defer func() {
+				if err != nil {
+					t.Logf("%d: error: %s", i, err)
+					var txnErr *kvpb.TransactionRetryWithProtoRefreshError
+					// NB: the string matching here is sad but the error has been
+					// flattened away at this point.
+					ignored := true
+					switch {
+					case errors.As(err, &txnErr) && strings.Contains(txnErr.String(), `missing intent on`):
+						observedAsyncWriteFailures.Add(1)
+					case testutils.IsError(err, `injected error`):
+						observedReproposalErrors.Add(1)
+					case errors.HasType(err, (*kvpb.AmbiguousResultError)(nil)):
+						t.Logf("%d: ignoring: %s", i, err)
+					default:
+						ignored = false
+					}
+					if ignored {
+						t.Logf("%d: ignoring: %s", i, err)
+					} else {
+						t.Errorf("%d: %s", i, err)
+					}
+				}
+			}()
+			// The handling of trace spans during reproposals is tricky,
+			// so make sure everyone is tracing to have the best chance
+			// at causing problems. Note that the tracer was configured
+			// to always trace and also to debug use-after-finish.
+			ctx, sp := tc.store.cfg.Tracer().StartSpanCtx(ctx, fmt.Sprintf("op %d", i))
+			defer sp.Finish()
+
+			// We write and delete the key first. If there were a bug in the
+			// reproposal pipeline, it could happen that the increment below and this
+			// rewrite cycle got reordered, and we would notice that the key didn't
+			// have the right value in the end. (The Put shouldn't make a difference
+			// but it removes the question that may arise in the mind of a reader of
+			// whether the Delete actually causes a write). Another benefit of this
+			// sequence is that if we leaked any latches, the test would stall, since
+			// we are mutating the same key repeatedly.
+			if err := txn.Put(ctx, key, "hello"); err != nil {
+				return err
+			}
+			if _, err := txn.Del(ctx, key); err != nil {
+				return err
+			}
+
+			resp, err := txn.Inc(ctx, key, 1)
+			if err != nil {
+				return err
+			}
+			n, err := resp.Value.GetInt()
+			if err != nil {
+				return err
+			}
+			if n != 1 {
+				return errors.Errorf("%d: got %d", i, n)
+			}
+			return txn.Commit(ctx)
+		}); err == nil {
+			expectations[string(key)] = 1
+		} else if !errors.HasType(err, (*kvpb.AmbiguousResultError)(nil)) {
+			expectations[string(key)] = 0
+		}
+	}
+
+	for keyString, exp := range expectations {
+		keyVal, err := tc.store.DB().Get(ctx, roachpb.Key(keyString))
+		require.NoError(t, err)
+		if exp == 0 {
+			require.Nil(t, keyVal.Value)
+			continue
+		}
+		n, err := keyVal.Value.GetInt()
+		require.NoError(t, err)
+		require.EqualValues(t, exp, n)
+	}
+	t.Logf("observed %d async write restarts, observed %d/%d injected aborts, %d injected illegal lease applied indexes",
+		observedAsyncWriteFailures.Load(), observedReproposalErrors.Load(), injectedReproposalErrors.Load(), insertedIllegalLeaseIndex.Load())
+	if pipelined {
+		// If we did pipelined writes, if we needed to repropose and injected an
+		// error, this should surface as an async write failure instead.
+		require.Zero(t, observedReproposalErrors.Load())
+	}
+	if !pipelined {
+		// If we're not pipelined, we shouldn't be able to get an async write
+		// failure. This isn't testing anything about reproposals per se, rather
+		// it's validation that we're truly not doing pipelined writes.
+		require.Zero(t, observedAsyncWriteFailures.Load())
+	}
+}
+
+func checkNoLeakedTraceSpans(t *testing.T, store *Store) {
+	testutils.SucceedsSoon(t, func() error {
+		var sps []tracing.RegistrySpan
+		_ = store.cfg.Tracer().VisitSpans(func(span tracing.RegistrySpan) error {
+			sps = append(sps, span)
+			return nil
+		})
+		if len(sps) == 0 {
+			return nil
+		}
+		var buf strings.Builder
+		fmt.Fprintf(&buf, "unexpectedly found %d active spans:\n", len(sps))
+		var ids []uint64
+		for _, sp := range sps {
+			trace := sp.GetFullRecording(tracingpb.RecordingVerbose)
+			for _, rs := range trace.Flatten() {
+				// NB: it would be a sight easier to just include these in the output of
+				// the string formatted recording, but making a change there presumably requires
+				// lots of changes across various testdata in the codebase and the author is
+				// trying to be nimble.
+				ids = append(ids, rs.GoroutineID)
+			}
+			fmt.Fprintln(&buf, trace)
+			fmt.Fprintln(&buf)
+		}
+		sl := allstacks.Get()
+		return errors.Newf("%s\n\ngoroutines of interest: %v\nstacks:\n\n%s", buf.String(), ids, sl)
+	})
 }

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -497,6 +497,10 @@ type StoreTestingKnobs struct {
 	// If nil is returned, reproposal will be attempted.
 	InjectReproposalError func(p *ProposalData) error
 
+	// LeaseIndexFilter can return nonzero to override the automatically assigned
+	// LeaseAppliedIndex.
+	LeaseIndexFilter func(*ProposalData) kvpb.LeaseAppliedIndex
+
 	// FlowControlTestingKnobs provide fine-grained control over the various
 	// kvflowcontrol components for testing.
 	FlowControlTestingKnobs *kvflowcontrol.TestingKnobs

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -493,6 +493,10 @@ type StoreTestingKnobs struct {
 	// required.
 	BaseQueueInterceptor func(ctx context.Context, bq *baseQueue)
 
+	// InjectReproposalError injects an error in tryReproposeWithNewLeaseIndex.
+	// If nil is returned, reproposal will be attempted.
+	InjectReproposalError func(p *ProposalData) error
+
 	// FlowControlTestingKnobs provide fine-grained control over the various
 	// kvflowcontrol components for testing.
 	FlowControlTestingKnobs *kvflowcontrol.TestingKnobs


### PR DESCRIPTION
This adds testing knobs that allow probabilistically invalidating the
`MaxLeaseIndex` of proposals in the replication layer, and also allows
injecting errors into the reproposals that result from doing so.o

It then uses these knobs in kvnemesis and in a newly added "more targeted"
`kvserver` unit test. This unit test was co-developed with the kvnemesis
flavor, and various amounts of cross-pollination have ensued. The idea is that
kvnemesis produces "more randomness" and thus has a higher chance of finding
interesting behavior, while the kvserver test is more suitable to
reproducing/regression testing that behavior. For example, tracing initially
caused problems in kvnemesis, so I added tracking to the kvserver test, and
sorted out the problems this encountered (which in turn addressed the problem
in kvnemesis as well).

I am adding this testing as part of my work on
https://github.com/cockroachdb/cockroach/pull/97779. Because the test is
agnostic to how exactly reproposals are implemented, I am landing it
separately which will make it very clear that it can pass without these
changes (and once did). With #97779, the plan is to metamorphically swap
the implementations to retain coverage for both, until we are willing to
commit to the new method in #97779.

Release note: None
Epic: CRDB-25287
