### PR TITLE
changefeedccl: add lagging_ranges and lagging_range_percentage metrics

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -91,9 +93,10 @@ type changeAggregator struct {
 	// eventConsumer consumes the event.
 	eventConsumer eventConsumer
 
-	lastHighWaterFlush time.Time     // last time high watermark was checkpointed.
-	flushFrequency     time.Duration // how often high watermark can be checkpointed.
-	lastSpanFlush      time.Time     // last time expensive, span based checkpoint was written.
+	lastHighWaterFlush   time.Time     // last time high watermark was checkpointed.
+	flushFrequency       time.Duration // how often high watermark can be checkpointed.
+	lastSpanFlush        time.Time     // last time expensive, span based checkpoint was written.
+	lastRangeHealthCheck time.Time     // last time all ranges were healthchecked
 
 	// frontier keeps track of resolved timestamps for spans along with schema change
 	// boundary information.
@@ -703,6 +706,8 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) error
 	if err != nil {
 		return err
 	}
+
+	ca.maybeLogRangeHealth(resolved)
 
 	forceFlush := resolved.BoundaryType != jobspb.ResolvedSpan_NONE
 
@@ -1549,6 +1554,51 @@ func (cf *changeFrontier) isBehind() bool {
 	return timeutil.Since(frontier.GoTime()) > cf.slownessThreshold()
 }
 
+func (ca *changeAggregator) maybeLogRangeHealth(resolved jobspb.ResolvedSpan) {
+	frequency := changefeedbase.RangeHealthCheckFrequency.Get(&ca.flowCtx.Cfg.Settings.SV)
+	if timeutil.Since(ca.lastRangeHealthCheck) < frequency {
+		return
+	}
+	defer func() { ca.lastRangeHealthCheck = timeutil.Now() }()
+
+	// The progress of ranges during a backfill is already tracked by the
+	// backfill_pending_ranges metric.  Ranges lagging during a backfill are going
+	// to be problematic at a different threshold to during normal operation, so
+	// the lagging ranges metrics are reserved for just the non-backfill case.
+	if resolved.Timestamp.Equal(ca.frontier.BackfillTS()) {
+		ca.sliMetrics.AggregatorLaggingRangePercentage.Update(0)
+		ca.sliMetrics.AggregatorLaggingRanges.Update(0)
+		return
+	}
+
+	lagThreshold := changefeedbase.LaggingRangesThreshold.Get(&ca.flowCtx.Cfg.Settings.SV)
+
+	// Don't bother calling the expensive AllRangeSpans if we know nothing is unhealthy
+	if timeutil.Since(ca.frontier.Frontier().GoTime()) < lagThreshold {
+		ca.sliMetrics.AggregatorLaggingRangePercentage.Update(0)
+		ca.sliMetrics.AggregatorLaggingRanges.Update(0)
+		return
+	}
+
+	// Grab all ranges being watched by the aggregator
+	db := ca.flowCtx.Cfg.DB.KV()
+	sender := db.NonTransactionalSender()
+	distSender := sender.(*kv.CrossRangeTxnWrapperSender).Wrapped().(*kvcoord.DistSender)
+	spans := make([]roachpb.Span, 0, len(ca.spec.Watches))
+	for _, watch := range ca.spec.Watches {
+		spans = append(spans, watch.Span)
+	}
+	ranges, _, err := distSender.AllRangeSpans(ca.Ctx(), spans)
+	if err != nil {
+		return
+	}
+
+	behindRanges := ca.frontier.countLaggingSpans(ranges, timeutil.Now().Add(-lagThreshold))
+
+	ca.sliMetrics.AggregatorLaggingRanges.Update(int64(behindRanges))
+	ca.sliMetrics.AggregatorLaggingRangePercentage.Update(float64(behindRanges) / float64(len(ranges)))
+}
+
 // Potentially log the most behind span in the frontier for debugging if the
 // frontier is behind
 func (cf *changeFrontier) maybeLogBehindSpan(frontierChanged bool) {
@@ -1762,6 +1812,37 @@ func (f *schemaChangeFrontier) getCheckpointSpans(
 	maxBytes int64,
 ) (spans []roachpb.Span, timestamp hlc.Timestamp) {
 	return getCheckpointSpans(f.frontierTimestamp(), f.Entries, maxBytes)
+}
+
+// countLaggingSpans, given a sorted list of spans, returns the number of spans
+// that according to the frontier are behind the provided lagThresholdTs
+func (f *schemaChangeFrontier) countLaggingSpans(
+	spansAscending []roachpb.Span, lagThresholdTs time.Time,
+) int {
+	spanIdx := 0
+	behindRanges := 0
+
+	// Ranges from both AllRangeSpans and ca.frontier.Entries are in ascending key
+	// order, so scanning across both together will handle every overlap.
+	f.Entries(func(sp roachpb.Span, ts hlc.Timestamp) span.OpResult {
+		// Scan through ranges until the next overlap is found
+		for spanIdx < len(spansAscending) && !sp.Overlaps(spansAscending[spanIdx]) && sp.EndKey.Compare(spansAscending[spanIdx].Key) >= 0 {
+			spanIdx++
+		}
+		for spanIdx < len(spansAscending) && sp.Overlaps(spansAscending[spanIdx]) {
+			if ts.GoTime().Before(lagThresholdTs) {
+				behindRanges += 1
+			} else if spansAscending[spanIdx].EndKey.Compare(sp.EndKey) >= 0 {
+				// If the range extends to the next span, check it against the next one
+				break
+			}
+
+			spanIdx++
+		}
+		return span.ContinueMatch
+	})
+
+	return behindRanges
 }
 
 // BackfillTS returns the timestamp of the incoming spans for an ongoing

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -90,6 +90,26 @@ var FrontierHighwaterLagCheckpointThreshold = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 	settings.WithPublic)
 
