### PR TITLE
kvserverpb: remove `RaftCommand.DeprecatedProposerLease`

### DIFF
--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -369,20 +369,14 @@ func tryRaftLogEntry(kv storage.MVCCKeyValue) (string, error) {
 	e.Data = nil
 	cmd := e.Cmd
 
-	var leaseStr string
-	if l := cmd.DeprecatedProposerLease; l != nil {
-		leaseStr = l.String() // use the full lease, if available
-	} else {
-		leaseStr = fmt.Sprintf("lease #%d", cmd.ProposerLeaseSequence)
-	}
-
 	wbStr, err := decodeWriteBatch(cmd.WriteBatch)
 	if err != nil {
 		wbStr = "failed to decode: " + err.Error() + "\nafter:\n" + wbStr
 	}
 	cmd.WriteBatch = nil
 
-	return fmt.Sprintf("%s (ID %s) by %s\n%s\nwrite batch:\n%s", &e.Entry, e.ID, leaseStr, &cmd, wbStr), nil
+	return fmt.Sprintf("%s (ID %s) by lease #%d\n%s\nwrite batch:\n%s",
+		&e.Entry, e.ID, cmd.ProposerLeaseSequence, &cmd, wbStr), nil
 }
 
 func tryTxn(kv storage.MVCCKeyValue) (string, error) {

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -269,14 +269,6 @@ message RaftCommand {
   // - the command applies on replica 2
   uint64 proposer_lease_sequence = 6 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.LeaseSequence"];
 
-  // deprecated_proposer_lease served the same purpose as proposer_lease_seq.
-  // As of VersionLeaseSequence, it is no longer in use.
-  //
-  // However, unless we add a check that all existing Raft logs on all nodes
-  // in the cluster contain only "new" leases, we won't be able to remove the
-  // legacy code.
-  roachpb.Lease deprecated_proposer_lease = 5;
-
   // When the command is applied, its result is an error if the lease log
   // counter has already reached (or exceeded) max_lease_index.
   //
@@ -336,7 +328,7 @@ message RaftCommand {
   // problem for sideloading, which reduces the size of the proto).
   util.hlc.Timestamp closed_timestamp = 17;
 
-  reserved 3;
+  reserved 3, 5;
 
   // replicated_eval_result is a set of structured information that instructs
   // replicated state changes to the part of a Range's replicated state machine

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -315,12 +315,11 @@ func (r *Replica) tryReproposeWithNewLeaseIndexV2(
 	}()
 
 	newCommand := kvserverpb.RaftCommand{
-		ProposerLeaseSequence:   origP.command.ProposerLeaseSequence,
-		DeprecatedProposerLease: origP.command.DeprecatedProposerLease,
-		ReplicatedEvalResult:    origP.command.ReplicatedEvalResult,
-		WriteBatch:              origP.command.WriteBatch,
-		LogicalOpLog:            origP.command.LogicalOpLog,
-		TraceData:               origP.command.TraceData,
+		ProposerLeaseSequence: origP.command.ProposerLeaseSequence,
+		ReplicatedEvalResult:  origP.command.ReplicatedEvalResult,
+		WriteBatch:            origP.command.WriteBatch,
+		LogicalOpLog:          origP.command.LogicalOpLog,
+		TraceData:             origP.command.TraceData,
 
 		MaxLeaseIndex:       0,   // assigned on flush
 		ClosedTimestamp:     nil, // assigned on flush

--- a/pkg/kv/kvserver/replica_application_result_test.go
+++ b/pkg/kv/kvserver/replica_application_result_test.go
@@ -33,17 +33,16 @@ func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	raftCommand := &kvserverpb.RaftCommand{
-		ProposerLeaseSequence:   1,
-		DeprecatedProposerLease: &roachpb.Lease{},
-		MaxLeaseIndex:           1,
-		ClosedTimestamp:         &hlc.Timestamp{},
-		ReplicatedEvalResult:    kvserverpb.ReplicatedEvalResult{IsProbe: true},
-		WriteBatch:              &kvserverpb.WriteBatch{},
-		LogicalOpLog:            &kvserverpb.LogicalOpLog{},
-		TraceData:               map[string]string{},
-		AdmissionPriority:       1,
-		AdmissionCreateTime:     1,
-		AdmissionOriginNode:     1,
+		ProposerLeaseSequence: 1,
+		MaxLeaseIndex:         1,
+		ClosedTimestamp:       &hlc.Timestamp{},
+		ReplicatedEvalResult:  kvserverpb.ReplicatedEvalResult{IsProbe: true},
+		WriteBatch:            &kvserverpb.WriteBatch{},
+		LogicalOpLog:          &kvserverpb.LogicalOpLog{},
+		TraceData:             map[string]string{},
+		AdmissionPriority:     1,
+		AdmissionCreateTime:   1,
+		AdmissionOriginNode:   1,
 	}
 
 	prop := &ProposalData{
@@ -70,11 +69,10 @@ func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
 	// desired semantics of that field in `tryReproposeWithNewLeaseIndex{,v2}`. Once
 	// this has been done, adjust the expected number of fields below, and populate
 	// the field above, to let this test pass.
-	// test pass.
 	//
 	// NB: we can't use zerofields for two reasons: First, we have unexported fields
 	// here, and second, we don't want to check for recursively populated structs (but
 	// only for the top level fields).
-	require.Equal(t, 11, reflect.TypeOf(*raftCommand).NumField())
+	require.Equal(t, 10, reflect.TypeOf(*raftCommand).NumField())
 	require.Equal(t, 17, reflect.TypeOf(*prop).NumField())
 }


### PR DESCRIPTION
This field was deprecated 6 years ago, and we've had several below-Raft migrations since then.

Touches #20953.
Epic: none

Release note: None