### PR TITLE
ci: allow apt background update to finish before updating packages

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -21,6 +21,9 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0EBFCD88
 cat > /etc/apt/sources.list.d/docker.list <<EOF
 deb https://download.docker.com/linux/ubuntu focal stable
 EOF
+# Some images come with apt autoupgrade job running at start, let's give it a few minutes to finish to avoid races.
+echo "Sleeping for 3 minutes to allow apt daily cronjob to finish..."
+sleep 3m
 apt-get update --yes
 
 # Install the sudo version patched for CVE-2021-3156


### PR DESCRIPTION
Previously, we run `apt` commands that required exclusive lock at the start of the bootstrap script.

Some base images (like the FIPS one) have daily apt autoupgrade cronjob, which is started on boot by systemd.

This PR gives the cronjob some time to finish before proceeding with `apt` commands.

Epic: none
Release note: None