+// RangeHealthCheckFrequency controls how often an aggregator checks all of its
+// ranges for whether or not they are sufficiently lagging behind.
+var RangeHealthCheckFrequency = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"changefeed.range_health_check_frequency",
+	"controls the frequency by which each aggregator checks each of its ranges for whether or not it is considered healthy and up to date",
+	1*time.Minute,
+	settings.NonNegativeDuration,
+)
+
+// LaggingRangesThreshold controls how far behind a range has to be from the
+// present in order to be considered "lagging" and logged as such.
+var LaggingRangesThreshold = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"changefeed.lagging_ranges_threshold",
+	"controls how far behind a range must be from the present to be considered as 'lagging' behind in metrics",
+	5*time.Minute,
+	settings.NonNegativeDuration,
+)
+
 // FrontierCheckpointMaxBytes controls the maximum number of key bytes that will be added
 // to the checkpoint record.
 // Checkpoint record could be fairly large.

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -47,27 +47,29 @@ const defaultSLIScope = "default"
 // AggMetrics are aggregated metrics keeping track of aggregated changefeed performance
 // indicators, combined with a limited number of per-changefeed indicators.
 type AggMetrics struct {
-	EmittedMessages           *aggmetric.AggCounter
-	FilteredMessages          *aggmetric.AggCounter
-	MessageSize               *aggmetric.AggHistogram
-	EmittedBytes              *aggmetric.AggCounter
-	FlushedBytes              *aggmetric.AggCounter
-	BatchHistNanos            *aggmetric.AggHistogram
-	Flushes                   *aggmetric.AggCounter
-	FlushHistNanos            *aggmetric.AggHistogram
-	SizeBasedFlushes          *aggmetric.AggCounter
-	ParallelIOQueueNanos      *aggmetric.AggHistogram
-	SinkIOInflight            *aggmetric.AggGauge
-	CommitLatency             *aggmetric.AggHistogram
-	BackfillCount             *aggmetric.AggGauge
-	BackfillPendingRanges     *aggmetric.AggGauge
-	ErrorRetries              *aggmetric.AggCounter
-	AdmitLatency              *aggmetric.AggHistogram
-	RunningCount              *aggmetric.AggGauge
-	BatchReductionCount       *aggmetric.AggGauge
-	InternalRetryMessageCount *aggmetric.AggGauge
-	SchemaRegistrations       *aggmetric.AggCounter
-	SchemaRegistryRetries     *aggmetric.AggCounter
+	EmittedMessages                  *aggmetric.AggCounter
+	FilteredMessages                 *aggmetric.AggCounter
+	MessageSize                      *aggmetric.AggHistogram
+	EmittedBytes                     *aggmetric.AggCounter
+	FlushedBytes                     *aggmetric.AggCounter
+	BatchHistNanos                   *aggmetric.AggHistogram
+	Flushes                          *aggmetric.AggCounter
+	FlushHistNanos                   *aggmetric.AggHistogram
+	SizeBasedFlushes                 *aggmetric.AggCounter
+	ParallelIOQueueNanos             *aggmetric.AggHistogram
+	SinkIOInflight                   *aggmetric.AggGauge
+	CommitLatency                    *aggmetric.AggHistogram
+	BackfillCount                    *aggmetric.AggGauge
+	BackfillPendingRanges            *aggmetric.AggGauge
+	ErrorRetries                     *aggmetric.AggCounter
+	AdmitLatency                     *aggmetric.AggHistogram
+	RunningCount                     *aggmetric.AggGauge
+	BatchReductionCount              *aggmetric.AggGauge
+	InternalRetryMessageCount        *aggmetric.AggGauge
+	SchemaRegistrations              *aggmetric.AggCounter
+	SchemaRegistryRetries            *aggmetric.AggCounter
+	AggregatorLaggingRangePercentage *aggmetric.AggGaugeFloat64
+	AggregatorLaggingRanges          *aggmetric.AggGauge
 
 	// There is always at least 1 sliMetrics created for defaultSLI scope.
 	mu struct {
@@ -107,27 +109,29 @@ func (a *AggMetrics) MetricStruct() {}
 
 // sliMetrics holds all SLI related metrics aggregated into AggMetrics.
 type sliMetrics struct {
-	EmittedMessages           *aggmetric.Counter
-	FilteredMessages          *aggmetric.Counter
-	MessageSize               *aggmetric.Histogram
-	EmittedBytes              *aggmetric.Counter
-	FlushedBytes              *aggmetric.Counter
-	BatchHistNanos            *aggmetric.Histogram
-	Flushes                   *aggmetric.Counter
-	FlushHistNanos            *aggmetric.Histogram
-	SizeBasedFlushes          *aggmetric.Counter
-	ParallelIOQueueNanos      *aggmetric.Histogram
-	SinkIOInflight            *aggmetric.Gauge
-	CommitLatency             *aggmetric.Histogram
-	ErrorRetries              *aggmetric.Counter
-	AdmitLatency              *aggmetric.Histogram
-	BackfillCount             *aggmetric.Gauge
-	BackfillPendingRanges     *aggmetric.Gauge
-	RunningCount              *aggmetric.Gauge
-	BatchReductionCount       *aggmetric.Gauge
-	InternalRetryMessageCount *aggmetric.Gauge
-	SchemaRegistrations       *aggmetric.Counter
-	SchemaRegistryRetries     *aggmetric.Counter
+	EmittedMessages                  *aggmetric.Counter
+	FilteredMessages                 *aggmetric.Counter
+	MessageSize                      *aggmetric.Histogram
+	EmittedBytes                     *aggmetric.Counter
+	FlushedBytes                     *aggmetric.Counter
+	BatchHistNanos                   *aggmetric.Histogram
+	Flushes                          *aggmetric.Counter
+	FlushHistNanos                   *aggmetric.Histogram
+	SizeBasedFlushes                 *aggmetric.Counter
+	ParallelIOQueueNanos             *aggmetric.Histogram
+	SinkIOInflight                   *aggmetric.Gauge
+	CommitLatency                    *aggmetric.Histogram
+	ErrorRetries                     *aggmetric.Counter
+	AdmitLatency                     *aggmetric.Histogram
+	BackfillCount                    *aggmetric.Gauge
+	BackfillPendingRanges            *aggmetric.Gauge
+	RunningCount                     *aggmetric.Gauge
+	BatchReductionCount              *aggmetric.Gauge
+	InternalRetryMessageCount        *aggmetric.Gauge
+	SchemaRegistrations              *aggmetric.Counter
+	SchemaRegistryRetries            *aggmetric.Counter
+	AggregatorLaggingRangePercentage *aggmetric.GaugeFloat64
+	AggregatorLaggingRanges          *aggmetric.Gauge
 }
 
 // sinkDoesNotCompress is a sentinel value indicating the sink
@@ -544,6 +548,18 @@ func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
 		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaAggregatorLaggingRangePercentage := metric.Metadata{
+		Name:        "changefeed.aggregator_lagging_range_percentage",
+		Help:        "The percentage of ranges the aggregator is responsible for that are considered to be lagging behind",
+		Measurement: "Total Ranges",
+		Unit:        metric.Unit_PERCENT,
+	}
+	metaAggregatorLaggingRanges := metric.Metadata{
+		Name:        "changefeed.aggregator_lagging_ranges",
+		Help:        "The number of ranges the aggregator for the node is tracking that are lagging behind the current time",
+		Measurement: "Lagging Ranges",
+		Unit:        metric.Unit_COUNT,
+	}
 	// NB: When adding new histograms, use sigFigs = 1.  Older histograms
 	// retain significant figures of 2.
 	b := aggmetric.MakeBuilder("scope")
@@ -599,13 +615,15 @@ func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
 			SigFigs:      1,
 			BucketConfig: metric.BatchProcessLatencyBuckets,
 		}),
