### PR TITLE
packer: remove explicit enable-FIPS step in agent script

### DIFF
--- a/build/packer/setup_fips.sh
+++ b/build/packer/setup_fips.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
 set -euo pipefail
-ua enable fips --assume-yes
+
+apt-get update
+apt-get install --yes jq
+if pro status --format json | jq -e '.services[] | select(.name == "fips") | select(.status == "enabled")'; then
+  echo "FIPS is already enabled"
+else
+  ua enable fips --assume-yes
+fi
 apt-get install -y dpkg-repack


### PR DESCRIPTION
Previously, we had to explicitly enable FIPS after installing all packages on the FIPS-enabled agents without checking if it is already enabled.

In recent base images the logic changed and the enable-FIPS step fails, because the feature is enabled.

This PR adds a check to prevent this failure.

Epic: none
Release note: None