### PR TITLE
streamingccl: fix a lint error to use the return value

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -358,11 +358,12 @@ func TestTenantStatusWithFutureCutoverTime(t *testing.T) {
 	// Cutover to a time far in the future, to make sure we see the pending-cutover state.
 	var cutoverTime time.Time
 	c.DestSysSQL.QueryRow(t, "SELECT clock_timestamp()").Scan(&cutoverTime)
-	cutoverTime.Add(time.Hour * 24)
+	cutoverTime = cutoverTime.Add(time.Hour * 24)
 	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO SYSTEM TIME $2::string`,
 		args.DestTenantName, cutoverTime)
 
 	require.Equal(c.T, "replication pending cutover", getTenantStatus())
+	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO LATEST`, args.DestTenantName)
 	unblockResumerExit()
 	jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 	require.Equal(c.T, "ready", getTenantStatus())


### PR DESCRIPTION
The return value was not used, meaning we were cutting over to now which is not what the test was trying to do.

This was caught by Ricky, running a lint that gave:
```
pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go:361:2:
Add doesn't have side effects and its return value is ignored (SA4017)
```

Epic: none

Release note: None