### PR TITLE
release 23-1: security: add back 22.1 TLS ciphers

### DIFF
--- a/pkg/security/tls_ciphersuites.go
+++ b/pkg/security/tls_ciphersuites.go
@@ -52,7 +52,7 @@ func RecommendedCipherSuites() []uint16 {
 }
 
 // OldCipherSuites returns a list of "old" cipher suites for TLS v1.2,
-// from the list created by Mozilla[1]. These are enabled with the
+// which adds back all ciphers from v22.1. These are enabled with the
 // use of the COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES environment
 // variable, and should strictly be used when the software
 // CockroachDB is being used with cannot be upgraded.
@@ -62,11 +62,15 @@ func RecommendedCipherSuites() []uint16 {
 // backwards compatibility should be added here, so organizations
 // can opt into using deprecated cipher suites rather than opting
 // every CRDB cluster into a worse security stance.
-//
-// [1]: https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
 func OldCipherSuites() []uint16 {
 	return []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
 		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #105347 on behalf of @kpatron-cockroachlabs.

/cc @cockroachdb/release

----

Previously, only some of the TLS ciphers that were valid in 22.1 were available even with `COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES` set. This produced a problem for some customers who upgrade to 22.2 as their applications suddenly might be unable to connect.

This change adds back the full list of 22.1 cipher suites behind the environment variable.

Note: this takes us away from the path of following the Mozilla standard for old cipher suites in favor of being consistent with old versions.

fixes: CC-24958

Release note (security update): The full set of TLS ciphers that was present in 22.1 have ben included in the old cipher suites list, which can be enabled with the
`COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES` environment variable

----

Release justification: Prevents app breakage during upgrades from 22.2.9 or before.