### PR TITLE
flowinfra: remove flowID from the "flow registry is draining" error

### DIFF
--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -287,8 +287,7 @@ func (fr *FlowRegistry) RegisterFlow(
 
 	if draining {
 		return &flowRetryableError{cause: errors.Errorf(
-			"could not register flowID %s because the registry is draining",
-			id,
+			"could not register flow because the registry is draining",
 		)}
 	}
 	entry := fr.getEntryLocked(id)


### PR DESCRIPTION
This doesn't seem that useful and unique values make it harder to aggregate this type of error.

Epic: None

Release note: None