### PR TITLE
release-23.1: multitenant: make the system tenant appear to have all capabilities

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
@@ -216,6 +216,26 @@ span_config_bounds         {}
 
 subtest end
 
+subtest regression_98749
+
+query TT colnames,rowsort
+SELECT capability_name, capability_value FROM [SHOW TENANT system WITH CAPABILITIES]
+----
+capability_name            capability_value
+can_admin_relocate_range   true
+can_admin_scatter          true
+can_admin_split            true
+can_admin_unsplit          true
+can_check_consistency      true
+can_use_nodelocal_storage  true
+can_view_node_info         true
+can_view_tsdb_metrics      true
+exempt_from_rate_limiting  true
+span_config_bounds         {}
+
+
+subtest end
+
 
 subtest span_config_bounds
 

--- a/pkg/configprofiles/testdata/multitenant-app
+++ b/pkg/configprofiles/testdata/multitenant-app
@@ -49,15 +49,15 @@ ORDER BY tenant_id, name
 system-sql
 SHOW TENANTS WITH CAPABILITIES
 ----
-1 system ready shared can_admin_relocate_range false
+1 system ready shared can_admin_relocate_range true
 1 system ready shared can_admin_scatter true
 1 system ready shared can_admin_split true
-1 system ready shared can_admin_unsplit false
-1 system ready shared can_check_consistency false
-1 system ready shared can_use_nodelocal_storage false
-1 system ready shared can_view_node_info false
-1 system ready shared can_view_tsdb_metrics false
-1 system ready shared exempt_from_rate_limiting false
+1 system ready shared can_admin_unsplit true
+1 system ready shared can_check_consistency true
+1 system ready shared can_use_nodelocal_storage true
+1 system ready shared can_view_node_info true
+1 system ready shared can_view_tsdb_metrics true
+1 system ready shared exempt_from_rate_limiting true
 1 system ready shared span_config_bounds {}
 2 template ready none can_admin_relocate_range true
 2 template ready none can_admin_scatter true

--- a/pkg/configprofiles/testdata/multitenant-noapp
+++ b/pkg/configprofiles/testdata/multitenant-noapp
@@ -42,15 +42,15 @@ ORDER BY tenant_id, name
 system-sql
 SHOW TENANTS WITH CAPABILITIES
 ----
-1 system ready shared can_admin_relocate_range false
+1 system ready shared can_admin_relocate_range true
 1 system ready shared can_admin_scatter true
 1 system ready shared can_admin_split true
-1 system ready shared can_admin_unsplit false
-1 system ready shared can_check_consistency false
-1 system ready shared can_use_nodelocal_storage false
-1 system ready shared can_view_node_info false
-1 system ready shared can_view_tsdb_metrics false
-1 system ready shared exempt_from_rate_limiting false
+1 system ready shared can_admin_unsplit true
+1 system ready shared can_check_consistency true
+1 system ready shared can_use_nodelocal_storage true
+1 system ready shared can_view_node_info true
+1 system ready shared can_view_tsdb_metrics true
+1 system ready shared exempt_from_rate_limiting true
 1 system ready shared span_config_bounds {}
 2 template ready none can_admin_relocate_range true
 2 template ready none can_admin_scatter true

