### PR TITLE
kv: fix data race during retry of EndTxn after refresh

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -452,7 +452,7 @@ func (tc *txnCommitter) retryTxnCommitAfterFailedParallelCommit(
 		et := baSuffix.Requests[0].GetEndTxn().ShallowCopy().(*kvpb.EndTxnRequest)
 		et.LockSpans, _ = mergeIntoSpans(et.LockSpans, et.InFlightWrites)
 		et.InFlightWrites = nil
-		baSuffix.Requests[0].Value.(*kvpb.RequestUnion_EndTxn).EndTxn = et
+		baSuffix.Requests[0].MustSetInner(et)
 	}
 	brSuffix, pErr := tc.wrapped.SendLocked(ctx, baSuffix)
 	if pErr != nil {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -408,7 +408,7 @@ func (sr *txnSpanRefresher) splitEndTxnAndRetrySend(
 		et = et.ShallowCopy().(*kvpb.EndTxnRequest)
 		et.LockSpans, _ = mergeIntoSpans(et.LockSpans, et.InFlightWrites)
 		et.InFlightWrites = nil
-		baSuffix.Requests[0].Value.(*kvpb.RequestUnion_EndTxn).EndTxn = et
+		baSuffix.Requests[0].MustSetInner(et)
 	}
 	brSuffix, pErr := sr.SendLocked(ctx, baSuffix)
 	if pErr != nil {


### PR DESCRIPTION
Fixes #103687.
Fixes #103247.
Fixes #104791.

This commit avoids a data race between `splitEndTxnAndRetrySend` and `raceTransport` by avoiding a mutation of a shared `RequestUnion_EndTxn` object within an unshared `RequestUnion` object. The `raceTransport` makes an effort to copy the `BatchRequest`'s `RequestUnion` slice, but it does not copy the inner interface, so we can't play tricks to avoid a reallocation of the `RequestUnion_EndTxn`.

The commit also addresses a similar problem in
`retryTxnCommitAfterFailedParallelCommit`.

We may be able to fix this in the `raceTransport`, but doing so would require some reflection magic and this is currently failing CI, so we make the easier change.

Release note: None