### PR TITLE
kv: Implement the BoundedStalenessNegotiator without caching

### DIFF
--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "kv",
     srcs = [
         "batch.go",
+        "bounded_staleness_negotiator.go",
         "db.go",
         "doc.go",
         "mock_transactional_sender.go",
@@ -30,7 +31,6 @@ go_library(
         "//pkg/util/admission",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/duration",
-        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",
@@ -82,7 +82,6 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/kvclientutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/encoding",

--- a/pkg/kv/bounded_staleness_negotiator.go
+++ b/pkg/kv/bounded_staleness_negotiator.go
@@ -1,0 +1,59 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kv
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// BoundedStalenessNegotiator provides the local resolved timestamp for a
+// collection of key spans.
+type BoundedStalenessNegotiator interface {
+	// LocalResolvedTimestamp determines the local resolved timestamp for the
+	// specified spans. If the local resolved timestamp is less than the
+	// minimum timestamp bound, then a MinTimestampBoundUnsatisfiableError is
+	// returned if the minimum timestamp bound is strict or the minimum
+	// timestamp bound is returned if not strict. If the local resolved
+	// timestamp is greater than the maximum timestamp bound, then the maximum
+	// timestamp bound is returned.
+	LocalResolvedTimestamp(ctx context.Context, ba *kvpb.BatchRequest) (hlc.Timestamp, *kvpb.Error)
+}
+
+// BoundedStalenessNegotiatorWithoutCaching implements the
+// BoundedStalenessNegotiator interface, but QueryResolvedTimestamp requests
+// to determine the local resolved timestamp are not cached.
+//
+// In the future, a BoundedStalenessNegotiator that caches
+// QueryResolvedTimestamp requests will be implemented to avoid the cost of
+// sending QueryResolvedTimestamp requests on every cross-range bounded
+// staleness read.
+type BoundedStalenessNegotiatorWithoutCaching struct {
+	db *DB
+}
+
+// LocalResolvedTimestamp implements the BoundedStalenessNegotiator interface.
+func (bsn BoundedStalenessNegotiatorWithoutCaching) LocalResolvedTimestamp(
+	ctx context.Context, ba *kvpb.BatchRequest,
+) (hlc.Timestamp, *kvpb.Error) {
+	sendFunc := func(ctx context.Context, queryResBa *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		queryResBa.RoutingPolicy = ba.RoutingPolicy
+		queryResBa.WaitPolicy = ba.WaitPolicy
+		return bsn.db.send(ctx, queryResBa)
+	}
+	resTS, pErr := BoundedStalenessNegotiateResolvedTimestamp(ctx, ba, sendFunc)
+	if pErr != nil {
+		return hlc.Timestamp{}, pErr
+	}
+	return resTS, nil
+}

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -1196,17 +1195,34 @@ func (txn *Txn) NegotiateAndSend(
 		return nil, pErr
 	}
 
-	// The read spans ranges, so bounded-staleness orchestration will need to be
-	// performed in two distinct phases - negotiation and execution. First we'll
-	// use the BoundedStalenessNegotiator to determines the timestamp to perform
-	// the read at and fix the transaction's timestamp to this result. Then we'll
-	// issue the request through the transaction, which will use the negotiated
-	// read timestamp from the previous phase to execute the read.
+	// The read spans ranges, so bounded-staleness orchestration will need to
+	// be performed in two distinct phases - negotiation and execution.
 	//
-	// TODO(nvanbenschoten): implement this. #67554.
+	// First we'll use the BoundedStalenessNegotiator to determine the
+	// timestamp to perform the read at and fix the transaction's timestamp to
+	// this result.
+	//
+	// The negotiated timestamp will be subject to the staleness bounds of ba
+	// and the txn deadline has already been applied (above) to these bounds.
+	//
+	// If the local resolved timestamp is less than the minimum timestamp
+	// bound, then a MinTimestampBoundUnsatisfiableError is returned if the
+	// minimum timestamp bound is strict or the minimum timestamp bound is
+	// returned if not strict. If the local resolved timestamp is greater than
+	// the maximum timestamp bound, then the maximum timestamp bound is
+	// returned.
+	negotiatedTimestamp, pErr := txn.db.Negotiator().LocalResolvedTimestamp(ctx, ba)
+	if pErr != nil {
+		return nil, pErr
+	}
 
-	return nil, kvpb.NewError(unimplemented.NewWithIssue(67554,
-		"cross-range bounded staleness reads not yet implemented"))
+	// Then we'll issue the request through the transaction, which will use the
+	// negotiated read timestamp from the previous phase to execute the read.
+	if err := txn.SetFixedTimestamp(ctx, negotiatedTimestamp); err != nil {
+		return nil, kvpb.NewError(err)
+	}
+	ba.BoundedStaleness = nil
+	return txn.Send(ctx, ba)
 }
 
 // checks preconditions on BatchRequest and Txn for NegotiateAndSend.

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -344,10 +343,6 @@ func TestTxnNegotiateAndSendDoesNotBlock(t *testing.T) {
 }
 
 func testTxnNegotiateAndSendDoesNotBlock(t *testing.T, multiRange, strict, routeNearest bool) {
-	if multiRange {
-		skip.IgnoreLint(t, "unimplemented, blocked on #67554.")
-	}
-
 	const testTime = 1 * time.Second
 	ctx := context.Background()
 
@@ -379,8 +374,13 @@ func testTxnNegotiateAndSendDoesNotBlock(t *testing.T, multiRange, strict, route
 	}
 	keySpan := roachpb.Span{Key: scratchKey, EndKey: scratchKey.PrefixEnd()}
 
-	// TODO(nvanbenschoten): if multiRange, split on each key in keySet.
-	// if multiRange { ... }
+	// If multiRange, split on each key in keySet.
+	if multiRange {
+		for _, key := range keySet {
+			_, _, err := tc.SplitRange(key)
+			require.NoError(t, err)
+		}
+	}
 
 	var g errgroup.Group
 	var done int32
@@ -408,8 +408,7 @@ func testTxnNegotiateAndSendDoesNotBlock(t *testing.T, multiRange, strict, route
 		})
 	}
 
