### PR TITLE
concurrency: hoist TxnMeta from {,un}replicatedLockInfo into the holder 

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -916,14 +916,6 @@ type queuedGuard struct {
 
 // Information about a lock holder for unreplicated locks.
 type unreplicatedLockHolderInfo struct {
-	// nil if there is no holder. Else this is the TxnMeta of the latest call to
-	// acquire/update the lock by this transaction. For a given transaction if
-	// the lock is continuously held by a succession of different TxnMetas, the
-	// epoch must be monotonic and the ts (derived from txn.WriteTimestamp for
-	// some calls, and request.ts for other calls) must be monotonic. After ts
-	// is initialized, the timestamps inside txn are not used.
-	txn *enginepb.TxnMeta
-
 	// All the TxnSeqs in the current epoch at which this lock has been acquired,
 	// in increasing order. We track these so that if a lock is acquired at both
 	// seq 5 and seq 7, rollback of 7 does not cause the lock to be released. This
@@ -931,7 +923,7 @@ type unreplicatedLockHolderInfo struct {
 	// https://www.postgresql.org/docs/12/sql-select.html#SQL-FOR-UPDATE-SHARE
 	seqs []enginepb.TxnSeq
 
-	// The timestamp at which the unreplicated lock is held.
+	// The timestamp at which the unreplicated lock is held. Must not regress.
 	ts hlc.Timestamp
 }
 
@@ -954,24 +946,12 @@ func (ulh *unreplicatedLockHolderInfo) safeFormat(sb *redact.StringBuilder) {
 // Information about a lock holder for replicated locks. Notably, unlike
 // unreplicated locks, this does not include any sequence numbers.
 type replicatedLockHolderInfo struct {
-	// nil if there is no holder. Else this is the TxnMeta of the latest call to
-	// acquire/update the lock by this transaction. For a given transaction if
-	// the lock is continuously held by a succession of different TxnMetas, the
-	// epoch must be monotonic and the ts (derived from txn.WriteTimestamp for
-	// some calls, and request.ts for other calls) must be monotonic. After ts
-	// is initialized, the timestamps inside txn are not used.
-	//
-	// TODO(arul): we don't really need to track the entire txnMeta here. We
-	// mostly use it as a proxy for whether the lock is held or not -- a simple
-	// boolean would do.
-	txn *enginepb.TxnMeta
-
-	// The timestamp at which the replicated lock is held.
+	// The timestamp at which the replicated lock is held. Must not regress.
 	ts hlc.Timestamp
 }
 
 func (rlh *replicatedLockHolderInfo) isEmpty() bool {
-	return rlh.txn == nil && rlh.ts.IsEmpty()
+	return rlh.ts.IsEmpty()
 }
 
 func (rlh *replicatedLockHolderInfo) safeFormat(sb *redact.StringBuilder) {
@@ -1015,7 +995,20 @@ type lockState struct {
 	// go through multiple epochs and TxnSeq and may acquire the same lock in
 	// replicated and unreplicated mode at different stages.
 	holder struct {
-		locked bool
+		// If held, the TxnMeta of the transaction that holds the lock. For a given
+		// transaction, the lock may be acquired/updated using a series of different
+		// TxnMetas. While doing so, we provide a few invariants:
+		//
+		// 1. The epoch of the TxnMeta stored here must be monotonically increasing.
+		// 2. The tracking of sequence numbers in unreplicatedLockInfo corresponds
+		// to the epoch of the TxnMeta stored below. This allows us to account for
+		// savepoint rollbacks within a particular epoch.
+		//
+		// As a result, the TxnMeta stored here may not correspond to the latest
+		// call to acquire/update the lock (if the call was made using a TxnMeta
+		// with an older epoch).
+		txn *enginepb.TxnMeta
+
 		// Lock strength is always lock.Intent.
 
 		// INVARIANT: If the lock is held (i.e. the locked boolean is set to true),
@@ -1309,15 +1302,9 @@ func (l *lockState) lockStateInfo(now time.Time) roachpb.LockStateInfo {
 
 	durability := lock.Unreplicated
 	if l.isHeld() {
-		switch {
-		case l.isHeldReplicated():
+		txnHolder = l.holder.txn
+		if l.isHeldReplicated() {
 			durability = lock.Replicated
-			txnHolder = l.holder.replicatedInfo.txn
-		case l.isHeldUnreplicated():
-			durability = lock.Unreplicated
-			txnHolder = l.holder.unreplicatedInfo.txn
-		default:
-			panic("lock says its held, but no {,un}replicatedHolderInfo found")
 		}
 	}
 
@@ -1616,14 +1603,14 @@ func (l *lockState) assertEmptyLockUnlocked() {
 //
 // REQUIRES: l.mu is locked.
 func (l *lockState) isHeld() bool {
-	return l.holder.locked
+	return l.holder.txn != nil
 }
 
 // isHeldReplicated returns true if the receiver is held as a replicated lock.
 //
 // REQUIRES: l.mu is locked.
 func (l *lockState) isHeldReplicated() bool {
-	return l.isHeld() && l.holder.replicatedInfo.txn != nil
+	return l.isHeld() && !l.holder.replicatedInfo.ts.IsEmpty()
 }
 
 // isheldUnreplicated returns true if the receiver is held as a unreplicated
@@ -1631,7 +1618,7 @@ func (l *lockState) isHeldReplicated() bool {
 //
 // REQUIRES: l.mu is locked.
 func (l *lockState) isHeldUnreplicated() bool {
-	return l.isHeld() && l.holder.unreplicatedInfo.txn != nil
+	return l.isHeld() && !l.holder.unreplicatedInfo.ts.IsEmpty()
 }
 
 // Returns the duration of time the lock has been tracked as held in the lock table.
@@ -1700,20 +1687,18 @@ func (l *lockState) getLockHolder() (*enginepb.TxnMeta, hlc.Timestamp) {
 
 	// If the lock is held as both replicated and unreplicated, we want to prefer
 	// the lower of the two timestamps, since the lower timestamp contends with
-	// more transactions. We always prefer to return the txn meta associated with
-	// the unreplicated lock.
+	// more transactions.
 	if l.isHeldReplicated() && l.isHeldUnreplicated() {
-		txnMeta := l.holder.unreplicatedInfo.txn
 		minTS := l.holder.unreplicatedInfo.ts
 		minTS.Backward(l.holder.replicatedInfo.ts)
-		return txnMeta, minTS
+		return l.holder.txn, minTS
 	}
 
 	// Else, we return whichever one the lock is held at.
 	if l.isHeldUnreplicated() {
-		return l.holder.unreplicatedInfo.txn, l.holder.unreplicatedInfo.ts
+		return l.holder.txn, l.holder.unreplicatedInfo.ts
 	}
-	return l.holder.replicatedInfo.txn, l.holder.replicatedInfo.ts
+	return l.holder.txn, l.holder.replicatedInfo.ts
 }
 
 // getLockMode returns the Mode with which a lock is held.
@@ -1729,7 +1714,7 @@ func (l *lockState) getLockMode() lock.Mode {
 // Removes the current lock holder from the lock.
 // REQUIRES: l.mu is locked.
 func (l *lockState) clearLockHolder() {
-	l.holder.locked = false
+	l.holder.txn = nil
 	l.holder.startTime = time.Time{}
 	l.holder.replicatedInfo = replicatedLockHolderInfo{}
 	l.holder.unreplicatedInfo = unreplicatedLockHolderInfo{}
@@ -2271,27 +2256,13 @@ func (l *lockState) acquireLock(acq *roachpb.LockAcquisition, clock *hlc.Clock) 
 		if acq.Txn.ID != beforeTxn.ID {
 			return errors.AssertionFailedf("existing lock cannot be acquired by different transaction")
 		}
-		// TODO(arul): Once we stop storing sequence numbers/transaction protos
-		// associated with replicated locks, the following logic can be deleted.
-		if acq.Durability == lock.Replicated &&
-			l.holder.replicatedInfo.txn != nil &&
-			l.holder.replicatedInfo.txn.Epoch > acq.Txn.Epoch {
-			// If we're dealing with a replicated lock (intent), and the transaction
-			// acquiring this lock belongs to a prior epoch, we expect mvccPutInternal
-			// to return an error. As such, the request should never call into
-			// AcquireLock and reach this point.
-			return errors.AssertionFailedf(
-				"locking request with epoch %d came after lock(replicated) had already been acquired at epoch %d in txn %s",
-				acq.Txn.Epoch, l.holder.replicatedInfo.txn.Epoch, acq.Txn.ID,
-			)
-		}
 		// An unreplicated lock is being re-acquired...
 		if acq.Durability == lock.Unreplicated && l.isHeldUnreplicated() {
 			switch {
-			case l.holder.unreplicatedInfo.txn.Epoch < acq.Txn.Epoch: // at a higher epoch
+			case l.holder.txn.Epoch < acq.Txn.Epoch: // at a higher epoch
 				// Clear sequence numbers from the older epoch.
 				l.holder.unreplicatedInfo.seqs = l.holder.unreplicatedInfo.seqs[:0]
-			case l.holder.unreplicatedInfo.txn.Epoch == acq.Txn.Epoch: // at the same epoch
+			case l.holder.txn.Epoch == acq.Txn.Epoch: // at the same epoch
 				// Prune the list of sequence numbers tracked for this lock by removing
 				// any sequence numbers that are considered ignored by virtue of a
 				// savepoint rollback.
@@ -2305,12 +2276,12 @@ func (l *lockState) acquireLock(acq *roachpb.LockAcquisition, clock *hlc.Clock) 
 				l.holder.unreplicatedInfo.seqs = removeIgnored(
 					l.holder.unreplicatedInfo.seqs, acq.IgnoredSeqNums,
 				)
-			case l.holder.unreplicatedInfo.txn.Epoch > acq.Txn.Epoch: // at a prior epoch
+			case l.holder.txn.Epoch > acq.Txn.Epoch: // at a prior epoch
 				// Reject the request; the logic here parallels how mvccPutInternal
 				// handles this case for intents.
 				return errors.Errorf(
 					"locking request with epoch %d came after lock(unreplicated) had already been acquired at epoch %d in txn %s",
-					acq.Txn.Epoch, l.holder.unreplicatedInfo.txn.Epoch, acq.Txn.ID,
+					acq.Txn.Epoch, l.holder.txn.Epoch, acq.Txn.ID,
 				)
 			default:
 				panic("unreachable")
@@ -2359,14 +2330,50 @@ func (l *lockState) acquireLock(acq *roachpb.LockAcquisition, clock *hlc.Clock) 
 		// different than the first time a lock is added to the lockTable.
 		switch acq.Durability {
 		case lock.Unreplicated:
-			l.holder.unreplicatedInfo.txn = &acq.Txn
 			l.holder.unreplicatedInfo.ts.Forward(acq.Txn.WriteTimestamp)
 			l.holder.unreplicatedInfo.seqs = append(l.holder.unreplicatedInfo.seqs, acq.Txn.Sequence)
 		case lock.Replicated:
-			l.holder.replicatedInfo.txn = &acq.Txn
 			l.holder.replicatedInfo.ts.Forward(acq.Txn.WriteTimestamp)
 		default:
 			panic(fmt.Sprintf("unknown lock durability: %s", acq.Durability))
+		}
+
+		// Selectively update the txn meta.
+		switch {
+		case l.holder.txn.Epoch > acq.Txn.Epoch: // lock is being acquired at a prior epoch
+			// We do not update the txn meta here -- the epoch is not allowed to
+			// regress.
+			//
+			// NB: We can get here if the lock acquisition here corresponds to an
+			// operation from a prior epoch. We've already handled the case for
+			// unreplicated lock acquisition above, so this can only happen if the
+			// lock acquisition corresponds to a replicated lock.
+			//
+			// If mvccPutInternal is aware of the newer epoch, it'll simply reject
+			// this operation and we'll never get here. However, it's not guaranteed
+			// that mvccPutInternal knows about this newer epoch. The in-memory lock
+			// table may know about the newer epoch though, if there's been a
+			// different unreplicated lock acquisition on this key by the transaction.
+			// So if we were to blindly update the TxnMeta here, we'd be regressing
+			// the epoch, which messes with our sequence number tracking inside of
+			// unreplicatedLockInfo.
+			assert(acq.Durability == lock.Replicated, "the unreplicated case should have been handled above")
+		case l.holder.txn.Epoch == acq.Txn.Epoch: // lock is being acquired at the same epoch
+			l.holder.txn = &acq.Txn
+		case l.holder.txn.Epoch < acq.Txn.Epoch: // lock is being acquired at a newer epoch
+			l.holder.txn = &acq.Txn
+			// The txn meta tracked here corresponds to unreplicated locks. When we
+			// learn about a newer epoch during lock acquisition of a replicated lock,
+			// we clear out the unreplicatedLockInfo state being tracked from the
+			// older epoch.
+			//
+			// Note that we don't clear out replicatedLockInfo when an unreplicated
+			// lock is being acquired at a newer epoch. This is because replicated
+			// locks are held across epochs, and there is no per-epoch tracking in the
+			// lock table for them.
+			if acq.Durability == lock.Replicated {
+				l.holder.unreplicatedInfo = unreplicatedLockHolderInfo{}
+			}
 		}
 
 		_, afterTs := l.getLockHolder()
@@ -2407,15 +2414,13 @@ func (l *lockState) acquireLock(acq *roachpb.LockAcquisition, clock *hlc.Clock) 
 		panic("lockTable bug")
 	}
 
-	l.holder.locked = true
+	l.holder.txn = &acq.Txn // first acquisition, blindly assign
 	l.holder.startTime = clock.PhysicalTime()
 	switch acq.Durability {
 	case lock.Unreplicated:
-		l.holder.unreplicatedInfo.txn = &acq.Txn
 		l.holder.unreplicatedInfo.ts = acq.Txn.WriteTimestamp
 		l.holder.unreplicatedInfo.seqs = append([]enginepb.TxnSeq(nil), acq.Txn.Sequence)
 	case lock.Replicated:
-		l.holder.replicatedInfo.txn = &acq.Txn
 		l.holder.replicatedInfo.ts = acq.Txn.WriteTimestamp
 	default:
 		panic(fmt.Sprintf("unknown lock durability: %s", acq.Durability))
@@ -2499,14 +2504,15 @@ func (l *lockState) discoveredLock(
 				"discovered lock by different transaction (%s) than existing lock (see issue #63592): %s",
 				txn, l)
 		}
+		// TODO(arul): If the discovered lock indicates a newer epoch than what's
+		// being tracked, should we clear out unreplicatedLockInfo here?
 	} else {
-		l.holder.locked = true
+		l.holder.txn = txn
 		l.holder.startTime = clock.PhysicalTime()
 	}
-	replicatedHolderInfo := &l.holder.replicatedInfo
-	if replicatedHolderInfo.isEmpty() {
-		replicatedHolderInfo.txn = txn
-		replicatedHolderInfo.ts = ts
+
+	if l.holder.replicatedInfo.isEmpty() {
+		l.holder.replicatedInfo.ts = ts
 	}
 
 	switch accessStrength {
@@ -2716,12 +2722,12 @@ func (l *lockState) tryUpdateLockLocked(up roachpb.LockUpdate) (heldByTxn, gc bo
 	if l.isHeldUnreplicated() {
 		switch {
 		//...update corresponds to a higher epoch.
-		case txn.Epoch > l.holder.unreplicatedInfo.txn.Epoch:
+		case txn.Epoch > l.holder.txn.Epoch:
 			// Forget what was tracked previously.
 			l.holder.unreplicatedInfo = unreplicatedLockHolderInfo{}
 
 			// ...update corresponds to the current epoch.
-		case txn.Epoch == l.holder.unreplicatedInfo.txn.Epoch:
+		case txn.Epoch == l.holder.txn.Epoch:
 			l.holder.unreplicatedInfo.seqs = removeIgnored(l.holder.unreplicatedInfo.seqs, up.IgnoredSeqNums)
 			if len(l.holder.unreplicatedInfo.seqs) == 0 {
 				l.holder.unreplicatedInfo = unreplicatedLockHolderInfo{}
@@ -2731,14 +2737,17 @@ func (l *lockState) tryUpdateLockLocked(up roachpb.LockUpdate) (heldByTxn, gc bo
 			if advancedTs {
 				// NB: Unlike the case below, where we can't update the txn object
 				// because of the desire to best-effort mirror mvccResolveWriteIntent
-				// internal, we can do so here because the epochs are the same.
-				l.holder.unreplicatedInfo.txn = txn
+				// internal, we can do so here because the epochs are the same. Note
+				// that doing so doesn't get us too much -- other than the epoch and
+				// transaction ID, we don't make use of the fields on the TxnMeta
+				// anyway (and we know both of those haven't changed).
+				l.holder.txn = txn
 				l.holder.unreplicatedInfo.ts = ts
 			}
 			isLocked = true
 
 			// ...update corresponds to an older epoch of the transaction.
-		case txn.Epoch < l.holder.unreplicatedInfo.txn.Epoch:
+		case txn.Epoch < l.holder.txn.Epoch:
 			if advancedTs {
 				// We may advance ts here but not update the holder.txn object below for
 				// the reason stated in the comment about mvccResolveWriteIntent(). The
@@ -2913,7 +2922,7 @@ func (l *lockState) tryFreeLockOnReplicatedAcquire() bool {
 	defer l.mu.Unlock()
 
 	// Bail if not locked with only the Unreplicated durability.
-	if !l.isHeld() || !l.holder.replicatedInfo.isEmpty() {
+	if !l.isHeld() || l.isHeldReplicated() {
 		return false
 	}
 

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -944,7 +944,7 @@ func (ulh *unreplicatedLockHolderInfo) safeFormat(sb *redact.StringBuilder) {
 		return
 	}
 	sb.SafeString("unrepl ")
-	sb.Printf("epoch: %d, seqs: [%d", redact.Safe(ulh.txn.Epoch), redact.Safe(ulh.seqs[0]))
+	sb.Printf("seqs: [%d", redact.Safe(ulh.seqs[0]))
 	for j := 1; j < len(ulh.seqs); j++ {
 		sb.Printf(", %d", redact.Safe(ulh.seqs[j]))
 	}
@@ -978,8 +978,7 @@ func (rlh *replicatedLockHolderInfo) safeFormat(sb *redact.StringBuilder) {
 	if rlh.isEmpty() {
 		return
 	}
-	sb.SafeString("repl ")
-	sb.Printf("epoch: %d", redact.Safe(rlh.txn.Epoch))
+	sb.SafeString("repl")
 }
 
 // Per lock state in lockTableImpl.
@@ -1213,7 +1212,7 @@ func (l *lockState) safeFormat(sb *redact.StringBuilder, txnStatusCache *txnStat
 	}
 	txn, ts := l.getLockHolder()
 	if txn != nil { // lock is held
-		sb.Printf("  holder: txn: %v, ts: %v, info: ", redact.Safe(txn.ID), redact.Safe(ts))
+		sb.Printf("  holder: txn: %v epoch: %d, ts: %v, info: ", redact.Safe(txn.ID), redact.Safe(txn.Epoch), redact.Safe(ts))
 		if !l.holder.replicatedInfo.isEmpty() {
 			l.holder.replicatedInfo.safeFormat(sb)
 			if !l.holder.unreplicatedInfo.isEmpty() {
@@ -1691,14 +1690,19 @@ func (l *lockState) getLockHolder() (*enginepb.TxnMeta, hlc.Timestamp) {
 		"lock held, but no replicated or unreplicated lock holder info",
 	)
 
-	// If the lock is held as both replicated and unreplicated we want to
-	// provide the lower of the two timestamps, since the lower timestamp
-	// contends with more transactions. Else we provide whichever one it is held
-	// at.
-	if !l.isHeldReplicated() || (l.isHeldUnreplicated() &&
-		// If we are evaluating the following clause we are sure that it is held
-		// as both replicated and unreplicated.
-		l.holder.unreplicatedInfo.ts.Less(l.holder.replicatedInfo.ts)) {
+	// If the lock is held as both replicated and unreplicated, we want to prefer
+	// the lower of the two timestamps, since the lower timestamp contends with
+	// more transactions. We always prefer to return the txn meta associated with
+	// the unreplicated lock.
+	if l.isHeldReplicated() && l.isHeldUnreplicated() {
+		if l.holder.unreplicatedInfo.ts.Less(l.holder.replicatedInfo.ts) {
+			return l.holder.unreplicatedInfo.txn, l.holder.unreplicatedInfo.ts
+		}
+		return l.holder.unreplicatedInfo.txn, l.holder.replicatedInfo.ts
+	}
+
+	// Else, we return whichever one the lock is held at.
+	if l.isHeldUnreplicated() {
 		return l.holder.unreplicatedInfo.txn, l.holder.unreplicatedInfo.ts
 	}
 	return l.holder.replicatedInfo.txn, l.holder.replicatedInfo.ts

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -939,26 +939,11 @@ func (ulh *unreplicatedLockHolderInfo) isEmpty() bool {
 	return ulh.txn == nil && ulh.seqs == nil && ulh.ts.IsEmpty()
 }
 
-func (ulh *unreplicatedLockHolderInfo) safeFormat(
-	sb *redact.StringBuilder, txnStatusCache *txnStatusCache,
-) {
+func (ulh *unreplicatedLockHolderInfo) safeFormat(sb *redact.StringBuilder) {
 	if ulh.isEmpty() {
 		return
 	}
 	sb.SafeString("unrepl ")
-	if txnStatusCache != nil {
-		finalizedTxn, ok := txnStatusCache.finalizedTxns.get(ulh.txn.ID)
-		if ok {
-			var statusStr string
-			switch finalizedTxn.Status {
-			case roachpb.COMMITTED:
-				statusStr = "committed"
-			case roachpb.ABORTED:
-				statusStr = "aborted"
-			}
-			sb.Printf("[holder finalized: %s] ", redact.Safe(statusStr))
-		}
-	}
 	sb.Printf("epoch: %d, seqs: [%d", redact.Safe(ulh.txn.Epoch), redact.Safe(ulh.seqs[0]))
 	for j := 1; j < len(ulh.seqs); j++ {
 		sb.Printf(", %d", redact.Safe(ulh.seqs[j]))
@@ -989,26 +974,11 @@ func (rlh *replicatedLockHolderInfo) isEmpty() bool {
 	return rlh.txn == nil && rlh.ts.IsEmpty()
 }
 
-func (rlh *replicatedLockHolderInfo) safeFormat(
-	sb *redact.StringBuilder, txnStatusCache *txnStatusCache,
-) {
+func (rlh *replicatedLockHolderInfo) safeFormat(sb *redact.StringBuilder) {
 	if rlh.isEmpty() {
 		return
 	}
 	sb.SafeString("repl ")
-	if txnStatusCache != nil {
-		finalizedTxn, ok := txnStatusCache.finalizedTxns.get(rlh.txn.ID)
-		if ok {
-			var statusStr string
-			switch finalizedTxn.Status {
-			case roachpb.COMMITTED:
-				statusStr = "committed"
-			case roachpb.ABORTED:
-				statusStr = "aborted"
-			}
-			sb.Printf("[holder finalized: %s] ", redact.Safe(statusStr))
-		}
-	}
 	sb.Printf("epoch: %d", redact.Safe(rlh.txn.Epoch))
 }
 
@@ -1245,13 +1215,26 @@ func (l *lockState) safeFormat(sb *redact.StringBuilder, txnStatusCache *txnStat
 	if txn != nil { // lock is held
 		sb.Printf("  holder: txn: %v, ts: %v, info: ", redact.Safe(txn.ID), redact.Safe(ts))
 		if !l.holder.replicatedInfo.isEmpty() {
-			l.holder.replicatedInfo.safeFormat(sb, txnStatusCache)
+			l.holder.replicatedInfo.safeFormat(sb)
 			if !l.holder.unreplicatedInfo.isEmpty() {
 				sb.Printf(", ")
 			}
 		}
 		if !l.holder.unreplicatedInfo.isEmpty() {
-			l.holder.unreplicatedInfo.safeFormat(sb, txnStatusCache)
+			l.holder.unreplicatedInfo.safeFormat(sb)
+		}
+		if txnStatusCache != nil {
+			finalizedTxn, ok := txnStatusCache.finalizedTxns.get(txn.ID)
+			if ok {
+				var statusStr string
+				switch finalizedTxn.Status {
+				case roachpb.COMMITTED:
+					statusStr = "committed"
+				case roachpb.ABORTED:
+					statusStr = "aborted"
+				}
+				sb.Printf(" [holder finalized: %s]", redact.Safe(statusStr))
+			}
 		}
 		sb.SafeString("\n")
 	}
@@ -1627,6 +1610,21 @@ func (l *lockState) assertEmptyLockUnlocked() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.assertEmptyLock()
+}
+
+// isHeldReplicated returns true if the receiver is held as a replicated lock.
+//
+// REQUIRES: l.mu is locked.
+func (l *lockState) isHeldReplicated() bool {
+	return l.holder.locked && l.holder.replicatedInfo.txn != nil
+}
+
+// isheldUnreplicated returns true if the receiver is held as a unreplicated
+// lock.
+//
+// REQUIRES: l.mu is locked.
+func (l *lockState) isHeldUnreplicated() bool {
+	return l.holder.locked && l.holder.unreplicatedInfo.txn != nil
 }
 
 // Returns the duration of time the lock has been tracked as held in the lock table.
@@ -3014,17 +3012,6 @@ func (l *lockState) maybeReleaseFirstTransactionalWriter() {
 
 	// Tell the active waiters who they are waiting for.
 	l.informActiveWaiters()
-}
-
-// isHeldReplicated returns true if the receiver is held as a replicated lock.
-func (l *lockState) isHeldReplicated() bool {
-	return l.holder.locked && l.holder.replicatedInfo.txn != nil
-}
-
-// isheldUnreplicated returns true if the receiver is held as a unreplicated
-// lock.
-func (l *lockState) isHeldUnreplicated() bool {
-	return l.holder.locked && l.holder.unreplicatedInfo.txn != nil
 }
 
 // Delete removes the specified lock from the tree.

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -1836,10 +1836,10 @@ func TestLockStateSafeFormat(t *testing.T) {
 		seqs: []enginepb.TxnSeq{1},
 	}
 	require.EqualValues(t,
-		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8, ts: 0.000000123,7, info: unrepl epoch: 0, seqs: [1]\n",
+		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, ts: 0.000000123,7, info: unrepl seqs: [1]\n",
 		redact.Sprint(l))
 	require.EqualValues(t,
-		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8, ts: 0.000000123,7, info: unrepl epoch: 0, seqs: [1]\n",
+		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, ts: 0.000000123,7, info: unrepl seqs: [1]\n",
 		redact.Sprint(l).Redact())
 }
 

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -815,11 +815,17 @@ func TestLockTableMaxLocks(t *testing.T) {
 		require.False(t, ltg.ShouldWait())
 		guards = append(guards, ltg)
 	}
+	txnMeta := enginepb.TxnMeta{
+		ID:             uuid.MakeV4(),
+		WriteTimestamp: hlc.Timestamp{WallTime: 10},
+	}
 	for i := range guards {
 		for j := 0; j < 10; j++ {
 			k := i*20 + j
 			added, err := lt.AddDiscoveredLock(
-				&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[k]}},
+				&roachpb.Intent{
+					Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[k]}, Txn: txnMeta,
+				},
 				0, false, guards[i])
 			require.True(t, added)
 			require.NoError(t, err)
@@ -839,7 +845,9 @@ func TestLockTableMaxLocks(t *testing.T) {
 	require.Equal(t, int64(10), lt.lockCountForTesting())
 	// Add another discovered lock, to trigger tryClearLocks.
 	added, err := lt.AddDiscoveredLock(
-		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+10]}},
+		&roachpb.Intent{
+			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+10]}, Txn: txnMeta,
+		},
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -848,7 +856,9 @@ func TestLockTableMaxLocks(t *testing.T) {
 	require.Equal(t, int64(101), int64(lt.locks.lockIDSeqNum))
 	// Add another discovered lock, to trigger tryClearLocks.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+11]}},
+		&roachpb.Intent{
+			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+11]}, Txn: txnMeta,
+		},
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -862,7 +872,9 @@ func TestLockTableMaxLocks(t *testing.T) {
 	lt.locks.lockAddMaxLocksCheckInterval = 2
 	// Add another discovered lock.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+12]}},
+		&roachpb.Intent{
+			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+12]}, Txn: txnMeta,
+		},
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -870,7 +882,9 @@ func TestLockTableMaxLocks(t *testing.T) {
 	require.Equal(t, int64(7), lt.lockCountForTesting())
 	// Add another discovered lock, to trigger tryClearLocks.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+13]}},
+		&roachpb.Intent{
+			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+13]}, Txn: txnMeta,
+		},
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -885,7 +899,9 @@ func TestLockTableMaxLocks(t *testing.T) {
 	lt.Dequeue(guards[8])
 	// Add another discovered lock.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+14]}},
+		&roachpb.Intent{
+			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+14]}, Txn: txnMeta,
+		},
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -893,7 +909,9 @@ func TestLockTableMaxLocks(t *testing.T) {
 	// Add another discovered lock, to trigger tryClearLocks, and push us over 5
 	// locks.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+15]}},
+		&roachpb.Intent{
+			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+15]}, Txn: txnMeta,
+		},
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -904,7 +922,9 @@ func TestLockTableMaxLocks(t *testing.T) {
 	// Add locks to push us over 5 locks.
 	for i := 16; i < 20; i++ {
 		added, err = lt.AddDiscoveredLock(
-			&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+i]}},
+			&roachpb.Intent{
+				Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+i]}, Txn: txnMeta,
+			},
 			0, false, guards[9])
 		require.True(t, added)
 		require.NoError(t, err)
@@ -943,10 +963,16 @@ func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 		require.False(t, ltg.ShouldWait())
 		guards = append(guards, ltg)
 	}
+	txnMeta := enginepb.TxnMeta{
+		ID:             uuid.MakeV4(),
+		WriteTimestamp: hlc.Timestamp{WallTime: 10},
+	}
 	// The first 6 requests discover 3 locks total.
 	for i := 0; i < 6; i++ {
 		added, err := lt.AddDiscoveredLock(
-			&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[i/2]}},
+			&roachpb.Intent{
+				Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[i/2]}, Txn: txnMeta,
+			},
 			0, false, guards[i])
 		require.True(t, added)
 		require.NoError(t, err)
@@ -961,7 +987,9 @@ func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 	}
 	// Add another lock using request 6.
 	added, err := lt.AddDiscoveredLock(
-		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[6/2]}},
+		&roachpb.Intent{
+			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[6/2]}, Txn: txnMeta,
+		},
 		0, false, guards[6])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -979,7 +1007,9 @@ func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 	require.Equal(t, int64(4), lt.lockCountForTesting())
 	// Add another lock using request 8.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[8/2]}},
+		&roachpb.Intent{
+			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[8/2]}, Txn: txnMeta,
+		},
 		0, false, guards[8])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -1828,10 +1858,9 @@ func TestLockStateSafeFormat(t *testing.T) {
 		key:    []byte("KEY"),
 		endKey: []byte("END"),
 	}
-	l.holder.locked = true
+	l.holder.txn = &enginepb.TxnMeta{ID: uuid.NamespaceDNS}
 	// TODO(arul): add something about replicated locks here too.
 	l.holder.unreplicatedInfo = unreplicatedLockHolderInfo{
-		txn:  &enginepb.TxnMeta{ID: uuid.NamespaceDNS},
 		ts:   hlc.Timestamp{WallTime: 123, Logical: 7},
 		seqs: []enginepb.TxnSeq{1},
 	}

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -58,7 +58,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 12.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,1, info: unrepl seqs: [0]
 
 finish req=req2
 ----
@@ -68,7 +68,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 12.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,1, info: unrepl seqs: [0]
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -204,7 +204,7 @@ num=2
    queued writers:
     active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl [holder finalized: committed] epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: committed]
    queued writers:
     active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
 
@@ -236,7 +236,7 @@ num=3
    queued writers:
     active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl [holder finalized: committed] epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: committed]
    queued writers:
     active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
 
@@ -621,7 +621,7 @@ num=4
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -37,25 +37,25 @@ debug-lock-table
 ----
 num=10
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 sequence req=req1
 ----
@@ -72,28 +72,28 @@ debug-lock-table
 ----
 num=10
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    waiting readers:
     req: 1, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 1
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 debug-advance-clock ts=123
 ----
@@ -164,7 +164,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
 
@@ -204,7 +204,7 @@ num=2
    queued writers:
     active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: committed]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl [holder finalized: committed]
    queued writers:
     active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
 
@@ -236,7 +236,7 @@ num=3
    queued writers:
     active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: committed]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl [holder finalized: committed]
    queued writers:
     active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
 
@@ -306,9 +306,9 @@ debug-lock-table
 ----
 num=2
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 new-request name=req2 txn=txn2 ts=10,1
   put key=g value=v1
@@ -338,13 +338,13 @@ debug-lock-table
 ----
 num=4
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 sequence req=req1
 ----
@@ -361,16 +361,16 @@ debug-lock-table
 ----
 num=4
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    waiting readers:
     req: 3, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 debug-advance-clock ts=123
 ----
@@ -449,15 +449,15 @@ debug-lock-table
 ----
 num=3
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
 
@@ -476,16 +476,16 @@ debug-lock-table
 ----
 num=3
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: true req: 5, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
 
@@ -531,20 +531,20 @@ debug-lock-table
 ----
 num=5
  lock: "a"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: true req: 5, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
 
@@ -568,23 +568,23 @@ debug-lock-table
 ----
 num=5
  lock: "a"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 8, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 8
  lock: "b"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: true req: 5, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
 
@@ -613,7 +613,7 @@ debug-lock-table
 ----
 num=4
  lock: "b"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 8, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 8
@@ -621,11 +621,11 @@ num=4
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: true req: 5, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
@@ -657,7 +657,7 @@ num=3
    queued writers:
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: true req: 5, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -34,7 +34,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 sequence req=req1
 ----
@@ -51,7 +51,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    waiting readers:
     req: 1, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -83,11 +83,11 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # --------------------------------
 # Setup complete, test starts here
@@ -145,17 +145,17 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 6, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 6
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 4, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 4
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 5, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 5
@@ -293,11 +293,11 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # --------------------------------
 # Setup complete, test starts here
@@ -370,18 +370,18 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 10, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 13, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 10
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 11
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 12, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 12
@@ -537,11 +537,11 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 new-request name=req4w txn=txn4 ts=10,1
   put key=b value=v2
@@ -573,12 +573,12 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
    queued writers:
     active: false req: 17, txn: 00000004-0000-0000-0000-000000000000
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 17, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 17
@@ -624,7 +624,7 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 19, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 19
@@ -634,7 +634,7 @@ num=3
     active: true req: 18, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 18
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 17, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 17
@@ -773,11 +773,11 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 new-request name=req4w txn=txn4 ts=10,1
   put key=b value=v2
@@ -809,12 +809,12 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
    queued writers:
     active: false req: 23, txn: 00000004-0000-0000-0000-000000000000
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 23, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 23
@@ -860,7 +860,7 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 25, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 25
@@ -870,7 +870,7 @@ num=3
     active: true req: 24, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 24
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 23, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 23
@@ -1016,11 +1016,11 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 new-request name=req4w txn=txn4 ts=10,1
   put key=a value=v2
@@ -1092,7 +1092,7 @@ num=3
     active: true req: 30, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 30
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 29, txn: 00000005-0000-0000-0000-000000000000
    distinguished req: 29
@@ -1133,7 +1133,7 @@ num=3
     active: true req: 30, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 30
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 29, txn: 00000005-0000-0000-0000-000000000000
    distinguished req: 29

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -138,7 +138,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,0, info: repl
 
 sequence req=req4
 ----
@@ -161,7 +161,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,0, info: repl
    waiting readers:
     req: 3, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -29,7 +29,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 sequence req=req1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
@@ -166,37 +166,37 @@ debug-lock-table
 ----
 num=16
  lock: "kRCHigh1"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh2"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh3"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh4"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal3"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal4"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSIHigh1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSIHigh2"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSIHigh3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSIHigh4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSINormal1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSINormal2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSINormal3"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSINormal4"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Pushee: isolation=serializable, priority=normal
@@ -335,37 +335,37 @@ debug-lock-table
 ----
 num=16
  lock: "kRCHigh1"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh2"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh3"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh4"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal3"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal4"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSIHigh1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSIHigh2"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSIHigh3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSIHigh4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSINormal1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal3"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal4"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Pushee: isolation=serializable, priority=high
@@ -504,37 +504,37 @@ debug-lock-table
 ----
 num=16
  lock: "kRCHigh1"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh2"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh3"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh4"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal3"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal4"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kSSIHigh1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh2"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal3"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal4"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Pushee: isolation=read-committed, priority=normal
@@ -668,37 +668,37 @@ debug-lock-table
 ----
 num=16
  lock: "kRCHigh1"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh2"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh3"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCHigh4"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kRCNormal1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "kRCNormal2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kRCNormal3"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0]
  lock: "kRCNormal4"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh2"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal3"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal4"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Pushee: isolation=read-committed, priority=high
@@ -832,37 +832,37 @@ debug-lock-table
 ----
 num=16
  lock: "kRCHigh1"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "kRCHigh2"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kRCHigh3"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0]
  lock: "kRCHigh4"
-  holder: txn: 00000004-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kRCNormal1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "kRCNormal2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kRCNormal3"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0]
  lock: "kRCNormal4"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh2"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSIHigh4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 11.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal3"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0]
  lock: "kSSINormal4"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 13.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 13.000000000,2, info: unrepl seqs: [0]
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -79,14 +79,14 @@ debug-lock-table
 ----
 num=3
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "k2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Read-only request with lock timeout hits lock. The request
@@ -143,7 +143,7 @@ num=2
    queued writers:
     active: false req: 3, txn: 00000003-0000-0000-0000-000000000000
  lock: "k3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
@@ -210,12 +210,12 @@ num=3
    queued writers:
     active: false req: 3, txn: 00000003-0000-0000-0000-000000000000
  lock: "k3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,1, info: repl
 
 # -------------------------------------------------------------
 # Read-only request with lock timeout discovers abandoned
@@ -273,7 +273,7 @@ debug-lock-table
 ----
 num=1
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,1, info: repl [holder finalized: aborted]
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -273,7 +273,7 @@ debug-lock-table
 ----
 num=1
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
@@ -23,7 +23,7 @@ debug-lock-table
 ----
 num=1
  lock: "d"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 finish req=req1
 ----
@@ -45,7 +45,7 @@ debug-lock-table
 ----
 num=1
  lock: "d"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # When checking with a span that does not include the existing lock, there is
 # no conflict.
@@ -74,7 +74,7 @@ debug-lock-table
 ----
 num=1
  lock: "d"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # Wider span for req3 has a conflict.
 check-opt-no-conflicts req=req3

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
@@ -259,7 +259,7 @@ num=5
  lock: "kHigh2"
   holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
  lock: "kNormal1"
   holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
  lock: "kNormal2"
@@ -329,7 +329,7 @@ num=5
  lock: "kHigh2"
   holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
  lock: "kNormal1"
   holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
  lock: "kNormal2"
@@ -405,9 +405,9 @@ num=4
  lock: "kHigh2"
   holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
  lock: "kNormal1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
 
 # -------------------------------------------------------------
 # Push (timestamp) the high priority txn using:
@@ -477,9 +477,9 @@ num=4
  lock: "kHigh2"
   holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
  lock: "kNormal1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
 
 # -------------------------------------------------------------
 # Push (abort) the high priority txn using:
@@ -549,11 +549,11 @@ debug-lock-table
 ----
 num=3
  lock: "kHigh1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: committed] epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: committed]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
  lock: "kNormal1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
 
 # -------------------------------------------------------------
 # Scan across keyspace to clear out all aborted locks.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
@@ -105,17 +105,17 @@ debug-lock-table
 ----
 num=6
  lock: "kHigh1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kHigh2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kLow2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kNormal1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kNormal2"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Push (timestamp) the low priority txn using:
@@ -177,17 +177,17 @@ debug-lock-table
 ----
 num=6
  lock: "kHigh1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kHigh2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "kLow2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kNormal1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kNormal2"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Push (abort) the low priority txn using:
@@ -255,15 +255,15 @@ debug-lock-table
 ----
 num=5
  lock: "kHigh1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kHigh2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0] [holder finalized: aborted]
  lock: "kNormal1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kNormal2"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Push (timestamp) the normal priority txn using:
@@ -325,15 +325,15 @@ debug-lock-table
 ----
 num=5
  lock: "kHigh1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kHigh2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0] [holder finalized: aborted]
  lock: "kNormal1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "kNormal2"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Push (abort) the normal priority txn using:
@@ -401,13 +401,13 @@ debug-lock-table
 ----
 num=4
  lock: "kHigh1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kHigh2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0] [holder finalized: aborted]
  lock: "kNormal1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0] [holder finalized: aborted]
 
 # -------------------------------------------------------------
 # Push (timestamp) the high priority txn using:
@@ -473,13 +473,13 @@ debug-lock-table
 ----
 num=4
  lock: "kHigh1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "kHigh2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0] [holder finalized: aborted]
  lock: "kNormal1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0] [holder finalized: aborted]
 
 # -------------------------------------------------------------
 # Push (abort) the high priority txn using:
@@ -549,11 +549,11 @@ debug-lock-table
 ----
 num=3
  lock: "kHigh1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: committed]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0] [holder finalized: committed]
  lock: "kLow1"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0] [holder finalized: aborted]
  lock: "kNormal1"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0] [holder finalized: aborted]
 
 # -------------------------------------------------------------
 # Scan across keyspace to clear out all aborted locks.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
