### PR TITLE
sqltelemetry: add missing schema telemetry

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index/create_index.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index/create_index.side_effects
@@ -13,6 +13,7 @@ CREATE INDEX id1
 begin transaction #1
 # begin StatementPhase
 checking for feature: CREATE INDEX
+increment telemetry for sql.schema.create_index
 write *eventpb.CreateIndex to event log:
   indexName: id1
   mutationId: 1

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -63,6 +65,8 @@ func (p *planner) AlterFunctionOptions(
 }
 
 func (n *alterFunctionOptionsNode) startExec(params runParams) error {
+	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounter("function"))
+
 	fnDesc, err := params.p.mustGetMutableFunctionForAlter(params.ctx, &n.n.Function)
 	if err != nil {
 		return err
@@ -147,6 +151,7 @@ func (p *planner) AlterFunctionRename(
 }
 
 func (n *alterFunctionRenameNode) startExec(params runParams) error {
+	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounter("function"))
 	// TODO(chengxiong): add validation that a function can not be altered if it's
 	// referenced by other objects. This is needed when want to allow function
 	// references.
@@ -220,6 +225,7 @@ func (p *planner) AlterFunctionSetOwner(
 }
 
 func (n *alterFunctionSetOwnerNode) startExec(params runParams) error {
+	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounter("function"))
 	fnDesc, err := params.p.mustGetMutableFunctionForAlter(params.ctx, &n.n.Function)
 	if err != nil {
 		return err
@@ -280,6 +286,7 @@ func (p *planner) AlterFunctionSetSchema(
 }
 
 func (n *alterFunctionSetSchemaNode) startExec(params runParams) error {
+	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounter("function"))
 	// TODO(chengxiong): add validation that a function can not be altered if it's
 	// referenced by other objects. This is needed when want to allow function
 	// references.

--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -68,6 +70,9 @@ func (n *createFunctionNode) startExec(params runParams) error {
 	if scDesc.SchemaKind() == catalog.SchemaTemporary {
 		return unimplemented.NewWithIssue(104687, "cannot create UDFs under a temporary schema")
 	}
+
+	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("function"))
+
 	mutScDesc, err := params.p.descCollection.MutableByName(params.p.Txn()).Schema(params.ctx, n.dbDesc, n.scDesc.GetName())
 	if err != nil {
 		return err

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -80,6 +81,7 @@ func (p *planner) CreateType(ctx context.Context, n *tree.CreateType) (planNode,
 }
 
 func (n *createTypeNode) startExec(params runParams) error {
+	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("type"))
 	// Check if a type with the same name exists already.
 	g := params.p.Descriptors().ByName(params.p.Txn()).MaybeGet()
 	_, typ, err := descs.PrefixAndType(params.ctx, g, n.typeName)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
@@ -28,6 +28,7 @@ func CreateFunction(b BuildCtx, n *tree.CreateFunction) {
 	if n.Replace {
 		panic(scerrors.NotImplementedError(n))
 	}
+	b.IncrementSchemaChangeCreateCounter("function")
 
 	dbElts, scElts := b.ResolvePrefix(n.FuncName.ObjectNamePrefix, privilege.CREATE)
 	_, _, sc := scpb.FindSchema(scElts)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -47,6 +47,7 @@ import (
 
 // CreateIndex implements CREATE INDEX.
 func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
+	b.IncrementSchemaChangeCreateCounter("index")
 	// Resolve the table name and start building the new index element.
 	relationElements := b.ResolveRelation(n.Table.ToUnresolvedObjectName(), ResolveParams{
 		IsExistenceOptional: false,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_schema.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_schema.go
@@ -40,6 +40,7 @@ func CreateSchema(b BuildCtx, n *tree.CreateSchema) {
 		}
 	}
 
+	b.IncrementSchemaChangeCreateCounter("schema")
 	sqltelemetry.IncrementUserDefinedSchemaCounter(sqltelemetry.UserDefinedSchemaCreate)
 	dbElts := b.ResolveDatabase(n.Schema.CatalogName, ResolveParams{
 		IsExistenceOptional: false,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -148,6 +148,10 @@ type TreeAnnotator interface {
 // Telemetry allows incrementing schema change telemetry counters.
 type Telemetry interface {
 
+	// IncrementSchemaChangeCreateCounter increments the selected CREATE telemetry
+	// counter.
+	IncrementSchemaChangeCreateCounter(counterType string)
+
 	// IncrementSchemaChangeAlterCounter increments the selected ALTER telemetry
 	// counter.
 	IncrementSchemaChangeAlterCounter(counterType string, extra ...string)

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -385,6 +385,12 @@ func (d *buildDeps) IncrementSchemaChangeAlterCounter(counterType string, extra 
 	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounterWithExtra(counterType, maybeExtra))
 }
 
+// IncrementSchemaChangeCreateCounter implements the scbuild.Dependencies
+// interface.
+func (d *buildDeps) IncrementSchemaChangeCreateCounter(counterType string) {
+	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter(counterType))
+}
+
 // IncrementSchemaChangeDropCounter implements the scbuild.Dependencies
 // interface.
 func (d *buildDeps) IncrementSchemaChangeDropCounter(counterType string) {

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -110,6 +110,12 @@ func (s *TestState) IncrementSchemaChangeDropCounter(counterType string) {
 	s.LogSideEffectf("increment telemetry for sql.schema.drop_%s", counterType)
 }
 
+// IncrementSchemaChangeCreateCounter implements the scbuild.Dependencies
+// interface.
+func (s *TestState) IncrementSchemaChangeCreateCounter(counterType string) {
+	s.LogSideEffectf("increment telemetry for sql.schema.create_%s", counterType)
+}
+
 // IncrementSchemaChangeAddColumnTypeCounter  implements the scbuild.Dependencies
 // interface.
 func (s *TestState) IncrementSchemaChangeAddColumnTypeCounter(typeName string) {

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.side_effects
@@ -31,6 +31,7 @@ $$;
 begin transaction #1
 # begin StatementPhase
 checking for feature: CREATE FUNCTION
+increment telemetry for sql.schema.create_function
 write *eventpb.CreateFunction to event log:
   functionName: defaultdb.public.f
   sql:

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn.side_effects
@@ -11,6 +11,7 @@ CREATE UNIQUE INDEX idx ON t(b);
 begin transaction #1
 # begin StatementPhase
 checking for feature: CREATE FUNCTION
+increment telemetry for sql.schema.create_function
 write *eventpb.CreateFunction to event log:
   functionName: defaultdb.public.t
   sql:
@@ -68,6 +69,7 @@ upsert descriptor #101
   -  version: "1"
   +  version: "2"
 checking for feature: CREATE INDEX
+increment telemetry for sql.schema.create_index
 write *eventpb.CreateIndex to event log:
   indexName: idx
   mutationId: 1

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index/create_index.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index/create_index.side_effects
@@ -13,6 +13,7 @@ CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 begin transaction #1
 # begin StatementPhase
 checking for feature: CREATE INDEX
+increment telemetry for sql.schema.create_index
 increment telemetry for sql.schema.partial_index
 write *eventpb.CreateIndex to event log:
   indexName: idx1

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements.side_effects
@@ -12,6 +12,7 @@ CREATE SCHEMA sc;
 begin transaction #1
 # begin StatementPhase
 checking for feature: CREATE INDEX
+increment telemetry for sql.schema.create_index
 increment telemetry for sql.schema.partial_index
 write *eventpb.CreateIndex to event log:
   indexName: idx
@@ -95,6 +96,7 @@ upsert descriptor #104
   -  version: "1"
   +  version: "2"
 checking for feature: CREATE SCHEMA
+increment telemetry for sql.schema.create_schema
 write *eventpb.CreateSchema to event log:
   owner: root
   schemaName: defaultdb.sc

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.side_effects
@@ -8,6 +8,7 @@ CREATE SCHEMA sc;
 begin transaction #1
 # begin StatementPhase
 checking for feature: CREATE SCHEMA
+increment telemetry for sql.schema.create_schema
 write *eventpb.CreateSchema to event log:
   owner: root
   schemaName: defaultdb.sc

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements.side_effects
@@ -10,6 +10,7 @@ CREATE SCHEMA sc;
 begin transaction #1
 # begin StatementPhase
 checking for feature: CREATE SCHEMA
+increment telemetry for sql.schema.create_schema
 write *eventpb.CreateSchema to event log:
   owner: root
   schemaName: defaultdb.sc
@@ -74,6 +75,7 @@ upsert descriptor #104
   +  state: DROP
      version: "1"
 checking for feature: CREATE SCHEMA
+increment telemetry for sql.schema.create_schema
 write *eventpb.CreateSchema to event log:
   owner: root
   schemaName: defaultdb.sc

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements.side_effects
@@ -207,6 +207,7 @@ upsert descriptor #104
   -  version: "1"
   +  version: "2"
 checking for feature: CREATE INDEX
+increment telemetry for sql.schema.create_index
 write *eventpb.CreateIndex to event log:
   indexName: idx
   mutationId: 1

--- a/pkg/sql/testdata/telemetry/schema
+++ b/pkg/sql/testdata/telemetry/schema
@@ -124,9 +124,54 @@ sql.schema.schema_changer_mode.legacy
 feature-usage
 CREATE FUNCTION f() RETURNS INT AS $$ SELECT 1 $$ LANGUAGE SQL IMMUTABLE
 ----
+sql.schema.create_function
 sql.schema.schema_changer_mode.declarative
 
 feature-usage
 ALTER FUNCTION f() OWNER TO admin
 ----
+sql.schema.alter_function
+sql.schema.schema_changer_mode.legacy
+
+feature-usage
+ALTER FUNCTION f() SET SCHEMA public
+----
+sql.schema.alter_function
+sql.schema.schema_changer_mode.legacy
+
+feature-usage
+ALTER FUNCTION f() VOLATILE
+----
+sql.schema.alter_function
+sql.schema.schema_changer_mode.legacy
+
+feature-usage
+ALTER FUNCTION f() RENAME TO g
+----
+sql.schema.alter_function
+sql.schema.schema_changer_mode.legacy
+
+feature-usage
+CREATE SCHEMA a
+----
+sql.schema.create_schema
+sql.schema.schema_changer_mode.declarative
+
+feature-usage
+CREATE INDEX ON t(b)
+----
+sql.schema.create_index
+sql.schema.get_virtual_table.pg_catalog.pg_attribute
+sql.schema.schema_changer_mode.declarative
+
+feature-usage
+CREATE TYPE enum_typ AS ENUM ('a', 'b')
+----
+sql.schema.create_type
+sql.schema.schema_changer_mode.legacy
+
+feature-usage
+CREATE TYPE composite_typ AS (a int, b int)
+----
+sql.schema.create_type
 sql.schema.schema_changer_mode.legacy


### PR DESCRIPTION
CREATE [ SCHEMA | INDEX | FUNCTION | TYPE ] and ALTER FUNCTION did not
have any telemetry, but they should.

Epic: None
Release note: None