### PR TITLE
catalog: low hanging fruit for optimizing PostDeserializationChanges

### DIFF
--- a/pkg/sql/catalog/catprivilege/fix.go
+++ b/pkg/sql/catalog/catprivilege/fix.go
@@ -17,48 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 )
 
-// MaybeFixUsagePrivForTablesAndDBs fixes cases where privilege descriptors
-// with ZONECONFIG were corrupted after upgrading from 20.1 to 20.2.
-// USAGE was mistakenly added in the privilege bitfield above ZONECONFIG
-// causing privilege descriptors with ZONECONFIG in 20.1 to have USAGE privilege
-// instead of ZONECONFIG.
-// Fortunately ZONECONFIG was only valid on TABLES/DB while USAGE is not valid
-// on either so we know if the descriptor was corrupted.
-func MaybeFixUsagePrivForTablesAndDBs(ptr **catpb.PrivilegeDescriptor) bool {
-	if *ptr == nil {
-		*ptr = &catpb.PrivilegeDescriptor{}
-	}
-	p := *ptr
-
-	if p.Version > catpb.InitialVersion {
-		// InitialVersion is for descriptors that were created in versions 20.1 and
-		// earlier. If the privilege descriptor was created after 20.1, then we
-		// do not have to fix it. Furthermore privilege descriptor versions are
-		// currently never updated so we're guaranteed to only have this issue
-		// on privilege descriptors that are on "InitialVersion".
-		return false
-	}
-
-	modified := false
-	for i := range p.Users {
-		// Users is a slice of values, we need pointers to make them mutable.
-		userPrivileges := &p.Users[i]
-		// Tables and Database should not have USAGE privilege in 20.2 onwards.
-		// The only reason they would have USAGE privilege is because they had
-		// ZoneConfig in 20.1 and upgrading to 20.2 where USAGE was added
-		// in the privilege bitfield where ZONECONFIG previously was.
-		if privilege.USAGE.Mask()&userPrivileges.Privileges != 0 {
-			// Remove USAGE privilege and add ZONECONFIG. The privilege was
-			// originally ZONECONFIG in 20.1 but got changed to USAGE in 20.2
-			// due to changing the bitfield values.
-			userPrivileges.Privileges = (userPrivileges.Privileges - privilege.USAGE.Mask()) | privilege.ZONECONFIG.Mask()
-			modified = true
-		}
-	}
-
-	return modified
-}
-
 // MaybeFixPrivileges fixes the privilege descriptor if needed, including:
 // * adding default privileges for the "admin" role
 // * fixing default privileges for the "root" user
@@ -109,10 +67,6 @@ func MaybeFixPrivileges(
 	// Check "root" user and "admin" role.
 	fixSuperUser(username.RootUserName())
 	fixSuperUser(username.AdminRoleName())
-
-	if objectType == privilege.Table || objectType == privilege.Database {
-		changed = MaybeFixUsagePrivForTablesAndDBs(&p) || changed
-	}
 
 	for i := range p.Users {
 		// Users is a slice of values, we need pointers to make them mutable.

--- a/pkg/sql/catalog/ingesting/write_descs.go
+++ b/pkg/sql/catalog/ingesting/write_descs.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -91,8 +90,6 @@ func WriteDescriptors(
 					desc.GetID(), desc)
 			}
 		}
-		privilegeDesc := desc.GetPrivileges()
-		catprivilege.MaybeFixUsagePrivForTablesAndDBs(&privilegeDesc)
 		if descCoverage == tree.RequestedDescriptors || desc.GetName() == inheritParentName {
 			wroteDBs[desc.GetID()] = desc
 		}
@@ -158,9 +155,6 @@ func WriteDescriptors(
 					table.GetID(), table)
 			}
 		}
-		privilegeDesc := table.GetPrivileges()
-		catprivilege.MaybeFixUsagePrivForTablesAndDBs(&privilegeDesc)
-
 		if err := processTableForMultiRegion(ctx, txn, descsCol, table); err != nil {
 			return err
 		}

--- a/pkg/sql/catalog/internal/catkv/catalog_query.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_query.go
@@ -191,9 +191,6 @@ func build(
 	if expectedType != catalog.Any && b.DescriptorType() != expectedType {
 		return nil, pgerror.Newf(pgcode.WrongObjectType, "descriptor is a %s", b.DescriptorType())
 	}
-	if err := b.RunPostDeserializationChanges(); err != nil {
-		return nil, errors.NewAssertionErrorWithWrappedErrf(err, "error during RunPostDeserializationChanges")
-	}
 	b.SetRawBytesInStorage(rowValue.TagAndDataBytes())
 	desc := b.BuildImmutable()
 	if id != desc.GetID() {


### PR DESCRIPTION
### catprivilege: remove MaybeFixUsagePrivForTablesAndDBs

This fix is no longer needed, since 92ad363 added a 21.2 upgrade job
that fixed this bug for all descriptors.

This is useful because it makes it easier in the future to avoid cloning the
protobuf unless we need to modify it.

---

### internal/catkv: remove redundant RunPostDeserializationChanges call

This function already calls descbuilder.FromSerializedValue, which does
the same thing.

A profile showed that this is very expensive for large numbers of
descriptors.

---

![image](https://github.com/cockroachdb/cockroach/assets/1320573/3fc8fe24-0d91-46f2-9620-7dfc2e4c3324)

Epic: None
Release note: None