-		BackfillCount:             b.Gauge(metaChangefeedBackfillCount),
-		BackfillPendingRanges:     b.Gauge(metaChangefeedBackfillPendingRanges),
-		RunningCount:              b.Gauge(metaChangefeedRunning),
-		BatchReductionCount:       b.Gauge(metaBatchReductionCount),
-		InternalRetryMessageCount: b.Gauge(metaInternalRetryMessageCount),
-		SchemaRegistryRetries:     b.Counter(metaSchemaRegistryRetriesCount),
-		SchemaRegistrations:       b.Counter(metaSchemaRegistryRegistrations),
+		BackfillCount:                    b.Gauge(metaChangefeedBackfillCount),
+		BackfillPendingRanges:            b.Gauge(metaChangefeedBackfillPendingRanges),
+		RunningCount:                     b.Gauge(metaChangefeedRunning),
+		BatchReductionCount:              b.Gauge(metaBatchReductionCount),
+		InternalRetryMessageCount:        b.Gauge(metaInternalRetryMessageCount),
+		SchemaRegistryRetries:            b.Counter(metaSchemaRegistryRetriesCount),
+		SchemaRegistrations:              b.Counter(metaSchemaRegistryRegistrations),
+		AggregatorLaggingRangePercentage: b.GaugeFloat64(metaAggregatorLaggingRangePercentage),
+		AggregatorLaggingRanges:          b.Gauge(metaAggregatorLaggingRanges),
 	}
 	a.mu.sliMetrics = make(map[string]*sliMetrics)
 	_, err := a.getOrCreateScope(defaultSLIScope)
