### PR TITLE
roachtest: fix library searching logic

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -254,7 +254,7 @@ func findBinaryOrLibrary(
 	for _, dir := range dirs {
 		var path string
 
-		if path, err = exec.LookPath(filepath.Join(dir, name)); err == nil {
+		if path, err = exec.LookPath(filepath.Join(dir, name+nameSuffix)); err == nil {
 			return validateBinaryFormat(path, arch, checkEA)
 		}
 		for _, archSuffix := range archSuffixes {


### PR DESCRIPTION
The change in beb35aa0e43dbf7e6fb928b008c3067c72ecd240 refactored this logic. Now we need to combine the name and suffix inside of findBinaryOrLibrary.

Epic: None
Release note: None

Fixes this error:
```
Locating and verifying binaries for os="linux", arch="amd64"
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach for cockroach-ea
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach/artifacts for cockroach-ea
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach/bin for cockroach-ea
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach/bin for cockroach-ea
WARN: unable to find "cockroach-ea" for "amd64": binary or library "cockroach-ea" not found (or was not executable)
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach for libgeos
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach/artifacts for libgeos
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach/lib for libgeos
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach/lib for libgeos
WARN: unable to find library libgeos, ignoring: binary or library "libgeos" not found (or was not executable)
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach for libgeos_c
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach/artifacts for libgeos_c
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach/lib for libgeos_c
looking in /home/rafiss/go/src/github.com/cockroachdb/cockroach/lib for libgeos_c
WARN: unable to find library libgeos_c, ignoring: binary or library "libgeos_c" not found (or was not executable)

Found the following binaries:
	cockroach "amd64" at: /home/rafiss/go/src/github.com/cockroachdb/cockroach/cockroach-short
	workload "amd64" at: /home/rafiss/go/src/github.com/cockroachdb/cockroach/bin/workload
AMD64 clusters will be provisioned with probability 1.00
HTTP server listening on all network interfaces, port 8080.
22:22:22 main.go:637: test runner logs in: artifacts/_runner-logs/test_runner-1687731742.log
test runner logs in: artifacts/_runner-logs/test_runner-1687731742.log
22:22:22 test_runner.go:1399: [w0] Selected test: hibernate run: 1.
22:22:22 test_runner.go:642: [w0] Using randomly chosen arch="amd64", hibernate
22:22:22 test_runner.go:658: [w0] Library verification failed: cluster.VerifyLibraries: missing required library libgeos (arch="amd64")
Library verification failed: cluster.VerifyLibraries: missing required library libgeos (arch="amd64")
22:22:22 test_runner.go:532: [w0] Worker exiting; no cluster to destroy.
22:22:22 test_runner.go:320: Worker 0 returned with error. Quiescing. Error: cluster.VerifyLibraries: missing required library libgeos (arch="amd64")
Worker 0 returned with error. Quiescing. Error: cluster.VerifyLibraries: missing required library libgeos (arch="amd64")
22:22:22 test_runner.go:346: FAIL (err: cluster.VerifyLibraries: missing required library libgeos (arch="amd64"))
FAIL (err: cluster.VerifyLibraries: missing required library libgeos (arch="amd64"))
22:22:22 main.go:539: runTests destroying all clusters
```