### PR TITLE
release-22.2: stats: automatically delete stats for dropped tables

### DIFF
--- a/pkg/sql/stats/delete_stats.go
+++ b/pkg/sql/stats/delete_stats.go
@@ -130,3 +130,17 @@ func DeleteOldStatsForOtherColumns(
 	)
 	return err
 }
+
+// deleteStatsForDroppedTables deletes all statistics for at most 'limit' number
+// of dropped tables.
+func deleteStatsForDroppedTables(
+	ctx context.Context, ex sqlutil.InternalExecutor, limit int64,
+) error {
+	_, err := ex.Exec(
+		ctx, "delete-statistics-for-dropped-tables", nil, /* txn */
+		fmt.Sprintf(`DELETE FROM system.table_statistics
+                            WHERE "tableID" NOT IN (SELECT table_id FROM crdb_internal.tables)
+                            LIMIT %d`, limit),
+	)
+	return err
+}

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -27,9 +27,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -664,4 +666,47 @@ func findStat(
 		)
 	}
 	return nil
+}
+
+// TestStatsAreDeletedForDroppedTables ensures that statistics for dropped
+// tables are automatically deleted.
+func TestStatsAreDeletedForDroppedTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Disable auto stats so that it doesn't interfere.
+	runner.Exec(t, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;")
+	// Lower the garbage collection interval to speed up the test.
+	runner.Exec(t, "SET CLUSTER SETTING sql.stats.garbage_collection_interval = '1s';")
+
+	// Create a table with short TTL and collect stats on it.
+	runner.Exec(t, "CREATE TABLE t (k PRIMARY KEY) AS SELECT 1;")
+	runner.Exec(t, "ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;")
+	runner.Exec(t, "ANALYZE t;")
+
+	r := runner.QueryRow(t, "SELECT 't'::regclass::oid")
+	var tableID int
+	r.Scan(&tableID)
+
+	// Ensure that we see a single statistic for the table.
+	var count int
+	runner.QueryRow(t, `SELECT count(*) FROM system.table_statistics WHERE "tableID" = $1;`, tableID).Scan(&count)
+	if count != 1 {
+		t.Fatalf("expected a single statistic for table 't', found %d", count)
+	}
+
+	// Now drop the table and make sure that the table statistic is deleted
+	// promptly.
+	runner.Exec(t, "DROP TABLE t;")
+	testutils.SucceedsSoon(t, func() error {
+		runner.QueryRow(t, `SELECT count(*) FROM system.table_statistics WHERE "tableID" = $1;`, tableID).Scan(&count)
+		if count != 0 {
+			return errors.Newf("expected no stats for the dropped table, found %d statistics", count)
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #105364.

/cc @cockroachdb/release

---

This commit adds another task to the stats refresher that periodically runs a query to delete stats for dropped tables from the system table. By default, this query runs once an hour, but this can be configured via a cluster setting (which also exposes a way to disable this new "stats garbage collector" when it is set to 0). The query also limits the number of dropped tables to process at once to 1000 by default (controled via another cluster setting). The rationale for introducing the limit is to prevent a huge DELETE when the cluster that has been running for long time with many dropped tables has just upgraded to the binary with this fix.

Fixes: #94195.

Release note (bug fix): CockroachDB now automatically deletes statistics for dropped tables from `system.table_statistics` table.

Release justification: bug fix.