@@ -644,27 +662,29 @@ func (a *AggMetrics) getOrCreateScope(scope string) (*sliMetrics, error) {
 	}
 
 	sm := &sliMetrics{
-		EmittedMessages:           a.EmittedMessages.AddChild(scope),
-		FilteredMessages:          a.FilteredMessages.AddChild(scope),
-		MessageSize:               a.MessageSize.AddChild(scope),
-		EmittedBytes:              a.EmittedBytes.AddChild(scope),
-		FlushedBytes:              a.FlushedBytes.AddChild(scope),
-		BatchHistNanos:            a.BatchHistNanos.AddChild(scope),
-		Flushes:                   a.Flushes.AddChild(scope),
-		FlushHistNanos:            a.FlushHistNanos.AddChild(scope),
-		SizeBasedFlushes:          a.SizeBasedFlushes.AddChild(scope),
-		ParallelIOQueueNanos:      a.ParallelIOQueueNanos.AddChild(scope),
-		SinkIOInflight:            a.SinkIOInflight.AddChild(scope),
-		CommitLatency:             a.CommitLatency.AddChild(scope),
-		ErrorRetries:              a.ErrorRetries.AddChild(scope),
-		AdmitLatency:              a.AdmitLatency.AddChild(scope),
-		BackfillCount:             a.BackfillCount.AddChild(scope),
-		BackfillPendingRanges:     a.BackfillPendingRanges.AddChild(scope),
-		RunningCount:              a.RunningCount.AddChild(scope),
-		BatchReductionCount:       a.BatchReductionCount.AddChild(scope),
-		InternalRetryMessageCount: a.InternalRetryMessageCount.AddChild(scope),
-		SchemaRegistryRetries:     a.SchemaRegistryRetries.AddChild(scope),
-		SchemaRegistrations:       a.SchemaRegistrations.AddChild(scope),
+		EmittedMessages:                  a.EmittedMessages.AddChild(scope),
+		FilteredMessages:                 a.FilteredMessages.AddChild(scope),
+		MessageSize:                      a.MessageSize.AddChild(scope),
+		EmittedBytes:                     a.EmittedBytes.AddChild(scope),
+		FlushedBytes:                     a.FlushedBytes.AddChild(scope),
+		BatchHistNanos:                   a.BatchHistNanos.AddChild(scope),
+		Flushes:                          a.Flushes.AddChild(scope),
+		FlushHistNanos:                   a.FlushHistNanos.AddChild(scope),
+		SizeBasedFlushes:                 a.SizeBasedFlushes.AddChild(scope),
+		ParallelIOQueueNanos:             a.ParallelIOQueueNanos.AddChild(scope),
+		SinkIOInflight:                   a.SinkIOInflight.AddChild(scope),
+		CommitLatency:                    a.CommitLatency.AddChild(scope),
+		ErrorRetries:                     a.ErrorRetries.AddChild(scope),
+		AdmitLatency:                     a.AdmitLatency.AddChild(scope),
+		BackfillCount:                    a.BackfillCount.AddChild(scope),
+		BackfillPendingRanges:            a.BackfillPendingRanges.AddChild(scope),
+		RunningCount:                     a.RunningCount.AddChild(scope),
+		BatchReductionCount:              a.BatchReductionCount.AddChild(scope),
+		InternalRetryMessageCount:        a.InternalRetryMessageCount.AddChild(scope),
+		SchemaRegistryRetries:            a.SchemaRegistryRetries.AddChild(scope),
+		SchemaRegistrations:              a.SchemaRegistrations.AddChild(scope),
+		AggregatorLaggingRangePercentage: a.AggregatorLaggingRangePercentage.AddChild(scope),
+		AggregatorLaggingRanges:          a.AggregatorLaggingRanges.AddChild(scope),
 	}
 
 	a.mu.sliMetrics[scope] = sm

--- a/pkg/cmd/roachtest/grafana/configs/changefeed-roachtest-grafana-dashboard.json
+++ b/pkg/cmd/roachtest/grafana/configs/changefeed-roachtest-grafana-dashboard.json
@@ -100,7 +100,7 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
+        "w": 4,
         "x": 0,
         "y": 1
       },
@@ -186,14 +186,107 @@
                 "value": 80
               }
             ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 82,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "editorMode": "code",
+          "expr": "time()*1000 - (changefeed_aggregator_progress{scope!=\"\"}/1000/1000)",
+          "legendFormat": "{{node}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Aggregator Lag",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "localprom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           }
         },
         "overrides": []
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 3,
+        "w": 4,
+        "x": 8,
         "y": 1
       },
       "id": 53,
@@ -278,18 +371,17 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "Bps"
+          }
         },
         "overrides": []
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 6,
+        "w": 4,
+        "x": 12,
         "y": 1
       },
-      "id": 56,
+      "id": 84,
       "options": {
         "legend": {
           "calcs": [],
@@ -309,13 +401,141 @@
             "uid": "localprom"
           },
           "editorMode": "code",
-          "expr": "sum(rate(changefeed_emitted_bytes{scope=\"\"}[$__rate_interval]))",
-          "legendFormat": "__auto",
+          "expr": "changefeed_aggregator_lagging_ranges{scope!=\"\"}",
+          "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Processed Bytes",
+      "title": "Lagging Ranges",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "localprom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 6
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "editorMode": "code",
+          "expr": "sum by(scope) (changefeed_error_retries{scope!=\"\"})",
+          "legendFormat": "retries[scope={{scope}}]",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "editorMode": "code",
+          "expr": "sum by (scope) (changefeed_error_failures{scope!=\"\"})",
+          "hide": false,
+          "legendFormat": "failures[scope={{scope}}]",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "editorMode": "code",
+          "expr": "sum by (scope) (changefeed_replan_count{scope!=\"\"})",
+          "hide": false,
+          "legendFormat": "replans[scope={{scope}}]",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "editorMode": "builder",
+          "expr": "",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Failures/Retries/Replans",
       "type": "timeseries"
     },
     {
@@ -378,9 +598,9 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 9,
-        "y": 1
+        "w": 4,
+        "x": 4,
+        "y": 6
       },
       "id": 17,
       "options": {
@@ -496,9 +716,9 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 12,
-        "y": 1
+        "w": 4,
+        "x": 8,
+        "y": 6
       },
       "id": 74,
       "options": {
@@ -582,17 +802,18 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "Bps"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 15,
-        "y": 1
+        "w": 4,
+        "x": 12,
+        "y": 6
       },
