### PR TITLE
kvserver: Fix WAL Bytes Written Metrics

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -222,7 +222,7 @@ export default function (props: GraphDashboardProps) {
         {_.map(nodeIDs, nid => (
           <Metric
             key={nid}
-            name="cr.store.rocksdb.wal-bytes-written"
+            name="cr.store.storage.wal.bytes_written"
             title={getNodeNameById(nid)}
             sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate


### PR DESCRIPTION
Currently the number of WAL bytes written does not show up. This pr fixes that by using a consistent metric name.

Informs: #104531
Release note: None