### PR TITLE
release-22.2: flowinfra: remove flowID from the "flow registry is draining" error

### DIFF
--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -301,8 +301,7 @@ func (fr *FlowRegistry) RegisterFlow(
 
 	if draining {
 		return &flowRetryableError{cause: errors.Errorf(
-			"could not register flowID %d because the registry is draining",
-			id,
+			"could not register flowID because the registry is draining",
 		)}
 	}
 	entry := fr.getEntryLocked(id)


### PR DESCRIPTION
Backport 1/1 commits from #105433.

/cc @cockroachdb/release

---

This doesn't seem that useful and unique values make it harder to aggregate this type of error.

Epic: None

Release note: None

Release justification: low-risk cleanup.