### PR TITLE
colinfo: add version gate for storing pg_lsn types

### DIFF
--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -105,7 +105,7 @@ func ValidateColumnDefType(ctx context.Context, version clusterversion.Handle, t
 		return ValidateColumnDefType(ctx, version, t.ArrayContents())
 
 	case types.BitFamily, types.IntFamily, types.FloatFamily, types.BoolFamily, types.BytesFamily, types.DateFamily,
-		types.INetFamily, types.IntervalFamily, types.JsonFamily, types.OidFamily, types.PGLSNFamily, types.TimeFamily,
+		types.INetFamily, types.IntervalFamily, types.JsonFamily, types.OidFamily, types.TimeFamily,
 		types.TimestampFamily, types.TimestampTZFamily, types.UuidFamily, types.TimeTZFamily,
 		types.GeographyFamily, types.GeometryFamily, types.EnumFamily, types.Box2DFamily:
 	// These types are OK.
@@ -122,6 +122,14 @@ func ValidateColumnDefType(ctx context.Context, version clusterversion.Handle, t
 		if !version.IsActive(ctx, clusterversion.V23_1) {
 			return pgerror.Newf(pgcode.FeatureNotSupported,
 				"TSVector/TSQuery not supported until version 23.1")
+		}
+
+	case types.PGLSNFamily:
+		if !version.IsActive(ctx, clusterversion.V23_2) {
+			return pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"pg_lsn not supported until version 23.2",
+			)
 		}
 
 	default:

--- a/pkg/sql/logictest/testdata/logic_test/pg_lsn
+++ b/pkg/sql/logictest/testdata/logic_test/pg_lsn
@@ -1,3 +1,4 @@
+# LogicTest: !local-mixed-22.2-23.1
 query T
 SELECT 'A01F0/1AAA'::pg_lsn
 ----
@@ -26,7 +27,6 @@ query TT
 SELECT * FROM pg_lsn_table WHERE id = '10/10' ORDER BY id
 ----
 10/10  A01/A100
-
 
 query TT
 SELECT * FROM pg_lsn_table WHERE val = 'A01/A1000' ORDER BY id

--- a/pkg/sql/logictest/testdata/logic_test/pg_lsn_mixed
+++ b/pkg/sql/logictest/testdata/logic_test/pg_lsn_mixed
@@ -1,0 +1,10 @@
+# LogicTest: local-mixed-22.2-23.1
+# TODO(otan): add tests for mixed 23.1-23.2.
+
+query T
+SELECT '1010F/AAAA'::pg_lsn
+----
+1010F/AAAA
+
+statement error pg_lsn not supported until version 23.2
+CREATE TABLE pg_lsn_table(id pg_lsn, val pg_lsn)

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -1297,11 +1297,11 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
-func TestLogic_pg_lsn(
+func TestLogic_pg_lsn_mixed(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "pg_lsn")
+	runLogicTest(t, "pg_lsn_mixed")
 }
 
 func TestLogic_pgcrypto_builtins(

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1360,6 +1360,14 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 		}
 		return false
 	}()
+	// PGLSN was added in 23.2.
+	pgLSNNotSupported, err := isClusterVersionLessThan(
+		ctx,
+		tx,
+		clusterversion.ByKey(clusterversion.V23_2))
+	if err != nil {
+		return nil, err
+	}
 	// Forward indexes for arrays were added in 23.1, so check the index
 	// definitions for them in mixed version states.
 	forwardIndexesOnArraysNotSupported, err := isClusterVersionLessThan(
@@ -1460,6 +1468,8 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	opStmt.potentialExecErrors.addAll(codesWithConditions{
 		{code: pgcode.Syntax, condition: hasUnsupportedTSQuery},
 		{code: pgcode.FeatureNotSupported, condition: hasUnsupportedTSQuery},
+		{code: pgcode.Syntax, condition: pgLSNNotSupported},
+		{code: pgcode.FeatureNotSupported, condition: pgLSNNotSupported},
 		{code: pgcode.FeatureNotSupported, condition: hasUnsupportedIdxQueries},
 		{code: pgcode.InvalidTableDefinition, condition: hasUnsupportedIdxQueries},
 	})


### PR DESCRIPTION
We don't want mixed version clusters storing pg_lsn types, in case they need to rollback / older versions do not understand the type.

Informs #105130

Release note: None