### PR TITLE
release-23.1: changefeedccl: maintain PTS record reference when altering changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -701,6 +702,10 @@ func generateNewProgress(
 ) (jobspb.Progress, hlc.Timestamp, error) {
 	prevHighWater := prevProgress.GetHighWater()
 	changefeedProgress := prevProgress.GetChangefeed()
+	ptsRecord := uuid.UUID{}
+	if changefeedProgress != nil {
+		ptsRecord = changefeedProgress.ProtectedTimestampRecord
+	}
 
 	haveHighwater := !(prevHighWater == nil || prevHighWater.IsEmpty())
 	haveCheckpoint := changefeedProgress != nil && changefeedProgress.Checkpoint != nil &&
@@ -743,6 +748,7 @@ func generateNewProgress(
 					Checkpoint: &jobspb.ChangefeedProgress_Checkpoint{
 						Spans: existingTargetSpans,
 					},
+					ProtectedTimestampRecord: ptsRecord,
 				},
 			},
 		}
@@ -772,6 +778,7 @@ func generateNewProgress(
 				Checkpoint: &jobspb.ChangefeedProgress_Checkpoint{
 					Spans: mergedSpanGroup.Slice(),
 				},
+				ProtectedTimestampRecord: ptsRecord,
 			},
 		},
 	}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -8543,3 +8543,43 @@ func TestChangefeedTopicNames(t *testing.T) {
 
 	cdcTest(t, testFn, feedTestForceSink("pubsub"))
 }
+
+// Regression test for (#103855).
+func TestAlterChangefeedAddTargetTracksPTS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE foo2 (a INT PRIMARY KEY, b STRING)`)
+		f2 := feed(t, f, `CREATE CHANGEFEED FOR table foo with protect_data_from_gc_on_pause,
+			resolved='1s', min_checkpoint_frequency='1s'`)
+		defer closeFeed(t, f2)
+
+		getNumPTSRecords := func() int {
+			rows := sqlDB.Query(t, "SELECT * FROM system.protected_ts_records")
+			r, err := sqlutils.RowsToStrMatrix(rows)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			return len(r)
+		}
+
+		jobFeed := f2.(cdctest.EnterpriseTestFeed)
+
+		_, _ = expectResolvedTimestamp(t, f2)
+
+		require.Equal(t, 1, getNumPTSRecords())
+
+		require.NoError(t, jobFeed.Pause())
+		sqlDB.Exec(t, fmt.Sprintf("ALTER CHANGEFEED %d ADD TABLE foo2 with initial_scan='yes'", jobFeed.JobID()))
+		require.NoError(t, jobFeed.Resume())
+
+		_, _ = expectResolvedTimestamp(t, f2)
+
+		require.Equal(t, 1, getNumPTSRecords())
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}


### PR DESCRIPTION
Backport 1/1 commits from #103868.

/cc @cockroachdb/release

Release justification: bug fix.

---

### changefeedccl: maintain PTS record reference when altering changefeed 

Previously, altering a changefeed in a particular manner would result in the changefeed losing its reference to its protected timestamp record. This would result in the creation of new PTS records without cleaning up the old ones. This change makes it so the old PTS record ID is copied when altering changefeeds so that we don't end up creating new ones.

This change does not address how to clean up old PTS records.

Informs: https://github.com/cockroachdb/cockroach/issues/103855
Release note: None
Epic: None

