### PR TITLE
concurrency: small bug fix

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1915,6 +1915,11 @@ func (l *lockState) tryActiveWait(
 			// non-transactional.
 			qg.active = false
 			wait = false
+			// If this request was previously designated as a distinguished waiter,
+			// and is now being marked inactive, clear out the designation.
+			if l.distinguishedWaiter == qg.guard {
+				l.distinguishedWaiter = nil
+			}
 		}
 	} else {
 		if replicatedLockFinalizedTxn != nil || unreplicatedLockFinalizedTxn != nil {

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -19,6 +19,12 @@ new-txn txn=txn5 ts=11,1 epoch=0
 new-txn txn=txn6 ts=11,1 epoch=0
 ----
 
+new-txn txn=txn7 ts=11,1 epoch=0
+----
+
+new-txn txn=txn8 ts=11,1 epoch=0
+----
+
 # -----------------------------------------------------------------------------
 # req1 waits for replicated locks held by txn2, txn3, and unreplicated lock
 # held by txn4. When txn2 is finalized and req1 scans, it notices it no longer
@@ -186,7 +192,6 @@ num=5
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl [holder finalized: aborted] epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 1
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl [holder finalized: aborted] epoch: 0, seqs: [0]
    queued writers:
@@ -215,7 +220,6 @@ num=5
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl [holder finalized: aborted] epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 1
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,1, info: repl [holder finalized: aborted] epoch: 0, seqs: [0]
    queued writers:
@@ -981,3 +985,104 @@ num=2
  lock: "b"
    queued writers:
     active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
+
+# -----------------------------------------------------------------------------
+# Ensure a claimant can never simultaneously be a distinguished waiter as well.
+# -----------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req17 txn=txn5 ts=11,0 spans=intent@a+intent@b
+----
+
+scan r=req17
+----
+start-waiting: false
+
+add-discovered r=req17 k=a txn=txn7
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+
+add-discovered r=req17 k=b txn=txn8
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000008, ts: 11.000000000,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+
+scan r=req17
+----
+start-waiting: true
+
+print
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 16, txn: 00000000-0000-0000-0000-000000000005
+   distinguished req: 16
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000008, ts: 11.000000000,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+
+pushed-txn-updated txn=txn7 status=aborted
+----
+
+scan r=req17
+----
+start-waiting: true
+
+guard-state r=req17
+----
+new: state=waitForDistinguished txn=txn8 key="b" held=true guard-strength=Intent
+
+# Now that req17 is able to wait on lock "b", and claim the lock on "a", it should
+# no longer be the distinguished waiter on lock "a" anymore.
+print
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl [holder finalized: aborted] epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000008, ts: 11.000000000,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 16, txn: 00000000-0000-0000-0000-000000000005
+   distinguished req: 16
+
+new-request r=req18 txn=txn8 ts=11,0 spans=intent@a
+----
+
+scan r=req18
+----
+start-waiting: true
+
+# Consequently, req18 should be able to become a distinguished waiter on lock "a".
+print
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000007, ts: 11.000000000,1, info: repl [holder finalized: aborted] epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+    active: true req: 17, txn: 00000000-0000-0000-0000-000000000008
+   distinguished req: 17
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000008, ts: 11.000000000,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 16, txn: 00000000-0000-0000-0000-000000000005
+   distinguished req: 16


### PR DESCRIPTION
Previously, as seen in the testing diff, an inactive waiter/claimant on a lock could continue to remain a distinguished waiter on that lock. This is now fixed.

Epic: none

Release note: None