### PR TITLE
roachtest: update hibernate version

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -23,7 +23,7 @@ import (
 )
 
 var hibernateReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var supportedHibernateTag = "5.6.9"
+var supportedHibernateTag = "5.6.15"
 
 type hibernateOptions struct {
 	testName string


### PR DESCRIPTION
The old version has issues fetching a stale dependency.

fixes https://github.com/cockroachdb/cockroach/issues/105432
fixes https://github.com/cockroachdb/cockroach/issues/105409
fixes https://github.com/cockroachdb/cockroach/issues/105407
fixes https://github.com/cockroachdb/cockroach/issues/105404
fixes https://github.com/cockroachdb/cockroach/issues/105336
fixes https://github.com/cockroachdb/cockroach/issues/105334

Release note: None