### PR TITLE
release-22.2: sql: fix CTAS when selecting from some internal virtual tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1366,3 +1366,10 @@ user root
 
 statement ok
 REVOKE SYSTEM VIEWACTIVITY FROM testuser
+
+# Regression tests for not setting SQL stats provider in the backfill (#76710).
+statement ok
+CREATE TABLE t76710_1 AS SELECT * FROM crdb_internal.statement_statistics;
+
+statement ok
+CREATE MATERIALIZED VIEW t76710_2 AS SELECT fingerprint_id FROM crdb_internal.cluster_statement_statistics;

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -463,17 +463,14 @@ CREATE TABLE error (a INT, b INT, INDEX idx (a), UNIQUE INDEX idx (b))
 statement error pgcode 42P07 duplicate index name: \"idx\"
 CREATE TABLE error (a INT, b INT, UNIQUE INDEX idx (a), UNIQUE INDEX idx (b))
 
-# Regression test for using some virtual tables in CREATE TABLE AS which is not
-# supported at the moment (#65512).
+statement ok
+CREATE TABLE ctas1 AS (SELECT * FROM crdb_internal.node_statement_statistics);
 
-query error crdb_internal.node_statement_statistics cannot be used in this context
-CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_statement_statistics);
+statement ok
+CREATE TABLE ctas2 AS (SELECT * FROM crdb_internal.node_transaction_statistics);
 
-query error crdb_internal.node_transaction_statistics cannot be used in this context
-CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_transaction_statistics);
-
-query error crdb_internal.node_txn_stats cannot be used in this context
-CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_txn_stats);
+statement ok
+CREATE TABLE ctas3 AS (SELECT * FROM crdb_internal.node_txn_stats);
 
 subtest generated_as_identity
 statement ok

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -472,12 +472,14 @@ func internalExtendedEvalCtx(
 	var sqlStatsController eval.SQLStatsController
 	var schemaTelemetryController eval.SchemaTelemetryController
 	var indexUsageStatsController eval.IndexUsageStatsController
+	var sqlStatsProvider *persistedsqlstats.PersistedSQLStats
 	if execCfg.InternalExecutor != nil {
 		if execCfg.InternalExecutor.s != nil {
 			indexUsageStats = execCfg.InternalExecutor.s.indexUsageStats
 			sqlStatsController = execCfg.InternalExecutor.s.sqlStatsController
 			schemaTelemetryController = execCfg.InternalExecutor.s.schemaTelemetryController
 			indexUsageStatsController = execCfg.InternalExecutor.s.indexUsageStatsController
+			sqlStatsProvider = execCfg.InternalExecutor.s.sqlStats
 		} else {
 			// If the indexUsageStats is nil from the sql.Server, we create a dummy
 			// index usage stats collector. The sql.Server in the ExecutorConfig
@@ -488,6 +490,7 @@ func internalExtendedEvalCtx(
 			sqlStatsController = &persistedsqlstats.Controller{}
 			schemaTelemetryController = &schematelemetrycontroller.Controller{}
 			indexUsageStatsController = &idxusage.Controller{}
+			sqlStatsProvider = &persistedsqlstats.PersistedSQLStats{}
 		}
 	}
 	ret := extendedEvalContext{
@@ -512,6 +515,7 @@ func internalExtendedEvalCtx(
 		Tracing:         &SessionTracing{},
 		Descs:           tables,
 		indexUsageStats: indexUsageStats,
+		statsProvider:   sqlStatsProvider,
 	}
 	ret.copyFromExecCfg(execCfg)
 	return ret


### PR DESCRIPTION
Backport 1/1 commits from #105324.

/cc @cockroachdb/release

---

This commit fixes an oversight where we forgot to set the SQL stats provider in some code paths (namely when `NewInternalPlanner` is called, one example is backfilling query into table that powers CREATE TABLE AS and CREATE MATERIALIZED VIEW AS features), and this is now fixed.

Fixes: #76710.

Release note (bug fix): Previously, CockroachDB would crash when evaluating CREATE TABLE .. AS or CREATE MATERIALIZED VIEW .. AS statements when AS clause selected data from
`crdb_internal.cluster_statement_statistics` or
`crdb_internal.cluster_transaction_statistics` virtual tables. The bug has been present since at least 22.1 and is now fixed.

Release justification: bug fix.