### PR TITLE
kvtenant,settingswatcher: ensure overrides are applied during start

### DIFF
--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -172,8 +172,16 @@ type connector struct {
 	settingsMu struct {
 		syncutil.Mutex
 
-		allTenantOverrides map[string]settings.EncodedValue
-		specificOverrides  map[string]settings.EncodedValue
+		// receivedFirstAllTenantOverrides is set to true when the first batch of
+		// all-tenant overrides has been received.
+		receivedFirstAllTenantOverrides bool
+		allTenantOverrides              map[string]settings.EncodedValue
+
+		// receivedFirstSpecificOverrides is set to true when the first batch of
+		// tenant-specific overrides has been received.
+		receivedFirstSpecificOverrides bool
+		specificOverrides              map[string]settings.EncodedValue
+
 		// notifyCh receives an event when there are changes to overrides.
 		notifyCh chan struct{}
 	}

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -160,6 +160,9 @@ type connector struct {
 	defaultZoneCfg  *zonepb.ZoneConfig
 	addrs           []string
 
+	startCh  chan struct{} // closed when connector has started up
+	startErr error
+
 	mu struct {
 		syncutil.RWMutex
 		client               *client
@@ -182,7 +185,7 @@ type connector struct {
 		receivedFirstSpecificOverrides bool
 		specificOverrides              map[string]settings.EncodedValue
 
-		// notifyCh receives an event when there are changes to overrides.
+		// notifyCh is closed when there are changes to overrides.
 		notifyCh chan struct{}
 	}
 }
@@ -255,6 +258,7 @@ func NewConnector(cfg ConnectorConfig, addrs []string) Connector {
 	c.mu.systemConfigChannels = make(map[chan<- struct{}]struct{})
 	c.settingsMu.allTenantOverrides = make(map[string]settings.EncodedValue)
 	c.settingsMu.specificOverrides = make(map[string]settings.EncodedValue)
+	c.settingsMu.notifyCh = make(chan struct{})
 	return c
 }
 
@@ -276,10 +280,36 @@ func (connectorFactory) NewConnector(
 	return NewConnector(cfg, []string{addressConfig.LoopbackAddress}), nil
 }
 
+// WaitForStart waits until the connector has started.
+func (c *connector) WaitForStart(ctx context.Context) error {
+	// Fast path check.
+	select {
+	case <-c.startCh:
+		return c.startErr
+	default:
+	}
+	if c.startCh == nil {
+		return errors.AssertionFailedf("Start() was not yet called")
+	}
+	select {
+	case <-c.startCh:
+		return c.startErr
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // Start launches the connector's worker thread and waits for it to successfully
 // connect to a KV node. Start returns once the connector has determined the
 // cluster's ID and set connector.rpcContext.ClusterID.
 func (c *connector) Start(ctx context.Context) error {
+	c.startCh = make(chan struct{})
+	c.startErr = c.internalStart(ctx)
+	close(c.startCh)
+	return c.startErr
+}
+
+func (c *connector) internalStart(ctx context.Context) error {
 	gossipStartupCh := make(chan struct{})
 	settingsStartupCh := make(chan struct{})
 	bgCtx := c.AnnotateCtx(context.Background())

--- a/pkg/kv/kvclient/kvtenant/connector_test.go
+++ b/pkg/kv/kvclient/kvtenant/connector_test.go
@@ -70,8 +70,15 @@ func (m *mockServer) TenantSettings(
 	req *kvpb.TenantSettingsRequest, stream kvpb.Internal_TenantSettingsServer,
 ) error {
 	if m.tenantSettingsFn == nil {
+		if err := stream.Send(&kvpb.TenantSettingsEvent{
+			Precedence:  kvpb.TenantSettingsEvent_TENANT_SPECIFIC_OVERRIDES,
+			Incremental: false,
+			Overrides:   nil,
+		}); err != nil {
+			return err
+		}
 		return stream.Send(&kvpb.TenantSettingsEvent{
-			Precedence:  kvpb.SpecificTenantOverrides,
+			Precedence:  kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES,
 			Incremental: false,
 			Overrides:   nil,
 		})
@@ -263,7 +270,12 @@ func TestConnectorGossipSubscription(t *testing.T) {
 	gossipSubC <- gossipEventForNodeDesc(node1)
 	gossipSubC <- gossipEventForNodeDesc(node2)
 	gossipSubC <- gossipEventForClusterID(clusterID)
-	require.NoError(t, <-startedC)
+	select {
+	case err := <-startedC:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatalf("failed to see start complete")
+	}
 
 	// Ensure that ClusterID was updated.
 	require.Equal(t, clusterID, rpcContext.StorageClusterID.Get())

--- a/pkg/kv/kvclient/kvtenant/setting_overrides.go
+++ b/pkg/kv/kvclient/kvtenant/setting_overrides.go
@@ -38,7 +38,7 @@ func (c *connector) runTenantSettingsSubscription(ctx context.Context, startupCh
 			c.tryForgetClient(ctx, client)
 			continue
 		}
-		for firstEventInStream := true; ; firstEventInStream = false {
+		for {
 			e, err := stream.Recv()
 			if err != nil {
 				if err == io.EOF {
@@ -55,17 +55,22 @@ func (c *connector) runTenantSettingsSubscription(ctx context.Context, startupCh
 				continue
 			}
 
-			if err := c.processSettingsEvent(e, firstEventInStream); err != nil {
+			settingsReady, err := c.processSettingsEvent(e)
+			if err != nil {
 				log.Errorf(ctx, "error processing tenant settings event: %v", err)
 				_ = stream.CloseSend()
 				c.tryForgetClient(ctx, client)
 				break
 			}
 
-			// Signal that startup is complete once we receive an event.
-			if startupCh != nil {
-				close(startupCh)
-				startupCh = nil
+			// Signal that startup is complete once we have enough events to start.
+			if settingsReady {
+				log.Infof(ctx, "received initial tenant settings")
+
+				if startupCh != nil {
+					close(startupCh)
+					startupCh = nil
+				}
 			}
 		}
 	}
@@ -73,22 +78,25 @@ func (c *connector) runTenantSettingsSubscription(ctx context.Context, startupCh
 
 // processSettingsEvent updates the setting overrides based on the event.
 func (c *connector) processSettingsEvent(
-	e *kvpb.TenantSettingsEvent, firstEventInStream bool,
-) error {
-	if firstEventInStream && e.Incremental {
-		return errors.Newf("first event must not be Incremental")
-	}
+	e *kvpb.TenantSettingsEvent,
+) (settingsReady bool, err error) {
 	c.settingsMu.Lock()
 	defer c.settingsMu.Unlock()
 
+	if (!c.settingsMu.receivedFirstAllTenantOverrides || !c.settingsMu.receivedFirstSpecificOverrides) && e.Incremental {
+		return false, errors.Newf("need to receive non-incremental setting events first")
+	}
+
 	var m map[string]settings.EncodedValue
 	switch e.Precedence {
-	case kvpb.AllTenantsOverrides:
+	case kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES:
+		c.settingsMu.receivedFirstAllTenantOverrides = true
 		m = c.settingsMu.allTenantOverrides
-	case kvpb.SpecificTenantOverrides:
+	case kvpb.TenantSettingsEvent_TENANT_SPECIFIC_OVERRIDES:
+		c.settingsMu.receivedFirstSpecificOverrides = true
 		m = c.settingsMu.specificOverrides
 	default:
-		return errors.Newf("unknown precedence value %d", e.Precedence)
+		return false, errors.Newf("unknown precedence value %d", e.Precedence)
 	}
 
 	// If the event is not incremental, clear the map.
@@ -115,7 +123,10 @@ func (c *connector) processSettingsEvent(
 	default:
 	}
 
-	return nil
+	// The protocol defines that the server sends one initial
+	// non-incremental message for both precedences.
+	settingsReady = c.settingsMu.receivedFirstAllTenantOverrides && c.settingsMu.receivedFirstSpecificOverrides
+	return settingsReady, nil
 }
 
 // RegisterOverridesChannel is part of the settingswatcher.OverridesMonitor

--- a/pkg/kv/kvclient/kvtenant/setting_overrides_test.go
+++ b/pkg/kv/kvclient/kvtenant/setting_overrides_test.go
@@ -87,10 +87,6 @@ func TestConnectorSettingOverrides(t *testing.T) {
 	case <-time.After(10 * time.Millisecond):
 	}
 
-	ch := c.RegisterOverridesChannel()
-	// We should always get an initial notification.
-	waitForSettings(t, ch)
-
 	ev := &kvpb.TenantSettingsEvent{
 		Precedence:  kvpb.TenantSettingsEvent_TENANT_SPECIFIC_OVERRIDES,
 		Incremental: false,
@@ -117,8 +113,7 @@ func TestConnectorSettingOverrides(t *testing.T) {
 		t.Fatalf("failed to see start complete")
 	}
 
-	waitForSettings(t, ch)
-	expectSettings(t, c, "foo=default bar=default baz=default")
+	ch := expectSettings(t, c, "foo=default bar=default baz=default")
 
 	st := func(name, val string) kvpb.TenantSetting {
 		return kvpb.TenantSetting{
@@ -135,7 +130,7 @@ func TestConnectorSettingOverrides(t *testing.T) {
 	}
 	eventCh <- ev
 	waitForSettings(t, ch)
-	expectSettings(t, c, "foo=all bar=all baz=default")
+	ch = expectSettings(t, c, "foo=all bar=all baz=default")
 
 	// Set some tenant-specific overrides, with all-tenant overlap.
 	ev = &kvpb.TenantSettingsEvent{
@@ -145,7 +140,7 @@ func TestConnectorSettingOverrides(t *testing.T) {
 	}
 	eventCh <- ev
 	waitForSettings(t, ch)
-	expectSettings(t, c, "foo=specific bar=all baz=specific")
+	ch = expectSettings(t, c, "foo=specific bar=all baz=specific")
 
 	// Remove an all-tenant override that has a specific override.
 	ev = &kvpb.TenantSettingsEvent{
@@ -155,7 +150,7 @@ func TestConnectorSettingOverrides(t *testing.T) {
 	}
 	eventCh <- ev
 	waitForSettings(t, ch)
-	expectSettings(t, c, "foo=specific bar=all baz=specific")
+	ch = expectSettings(t, c, "foo=specific bar=all baz=specific")
 
 	// Remove a specific override.
 	ev = &kvpb.TenantSettingsEvent{
@@ -165,7 +160,7 @@ func TestConnectorSettingOverrides(t *testing.T) {
 	}
 	eventCh <- ev
 	waitForSettings(t, ch)
-	expectSettings(t, c, "foo=default bar=all baz=specific")
+	ch = expectSettings(t, c, "foo=default bar=all baz=specific")
 
 	// Non-incremental change to all-tenants override.
 	ev = &kvpb.TenantSettingsEvent{
@@ -175,7 +170,7 @@ func TestConnectorSettingOverrides(t *testing.T) {
 	}
 	eventCh <- ev
 	waitForSettings(t, ch)
-	expectSettings(t, c, "foo=default bar=all baz=specific")
+	_ = expectSettings(t, c, "foo=default bar=all baz=specific")
 }
 
 func waitForSettings(t *testing.T, ch <-chan struct{}) {
@@ -187,14 +182,15 @@ func waitForSettings(t *testing.T, ch <-chan struct{}) {
 		t.Fatalf("waitForSettings timed out")
 	}
 }
-func expectSettings(t *testing.T, c *connector, exp string) {
+
+func expectSettings(t *testing.T, c *connector, exp string) <-chan struct{} {
 	t.Helper()
 	vars := []string{"foo", "bar", "baz"}
 	values := make(map[string]string)
 	for i := range vars {
 		values[vars[i]] = "default"
 	}
-	overrides := c.Overrides()
+	overrides, updateCh := c.Overrides()
 	for _, v := range vars {
 		if val, ok := overrides[v]; ok {
 			values[v] = val.Value
@@ -208,4 +204,6 @@ func expectSettings(t *testing.T, c *connector, exp string) {
 	if str != exp {
 		t.Errorf("expected:  %s  got:  %s", exp, str)
 	}
+
+	return updateCh
 }

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1878,22 +1878,6 @@ func (s *ScanStats) String() string {
 	return redact.StringWithoutMarkers(s)
 }
 
-// TenantSettingsPrecedence identifies the precedence of a set of setting
-// overrides. It is used by the TenantSettings API which supports passing
-// multiple overrides for the same setting.
-type TenantSettingsPrecedence uint32
-
-const (
-	// SpecificTenantOverrides is the high precedence for tenant setting overrides.
-	// These overrides take precedence over AllTenantsOverrides.
-	SpecificTenantOverrides TenantSettingsPrecedence = 1 + iota
-
-	// AllTenantsOverrides is the low precedence for tenant setting overrides.
-	// These overrides are only effectual for a tenant if there is no override
-	// with the SpecificTenantOverrides precedence..
-	AllTenantsOverrides
-)
-
 // RangeFeedEventSink is an interface for sending a single rangefeed event.
 type RangeFeedEventSink interface {
 	Context() context.Context

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3078,15 +3078,28 @@ message TenantSettingsRequest {
 
 // TenantSettingsEvent is used to report changes to setting overrides for a
 // particular tenant.
-//
-// Each event pertains to a certain precedence value (see
-// TenantSettingsPrecedence).
+// The protocol is as follows:
+// - When a tenant server first connects, a non-incremental TenantSettingsEvent
+//   settings event is sent to the client for each precedence value.
+//   This reports to the client the initial values of all the cluster setting
+//   overrides.
+// - Afterwards, more TenantSettingsEvent are sent (with Incremental set or not)
+//   whenever settings are updated.
 //
 // Note: this API is designed to allow flexibility of implementation on the
 // server side (e.g. to make it maintain very little state per tenant).
 message TenantSettingsEvent {
-  // Precedence must be a valid TenantSettingsPrecedence value.
-  uint32 precedence = 1 [(gogoproto.casttype) = "TenantSettingsPrecedence"];
+  enum Precedence {
+    // Sentinel value to ensure that the 0 value is not a valid precedence.
+    INVALID = 0;
+    // Setting overrides specific to 1 tenant.
+    TENANT_SPECIFIC_OVERRIDES = 1;
+    // Setting overrides applied to all tenants.
+    ALL_TENANTS_OVERRIDES = 2;
+  }
+
+  // Precedence is the type of overrides that are reported in this event.
+  Precedence precedence = 1;
 
   // Incremental is true if the list of overrides is a list of changes since the
   // last event. In that case, any overrides that have been removed are returned

--- a/pkg/server/settingswatcher/overrides.go
+++ b/pkg/server/settingswatcher/overrides.go
@@ -10,22 +10,21 @@
 
 package settingswatcher
 
-import "github.com/cockroachdb/cockroach/pkg/settings"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+)
 
 // OverridesMonitor is an interface through which the settings watcher can
 // receive setting overrides. Used for non-system tenants.
-//
-// The expected usage is to listen for a message on NotifyCh(), and use
-// Current() to retrieve the updated list of overrides when a message is
-// received.
 type OverridesMonitor interface {
-	// RegisterOverridesChannel returns a channel that receives a message
-	// any time the current set of overrides changes.
-	// The channel receives an initial event immediately.
-	RegisterOverridesChannel() <-chan struct{}
+	// WaitForStart waits until the overrides are ready for consumption.
+	WaitForStart(ctx context.Context) error
 
-	// Overrides retrieves the current set of setting overrides, as a map from
-	// setting key to EncodedValue. Any settings that are present must be set to
-	// the overridden value.
-	Overrides() map[string]settings.EncodedValue
+	// Overrides retrieves the current set of setting overrides, as a
+	// map from setting key to EncodedValue. Any settings that are
+	// present must be set to the overridden value. It also returns a
+	// channel that will be closed when the overrides are updated.
+	Overrides() (map[string]settings.EncodedValue, <-chan struct{})
 }


### PR DESCRIPTION
See individual commits for details.

Fixes #96512.
Needed to unblock #104859.
Epic: CRDB-26691