@@ -89,7 +89,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000002-0000-0000-0000-000000000000
     active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
@@ -169,7 +169,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
     active: true req: 4, txn: 00000004-0000-0000-0000-000000000000

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -79,9 +79,9 @@ debug-lock-table
 ----
 num=2
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "k2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # --------------------------------
 # Setup complete, test starts here
@@ -101,12 +101,12 @@ debug-lock-table
 ----
 num=2
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 2
  lock: "k2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # Replica loses lease.
 on-lease-updated leaseholder=false lease-seq=2
@@ -164,7 +164,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 3, txn: 00000002-0000-0000-0000-000000000000
 
@@ -223,7 +223,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 finish req=req2
 ----
@@ -279,7 +279,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 4, txn: 00000003-0000-0000-0000-000000000000
 
@@ -333,7 +333,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 finish req=req3
 ----
@@ -390,7 +390,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # --------------------------------
 # Setup complete, test starts here
@@ -410,7 +410,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 6
@@ -437,7 +437,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 6, txn: 00000002-0000-0000-0000-000000000000
 
@@ -491,7 +491,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 finish req=req2
 ----
@@ -562,7 +562,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # --------------------------------
 # Setup complete, test starts here
@@ -589,7 +589,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 8, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 8
@@ -657,7 +657,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 10, txn: 00000002-0000-0000-0000-000000000000
 
