### PR TITLE
release-22.2: sql: add system privileges to crdb_internal queries tables

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -906,11 +906,7 @@ func (p *planner) HasViewActivityOrViewActivityRedactedRole(ctx context.Context)
 	} else if hasAdmin {
 		return true, nil
 	}
-	hasView := p.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWACTIVITY) == nil
-	if hasView {
-		return true, nil
-	}
-	if hasView, err := p.HasRoleOption(ctx, roleoption.VIEWACTIVITY); err != nil {
+	if hasView, err := p.HasViewActivity(ctx); err != nil {
 		return false, err
 	} else if hasView {
 		return true, nil
@@ -931,6 +927,20 @@ func (p *planner) HasViewActivityRedacted(ctx context.Context) (bool, error) {
 			return true, err
 		}
 		if !hasViewRedacted {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (p *planner) HasViewActivity(ctx context.Context) (bool, error) {
+	hasView := p.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWACTIVITY) == nil
+	if !hasView {
+		hasView, err := p.HasRoleOption(ctx, roleoption.VIEWACTIVITY)
+		if err != nil {
+			return true, err
+		}
+		if !hasView {
 			return false, nil
 		}
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1907,7 +1907,7 @@ var crdbInternalLocalQueriesTable = virtualSchemaTable{
 		if err != nil {
 			return err
 		}
-		return populateQueriesTable(ctx, addRow, response)
+		return populateQueriesTable(ctx, p, addRow, response)
 	},
 }
 
@@ -1925,13 +1925,37 @@ var crdbInternalClusterQueriesTable = virtualSchemaTable{
 		if err != nil {
 			return err
 		}
-		return populateQueriesTable(ctx, addRow, response)
+		return populateQueriesTable(ctx, p, addRow, response)
 	},
 }
 
 func populateQueriesTable(
-	ctx context.Context, addRow func(...tree.Datum) error, response *serverpb.ListSessionsResponse,
+	ctx context.Context,
+	p *planner,
+	addRow func(...tree.Datum) error,
+	response *serverpb.ListSessionsResponse,
 ) error {
+	shouldRedactQuery := false
+	// Check if the user is admin.
+	if isAdmin, err := p.HasAdminRole(ctx); err != nil {
+		return err
+	} else if !isAdmin {
+		// If the user is not admin, check the individual VIEWACTIVITY and VIEWACTIVITYREDACTED
+		// privileges.
+		if hasViewActivityRedacted, err := p.HasViewActivityRedacted(ctx); err != nil {
+			return err
+		} else if hasViewActivityRedacted {
+			// If the user has VIEWACTIVITYREDACTED, redact the query as it takes precedence
+			// over VIEWACTIVITY.
+			shouldRedactQuery = true
+		} else if hasViewActivity, err := p.HasViewActivity(ctx); err != nil {
+			return err
+		} else if !hasViewActivity {
+			// If the user is not admin and does not have VIEWACTIVITY or VIEWACTIVITYREDACTED,
+			// return insufficient privileges error.
+			return noViewActivityOrViewActivityRedactedRoleError(p.User())
+		}
+	}
 	for _, session := range response.Sessions {
 		sessionID := getSessionID(session)
 		for _, query := range session.ActiveQueries {
@@ -1974,6 +1998,11 @@ func populateQueriesTable(
 				planGistDatum = tree.NewDString(query.PlanGist)
 			}
 
+			sql := query.Sql
+			// If the user does not have the correct privileges, show the query without literals or constants.
+			if shouldRedactQuery {
+				sql = query.SqlNoConstants
+			}
 			if err := addRow(
 				tree.NewDString(query.ID),
 				txnID,
@@ -1981,7 +2010,7 @@ func populateQueriesTable(
 				sessionID,
 				tree.NewDString(session.Username),
 				ts,
-				tree.NewDString(query.Sql),
+				tree.NewDString(sql),
 				tree.NewDString(session.ClientAddress),
 				tree.NewDString(session.ApplicationName),
 				isDistributedDatum,

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -958,6 +959,145 @@ func TestShowSessionPrivileges(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestShowRedactedActiveStatements tests the crdb_internal.cluster_queries table for system permissions.
+func TestShowRedactedActiveStatements(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+	params.Insecure = true
+	ctx, cancel := context.WithCancel(context.Background())
+	s, rawSQLDBroot, _ := serverutils.StartServer(t, params)
+	sqlDBroot := sqlutils.MakeSQLRunner(rawSQLDBroot)
+	defer s.Stopper().Stop(context.Background())
+
+	// Create four users: one with no special permissions, one with the
+	// VIEWACTIVITY role option, one with VIEWACTIVITYREDACTED option,
+	// and one with both permissions.
+	_ = sqlDBroot.Exec(t, `CREATE USER noperms`)
+	_ = sqlDBroot.Exec(t, `CREATE USER onlyviewactivity`)
+	_ = sqlDBroot.Exec(t, `CREATE USER onlyviewactivityredacted`)
+	_ = sqlDBroot.Exec(t, `CREATE USER bothperms`)
+	_ = sqlDBroot.Exec(t, `GRANT SYSTEM VIEWACTIVITY TO onlyviewactivity`)
+	_ = sqlDBroot.Exec(t, `GRANT SYSTEM VIEWACTIVITYREDACTED TO onlyviewactivityredacted`)
+	_ = sqlDBroot.Exec(t, `GRANT SYSTEM VIEWACTIVITY TO bothperms`)
+	_ = sqlDBroot.Exec(t, `GRANT SYSTEM VIEWACTIVITYREDACTED TO bothperms`)
+
+	type user struct {
+		username        string
+		canViewTable    bool // Can the user view the `cluster_queries` table?
+		isQueryRedacted bool // Is the user's query redacted?
+		sqlRunner       *sqlutils.SQLRunner
+	}
+
+	// A user with no permissions should not see the table. A user with only
+	// VIEWACTIVITY should be able to see the whole query. A user with only
+	// VIEWACTIVITYREDACTED should see a redacted query. A user with both should
+	// see the redacted query, as VIEWACTIVITYREDACTED takes precedence.
+	users := []user{
+		{"onlyviewactivityredacted", true, true, nil},
+		{"onlyviewactivity", true, false, nil},
+		{"noperms", false, false, nil},
+		{"bothperms", true, true, nil},
+	}
+	for i, tc := range users {
+		pgURL := url.URL{
+			Scheme:   "postgres",
+			User:     url.User(tc.username),
+			Host:     s.ServingSQLAddr(),
+			RawQuery: "sslmode=disable",
+		}
+		db, err := gosql.Open("postgres", pgURL.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		users[i].sqlRunner = sqlutils.MakeSQLRunner(db)
+
+		// Ensure the session is open.
+		users[i].sqlRunner.Exec(t, `SELECT version()`)
+	}
+
+	// Run a long-running sleep query in the background.
+	startSignal := make(chan struct{})
+	waiter := make(chan struct{})
+	go func() {
+		// Signal that we have started the query.
+		close(startSignal)
+		_, _ = rawSQLDBroot.ExecContext(ctx, `SELECT pg_sleep(30)`)
+		// Signal that we have finished the query.
+		close(waiter)
+	}()
+
+	// Wait for the start signal.
+	<-startSignal
+
+	selectQuery := `SELECT query FROM [SHOW CLUSTER QUERIES] WHERE query LIKE 'SELECT pg_sleep%'`
+
+	testutils.SucceedsSoon(t, func() error {
+		rows := sqlDBroot.Query(t, selectQuery)
+		defer rows.Close()
+		count := 0
+		for rows.Next() {
+			count++
+			var query string
+			if err := rows.Scan(&query); err != nil {
+				return err
+			}
+			if query != "SELECT pg_sleep(30)" {
+				return errors.Errorf("Expected `SELECT pg_sleep(30)`, got %s", query)
+			}
+		}
+		if count != 1 {
+			return errors.Errorf("expected 1 row, got %d", count)
+		}
+		return nil
+	})
+
+	for _, u := range users {
+		t.Run(u.username, func(t *testing.T) {
+			// Make sure that if the user can't view the table, they get an error.
+			if !u.canViewTable {
+				u.sqlRunner.ExpectErr(t, "does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege", selectQuery)
+			} else {
+				rows := u.sqlRunner.Query(t, selectQuery)
+				defer rows.Close()
+				if err := rows.Err(); err != nil {
+					t.Fatal(err)
+				}
+				count := 0
+				for rows.Next() {
+					count++
+
+					var query string
+					if err := rows.Scan(&query); err != nil {
+						t.Fatal(err)
+					}
+
+					t.Log(query)
+					// Make sure that if the user is supposed to see a redacted query, they do.
+					if u.isQueryRedacted {
+						if !strings.HasPrefix(query, "SELECT pg_sleep(_)") {
+							t.Fatalf("Expected `SELECT pg_sleep(_)`, got %s", query)
+						}
+						// Make sure that if the user is supposed to see the full query, they do.
+					} else {
+						if !strings.HasPrefix(query, "SELECT pg_sleep(30)") {
+							t.Fatalf("Expected `SELECT pg_sleep(30)`, got %s", query)
+						}
+					}
+				}
+				if count != 1 {
+					t.Fatalf("expected 1 row, got %d", count)
+				}
+			}
+		})
+	}
+
+	cancel()
+	<-waiter
 }
 
 func TestLintClusterSettingNames(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #104897.

/cc @cockroachdb/release

---

Fixes: #103560.

This commit implements the `VIEWACTIVITY` and `VIEWACTIVITYREDACTED`
system privileges for the crdb_internal queries tables. If a user does
not have either privilege, or is not admin, an error is returned. If a
user only has `VIEWACTIVITYREDACTED`, they will see a redacted form of
the SQL queries. If they only have `VIEWACTIVITY`, they will see the
unredacted SQL queries. If they have both, `VIEWACTIVITYREDACTED` takes
precedence.

Loom: https://www.loom.com/share/64649c3377d84cc5a1d2091136344594



Release note (sql change): The `crdb_internal.cluster_queries` and
`crdb_internal.node_queries` tables redact the SQL queries if the user
has `VIEWACTIVITYREDACTED`, and not redact the SQL queries if the user
has `VIEWACTIVITY`. The `crdb_internal.cluster_queries` and
`crdb_internal.node_queries` can now only be viewed if the user has any
of `admin`, `VIEWACTIVITY`, or `VIEWACTIVITYREDACTED`.

---

Release justification: bug fix for customer