-      "id": 43,
+      "id": 56,
       "options": {
         "legend": {
           "calcs": [],
@@ -612,49 +833,13 @@
             "uid": "localprom"
           },
           "editorMode": "code",
-          "expr": "sum by(scope) (changefeed_error_retries{scope!=\"\"})",
-          "legendFormat": "retries[scope={{scope}}]",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "sum by (scope) (changefeed_error_failures{scope!=\"\"})",
-          "hide": false,
-          "legendFormat": "failures[scope={{scope}}]",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "sum by (scope) (changefeed_replan_count{scope!=\"\"})",
-          "hide": false,
-          "legendFormat": "replans[scope={{scope}}]",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "builder",
-          "expr": "",
-          "hide": false,
+          "expr": "sum(rate(changefeed_emitted_bytes{scope=\"\"}[$__rate_interval]))",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "D"
+          "refId": "A"
         }
       ],
-      "title": "Failures/Retries/Replans",
+      "title": "Processed Bytes",
       "type": "timeseries"
     },
     {
@@ -663,7 +848,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 11
       },
       "id": 47,
       "panels": [],
@@ -732,7 +917,7 @@
         "h": 10,
         "w": 8,
         "x": 0,
-        "y": 7
+        "y": 12
       },
       "id": 2,
       "options": {
@@ -838,7 +1023,7 @@
         "h": 10,
         "w": 8,
         "x": 8,
-        "y": 7
+        "y": 12
       },
       "id": 20,
       "options": {
@@ -946,7 +1131,7 @@
         "h": 5,
         "w": 5,
         "x": 16,
-        "y": 7
+        "y": 12
       },
       "id": 29,
       "options": {
@@ -1039,7 +1224,7 @@
         "h": 5,
         "w": 5,
         "x": 16,
-        "y": 12
+        "y": 17
       },
       "id": 41,
       "options": {
@@ -1076,7 +1261,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 22
       },
       "id": 62,
       "panels": [
@@ -1141,7 +1326,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 40
+            "y": 64
           },
           "id": 18,
           "options": {
@@ -1260,7 +1445,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 40
+            "y": 64
           },
           "id": 57,
           "options": {
@@ -1353,7 +1538,7 @@
             "h": 7,
             "w": 5,
             "x": 12,
-            "y": 40
+            "y": 64
           },
           "id": 72,
           "options": {
@@ -1394,7 +1579,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 23
       },
       "id": 69,
       "panels": [
@@ -1459,7 +1644,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 43
+            "y": 67
           },
           "id": 35,
           "options": {
@@ -1564,7 +1749,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 43
+            "y": 67
           },
           "id": 33,
           "options": {
@@ -1657,7 +1842,7 @@
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 43
+            "y": 67
           },
           "id": 39,
           "options": {
@@ -1698,7 +1883,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 24
       },
       "id": 71,
       "panels": [
@@ -1764,7 +1949,7 @@
             "h": 6,
             "w": 4,
             "x": 0,
-            "y": 36
+            "y": 60
           },
           "id": 63,
           "options": {
@@ -1883,7 +2068,7 @@
             "h": 6,
             "w": 4,
             "x": 4,
-            "y": 36
+            "y": 60
           },
           "id": 64,
           "options": {
@@ -2002,7 +2187,7 @@
             "h": 6,
             "w": 4,
             "x": 8,
-            "y": 36
+            "y": 60
           },
           "id": 65,
           "options": {
@@ -2097,7 +2282,7 @@
             "h": 6,
             "w": 4,
             "x": 12,
-            "y": 36
+            "y": 60
           },
           "id": 75,
           "options": {
@@ -2191,7 +2376,7 @@
             "h": 6,
             "w": 4,
             "x": 16,
-            "y": 36
+            "y": 60
           },
           "id": 19,
           "options": {
@@ -2228,16 +2413,681 @@
       "type": "row"
     },
     {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 14,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ns"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 0,
+            "y": 36
+          },
+          "id": 54,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.2.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum(rate(changefeed_sink_batch_hist_nanos_bucket[$__rate_interval])) by (le))",
+              "hide": false,
+              "legendFormat": "p50 {{label_name}}",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.75, sum(rate(changefeed_sink_batch_hist_nanos_bucket[$__rate_interval])) by (le))",
+              "hide": false,
+              "legendFormat": "p75 {{label_name}}",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum(rate(changefeed_sink_batch_hist_nanos_bucket[$__rate_interval])) by (le))",
+              "hide": false,
+              "legendFormat": "p95 {{label_name}}",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "title": "Sink Buffer Time Batched",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ns"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 6,
+            "y": 36
+          },
+          "id": 55,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.2.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum(rate(changefeed_flush_hist_nanos_bucket[$__rate_interval])) by (le))",
+              "hide": false,
+              "legendFormat": "p50 {{label_name}}",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.75, sum(rate(changefeed_flush_hist_nanos_bucket[$__rate_interval])) by (le))",
+              "hide": false,
+              "legendFormat": "p75 {{label_name}}",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum(rate(changefeed_flush_hist_nanos_bucket[$__rate_interval])) by (le))",
+              "hide": false,
+              "legendFormat": "p95 {{label_name}}",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "title": "Sink Flush Time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 11,
+            "y": 36
+          },
+          "id": 60,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.2.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(changefeed_flushes[$__rate_interval]))",
+              "hide": false,
+              "legendFormat": "total_flushes",
+              "range": true,
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(changefeed_size_based_flushes[$__rate_interval]))",
+              "hide": false,
+              "legendFormat": "size_based_flushes",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sink Flush Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ns"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 16,
+            "y": 36
+          },
+          "id": 25,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.2.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum(rate(changefeed_checkpoint_hist_nanos_bucket[5m])) by (le))",
+              "hide": false,
+              "legendFormat": "p50 {{label_name}}",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.75, sum(rate(changefeed_checkpoint_hist_nanos_bucket[5m])) by (le))",
+              "hide": false,
+              "legendFormat": "p75 {{label_name}}",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum(rate(changefeed_checkpoint_hist_nanos_bucket[5m])) by (le))",
+              "hide": false,
+              "legendFormat": "p95 {{label_name}}",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "title": "Time Spent Checkpointing",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 0,
+            "y": 42
+          },
+          "id": 77,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "sum by(scope) (rate(changefeed_sink_io_inflight{scope!=\"\"}[$__rate_interval]))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Batches currently in IO",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ns"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 6,
+            "y": 42
+          },
+          "id": 80,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "localprom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (scope) ((rate(changefeed_parallel_io_queue_nanos_sum{scope!=\"\"}[5m]) / rate(changefeed_parallel_io_queue_nanos_count{scope!=\"\"}[5m])))",
+              "legendFormat": "{{scope}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Parallel IO Average Queue Time",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Sink",
+      "type": "row"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 26
       },
