### PR TITLE
builtins: create function to aggregate aggregated stmt metadata

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -337,6 +337,8 @@
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="cardinality"></a><code>cardinality(input: anyelement[]) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of elements contained in <code>input</code></p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="crdb_internal.merge_aggregated_stmt_metadata"></a><code>crdb_internal.merge_aggregated_stmt_metadata(input: jsonb[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Merge an array of AggregatedStatementMetadata into a single JSONB object</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="crdb_internal.merge_statement_stats"></a><code>crdb_internal.merge_statement_stats(input: jsonb[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Merge an array of appstatspb.StatementStatistics into a single JSONB object</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="crdb_internal.merge_stats_metadata"></a><code>crdb_internal.merge_stats_metadata(input: jsonb[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Merge an array of StmtStatsMetadata into a single JSONB object</p>

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -329,7 +329,7 @@ FROM %s
 		}
 		// If there are no results from the activity table, retrieve the data from the persisted table.
 		if stmtsRuntime == 0 {
-			stmtsRuntime, err = getRuntime(fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix))
+			stmtsRuntime, err = getRuntime("crdb_internal.statement_statistics_persisted" + tableSuffix)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -354,7 +354,7 @@ FROM %s
 		}
 		// If there are no results from the activity table, retrieve the data from the persisted table.
 		if txnsRuntime == 0 {
-			txnsRuntime, err = getRuntime(fmt.Sprintf("crdb_internal.transaction_statistics_persisted%s", tableSuffix))
+			txnsRuntime, err = getRuntime("crdb_internal.transaction_statistics_persisted" + tableSuffix)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -620,7 +620,7 @@ GROUP BY
 			ctx,
 			ie,
 			queryFormat,
-			fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix),
+			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			"combined-stmts-persisted-by-interval",
 			whereClause,
 			args,
@@ -801,7 +801,7 @@ GROUP BY
 			ctx,
 			ie,
 			queryFormat,
-			fmt.Sprintf("crdb_internal.transaction_statistics_persisted%s", tableSuffix),
+			"crdb_internal.transaction_statistics_persisted"+tableSuffix,
 			"combined-txns-persisted-by-interval",
 			whereClause,
 			args,
@@ -932,7 +932,7 @@ GROUP BY
 		}
 		query = fmt.Sprintf(
 			queryFormat,
-			fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix),
+			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			whereClause)
 		it, err = ie.QueryIteratorEx(ctx, "stmts-persisted-for-txn", nil,
 			sessiondata.NodeUserSessionDataOverride, query, args...)
@@ -1234,7 +1234,7 @@ func getTotalStatementDetails(
 	if row == nil || row.Len() == 0 {
 		query = fmt.Sprintf(
 			queryFormat,
-			fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix),
+			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			whereClause)
 		row, err = ie.QueryRowEx(ctx, "combined-stmts-persisted-details-total", nil,
 			sessiondata.NodeUserSessionDataOverride, query, args...)
@@ -1346,7 +1346,7 @@ func getStatementDetailsPerAggregatedTs(
 		}
 		query = fmt.Sprintf(
 			queryFormat,
-			fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix),
+			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			whereClause,
 			len(args))
 
@@ -1529,7 +1529,7 @@ func getStatementDetailsPerPlanHash(
 		}
 		query = fmt.Sprintf(
 			queryFormat,
-			fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix),
+			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			whereClause,
 			len(args))
 		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-persisted-details-by-plan-hash", nil,

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -591,7 +591,20 @@ FROM (SELECT fingerprint_id,
 		it, err = getIterator(
 			ctx,
 			ie,
-			queryFormat,
+			// The statement activity table has aggregated metadata.
+			`
+SELECT *
+FROM (SELECT fingerprint_id,
+             array_agg(distinct transaction_fingerprint_id),
+             app_name,
+             max(aggregated_ts)                                                AS aggregated_ts,
+             crdb_internal.merge_aggregated_stmt_metadata(array_agg(metadata)) AS metadata,
+             crdb_internal.merge_statement_stats(array_agg(statistics))        AS statistics
+      FROM %s %s
+      GROUP BY
+          fingerprint_id,
+          app_name) %s
+%s`,
 			"crdb_internal.statement_activity",
 			"combined-stmts-activity-by-interval",
 			whereClause,
@@ -900,18 +913,28 @@ GROUP BY
 	const expectedNumDatums = 5
 	var it isql.Rows
 	var err error
-	var query string
 
 	if activityTableHasAllData {
-		query = fmt.Sprintf(queryFormat, "crdb_internal.statement_activity", whereClause)
 		it, err = ie.QueryIteratorEx(ctx, "stmts-activity-for-txn", nil,
-			sessiondata.NodeUserSessionDataOverride, query, args...)
+			sessiondata.NodeUserSessionDataOverride, fmt.Sprintf(`
+SELECT fingerprint_id,
+       transaction_fingerprint_id,
+       crdb_internal.merge_aggregated_stmt_metadata(array_agg(metadata))   AS metadata,
+       crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
+       app_name
+FROM crdb_internal.statement_activity %s
+GROUP BY
+    fingerprint_id,
+    transaction_fingerprint_id,
+    app_name`, whereClause),
+			args...)
 		if err != nil {
 			return nil, serverError(ctx, err)
 		}
 	}
 
 	// If there are no results from the activity table, retrieve the data from the persisted table.
+	var query string
 	if it == nil || !it.HasResults() {
 		if it != nil {
 			err = closeIterator(it, err)
@@ -1210,24 +1233,30 @@ LIMIT 1`
 
 	var row tree.Datums
 	var err error
-	var query string
 
 	if activityTableHasAllData {
-		query = fmt.Sprintf(queryFormat, "crdb_internal.statement_activity", whereClause)
 		row, err = ie.QueryRowEx(ctx, "combined-stmts-activity-details-total", nil,
-			sessiondata.NodeUserSessionDataOverride, query, args...)
+			sessiondata.NodeUserSessionDataOverride, fmt.Sprintf(`
+SELECT crdb_internal.merge_aggregated_stmt_metadata(array_agg(metadata)) AS metadata,
+       array_agg(app_name)                                               AS app_names,
+       crdb_internal.merge_statement_stats(array_agg(statistics))        AS statistics,
+       encode(fingerprint_id, 'hex')                                     AS fingerprint_id
+FROM crdb_internal.statement_activity %s
+GROUP BY
+    fingerprint_id
+LIMIT 1`, whereClause), args...)
 		if err != nil {
 			return statement, serverError(ctx, err)
 		}
 	}
 	// If there are no results from the activity table, retrieve the data from the persisted table.
 	if row == nil || row.Len() == 0 {
-		query = fmt.Sprintf(
-			queryFormat,
-			"crdb_internal.statement_statistics_persisted"+tableSuffix,
-			whereClause)
 		row, err = ie.QueryRowEx(ctx, "combined-stmts-persisted-details-total", nil,
-			sessiondata.NodeUserSessionDataOverride, query, args...)
+			sessiondata.NodeUserSessionDataOverride,
+			fmt.Sprintf(
+				queryFormat,
+				"crdb_internal.statement_statistics_persisted"+tableSuffix,
+				whereClause), args...)
 		if err != nil {
 			return statement, serverError(ctx, err)
 		}
@@ -1236,9 +1265,9 @@ LIMIT 1`
 	// If there are no results from the persisted table, retrieve the data from the combined view
 	// with data in-memory.
 	if row.Len() == 0 {
-		query = fmt.Sprintf(queryFormat, "crdb_internal.statement_statistics", whereClause)
 		row, err = ie.QueryRowEx(ctx, "combined-stmts-details-total-with-memory", nil,
-			sessiondata.NodeUserSessionDataOverride, query, args...)
+			sessiondata.NodeUserSessionDataOverride,
+			fmt.Sprintf(queryFormat, "crdb_internal.statement_statistics", whereClause), args...)
 		if err != nil {
 			return statement, serverError(ctx, err)
 		}
@@ -1308,21 +1337,24 @@ ORDER BY aggregated_ts ASC
 LIMIT $%d`
 	var it isql.Rows
 	var err error
-	var query string
 	defer func() {
 		err = closeIterator(it, err)
 	}()
 	args = append(args, limit)
 
 	if activityTableHasAllData {
-		query = fmt.Sprintf(
-			queryFormat,
-			"crdb_internal.statement_activity",
-			whereClause,
-			len(args))
-
 		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-activity-details-by-aggregated-timestamp", nil,
-			sessiondata.NodeUserSessionDataOverride, query, args...)
+			sessiondata.NodeUserSessionDataOverride,
+			fmt.Sprintf(`
+SELECT aggregated_ts,
+       crdb_internal.merge_aggregated_stmt_metadata(array_agg(metadata)) AS metadata,
+       crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
+FROM crdb_internal.statement_activity %s
+GROUP BY
+    aggregated_ts
+ORDER BY aggregated_ts ASC
+LIMIT $%d`, whereClause, len(args)),
+			args...)
 
 		if err != nil {
 			return nil, serverError(ctx, err)
@@ -1330,6 +1362,7 @@ LIMIT $%d`
 	}
 
 	// If there are no results from the activity table, retrieve the data from the persisted table.
+	var query string
 	if it == nil || !it.HasResults() {
 		if it != nil {
 			err = closeIterator(it, err)
@@ -1483,7 +1516,7 @@ func getStatementDetailsPerPlanHash(
 	expectedNumDatums := 5
 	const queryFormat = `
 SELECT plan_hash,
-       (statistics - > 'statistics' - > 'planGists' ->>0)         AS plan_gist,
+       (statistics -> 'statistics' -> 'planGists' ->> 0)          AS plan_gist,
        crdb_internal.merge_stats_metadata(array_agg(metadata))    AS metadata,
        crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
        index_recommendations
@@ -1493,28 +1526,41 @@ GROUP BY
     plan_gist,
     index_recommendations
 LIMIT $%d`
+
 	args = append(args, limit)
-	var it isql.Rows
 	var err error
-	var query string
+	// We will have 1 open iterator at a time. For the deferred close operation, we will
+	// only close the iterator if there were no errors creating the iterator. Closing an
+	// iterator that returned an error on creation will cause a nil pointer deref.
+	var it isql.Rows
+	var iterErr error
 	defer func() {
-		err = closeIterator(it, err)
+		if iterErr == nil {
+			err = closeIterator(it, err)
+		}
 	}()
 
 	if activityTableHasAllData {
-		query = fmt.Sprintf(
-			queryFormat,
-			"crdb_internal.statement_activity",
-			whereClause,
-			len(args))
-		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-activity-details-by-plan-hash", nil,
-			sessiondata.NodeUserSessionDataOverride, query, args...)
-		if err != nil {
+		it, iterErr = ie.QueryIteratorEx(ctx, "combined-stmts-activity-details-by-plan-hash", nil,
+			sessiondata.NodeUserSessionDataOverride, fmt.Sprintf(`
+SELECT plan_hash,
+       (statistics -> 'statistics' -> 'planGists' ->> 0)                 AS plan_gist,
+       crdb_internal.merge_aggregated_stmt_metadata(array_agg(metadata)) AS metadata,
+       crdb_internal.merge_statement_stats(array_agg(statistics))        AS statistics,
+       index_recommendations
+FROM crdb_internal.statement_activity %s
+GROUP BY
+    plan_hash,
+    plan_gist,
+    index_recommendations
+LIMIT $%d`, whereClause, len(args)), args...)
+		if iterErr != nil {
 			return nil, serverError(ctx, err)
 		}
 	}
 
 	// If there are no results from the activity table, retrieve the data from the persisted table.
+	var query string
 	if it == nil || !it.HasResults() {
 		if it != nil {
 			err = closeIterator(it, err)
@@ -1524,9 +1570,9 @@ LIMIT $%d`
 			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			whereClause,
 			len(args))
-		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-persisted-details-by-plan-hash", nil,
+		it, iterErr = ie.QueryIteratorEx(ctx, "combined-stmts-persisted-details-by-plan-hash", nil,
 			sessiondata.NodeUserSessionDataOverride, query, args...)
-		if err != nil {
+		if iterErr != nil {
 			return nil, serverError(ctx, err)
 		}
 	}
@@ -1536,9 +1582,9 @@ LIMIT $%d`
 	if !it.HasResults() {
 		err = closeIterator(it, err)
 		query = fmt.Sprintf(queryFormat, "crdb_internal.statement_statistics", whereClause, len(args))
-		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-details-by-plan-hash-with-memory", nil,
+		it, iterErr = ie.QueryIteratorEx(ctx, "combined-stmts-details-by-plan-hash-with-memory", nil,
 			sessiondata.NodeUserSessionDataOverride, query, args...)
-		if err != nil {
+		if iterErr != nil {
 			return nil, serverError(ctx, err)
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4013,3 +4013,27 @@ statement ok
 CREATE TABLE conscheckresult AS (SELECT * FROM crdb_internal.check_consistency(false, '', ''));
 
 subtest end
+
+subtest merge_aggregated_stmts_metadata
+
+query T
+SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[ '{ "db": [ "defaultdb", "movr" ], "distSQLCount": 1, "failedCount": 2, "fullScanCount": 0, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 33, "vecCount": 0 }'::JSON, '{ "db": ["tpcc"], "distSQLCount": 1, "failedCount": 2, "fullScanCount": 0, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 85, "vecCount": 2 }'::JSON ])
+----
+{"appNames": [], "db": ["defaultdb", "movr", "tpcc"], "distSQLCount": 2, "failedCount": 4, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 0, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 118, "vecCount": 2}
+
+query T
+SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[])
+----
+{"appNames": [], "db": [], "distSQLCount": 0, "failedCount": 0, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 0, "implicitTxn": false, "query": "", "querySummary": "", "stmtType": "", "totalCount": 0, "vecCount": 0}
+
+query T
+SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[ '{ "db": [ "defaultdb", "tpcc" ], "distSQLCount": 1, "failedCount": 2, "fullScanCount": 0, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 33, "vecCount": 0 }'::JSON, '{ "db": ["tpcc"], "distSQLCount": 23, "failedCount": 0, "fullScanCount": 99, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 3, "vecCount": 2 }'::JSON, '{"hello": "world"}'::JSON ])
+----
+{"appNames": [], "db": ["defaultdb", "tpcc"], "distSQLCount": 47, "failedCount": 2, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 198, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 39, "vecCount": 4}
+
+query T
+SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[ '{"aMalformedMetadaObj": 123}'::JSON, '{"key": "value"}'::JSON ])
+----
+{"appNames": [], "db": [], "distSQLCount": 0, "failedCount": 0, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 0, "implicitTxn": false, "query": "", "querySummary": "", "stmtType": "", "totalCount": 0, "vecCount": 0}
+
+subtest end

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4331,6 +4331,61 @@ value if you rely on the HLC for accuracy.`,
 			Volatility: volatility.Immutable,
 		},
 	),
+	"crdb_internal.merge_aggregated_stmt_metadata": makeBuiltin(arrayProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "input", Typ: types.JSONBArray}},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				arr := tree.MustBeDArray(args[0])
+				metadata := &appstatspb.AggregatedStatementMetadata{}
+
+				var other appstatspb.AggregatedStatementMetadata
+				for _, metadataDatum := range arr.Array {
+					if metadataDatum == tree.DNull {
+						continue
+					}
+
+					metadataJSON := tree.MustBeDJSON(metadataDatum).JSON
+					// Ensure we start with an empty slice, otherwise the decode method below
+					// will just append the JSON datum value to what's already there.
+					other.Databases = nil
+					err := sqlstatsutil.DecodeAggregatedMetadataJSON(metadataJSON, &other)
+					//  Failure to decode should NOT return an error. Instead let's just ignore
+					// this JSON object that is not the correct format.
+					if err != nil {
+						continue
+					}
+
+					// Aggregate relevant stats.
+					metadata.Databases = util.CombineUnique(metadata.Databases, other.Databases)
+
+					metadata.DistSQLCount += other.DistSQLCount
+					metadata.FailedCount += other.FailedCount
+					metadata.FullScanCount += other.FullScanCount
+					metadata.VecCount += other.VecCount
+					metadata.TotalCount += other.TotalCount
+				}
+
+				// Set the constant info from the last decoded metadata object. If there were no
+				// elements then we can skip this as we are already at the zero values.
+				if len(arr.Array) > 0 {
+					metadata.ImplicitTxn = other.ImplicitTxn
+					metadata.Query = other.Query
+					metadata.QuerySummary = other.QuerySummary
+					metadata.StmtType = other.StmtType
+				}
+
+				aggregatedJSON, err := sqlstatsutil.BuildStmtDetailsMetadataJSON(metadata)
+				if err != nil {
+					return nil, err
+				}
+
+				return tree.NewDJSON(aggregatedJSON), nil
+			},
+			Info:       "Merge an array of AggregatedStatementMetadata into a single JSONB object",
+			Volatility: volatility.Immutable,
+		},
+	),
 
 	// Enum functions.
 	"enum_first": makeBuiltin(

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2426,6 +2426,7 @@ var builtinOidsArray = []string{
 	2453: `crdb_internal.reset_activity_tables() -> bool`,
 	2454: `crdb_internal.sstable_metrics(node_id: int, store_id: int, start_key: bytes, end_key: bytes) -> tuple{int AS node_id,, int AS store_id, int AS level, int AS file_num, jsonb AS metrics}`,
 	2455: `crdb_internal.repair_catalog_corruption(descriptor_id: int, corruption: string) -> bool`,
+	2456: `crdb_internal.merge_aggregated_stmt_metadata(input: jsonb[]) -> jsonb`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
## server: prefer string concat over str format where possible

A number of places in the combined stats api were using string
format where a string concatenation would have worked.

Release note: None

Epic: none

## server: format sql activity queries

Reformat queries for consistency and readability.

Epic: none

Release note: None


## builtins: create function to aggregate aggregated stmt metadata
The statement activity table used to cache aggregated stmt stats for the sql activity page stores aggregated metadata. Previously we used the same query as the one used for system.statement_statistics, which stores unaggregated metadata, on the activity table. Using the aggregate function for unaggregated metadata on aggregated metadata was nto valid, leading to incorrect JSON fields being produced. This commit introduces the builtin `crdb_internal.combine_aggregated_stmt_metadata` which can be used to correctly aggregate the  metadata column on the stmt activity table.

Fixes: #103895

Release note (bug fix): On the UI, selecting a database filter from the filters menu in the sql activity page should function as expected. This fixes a preivous bug where the filter would break and not show any results when the results were retrieved from the stmt activity table instead of the persisted table.