### PR TITLE
roachtest: address c2c roachtest goroutine leaks

### DIFF
--- a/pkg/cmd/roachtest/cluster/monitor_interface.go
+++ b/pkg/cmd/roachtest/cluster/monitor_interface.go
@@ -24,6 +24,10 @@ type Monitor interface {
 	ExpectDeath()
 	ExpectDeaths(count int32)
 	ResetDeaths()
+
+	// Go spawns a goroutine whose fatal errors will be handled gracefully leading to a
+	// clean roachtest shutdown. To prevent leaky goroutines, the caller must call
+	// Wait() or WaitE() before returning.
 	Go(fn func(context.Context) error)
 	GoWithCancel(fn func(context.Context) error) func()
 	WaitE() error

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -136,6 +136,7 @@ func runDiskStalledDetection(
 			`{pgurl:1-3}`)
 		return nil
 	})
+	defer m.Wait()
 
 	// Wait between [3m,6m) before stalling the disk.
 	pauseDur := 3*time.Minute + time.Duration(rand.Intn(3))*time.Minute


### PR DESCRIPTION
Previously in the c2c roachtest driver, the monitor which mangaged the
goroutine running the foreground workload was initiated with the wrong context.
This allowed the workload goroutine to continue running even after node deaths
and after the run() function returned.  The monitor is now initiated with the
context the driver later uses to cleanly cancel the workload

Further, there were several other goroutines in the c2c driver and in 2 other
roachtests (in mixed_version_c2c.go and in disk_stall.go) which leaked after
the caller returned. Further, all goroutine callers now wait for their
goroutines to complete.

Epic: none

Release note: None