### PR TITLE
sql: fix logic test for showing cluster setting defaults and origin

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -110,7 +110,7 @@ ALTER TENANT ALL SET CLUSTER SETTING sql.index_recommendation.drop_unused_durati
 user root
 
 onlyif config 3node-tenant-default-configs
-query TTTT
+query TTTT retry
 SELECT variable, value, default_value, origin FROM [SHOW ALL CLUSTER SETTINGS]
 WHERE variable IN ('sql.index_recommendation.drop_unused_duration')
 ----


### PR DESCRIPTION
A logic test that was verifying the results of
`ALTER TENANT ALL SET CLUSTER SETTING` was failing under stress runs as the effects of this query can take some time to propagate to tenants. Adding a retry to the select stmt fixes this issue by ensuring we wait for the setting to change.

Fixes: #105485

Release note: None