### PR TITLE
DEPS: upgrade Raft to 72d62a1

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -6547,7 +6547,7 @@ func TestRaftLeaderRemovesItself(t *testing.T) {
 				// Set a large election timeout. We don't want replicas to call
 				// elections due to timeouts, we want them to campaign and obtain
 				// votes despite PreVote+CheckQuorum.
-				RaftElectionTimeoutTicks: 200,
+				RaftElectionTimeoutTicks: 300,
 			},
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
@@ -6601,6 +6601,9 @@ func TestRaftLeaderRemovesItself(t *testing.T) {
 	tc.RemoveVotersOrFatal(t, key, tc.Target(0))
 	t.Logf("n1 removed from range")
 
+	// Make sure we didn't time out on the above.
+	require.NoError(t, ctx.Err())
+
 	require.Eventually(t, func() bool {
 		logStatus(repl2.RaftStatus())
 		logStatus(repl3.RaftStatus())
@@ -6610,6 +6613,8 @@ func TestRaftLeaderRemovesItself(t *testing.T) {
 		}
 		return false
 	}, 10*time.Second, 500*time.Millisecond)
+
+	require.NoError(t, ctx.Err())
 }
 
 // TestRaftUnquiesceLeaderNoProposal tests that unquiescing a Raft leader does

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -255,12 +255,14 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState
 // initRaftGroupRaftMuLockedReplicaMuLocked initializes a Raft group for the
 // replica, replacing the existing Raft group if any.
 func (r *Replica) initRaftGroupRaftMuLockedReplicaMuLocked() error {
+	ctx := r.AnnotateCtx(context.Background())
 	rg, err := raft.NewRawNode(newRaftConfig(
+		ctx,
 		raft.Storage((*replicaRaftStorage)(r)),
 		uint64(r.replicaID),
 		r.mu.state.RaftAppliedIndex,
 		r.store.cfg,
-		&raftLogger{ctx: r.AnnotateCtx(context.Background())},
+		&raftLogger{ctx: ctx},
 	))
 	if err != nil {
 		return err


### PR DESCRIPTION
Makes Raft leaders step down when removing themselves from the range.

```
72d62a1 2023-06-13: step down when leader removes itself [Erik Grinaker]
```

Epic: none
Release note: None