### PR TITLE
kvserver: DistSender lease detection prototype 

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2464,3 +2464,8 @@ func (r *Replica) ReadProtectedTimestampsForTesting(ctx context.Context) (err er
 	ts, err = r.readProtectedTimestampsRLocked(ctx)
 	return err
 }
+
+// GetMutex returns the replica's RWMutex.
+func (r *Replica) GetMutex() *sync.RWMutex {
+	return &r.mu.RWMutex
+}


### PR DESCRIPTION
When a DistSender request has been running for some time without a response, asynchronously scan the range replicas for a different leaseholder. If found, cancel the in-flight request and retry it on a different replica.

Combined with expiration-based leases, this successfully recovers from disk stalls, replica deadlocks, and partial network partitions in less than 10 seconds.

Touches #105168.