-      "id": 14,
+      "id": 16,
       "panels": [],
-      "title": "Sink",
+      "title": "Resources",
       "type": "row"
     },
     {
@@ -2245,6 +3095,7 @@
         "type": "prometheus",
         "uid": "localprom"
       },
+      "description": "sys_cpu_combined_percent_normalized",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2294,17 +3145,17 @@
               }
             ]
           },
-          "unit": "ns"
+          "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 6,
+        "h": 8,
+        "w": 8,
         "x": 0,
-        "y": 21
+        "y": 27
       },
-      "id": 54,
+      "id": 22,
       "options": {
         "legend": {
           "calcs": [],
@@ -2317,7 +3168,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "9.2.3",
       "targets": [
         {
           "datasource": {
@@ -2325,383 +3175,13 @@
             "uid": "localprom"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(changefeed_sink_batch_hist_nanos_bucket[$__rate_interval])) by (le))",
-          "hide": false,
-          "legendFormat": "p50 {{label_name}}",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.75, sum(rate(changefeed_sink_batch_hist_nanos_bucket[$__rate_interval])) by (le))",
-          "hide": false,
-          "legendFormat": "p75 {{label_name}}",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(changefeed_sink_batch_hist_nanos_bucket[$__rate_interval])) by (le))",
-          "hide": false,
-          "legendFormat": "p95 {{label_name}}",
-          "range": true,
-          "refId": "E"
-        }
-      ],
-      "title": "Sink Buffer Time Batched",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "localprom"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ns"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 5,
-        "x": 6,
-        "y": 21
-      },
-      "id": 55,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.2.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(changefeed_flush_hist_nanos_bucket[$__rate_interval])) by (le))",
-          "hide": false,
-          "legendFormat": "p50 {{label_name}}",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.75, sum(rate(changefeed_flush_hist_nanos_bucket[$__rate_interval])) by (le))",
-          "hide": false,
-          "legendFormat": "p75 {{label_name}}",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(changefeed_flush_hist_nanos_bucket[$__rate_interval])) by (le))",
-          "hide": false,
-          "legendFormat": "p95 {{label_name}}",
-          "range": true,
-          "refId": "E"
-        }
-      ],
-      "title": "Sink Flush Time",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "localprom"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "cps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 5,
-        "x": 11,
-        "y": 21
-      },
-      "id": 60,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.2.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(changefeed_flushes[$__rate_interval]))",
-          "hide": false,
-          "legendFormat": "total_flushes",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(changefeed_size_based_flushes[$__rate_interval]))",
-          "hide": false,
-          "legendFormat": "size_based_flushes",
+          "expr": "sys_cpu_combined_percent_normalized",
+          "legendFormat": "node={{node}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Sink Flush Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "localprom"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ns"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 5,
-        "x": 16,
-        "y": 21
-      },
-      "id": 25,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.2.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(changefeed_checkpoint_hist_nanos_bucket[5m])) by (le))",
-          "hide": false,
-          "legendFormat": "p50 {{label_name}}",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.75, sum(rate(changefeed_checkpoint_hist_nanos_bucket[5m])) by (le))",
-          "hide": false,
-          "legendFormat": "p75 {{label_name}}",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(changefeed_checkpoint_hist_nanos_bucket[5m])) by (le))",
-          "hide": false,
-          "legendFormat": "p95 {{label_name}}",
-          "range": true,
-          "refId": "E"
-        }
-      ],
-      "title": "Time Spent Checkpointing",
+      "title": "Node CPU Usage",
       "type": "timeseries"
     },
     {
@@ -2759,17 +3239,17 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 0,
+        "h": 8,
+        "w": 10,
+        "x": 8,
         "y": 27
       },
