### PR TITLE
roachtest: add delay after adding constraints.

### DIFF
--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -271,6 +271,8 @@ func (h *replicagcTestHelper) isolateDeadNodes(ctx context.Context, runNode int)
 			h.t.Fatal(err)
 		}
 	}
+	// Wait to make sure the new constraints are read by all nodes.
+	time.Sleep(time.Minute)
 }
 
 func waitForZeroReplicasOnN3(ctx context.Context, t test.Test, db *gosql.DB) {


### PR DESCRIPTION
Fixes: #105506.
Fixes: #105505.

Add a delay after adding the constraints before recommissioning the
node. This allows the constraints to propagate to all nodes and avoids
replicas being added back to the node.

Epic: none

Release note: None