### PR TITLE
ccl/serverccl/diagnosticsccl: skip TestTenantReport

### DIFF
--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -43,6 +43,7 @@ const elemName = "somestring"
 
 func TestTenantReport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 101622, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	rt := startReporterTest(t, base.TestTenantDisabled)


### PR DESCRIPTION
Refs: #101622

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None
Epic: None