-      "id": 77,
+      "id": 24,
       "options": {
         "legend": {
           "calcs": [],
@@ -2789,13 +3269,108 @@
             "uid": "localprom"
           },
           "editorMode": "code",
-          "expr": "sum by(scope) (rate(changefeed_sink_io_inflight{scope!=\"\"}[$__rate_interval]))",
+          "expr": "sum by (cpu, node) (rate(node_cpu_seconds_total{mode != \"idle\"}[$__rate_interval]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Batches currently in IO",
+      "title": "CPU Usage (Per processor)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "localprom"
+      },
+      "description": "sys_cpu_combined_percent_normalized",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 35
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "localprom"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_Active_bytes/node_memory_MemTotal_bytes",
+          "hide": false,
+          "legendFormat": "node={{node}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Node Memory Usage",
       "type": "timeseries"
     },
     {
@@ -2852,17 +3427,17 @@
               }
             ]
           },
-          "unit": "ns"
+          "unit": "Bps"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 5,
-        "x": 6,
-        "y": 27
+        "x": 8,
+        "y": 35
       },
-      "id": 80,
+      "id": 50,
       "options": {
         "legend": {
           "calcs": [],
@@ -2882,493 +3457,108 @@
             "uid": "localprom"
           },
           "editorMode": "code",
-          "expr": "sum by (scope) ((rate(changefeed_parallel_io_queue_nanos_sum{scope!=\"\"}[5m]) / rate(changefeed_parallel_io_queue_nanos_count{scope!=\"\"}[5m])))",
-          "legendFormat": "{{scope}}",
+          "expr": "sum by (node) (rate(node_network_transmit_bytes_total[$__rate_interval]))",
+          "legendFormat": "transmit[node={{node}}]",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Parallel IO Average Queue Time",
+      "title": "Node Network Bytes Transmit",
       "type": "timeseries"
     },
     {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 34
+      "datasource": {
+        "type": "prometheus",
+        "uid": "localprom"
       },
-      "id": 16,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
           },
-          "description": "sys_cpu_combined_percent_normalized",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
             },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 8,
-            "x": 0,
-            "y": 38
-          },
-          "id": 22,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
             },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
           },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "localprom"
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               },
-              "editorMode": "code",
-              "expr": "sys_cpu_combined_percent_normalized",
-              "legendFormat": "node={{node}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Node CPU Usage",
-          "type": "timeseries"
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
         },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 10,
-            "x": 8,
-            "y": 38
-          },
-          "id": 24,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "localprom"
-              },
-              "editorMode": "code",
-              "expr": "sum by (cpu, node) (rate(node_cpu_seconds_total{mode != \"idle\"}[$__rate_interval]))",
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "CPU Usage (Per processor)",
-          "type": "timeseries"
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 13,
+        "y": 35
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "localprom"
           },
-          "description": "sys_cpu_combined_percent_normalized",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 8,
-            "x": 0,
-            "y": 46
-          },
-          "id": 23,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "localprom"
-              },
-              "editorMode": "code",
-              "expr": "node_memory_Active_bytes/node_memory_MemTotal_bytes",
-              "hide": false,
-              "legendFormat": "node={{node}}",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Node Memory Usage",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "Bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 5,
-            "x": 8,
-            "y": 46
-          },
-          "id": 50,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "localprom"
-              },
-              "editorMode": "code",
-              "expr": "sum by (node) (rate(node_network_transmit_bytes_total[$__rate_interval]))",
-              "legendFormat": "transmit[node={{node}}]",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Node Network Bytes Transmit",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "localprom"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "Bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 5,
-            "x": 13,
-            "y": 46
-          },
-          "id": 51,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "localprom"
-              },
-              "editorMode": "code",
-              "expr": "sum by (node) (rate(node_network_receive_bytes_total[$__rate_interval]))",
-              "hide": false,
-              "legendFormat": "receive[node={{node}}]",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Node Network Bytes Receive",
-          "type": "timeseries"
+          "editorMode": "code",
+          "expr": "sum by (node) (rate(node_network_receive_bytes_total[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "receive[node={{node}}]",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "Resources",
-      "type": "row"
+      "title": "Node Network Bytes Receive",
+      "type": "timeseries"
     },
     {
       "collapsed": false,
@@ -3376,7 +3566,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 43
       },
       "id": 59,
       "panels": [],
