### PR TITLE
util/mon: fix deadlock

### DIFF
--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -593,7 +593,7 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 			ctx, &mm.settings.SV,
 			"%s: unexpected %d leftover bytes",
 			mm.name, mm.mu.curAllocated)
-		mm.releaseBytes(ctx, mm.mu.curAllocated)
+		mm.releaseBytesLocked(ctx, mm.mu.curAllocated)
 	}
 
 	mm.releaseBudget(ctx)
@@ -1026,6 +1026,13 @@ func (mm *BytesMonitor) reserveBytes(ctx context.Context, x int64) error {
 func (mm *BytesMonitor) releaseBytes(ctx context.Context, sz int64) {
 	mm.mu.Lock()
 	defer mm.mu.Unlock()
+	mm.releaseBytesLocked(ctx, sz)
+}
+
+// releaseBytesLocked is similar to releaseBytes but requires that mm.mu has
+// already been locked.
+func (mm *BytesMonitor) releaseBytesLocked(ctx context.Context, sz int64) {
+	mm.mu.AssertHeld()
 	if mm.mu.curAllocated < sz {
 		logcrash.ReportOrPanic(ctx, &mm.settings.SV,
 			"%s: no bytes to release, current %d, free %d",


### PR DESCRIPTION
This commit fixes a deadlock in `mon.BytesMonitor` where `releaseBytes`
could deadlock when called from `doStop` because it tries to a lock a
mutex that was already locked by `doStop`. This deadlock hasn't been
caught in tests because tests will panic before `releaseBytes` is
called.

Epic: None

Release note: None
