### PR TITLE
roachtest: add a test to the activerecord blocklist

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -30,6 +30,7 @@ var activeRecordBlocklist = blocklist{
 	"ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_type_with_symbol_using_timestamp_with_timestamptz_as_default": "49329",
 	"ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_type_with_symbol_with_timestamptz_as_default":                 "49329",
 	"ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_type_with_symbol_with_timestamptz":                            "49329",
+	"PessimisticLockingTest#test_with_lock_sets_isolation":                                                                              "100144",
 }
 
 var activeRecordIgnoreList = blocklist{


### PR DESCRIPTION
The `PessimisticLockingTest#test_with_lock_sets_isolation` test is now
expected to fail because of a recent change in CRDB.

Informs #97283

Release note: None