@@ -711,7 +711,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 finish req=req2
 ----
@@ -768,7 +768,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # --------------------------------
 # Setup complete, test starts here
@@ -788,7 +788,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 12, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 12
@@ -815,7 +815,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 12, txn: 00000002-0000-0000-0000-000000000000
 
@@ -869,7 +869,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 finish req=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -40,25 +40,25 @@ debug-lock-table
 ----
 num=10
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 # Before re-scanning and pushing, add a waiter on a single key to demonstrate
 # that uncontended, replicated keys are released when pushed, while contended,
@@ -168,9 +168,9 @@ debug-lock-table
 ----
 num=2
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 new-request name=req2 txn=txn2 ts=10,1
   put key=g value=v1
@@ -200,13 +200,13 @@ debug-lock-table
 ----
 num=4
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 sequence req=req1
 ----
@@ -235,9 +235,9 @@ debug-lock-table
 ----
 num=2
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
 
 reset namespace
 ----
@@ -276,11 +276,11 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 sequence req=req1
 ----
@@ -366,25 +366,25 @@ debug-lock-table
 ----
 num=10
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 # Before re-scanning and pushing, add a waiter on a single key to demonstrate
 # that uncontended, replicated keys are released when pushed, while contended,

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -34,7 +34,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 sequence req=req1
 ----
