### PR TITLE
release-23.1: ttl: allow inbound foreign keys on TTL tables

### DIFF
--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -198,16 +198,6 @@ func (desc *wrapper) ValidateForwardReferences(
 		}
 	}
 
-	// Row-level TTL is not compatible with inbound foreign keys.
-	// This check should be in ValidateSelf but interferes with AllocateIDs.
-	if desc.HasRowLevelTTL() && len(desc.InboundForeignKeys()) > 0 {
-		vea.Report(unimplemented.NewWithIssuef(
-			76407,
-			`foreign keys to table with TTL %q are not permitted`,
-			desc.GetName(),
-		))
-	}
-
 	// Check enforced outbound foreign keys.
 	for _, fk := range desc.EnforcedOutboundForeignKeys() {
 		vea.Report(desc.validateOutboundFK(fk.ForeignKeyDesc(), vdg))

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -962,31 +962,6 @@ ALTER TABLE tbl_crdb_internal_expiration_already_defined SET (ttl_expire_after =
 
 subtest end
 
-subtest foreign_key_constraint
-
-statement ok
-CREATE TABLE ttl_table (id INT PRIMARY KEY) WITH (ttl_expire_after = '10 mins')
-
-statement error foreign keys to table with TTL "ttl_table" are not permitted
-CREATE TABLE ref_table (id INT PRIMARY KEY, ref INT REFERENCES ttl_table(id))
-
-statement ok
-CREATE TABLE ref_table (id INT PRIMARY KEY, ref INT)
-
-statement error foreign keys to table with TTL "ttl_table" are not permitted
-ALTER TABLE ref_table ADD CONSTRAINT fk FOREIGN KEY (ref) REFERENCES ttl_table (id)
-
-statement ok
-CREATE TABLE become_ttl_table (id INT PRIMARY KEY)
-
-statement ok
-CREATE TABLE become_ref_table (id INT PRIMARY KEY, ref INT REFERENCES become_ttl_table(id))
-
-statement error foreign keys to table with TTL "become_ttl_table" are not permitted
-ALTER TABLE become_ttl_table SET (ttl_expire_after = '10 mins')
-
-subtest end
-
 subtest desc_pk_with_ttl
 
 statement error non-ascending ordering on PRIMARY KEYs are not supported

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -423,13 +423,6 @@ func fallBackIfDescColInRowLevelTTLTables(b BuildCtx, tableID catid.DescID, t al
 			panic(scerrors.NotImplementedErrorf(t.n, "non-ascending ordering on PRIMARY KEYs are not supported"))
 		}
 	}
-
-	_, _, ns := scpb.FindNamespace(b.QueryByID(tableID))
-	// Panic if there are any inbound FK constraints.
-	if _, _, inboundFKElem := scpb.FindForeignKeyConstraint(b.BackReferences(tableID)); inboundFKElem != nil {
-		panic(scerrors.NotImplementedErrorf(t.n,
-			`foreign keys to table with TTL %q are not permitted`, ns.Name))
-	}
 }
 
 func mustRetrievePrimaryIndexElement(b BuildCtx, tableID catid.DescID) (res *scpb.PrimaryIndex) {

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -915,3 +915,99 @@ func TestOutboundForeignKey(t *testing.T) {
 	results := sqlDB.QueryStr(t, "SELECT * FROM tbl")
 	require.Empty(t, results)
 }
+
+func TestInboundForeignKeyOnDeleteCascade(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	th, cleanupFunc := newRowLevelTTLTestJobTestHelper(
+		t,
+		&sql.TTLTestingKnobs{
+			AOSTDuration:     &zeroDuration,
+			ReturnStatsError: true,
+		},
+		false, /* testMultiTenant */
+		1,     /* numNodes */
+	)
+	defer cleanupFunc()
+
+	sqlDB := th.sqlDB
+	sqlDB.Exec(t, "CREATE TABLE tbl (id INT PRIMARY KEY, expire_at TIMESTAMPTZ) WITH (ttl_expiration_expression = 'expire_at')")
+	sqlDB.Exec(t, "CREATE TABLE child (id INT PRIMARY KEY, tbl_id INT REFERENCES tbl (id) ON DELETE CASCADE)")
+
+	sqlDB.Exec(t, "INSERT INTO tbl VALUES (1, '2020-01-01')")
+	sqlDB.Exec(t, "INSERT INTO child VALUES (1, 1)")
+
+	// Force the schedule to execute.
+	th.waitForScheduledJob(t, jobs.StatusSucceeded, "")
+
+	results := sqlDB.QueryStr(t, "SELECT * FROM tbl")
+	require.Empty(t, results)
+
+	results = sqlDB.QueryStr(t, "SELECT * FROM child")
+	require.Empty(t, results)
+}
+
+func TestInboundForeignKeyOnDeleteRestrict(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	th, cleanupFunc := newRowLevelTTLTestJobTestHelper(
+		t,
+		&sql.TTLTestingKnobs{
+			AOSTDuration:     &zeroDuration,
+			ReturnStatsError: true,
+		},
+		false, /* testMultiTenant */
+		1,     /* numNodes */
+	)
+	defer cleanupFunc()
+
+	sqlDB := th.sqlDB
+	sqlDB.Exec(t, "CREATE TABLE tbl (id INT PRIMARY KEY, expire_at TIMESTAMPTZ) WITH (ttl_expiration_expression = 'expire_at')")
+	sqlDB.Exec(t, "CREATE TABLE child (id INT PRIMARY KEY, tbl_id INT REFERENCES tbl (id) ON DELETE RESTRICT)")
+
+	sqlDB.Exec(t, "INSERT INTO tbl VALUES (1, '2020-01-01')")
+	sqlDB.Exec(t, "INSERT INTO child VALUES (1, 1)")
+
+	// Force the schedule to execute.
+	th.waitForScheduledJob(t, jobs.StatusFailed, `delete on table "tbl" violates foreign key constraint "child_tbl_id_fkey" on table "child"`)
+
+	results := sqlDB.QueryStr(t, "SELECT * FROM tbl")
+	require.Len(t, results, 1)
+
+	results = sqlDB.QueryStr(t, "SELECT * FROM child")
+	require.Len(t, results, 1)
+}
+
+func TestInboundForeignKeyOnDeleteRestrictNull(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	th, cleanupFunc := newRowLevelTTLTestJobTestHelper(
+		t,
+		&sql.TTLTestingKnobs{
+			AOSTDuration:     &zeroDuration,
+			ReturnStatsError: true,
+		},
+		false, /* testMultiTenant */
+		1,     /* numNodes */
+	)
+	defer cleanupFunc()
+
+	sqlDB := th.sqlDB
+	sqlDB.Exec(t, "CREATE TABLE tbl (id INT PRIMARY KEY, expire_at TIMESTAMPTZ) WITH (ttl_expiration_expression = 'expire_at')")
+	sqlDB.Exec(t, "CREATE TABLE child (id INT PRIMARY KEY, tbl_id INT REFERENCES tbl (id) ON DELETE RESTRICT)")
+
+	sqlDB.Exec(t, "INSERT INTO tbl VALUES (1, '2020-01-01')")
+	sqlDB.Exec(t, "INSERT INTO child VALUES (1, NULL)")
+
+	// Force the schedule to execute.
+	th.waitForScheduledJob(t, jobs.StatusSucceeded, "")
+
+	results := sqlDB.QueryStr(t, "SELECT * FROM tbl")
+	require.Len(t, results, 0)
+
+	results = sqlDB.QueryStr(t, "SELECT * FROM child")
+	require.Len(t, results, 1)
+}


### PR DESCRIPTION
Backport 2/2 commits from #101376.

/cc @cockroachdb/release

---

Fixes #76407

This change allows TTL tables to have inbound foreign keys. If the inbound foreign key has the ON DELETE CASCADE option, the TTL job will work as usual. If it has the ON DELETE RESTRICT option, the TTL job will fail if a row references the TTL table (see #101372).

Release note (sql change): Allow inbound foreign keys on TTL tables.

Release justification: Unblock customers needing inbound FKs on TTL table.