@@ -3389,7 +3579,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 44
       },
       "id": 27,
       "panels": [
@@ -3453,7 +3643,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 40
+            "y": 64
           },
           "id": 31,
           "options": {

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
@@ -52,8 +52,28 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Emitted Messages"
+      isKvGraph={false}
+      sources={storeSources}
+      tenantSource={tenantSource}
+    >
+      <Axis units={AxisUnits.Count} label="actions">
+        <Metric
+          name="cr.node.changefeed.emitted_messages"
+          title="Messages"
+          nonNegativeRate
+        />
+        <Metric
+          name="cr.node.changefeed.flushes"
+          title="Flushes"
+          nonNegativeRate
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Commit Latency"
-      tooltip={`The difference between an event's MVCC timestamp and the time it was acknowledged as received by the downstream sink.`}
+      tooltip={`The difference between an event's MVCC timestamp and the time it was acknowledged as received by the downstream sink.  To reduce latency, consider setting schema_locked on the relevant tables`}
       isKvGraph={false}
       sources={storeSources}
       tenantSource={tenantSource}
@@ -88,21 +108,31 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Sink Counts"
+      title="Changefeed Restarts"
+      tooltip={`The rate of transient non-fatal errors, such as temporary connectivity issues or a rolling upgrade. This rate constantly becoming non-zero may indicate a more persistent issue.`}
       isKvGraph={false}
       sources={storeSources}
       tenantSource={tenantSource}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
-          name="cr.node.changefeed.emitted_messages"
-          title="Messages"
+          name="cr.node.changefeed.error_retries"
+          title="Retryable Errors"
           nonNegativeRate
         />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Backfill Pending Ranges"
+      tooltip={`The number of ranges being backfilled (ex: due to an initial scan or schema change) that are yet to completely enter the Changefeed pipeline.`}
+      isKvGraph={false}
+      sources={storeSources}
+    >
+      <Axis units={AxisUnits.Count} label="count">
         <Metric
-          name="cr.node.changefeed.flushes"
-          title="Flushes"
-          nonNegativeRate
+          name="cr.node.changefeed.backfill_pending_ranges"
+          title="Backfill Pending Ranges"
         />
       </Axis>
     </LineGraph>,
@@ -124,22 +154,6 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Changefeed Restarts"
-      tooltip={`The rate of transient non-fatal errors, such as temporary connectivity issues or a rolling upgrade. This rate constantly becoming non-zero may indicate a more persistent issue.`}
-      isKvGraph={false}
-      sources={storeSources}
-      tenantSource={tenantSource}
-    >
-      <Axis units={AxisUnits.Count} label="actions">
-        <Metric
-          name="cr.node.changefeed.error_retries"
-          title="Retryable Errors"
-          nonNegativeRate
-        />
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
       title="Oldest Protected Timestamp"
       tooltip={`The oldest data that any changefeed is protecting from being able to be automatically garbage collected.`}
       isKvGraph={false}
@@ -156,15 +170,37 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Backfill Pending Ranges"
-      tooltip={`The number of ranges being backfilled (ex: due to an initial scan or schema change) that are yet to completely enter the Changefeed pipeline.`}
+      title="Lagging Ranges"
       isKvGraph={false}
       sources={storeSources}
+      tooltip="Total number of ranges that haven't been able to emit a value for longer than the configured changefeed.lagging_ranges_threshold duration (default 10min)"
     >
-      <Axis units={AxisUnits.Count} label="count">
+      <Axis units={AxisUnits.Count} label="ranges">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.changefeed.aggregator_lagging_ranges"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={[nid]}
+          />
+        ))}
         <Metric
-          name="cr.node.changefeed.backfill_pending_ranges"
-          title="Backfill Pending Ranges"
+          name="cr.node.changefeed.aggregator_lagging_ranges"
+          title={"Total Lagging Ranges"}
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Lagging Range Percentage"
+      isKvGraph={false}
+      sources={storeSources}
+      tooltip="The percentage of ranges being tracked by changefeeds which are considered to be lagging behind"
+    >
+      <Axis units={AxisUnits.Percentage} label="lagging range percentage">
+        <Metric
+          name="cr.node.changefeed.aggregator_lagging_range_percentage"
+          title={"Lagging Range Percentage"}
+          downsampler={TimeSeriesQueryAggregator.AVG}
         />
       </Axis>
     </LineGraph>,
@@ -185,10 +221,10 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Ranges in catchup mode"
+      title="Ranges in Catchup Mode"
       isKvGraph={false}
       sources={storeSources}
-      tooltip="Total number of ranges with an active rangefeed that are performing catchup scan"
+      tooltip="Total number of ranges with an active rangefeed that are performing a catchup scan"
     >
       <Axis units={AxisUnits.Count} label="ranges">
         <Metric
@@ -200,7 +236,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="RangeFeed catchup scans duration"
+      title="RangeFeed Catchup Scans Duration"
       isKvGraph={false}
       sources={storeSources}
     >


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/102146

This PR adds `aggregator_lagging_range_percentage` and `aggregator_lagging_ranges` metrics to be able to measure the health of each aggregator node individually over time.  A Lagging Ranges graph has also been added to the db console page that just shows the total number of lagging ranges across the cluster.

Every `changefeed.lagging_ranges_log_frequency` (default 1 minute), each aggregator will check each of its ranges, recording the total count, then comparing them against its frontier to determine how many are behind by more than `changefeed.lagging_ranges_threshold` (default 10 minutes).

A graph for it has been added to the dbconsole.  The following images were taken while simulating unhealthy ranges by having certain keys resolved timestamps not be emitted by the kvfeed when a cluster setting was enabled.
<img width="964" alt="Screenshot 2023-06-21 at 9 54 22 AM" src="https://github.com/cockroachdb/cockroach/assets/6236424/fb6ad9d9-fc96-4afd-9df4-8d79b306fd4a">

I also added mention of `schema_locked` to the description of commit latency in dbconsole

---

This image just showcases that you can have all of this data displayed now:
<img width="791" alt="Screenshot 2023-06-21 at 9 45 41 AM" src="https://github.com/cockroachdb/cockroach/assets/6236424/c67fa73f-6665-4ecd-87e7-5923f6984289">


This is what I updated the actual grafana dashboard that shows up for roachtest testing to:
<img width="1302" alt="Screenshot 2023-06-21 at 9 53 06 AM" src="https://github.com/cockroachdb/cockroach/assets/6236424/238ad1f1-1b20-485d-909c-977c178e36cb">

---

Release note (ops change): New aggregator_lagging_range_percentage and aggregator_lagging_ranges metrics have been added to track how many ranges are behind a configurable changefeed.lagging_ranges_threshold duration.