### PR TITLE
ProtectedTS : Adding metrics for Protected Timestamps

### DIFF
--- a/pkg/kv/kvserver/protectedts/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "protectedts",
     srcs = [
+        "metrics.go",
         "protectedts.go",
         "settings.go",
         "testing_knobs.go",
@@ -21,6 +22,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_prometheus_client_model//go",
     ],
 )
 

--- a/pkg/kv/kvserver/protectedts/metrics.go
+++ b/pkg/kv/kvserver/protectedts/metrics.go
@@ -21,7 +21,7 @@ type ProtectedTSMetrics struct {
 	RecordsProcessed     *metric.Counter
 	RecordsRemoved       *metric.Counter
 	ReconciliationErrors *metric.Counter
-	ProtectedRecords     *metric.Counter
+	ProtectedRecords     *metric.Gauge
 }
 
 func MakeMetrics() metric.Struct {
@@ -30,7 +30,7 @@ func MakeMetrics() metric.Struct {
 		RecordsProcessed:     metric.NewCounter(metaRecordsProcessed),
 		RecordsRemoved:       metric.NewCounter(metaRecordsRemoved),
 		ReconciliationErrors: metric.NewCounter(metaReconciliationErrors),
-		ProtectedRecords:     metric.NewCounter(metaProtectedRecords),
+		ProtectedRecords:     metric.NewGauge(metaProtectedRecords),
 	}
 }
 
@@ -73,7 +73,7 @@ var (
 	metaProtectedRecords = metric.Metadata{
 		Name:        "kv.protectedts.storage.protected.records",
 		Help:        "number of records protected timestamp records",
-		Measurement: "Count",
+		Measurement: "Records",
 		Unit:        metric.Unit_COUNT,
 		MetricType:  io_prometheus_client.MetricType_GAUGE,
 	}

--- a/pkg/kv/kvserver/protectedts/metrics.go
+++ b/pkg/kv/kvserver/protectedts/metrics.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package ptreconcile
+package protectedts
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -16,28 +16,31 @@ import (
 )
 
 // Metrics encapsulates the metrics exported by the Reconciler.
-type Metrics struct {
+type ProtectedTSMetrics struct {
 	ReconcilationRuns    *metric.Counter
 	RecordsProcessed     *metric.Counter
 	RecordsRemoved       *metric.Counter
 	ReconciliationErrors *metric.Counter
+	ProtectedRecords     *metric.Counter
 }
 
-func makeMetrics() Metrics {
-	return Metrics{
+func MakeMetrics() metric.Struct {
+	return &ProtectedTSMetrics{
 		ReconcilationRuns:    metric.NewCounter(metaReconciliationRuns),
 		RecordsProcessed:     metric.NewCounter(metaRecordsProcessed),
 		RecordsRemoved:       metric.NewCounter(metaRecordsRemoved),
 		ReconciliationErrors: metric.NewCounter(metaReconciliationErrors),
+		ProtectedRecords:     metric.NewCounter(metaProtectedRecords),
 	}
 }
 
-var _ metric.Struct = (*Metrics)(nil)
+var _ metric.Struct = (*ProtectedTSMetrics)(nil)
 
 // MetricStruct makes Metrics a metric.Struct.
-func (m *Metrics) MetricStruct() {}
+func (m *ProtectedTSMetrics) MetricStruct() {}
 
 var (
+	// Protected TS Reconciliation Metrics
 	metaReconciliationRuns = metric.Metadata{
 		Name:        "kv.protectedts.reconciliation.num_runs",
 		Help:        "number of successful reconciliation runs on this node",
@@ -65,5 +68,13 @@ var (
 		Measurement: "Count",
 		Unit:        metric.Unit_COUNT,
 		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
+	// Protected TS Storage Metrics
+	metaProtectedRecords = metric.Metadata{
+		Name:        "kv.protectedts.storage.protected.records",
+		Help:        "number of records protected timestamp records",
+		Measurement: "Count",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_GAUGE,
 	}
 )

--- a/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
@@ -89,7 +89,7 @@ func TestCacheBasic(t *testing.T) {
 	insqlDB := s.InternalDB().(isql.DB)
 	m := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
 		DisableProtectedTimestampForMultiTenant: true,
-	})
+	}, protectedts.MakeMetrics().(*protectedts.ProtectedTSMetrics))
 	p := withDatabase(m, insqlDB)
 
 	// Set the poll interval to be very short.
@@ -164,7 +164,7 @@ func TestRefresh(t *testing.T) {
 		})
 	defer s.Stopper().Stop(ctx)
 	db := s.InternalDB().(isql.DB)
-	m := ptstorage.New(s.ClusterSettings(), ptsKnobs)
+	m := ptstorage.New(s.ClusterSettings(), ptsKnobs, protectedts.MakeMetrics().(*protectedts.ProtectedTSMetrics))
 	p := withDatabase(m, db)
 
 	// Set the poll interval to be very long.
@@ -313,7 +313,7 @@ func TestQueryRecord(t *testing.T) {
 	db := s.InternalDB().(isql.DB)
 	storage := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
 		DisableProtectedTimestampForMultiTenant: true,
-	})
+	}, protectedts.MakeMetrics().(*protectedts.ProtectedTSMetrics))
 	p := withDatabase(storage, db)
 	// Set the poll interval to be very long.
 	protectedts.PollInterval.Override(ctx, &s.ClusterSettings().SV, 500*time.Hour)
