### PR TITLE
sql: re-add encoding test for pg_lsn

### DIFF
--- a/pkg/cmd/generate-binary/main.go
+++ b/pkg/cmd/generate-binary/main.go
@@ -367,6 +367,10 @@ var inputs = map[string][]string{
 		"epoch",
 	},
 
+	"'%s'::pg_lsn": {
+		"010011F/1ABCDEF0",
+	},
+
 	"'%s'::time": {
 		"00:00:00",
 		"12:00:00.000001",


### PR DESCRIPTION
I committed the json but not the binary test. Woops!

Informs: #105130

Release note: None