### PR TITLE
release-22.2: changefeedccl: maintain PTS record reference when altering changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -671,6 +672,10 @@ func generateNewProgress(
 ) (jobspb.Progress, hlc.Timestamp, error) {
 	prevHighWater := prevProgress.GetHighWater()
 	changefeedProgress := prevProgress.GetChangefeed()
+	ptsRecord := uuid.UUID{}
+	if changefeedProgress != nil {
+		ptsRecord = changefeedProgress.ProtectedTimestampRecord
+	}
 
 	haveHighwater := !(prevHighWater == nil || prevHighWater.IsEmpty())
 	haveCheckpoint := changefeedProgress != nil && changefeedProgress.Checkpoint != nil &&
@@ -713,6 +718,7 @@ func generateNewProgress(
 					Checkpoint: &jobspb.ChangefeedProgress_Checkpoint{
 						Spans: existingTargetSpans,
 					},
+					ProtectedTimestampRecord: ptsRecord,
 				},
 			},
 		}
@@ -742,6 +748,7 @@ func generateNewProgress(
 				Checkpoint: &jobspb.ChangefeedProgress_Checkpoint{
 					Spans: mergedSpanGroup.Slice(),
 				},
+				ProtectedTimestampRecord: ptsRecord,
 			},
 		},
 	}


### PR DESCRIPTION
Backport 1/1 commits from #103868.

/cc @cockroachdb/release

Release justification: bug fix.

---

### changefeedccl: maintain PTS record reference when altering changefeed 

Previously, altering a changefeed in a particular manner would result in the changefeed losing its reference to its protected timestamp record. This would result in the creation of new PTS records without cleaning up the old ones. This change makes it so the old PTS record ID is copied when altering changefeeds so that we don't end up creating new ones.

This change does not address how to clean up old PTS records.

Informs: https://github.com/cockroachdb/cockroach/issues/103855
Release note: None
Epic: None

