### PR TITLE
roachprod: add `--gce-use-spot`

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -326,6 +326,13 @@ hosts file.
 							}
 						}
 						timeRemaining := c.LifetimeRemaining().Round(time.Second)
+						formatTTL := func(ttl time.Duration) string {
+							if c.VMs[0].Preemptible {
+								return color.HiMagentaString(ttl.String())
+							} else {
+								return color.HiBlueString(ttl.String())
+							}
+						}
 						cost := c.CostPerHour
 						totalCostPerHour += cost
 						alive := timeutil.Since(c.CreatedAt).Round(time.Minute)
@@ -336,14 +343,14 @@ hosts file.
 								color.HiGreenString(p.Sprintf("$%.2f", cost)),
 								colorByCostBucket(costSinceCreation)(p.Sprintf("$%.2f", costSinceCreation)),
 								color.HiWhiteString(alive.String()),
-								color.HiBlueString(timeRemaining.String()),
+								formatTTL(timeRemaining),
 								colorByCostBucket(costRemaining)(p.Sprintf("$%.2f", costRemaining)))
 						} else {
 							fmt.Fprintf(tw, "\t%s\t%s\t%s\t%s\t%s\t",
 								color.HiGreenString(""),
 								color.HiGreenString(""),
 								color.HiWhiteString(alive.String()),
-								color.HiBlueString(timeRemaining.String()),
+								formatTTL(timeRemaining),
 								color.HiGreenString(""))
 						}
 					} else {

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -73,9 +73,10 @@ type VM struct {
 	CreatedAt time.Time `json:"created_at"`
 	// If non-empty, indicates that some or all of the data in the VM instance
 	// is not present or otherwise invalid.
-	Errors   []error           `json:"errors"`
-	Lifetime time.Duration     `json:"lifetime"`
-	Labels   map[string]string `json:"labels"`
+	Errors      []error           `json:"errors"`
+	Lifetime    time.Duration     `json:"lifetime"`
+	Preemptible bool              `json:"preemptible"`
+	Labels      map[string]string `json:"labels"`
 	// The provider-internal DNS name for the VM instance
 	DNS string `json:"dns"`
 	// The name of the cloud provider that hosts the VM instance
@@ -129,9 +130,10 @@ func Name(cluster string, idx int) string {
 
 // Error values for VM.Error
 var (
-	ErrBadNetwork   = errors.New("could not determine network information")
-	ErrInvalidName  = errors.New("invalid VM name")
-	ErrNoExpiration = errors.New("could not determine expiration")
+	ErrBadNetwork    = errors.New("could not determine network information")
+	ErrBadScheduling = errors.New("could not determine scheduling information")
+	ErrInvalidName   = errors.New("invalid VM name")
+	ErrNoExpiration  = errors.New("could not determine expiration")
 )
 
 var regionRE = regexp.MustCompile(`(.*[^-])-?[a-z]$`)


### PR DESCRIPTION
Previously, `--gce-preemptible` was available.
This change adds an option to create a GCE spot
instance, whose lifetime can extend 24h; otherwise, it's essentially equivalent to a GCE preemptible.
VM metadata and billing estimator are updated to
handle both preemptible and spot instances.

Epic: none

Release note: None