### PR TITLE
sql: enable secondary_region test

### DIFF
--- a/pkg/ccl/multiregionccl/testdata/secondary_region
+++ b/pkg/ccl/multiregionccl/testdata/secondary_region
@@ -1,6 +1,3 @@
-skip issue-num=98020
-----
-
 new-cluster localities=us-east-1,us-east-1,us-west-1,us-west-1,us-central-1,us-central-1,us-central-1,eu-west-1,eu-west-1,eu-west-1
 ----
 


### PR DESCRIPTION
we unskipped `regional_by_table` test in #104877 and haven't seen any error for 7 days now. But still unskipping one test at a time.

Informs: https://github.com/cockroachdb/cockroach/issues/98020

Release note: None