-	// Reader goroutines: perform bounded-staleness reads that hit the server-side
-	// negotiation fast-path.
+	// Reader goroutines: perform bounded-staleness reads.
 	for _, s := range tc.Servers {
 		store, err := s.Stores().GetStore(s.GetFirstStoreID())
 		require.NoError(t, err)
@@ -496,7 +495,12 @@ func testTxnNegotiateAndSendDoesNotBlock(t *testing.T, multiRange, strict, route
 					// assertion.
 					rec := collectAndFinish()
 					expFollowerRead := store.StoreID() != lh.StoreID && strict && routeNearest
-					wasFollowerRead := kv.OnlyFollowerReads(rec)
+					wasFollowerRead := false
+					if multiRange {
+						wasFollowerRead = kv.OnlyFollowerReadsOrAllowedRequestType(rec, "QueryResolvedTimestamp")
+					} else {
+						wasFollowerRead = kv.OnlyFollowerReads(rec)
+					}
 					ambiguous := !strict && routeNearest
 					if expFollowerRead != wasFollowerRead && !ambiguous {
 						if expFollowerRead {


### PR DESCRIPTION
Informs #67554

Previously, bounded staleness reads only supported the fast path where the read only spanned a single range, effectively limiting bounded staleness reads to returning a single row. In this PR, we implement the first step to supporting bounded staleness reads spanning multiple ranges.

In this PR, we implement the BoundedStalenessNegotiator without LRU caching of the QueryResolvedTimestamp request values and integrate it into the bounded staleness reads to enable the two-phase (negotiation + execution) approach for multi-range reads on the KV side.

Note that this PR does not fully enable multi-range bounded staleness reads yet, as it is not yet supported on the SQL side.

Release note: None