### PR TITLE
rpc: make `ErrQuiescing` error exported from `rpc` package

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -2099,7 +2099,7 @@ func TestRejectDialOnQuiesce(t *testing.T) {
 	// First, we shouldn't be able to dial again, even though we already have a
 	// connection.
 	_, err = rpcCtx.GRPCDialNode(addr, serverNodeID, SystemClass).Connect(ctx)
-	require.ErrorIs(t, err, errQuiescing)
+	require.ErrorIs(t, err, ErrQuiescing)
 	require.True(t, grpcutil.IsConnectionRejected(err))
 	require.True(t, grpcutil.IsAuthError(err))
 

--- a/pkg/rpc/errors.go
+++ b/pkg/rpc/errors.go
@@ -16,11 +16,11 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// errQuiescing is returned from client interceptors when the server's
+// ErrQuiescing is returned from client interceptors when the server's
 // stopper is quiescing. The error is constructed to return true in
 // `grpcutil.IsConnectionRejected` which prevents infinite retry loops during
 // cluster shutdown, especially in unit testing.
-var errQuiescing = status.Error(codes.PermissionDenied, "refusing to dial; node is quiescing")
+var ErrQuiescing = status.Error(codes.PermissionDenied, "refusing to dial; node is quiescing")
 
 // ErrNotHeartbeated is returned by ConnHealth or Connection.Health when we have
 // not yet performed the first heartbeat. This error will typically only be

--- a/pkg/rpc/peer.go
+++ b/pkg/rpc/peer.go
@@ -282,7 +282,7 @@ func (p *peer) run(ctx context.Context, report func(error), done func()) {
 		// If ctx is done, Stopper is draining. Unconditionally override the error
 		// to clean up the logging in this case.
 		if ctx.Err() != nil {
-			err = errQuiescing
+			err = ErrQuiescing
 		}
 
 		// Transition peer into unhealthy state.
@@ -293,7 +293,7 @@ func (p *peer) run(ctx context.Context, report func(error), done func()) {
 		// whether this happened after looping around.
 		p.maybeDelete(ctx, now)
 
-		if errors.Is(err, errQuiescing) {
+		if errors.Is(err, ErrQuiescing) {
 			// Heartbeat loop ended due to shutdown. Exit the probe, it won't be
 			// started again since that means running an async task through the
 			// Stopper.
@@ -558,7 +558,7 @@ func maybeLogOnFailedHeartbeat(
 	snap PeerSnap, // already accounting for `err`
 	every *log.EveryN,
 ) {
-	if errors.Is(err, errQuiescing) {
+	if errors.Is(err, ErrQuiescing) {
 		return
 	}
 	// If the error is wrapped in InitialHeartbeatFailedError, unwrap it because that
@@ -695,11 +695,11 @@ func (p *peer) onHeartbeatFailed(
 // quiescing.
 func (p *peer) onQuiesce(report func(error)) {
 	// Stopper quiescing, node shutting down.
-	report(errQuiescing)
+	report(ErrQuiescing)
 	// NB: it's important that connFuture is resolved, or a caller sitting on
 	// `c.ConnectNoBreaker` would never be unblocked; after all, the probe won't
 	// start again in the future.
-	p.snap().c.connFuture.Resolve(nil, errQuiescing)
+	p.snap().c.connFuture.Resolve(nil, ErrQuiescing)
 }
 
 func (p PeerSnap) deletable(now time.Time) bool {


### PR DESCRIPTION
This change makes `ErrQuiescing` exported to reuse it later in `server` package (in scope of PR #95429) to rely on it as an indicator of initiated node shutdown.

Part of #95429

Release note: None