--- a/pkg/multitenant/tenantcapabilities/BUILD.bazel
+++ b/pkg/multitenant/tenantcapabilities/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     embed = [":tenantcapabilities"],
     deps = [
         "//pkg/multitenant/tenantcapabilities/tenantcapabilitiespb",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/multitenant/tenantcapabilities/interfaces.go
+++ b/pkg/multitenant/tenantcapabilities/interfaces.go
@@ -94,8 +94,3 @@ func (u Update) String() string {
 func (u Entry) String() string {
 	return fmt.Sprintf("ten=%v cap=%v", u.TenantID, u.TenantCapabilities)
 }
-
-// DefaultCapabilities returns the default state of capabilities.
-func DefaultCapabilities() *tenantcapabilitiespb.TenantCapabilities {
-	return &tenantcapabilitiespb.TenantCapabilities{}
-}

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer_test.go
@@ -171,7 +171,7 @@ func TestAllBatchCapsAreBoolean(t *testing.T) {
 			// One of the special values.
 			continue
 		}
-		caps := tenantcapabilities.DefaultCapabilities()
+		caps := &tenantcapabilitiespb.TenantCapabilities{}
 		var v *tenantcapabilities.BoolValue
 		require.Implements(t, v, tenantcapabilities.MustGetValueByID(caps, capID))
 	}

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiestestutils/testutils.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiestestutils/testutils.go
@@ -108,11 +108,10 @@ func GetTenantID(t *testing.T, d *datadriven.TestData) roachpb.TenantID {
 	return tID
 }
 
-// AlteredCapabilitiesString prints all altered capability values that no
-// longer match DefaultCapabilities. This is different from
-// Capabilities.String which only prints non-zero value fields.
+// AlteredCapabilitiesString pretty-prints all altered capability
+// values that no longer match an empty protobuf.
 func AlteredCapabilitiesString(capabilities *tenantcapabilitiespb.TenantCapabilities) string {
-	defaultCapabilities := tenantcapabilities.DefaultCapabilities()
+	defaultCapabilities := &tenantcapabilitiespb.TenantCapabilities{}
 	var builder strings.Builder
 	builder.WriteByte('{')
 	space := ""

--- a/pkg/multitenant/tenantcapabilities/values_test.go
+++ b/pkg/multitenant/tenantcapabilities/values_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,6 +32,9 @@ func TestIDs(t *testing.T) {
 	}
 }
 
+// TestGetSet ensures that Get and Set are implemented for all
+// capability types, and all default Get results are valid input for
+// Set.
 func TestGetSet(t *testing.T) {
 	var v tenantcapabilitiespb.TenantCapabilities
 	for _, id := range IDs {
@@ -39,6 +43,8 @@ func TestGetSet(t *testing.T) {
 			c.Value(&v).Set(c.Value(someCaps()).Get())
 		case SpanConfigBoundsCapability:
 			c.Value(&v).Set(c.Value(someCaps()).Get())
+		default:
+			panic(errors.AssertionFailedf("unknown capability type %T", c))
 		}
 	}
 }

--- a/pkg/multitenant/tenantcapabilities/values_test.go
+++ b/pkg/multitenant/tenantcapabilities/values_test.go
@@ -17,10 +17,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func someCaps() *tenantcapabilitiespb.TenantCapabilities {
+	return &tenantcapabilitiespb.TenantCapabilities{}
+}
+
 // TestIDs ensures that iterating IDs always works for the ID lookup functions.
 func TestIDs(t *testing.T) {
 	for _, id := range IDs {
-		_, err := GetValueByID(DefaultCapabilities(), id)
+		_, err := GetValueByID(someCaps(), id)
 		require.NoError(t, err, id)
 		_, ok := FromID(id)
 		require.True(t, ok, id)
@@ -32,9 +36,9 @@ func TestGetSet(t *testing.T) {
 	for _, id := range IDs {
 		switch c, _ := FromID(id); c := c.(type) {
 		case BoolCapability:
-			c.Value(&v).Set(c.Value(DefaultCapabilities()).Get())
+			c.Value(&v).Set(c.Value(someCaps()).Get())
 		case SpanConfigBoundsCapability:
-			c.Value(&v).Set(c.Value(DefaultCapabilities()).Get())
+			c.Value(&v).Set(c.Value(someCaps()).Get())
 		}
 	}
 }
@@ -43,7 +47,7 @@ func TestGetSet(t *testing.T) {
 // been previously modified using a Set returns the correct value.
 func TestSpanConfigBoundsSetGet(t *testing.T) {
 	capability := spanConfigBoundsCapability(TenantSpanConfigBounds)
-	val := capability.Value(DefaultCapabilities())
+	val := capability.Value(someCaps())
 
 	// Construct some span config bounds that apply to GC TTLs.
 	var v tenantcapabilitiespb.TenantCapabilities


### PR DESCRIPTION
Backport 2/2 commits from #105146.

/cc @cockroachdb/release

---

Epic: CRDB-26691
Fixes #98749.

Release justification: improves UX for operators