@@ -372,7 +372,7 @@ func TestIterate(t *testing.T) {
 	db := s.InternalDB().(isql.DB)
 	m := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
 		DisableProtectedTimestampForMultiTenant: true,
-	})
+	}, protectedts.MakeMetrics().(*protectedts.ProtectedTSMetrics))
 	p := withDatabase(m, db)
 
 	// Set the poll interval to be very long.
@@ -517,7 +517,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			storage := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
 				DisableProtectedTimestampForMultiTenant: true,
-			})
+			}, protectedts.MakeMetrics().(*protectedts.ProtectedTSMetrics))
 			p := withDatabase(storage, s.InternalDB().(isql.DB))
 			c := ptcache.New(ptcache.Config{
 				Settings: s.ClusterSettings(),
@@ -542,7 +542,7 @@ func TestSettingChangedLeadsToFetch(t *testing.T) {
 	db := s.InternalDB().(isql.DB)
 	m := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
 		DisableProtectedTimestampForMultiTenant: true,
-	})
+	}, protectedts.MakeMetrics().(*protectedts.ProtectedTSMetrics))
 
 	// Set the poll interval to be very long.
 	protectedts.PollInterval.Override(ctx, &s.ClusterSettings().SV, 500*time.Hour)

--- a/pkg/kv/kvserver/protectedts/ptreconcile/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/BUILD.bazel
@@ -3,7 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "ptreconcile",
     srcs = [
-        "metrics.go",
         "reconciler.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptreconcile",
@@ -18,8 +17,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
-        "@com_github_cockroachdb_errors//:errors",
-        "@com_github_prometheus_client_model//go",
+        "@com_github_cockroachdb_errors//:errors"
     ],
 )
 

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
@@ -54,19 +54,19 @@ type Reconciler struct {
 	settings    *cluster.Settings
 	db          isql.DB
 	pts         protectedts.Manager
-	metrics     Metrics
 	statusFuncs StatusFuncs
+	metrics     *protectedts.ProtectedTSMetrics
 }
 
 // New constructs a Reconciler.
 func New(
-	st *cluster.Settings, db isql.DB, storage protectedts.Manager, statusFuncs StatusFuncs,
+	st *cluster.Settings, db isql.DB, storage protectedts.Manager, statusFuncs StatusFuncs, metrics *protectedts.ProtectedTSMetrics,
 ) *Reconciler {
 	return &Reconciler{
 		settings:    st,
 		db:          db,
 		pts:         storage,
-		metrics:     makeMetrics(),
+		metrics:     metrics,
 		statusFuncs: statusFuncs,
 	}
 }
@@ -79,8 +79,8 @@ func (r *Reconciler) StartReconciler(ctx context.Context, stopper *stop.Stopper)
 }
 
 // Metrics returns the reconciler's metrics.
-func (r *Reconciler) Metrics() *Metrics {
-	return &r.metrics
+func (r *Reconciler) Metrics() *protectedts.ProtectedTSMetrics {
+	return r.metrics
 }
 
 func (r *Reconciler) run(ctx context.Context, stopper *stop.Stopper) {

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler_test.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler_test.go
@@ -73,7 +73,7 @@ func TestReconciler(t *testing.T) {
 					_, shouldRemove = state.toRemove[string(meta)]
 					return shouldRemove, nil
 				},
-			})
+			}, ptp.Metrics().(*protectedts.ProtectedTSMetrics))
 		require.NoError(t, r.StartReconciler(ctx, s0.Stopper()))
 		recMeta := "a"
 		rec1 := ptpb.Record{

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -490,7 +490,7 @@ func (test testCase) run(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	s := tc.Server(0)
-	ptm := ptstorage.New(s.ClusterSettings(), ptsKnobs)
+	ptm := ptstorage.New(s.ClusterSettings(), ptsKnobs, protectedts.MakeMetrics().(*protectedts.ProtectedTSMetrics))
 	tCtx := testContext{
 		pts:                    ptm,
 		db:                     s.InternalDB().(isql.DB),
@@ -754,7 +754,7 @@ func TestErrorsFromSQL(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	s := tc.Server(0)
-	pts := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{})
+	pts := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{}, protectedts.MakeMetrics().(*protectedts.ProtectedTSMetrics))
 	db := s.InternalDB().(isql.DB)
 	errFunc := func(string) error { return errors.New("boom") }
 	rec := newRecord(&testContext{}, s.Clock().Now(), "foo", []byte("bar"), tableTarget(42), tableSpan(42))


### PR DESCRIPTION
Fixes: #104159
Raising a draft PR to initiate a discussion.

Approach - 
1. Implement metrics structure within `protectedts` package
2. When a new object of `protectedts.Provider` is created so is the `metric.Struct`.
3. During the same initialisation of the `protectedts.Provider` the `metrict.Struct` is passed down to `ptreconcile.Reconciler` and [`ptstorage.Manager`, `ptstorage.Storage`]

---
I have a few questions related to the implementation -

1. Added a `Gauge` metric to track `Protect` and `Release` of a Target record. Is this the expected metric? Do we need more?
2. Does the overall implementation look correct?

TODO - 
- [ ] Add test case for metrics