@@ -146,7 +146,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 sequence req=req1
 ----
@@ -202,23 +202,23 @@ debug-lock-table
 ----
 num=9
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 sequence req=req2
 ----
@@ -317,7 +317,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 sequence req=req1
 ----
@@ -373,23 +373,23 @@ debug-lock-table
 ----
 num=9
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 sequence req=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -31,7 +31,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 sequence req=req1
 ----
@@ -97,7 +97,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 100.000000000,1, info: repl epoch: 0
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 100.000000000,1, info: repl
 
 sequence req=req1
 ----
@@ -166,7 +166,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 100.000000000,1, info: repl epoch: 0
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 100.000000000,1, info: repl
 
 sequence req=req1
 ----
@@ -241,7 +241,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 14.000000000,1, info: repl epoch: 0
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 14.000000000,1, info: repl
 
 sequence req=req1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -58,7 +58,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 2, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 2
@@ -85,7 +85,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0]
 
 # Issue another write to the same key for txn1 at its initial
 # timestamp. The timestamp in the lock table does not regress.
@@ -113,7 +113,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0, 1]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0, 1]
 
 reset namespace
 ----
@@ -177,7 +177,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 5, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 5
@@ -204,7 +204,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0]
 
 # The txn restarts at a new timestamp, but below the pushed
 # timestamp. It re-issues the same write at the new epoch. The
