### PR TITLE
roachpb: increase server.span_stats.span_batch_limit default value to 2048

### DIFF
--- a/pkg/roachpb/span_stats.go
+++ b/pkg/roachpb/span_stats.go
@@ -18,7 +18,7 @@ import (
 
 // Put span statistics cluster settings here to avoid import cycle.
 
-const DefaultSpanStatsSpanLimit = 500
+const DefaultSpanStatsSpanLimit = 2048
 
 // SpanStatsBatchLimit registers the maximum number of spans allowed in a
 // span stats request payload.


### PR DESCRIPTION
The cluster setting `server.span_stats.span_batch_limit` controls the maximum number of spans that can be in a single roachpb.SpanStatsRequest.

This affects consumers of span stats, like `SHOW RANGES WITH DETAILS`.

Recent roachtest failures have shown that the previous default setting is too low.

Epic: none
Fixes: #105274, #105285, #105284, #105281, #105279, #105276, #105275, #105271

Release note (sql change): The default value for the cluster setting `server.span_stats.span_batch_limit` has been increased to 2048. The setting controls the maximum number of spans that can be batched into a single span stats request. This is of particular importance for invocations of `SHOW RANGES WITH DETAILS`.