### PR TITLE
kvserver: use blind puts for lease records

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_lease.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease.go
@@ -131,7 +131,7 @@ func evalNewLease(
 	}
 
 	// Store the lease to disk & in-memory.
-	if err := MakeStateLoader(rec).SetLease(ctx, readWriter, ms, lease); err != nil {
+	if err := MakeStateLoader(rec).SetLeaseBlind(ctx, readWriter, ms, lease, prevLease); err != nil {
 		return newFailedLeaseTrigger(isTransfer), err
 	}
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -868,6 +868,51 @@ func MVCCBlindPutProto(
 	return MVCCBlindPut(ctx, writer, ms, key, timestamp, localTimestamp, value, txn)
 }
 
+// MVCCBlindPutInlineWithPrev updates an inline value using a blind put when the
+// previous value is known. The previous value is used to update MVCC stats.
+func MVCCBlindPutInlineWithPrev(
+	ctx context.Context,
+	rw ReadWriter,
+	ms *enginepb.MVCCStats,
+	key roachpb.Key,
+	value, prev roachpb.Value,
+) error {
+	// MVCCBlindPut() will update stats for the new key as if there was no
+	// existing key. Adjust stats for the removal of the previous value, if any.
+	var origMetaKeySize, origMetaValSize int64
+	if prev.IsPresent() && ms != nil {
+		origMetaKeySize = int64(MVCCKey{Key: key}.EncodedSize())
+		origMetaValSize = int64((&enginepb.MVCCMetadata{RawBytes: prev.RawBytes}).Size())
+		updateStatsForInline(ms, key, origMetaKeySize, origMetaValSize, 0, 0)
+	}
+	// Assert correct stats. Must be enabled manually, because the primary caller
+	// is lease requests, and these can race with concurrent lease requests since
+	// they don't hold latches. That's ok, because the lease request will be
+	// rejected below Raft in that case, but it would trip this assertion. We have
+	// plenty of other tests and assertions for this.
+	if false && ms != nil {
+		iter := newMVCCIterator(
+			rw, hlc.Timestamp{}, false /* rangeKeyMasking */, false, /* noInterleavedIntents */
+			IterOptions{
+				KeyTypes: IterKeyTypePointsAndRanges,
+				Prefix:   true,
+			},
+		)
+		defer iter.Close()
+		var meta enginepb.MVCCMetadata
+		ok, metaKeySize, metaValSize, _, err := mvccGetMetadata(iter, MVCCKey{Key: key}, &meta)
+		if err != nil {
+			return err
+		}
+		if ok != prev.IsPresent() || metaKeySize != origMetaKeySize || metaValSize != origMetaValSize {
+			log.Fatalf(ctx,
+				"MVCCBlindPutInlineWithPrev IsPresent=%t (%t) origMetaKeySize=%d (%d) origMetaValSize=%d (%d)",
+				prev.IsPresent(), ok, origMetaKeySize, metaKeySize, origMetaValSize, metaValSize)
+		}
+	}
+	return MVCCBlindPut(ctx, rw, ms, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, value, nil)
+}
+
 // LockTableView is a transaction-bound view into an in-memory collections of
 // key-level locks. The set of per-key locks stored in the in-memory lock table
 // structure overlaps with those stored in the persistent lock table keyspace

--- a/pkg/storage/testdata/mvcc_histories/blind_put_inline_with_prev
+++ b/pkg/storage/testdata/mvcc_histories/blind_put_inline_with_prev
@@ -1,0 +1,73 @@
+# Test MVCCBlindPutInlineWithPrev -- in particular, MVCC stats updates.
+
+# Populate some initial data.
+run stats ok
+put k=%sys v=system
+put k=i v=value
+----
+>> put k=%sys v=system
+stats: sys_bytes=+31 sys_count=+1
+>> put k=i v=value
+stats: key_count=+1 key_bytes=+2 val_count=+1 val_bytes=+24 live_count=+1 live_bytes=+26
+>> at end:
+meta: /Local/Range/"sys"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/system mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/value mergeTs=<nil> txnDidNotUpdateMeta=false
+stats: key_count=1 key_bytes=2 val_count=1 val_bytes=24 live_count=1 live_bytes=26 sys_bytes=31 sys_count=1
+
+# Replace existing keys.
+run stats ok
+put_blind_inline k=%sys v=new prev=system
+put_blind_inline k=i v=new prev=value
+----
+>> put_blind_inline k=%sys v=new prev=system
+stats: sys_bytes=-3
+>> put_blind_inline k=i v=new prev=value
+stats: val_bytes=-2 live_bytes=-2
+>> at end:
+meta: /Local/Range/"sys"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/new mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/new mergeTs=<nil> txnDidNotUpdateMeta=false
+stats: key_count=1 key_bytes=2 val_count=1 val_bytes=22 live_count=1 live_bytes=24 sys_bytes=28 sys_count=1
+
+# Write new keys.
+run stats ok
+put_blind_inline k=%foo v=bar
+put_blind_inline k=foo v=bar
+----
+>> put_blind_inline k=%foo v=bar
+stats: sys_bytes=+28 sys_count=+1
+>> put_blind_inline k=foo v=bar
+stats: key_count=+1 key_bytes=+4 val_count=+1 val_bytes=+22 live_count=+1 live_bytes=+26
+>> at end:
+meta: /Local/Range/"foo"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/bar mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: /Local/Range/"sys"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/new mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "foo"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/bar mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/new mergeTs=<nil> txnDidNotUpdateMeta=false
+stats: key_count=2 key_bytes=6 val_count=2 val_bytes=44 live_count=2 live_bytes=50 sys_bytes=56 sys_count=2
+
+# Delete existing keys.
+run stats ok
+put_blind_inline k=%foo prev=bar
+put_blind_inline k=foo prev=bar
+----
+>> put_blind_inline k=%foo prev=bar
+stats: sys_bytes=-28 sys_count=-1
+>> put_blind_inline k=foo prev=bar
+stats: key_count=-1 key_bytes=-4 val_count=-1 val_bytes=-22 live_count=-1 live_bytes=-26
+>> at end:
+meta: /Local/Range/"sys"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/new mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/new mergeTs=<nil> txnDidNotUpdateMeta=false
+stats: key_count=1 key_bytes=2 val_count=1 val_bytes=22 live_count=1 live_bytes=24 sys_bytes=28 sys_count=1
+
+# Delete non-existant keys.
+run stats ok
+put_blind_inline k=%foo
+put_blind_inline k=foo
+----
+>> put_blind_inline k=%foo
+stats: no change
+>> put_blind_inline k=foo
+stats: no change
+>> at end:
+meta: /Local/Range/"sys"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/new mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/new mergeTs=<nil> txnDidNotUpdateMeta=false
+stats: key_count=1 key_bytes=2 val_count=1 val_bytes=22 live_count=1 live_bytes=24 sys_bytes=28 sys_count=1


### PR DESCRIPTION
Expiration lease extensions across many ranges, e.g. O(10k), spend a significant amount of resources reading the existing lease record, due to the frequent Pebble seeks across wide swaths of the keyspace, and the associated block cache thrashing.

These reads were only needed to update MVCC stats when persisting the new lease record. However, we already have the previous lease record in the replica state. This patch therefore uses a blind put for the lease record, adjusting stats based on the in-memory record.

Resolves #103288.

Epic: none
Release note: None