@@ -236,7 +236,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 1, ts: 12.000000000,2, info: unrepl seqs: [0]
 
 reset namespace
 ----
@@ -305,7 +305,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 8, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 8
@@ -332,7 +332,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 12.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 12.000000000,2, info: unrepl seqs: [0]
 
 # Issue another write to the same key for txn1 at its initial timestamp,
 # this time with a replicated durability. The timestamp in the lock
@@ -381,7 +381,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl, unrepl seqs: [0]
    queued writers:
     active: true req: 9, txn: none
    distinguished req: 9

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -69,7 +69,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: true req: 2, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 2
@@ -211,12 +211,12 @@ debug-lock-table
 ----
 num=2
  lock: "k1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    waiting readers:
     req: 5, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "k2"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
 
 # Simulate that the replicated locks were discovered, so they are added to the
 # lock table. Keys "k1" and "k2" were previously discovered, but "k3" is new.
@@ -242,7 +242,7 @@ debug-lock-table
 ----
 num=1
  lock: "k1"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,1, info: repl
    waiting readers:
     req: 6, txn: 00000002-0000-0000-0000-000000000000
     req: 5, txn: 00000002-0000-0000-0000-000000000000

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -276,7 +276,7 @@ debug-lock-table
 ----
 num=1
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -79,14 +79,14 @@ debug-lock-table
 ----
 num=3
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "k2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Read-only request with WaitPolicy_Error hits lock. The request
@@ -145,7 +145,7 @@ num=2
    queued writers:
     active: false req: 3, txn: 00000003-0000-0000-0000-000000000000
  lock: "k3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
@@ -210,12 +210,12 @@ num=3
    queued writers:
     active: false req: 3, txn: 00000003-0000-0000-0000-000000000000
  lock: "k3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,1, info: repl
 
 # -------------------------------------------------------------
 # Read-only request with WaitPolicy_Error discovers abandoned
@@ -276,7 +276,7 @@ debug-lock-table
 ----
 num=1
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,1, info: repl [holder finalized: aborted]
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
@@ -107,11 +107,11 @@ debug-lock-table
 ----
 num=4
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "k2"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "k3"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "k4"
    queued writers:
     active: false req: 4, txn: 00000004-0000-0000-0000-000000000000

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
@@ -25,13 +25,13 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1]
 
 dequeue r=req1
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1]
 
 new-txn txn=txn1 ts=10,1 epoch=0 seq=2
 ----
@@ -47,13 +47,13 @@ acquire r=req2 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2]
 
 dequeue r=req2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2]
 
 new-txn txn=txn1 ts=10,1 epoch=0 seq=4
 ----
@@ -69,13 +69,13 @@ acquire r=req3 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 4]
 
 dequeue r=req3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 4]
 
 # -------------------------------------------------------------
 # Re-Acquire lock with sequence number 4
@@ -95,13 +95,13 @@ acquire r=req3 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 4]
 
 dequeue r=req3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 4]
 
 # -------------------------------------------------------------
 # Re-Acquire lock with sequence number 2
@@ -121,13 +121,13 @@ acquire r=req4 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 4]
 
 dequeue r=req4
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 4]
 
 # -------------------------------------------------------------
 # Try to acquire lock with sequence number 3. Should update the
@@ -149,13 +149,13 @@ acquire r=req5 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 3, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 3, 4]
 
 dequeue r=req5
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 3, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 3, 4]
 
 # -------------------------------------------------------------
 # Acquire lock with sequence numbers 5
@@ -175,10 +175,10 @@ acquire r=req6 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 3, 4, 5]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 3, 4, 5]
 
 dequeue r=req6
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 3, 4, 5]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 3, 4, 5]

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
@@ -35,19 +35,19 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1]
 
 acquire r=req2 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2]
 
 acquire r=req3 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [1, 2, 3]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2, 3]
 
 
 # ------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ acquire r=req4 k=a durability=u ignored-seqs=1,3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [2, 5]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [2, 5]
 
 # ------------------------------------------------------------------------------
 # Re-acquire the (unreplicated) lock at a higher sequence number. This time,
@@ -82,7 +82,7 @@ acquire r=req5 k=a durability=u ignored-seqs=4
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [2, 5, 8]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [2, 5, 8]
 
 # ------------------------------------------------------------------------------
 # Ensure sequence numbers are only pruned when acquiring unreplicated locks.
@@ -117,7 +117,7 @@ acquire r=req7 k=a durability=r ignored-seqs=8
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: repl epoch: 0, unrepl epoch: 0, seqs: [2, 5, 8]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: repl, unrepl seqs: [2, 5, 8]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
@@ -128,7 +128,7 @@ acquire r=req7 k=a durability=u ignored-seqs=8
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: repl epoch: 0, unrepl epoch: 0, seqs: [2, 5, 9]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: repl, unrepl seqs: [2, 5, 9]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
@@ -151,7 +151,7 @@ acquire r=req8 k=a durability=u ignored-seqs=2-5,9
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: repl epoch: 0, unrepl epoch: 0, seqs: [11]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: repl, unrepl seqs: [11]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
@@ -85,11 +85,9 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [2, 5, 8]
 
 # ------------------------------------------------------------------------------
-# Ensure sequence numbers are only pruned when acquiring unreplicated locks.
-# The interesting case here is when a replicated lock is being acquired and the
-# acquisition struct says a sequence number at which an unreplicated lock is
-# held is considered ignored -- nothing gets pruned in such cases (even though
-# it technically could).
+# Ensure sequence numbers get pruned when acquiring replicated locks, and the
+# the lock acquisition struct says a sequence number at which an unreplicated
+# lock is held is considered ignored.
 # ------------------------------------------------------------------------------
 
 # First, add a waiting writer on this lock so that it counts as contended.
@@ -152,6 +150,28 @@ acquire r=req8 k=a durability=u ignored-seqs=2-5,9
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: repl, unrepl seqs: [11]
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 3
+
+# ------------------------------------------------------------------------------
+# Ensure acquiring a replicated lock at a higher epoch than the one with which
+# an unreplicated lock is held with clears out the sequence numbers being
+# tracked for the prior epoch. Moreover, the epoch associated with the txn
+# meta should also be updated.
+# ------------------------------------------------------------------------------
+
+new-txn txn=txn1 ts=11,1 epoch=1 seq=12
+----
+
+new-request r=req9 txn=txn1 ts=11,1 spans=intent@a
+----
+
+acquire r=req9 k=a durability=r
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 11.000000000,1, info: repl
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
@@ -42,13 +42,13 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 new-request r=req2 txn=txn2 ts=10,1 spans=intent@a
 ----
@@ -89,7 +89,7 @@ add-discovered r=req2 k=a txn=txn3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
 
@@ -109,7 +109,7 @@ dequeue r=req3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered_old_lease
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered_old_lease
@@ -29,7 +29,7 @@ add-discovered r=req1 k=b txn=txn2 lease-seq=5
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
 
 add-discovered r=req1 k=c txn=txn2 lease-seq=6
 ----
@@ -39,4 +39,4 @@ print
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -27,23 +27,23 @@ acquire r=req1 k=c durability=u
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 acquire r=req1 k=e durability=u
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # 200ms passes between req1 and req2
 time-tick ms=200
