### PR TITLE
bazel: fix builds under `--force_build_cdeps`

### DIFF
--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -351,6 +351,17 @@ config_setting(
 )
 
 config_setting(
+    name = "is_non_dev_macos_arm64",
+    constraint_values = [
+        "@io_bazel_rules_go//go/toolchain:darwin",
+        "@platforms//cpu:aarch64",
+    ],
+    flag_values = {
+        ":dev_flag": "false",
+    },
+)
+
+config_setting(
     name = "is_dev_macos_arm64",
     constraint_values = [
         "@io_bazel_rules_go//go/toolchain:darwin",
@@ -513,4 +524,79 @@ config_setting(
     values = {
         "define": "use_ci_timeouts=true",
     },
+)
+
+config_setting(
+    name = "is_linux_amd64_no_force_build_cdeps",
+    constraint_values = [
+        "@io_bazel_rules_go//go/toolchain:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    flag_values = {
+        ":force_build_cdeps_flag": "false",
+    },
+    visibility = [
+        "//build/bazelutil:__pkg__",
+        "//c-deps:__pkg__",
+    ],
+)
+
+config_setting(
+    name = "is_linux_arm64_no_force_build_cdeps",
+    constraint_values = [
+        "@io_bazel_rules_go//go/toolchain:linux",
+        "@platforms//cpu:arm64",
+    ],
+    flag_values = {
+        ":force_build_cdeps_flag": "false",
+    },
+    visibility = [
+        "//build/bazelutil:__pkg__",
+        "//c-deps:__pkg__",
+    ],
+)
+
+config_setting(
+    name = "is_darwin_amd64_no_force_build_cdeps",
+    constraint_values = [
+        "@io_bazel_rules_go//go/toolchain:darwin",
+        "@platforms//cpu:x86_64",
+    ],
+    flag_values = {
+        ":force_build_cdeps_flag": "false",
+    },
+    visibility = [
+        "//build/bazelutil:__pkg__",
+        "//c-deps:__pkg__",
+    ],
+)
+
+config_setting(
+    name = "is_darwin_arm64_no_force_build_cdeps",
+    constraint_values = [
+        "@io_bazel_rules_go//go/toolchain:darwin",
+        "@platforms//cpu:arm64",
+    ],
+    flag_values = {
+        ":force_build_cdeps_flag": "false",
+    },
+    visibility = [
+        "//build/bazelutil:__pkg__",
+        "//c-deps:__pkg__",
+    ],
+)
+
+config_setting(
+    name = "is_windows_amd64_no_force_build_cdeps",
+    constraint_values = [
+        "@io_bazel_rules_go//go/toolchain:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    flag_values = {
+        ":force_build_cdeps_flag": "false",
+    },
+    visibility = [
+        "//build/bazelutil:__pkg__",
+        "//c-deps:__pkg__",
+    ],
 )

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -19,7 +19,7 @@ configure_make(
     ] + select({
         "@io_bazel_rules_go//go/platform:windows": ["--host=x86_64-w64-mingw32"],
         "@io_bazel_rules_go//go/platform:darwin_amd64": ["--host=x86_64-apple-darwin21.2"],
-        "@io_bazel_rules_go//go/platform:darwin_arm64": [
+        "//build/toolchains:is_non_dev_macos_arm64": [
             "--host=aarch64-apple-darwin21.2",
             "--with-lg-page=14",
         ],

--- a/c-deps/archived.bzl
+++ b/c-deps/archived.bzl
@@ -136,14 +136,14 @@ filegroup(
 def cdep_alias(lib):
     actual = {
         "//build/toolchains:force_build_cdeps": ":{}_foreign".format(lib),
-        "@io_bazel_rules_go//go/platform:linux_amd64": ":archived_cdep_{}_linux".format(lib),
-        "@io_bazel_rules_go//go/platform:linux_arm64": ":archived_cdep_{}_linuxarm".format(lib),
+        "//build/toolchains:is_linux_amd64_no_force_build_cdeps": ":archived_cdep_{}_linux".format(lib),
+        "//build/toolchains:is_linux_arm64_no_force_build_cdeps": ":archived_cdep_{}_linuxarm".format(lib),
         "//conditions:default": ":{}_foreign".format(lib),
     }
     if lib != "libkrb5":
-        actual["@io_bazel_rules_go//go/platform:darwin_amd64"] = ":archived_cdep_{}_macos".format(lib)
-        actual["@io_bazel_rules_go//go/platform:darwin_arm64"] = ":archived_cdep_{}_macosarm".format(lib)
-        actual["@io_bazel_rules_go//go/platform:windows"] = ":archived_cdep_{}_windows".format(lib)
+        actual["//build/toolchains:is_darwin_amd64_no_force_build_cdeps"] = ":archived_cdep_{}_macos".format(lib)
+        actual["//build/toolchains:is_darwin_arm64_no_force_build_cdeps"] = ":archived_cdep_{}_macosarm".format(lib)
+        actual["//build/toolchains:is_windows_amd64_no_force_build_cdeps"] = ":archived_cdep_{}_windows".format(lib)
     native.alias(
         name = lib,
         actual = select(actual),


### PR DESCRIPTION
This codepath isn't exercised in CI, so we didn't notice it was broken with the Bazel 6.2.1 upgrade.

Epic: none
Release note: None