### PR TITLE
backupccl: skip timing based regression test under deadlock

### DIFF
--- a/pkg/ccl/backupccl/backup_intents_test.go
+++ b/pkg/ccl/backupccl/backup_intents_test.go
@@ -31,7 +31,8 @@ func TestCleanupIntentsDuringBackupPerformanceRegression(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	defer ccl.TestingEnableEnterprise()()
 
-	skip.UnderRace(t, "measures backup times not to regress, can't work under race")
+	skip.UnderRace(t, "measures backup times to ensure intent resolution does not regress, can't work under race")
+	skip.UnderDeadlock(t, "measures backup times to ensure intent resolution does not regress, can't work under deadlock")
 
 	// Time to create backup in presence of intents differs roughly 10x so some
 	// arbitrary number is picked which is 2x higher than current backup time on


### PR DESCRIPTION
TestCleanupIntentsDuringBackupPerformanceRegression ensures that intent resolution does not take >20s when running in a controlled environment. We have seen instances of this test when run under deadlock taking 22-24s causing the test to fail. Given that this test is very sensitive to timing, it does not make sense to run it under deadlock.

Fixes: #100034
Release note: None