@@ -62,21 +62,21 @@ acquire r=req2 k=b durability=u
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req2
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # 1s passes before txn2 begins
 time-tick s=1
@@ -100,11 +100,11 @@ dequeue r=req3
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # 200ms passes between req3 and req4
 time-tick ms=200
@@ -138,9 +138,9 @@ num=3
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # Still waiting, but on lock c which has a different ts in the TxnMeta.
 
@@ -163,7 +163,7 @@ num=3
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # No longer waiting since does not conflict with lock on e.
 
@@ -187,7 +187,7 @@ add-discovered r=req4 k=a txn=txn3
 ----
 num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
@@ -197,13 +197,13 @@ num=4
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 add-discovered r=req4 k=f txn=txn3
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
@@ -213,9 +213,9 @@ num=5
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
 
 # Note that guard state has not changed yet. Discovering these locks means the caller has to
 # scan again.
@@ -254,7 +254,7 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -265,9 +265,9 @@ num=5
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
 
 query
 ----
@@ -392,7 +392,7 @@ dequeue r=req5
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -403,9 +403,9 @@ num=5
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
 
 # 100ms passes between req5 and req6
 time-tick ms=100
@@ -440,7 +440,7 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -453,9 +453,9 @@ num=5
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
 
 metrics
 ----
@@ -595,7 +595,7 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -610,9 +610,9 @@ num=5
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
 
 metrics
 ----
@@ -750,9 +750,9 @@ num=5
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
 
 guard-state r=req4
 ----
@@ -779,9 +779,9 @@ num=5
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 6.000000000,0, info: repl
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -922,7 +922,7 @@ num=4
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 guard-state r=req4
 ----
@@ -955,7 +955,7 @@ num=4
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
@@ -965,7 +965,7 @@ num=4
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 acquire r=req4 k=c durability=r
 ----
@@ -974,17 +974,17 @@ num=4
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 guard-state r=req6
 ----
@@ -1001,17 +1001,17 @@ num=4
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 metrics
 ----
@@ -1113,17 +1113,17 @@ dequeue r=req4
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # Locks:
 #             a    b    c    d    e    f    g
@@ -1149,7 +1149,7 @@ release txn=txn2 span=c,f
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
@@ -1157,7 +1157,7 @@ num=3
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 guard-state r=req7
 ----
@@ -1171,7 +1171,7 @@ print
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
@@ -1179,7 +1179,7 @@ num=3
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 metrics
 ----
@@ -1292,7 +1292,7 @@ num=3
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 guard-state r=req6
 ----
@@ -1329,7 +1329,7 @@ num=3
     active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 metrics
 ----
@@ -1443,7 +1443,7 @@ num=2
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 guard-state r=req7
 ----
@@ -1457,7 +1457,7 @@ dequeue r=req7
 ----
 num=1
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # e is still locked
 
@@ -1481,7 +1481,7 @@ dequeue r=req8
 ----
 num=1
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # 100ms passes between before releasing c-f
 time-tick ms=100
@@ -1597,19 +1597,19 @@ acquire r=req9 k=c durability=u
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req9
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 print
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 metrics
 ----
@@ -1736,7 +1736,7 @@ print
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 10, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
@@ -1962,7 +1962,7 @@ acquire r=req10 k=c durability=u
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: unrepl seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -1980,7 +1980,7 @@ print
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: unrepl seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -2079,7 +2079,7 @@ dequeue r=req10
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: unrepl seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -2088,7 +2088,7 @@ acquire r=req12 k=c durability=r
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl, unrepl seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -2097,7 +2097,7 @@ dequeue r=req12
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: repl, unrepl seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -2231,7 +2231,7 @@ acquire r=req13 k=c durability=u
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,12, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,12, info: unrepl seqs: [0]
 
 new-request r=req14 txn=txn1 ts=9,0 spans=intent@c
 ----
@@ -2382,23 +2382,23 @@ acquire r=req17 k=c durability=u
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req17 k=d durability=u
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req17
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
 
 new-request r=req18 txn=txn2 ts=10,0 spans=intent@c+intent@d
 ----
@@ -2418,12 +2418,12 @@ print
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 18, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 18
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 19
@@ -2528,7 +2528,7 @@ num=2
    queued writers:
     active: false req: 18, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 19
@@ -2544,7 +2544,7 @@ num=2
    queued writers:
     active: false req: 18, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 9.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 18, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
@@ -2664,7 +2664,7 @@ num=2
    queued writers:
     active: false req: 18, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 guard-state r=req19
 ----
@@ -2678,13 +2678,13 @@ dequeue r=req18
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req19
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 release txn=txn2 span=d
 ----
@@ -2704,13 +2704,13 @@ acquire r=req20 k=c durability=u
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req20
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 new-request r=req21 txn=txn1 ts=10 spans=intent@d
 ----
@@ -2723,17 +2723,17 @@ acquire r=req21 k=d durability=u
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req21
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 new-request r=req22 txn=txn2 ts=10 spans=intent@c+intent@d
 ----
@@ -2746,12 +2746,12 @@ print
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 22, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 22
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 metrics
 ----
@@ -2855,7 +2855,7 @@ release txn=txn1 span=d
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 22, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 22
@@ -2999,7 +2999,7 @@ num=2
    queued writers:
     active: false req: 22, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: false req: 22, txn: 00000000-0000-0000-0000-000000000002
 
@@ -3007,13 +3007,13 @@ dequeue r=req22
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req23
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 release txn=txn3 span=d
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
@@ -29,23 +29,23 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 acquire r=req1 k=b durability=u
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # In its next request, txn1 discovers a lock at c held by txn2.
 
@@ -64,11 +64,11 @@ add-discovered r=req2 k=c txn=txn2
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,1, info: repl
 
 # A non-transactional read comes in at a and blocks on the lock.
 
@@ -113,19 +113,19 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 3, txn: none
    queued writers:
     active: true req: 4, txn: none
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 8.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 8.000000000,1, info: repl
 
 # Clearing removes all locks and allows all waiting requests to proceed.
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -189,11 +189,11 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
@@ -217,22 +217,22 @@ release txn=txn4 span=c
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl [holder finalized: committed] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: committed]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl [holder finalized: committed] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: committed]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -450,13 +450,13 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
 
@@ -469,7 +469,7 @@ num=2
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 6
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
 
@@ -674,9 +674,9 @@ print
 ----
 num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: repl epoch: 0
    waiting readers:
@@ -703,7 +703,7 @@ release txn=txn4 span=c
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
 
 guard-state r=req9
 ----
@@ -924,13 +924,13 @@ num=6
    queued writers:
     active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
 
 scan r=req15
 ----
@@ -950,9 +950,9 @@ num=4
    queued writers:
     active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
 
 print
 ----
@@ -964,9 +964,9 @@ num=4
    queued writers:
     active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
 
 scan r=req16
 ----
@@ -1055,7 +1055,7 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
@@ -1076,7 +1076,7 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
     active: true req: 17, txn: 00000000-0000-0000-0000-000000000008

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -47,7 +47,7 @@ add-discovered r=req1 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -55,11 +55,11 @@ add-discovered r=req1 k=b txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -67,15 +67,15 @@ add-discovered r=req1 k=d txn=txn3
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -83,19 +83,19 @@ add-discovered r=req1 k=e txn=txn3
 ----
 num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -107,21 +107,21 @@ acquire r=req2 k=c durability=u
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -129,21 +129,21 @@ dequeue r=req2
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -155,22 +155,22 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -189,24 +189,24 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -217,22 +217,22 @@ release txn=txn4 span=c
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: committed]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl [holder finalized: committed]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: committed]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 11.000000000,1, info: repl [holder finalized: committed]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -295,7 +295,7 @@ add-discovered r=req3 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
 
@@ -303,11 +303,11 @@ add-discovered r=req3 k=c txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
 
@@ -319,13 +319,13 @@ acquire r=req4 k=b durability=u
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
 
@@ -333,13 +333,13 @@ dequeue r=req4
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
 
@@ -398,7 +398,7 @@ add-discovered r=req5 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
 
@@ -406,11 +406,11 @@ add-discovered r=req5 k=b txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
 
@@ -422,12 +422,12 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 5
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
 
@@ -450,13 +450,13 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
 
@@ -469,7 +469,7 @@ num=2
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 6
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
 
@@ -530,7 +530,7 @@ add-discovered r=req7 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
 
@@ -538,11 +538,11 @@ add-discovered r=req7 k=b txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
 
@@ -558,12 +558,12 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 7
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
 
@@ -627,37 +627,37 @@ add-discovered r=req9 k=a txn=txn3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 12.000000000,1, info: repl
 
 add-discovered r=req9 k=b txn=txn3
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 12.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 12.000000000,1, info: repl
 
 add-discovered r=req9 k=c txn=txn4
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 12.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 12.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 11.000000000,1, info: repl
 
 add-discovered r=req9 k=d txn=txn4
 ----
 num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 12.000000000,1, info: repl
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 12.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 11.000000000,1, info: repl
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 11.000000000,1, info: repl
 
 pushed-txn-updated txn=txn3 status=aborted
 ----
@@ -674,16 +674,16 @@ print
 ----
 num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 12.000000000,1, info: repl [holder finalized: aborted]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 12.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, ts: 12.000000000,1, info: repl [holder finalized: aborted]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 11.000000000,1, info: repl
    waiting readers:
     req: 9, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 9
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 11.000000000,1, info: repl
 
 scan r=req10
 ----
@@ -703,7 +703,7 @@ release txn=txn4 span=c
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 11.000000000,1, info: repl [holder finalized: aborted]
 
 guard-state r=req9
 ----
@@ -733,7 +733,7 @@ add-discovered r=req11 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 12.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 12.000000000,1, info: repl
    queued writers:
     active: false req: 11, txn: none
 
@@ -778,7 +778,7 @@ add-discovered r=req12 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 12.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 12.000000000,1, info: repl
 
 pushed-txn-updated txn=txn2 status=aborted
 ----
@@ -837,67 +837,67 @@ acquire r=req13 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req13 k=b durability=u
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req13 k=c durability=u
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req13 k=d durability=u
 ----
 num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req13 k=e durability=u
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req13 k=f durability=u
 ----
 num=6
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
 pushed-txn-updated txn=txn6 status=aborted
 ----
@@ -924,13 +924,13 @@ num=6
    queued writers:
     active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0] [holder finalized: aborted]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0] [holder finalized: aborted]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0] [holder finalized: aborted]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0] [holder finalized: aborted]
 
 scan r=req15
 ----
@@ -950,9 +950,9 @@ num=4
    queued writers:
     active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0] [holder finalized: aborted]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0] [holder finalized: aborted]
 
 print
 ----
