### PR TITLE
kvserver: increase `COCKROACH_SCHEDULER_CONCURRENCY` cap

### DIFF
--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -370,15 +370,15 @@ func TestNewSchedulerShards(t *testing.T) {
 		{pri, 12, 3, []int{pri, 3, 3, 3, 3}},
 
 		// Typical examples, using 8 workers per CPU core. Note that we cap workers
-		// at 96 by default.
+		// at 128 by default.
 		{pri, 1 * 8, 16, []int{pri, 8}},
 		{pri, 2 * 8, 16, []int{pri, 16}},
 		{pri, 3 * 8, 16, []int{pri, 12, 12}},
 		{pri, 4 * 8, 16, []int{pri, 16, 16}},
 		{pri, 6 * 8, 16, []int{pri, 16, 16, 16}},
 		{pri, 8 * 8, 16, []int{pri, 16, 16, 16, 16}},
-		{pri, 12 * 8, 16, []int{pri, 16, 16, 16, 16, 16, 16}}, // 96 workers
-		{pri, 16 * 8, 16, []int{pri, 16, 16, 16, 16, 16, 16, 16, 16}},
+		{pri, 12 * 8, 16, []int{pri, 16, 16, 16, 16, 16, 16}},
+		{pri, 16 * 8, 16, []int{pri, 16, 16, 16, 16, 16, 16, 16, 16}}, // 128 workers
 	}
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("workers=%d/shardSize=%d", tc.workers, tc.shardSize), func(t *testing.T) {


### PR DESCRIPTION
For experimental results see https://github.com/cockroachdb/cockroach/issues/99063#issuecomment-1606169390.

---

This patch increases the Raft scheduler worker cap from 96 to 128, to reduce the chance of starvation with scheduler shards or multi-store. Experiments showed little effect of varying workers per CPU between 2 and 10 up to 32 CPUs, but at 96 CPUs they showed significant degradation with increasing worker counts. Both the linear scaling and cap are therefore retained.

Resolves #99063.
Epic: none.

Release note (ops change): the default Raft scheduler concurrency cap has been increased from 96 to 128 workers, scaling with 8 workers per CPU up to the cap. The scheduler concurrency can be controlled via `COCKROACH_SCHEDULER_CONCURRENCY`.