### PR TITLE
build: add google-cloud-cli-gke-gcloud-auth-plugin to builder image

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20230614-164006
+version=20230622-223455
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -156,6 +156,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ccache \
     google-cloud-sdk \
+    google-cloud-cli-gke-gcloud-auth-plugin \
     lsof \
     netcat \
     netbase \


### PR DESCRIPTION
Previously, with GKE v1.26 in order to auth in `kubectl` a new auth plugin is required. See
https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke for the details.

This adds the google-cloud-cli-gke-gcloud-auth-plugin package to the builder image.

Epic: none
Release note: None