### PR TITLE
cloud: surface more AWS errors

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -46,11 +46,12 @@ go_library(
 
 go_test(
     name = "amazon_test",
+    size = "small",
     srcs = [
         "aws_kms_test.go",
         "s3_storage_test.go",
     ],
-    args = ["-test.timeout=295s"],
+    args = ["-test.timeout=55s"],
     embed = [":amazon"],
     deps = [
         "//pkg/base",
@@ -63,8 +64,10 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/skip",
         "//pkg/util/leaktest",
+        "@com_github_aws_aws_sdk_go//aws/awserr",
         "@com_github_aws_aws_sdk_go//aws/credentials",
         "@com_github_aws_aws_sdk_go//aws/session",
+        "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],


### PR DESCRIPTION
Surface errors that would otherwise be redacted, making diagnosis in (e.g.) Splunk difficult.

Where before it might say:

`stepping through state failed with error: failed to get s3 object: ‹×›`

It now will say:

`stepping through state failed with error: failed to get s3 object: AssumeRole: AccessDenied: ‹×›`

#### User story
The user story is "make known failures grep-able / searchable in redacted logs". In the current state, the failure examples above are not knowable in a redacted log. The troubleshooter needs to get privileged access to see the real cause. This means an hour to initial diagnosis. With the above, we hope the initial diagnosis will be minutes.

#### Details
awserr.Code() is just a string (an enum really), let's return it. Doesn't contain sensitive information.

Look for "AccessDenied" and "AssumeRole" keywords in the unredacted error, and surface them without sensitive information.

Retains the previous stringy error messages, in case something is depending on them.

Also reduced the Bazel timeout for test run, as a local convenience -- maybe too little for the real tests, let's see

Jira: none
Epic: CRDB-26887
