### PR TITLE
internal/issues: do not rely on git tags to find milestone

### DIFF
--- a/pkg/cmd/internal/issues/BUILD.bazel
+++ b/pkg/cmd/internal/issues/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/internal/issues",
     visibility = ["//pkg/cmd:__subpackages__"],
     deps = [
+        "//pkg/build",
         "//pkg/roachprod/logger",
         "//pkg/util/version",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -267,10 +267,10 @@ test logs left over in: /go/src/github.com/cockroachdb/cockroach/artifacts/logTe
 
 			var buf strings.Builder
 			opts := opts // play it safe since we're mutating it below
-			opts.getLatestTag = func() (string, error) {
-				const tag = "v3.3.0"
-				_, _ = fmt.Fprintf(&buf, "getLatestTag: result %s\n", tag)
-				return tag, nil
+			opts.getBinaryVersion = func() string {
+				const v = "v3.3.0"
+				_, _ = fmt.Fprintf(&buf, "getBinaryVersion: result %s\n", v)
+				return v
 			}
 
 			l, err := logger.RootLogger("", false)

--- a/pkg/cmd/internal/issues/testdata/post/failure-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/failure-no-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestReplicateQueueRebalance failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestReplicateQueueRebalance failed" -label:branch-release-0.1: []
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/failure-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/failure-related-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestReplicateQueueRebalance failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestReplicateQueueRebalance failed" -label:branch-release-0.1: [github.Issue{Number:32, Title:"storage: TestReplicateQueueRebalance-similar failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]} github.Issue{Number:31, Title:"storage: TestReplicateQueueRebalance failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]}]
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/failure-with-url-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/failure-with-url-no-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "cmd/roachtest: some-roachtest failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "cmd/roachtest: some-roachtest failed" -label:branch-release-0.1: []
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/failure-with-url-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/failure-with-url-related-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "cmd/roachtest: some-roachtest failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "cmd/roachtest: some-roachtest failed" -label:branch-release-0.1: [github.Issue{Number:32, Title:"cmd/roachtest: some-roachtest-similar failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]} github.Issue{Number:31, Title:"cmd/roachtest: some-roachtest failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]}]
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/fatal-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/fatal-no-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestGossipHandlesReplacedNode failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestGossipHandlesReplacedNode failed" -label:branch-release-0.1: []
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/fatal-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/fatal-related-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestGossipHandlesReplacedNode failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestGossipHandlesReplacedNode failed" -label:branch-release-0.1: [github.Issue{Number:32, Title:"storage: TestGossipHandlesReplacedNode-similar failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]} github.Issue{Number:31, Title:"storage: TestGossipHandlesReplacedNode failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]}]
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/panic-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/panic-no-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestGossipHandlesReplacedNode failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestGossipHandlesReplacedNode failed" -label:branch-release-0.1: []
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/panic-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/panic-related-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestGossipHandlesReplacedNode failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: TestGossipHandlesReplacedNode failed" -label:branch-release-0.1: [github.Issue{Number:32, Title:"storage: TestGossipHandlesReplacedNode-similar failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]} github.Issue{Number:31, Title:"storage: TestGossipHandlesReplacedNode failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]}]
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/rsg-crash-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/rsg-crash-no-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "sql/tests: TestRandomSyntaxSQLSmith failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "sql/tests: TestRandomSyntaxSQLSmith failed" -label:branch-release-0.1: []
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/rsg-crash-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/rsg-crash-related-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "sql/tests: TestRandomSyntaxSQLSmith failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "sql/tests: TestRandomSyntaxSQLSmith failed" -label:branch-release-0.1: [github.Issue{Number:32, Title:"sql/tests: TestRandomSyntaxSQLSmith-similar failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]} github.Issue{Number:31, Title:"sql/tests: TestRandomSyntaxSQLSmith failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]}]
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/with-artifacts-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/with-artifacts-no-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: kv/splits/nodes=3/quiesce=true failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: kv/splits/nodes=3/quiesce=true failed" -label:branch-release-0.1: []
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}

--- a/pkg/cmd/internal/issues/testdata/post/with-artifacts-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/with-artifacts-related-issue.txt
@@ -3,7 +3,7 @@ post
 ----
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: kv/splits/nodes=3/quiesce=true failed" label:branch-release-0.1 -label:X-noreuse: []
 searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"C-test-failure" sort:created-desc "storage: kv/splits/nodes=3/quiesce=true failed" -label:branch-release-0.1: [github.Issue{Number:32, Title:"storage: kv/splits/nodes=3/quiesce=true-similar failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]} github.Issue{Number:31, Title:"storage: kv/splits/nodes=3/quiesce=true failed", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]}]
-getLatestTag: result v3.3.0
+getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
 github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}


### PR DESCRIPTION
We stopped relying on git tags to determine binary version a while ago, but there was still some leftover logic in the GitHub issue poster that relied on tags to determine the current binary version (and therefore a milestone to assign issues to).

With this change, we use `build.BinaryVersion` which relies the version contained in the `version.txt` file.

Epic: none

Release note: None