### PR TITLE
changefeedccl: add logging when decoding avro messages fails

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/schema_registry.go
+++ b/pkg/ccl/changefeedccl/cdctest/schema_registry.go
@@ -9,6 +9,7 @@
 package cdctest
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
@@ -18,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/linkedin/goavro/v2"
@@ -203,7 +205,7 @@ func (r *SchemaRegistry) EncodedAvroToNative(b []byte) (interface{}, error) {
 		return ``, errors.Errorf(`missing registry id`)
 	}
 	id := int32(binary.BigEndian.Uint32(b[:4]))
-	b = b[4:]
+	remaining := b[4:]
 
 	r.mu.Lock()
 	jsonSchema := r.mu.schemas[id]
@@ -212,7 +214,11 @@ func (r *SchemaRegistry) EncodedAvroToNative(b []byte) (interface{}, error) {
 	if err != nil {
 		return ``, err
 	}
-	native, _, err := codec.NativeFromBinary(b)
+	native, _, err := codec.NativeFromBinary(remaining)
+	if err != nil {
+		// TODO (#105405): we can remove this log line once the bug is fixed.
+		log.Errorf(context.TODO(), `error decoding native from binary: with registry id: %X, without registry id: %X, schema: %s, registry id: %d`, b, remaining, jsonSchema, id)
+	}
 	return native, err
 }
 


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/issues/105405 shows that decoding avro messages
can fail sometimes, but it is not clear why. This change adds logging non-decodable message,
expected schema, and metadata for debugging.

Informs: https://github.com/cockroachdb/cockroach/issues/105405
Release note: None
Epic: None