### PR TITLE
ccl/sqlproxyccl: fix TestACLWatcher flake

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/watcher_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/watcher_test.go
@@ -75,6 +75,15 @@ func TestACLWatcher(t *testing.T) {
 
 	dir, tds := tenantdirsvr.SetupTestDirectory(t, ctx, stopper, nil /* timeSource */)
 	tenantID := roachpb.MustMakeTenantID(10)
+
+	// Wait until the tenant watcher has been established.
+	testutils.SucceedsSoon(t, func() error {
+		if tds.WatchTenantsListenersCount() == 0 {
+			return errors.New("watchers have not been established yet")
+		}
+		return nil
+	})
+
 	tds.CreateTenant(tenantID, &tenant.Tenant{
 		Version:                 "001",
 		TenantID:                tenantID.ToUint64(),
@@ -269,7 +278,7 @@ func TestACLWatcher(t *testing.T) {
 				return err
 			}
 			if ten.Version != "002" {
-				return errors.New("tenant is not up-to-date")
+				return errors.Newf("tenant is not up-to-date, found version=%s", ten.Version)
 			}
 			return nil
 		})
@@ -321,7 +330,7 @@ func TestACLWatcher(t *testing.T) {
 				return err
 			}
 			if ten.Version != "003" {
-				return errors.New("tenant is not up-to-date")
+				return errors.Newf("tenant is not up-to-date, found version=%s", ten.Version)
 			}
 			return nil
 		})

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
@@ -145,7 +145,16 @@ func (d *TestStaticDirectoryServer) WatchPods(
 	removeListener := func(e *list.Element) chan *tenant.WatchPodsResponse {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		return d.mu.podEventListeners.Remove(e).(chan *tenant.WatchPodsResponse)
+		// Check for existence before removing the entry.
+		//
+		// list.Remove(e) will always return e.Value regardless of whether the
+		// element exists in the list.
+		for el := d.mu.podEventListeners.Front(); el != nil; el = el.Next() {
+			if el.Value == e.Value {
+				return d.mu.podEventListeners.Remove(el).(chan *tenant.WatchPodsResponse)
+			}
+		}
+		return nil
 	}
 
 	// Construct the channel with a small buffer to allow for a burst of
@@ -248,7 +257,16 @@ func (d *TestStaticDirectoryServer) WatchTenants(
 	removeListener := func(e *list.Element) chan *tenant.WatchTenantsResponse {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		return d.mu.tenantEventListeners.Remove(e).(chan *tenant.WatchTenantsResponse)
+		// Check for existence before removing the entry.
+		//
+		// list.Remove(e) will always return e.Value regardless of whether the
+		// element exists in the list.
+		for el := d.mu.tenantEventListeners.Front(); el != nil; el = el.Next() {
+			if el.Value == e.Value {
+				return d.mu.tenantEventListeners.Remove(el).(chan *tenant.WatchTenantsResponse)
+			}
+		}
+		return nil
 	}
 
 	// Construct the channel with a small buffer to allow for a burst of


### PR DESCRIPTION
Fixes #104105.

Previously, there was a possibility where that WatchTenants stream has not
been established before running the tests, resulting in events to be missed
when they were sent in the tests. They then fail because they were waiting for
an event that would never come. In production, this isn't an issue because the
next time WatchTenants re-establishes, the tenant directory sends the entire
state of the server to the client (which is up-to-date, and the behavior is
different from the test tenant directory server here).

This commit fixes the test flake by ensuring that the WatchTenants stream
has been established before running the test logic. At the same time, we also
fix a case where we panic when trying to close the same channel twice. This
was due to a misuse of the Remove function in container/list (which will
always return a value regardless of whether the element was in the list
previously).

Release note: None

Release justification: Test only fix.

Epic: none