### PR TITLE
testccl/sqlccl: unskip TestExplainRedactDDL

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -32,9 +31,6 @@ import (
 func TestExplainRedactDDL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.WithIssue(t, 99005)
-	skip.UnderStressWithIssue(t, 99005)
 
 	const numStatements = 10
 


### PR DESCRIPTION
`TestExplainRedactDDL` is a randomized SQL test which runs variants of `EXPLAIN (REDACT)` on random SQL statements and checks that an injected poison string is always redacted in the output. It is very similar to another randomized test, `TestExplainRedact`, but also includes DDL in the random statements.

During development of v23.1 this test was skipped because the random DDL statements were running into other bugs unrelated to redaction. Now that things are more stable, let's unskip this test.

Fixes: #99005

Epic: None

Release note: None