### PR TITLE
release-23.1: roachtest: clean up `failover` tests

### DIFF
--- a/pkg/cmd/roachtest/cluster/monitor_interface.go
+++ b/pkg/cmd/roachtest/cluster/monitor_interface.go
@@ -25,6 +25,7 @@ type Monitor interface {
 	ExpectDeaths(count int32)
 	ResetDeaths()
 	Go(fn func(context.Context) error)
+	GoWithCancel(fn func(context.Context) error) func()
 	WaitE() error
 	Wait()
 }

--- a/pkg/cmd/roachtest/monitor.go
+++ b/pkg/cmd/roachtest/monitor.go
@@ -106,6 +106,16 @@ func (m *monitorImpl) Go(fn func(context.Context) error) {
 	})
 }
 
+// GoWithCancel is like Go, but returns a function that can be used to cancel
+// the goroutine.
+func (m *monitorImpl) GoWithCancel(fn func(context.Context) error) func() {
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.Go(func(_ context.Context) error {
+		return fn(ctx)
+	})
+	return cancel
+}
+
 func (m *monitorImpl) WaitE() error {
 	if m.t.Failed() {
 		// If the test has failed, don't try to limp along.

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -295,6 +295,7 @@ func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
 }
 
 func (s *dmsetupDiskStaller) Cleanup(ctx context.Context) {
+	s.c.Run(ctx, s.c.All(), `sudo dmsetup resume data1`)
 	s.c.Run(ctx, s.c.All(), `sudo umount /mnt/data1`)
 	s.c.Run(ctx, s.c.All(), `sudo dmsetup remove_all`)
 	s.c.Run(ctx, s.c.All(), `sudo mount /mnt/data1`)

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -166,7 +166,7 @@ func runFailoverChaos(
 	for _, failureMode := range allFailureModes {
 		failer := makeFailerWithoutLocalNoop(t, c, failureMode, opts, settings)
 		if c.IsLocal() && !failer.CanUseLocal() {
-			t.Status(fmt.Sprintf("skipping failure mode %q on local cluster", failureMode))
+			t.L().Printf("skipping failure mode %q on local cluster", failureMode)
 			continue
 		}
 		failer.Setup(ctx)
@@ -196,14 +196,14 @@ func runFailoverChaos(
 	if readOnly {
 		insertCount = 100000
 	}
-	t.Status("creating workload database")
+	t.L().Printf("creating workload database")
 	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	c.Run(ctx, c.Node(10), fmt.Sprintf(
 		`./cockroach workload init kv --splits 1000 --insert-count %d {pgurl:1}`, insertCount))
 
 	// Scatter the ranges, then relocate them off of the SQL gateways n1-n2.
-	t.Status("scattering table")
+	t.L().Printf("scattering table")
 	_, err = conn.ExecContext(ctx, `ALTER TABLE kv.kv SCATTER`)
 	require.NoError(t, err)
 	relocateRanges(t, ctx, conn, `true`, []int{1, 2}, []int{3, 4, 5, 6, 7, 8, 9})
@@ -212,7 +212,7 @@ func runFailoverChaos(
 	require.NoError(t, WaitForReplication(ctx, t, conn, 5 /* replicationFactor */))
 
 	// Start workload on n10 using n1-n2 as gateways.
-	t.Status("running workload")
+	t.L().Printf("running workload")
 	m := c.NewMonitor(ctx, c.Range(1, 9))
 	m.Go(func(ctx context.Context) error {
 		readPercent := 50
@@ -286,10 +286,10 @@ func runFailoverChaos(
 					for partialPeer == 0 || partialPeer == node {
 						partialPeer = 1 + rng.Intn(9)
 					}
-					t.Status(fmt.Sprintf("failing n%d to n%d (%s)", node, partialPeer, failer))
+					t.L().Printf("failing n%d to n%d (%s)", node, partialPeer, failer)
 					partialFailer.FailPartial(ctx, node, []int{partialPeer})
 				} else {
-					t.Status(fmt.Sprintf("failing n%d (%s)", node, failer))
+					t.L().Printf("failing n%d (%s)", node, failer)
 					failer.Fail(ctx, node)
 				}
 			}
@@ -301,7 +301,7 @@ func runFailoverChaos(
 			}
 
 			for node, failer := range nodeFailers {
-				t.Status(fmt.Sprintf("recovering n%d (%s)", node, failer))
+				t.L().Printf("recovering n%d (%s)", node, failer)
 				failer.Recover(ctx, node)
 			}
 		}
@@ -374,7 +374,7 @@ func runFailoverPartialLeaseGateway(
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
 
 	// Create the kv database with 5 replicas on n2-n6, and leases on n4.
-	t.Status("creating workload database")
+	t.L().Printf("creating workload database")
 	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{
@@ -394,7 +394,7 @@ func runFailoverPartialLeaseGateway(
 	relocateLeases(t, ctx, conn, `database_name = 'kv'`, 4)
 
 	// Start workload on n8 using n6-n7 as gateways.
-	t.Status("running workload")
+	t.L().Printf("running workload")
 	m := c.NewMonitor(ctx, c.Range(1, 7))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
@@ -455,7 +455,7 @@ func runFailoverPartialLeaseGateway(
 				}
 
 				for _, node := range tc.nodes {
-					t.Status(fmt.Sprintf("failing n%d to n%v (%s lease/gateway)", node, tc.peers, failer))
+					t.L().Printf("failing n%d to n%v (%s lease/gateway)", node, tc.peers, failer)
 					failer.FailPartial(ctx, node, tc.peers)
 				}
 
@@ -466,7 +466,7 @@ func runFailoverPartialLeaseGateway(
 				}
 
 				for _, node := range tc.nodes {
-					t.Status(fmt.Sprintf("recovering n%d to n%v (%s lease/gateway)", node, tc.peers, failer))
+					t.L().Printf("recovering n%d to n%v (%s lease/gateway)", node, tc.peers, failer)
 					failer.Recover(ctx, node)
 				}
 			}
@@ -536,7 +536,7 @@ func runFailoverPartialLeaseLeader(
 	c.Start(ctx, t.L(), opts, settings, c.Range(4, 6))
 
 	// Create the kv database on n4-n6.
-	t.Status("creating workload database")
+	t.L().Printf("creating workload database")
 	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{4, 5, 6}})
@@ -556,7 +556,7 @@ func runFailoverPartialLeaseLeader(
 		for _, node := range []int{4, 5, 6} {
 			count += nodeMetric(ctx, t, c, node, "replicas.leaders_not_leaseholders")
 		}
-		t.Status(fmt.Sprintf("%.0f split leaders/leaseholders", count))
+		t.L().Printf("%.0f split leaders/leaseholders", count)
 		if count >= 3 {
 			break
 		} else if i >= 10 {
@@ -566,7 +566,7 @@ func runFailoverPartialLeaseLeader(
 	}
 
 	// Start workload on n7 using n1-n3 as gateways.
-	t.Status("running workload")
+	t.L().Printf("running workload")
 	m := c.NewMonitor(ctx, c.Range(1, 6))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
@@ -614,7 +614,7 @@ func runFailoverPartialLeaseLeader(
 				if peer > 6 {
 					peer = 4
 				}
-				t.Status(fmt.Sprintf("failing n%d to n%d (%s lease/leader)", node, peer, failer))
+				t.L().Printf("failing n%d to n%d (%s lease/leader)", node, peer, failer)
 				failer.FailPartial(ctx, node, []int{peer})
 
 				select {
@@ -623,7 +623,7 @@ func runFailoverPartialLeaseLeader(
 					return ctx.Err()
 				}
 
-				t.Status(fmt.Sprintf("recovering n%d to n%d (%s lease/leader)", node, peer, failer))
+				t.L().Printf("recovering n%d to n%d (%s lease/leader)", node, peer, failer)
 				failer.Recover(ctx, node)
 			}
 		}
@@ -686,7 +686,7 @@ func runFailoverPartialLeaseLiveness(
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
 
 	// Create the kv database on n5-n7.
-	t.Status("creating workload database")
+	t.L().Printf("creating workload database")
 	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{5, 6, 7}})
@@ -702,7 +702,7 @@ func runFailoverPartialLeaseLiveness(
 	relocateRanges(t, ctx, conn, `range_id != 2`, []int{4}, []int{1, 2, 3})
 
 	// Start workload on n8 using n1-n3 as gateways (not partitioned).
-	t.Status("running workload")
+	t.L().Printf("running workload")
 	m := c.NewMonitor(ctx, c.Range(1, 7))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
@@ -750,7 +750,7 @@ func runFailoverPartialLeaseLiveness(
 				}
 
 				peer := 4
-				t.Status(fmt.Sprintf("failing n%d to n%d (%s lease/liveness)", node, peer, failer))
+				t.L().Printf("failing n%d to n%d (%s lease/liveness)", node, peer, failer)
 				failer.FailPartial(ctx, node, []int{peer})
 
 				select {
@@ -759,7 +759,7 @@ func runFailoverPartialLeaseLiveness(
 					return ctx.Err()
 				}
 
-				t.Status(fmt.Sprintf("recovering n%d to n%d (%s lease/liveness)", node, peer, failer))
+				t.L().Printf("recovering n%d to n%d (%s lease/liveness)", node, peer, failer)
 				failer.Recover(ctx, node)
 			}
 		}
@@ -818,7 +818,7 @@ func runFailoverNonSystem(
 	defer conn.Close()
 
 	// Configure cluster. This test controls the ranges manually.
-	t.Status("configuring cluster")
+	t.L().Printf("configuring cluster")
 	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
 	require.NoError(t, err)
 	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
@@ -833,7 +833,7 @@ func runFailoverNonSystem(
 
 	// Create the kv database, constrained to n4-n6. Despite the zone config, the
 	// ranges will initially be distributed across all cluster nodes.
-	t.Status("creating workload database")
+	t.L().Printf("creating workload database")
 	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{4, 5, 6}})
@@ -848,7 +848,7 @@ func runFailoverNonSystem(
 	// Start workload on n7, using n1-n3 as gateways. Run it for 20
 	// minutes, since we take ~2 minutes to fail and recover each node, and
 	// we do 3 cycles of each of the 3 nodes in order.
-	t.Status("running workload")
+	t.L().Printf("running workload")
 	m := c.NewMonitor(ctx, c.Range(1, 6))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
@@ -891,7 +891,7 @@ func runFailoverNonSystem(
 				case <-ctx.Done():
 				}
 
-				t.Status(fmt.Sprintf("failing n%d (%s)", node, failer))
+				t.L().Printf("failing n%d (%s)", node, failer)
 				failer.Fail(ctx, node)
 
 				select {
@@ -900,7 +900,7 @@ func runFailoverNonSystem(
 					return ctx.Err()
 				}
 
-				t.Status(fmt.Sprintf("recovering n%d (%s)", node, failer))
+				t.L().Printf("recovering n%d (%s)", node, failer)
 				failer.Recover(ctx, node)
 			}
 		}
@@ -960,7 +960,7 @@ func runFailoverLiveness(
 	defer conn.Close()
 
 	// Configure cluster. This test controls the ranges manually.
-	t.Status("configuring cluster")
+	t.L().Printf("configuring cluster")
 	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
 	require.NoError(t, err)
 	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
@@ -979,7 +979,7 @@ func runFailoverLiveness(
 
 	// Create the kv database, constrained to n1-n3. Despite the zone config, the
 	// ranges will initially be distributed across all cluster nodes.
-	t.Status("creating workload database")
+	t.L().Printf("creating workload database")
 	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -996,7 +996,7 @@ func runFailoverLiveness(
 
 	// Start workload on n7, using n1-n3 as gateways. Run it for 20 minutes, since
 	// we take ~2 minutes to fail and recover the node, and we do 9 cycles.
-	t.Status("running workload")
+	t.L().Printf("running workload")
 	m := c.NewMonitor(ctx, c.Range(1, 4))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(5), `./cockroach workload run kv --read-percent 50 `+
@@ -1038,7 +1038,7 @@ func runFailoverLiveness(
 			case <-ctx.Done():
 			}
 
-			t.Status(fmt.Sprintf("failing n%d (%s)", 4, failer))
+			t.L().Printf("failing n%d (%s)", 4, failer)
 			failer.Fail(ctx, 4)
 
 			select {
@@ -1047,7 +1047,7 @@ func runFailoverLiveness(
 				return ctx.Err()
 			}
 
-			t.Status(fmt.Sprintf("recovering n%d (%s)", 4, failer))
+			t.L().Printf("recovering n%d (%s)", 4, failer)
 			failer.Recover(ctx, 4)
 			relocateLeases(t, ctx, conn, `range_id = 2`, 4)
 		}
@@ -1106,7 +1106,7 @@ func runFailoverSystemNonLiveness(
 	defer conn.Close()
 
 	// Configure cluster. This test controls the ranges manually.
-	t.Status("configuring cluster")
+	t.L().Printf("configuring cluster")
 	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
 	require.NoError(t, err)
 	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
@@ -1124,7 +1124,7 @@ func runFailoverSystemNonLiveness(
 
 	// Create the kv database, constrained to n1-n3. Despite the zone config, the
 	// ranges will initially be distributed across all cluster nodes.
-	t.Status("creating workload database")
+	t.L().Printf("creating workload database")
 	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -1142,7 +1142,7 @@ func runFailoverSystemNonLiveness(
 	// Start workload on n7, using n1-n3 as gateways. Run it for 20 minutes, since
 	// we take ~2 minutes to fail and recover each node, and we do 3 cycles of each
 	// of the 3 nodes in order.
-	t.Status("running workload")
+	t.L().Printf("running workload")
 	m := c.NewMonitor(ctx, c.Range(1, 6))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
@@ -1187,7 +1187,7 @@ func runFailoverSystemNonLiveness(
 				case <-ctx.Done():
 				}
 
-				t.Status(fmt.Sprintf("failing n%d (%s)", node, failer))
+				t.L().Printf("failing n%d (%s)", node, failer)
 				failer.Fail(ctx, node)
 
 				select {
@@ -1196,7 +1196,7 @@ func runFailoverSystemNonLiveness(
 					return ctx.Err()
 				}
 
-				t.Status(fmt.Sprintf("recovering n%d (%s)", node, failer))
+				t.L().Printf("recovering n%d (%s)", node, failer)
 				failer.Recover(ctx, node)
 			}
 		}
@@ -1239,9 +1239,9 @@ func makeFailer(
 ) Failer {
 	f := makeFailerWithoutLocalNoop(t, c, failureMode, opts, settings)
 	if c.IsLocal() && !f.CanUseLocal() {
-		t.Status(fmt.Sprintf(
+		t.L().Printf(
 			`failure mode %q not supported on local clusters, using "noop" failure mode instead`,
-			failureMode))
+			failureMode)
 		f = &noopFailer{}
 	}
 	return f
@@ -1592,7 +1592,7 @@ func waitForUpreplication(
 		if count == 0 {
 			break
 		}
-		t.Status(fmt.Sprintf("waiting for %d ranges to upreplicate (%s)", count, predicate))
+		t.L().Printf("waiting for %d ranges to upreplicate (%s)", count, predicate)
 		time.Sleep(time.Second)
 	}
 }
@@ -1614,13 +1614,13 @@ func relocateRanges(
 			if count == 0 {
 				break
 			}
-			t.Status(fmt.Sprintf("moving %d ranges off of n%d (%s)", count, source, predicate))
+			t.L().Printf("moving %d ranges off of n%d (%s)", count, source, predicate)
 			for _, target := range to {
 				_, err := conn.ExecContext(ctx, `ALTER RANGE RELOCATE FROM $1::int TO $2::int FOR `+
 					`SELECT DISTINCT range_id FROM [SHOW CLUSTER RANGES WITH TABLES] WHERE `+where,
 					source, target)
 				if err != nil {
-					t.Status(fmt.Sprintf("failed to move ranges: %s", err))
+					t.L().Printf("failed to move ranges: %s", err)
 				}
 			}
 			time.Sleep(time.Second)
@@ -1642,11 +1642,11 @@ func relocateLeases(t test.Test, ctx context.Context, conn *gosql.DB, predicate 
 		if count == 0 {
 			break
 		}
-		t.Status(fmt.Sprintf("moving %d leases to n%d (%s)", count, to, predicate))
+		t.L().Printf("moving %d leases to n%d (%s)", count, to, predicate)
 		_, err := conn.ExecContext(ctx, `ALTER RANGE RELOCATE LEASE TO $1::int FOR `+
 			`SELECT DISTINCT range_id FROM [SHOW CLUSTER RANGES WITH TABLES, DETAILS] WHERE `+where, to)
 		if err != nil {
-			t.Status(fmt.Sprintf("failed to move leases: %s", err))
+			t.L().Printf("failed to move leases: %s", err)
 		}
 		time.Sleep(time.Second)
 	}
@@ -1696,7 +1696,7 @@ func configureZone(
 	query := fmt.Sprintf(
 		`ALTER %s CONFIGURE ZONE USING num_replicas = %d, constraints = '[%s]', lease_preferences = '[%s]'`,
 		target, cfg.replicas, constraintsString, leaseString)
-	t.Status(query)
+	t.L().Printf(query)
 	_, err := conn.ExecContext(ctx, query)
 	require.NoError(t, err)
 }

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -793,11 +793,6 @@ func runFailoverNonSystem(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	// Configure cluster. This test controls the ranges manually.
-	t.L().Printf("configuring cluster")
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-
 	// Constrain all existing zone configs to n1-n3.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 
@@ -807,7 +802,7 @@ func runFailoverNonSystem(
 	// Create the kv database, constrained to n4-n6. Despite the zone config, the
 	// ranges will initially be distributed across all cluster nodes.
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{4, 5, 6}})
 	c.Run(ctx, c.Node(7), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
@@ -932,17 +927,11 @@ func runFailoverLiveness(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	// Configure cluster. This test controls the ranges manually.
-	t.L().Printf("configuring cluster")
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-
 	// Constrain all existing zone configs to n1-n3.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 
 	// Constrain the liveness range to n1-n4, with leaseholder preference on n4.
 	configureZone(t, ctx, conn, `RANGE liveness`, zoneConfig{replicas: 4, leaseNode: 4})
-	require.NoError(t, err)
 
 	// Wait for upreplication.
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
@@ -950,7 +939,7 @@ func runFailoverLiveness(
 	// Create the kv database, constrained to n1-n3. Despite the zone config, the
 	// ranges will initially be distributed across all cluster nodes.
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 	c.Run(ctx, c.Node(5), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
@@ -1075,16 +1064,10 @@ func runFailoverSystemNonLiveness(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	// Configure cluster. This test controls the ranges manually.
-	t.L().Printf("configuring cluster")
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-
 	// Constrain all existing zone configs to n4-n6, except liveness which is
 	// constrained to n1-n3.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{4, 5, 6}})
 	configureZone(t, ctx, conn, `RANGE liveness`, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
-	require.NoError(t, err)
 
 	// Wait for upreplication.
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
@@ -1092,7 +1075,7 @@ func runFailoverSystemNonLiveness(
 	// Create the kv database, constrained to n1-n3. Despite the zone config, the
 	// ranges will initially be distributed across all cluster nodes.
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 	c.Run(ctx, c.Node(7), `./cockroach workload init kv --splits 1000 {pgurl:1}`)

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -143,6 +143,7 @@ func registerFailover(r registry.Registry) {
 			r.Add(registry.TestSpec{
 				Name:                fmt.Sprintf("failover/liveness/%s%s", failureMode, suffix),
 				Owner:               registry.OwnerKV,
+				Tags:                []string{"weekly"},
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
 				Cluster:             r.MakeClusterSpec(5, spec.CPU(2), spec.PreferLocalSSD(!usePD)),
@@ -155,6 +156,7 @@ func registerFailover(r registry.Registry) {
 			r.Add(registry.TestSpec{
 				Name:                fmt.Sprintf("failover/system-non-liveness/%s%s", failureMode, suffix),
 				Owner:               registry.OwnerKV,
+				Tags:                []string{"weekly"},
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
 				Cluster:             r.MakeClusterSpec(7, spec.CPU(2), spec.PreferLocalSSD(!usePD)),

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -192,9 +192,11 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
+	m := c.NewMonitor(ctx, c.Range(1, 9))
+
 	failers := []Failer{}
 	for _, failureMode := range allFailureModes {
-		failer := makeFailerWithoutLocalNoop(t, c, failureMode, opts, settings, rng)
+		failer := makeFailerWithoutLocalNoop(t, c, m, failureMode, opts, settings, rng)
 		if c.IsLocal() && !failer.CanUseLocal() {
 			t.L().Printf("skipping failure mode %q on local cluster", failureMode)
 			continue
@@ -207,7 +209,6 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 9))
 
-	m := c.NewMonitor(ctx, c.Range(1, 9))
 	conn := c.Conn(ctx, t.L(), 1)
 
 	// Place 5 replicas of all ranges on n3-n9, keeping n1-n2 as SQL gateways.
@@ -279,7 +280,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 						}
 					}
 				}
-				failer.Ready(ctx, m)
+				failer.Ready(ctx)
 				nodeFailers[node] = failer
 			}
 
@@ -361,14 +362,15 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	failer := makeFailer(t, c, failureModeBlackhole, opts, settings, rng).(PartialFailer)
+	m := c.NewMonitor(ctx, c.Range(1, 7))
+
+	failer := makeFailer(t, c, m, failureModeBlackhole, opts, settings, rng).(PartialFailer)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 7))
 
-	m := c.NewMonitor(ctx, c.Range(1, 7))
 	conn := c.Conn(ctx, t.L(), 1)
 
 	// Place all ranges on n1-n3 to start with.
@@ -433,7 +435,7 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 			for _, tc := range testcases {
 				sleepFor(ctx, t, time.Minute)
 
-				failer.Ready(ctx, m)
+				failer.Ready(ctx)
 
 				// Ranges and leases may occasionally escape their constraints. Move
 				// them to where they should be.
@@ -493,7 +495,9 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 	settings.Env = append(settings.Env, "COCKROACH_DISABLE_LEADER_FOLLOWS_LEASEHOLDER=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	failer := makeFailer(t, c, failureModeBlackhole, opts, settings, rng).(PartialFailer)
+	m := c.NewMonitor(ctx, c.Range(1, 6))
+
+	failer := makeFailer(t, c, m, failureModeBlackhole, opts, settings, rng).(PartialFailer)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
@@ -514,7 +518,6 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 
 	// Now that system ranges are properly placed on n1-n3, start n4-n6.
 	c.Start(ctx, t.L(), opts, settings, c.Range(4, 6))
-	m := c.NewMonitor(ctx, c.Range(1, 6))
 
 	// Create the kv database on n4-n6.
 	t.L().Printf("creating workload database")
@@ -567,7 +570,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 			for _, node := range []int{4, 5, 6} {
 				sleepFor(ctx, t, time.Minute)
 
-				failer.Ready(ctx, m)
+				failer.Ready(ctx)
 
 				// Ranges may occasionally escape their constraints. Move them to where
 				// they should be.
@@ -625,14 +628,15 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	failer := makeFailer(t, c, failureModeBlackhole, opts, settings, rng).(PartialFailer)
+	m := c.NewMonitor(ctx, c.Range(1, 7))
+
+	failer := makeFailer(t, c, m, failureModeBlackhole, opts, settings, rng).(PartialFailer)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 7))
 
-	m := c.NewMonitor(ctx, c.Range(1, 7))
 	conn := c.Conn(ctx, t.L(), 1)
 
 	// Place all ranges on n1-n3, and an extra liveness leaseholder replica on n4.
@@ -682,7 +686,7 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 			for _, node := range []int{5, 6, 7} {
 				sleepFor(ctx, t, time.Minute)
 
-				failer.Ready(ctx, m)
+				failer.Ready(ctx)
 
 				// Ranges and leases may occasionally escape their constraints. Move
 				// them to where they should be.
@@ -740,14 +744,15 @@ func runFailoverNonSystem(
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	failer := makeFailer(t, c, failureMode, opts, settings, rng)
+	m := c.NewMonitor(ctx, c.Range(1, 6))
+
+	failer := makeFailer(t, c, m, failureMode, opts, settings, rng)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 6))
 
-	m := c.NewMonitor(ctx, c.Range(1, 6))
 	conn := c.Conn(ctx, t.L(), 1)
 
 	// Constrain all existing zone configs to n1-n3.
@@ -790,7 +795,7 @@ func runFailoverNonSystem(
 			for _, node := range []int{4, 5, 6} {
 				sleepFor(ctx, t, time.Minute)
 
-				failer.Ready(ctx, m)
+				failer.Ready(ctx)
 
 				// Ranges may occasionally escape their constraints. Move them
 				// to where they should be.
@@ -848,14 +853,15 @@ func runFailoverLiveness(
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	failer := makeFailer(t, c, failureMode, opts, settings, rng)
+	m := c.NewMonitor(ctx, c.Range(1, 4))
+
+	failer := makeFailer(t, c, m, failureMode, opts, settings, rng)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 4))
 
-	m := c.NewMonitor(ctx, c.Range(1, 4))
 	conn := c.Conn(ctx, t.L(), 1)
 
 	// Constrain all existing zone configs to n1-n3.
@@ -903,7 +909,7 @@ func runFailoverLiveness(
 		for i := 0; i < 9; i++ {
 			sleepFor(ctx, t, time.Minute)
 
-			failer.Ready(ctx, m)
+			failer.Ready(ctx)
 
 			// Ranges and leases may occasionally escape their constraints. Move them
 			// to where they should be.
@@ -960,14 +966,15 @@ func runFailoverSystemNonLiveness(
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	failer := makeFailer(t, c, failureMode, opts, settings, rng)
+	m := c.NewMonitor(ctx, c.Range(1, 6))
+
+	failer := makeFailer(t, c, m, failureMode, opts, settings, rng)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 6))
 
-	m := c.NewMonitor(ctx, c.Range(1, 6))
 	conn := c.Conn(ctx, t.L(), 1)
 
 	// Constrain all existing zone configs to n4-n6, except liveness which is
@@ -1015,7 +1022,7 @@ func runFailoverSystemNonLiveness(
 			for _, node := range []int{4, 5, 6} {
 				sleepFor(ctx, t, time.Minute)
 
-				failer.Ready(ctx, m)
+				failer.Ready(ctx)
 
 				// Ranges may occasionally escape their constraints. Move them
 				// to where they should be.
@@ -1070,12 +1077,13 @@ var allFailureModes = []failureMode{
 func makeFailer(
 	t test.Test,
 	c cluster.Cluster,
+	m cluster.Monitor,
 	failureMode failureMode,
 	opts option.StartOpts,
 	settings install.ClusterSettings,
 	rng *rand.Rand,
 ) Failer {
-	f := makeFailerWithoutLocalNoop(t, c, failureMode, opts, settings, rng)
+	f := makeFailerWithoutLocalNoop(t, c, m, failureMode, opts, settings, rng)
 	if c.IsLocal() && !f.CanUseLocal() {
 		t.L().Printf(
 			`failure mode %q not supported on local clusters, using "noop" failure mode instead`,
@@ -1088,6 +1096,7 @@ func makeFailer(
 func makeFailerWithoutLocalNoop(
 	t test.Test,
 	c cluster.Cluster,
+	m cluster.Monitor,
 	failureMode failureMode,
 	opts option.StartOpts,
 	settings install.ClusterSettings,
@@ -1117,6 +1126,7 @@ func makeFailerWithoutLocalNoop(
 		return &crashFailer{
 			t:             t,
 			c:             c,
+			m:             m,
 			startOpts:     opts,
 			startSettings: settings,
 		}
@@ -1124,6 +1134,7 @@ func makeFailerWithoutLocalNoop(
 		return &diskStallFailer{
 			t:             t,
 			c:             c,
+			m:             m,
 			startOpts:     opts,
 			startSettings: settings,
 			staller:       &dmsetupDiskStaller{t: t, c: c},
@@ -1161,7 +1172,7 @@ type Failer interface {
 
 	// Ready is called some time before failing each node, when the cluster and
 	// workload is running and after recovering the previous node failure if any.
-	Ready(ctx context.Context, m cluster.Monitor)
+	Ready(ctx context.Context)
 
 	// Cleanup cleans up when the test exits. This is needed e.g. when the cluster
 	// is reused by a different test.
@@ -1190,7 +1201,7 @@ func (f *noopFailer) String() string                          { return string(f.
 func (f *noopFailer) CanUseLocal() bool                       { return true }
 func (f *noopFailer) CanRunWith(failureMode) bool             { return true }
 func (f *noopFailer) Setup(context.Context)                   {}
-func (f *noopFailer) Ready(context.Context, cluster.Monitor)  {}
+func (f *noopFailer) Ready(context.Context)                   {}
 func (f *noopFailer) Cleanup(context.Context)                 {}
 func (f *noopFailer) Fail(context.Context, int)               {}
 func (f *noopFailer) FailPartial(context.Context, int, []int) {}
@@ -1218,11 +1229,11 @@ func (f *blackholeFailer) Mode() failureMode {
 	return failureModeBlackhole
 }
 
-func (f *blackholeFailer) String() string                         { return string(f.Mode()) }
-func (f *blackholeFailer) CanUseLocal() bool                      { return false } // needs iptables
-func (f *blackholeFailer) CanRunWith(failureMode) bool            { return true }
-func (f *blackholeFailer) Setup(context.Context)                  {}
-func (f *blackholeFailer) Ready(context.Context, cluster.Monitor) {}
+func (f *blackholeFailer) String() string              { return string(f.Mode()) }
+func (f *blackholeFailer) CanUseLocal() bool           { return false } // needs iptables
+func (f *blackholeFailer) CanRunWith(failureMode) bool { return true }
+func (f *blackholeFailer) Setup(context.Context)       {}
+func (f *blackholeFailer) Ready(context.Context)       {}
 
 func (f *blackholeFailer) Cleanup(ctx context.Context) {
 	f.c.Run(ctx, f.c.All(), `sudo iptables -F`)
@@ -1303,13 +1314,13 @@ type crashFailer struct {
 	startSettings install.ClusterSettings
 }
 
-func (f *crashFailer) Mode() failureMode                          { return failureModeCrash }
-func (f *crashFailer) String() string                             { return string(f.Mode()) }
-func (f *crashFailer) CanUseLocal() bool                          { return true }
-func (f *crashFailer) CanRunWith(failureMode) bool                { return true }
-func (f *crashFailer) Setup(_ context.Context)                    {}
-func (f *crashFailer) Ready(_ context.Context, m cluster.Monitor) { f.m = m }
-func (f *crashFailer) Cleanup(_ context.Context)                  {}
+func (f *crashFailer) Mode() failureMode           { return failureModeCrash }
+func (f *crashFailer) String() string              { return string(f.Mode()) }
+func (f *crashFailer) CanUseLocal() bool           { return true }
+func (f *crashFailer) CanRunWith(failureMode) bool { return true }
+func (f *crashFailer) Setup(context.Context)       {}
+func (f *crashFailer) Ready(context.Context)       {}
+func (f *crashFailer) Cleanup(context.Context)     {}
 
 func (f *crashFailer) Fail(ctx context.Context, nodeID int) {
 	f.m.ExpectDeath()
@@ -1335,13 +1346,10 @@ func (f *diskStallFailer) Mode() failureMode           { return failureModeDiskS
 func (f *diskStallFailer) String() string              { return string(f.Mode()) }
 func (f *diskStallFailer) CanUseLocal() bool           { return false } // needs dmsetup
 func (f *diskStallFailer) CanRunWith(failureMode) bool { return true }
+func (f *diskStallFailer) Ready(context.Context)       {}
 
 func (f *diskStallFailer) Setup(ctx context.Context) {
 	f.staller.Setup(ctx)
-}
-
-func (f *diskStallFailer) Ready(_ context.Context, m cluster.Monitor) {
-	f.m = m
 }
 
 func (f *diskStallFailer) Cleanup(ctx context.Context) {
@@ -1385,7 +1393,7 @@ func (f *pauseFailer) CanRunWith(other failureMode) bool {
 	return other != failureModeDiskStall
 }
 
-func (f *pauseFailer) Ready(ctx context.Context, _ cluster.Monitor) {
+func (f *pauseFailer) Ready(ctx context.Context) {
 	// The process pause can trip the disk stall detector, so we disable it. We
 	// could let it fire, but we'd like to see if the node can recover from the
 	// pause and keep working.

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -263,7 +263,17 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 		for i := 0; i < 20; i++ {
 			sleepFor(ctx, t, time.Minute)
 
-			// Pick 1 or 2 random nodes and failure modes.
+			// Ranges may occasionally escape their constraints. Move them to where
+			// they should be.
+			relocateRanges(t, ctx, conn, `true`, []int{1, 2}, []int{3, 4, 5, 6, 7, 8, 9})
+
+			// Randomly sleep up to the lease renewal interval, to vary the time
+			// between the last lease renewal and the failure.
+			sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
+
+			// Pick 1 or 2 random nodes and failure modes. Make sure we call Ready()
+			// on both before failing, since we may need to fetch information from the
+			// cluster which won't work if there's an active failure.
 			nodeFailers := map[int]Failer{}
 			for numNodes := 1 + rng.Intn(2); len(nodeFailers) < numNodes; {
 				var node int
@@ -280,17 +290,9 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 						}
 					}
 				}
-				failer.Ready(ctx)
+				failer.Ready(ctx, node)
 				nodeFailers[node] = failer
 			}
-
-			// Ranges may occasionally escape their constraints. Move them to where
-			// they should be.
-			relocateRanges(t, ctx, conn, `true`, []int{1, 2}, []int{3, 4, 5, 6, 7, 8, 9})
-
-			// Randomly sleep up to the lease renewal interval, to vary the time
-			// between the last lease renewal and the failure.
-			sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 			for node, failer := range nodeFailers {
 				// If the failer supports partial failures (e.g. partial partitions), do
@@ -437,8 +439,6 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 			for _, tc := range testcases {
 				sleepFor(ctx, t, time.Minute)
 
-				failer.Ready(ctx)
-
 				// Ranges and leases may occasionally escape their constraints. Move
 				// them to where they should be.
 				relocateRanges(t, ctx, conn, `database_name = 'kv'`, []int{1, 7}, []int{2, 3, 4, 5, 6})
@@ -448,6 +448,10 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 				// Randomly sleep up to the lease renewal interval, to vary the time
 				// between the last lease renewal and the failure.
 				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
+
+				for _, node := range tc.nodes {
+					failer.Ready(ctx, node)
+				}
 
 				for _, node := range tc.nodes {
 					t.L().Printf("failing n%d to n%v (%s lease/gateway)", node, tc.peers, failer)
@@ -574,8 +578,6 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 			for _, node := range []int{4, 5, 6} {
 				sleepFor(ctx, t, time.Minute)
 
-				failer.Ready(ctx)
-
 				// Ranges may occasionally escape their constraints. Move them to where
 				// they should be.
 				relocateRanges(t, ctx, conn, `database_name = 'kv'`, []int{1, 2, 3}, []int{4, 5, 6})
@@ -584,6 +586,8 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 				// Randomly sleep up to the lease renewal interval, to vary the time
 				// between the last lease renewal and the failure.
 				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
+
+				failer.Ready(ctx, node)
 
 				peer := node + 1
 				if peer > 6 {
@@ -692,8 +696,6 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 			for _, node := range []int{5, 6, 7} {
 				sleepFor(ctx, t, time.Minute)
 
-				failer.Ready(ctx)
-
 				// Ranges and leases may occasionally escape their constraints. Move
 				// them to where they should be.
 				relocateRanges(t, ctx, conn, `database_name = 'kv'`, []int{1, 2, 3, 4}, []int{5, 6, 7})
@@ -704,6 +706,8 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 				// Randomly sleep up to the lease renewal interval, to vary the time
 				// between the last lease renewal and the failure.
 				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
+
+				failer.Ready(ctx, node)
 
 				peer := 4
 				t.L().Printf("failing n%d to n%d (%s lease/liveness)", node, peer, failer)
@@ -803,8 +807,6 @@ func runFailoverNonSystem(
 			for _, node := range []int{4, 5, 6} {
 				sleepFor(ctx, t, time.Minute)
 
-				failer.Ready(ctx)
-
 				// Ranges may occasionally escape their constraints. Move them
 				// to where they should be.
 				relocateRanges(t, ctx, conn, `database_name = 'kv'`, []int{1, 2, 3}, []int{4, 5, 6})
@@ -813,6 +815,8 @@ func runFailoverNonSystem(
 				// Randomly sleep up to the lease renewal interval, to vary the time
 				// between the last lease renewal and the failure.
 				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
+
+				failer.Ready(ctx, node)
 
 				t.L().Printf("failing n%d (%s)", node, failer)
 				failer.Fail(ctx, node)
@@ -917,8 +921,6 @@ func runFailoverLiveness(
 		for i := 0; i < 9; i++ {
 			sleepFor(ctx, t, time.Minute)
 
-			failer.Ready(ctx)
-
 			// Ranges and leases may occasionally escape their constraints. Move them
 			// to where they should be.
 			relocateRanges(t, ctx, conn, `range_id != 2`, []int{4}, []int{1, 2, 3})
@@ -927,6 +929,8 @@ func runFailoverLiveness(
 			// Randomly sleep up to the lease renewal interval, to vary the time
 			// between the last lease renewal and the failure.
 			sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
+
+			failer.Ready(ctx, 4)
 
 			t.L().Printf("failing n%d (%s)", 4, failer)
 			failer.Fail(ctx, 4)
@@ -1032,8 +1036,6 @@ func runFailoverSystemNonLiveness(
 			for _, node := range []int{4, 5, 6} {
 				sleepFor(ctx, t, time.Minute)
 
-				failer.Ready(ctx)
-
 				// Ranges may occasionally escape their constraints. Move them
 				// to where they should be.
 				relocateRanges(t, ctx, conn, `database_name != 'kv' AND range_id != 2`,
@@ -1044,6 +1046,8 @@ func runFailoverSystemNonLiveness(
 				// Randomly sleep up to the lease renewal interval, to vary the time
 				// between the last lease renewal and the failure.
 				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
+
+				failer.Ready(ctx, node)
 
 				t.L().Printf("failing n%d (%s)", node, failer)
 				failer.Fail(ctx, node)
@@ -1182,13 +1186,13 @@ type Failer interface {
 	// Setup prepares the failer. It is called before the cluster is started.
 	Setup(ctx context.Context)
 
-	// Ready is called some time before failing each node, when the cluster and
-	// workload is running and after recovering the previous node failure if any.
-	Ready(ctx context.Context)
-
 	// Cleanup cleans up when the test exits. This is needed e.g. when the cluster
 	// is reused by a different test.
 	Cleanup(ctx context.Context)
+
+	// Ready is called before failing each node, when the cluster and workload is
+	// running and after recovering the previous node failure if any.
+	Ready(ctx context.Context, nodeID int)
 
 	// Fail fails the given node.
 	Fail(ctx context.Context, nodeID int)
@@ -1213,7 +1217,7 @@ func (f *noopFailer) String() string                          { return string(f.
 func (f *noopFailer) CanUseLocal() bool                       { return true }
 func (f *noopFailer) CanRunWith(failureMode) bool             { return true }
 func (f *noopFailer) Setup(context.Context)                   {}
-func (f *noopFailer) Ready(context.Context)                   {}
+func (f *noopFailer) Ready(context.Context, int)              {}
 func (f *noopFailer) Cleanup(context.Context)                 {}
 func (f *noopFailer) Fail(context.Context, int)               {}
 func (f *noopFailer) FailPartial(context.Context, int, []int) {}
@@ -1245,7 +1249,7 @@ func (f *blackholeFailer) String() string              { return string(f.Mode())
 func (f *blackholeFailer) CanUseLocal() bool           { return false } // needs iptables
 func (f *blackholeFailer) CanRunWith(failureMode) bool { return true }
 func (f *blackholeFailer) Setup(context.Context)       {}
-func (f *blackholeFailer) Ready(context.Context)       {}
+func (f *blackholeFailer) Ready(context.Context, int)  {}
 
 func (f *blackholeFailer) Cleanup(ctx context.Context) {
 	f.c.Run(ctx, f.c.All(), `sudo iptables -F`)
@@ -1331,7 +1335,7 @@ func (f *crashFailer) String() string              { return string(f.Mode()) }
 func (f *crashFailer) CanUseLocal() bool           { return true }
 func (f *crashFailer) CanRunWith(failureMode) bool { return true }
 func (f *crashFailer) Setup(context.Context)       {}
-func (f *crashFailer) Ready(context.Context)       {}
+func (f *crashFailer) Ready(context.Context, int)  {}
 func (f *crashFailer) Cleanup(context.Context)     {}
 
 func (f *crashFailer) Fail(ctx context.Context, nodeID int) {
@@ -1358,7 +1362,7 @@ func (f *diskStallFailer) Mode() failureMode           { return failureModeDiskS
 func (f *diskStallFailer) String() string              { return string(f.Mode()) }
 func (f *diskStallFailer) CanUseLocal() bool           { return false } // needs dmsetup
 func (f *diskStallFailer) CanRunWith(failureMode) bool { return true }
-func (f *diskStallFailer) Ready(context.Context)       {}
+func (f *diskStallFailer) Ready(context.Context, int)  {}
 
 func (f *diskStallFailer) Setup(ctx context.Context) {
 	f.staller.Setup(ctx)
@@ -1405,11 +1409,11 @@ func (f *pauseFailer) CanRunWith(other failureMode) bool {
 	return other != failureModeDiskStall
 }
 
-func (f *pauseFailer) Ready(ctx context.Context) {
+func (f *pauseFailer) Ready(ctx context.Context, nodeID int) {
 	// The process pause can trip the disk stall detector, so we disable it. We
 	// could let it fire, but we'd like to see if the node can recover from the
 	// pause and keep working.
-	conn := f.c.Conn(ctx, f.t.L(), 1)
+	conn := f.c.Conn(ctx, f.t.L(), nodeID)
 	_, err := conn.ExecContext(ctx,
 		`SET CLUSTER SETTING storage.max_sync_duration.fatal.enabled = false`)
 	require.NoError(f.t, err)

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -175,8 +175,8 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 9))
 
+	m := c.NewMonitor(ctx, c.Range(1, 9))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Place 5 replicas of all ranges on n3-n9, keeping n1-n2 as SQL gateways.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 5, onlyNodes: []int{3, 4, 5, 6, 7, 8, 9}})
@@ -207,7 +207,6 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 
 	// Start workload on n10 using n1-n2 as gateways.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 9))
 	m.Go(func(ctx context.Context) error {
 		readPercent := 50
 		if readOnly {
@@ -352,8 +351,8 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 7))
 
+	m := c.NewMonitor(ctx, c.Range(1, 7))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Place all ranges on n1-n3 to start with.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -383,7 +382,6 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 
 	// Start workload on n8 using n6-n7 as gateways.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 7))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
@@ -502,7 +500,6 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 3))
 
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Place all ranges on n1-n3 to start with, and wait for upreplication.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -516,6 +513,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 
 	// Now that system ranges are properly placed on n1-n3, start n4-n6.
 	c.Start(ctx, t.L(), opts, settings, c.Range(4, 6))
+	m := c.NewMonitor(ctx, c.Range(1, 6))
 
 	// Create the kv database on n4-n6.
 	t.L().Printf("creating workload database")
@@ -549,7 +547,6 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 
 	// Start workload on n7 using n1-n3 as gateways.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 6))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
@@ -650,8 +647,8 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 7))
 
+	m := c.NewMonitor(ctx, c.Range(1, 7))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Place all ranges on n1-n3, and an extra liveness leaseholder replica on n4.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -679,7 +676,6 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 
 	// Start workload on n8 using n1-n3 as gateways (not partitioned).
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 7))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
@@ -790,8 +786,8 @@ func runFailoverNonSystem(
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 6))
 
+	m := c.NewMonitor(ctx, c.Range(1, 6))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Constrain all existing zone configs to n1-n3.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -817,7 +813,6 @@ func runFailoverNonSystem(
 	// minutes, since we take ~2 minutes to fail and recover each node, and
 	// we do 3 cycles of each of the 3 nodes in order.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 6))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
@@ -924,8 +919,8 @@ func runFailoverLiveness(
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 4))
 
+	m := c.NewMonitor(ctx, c.Range(1, 4))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Constrain all existing zone configs to n1-n3.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
@@ -956,7 +951,6 @@ func runFailoverLiveness(
 	// Start workload on n7, using n1-n3 as gateways. Run it for 20 minutes, since
 	// we take ~2 minutes to fail and recover the node, and we do 9 cycles.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 4))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(5), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
@@ -1061,8 +1055,8 @@ func runFailoverSystemNonLiveness(
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, t.L(), opts, settings, c.Range(1, 6))
 
+	m := c.NewMonitor(ctx, c.Range(1, 6))
 	conn := c.Conn(ctx, t.L(), 1)
-	defer conn.Close()
 
 	// Constrain all existing zone configs to n4-n6, except liveness which is
 	// constrained to n1-n3.
@@ -1093,7 +1087,6 @@ func runFailoverSystemNonLiveness(
 	// we take ~2 minutes to fail and recover each node, and we do 3 cycles of each
 	// of the 3 nodes in order.
 	t.L().Printf("running workload")
-	m := c.NewMonitor(ctx, c.Range(1, 6))
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -76,7 +76,7 @@ func registerFailover(r registry.Registry) {
 				Name:                "failover/chaos" + suffix,
 				Owner:               registry.OwnerKV,
 				Timeout:             60 * time.Minute,
-				Cluster:             r.MakeClusterSpec(10, spec.CPU(4), spec.PreferLocalSSD(false)), // uses disk stalls
+				Cluster:             r.MakeClusterSpec(10, spec.CPU(2), spec.PreferLocalSSD(false)), // uses disk stalls
 				Leases:              leases,
 				SkipPostValidations: registry.PostValidationNoDeadNodes, // cleanup kills nodes
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -90,7 +90,7 @@ func registerFailover(r registry.Registry) {
 			Owner:     registry.OwnerKV,
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
-			Cluster:   r.MakeClusterSpec(8, spec.CPU(4)),
+			Cluster:   r.MakeClusterSpec(8, spec.CPU(2)),
 			Leases:    leases,
 			Run:       runFailoverPartialLeaseGateway,
 		})
@@ -100,7 +100,7 @@ func registerFailover(r registry.Registry) {
 			Owner:     registry.OwnerKV,
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
-			Cluster:   r.MakeClusterSpec(7, spec.CPU(4)),
+			Cluster:   r.MakeClusterSpec(7, spec.CPU(2)),
 			Leases:    leases,
 			Run:       runFailoverPartialLeaseLeader,
 		})
@@ -110,7 +110,7 @@ func registerFailover(r registry.Registry) {
 			Owner:     registry.OwnerKV,
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
-			Cluster:   r.MakeClusterSpec(8, spec.CPU(4)),
+			Cluster:   r.MakeClusterSpec(8, spec.CPU(2)),
 			Leases:    leases,
 			Run:       runFailoverPartialLeaseLiveness,
 		})
@@ -133,7 +133,7 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
-				Cluster:             r.MakeClusterSpec(7, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Cluster:             r.MakeClusterSpec(7, spec.CPU(2), spec.PreferLocalSSD(!usePD)),
 				Leases:              leases,
 				SkipPostValidations: postValidation,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -145,7 +145,7 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
-				Cluster:             r.MakeClusterSpec(5, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Cluster:             r.MakeClusterSpec(5, spec.CPU(2), spec.PreferLocalSSD(!usePD)),
 				Leases:              leases,
 				SkipPostValidations: postValidation,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -157,7 +157,7 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
-				Cluster:             r.MakeClusterSpec(7, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Cluster:             r.MakeClusterSpec(7, spec.CPU(2), spec.PreferLocalSSD(!usePD)),
 				Leases:              leases,
 				SkipPostValidations: postValidation,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -244,7 +244,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 		}
 		err := c.RunE(ctx, c.Node(10), fmt.Sprintf(
 			`./cockroach workload run kv --read-percent %d --write-seq R%d `+
-				`--concurrency 256 --max-rate 8192 --timeout 1m --tolerate-errors `+
+				`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
 				`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-2}`,
 			readPercent, insertCount))
 		if ctx.Err() != nil {

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -76,7 +76,7 @@ func registerFailover(r registry.Registry) {
 				Name:                "failover/chaos" + suffix,
 				Owner:               registry.OwnerKV,
 				Timeout:             60 * time.Minute,
-				Cluster:             r.MakeClusterSpec(10, spec.CPU(2), spec.PreferLocalSSD(false)), // uses disk stalls
+				Cluster:             r.MakeClusterSpec(10, spec.CPU(2), spec.PreferLocalSSD(false)),
 				Leases:              leases,
 				SkipPostValidations: registry.PostValidationNoDeadNodes, // cleanup kills nodes
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -28,10 +28,9 @@ import (
 )
 
 func registerFailover(r registry.Registry) {
-	for _, expirationLeases := range []bool{false, true} {
-		expirationLeases := expirationLeases // pin loop variable
+	for _, leases := range []registry.LeaseType{registry.EpochLeases, registry.ExpirationLeases} {
 		var suffix string
-		if expirationLeases {
+		if leases == registry.ExpirationLeases {
 			suffix = "/lease=expiration"
 		}
 
@@ -48,9 +47,10 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Timeout:             60 * time.Minute,
 				Cluster:             r.MakeClusterSpec(10, spec.CPU(4), spec.PreferLocalSSD(false)), // uses disk stalls
-				SkipPostValidations: registry.PostValidationNoDeadNodes,                             // cleanup kills nodes
+				Leases:              leases,
+				SkipPostValidations: registry.PostValidationNoDeadNodes, // cleanup kills nodes
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runFailoverChaos(ctx, t, c, readOnly, expirationLeases)
+					runFailoverChaos(ctx, t, c, readOnly)
 				},
 			})
 		}
@@ -61,9 +61,8 @@ func registerFailover(r registry.Registry) {
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
 			Cluster:   r.MakeClusterSpec(8, spec.CPU(4)),
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runFailoverPartialLeaseGateway(ctx, t, c, expirationLeases)
-			},
+			Leases:    leases,
+			Run:       runFailoverPartialLeaseGateway,
 		})
 
 		r.Add(registry.TestSpec{
@@ -72,9 +71,8 @@ func registerFailover(r registry.Registry) {
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
 			Cluster:   r.MakeClusterSpec(7, spec.CPU(4)),
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runFailoverPartialLeaseLeader(ctx, t, c, expirationLeases)
-			},
+			Leases:    leases,
+			Run:       runFailoverPartialLeaseLeader,
 		})
 
 		r.Add(registry.TestSpec{
@@ -83,9 +81,8 @@ func registerFailover(r registry.Registry) {
 			Benchmark: true,
 			Timeout:   30 * time.Minute,
 			Cluster:   r.MakeClusterSpec(8, spec.CPU(4)),
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runFailoverPartialLeaseLiveness(ctx, t, c, expirationLeases)
-			},
+			Leases:    leases,
+			Run:       runFailoverPartialLeaseLiveness,
 		})
 
 		for _, failureMode := range allFailureModes {
@@ -107,9 +104,10 @@ func registerFailover(r registry.Registry) {
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
 				Cluster:             r.MakeClusterSpec(7, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Leases:              leases,
 				SkipPostValidations: postValidation,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runFailoverNonSystem(ctx, t, c, failureMode, expirationLeases)
+					runFailoverNonSystem(ctx, t, c, failureMode)
 				},
 			})
 			r.Add(registry.TestSpec{
@@ -118,9 +116,10 @@ func registerFailover(r registry.Registry) {
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
 				Cluster:             r.MakeClusterSpec(5, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Leases:              leases,
 				SkipPostValidations: postValidation,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runFailoverLiveness(ctx, t, c, failureMode, expirationLeases)
+					runFailoverLiveness(ctx, t, c, failureMode)
 				},
 			})
 			r.Add(registry.TestSpec{
@@ -129,9 +128,10 @@ func registerFailover(r registry.Registry) {
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
 				Cluster:             r.MakeClusterSpec(7, spec.CPU(4), spec.PreferLocalSSD(!usePD)),
+				Leases:              leases,
 				SkipPostValidations: postValidation,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runFailoverSystemNonLiveness(ctx, t, c, failureMode, expirationLeases)
+					runFailoverSystemNonLiveness(ctx, t, c, failureMode)
 				},
 			})
 		}
@@ -148,9 +148,7 @@ func registerFailover(r registry.Registry) {
 // unavailability for graphing. The read-only workload is useful to test e.g.
 // recovering nodes stealing Raft leadership away, since this requires the
 // replica to still be up-to-date on the log.
-func runFailoverChaos(
-	ctx context.Context, t test.Test, c cluster.Cluster, readOnly, expLeases bool,
-) {
+func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readOnly bool) {
 	require.Equal(t, 10, c.Spec().NodeCount)
 
 	rng, _ := randutil.NewTestRand()
@@ -180,10 +178,6 @@ func runFailoverChaos(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
-	require.NoError(t, err)
-
 	// Place 5 replicas of all ranges on n3-n9, keeping n1-n2 as SQL gateways.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 5, onlyNodes: []int{3, 4, 5, 6, 7, 8, 9}})
 
@@ -197,7 +191,7 @@ func runFailoverChaos(
 		insertCount = 100000
 	}
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	c.Run(ctx, c.Node(10), fmt.Sprintf(
 		`./cockroach workload init kv --splits 1000 --insert-count %d {pgurl:1}`, insertCount))
@@ -340,9 +334,7 @@ func runFailoverChaos(
 // - Skips follower replica in B that's unreachable (n5).
 //
 // We run a kv50 workload on SQL gateways and collect pMax latency for graphing.
-func runFailoverPartialLeaseGateway(
-	ctx context.Context, t test.Test, c cluster.Cluster, expLeases bool,
-) {
+func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 8, c.Spec().NodeCount)
 
 	rng, _ := randutil.NewTestRand()
@@ -363,10 +355,6 @@ func runFailoverPartialLeaseGateway(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
-	require.NoError(t, err)
-
 	// Place all ranges on n1-n3 to start with.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 
@@ -375,7 +363,7 @@ func runFailoverPartialLeaseGateway(
 
 	// Create the kv database with 5 replicas on n2-n6, and leases on n4.
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{
 		replicas: 5, onlyNodes: []int{2, 3, 4, 5, 6}, leaseNode: 4})
@@ -492,9 +480,7 @@ func runFailoverPartialLeaseGateway(
 // and simply create partial partitions between each of n4-n6 in sequence.
 //
 // We run a kv50 workload on SQL gateways and collect pMax latency for graphing.
-func runFailoverPartialLeaseLeader(
-	ctx context.Context, t test.Test, c cluster.Cluster, expLeases bool,
-) {
+func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
 	rng, _ := randutil.NewTestRand()
@@ -518,10 +504,6 @@ func runFailoverPartialLeaseLeader(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
-	require.NoError(t, err)
-
 	// Place all ranges on n1-n3 to start with, and wait for upreplication.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
@@ -529,7 +511,7 @@ func runFailoverPartialLeaseLeader(
 	// Disable the replicate queue. It can otherwise end up with stuck
 	// overreplicated ranges during rebalancing, because downreplication requires
 	// the Raft leader to be colocated with the leaseholder.
-	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.replicate_queue.enabled = false`)
+	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.replicate_queue.enabled = false`)
 	require.NoError(t, err)
 
 	// Now that system ranges are properly placed on n1-n3, start n4-n6.
@@ -650,9 +632,7 @@ func runFailoverPartialLeaseLeader(
 // n5-n7 sequentially, 3 times per node for a total of 9 times. A kv50 workload
 // is running against SQL gateways on n1-n3, and we collect the pMax latency for
 // graphing.
-func runFailoverPartialLeaseLiveness(
-	ctx context.Context, t test.Test, c cluster.Cluster, expLeases bool,
-) {
+func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 8, c.Spec().NodeCount)
 
 	rng, _ := randutil.NewTestRand()
@@ -673,10 +653,6 @@ func runFailoverPartialLeaseLiveness(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
-	require.NoError(t, err)
-
 	// Place all ranges on n1-n3, and an extra liveness leaseholder replica on n4.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 	configureZone(t, ctx, conn, `RANGE liveness`, zoneConfig{
@@ -687,7 +663,7 @@ func runFailoverPartialLeaseLiveness(
 
 	// Create the kv database on n5-n7.
 	t.L().Printf("creating workload database")
-	_, err = conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{5, 6, 7}})
 
@@ -795,7 +771,7 @@ func runFailoverPartialLeaseLiveness(
 // order, with 1 minute between each operation, for 3 cycles totaling 9
 // failures.
 func runFailoverNonSystem(
-	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode, expLeases bool,
+	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode,
 ) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
@@ -820,9 +796,6 @@ func runFailoverNonSystem(
 	// Configure cluster. This test controls the ranges manually.
 	t.L().Printf("configuring cluster")
 	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
 	require.NoError(t, err)
 
 	// Constrain all existing zone configs to n1-n3.
@@ -937,7 +910,7 @@ func runFailoverNonSystem(
 // directed at n1-n3 with a rate of 2048 reqs/s. n4 fails and recovers, with 1
 // minute between each operation, for 9 cycles.
 func runFailoverLiveness(
-	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode, expLeases bool,
+	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode,
 ) {
 	require.Equal(t, 5, c.Spec().NodeCount)
 
@@ -962,9 +935,6 @@ func runFailoverLiveness(
 	// Configure cluster. This test controls the ranges manually.
 	t.L().Printf("configuring cluster")
 	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
 	require.NoError(t, err)
 
 	// Constrain all existing zone configs to n1-n3.
@@ -1083,7 +1053,7 @@ func runFailoverLiveness(
 // order, with 1 minute between each operation, for 3 cycles totaling 9
 // failures.
 func runFailoverSystemNonLiveness(
-	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode, expLeases bool,
+	ctx context.Context, t test.Test, c cluster.Cluster, failureMode failureMode,
 ) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
@@ -1108,9 +1078,6 @@ func runFailoverSystemNonLiveness(
 	// Configure cluster. This test controls the ranges manually.
 	t.L().Printf("configuring cluster")
 	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
-	require.NoError(t, err)
-	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = $1`,
-		expLeases)
 	require.NoError(t, err)
 
 	// Constrain all existing zone configs to n4-n6, except liveness which is

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -1693,11 +1693,9 @@ func configureZone(
 		leaseString += fmt.Sprintf("[+node%d]", cfg.leaseNode)
 	}
 
-	query := fmt.Sprintf(
+	_, err := conn.ExecContext(ctx, fmt.Sprintf(
 		`ALTER %s CONFIGURE ZONE USING num_replicas = %d, constraints = '[%s]', lease_preferences = '[%s]'`,
-		target, cfg.replicas, constraintsString, leaseString)
-	t.L().Printf(query)
-	_, err := conn.ExecContext(ctx, query)
+		target, cfg.replicas, constraintsString, leaseString))
 	require.NoError(t, err)
 }
 

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -27,6 +27,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var rangeLeaseRenewalDuration = func() time.Duration {
+	var raftCfg base.RaftConfig
+	raftCfg.SetDefaults()
+	return raftCfg.RangeLeaseRenewalDuration()
+}()
+
 func registerFailover(r registry.Registry) {
 	for _, leases := range []registry.LeaseType{registry.EpochLeases, registry.ExpirationLeases} {
 		var suffix string
@@ -151,6 +157,7 @@ func registerFailover(r registry.Registry) {
 func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readOnly bool) {
 	require.Equal(t, 10, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster, and set up failers for all failure modes.
@@ -205,35 +212,30 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	// Wait for upreplication of the new ranges.
 	require.NoError(t, WaitForReplication(ctx, t, conn, 5 /* replicationFactor */))
 
-	// Start workload on n10 using n1-n2 as gateways.
+	// Run workload on n10 via n1-n2 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
 		readPercent := 50
 		if readOnly {
 			readPercent = 100
 		}
-		c.Run(ctx, c.Node(10), fmt.Sprintf(
+		err := c.RunE(ctx, c.Node(10), fmt.Sprintf(
 			`./cockroach workload run kv --read-percent %d --write-seq R%d `+
-				`--duration 45m --concurrency 256 --max-rate 8192 --timeout 1m --tolerate-errors `+
-				`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-				`{pgurl:1-2}`, readPercent, insertCount))
-		return nil
+				`--concurrency 256 --max-rate 8192 --timeout 1m --tolerate-errors `+
+				`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-2}`,
+			readPercent, insertCount))
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to randomly fail random nodes for 1 minute, with 20 cycles.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 20; i++ {
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			sleepFor(ctx, t, time.Minute)
 
 			// Pick 1 or 2 random nodes and failure modes.
 			nodeFailers := map[int]Failer{}
@@ -256,19 +258,13 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 				nodeFailers[node] = failer
 			}
 
-			randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
-
 			// Ranges may occasionally escape their constraints. Move them to where
 			// they should be.
 			relocateRanges(t, ctx, conn, `true`, []int{1, 2}, []int{3, 4, 5, 6, 7, 8, 9})
 
 			// Randomly sleep up to the lease renewal interval, to vary the time
-			// between the last lease renewal and the failure. We start the timer
-			// before the range relocation above to run them concurrently.
-			select {
-			case <-randTimer:
-			case <-ctx.Done():
-			}
+			// between the last lease renewal and the failure.
+			sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 			for node, failer := range nodeFailers {
 				// If the failer supports partial failures (e.g. partial partitions), do
@@ -287,11 +283,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 				}
 			}
 
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			sleepFor(ctx, t, time.Minute)
 
 			for node, failer := range nodeFailers {
 				t.L().Printf("recovering n%d (%s)", node, failer)
@@ -336,6 +328,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 8, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster.
@@ -380,25 +373,23 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	relocateRanges(t, ctx, conn, `database_name != 'kv'`, []int{4, 5, 6, 7}, []int{1, 2, 3})
 	relocateLeases(t, ctx, conn, `database_name = 'kv'`, 4)
 
-	// Start workload on n8 using n6-n7 as gateways.
+	// Run workload on n8 via n6-n7 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:6-7}`)
-		return nil
+		err := c.RunE(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:6-7}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover partial partitions between n4,n5
 	// (leases) and n6,n7 (gateways), both fully and individually, for 3 cycles.
 	// Leases are only placed on n4.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 3; i++ {
 			testcases := []struct {
@@ -416,15 +407,9 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 				{[]int{7}, []int{4}},
 			}
 			for _, tc := range testcases {
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				failer.Ready(ctx, m)
-
-				randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 				// Ranges and leases may occasionally escape their constraints. Move
 				// them to where they should be.
@@ -433,23 +418,15 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 				relocateLeases(t, ctx, conn, `database_name = 'kv'`, 4)
 
 				// Randomly sleep up to the lease renewal interval, to vary the time
-				// between the last lease renewal and the failure. We start the timer
-				// before the range relocation above to run them concurrently.
-				select {
-				case <-randTimer:
-				case <-ctx.Done():
-				}
+				// between the last lease renewal and the failure.
+				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 				for _, node := range tc.nodes {
 					t.L().Printf("failing n%d to n%v (%s lease/gateway)", node, tc.peers, failer)
 					failer.FailPartial(ctx, node, tc.peers)
 				}
 
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				for _, node := range tc.nodes {
 					t.L().Printf("recovering n%d to n%v (%s lease/gateway)", node, tc.peers, failer)
@@ -481,6 +458,7 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster, disabling leader/leaseholder colocation. We only start
@@ -545,36 +523,28 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 		time.Sleep(time.Second)
 	}
 
-	// Start workload on n7 using n1-n3 as gateways.
+	// Run workload on n7 via n1-n3 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
+		err := c.RunE(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:1-3}`)
-		return nil
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover partial partitions between each pair of
 	// n4-n6 for 3 cycles (9 failures total).
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 3; i++ {
 			for _, node := range []int{4, 5, 6} {
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				failer.Ready(ctx, m)
-
-				randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 				// Ranges may occasionally escape their constraints. Move them to where
 				// they should be.
@@ -582,12 +552,8 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 				relocateRanges(t, ctx, conn, `database_name != 'kv'`, []int{4, 5, 6}, []int{1, 2, 3})
 
 				// Randomly sleep up to the lease renewal interval, to vary the time
-				// between the last lease renewal and the failure. We start the timer
-				// before the range relocation above to run them concurrently.
-				select {
-				case <-randTimer:
-				case <-ctx.Done():
-				}
+				// between the last lease renewal and the failure.
+				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 				peer := node + 1
 				if peer > 6 {
@@ -596,11 +562,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 				t.L().Printf("failing n%d to n%d (%s lease/leader)", node, peer, failer)
 				failer.FailPartial(ctx, node, []int{peer})
 
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				t.L().Printf("recovering n%d to n%d (%s lease/leader)", node, peer, failer)
 				failer.Recover(ctx, node)
@@ -632,6 +594,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Equal(t, 8, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster.
@@ -674,37 +637,30 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 	relocateRanges(t, ctx, conn, `database_name != 'kv'`, []int{5, 6, 7}, []int{1, 2, 3, 4})
 	relocateRanges(t, ctx, conn, `range_id != 2`, []int{4}, []int{1, 2, 3})
 
-	// Start workload on n8 using n1-n3 as gateways (not partitioned).
+	// Run workload on n8 using n1-n3 as gateways (not partitioned) until test
+	// ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:1-3}`)
-		return nil
+		err := c.RunE(ctx, c.Node(8), `./cockroach workload run kv --read-percent 50 `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover partial partitions between n4 (liveness)
 	// and workload leaseholders n5-n7 for 1 minute each, 3 times per node for 9
 	// times total.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 3; i++ {
 			for _, node := range []int{5, 6, 7} {
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				failer.Ready(ctx, m)
-
-				randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 				// Ranges and leases may occasionally escape their constraints. Move
 				// them to where they should be.
@@ -714,22 +670,14 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 				relocateLeases(t, ctx, conn, `range_id = 2`, 4)
 
 				// Randomly sleep up to the lease renewal interval, to vary the time
-				// between the last lease renewal and the failure. We start the timer
-				// before the range relocation above to run them concurrently.
-				select {
-				case <-randTimer:
-				case <-ctx.Done():
-				}
+				// between the last lease renewal and the failure.
+				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 				peer := 4
 				t.L().Printf("failing n%d to n%d (%s lease/liveness)", node, peer, failer)
 				failer.FailPartial(ctx, node, []int{peer})
 
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				t.L().Printf("recovering n%d to n%d (%s lease/liveness)", node, peer, failer)
 				failer.Recover(ctx, node)
@@ -771,6 +719,7 @@ func runFailoverNonSystem(
 ) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster.
@@ -809,37 +758,27 @@ func runFailoverNonSystem(
 	// the ranges across all nodes regardless.
 	relocateRanges(t, ctx, conn, `database_name = 'kv'`, []int{1, 2, 3}, []int{4, 5, 6})
 
-	// Start workload on n7, using n1-n3 as gateways. Run it for 20
-	// minutes, since we take ~2 minutes to fail and recover each node, and
-	// we do 3 cycles of each of the 3 nodes in order.
+	// Run workload on n7 via n1-n3 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:1-3}`)
-		return nil
+		err := c.RunE(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover n4-n6 in order.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 3; i++ {
 			for _, node := range []int{4, 5, 6} {
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				failer.Ready(ctx, m)
-
-				randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 				// Ranges may occasionally escape their constraints. Move them
 				// to where they should be.
@@ -847,21 +786,13 @@ func runFailoverNonSystem(
 				relocateRanges(t, ctx, conn, `database_name != 'kv'`, []int{node}, []int{1, 2, 3})
 
 				// Randomly sleep up to the lease renewal interval, to vary the time
-				// between the last lease renewal and the failure. We start the timer
-				// before the range relocation above to run them concurrently.
-				select {
-				case <-randTimer:
-				case <-ctx.Done():
-				}
+				// between the last lease renewal and the failure.
+				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 				t.L().Printf("failing n%d (%s)", node, failer)
 				failer.Fail(ctx, node)
 
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				t.L().Printf("recovering n%d (%s)", node, failer)
 				failer.Recover(ctx, node)
@@ -904,6 +835,7 @@ func runFailoverLiveness(
 ) {
 	require.Equal(t, 5, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster. Don't schedule a backup as this roachtest reports to roachperf.
@@ -948,35 +880,26 @@ func runFailoverLiveness(
 	// We also make sure the lease is located on n4.
 	relocateLeases(t, ctx, conn, `range_id = 2`, 4)
 
-	// Start workload on n7, using n1-n3 as gateways. Run it for 20 minutes, since
-	// we take ~2 minutes to fail and recover the node, and we do 9 cycles.
+	// Run workload on n7 via n1-n3 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(5), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:1-3}`)
-		return nil
+		err := c.RunE(ctx, c.Node(5), `./cockroach workload run kv --read-percent 50 `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover n4.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 9; i++ {
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			sleepFor(ctx, t, time.Minute)
 
 			failer.Ready(ctx, m)
-
-			randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 			// Ranges and leases may occasionally escape their constraints. Move them
 			// to where they should be.
@@ -984,21 +907,13 @@ func runFailoverLiveness(
 			relocateLeases(t, ctx, conn, `range_id = 2`, 4)
 
 			// Randomly sleep up to the lease renewal interval, to vary the time
-			// between the last lease renewal and the failure. We start the timer
-			// before the range relocation above to run them concurrently.
-			select {
-			case <-randTimer:
-			case <-ctx.Done():
-			}
+			// between the last lease renewal and the failure.
+			sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 			t.L().Printf("failing n%d (%s)", 4, failer)
 			failer.Fail(ctx, 4)
 
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			sleepFor(ctx, t, time.Minute)
 
 			t.L().Printf("recovering n%d (%s)", 4, failer)
 			failer.Recover(ctx, 4)
@@ -1040,6 +955,7 @@ func runFailoverSystemNonLiveness(
 ) {
 	require.Equal(t, 7, c.Spec().NodeCount)
 
+	ctx, cancel := context.WithCancel(ctx)
 	rng, _ := randutil.NewTestRand()
 
 	// Create cluster.
@@ -1083,37 +999,27 @@ func runFailoverSystemNonLiveness(
 	relocateRanges(t, ctx, conn, `database_name != 'kv' AND range_id != 2`,
 		[]int{1, 2, 3}, []int{4, 5, 6})
 
-	// Start workload on n7, using n1-n3 as gateways. Run it for 20 minutes, since
-	// we take ~2 minutes to fail and recover each node, and we do 3 cycles of each
-	// of the 3 nodes in order.
+	// Run workload on n7 via n1-n3 as gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
-			`--duration 20m --concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
-			`--histograms=`+t.PerfArtifactsDir()+`/stats.json `+
-			`{pgurl:1-3}`)
-		return nil
+		err := c.RunE(ctx, c.Node(7), `./cockroach workload run kv --read-percent 50 `+
+			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
+			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
+		if ctx.Err() != nil {
+			return nil // test requested workload shutdown
+		}
+		return err
 	})
 
 	// Start a worker to fail and recover n4-n6 in order.
 	m.Go(func(ctx context.Context) error {
-		var raftCfg base.RaftConfig
-		raftCfg.SetDefaults()
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
+		defer cancel() // stop workload when done
 
 		for i := 0; i < 3; i++ {
 			for _, node := range []int{4, 5, 6} {
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				failer.Ready(ctx, m)
-
-				randTimer := time.After(randutil.RandDuration(rng, raftCfg.RangeLeaseRenewalDuration()))
 
 				// Ranges may occasionally escape their constraints. Move them
 				// to where they should be.
@@ -1123,21 +1029,13 @@ func runFailoverSystemNonLiveness(
 					[]int{4, 5, 6}, []int{1, 2, 3})
 
 				// Randomly sleep up to the lease renewal interval, to vary the time
-				// between the last lease renewal and the failure. We start the timer
-				// before the range relocation above to run them concurrently.
-				select {
-				case <-randTimer:
-				case <-ctx.Done():
-				}
+				// between the last lease renewal and the failure.
+				sleepFor(ctx, t, randutil.RandDuration(rng, rangeLeaseRenewalDuration))
 
 				t.L().Printf("failing n%d (%s)", node, failer)
 				failer.Fail(ctx, node)
 
-				select {
-				case <-ticker.C:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				sleepFor(ctx, t, time.Minute)
 
 				t.L().Printf("recovering n%d (%s)", node, failer)
 				failer.Recover(ctx, node)
@@ -1664,4 +1562,13 @@ func nodeMetric(
 		ctx, `SELECT value FROM crdb_internal.node_metrics WHERE name = $1`, metric).Scan(&value)
 	require.NoError(t, err)
 	return value
+}
+
+// sleepFor sleeps for the given duration. The test fails on context cancellation.
+func sleepFor(ctx context.Context, t test.Test, duration time.Duration) {
+	select {
+	case <-time.After(duration):
+	case <-ctx.Done():
+		t.Fatalf("sleep failed: %s", ctx.Err())
+	}
 }

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -316,6 +316,8 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 				failer.Recover(ctx, node)
 			}
 		}
+
+		sleepFor(ctx, t, time.Minute) // let cluster recover
 		return nil
 	})
 	m.Wait()
@@ -460,6 +462,8 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 				}
 			}
 		}
+
+		sleepFor(ctx, t, time.Minute) // let cluster recover
 		return nil
 	})
 	m.Wait()
@@ -594,6 +598,8 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 				failer.Recover(ctx, node)
 			}
 		}
+
+		sleepFor(ctx, t, time.Minute) // let cluster recover
 		return nil
 	})
 	m.Wait()
@@ -709,6 +715,8 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 				failer.Recover(ctx, node)
 			}
 		}
+
+		sleepFor(ctx, t, time.Minute) // let cluster recover
 		return nil
 	})
 	m.Wait()
@@ -929,6 +937,8 @@ func runFailoverLiveness(
 			failer.Recover(ctx, 4)
 			relocateLeases(t, ctx, conn, `range_id = 2`, 4)
 		}
+
+		sleepFor(ctx, t, time.Minute) // let cluster recover
 		return nil
 	})
 	m.Wait()
@@ -1044,6 +1054,8 @@ func runFailoverSystemNonLiveness(
 				failer.Recover(ctx, node)
 			}
 		}
+
+		sleepFor(ctx, t, time.Minute) // let cluster recover
 		return nil
 	})
 	m.Wait()


### PR DESCRIPTION
Backport:
  * 7/7 commits from "roachtest: clean up `failover` tests" (#103264)
  * 1/2 commits from "roachtest: fix `failover` chaos tests" (#104023)
  * 2/2 commits from "roachtest: deflake `failover/chaos` deadlock failures" (#104138)
  * 2/2 commits from "roachtest: fix `failover` workload cancellation" (#104468)
  * 1/1 commits from "roachtest: run `failover` tests with 2 CPUs" (#104472)
  * 1/1 commits from "roachtest: run `failover` liveness/system variants weekly" (#104473)
  * 1/1 commits from "roachtest: pass monitor via `makeFailer` in failover tests" (#105180)
  * 1/1 commits from "roachtest: let `failover` clusters recover" (#105190)
  * 1/1 commits from "roachtest: prepare `failover` deadlock conn in `Ready()`" (#105184)

Please see individual PRs for details.

/cc @cockroachdb/release