@@ -964,9 +964,9 @@ num=4
    queued writers:
     active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0] [holder finalized: aborted]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0] [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0] [holder finalized: aborted]
 
 scan r=req16
 ----
@@ -1005,7 +1005,7 @@ add-discovered r=req17 k=a txn=txn7
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
 
@@ -1013,11 +1013,11 @@ add-discovered r=req17 k=b txn=txn8
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000008, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
 
@@ -1029,12 +1029,12 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: true req: 16, txn: 00000000-0000-0000-0000-000000000005
    distinguished req: 16
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000008, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
 
@@ -1055,11 +1055,11 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, ts: 11.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
     active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000008, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: true req: 16, txn: 00000000-0000-0000-0000-000000000005
    distinguished req: 16
@@ -1076,13 +1076,13 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, ts: 11.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
     active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
     active: true req: 17, txn: 00000000-0000-0000-0000-000000000008
    distinguished req: 17
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000008, ts: 11.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, ts: 11.000000000,1, info: repl
    queued writers:
     active: true req: 16, txn: 00000000-0000-0000-0000-000000000005
    distinguished req: 16

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
@@ -73,7 +73,7 @@ add-discovered r=req2 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    queued writers:
     active: false req: 2, txn: 00000000-0000-0000-0000-000000000001
 
@@ -103,10 +103,10 @@ num=2
    queued writers:
     active: false req: 2, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req2
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -40,7 +40,7 @@ add-discovered r=req1 k=a txn=txn2 consult-txn-status-cache=false
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl [holder finalized: aborted] epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0 [holder finalized: aborted]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -40,7 +40,7 @@ add-discovered r=req1 k=a txn=txn2 consult-txn-status-cache=false
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0 [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl [holder finalized: aborted]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -97,7 +97,7 @@ num=2
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -120,7 +120,7 @@ dequeue r=req1
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, ts: 10.000000000,0, info: repl
 
 clear
 ----
@@ -144,7 +144,7 @@ add-discovered r=req2 k=e txn=txn5 consult-txn-status-cache=false
 ----
 num=1
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000005, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, ts: 10.000000000,0, info: repl
 
 # Nothing to resolve yet.
 resolve-before-scanning r=req2
@@ -187,7 +187,7 @@ add-discovered r=req2 k=g txn=txn7 consult-txn-status-cache=true
 ----
 num=1
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, ts: 10.000000000,0, info: repl
 
 # Locks for f and g were not added to lock table.
 resolve-before-scanning r=req2
@@ -208,7 +208,7 @@ dequeue r=req2
 ----
 num=1
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, ts: 10.000000000,0, info: repl
 
 clear
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
@@ -28,13 +28,13 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 new-request r=req2 txn=txn2 ts=10 spans=intent@a+none@a
 ----
@@ -51,7 +51,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
@@ -87,35 +87,35 @@ acquire r=req3 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req3 k=b durability=u
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req3 k=c durability=u
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req3
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 new-request r=req4 txn=txn2 ts=10 spans=intent@a+intent@b
 ----
@@ -143,17 +143,17 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 # req5 reserves "b" and waits at "c".
 
@@ -161,7 +161,7 @@ release txn=txn1 span=b
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -169,7 +169,7 @@ num=3
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 guard-state r=req5
 ----
@@ -179,7 +179,7 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -187,7 +187,7 @@ num=3
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -204,7 +204,7 @@ num=3
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -224,7 +224,7 @@ num=3
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -304,35 +304,35 @@ acquire r=req6 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req6 k=b durability=u
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req6 k=c durability=u
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req6
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 new-request r=req7 txn=txn2 ts=10 spans=intent@a+intent@b
 ----
@@ -374,18 +374,18 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 8, txn: none
     active: true req: 9, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 8
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 # req8 waits at "c".
 
@@ -393,7 +393,7 @@ release txn=txn1 span=b
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
@@ -401,7 +401,7 @@ num=3
    queued writers:
     active: false req: 9, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 guard-state r=req8
 ----
@@ -411,7 +411,7 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
@@ -419,7 +419,7 @@ num=3
    queued writers:
     active: false req: 9, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -436,7 +436,7 @@ num=3
    queued writers:
     active: false req: 9, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -456,7 +456,7 @@ num=3
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 9, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -472,9 +472,9 @@ num=3
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -487,7 +487,7 @@ num=2
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 guard-state r=req8
 ----
@@ -500,7 +500,7 @@ num=2
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    waiting readers:
     req: 8, txn: none
    distinguished req: 8
@@ -509,7 +509,7 @@ dequeue r=req7
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    waiting readers:
     req: 8, txn: none
    distinguished req: 8
@@ -518,7 +518,7 @@ dequeue r=req8
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 release txn=txn2 span=b
 ----
@@ -541,23 +541,23 @@ acquire r=req10 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req10 k=b durability=u
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req10
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 new-request r=req11 txn=txn2 ts=10 spans=intent@a+intent@b
 ----
@@ -585,12 +585,12 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 11
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 12, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 12
@@ -601,7 +601,7 @@ release txn=txn1 span=b
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 11
@@ -647,7 +647,7 @@ num=2
    queued writers:
     active: false req: 11, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: false req: 12, txn: 00000000-0000-0000-0000-000000000003
 
@@ -670,7 +670,7 @@ dequeue r=req11
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 12, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 12
@@ -679,7 +679,7 @@ dequeue r=req12
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 release txn=txn2 span=b
 -----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -20,13 +20,13 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
 
 release txn=txn2 span=a,c
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
 
 # ---------------------------------------------------------------------------------
 # Lock is reacquired at same epoch with lower timestamp. This is allowed,
@@ -44,7 +44,7 @@ acquire r=req2 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2, 3]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2, 3]
 
 # ---------------------------------------------------------------------------------
 # Lock is reacquired at same epoch with lower timestamp and different durability.
@@ -66,7 +66,7 @@ acquire r=req2 k=a durability=r
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 8.000000000,0, info: repl epoch: 0, unrepl epoch: 0, seqs: [2, 3]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 8.000000000,0, info: repl, unrepl seqs: [2, 3]
    queued writers:
     active: true req: 1, txn: none
    distinguished req: 1
@@ -75,7 +75,7 @@ dequeue r=reqContend
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 8.000000000,0, info: repl epoch: 0, unrepl epoch: 0, seqs: [2, 3]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 8.000000000,0, info: repl, unrepl seqs: [2, 3]
 
 # ---------------------------------------------------------------------------------
 # Lock is reacquired at a different epoch. The old sequence numbers are discarded.
@@ -91,7 +91,7 @@ acquire r=req3 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 8.000000000,0, info: repl epoch: 0, unrepl epoch: 1, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 8.000000000,0, info: repl, unrepl seqs: [1]
 
 # ---------------------------------------------------------------------------------
 # Lock is reacquired at a different epoch with lower timestamp. This is allowed,
@@ -109,7 +109,7 @@ acquire r=req4 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 8.000000000,0, info: repl epoch: 0, unrepl epoch: 2, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, ts: 8.000000000,0, info: repl, unrepl seqs: [0]
 
 # ---------------------------------------------------------------------------------
 # Reader waits until the timestamp of the lock is updated.
