### PR TITLE
configprofiles: further automate the replication profiles

### DIFF
--- a/pkg/configprofiles/testdata/multitenant-app-repl
+++ b/pkg/configprofiles/testdata/multitenant-app-repl
@@ -1,7 +1,7 @@
 profile
-multitenant+app+sharedservice
+multitenant+app+sharedservice+repl
 ----
-canonical profile name: multitenant+app+sharedservice
+canonical profile name: multitenant+app+sharedservice+repl
 server started
 
 connect-tenant

--- a/pkg/configprofiles/testdata/multitenant-noapp
+++ b/pkg/configprofiles/testdata/multitenant-noapp
@@ -15,10 +15,14 @@ WHERE variable IN (
 'spanconfig.tenant_coalesce_adjacent.enabled',
 'sql.drop_tenant.enabled',
 'sql.create_tenant.default_template',
-'server.controller.default_tenant'
+'server.controller.default_tenant',
+'kv.rangefeed.enabled',
+'cross_cluster_replication.enabled'
 )
 ORDER BY variable
 ----
+cross_cluster_replication.enabled false
+kv.rangefeed.enabled false
 server.controller.default_tenant system
 server.secondary_tenants.redact_trace.enabled false
 spanconfig.storage_coalesce_adjacent.enabled false

--- a/pkg/configprofiles/testdata/multitenant-noapp-repl
+++ b/pkg/configprofiles/testdata/multitenant-noapp-repl
@@ -1,13 +1,8 @@
 profile
-multitenant+app+sharedservice
+multitenant+noapp+repl
 ----
-canonical profile name: multitenant+app+sharedservice
+canonical profile name: multitenant+noapp+repl
 server started
-
-connect-tenant
-application
-----
-ok
 
 system-sql
 SELECT variable, value FROM [SHOW ALL CLUSTER SETTINGS]
@@ -26,9 +21,9 @@ WHERE variable IN (
 )
 ORDER BY variable
 ----
-cross_cluster_replication.enabled false
-kv.rangefeed.enabled false
-server.controller.default_tenant application
+cross_cluster_replication.enabled true
+kv.rangefeed.enabled true
+server.controller.default_tenant system
 server.secondary_tenants.redact_trace.enabled false
 spanconfig.storage_coalesce_adjacent.enabled false
 spanconfig.tenant_coalesce_adjacent.enabled false
@@ -47,8 +42,6 @@ ORDER BY tenant_id, name
 ----
 2 sql.scatter.allow_for_secondary_tenant.enabled true
 2 sql.split_at.allow_for_secondary_tenant.enabled true
-3 sql.scatter.allow_for_secondary_tenant.enabled true
-3 sql.split_at.allow_for_secondary_tenant.enabled true
 
 system-sql
 SHOW TENANTS WITH CAPABILITIES
@@ -73,13 +66,18 @@ SHOW TENANTS WITH CAPABILITIES
 2 template ready none can_view_tsdb_metrics true
 2 template ready none exempt_from_rate_limiting true
 2 template ready none span_config_bounds {}
-3 application ready shared can_admin_relocate_range true
-3 application ready shared can_admin_scatter true
-3 application ready shared can_admin_split true
-3 application ready shared can_admin_unsplit true
-3 application ready shared can_check_consistency true
-3 application ready shared can_use_nodelocal_storage true
-3 application ready shared can_view_node_info true
-3 application ready shared can_view_tsdb_metrics true
-3 application ready shared exempt_from_rate_limiting true
-3 application ready shared span_config_bounds {}
+
+system-sql
+CREATE TENANT application LIKE template
+----
+<no rows>
+
+system-sql
+ALTER TENANT application START SERVICE SHARED
+----
+<no rows>
+
+connect-tenant
+application
+----
+ok

--- a/pkg/configprofiles/testdata/replication-source
+++ b/pkg/configprofiles/testdata/replication-source
@@ -1,5 +1,5 @@
 profile
 replication-source
 ----
-canonical profile name: multitenant+app+sharedservice
+canonical profile name: multitenant+app+sharedservice+repl
 server started

--- a/pkg/configprofiles/testdata/replication-target
+++ b/pkg/configprofiles/testdata/replication-target
@@ -1,5 +1,5 @@
 profile
 replication-target
 ----
-canonical profile name: multitenant+noapp
+canonical profile name: multitenant+noapp+repl
 server started


### PR DESCRIPTION
This patch introduces the following two profiles:

- `multitenant+app+sharedservice+repl`
- `multitenant+noapp+repl`

Both extend the other profile without the `+repl` suffix, with the following definition:

```sql
SET CLUSTER SETTING kv.rangefeed.enabled=true;
SET CLUSTER SETTING cross_cluster_replication.enabled = true;
```

Furthermore, the profile aliases `replication-source` and `replication-target` are updated to point to the two new profiles.

Release note: None
Fixes #105296.
Epic: CRDB-26691