### PR TITLE
release-23.1: cluster-ui: fix database and table details sagas

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPageConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPageConnected.ts
@@ -48,11 +48,11 @@ const mapStateToProps = (state: AppState): DatabasesPageData => {
   const nodeRegions = nodeRegionsByIDSelector(state);
   const isTenant = selectIsTenant(state);
   return {
-    loading: databasesListState.inFlight,
-    loaded: databasesListState.valid,
-    lastError: databasesListState.lastError,
+    loading: !!databasesListState?.inFlight,
+    loaded: !!databasesListState?.valid,
+    lastError: databasesListState?.lastError,
     databases: deriveDatabaseDetailsMemoized({
-      dbListResp: databasesListState.data,
+      dbListResp: databasesListState?.data,
       databaseDetails: state.adminUI?.databaseDetails,
       nodeRegions,
       isTenant,

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.saga.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.saga.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { all, call, put, takeLatest } from "redux-saga/effects";
+import { all, call, put, takeEvery } from "redux-saga/effects";
 
 import { actions } from "./databaseDetails.reducer";
 import { ErrorWithKey, getDatabaseDetails } from "src/api";
@@ -45,7 +45,7 @@ export function* requestDatabaseDetailsSaga(
 
 export function* databaseDetailsSaga() {
   yield all([
-    takeLatest(actions.refresh, refreshDatabaseDetailsSaga),
-    takeLatest(actions.request, requestDatabaseDetailsSaga),
+    takeEvery(actions.refresh, refreshDatabaseDetailsSaga),
+    takeEvery(actions.request, requestDatabaseDetailsSaga),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/tableDetails.saga.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/tableDetails.saga.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { all, call, put, takeLatest } from "redux-saga/effects";
+import { all, call, put, takeEvery } from "redux-saga/effects";
 
 import { actions } from "./tableDetails.reducer";
 import { ErrorWithKey, getTableDetails, TableDetailsReqParams } from "src/api";
@@ -44,7 +44,7 @@ export function* requestTableDetailsSaga(
 
 export function* tableDetailsSaga() {
   yield all([
-    takeLatest(actions.refresh, refreshTableDetailsSaga),
-    takeLatest(actions.request, requestTableDetailsSaga),
+    takeEvery(actions.refresh, refreshTableDetailsSaga),
+    takeEvery(actions.request, requestTableDetailsSaga),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/databasesList/databasesList.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databasesList/databasesList.selectors.ts
@@ -17,7 +17,7 @@ import { Filters } from "../../queryFilter";
 
 export const databasesListSelector = createSelector(
   adminUISelector,
-  adminUiState => adminUiState.databasesList,
+  adminUiState => adminUiState?.databasesList,
 );
 
 export const selectDatabasesSortSetting = (state: AppState): SortSetting => {

--- a/pkg/ui/workspaces/cluster-ui/src/store/schemaInsights/schemaInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/schemaInsights/schemaInsights.selectors.ts
@@ -16,7 +16,7 @@ const selectSchemaInsightState = createSelector(
   adminUISelector,
   adminUiState => {
     if (!adminUiState.schemaInsights) return null;
-    return adminUiState.schemaInsights;
+    return adminUiState?.schemaInsights;
   },
 );
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
@@ -24,7 +24,7 @@ export const localStorageSelector = createSelector(
   adminUISelector,
   adminUiState => {
     if (adminUiState) {
-      return adminUiState.localStorage;
+      return adminUiState?.localStorage;
     }
     return {} as LocalStorageState;
   },

--- a/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
@@ -178,8 +178,8 @@ export const schemaInsightsSortLocalSetting = new LocalSetting<
 export const selectSchemaInsights = createSelector(
   (state: AdminUIState) => state.cachedData,
   adminUiState => {
-    if (!adminUiState.schemaInsights) return [];
-    return adminUiState.schemaInsights.data?.results;
+    if (!adminUiState?.schemaInsights) return [];
+    return adminUiState?.schemaInsights.data?.results;
   },
 );
 


### PR DESCRIPTION
Backport 1/1 commits from #105300.

/cc @cockroachdb/release

---

Epic: None

This change fixes the database details and table details sagas. Previously, we only took the latest request, causing only the last database/table to properly fetch statistics. All other databases/tables would have their reducer state updated to have their `inFlight` state to true, but no request would actually fire, causing the state to get stuck. Consequently, navigating to a database/table in this state would cause the page to render a Spinner, infinitely. With this change, we correctly fetch statistics for all databases/tables.

Fixes working on CC: https://www.loom.com/share/e7ac551b4eb242c3b32bb297fd207680

Release note (bug fix): This change fixes the data fetching for the database & table details pages. Prior to this change, some databases/tables could be permanently stuck in a loading state, causing their corresponding page to permanently show a Spinner. This change fixes the data fetching for these pages to ensure all databases/tables are loaded correctly.

---

Release justification: bug fix for CC Console only