@@ -130,7 +130,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 8.000000000,0, info: repl epoch: 0, unrepl epoch: 2, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, ts: 8.000000000,0, info: repl, unrepl seqs: [0]
    waiting readers:
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
@@ -145,7 +145,7 @@ acquire r=req6 k=a durability=r
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 2, unrepl epoch: 2, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, ts: 10.000000000,0, info: repl, unrepl seqs: [0]
    waiting readers:
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
@@ -158,7 +158,7 @@ acquire r=req6 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 14.000000000,0, info: repl epoch: 2, unrepl epoch: 2, seqs: [0, 1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, ts: 14.000000000,0, info: repl, unrepl seqs: [0, 1]
 
 guard-state r=req5
 ----
@@ -186,7 +186,7 @@ add-discovered r=req7 k=a txn=txn1
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 14.000000000,0, info: repl epoch: 2, unrepl epoch: 2, seqs: [0, 1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, ts: 14.000000000,0, info: repl, unrepl seqs: [0, 1]
    waiting readers:
     req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
@@ -211,7 +211,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 14.000000000,0, info: repl epoch: 2, unrepl epoch: 2, seqs: [0, 1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, ts: 14.000000000,0, info: repl, unrepl seqs: [0, 1]
    waiting readers:
     req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -200,11 +200,6 @@ old: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 # This should result in an error, similar to how mvccPutInternal handles this
 # case for intents, as the in-memory lock table is the source of truth for
 # unreplicated locks.
-#
-# We also test the same scenario for replicated locks. The only difference here
-# being that this time, we get an AssertionFailed error -- this is because we
-# expect mvccPutInternal to return an error, and never actually call into the
-# lock table to try and acquire this lock.
 # ------------------------------------------------------------------------------
 
 print
@@ -230,7 +225,3 @@ acquire r=req8 k=a durability=u
 ----
 locking request with epoch 1 came after lock(unreplicated) had already been acquired at epoch 2 in txn 00000000-0000-0000-0000-000000000001
 
-
-acquire r=req8 k=a durability=r
-----
-locking request with epoch 1 came after lock(replicated) had already been acquired at epoch 2 in txn 00000000-0000-0000-0000-000000000001

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -81,7 +81,7 @@ num=1
 # Lock is reacquired at a different epoch. The old sequence numbers are discarded.
 # ---------------------------------------------------------------------------------
 
-new-txn txn=txn1 ts=10 epoch=1 seq=0
+new-txn txn=txn1 ts=10 epoch=1 seq=1
 ----
 
 new-request r=req3 txn=txn1 ts=10 spans=intent@a
@@ -91,7 +91,7 @@ acquire r=req3 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 8.000000000,0, info: repl epoch: 0, unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 8.000000000,0, info: repl epoch: 0, unrepl epoch: 1, seqs: [1]
 
 # ---------------------------------------------------------------------------------
 # Lock is reacquired at a different epoch with lower timestamp. This is allowed,

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
@@ -26,7 +26,7 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
 
 acquire r=req1 k=a durability=r
 ----
@@ -44,7 +44,7 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
 
 scan r=reqContendReader
 ----
@@ -54,7 +54,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
    waiting readers:
     req: 1, txn: none
    distinguished req: 1
@@ -79,7 +79,7 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
 
 scan r=reqContendReader
 ----
@@ -93,7 +93,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
    waiting readers:
     req: 1, txn: none
    queued writers:
@@ -104,7 +104,7 @@ acquire r=req1 k=a durability=r
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0, unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: repl, unrepl seqs: [2]
    waiting readers:
     req: 1, txn: none
    queued writers:
@@ -139,7 +139,7 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
 
 new-txn txn=txn2 ts=10 epoch=0 seq=0
 ----
@@ -151,9 +151,9 @@ acquire r=req2 k=b durability=u
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 new-request r=req3 txn=none ts=10 spans=none@a,c
 ----
@@ -170,7 +170,7 @@ acquire r=req2 k=b durability=r
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
    waiting readers:
     req: 3, txn: none
    distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
@@ -20,7 +20,7 @@ add-discovered r=req1 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -28,23 +28,23 @@ add-discovered r=req1 k=b txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
 
 add-discovered r=req1 k=c txn=txn2
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -54,13 +54,13 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 
@@ -77,13 +77,13 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -101,14 +101,14 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -122,9 +122,9 @@ num=3
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -141,9 +141,9 @@ num=3
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -158,7 +158,7 @@ num=3
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
  lock: "c"
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
@@ -179,7 +179,7 @@ num=3
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    waiting readers:
     req: 1, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
@@ -22,35 +22,35 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req1 k=b durability=u
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req1 k=c durability=u
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 # Next, two different transactional requests wait at a and b.
 new-request r=req2 txn=txn2 ts=10 spans=intent@a
@@ -89,18 +89,18 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, txn: none
    distinguished req: 2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 3
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -248,7 +248,7 @@ num=2
    queued writers:
     active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 4, txn: none
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000003

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/optimistic
@@ -24,23 +24,23 @@ acquire r=req1 k=c durability=u
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 acquire r=req1 k=g durability=u
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 new-request r=req2 txn=txn2 ts=11,1 spans=none@a,d
 ----
@@ -57,9 +57,9 @@ dequeue r=req2
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 new-request r=req3 txn=txn2 ts=11,1 spans=none@a,d+none@f,i
 ----
@@ -76,9 +76,9 @@ print
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 check-opt-no-conflicts r=req3 spans=none@a,c
 ----
@@ -100,9 +100,9 @@ dequeue r=req3
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # ---------------------------------------------------------------------------------
 # Test with a Skip wait policy. Even though the lock table has a conflicting lock,
@@ -129,6 +129,6 @@ dequeue r=req4
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/query
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/query
@@ -21,23 +21,23 @@ acquire r=req1 k=c durability=u
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 acquire r=req1 k=e durability=u
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 query span=a,d
 ----
@@ -62,21 +62,21 @@ acquire r=req2 k=b durability=u
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req2
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # make sure query limits work
 
@@ -135,14 +135,14 @@ print
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,2, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 4

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
@@ -27,7 +27,7 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 scan r=req2
 ----
@@ -41,7 +41,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
@@ -70,7 +70,7 @@ dequeue r=req4
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
@@ -98,7 +98,7 @@ dequeue r=req5
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
@@ -126,7 +126,7 @@ dequeue r=req6
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
@@ -151,7 +151,7 @@ dequeue r=req7
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
@@ -172,7 +172,7 @@ dequeue r=req8
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
@@ -199,13 +199,13 @@ acquire r=req9 k=b durability=u
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 new-txn txn=txn7 ts=10 epoch=0
 ----
@@ -225,13 +225,13 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000006, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 10, txn: 00000000-0000-0000-0000-000000000007
    distinguished req: 10

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
@@ -36,15 +36,15 @@ add-discovered r=req4 k=b txn=txn2
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
 
 add-discovered r=req4 k=c txn=txn2
 ----
 num=2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
 
 new-request r=reqLock txn=txn2 ts=10,1 spans=intent@a+intent@b+intent@c+intent@d
 ----
@@ -57,31 +57,31 @@ acquire r=reqLock k=a durability=u
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
 
 acquire r=reqLock k=b durability=u
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl, unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
 
 dequeue r=reqLock
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl, unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
 
 scan r=req1
 ----
@@ -99,17 +99,17 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 3, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl, unrepl seqs: [0]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 4
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 5
@@ -125,14 +125,14 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl, unrepl seqs: [0]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 4
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 5
@@ -160,11 +160,11 @@ update txn=txn2 ts=11,1 epoch=0 span=b
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 5
@@ -173,9 +173,9 @@ update txn=txn2 ts=11,1 epoch=0 span=c
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
 
 guard-state r=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
@@ -26,15 +26,15 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 acquire r=req1 k=b durability=u
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 # c is first locked as unreplicated and establishes a writer queue
 # before being locked as replicated. We really only need it replicated
@@ -47,11 +47,11 @@ acquire r=req1 k=c durability=u
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 new-request r=reqContend txn=none ts=10 spans=intent@c
 ----
@@ -64,11 +64,11 @@ acquire r=req1 k=c durability=r
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: repl, unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: none
    distinguished req: 2
@@ -77,21 +77,21 @@ dequeue r=reqContend
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: repl, unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: repl, unrepl seqs: [0]
 
 new-request r=req2 txn=txn2 ts=10 spans=intent@a,c
 ----
@@ -111,15 +111,15 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: repl, unrepl seqs: [0]
 
 release txn=txn1 span=a
 ----
@@ -129,9 +129,9 @@ num=3
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: repl, unrepl seqs: [0]
 
 guard-state r=req2
 ----
@@ -149,12 +149,12 @@ num=3
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: repl, unrepl seqs: [0]
 
 new-request r=req4 txn=txn2 ts=10 spans=none@b
 ----
@@ -196,7 +196,7 @@ num=4
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000002
    queued writers:
@@ -204,12 +204,12 @@ num=4
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0, unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: repl, unrepl seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 8, txn: 00000000-0000-0000-0000-000000000002
 
@@ -226,7 +226,7 @@ acquire r=req8 k=e durability=u
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: repl epoch: 0
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: repl
    queued writers:
     active: false req: 8, txn: 00000000-0000-0000-0000-000000000002
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -30,23 +30,23 @@ acquire r=req1 k=b durability=u
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 acquire r=req1 k=d durability=u
 ----
 num=2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 new-request r=req2 txn=txn2 ts=9,1 spans=intent@c+intent@f
 ----
@@ -63,35 +63,35 @@ acquire r=req2 k=c durability=u
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 9.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 acquire r=req2 k=f durability=u
 ----
 num=4
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 9.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 9.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req2
 ----
 num=4
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 9.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 9.000000000,1, info: unrepl seqs: [0]
 
 new-request r=req3 txn=txn1 ts=10,1 spans=intent@f
 ----
@@ -108,11 +108,11 @@ release txn=txn2 span=f
 ----
 num=4
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 9.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
@@ -186,11 +186,11 @@ dequeue r=req4
 ----
 num=4
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 9.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
@@ -239,11 +239,11 @@ dequeue r=req5
 ----
 num=4
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 9.000000000,1, info: unrepl seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
  lock: "f"
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -29,13 +29,13 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
 # -------------------------------------------------------------
 # Wait on this lock as:
@@ -93,7 +93,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 4, txn: none
     req: 2, txn: 00000000-0000-0000-0000-000000000002
@@ -200,7 +200,7 @@ update txn=txn1 ts=11,1 epoch=0 span=a
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 11.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 11.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 4, txn: none
     req: 2, txn: 00000000-0000-0000-0000-000000000002
@@ -219,7 +219,7 @@ update txn=txn1 ts=13,1 epoch=0 span=a
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 13.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 13.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -239,7 +239,7 @@ dequeue r=req2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 13.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 13.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -256,7 +256,7 @@ update txn=txn1 ts=10,1 epoch=0 span=a
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 13.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 13.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -272,7 +272,7 @@ update txn=txn1 ts=15,1 epoch=0 span=a
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 15.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 15.000000000,1, info: unrepl seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -290,7 +290,7 @@ update txn=txn1 ts=17,1 epoch=0 span=a
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 17.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 17.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, txn: none
@@ -308,7 +308,7 @@ dequeue r=req4
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 17.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 17.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, txn: none
@@ -322,7 +322,7 @@ update txn=txn1 ts=19,1 epoch=0 span=a
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 19.000000000,1, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 19.000000000,1, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, txn: none
@@ -393,7 +393,7 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [1]
 
 new-txn txn=txn1 ts=10 epoch=1 seq=5
 ----
@@ -405,7 +405,7 @@ acquire r=req2 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [1, 5]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [1, 5]
 
 new-txn txn=txn1 ts=10 epoch=1 seq=7
 ----
@@ -417,7 +417,7 @@ acquire r=req3 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [1, 5, 7]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [1, 5, 7]
 
 new-txn txn=txn1 ts=10 epoch=1 seq=10
 ----
@@ -429,7 +429,7 @@ acquire r=req4 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [1, 5, 7, 10]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [1, 5, 7, 10]
 
 # No seqnum change since lock is not held at seqnum 3, 8, 9.
 
@@ -437,7 +437,7 @@ update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3,8-9
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [1, 5, 7, 10]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [1, 5, 7, 10]
 
 # No change since update is using older epoch.
 
@@ -445,19 +445,19 @@ update txn=txn1 ts=10 epoch=0 span=a ignored-seqs=3,5-7
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [1, 5, 7, 10]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [1, 5, 7, 10]
 
 update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3,5-7
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [1, 10]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [1, 10]
 
 update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=9-11
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 1, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [1]
 
 # No seqnum change since update is using older epoch. But since the update is using
 # a higher timestamp, the ts is advanced.
@@ -466,7 +466,7 @@ update txn=txn1 ts=15 epoch=0 span=a ignored-seqs=1
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 15.000000000,0, info: unrepl epoch: 1, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 15.000000000,0, info: unrepl seqs: [1]
 
 # No change, since seqnum 3 is not held. Note that the ts is not updated.
 
@@ -474,14 +474,14 @@ update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 15.000000000,0, info: unrepl epoch: 1, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 15.000000000,0, info: unrepl seqs: [1]
 
 # Timestamp is updated again.
 update txn=txn1 ts=16 epoch=1 span=a
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 16.000000000,0, info: unrepl epoch: 1, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 16.000000000,0, info: unrepl seqs: [1]
 
 # Seqnum 1 is also ignored, so the lock is released. Note that it does not
 # matter that the update is using an older timestamp.

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
@@ -37,13 +37,13 @@ acquire r=req1 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 dequeue r=req1
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
 scan r=req2
 ----
@@ -73,7 +73,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
@@ -130,7 +130,7 @@ acquire r=req2 k=a durability=u
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 3


### PR DESCRIPTION
Previously, we were storing the TxnMeta separately for both
{,un}replicatedLockInfo. The lock table is quite dumb when it comes to
replicated locks -- for good reason. As a result, tracking TxnMeta's
for replicated locks isn't of much use, as we don't make use of it,
and this patch does exactly that. This also allows us to hoist the
TxnMeta object one level higher, into the holder struct.

Epic: none

Release note: None