### PR TITLE
packer: fix go symlinks

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -74,7 +74,7 @@ EOF
     tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
     # Explicitly symlink the pinned version to /usr/bin.
     for f in /usr/local/go/bin/*; do
-        ln -s "/usr/local/go/bin/$f" /usr/bin
+        ln -s "$f" /usr/bin
     done
 fi
 


### PR DESCRIPTION
Previously, we used the result of `ls`, which returns a relative path. After replacing it with shell globbing, which returns full paths, the corresponding `ln` call wasn't updated.

This PR fixes the corresponding logic.

Epic: none
Release note: None