### PR TITLE
tenantcostmodel: charge for cross region network traffic

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
@@ -364,9 +364,9 @@ PGWire egress:  12345 bytes
 ExternalIO egress: 1026000 bytes
 ExternalIO ingress: 1034000 bytes
 
-# Read the same amount of bytes as the first subtest. Increase in RUs should be
-# multiplied by 2 of the ones in the first subtest.
-read bytes=1048576 ruMultiplier=2.0
+# Read the same amount of bytes as the first subtest. Should have an increase
+# of ~10.5 RUs compared to the first test.
+read bytes=1048576 networkCost=0.00001
 ----
 
 advance
@@ -380,8 +380,8 @@ token-bucket-response
 
 usage
 ----
-RU:  2357.64
-KVRU:  72.25
+RU:  2351.50
+KVRU:  66.11
 Reads:  5 requests in 4 batches (2228224 bytes)
 Writes:  5 requests in 4 batches (10240 bytes)
 SQL Pods CPU seconds:  3.82
@@ -389,9 +389,8 @@ PGWire egress:  12345 bytes
 ExternalIO egress: 1026000 bytes
 ExternalIO ingress: 1034000 bytes
 
-# Test write operation consumption with RU multiplier of 3.5 on the RUs
-# increased in the second subtest.
-write bytes=1024 ruMultiplier=3.5
+# This write is expected to consume an extra 5.12 RUs from network cost usage.
+write bytes=1024 networkCost=0.005
 ----
 
 advance
@@ -405,8 +404,8 @@ token-bucket-response
 
 usage
 ----
-RU:  2368.14
-KVRU:  82.75
+RU:  2359.62
+KVRU:  74.23
 Reads:  5 requests in 4 batches (2228224 bytes)
 Writes:  6 requests in 5 batches (11264 bytes)
 SQL Pods CPU seconds:  3.82
@@ -415,10 +414,10 @@ ExternalIO egress: 1026000 bytes
 ExternalIO ingress: 1034000 bytes
 
 # Test multiple requests in the same batch with RU multiplier of 1.
-write count=2 bytes=1024 ruMultiplier=1.0
+write count=2 bytes=1024 networkCost=0
 ----
 
-read count=2 bytes=65536 ruMultiplier=1.0
+read count=2 bytes=65536 networkCost=0
 ----
 
 advance
@@ -432,8 +431,8 @@ token-bucket-response
 
 usage
 ----
-RU:  2373.89
-KVRU:  88.50
+RU:  2365.37
+KVRU:  79.98
 Reads:  7 requests in 5 batches (2293760 bytes)
 Writes:  8 requests in 6 batches (12288 bytes)
 SQL Pods CPU seconds:  3.82

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2387,20 +2387,12 @@ func (ds *DistSender) sendToReplicas(
 					var reqInfo tenantcostmodel.RequestInfo
 					var respInfo tenantcostmodel.ResponseInfo
 					if ba.IsWrite() {
-						// It is important to pass nil for replicas here so we
-						// will fetch a new list of *all* replicas, instead of
-						// just a subset (which routing uses).
-						writeMultiplier := ds.computeSendRUMultiplier(
-							ctx, desc, nil /* replicas */, &curReplica, false /* isRead */)
-						numReplicas := len(desc.Replicas().Descriptors())
-						reqInfo = tenantcostmodel.MakeRequestInfo(ba, numReplicas, writeMultiplier)
+						networkCost := ds.computeNetworkCost(ctx, desc, &curReplica, true /* isWrite */)
+						reqInfo = tenantcostmodel.MakeRequestInfo(ba, len(desc.Replicas().Descriptors()), networkCost)
 					}
 					if !reqInfo.IsWrite() {
-						// Use replicas here since it is guaranteed to include
-						// curReplica, and we only need that for computation.
-						readMultiplier := ds.computeSendRUMultiplier(
-							ctx, desc, replicas, &curReplica, true /* isRead */)
-						respInfo = tenantcostmodel.MakeResponseInfo(br, true, readMultiplier)
+						networkCost := ds.computeNetworkCost(ctx, desc, &curReplica, false /* isWrite */)
+						respInfo = tenantcostmodel.MakeResponseInfo(br, true, networkCost)
 					}
 					if err := ds.kvInterceptor.OnResponseWait(ctx, reqInfo, respInfo); err != nil {
 						return nil, err
@@ -2583,107 +2575,73 @@ func (ds *DistSender) getCostControllerConfig(ctx context.Context) *tenantcostmo
 	return cfg
 }
 
-// computeSendRUMultiplier returns the RU multiplier for a batch that is sent
-// from the current DistSender node to the node with curReplica. If isRead=true,
-// the read RU multiplier will be returned instead of a write RU multiplier.
-//
-//  1. Write requests account traffic for all replicas since the data is
-//     eventually replicated to the remaining replicas. For simplicity of
-//     computation, we will assume that the writes were replicated from the
-//     DistSender node instead of the node that received the writes.
-//  2. Read requests only account traffic from the DistSender node to the node
-//     that received the read.
-//
-// NOTE: desc cannot be nil, and numReplicas >= len(replicas). If replicas is
-// nil, desc will be used to construct a new ReplicaSlice by fetching the node
-// descriptors for all replicas.
-func (ds *DistSender) computeSendRUMultiplier(
+// computeNetworkCost calculates the network cost multiplier for a read or
+// write operation. The network cost accounts for the logical byte traffic
+// between the client region and the replica regions.
+func (ds *DistSender) computeNetworkCost(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
-	replicas ReplicaSlice,
-	curReplica *roachpb.ReplicaDescriptor,
-	isRead bool,
-) tenantcostmodel.RUMultiplier {
-	numReplicas := len(desc.Replicas().Descriptors())
-
-	// Set default multipliers.
-	var res tenantcostmodel.RUMultiplier
-	if isRead {
-		res = 1
-	} else {
-		res = tenantcostmodel.RUMultiplier(numReplicas)
+	targetReplica *roachpb.ReplicaDescriptor,
+	isWrite bool,
+) tenantcostmodel.NetworkCost {
+	// It is unfortunate that we hardcode a particular locality tier name here.
+	// Ideally, we would have a cluster setting that specifies the name or some
+	// other way to configure it.
+	clientRegion, _ := ds.locality.Find("region")
+	if clientRegion == "" {
+		// If we do not have the source, there is no way to find the multiplier.
+		log.VErrEventf(ctx, 2, "missing region tier in current node: locality=%s",
+			ds.locality.String())
+		return tenantcostmodel.NetworkCost(0)
 	}
 
 	costCfg := ds.getCostControllerConfig(ctx)
 	if costCfg == nil {
 		// This case is unlikely to happen since this method will only be
 		// called through tenant processes, which has a KV interceptor.
-		return res
+		return tenantcostmodel.NetworkCost(0)
 	}
 
-	// It is unfortunate that we hardcode a particular locality tier name here.
-	// Ideally, we would have a cluster setting that specifies the name or some
-	// other way to configure it.
-	fromRegion, _ := ds.locality.Find("region")
-	if fromRegion == "" {
-		// If we do not have the source, there is no way to find the multiplier.
-		log.VErrEventf(ctx, 2, "missing region tier in current node: locality=%s",
-			ds.locality.String())
-		return res
-	}
-
-	// Input replicas wasn't provided, so we'd try to fetch all of them.
-	if len(replicas) == 0 {
-		// A leaseholder is not needed here since we are interested in returning
-		// all replicas, which will already include the leaseholder by definition.
-		var err error
-		replicas, err = NewReplicaSlice(ctx, ds.nodeDescs, desc, nil /* leaseholder */, AllReplicas)
-		if err != nil {
-			log.VErrEventf(ctx, 2, "empty replica slice: %s", err)
-			return res
-		}
-	}
-
-	// This should not happen, and if it does, is a bug.
-	if numReplicas < len(replicas) {
-		log.VErrEventf(ctx, 2, "fewer descriptors than replicas: numReplicas=%d, len(replicas)=%d",
-			numReplicas, len(replicas))
-		return res
-	}
-
-	if isRead {
-		var toRegion string
-		if idx := replicas.Find(curReplica.ReplicaID); idx != -1 {
-			toRegion = replicas[idx].LocalityValue("region")
-		}
-		if toRegion == "" {
-			log.VErrEventf(ctx, 2, "missing region locality for n%d", curReplica.NodeID)
-		}
-		res = costCfg.KVInterRegionCostMultiplier(fromRegion, toRegion)
-	} else {
-		for _, r := range replicas {
-			toRegion := r.LocalityValue("region")
-			if toRegion == "" {
-				log.VErrEventf(ctx, 2, "missing region locality for n%d", r.NodeID)
+	cost := tenantcostmodel.NetworkCost(0)
+	if isWrite {
+		for i := range desc.Replicas().Descriptors() {
+			if replicaRegion, ok := ds.getReplicaRegion(ctx, &desc.Replicas().Descriptors()[i]); ok {
+				cost += costCfg.NetworkCost(tenantcostmodel.NetworkPath{
+					ToRegion:   replicaRegion,
+					FromRegion: clientRegion,
+				})
 			}
-
-			// There is a possibility where len(replicas) != numReplicas, which
-			// occurs when the DistSender node has not received gossip
-			// subscription data for node descriptors. When that happens, we
-			// don't have locality information, so we will assume 1 for each
-			// replica.
-			//
-			// Since we started with numReplicas initially, this basically
-			// converts the multiplier accounted for that replica with its
-			// actual cost multiplier.
-			//
-			// Earlier we ensured that numReplicas >= len(replicas). Since
-			// cost multipliers are always non-negative (>= 0), res will never
-			// be negative (< 0).
-			res += (costCfg.KVInterRegionCostMultiplier(fromRegion, toRegion) - 1)
+		}
+	} else {
+		if replicaRegion, ok := ds.getReplicaRegion(ctx, targetReplica); ok {
+			cost = costCfg.NetworkCost(tenantcostmodel.NetworkPath{
+				ToRegion:   clientRegion,
+				FromRegion: replicaRegion,
+			})
 		}
 	}
-	return res
+
+	return cost
+}
+
+func (ds *DistSender) getReplicaRegion(
+	ctx context.Context, replica *roachpb.ReplicaDescriptor,
+) (region string, ok bool) {
+	nodeDesc, err := ds.nodeDescs.GetNodeDescriptor(replica.NodeID)
+	if err != nil {
+		log.VErrEventf(ctx, 2, "node %d is not gossiped: %v", replica.NodeID, err)
+		// If we don't know where a node is, we can't determine the network cost
+		// for the operation.
+		return "", false
+	}
+
+	region, ok = nodeDesc.Locality.Find("region")
+	if !ok {
+		log.VErrEventf(ctx, 2, "missing region locality for n %d", nodeDesc.NodeID)
+		return "", false
+	}
+
+	return region, true
 }
 
 func (ds *DistSender) maybeIncrementErrCounters(br *kvpb.BatchResponse, err error) {

--- a/pkg/multitenant/tenantcostmodel/model.go
+++ b/pkg/multitenant/tenantcostmodel/model.go
@@ -19,10 +19,9 @@ import "github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 // a small point read of < 64 bytes costs 1 RU.
 type RU float64
 
-// RUMultiplier is the multiplier for Request Unit(s). For example, a multiplier
-// of 1.5 means that all Request Unit(s) are multiplied by a factor of 1.5 when
-// computing consumed RUs.
-type RUMultiplier float64
+// NetworkCost records how expensive network traffic is between two regions.
+// bytes_transmitted * NetworkCost is the RU cost of the network traffic.
+type NetworkCost float64
 
 // Config contains the cost model parameters. The values are controlled by
 // cluster settings.
@@ -84,9 +83,8 @@ type Config struct {
 	// service into the SQL pod.
 	ExternalIOIngressByte RU
 
-	// KVInterRegionRUMultiplierTable is a table describing the cost multipliers
-	// for transferring between regions.
-	KVInterRegionRUMultiplierTable RegionalCostMultiplierTable
+	// NetworkCostTable is a table describing the network cost between regions.
+	NetworkCostTable NetworkCostTable
 }
 
 // KVReadCost calculates the cost of a KV read operation.
@@ -120,31 +118,41 @@ func (c *Config) ExternalIOIngressCost(bytes int64) RU {
 	return RU(bytes) * c.ExternalIOIngressByte
 }
 
-// KVInterRegionCostMultiplier retrieves the RU multiplier for inter-region
-// transfers between r1 and r2. Ordering does not matter since the model assumes
-// that the multiplier is the same for both directions.
-func (c *Config) KVInterRegionCostMultiplier(r1, r2 string) RUMultiplier {
-	return c.KVInterRegionRUMultiplierTable.CostMultiplier(r1, r2)
+// NetworkCost retrieves the RU per byte cost for inter-region transfers from
+// the source to the destination region. The order of this relationship matters
+// because some clouds have asymetric networking charging.
+func (c *Config) NetworkCost(path NetworkPath) NetworkCost {
+	return c.NetworkCostTable.Matrix[path]
 }
 
-// RequestCost returns the cost, in RUs, of the given request. If it is a write,
-// that includes the per-batch, per-request, and per-byte costs, multiplied by
-// the write multiplier. If it is a read, then the cost is zero, since reads can
-// only be costed by examining the ResponseInfo.
+// RequestCost returns the cost, in RUs, of the given request. If it is a
+// write, that includes the per-batch, per-request, and per-byte costs,
+// multiplied by the number of replicas plus the cost of the cross region
+// networking. If it is a read, then the cost is zero, since reads can only be
+// costed by examining the ResponseInfo.
 func (c *Config) RequestCost(bri RequestInfo) RU {
 	if !bri.IsWrite() {
 		return 0
 	}
-	cost := c.KVWriteBatch
-	cost += RU(bri.writeCount) * c.KVWriteRequest
-	cost += RU(bri.writeBytes) * c.KVWriteByte
-	return cost * RU(bri.writeMultiplier)
+	// writeCost measures how expensive each replica is for crdb to write. This
+	// covers things like the cost of serving the RPC, raft consensus, and pebble
+	// write amplification.
+	writeCost := c.KVWriteBatch
+	writeCost += RU(bri.writeCount) * c.KVWriteRequest
+	writeCost += RU(bri.writeBytes) * c.KVWriteByte
+
+	// networkCost is intended to cover the cost of cross region networking. The
+	// network cost per byte is calculated by distsender and already includes the
+	// overhead of each replica.
+	networkCost := RU(bri.networkCost) * RU(bri.writeBytes)
+
+	return writeCost*RU(bri.writeReplicas) + networkCost
 }
 
 // ResponseCost returns the cost, in RUs, of the given response. If it is a
-// read, that includes the per-batch, per-request, and per-byte costs,
-// multiplied by the read multiplier. If it is a write, then the cost is zero,
-// since writes can only be costed by examining the RequestInfo.
+// read, that includes the per-batch, per-request, and per-byte costs, and the
+// cross region networking cost. If it is a write, then the cost is zero, since
+// writes can only be costed by examining the RequestInfo.
 func (c *Config) ResponseCost(bri ResponseInfo) RU {
 	if !bri.IsRead() {
 		return 0
@@ -152,14 +160,15 @@ func (c *Config) ResponseCost(bri ResponseInfo) RU {
 	cost := c.KVReadBatch
 	cost += RU(bri.readCount) * c.KVReadRequest
 	cost += RU(bri.readBytes) * c.KVReadByte
-	return cost * RU(bri.readMultiplier)
+	cost += RU(bri.readBytes) * RU(bri.networkCost)
+	return cost
 }
 
-// RequestInfo captures the BatchRequest information that is used (together with
-// the cost model) to determine the portion of the cost that can be calculated
-// up-front. Specifically: how many writes were batched together, their total
-// size, the number of target replicas (if the request is a write batch), and
-// the RU multiplier for the request.
+// RequestInfo captures the BatchRequest information that is used (together
+// with the cost model) to determine the portion of the cost that can be
+// calculated up-front. Specifically: how many writes were batched together,
+// their total size, the number of target replicas (if the request is a write
+// batch), and the cross region network cost.
 type RequestInfo struct {
 	// writeReplicas is the number of range replicas to which this write was sent
 	// (i.e. the replication factor). This is 0 if it is a read-only batch.
@@ -170,17 +179,14 @@ type RequestInfo struct {
 	// writeBytes is the total size of all batched writes in the request, in
 	// bytes, or 0 if it is a read-only batch.
 	writeBytes int64
-	// writeMultiplier is the RU multiplier for which this write was sent.
-	// This is usually the same as the number of range replicas (unless a
-	// custom multiplier table was specified for inter-region transfers). This
-	// is 0 if it is a read-only batch.
-	writeMultiplier RUMultiplier
+	// networkCost is the per byte cost of the cross region network cost. This is
+	// calculated ahead of time by distsender and accounts for the network cost
+	// of each replica written.
+	networkCost NetworkCost
 }
 
 // MakeRequestInfo extracts the relevant information from a BatchRequest.
-func MakeRequestInfo(
-	ba *kvpb.BatchRequest, replicas int, writeMultiplier RUMultiplier,
-) RequestInfo {
+func MakeRequestInfo(ba *kvpb.BatchRequest, replicas int, networkCost NetworkCost) RequestInfo {
 	// The cost of read-only batches is captured by MakeResponseInfo.
 	if !ba.IsWrite() {
 		return RequestInfo{}
@@ -203,10 +209,10 @@ func MakeRequestInfo(
 		}
 	}
 	return RequestInfo{
-		writeReplicas:   int64(replicas),
-		writeCount:      writeCount,
-		writeBytes:      writeBytes,
-		writeMultiplier: writeMultiplier,
+		writeReplicas: int64(replicas),
+		writeCount:    writeCount,
+		writeBytes:    writeBytes,
+		networkCost:   networkCost,
 	}
 }
 
@@ -235,40 +241,38 @@ func (bri RequestInfo) WriteBytes() int64 {
 
 // TestingRequestInfo creates a RequestInfo for testing purposes.
 func TestingRequestInfo(
-	writeReplicas, writeCount, writeBytes int64, writeMultiplier RUMultiplier,
+	writeReplicas, writeCount, writeBytes int64, networkCost NetworkCost,
 ) RequestInfo {
 	return RequestInfo{
-		writeReplicas:   writeReplicas,
-		writeCount:      writeCount,
-		writeBytes:      writeBytes,
-		writeMultiplier: writeMultiplier,
+		writeReplicas: writeReplicas,
+		writeCount:    writeCount,
+		writeBytes:    writeBytes,
+		networkCost:   networkCost,
 	}
 }
 
 // ResponseInfo captures the BatchResponse information that is used (together
 // with the cost model) to determine the portion of the cost that can only be
-// calculated after-the-fact. Specifically: how many reads were batched together
-// their total size (if the request is a read-only batch), and the RU multiplier
-// for the request.
+// calculated after-the-fact. Specifically: how many reads were batched
+// together their total size (if the request is a read-only batch), and the
+// network cost for the read.
 type ResponseInfo struct {
 	// isRead is true if this batch contained only read requests, or false if it
 	// was a write batch.
 	isRead bool
-	// readCount is the number of reads that were batched together. This is 0
-	// if it is a write batch.
+	// readCount is the number of reads that were batched together. This is 0 if
+	// it is a write batch.
 	readCount int64
 	// readBytes is the total size of all batched reads in the response, in
-	// bytes, or 0 if it is a write batch.
+	// bytee, or 0 if it is a write batch.
 	readBytes int64
-	// readMultiplier is the RU multiplier for which this read was sent. This
-	// is usually 1 (unless a custom multiplier table was specified for
-	// inter-region transfers). This is 0 if it is a write batch.
-	readMultiplier RUMultiplier
+	// networkCost is RU/byte cost for this read request.
+	networkCost NetworkCost
 }
 
 // MakeResponseInfo extracts the relevant information from a BatchResponse.
 func MakeResponseInfo(
-	br *kvpb.BatchResponse, isReadOnly bool, readMultiplier RUMultiplier,
+	br *kvpb.BatchResponse, isReadOnly bool, networkCost NetworkCost,
 ) ResponseInfo {
 	// The cost of non read-only batches is captured by MakeRequestInfo.
 	if !isReadOnly {
@@ -289,10 +293,10 @@ func MakeResponseInfo(
 		}
 	}
 	return ResponseInfo{
-		isRead:         true,
-		readCount:      readCount,
-		readBytes:      readBytes,
-		readMultiplier: readMultiplier,
+		isRead:      true,
+		readCount:   readCount,
+		readBytes:   readBytes,
+		networkCost: networkCost,
 	}
 }
 
@@ -315,12 +319,12 @@ func (bri ResponseInfo) ReadBytes() int64 {
 
 // TestingResponseInfo creates a ResponseInfo for testing purposes.
 func TestingResponseInfo(
-	isRead bool, readCount, readBytes int64, readMultiplier RUMultiplier,
+	isRead bool, readCount, readBytes int64, networkCost NetworkCost,
 ) ResponseInfo {
 	return ResponseInfo{
-		isRead:         isRead,
-		readCount:      readCount,
-		readBytes:      readBytes,
-		readMultiplier: readMultiplier,
+		isRead:      isRead,
+		readCount:   readCount,
+		readBytes:   readBytes,
+		networkCost: networkCost,
 	}
 }

--- a/pkg/multitenant/tenantcostmodel/settings_test.go
+++ b/pkg/multitenant/tenantcostmodel/settings_test.go
@@ -30,106 +30,62 @@ func TestParseRegionalCostMultiplierTableSetting(t *testing.T) {
 			input: "",
 		},
 		{
+			name:  "empty_json",
+			input: `{"regionPairs":[]}`,
+		},
+		{
+			name: "valid",
+			input: `{"regionPairs": [
+				{"fromRegion": "us-central1", "toRegion": "us-west1", "cost": 10},
+				{"fromRegion": "us-west1", "toRegion": "us-central1", "cost": 20}
+			]}`,
+		},
+		{
 			name:  "malformed",
 			input: "testing",
 			err:   "invalid character",
 		},
 		{
-			name:  "valid_json",
-			input: `{"regions":["asia-southeast1"],"matrix":[[1,1.5,2.6],[1,3.5],[1]]}`,
-			err:   "unexpected number of rows",
+			name: "entry_missing_from_region",
+			input: `{"regionPairs": [
+				{"toRegion": "us-central1", "cost": 0}
+			]}`,
+			err: "entry 0 is missing 'fromRegion'",
 		},
 		{
-			name:  "empty_json",
-			input: `{"regions":[],"matrix":[]}`,
+			name: "entry_missing_to_region",
+			input: `{"regionPairs": [
+				{"fromRegion": "us-central1", "cost": 0}
+			]}`,
+			err: "entry 0 is missing 'toRegion'",
 		},
 		{
-			name:  "valid",
-			input: `{"regions":["us-east1","eu-central1","asia-southeast1"],"matrix":[[1,1.5,2.6],[1,3.5],[1]]}`,
+			name: "loopback_entry",
+			input: `{"regionPairs": [
+				{"fromRegion": "us-central1", "toRegion": "us-central1", "cost": 0}
+			]}`,
+			err: "'us-central1' contains an entry for itself",
+		},
+		{
+			name: "entry_negative_cost",
+			input: `{"regionPairs": [
+				{"fromRegion": "us-central1", "toRegion": "us-west1", "cost": 10},
+				{"fromRegion": "us-west1", "toRegion": "us-central1", "cost": -20}
+			]}`,
+			err: "must not be negative",
+		},
+		{
+			name: "missing_region",
+			input: `{"regionPairs": [
+				{"fromRegion": "us-central1", "toRegion": "us-west1", "cost": 0}
+			]}`,
+			err: "missing from region 'us-west1' to region 'us-central1'",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			table, err := parseRegionalCostMultiplierTableSetting(tc.input)
+			err := CrossRegionNetworkCostSetting.Validate(nil, tc.input)
 			if tc.err != "" {
 				require.Regexp(t, tc.err, err.Error())
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, table)
-			}
-		})
-	}
-}
-
-func TestRegionalCostMultiplierCompactTable_Validate(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	for _, tc := range []struct {
-		name  string
-		table *RegionalCostMultiplierCompactTable
-		err   string
-	}{
-		{
-			name: "mismatched_rows",
-			table: &RegionalCostMultiplierCompactTable{
-				Regions: []string{"a"},
-			},
-			err: "unexpected number of rows: found 1 regions, but 0 rows in matrix",
-		},
-		{
-			name: "invalid_matrix_start",
-			table: &RegionalCostMultiplierCompactTable{
-				Regions: []string{"a"},
-				Matrix: [][]RUMultiplier{
-					{1, 2},
-				},
-			},
-			err: "malformed cost multiplier matrix",
-		},
-		{
-			name: "invalid_matrix_end",
-			table: &RegionalCostMultiplierCompactTable{
-				Regions: []string{"a", "b", "c"},
-				Matrix: [][]RUMultiplier{
-					{1, 2, 3},
-					{2, 3},
-					{},
-				},
-			},
-			err: "malformed cost multiplier matrix",
-		},
-		{
-			name: "negative values",
-			table: &RegionalCostMultiplierCompactTable{
-				Regions: []string{"a", "b", "c"},
-				Matrix: [][]RUMultiplier{
-					{2, -3, 4},
-					{3, 4},
-					{4},
-				},
-			},
-			err: "values must be non-negative",
-		},
-		{
-			name: "valid",
-			table: &RegionalCostMultiplierCompactTable{
-				Regions: []string{"a", "b", "c", "d"},
-				Matrix: [][]RUMultiplier{
-					{1, 2, 3, 4},
-					{2, 3, 4},
-					{3, 4},
-					{0},
-				},
-			},
-		},
-		{
-			name:  "valid_empty",
-			table: &RegionalCostMultiplierCompactTable{},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.table.Validate()
-			if tc.err != "" {
-				require.EqualError(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
 			}
@@ -140,317 +96,31 @@ func TestRegionalCostMultiplierCompactTable_Validate(t *testing.T) {
 func TestRegionalCostMultiplierTable_CostMultiplier(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	for _, tc := range []struct {
-		name     string
-		table    *RegionalCostMultiplierTable
-		r1       string
-		r2       string
-		expected RUMultiplier
-	}{
-		{
-			name:     "nil_matrix",
-			table:    &RegionalCostMultiplierTable{},
-			r1:       "a",
-			r2:       "b",
-			expected: 1,
-		},
-		{
-			name: "no_row_key",
-			table: &RegionalCostMultiplierTable{
-				Matrix: map[string]map[string]RUMultiplier{},
-			},
-			r1:       "a",
-			r2:       "b",
-			expected: 1,
-		},
-		{
-			name: "nil_row",
-			table: &RegionalCostMultiplierTable{
-				Matrix: map[string]map[string]RUMultiplier{
-					"a": nil,
-				},
-			},
-			r1:       "a",
-			r2:       "b",
-			expected: 1,
-		},
-		{
-			name: "no_col_key",
-			table: &RegionalCostMultiplierTable{
-				Matrix: map[string]map[string]RUMultiplier{
-					"a": {},
-				},
-			},
-			r1:       "a",
-			r2:       "b",
-			expected: 1,
-		},
-		{
-			name: "found",
-			table: &RegionalCostMultiplierTable{
-				Matrix: map[string]map[string]RUMultiplier{
-					"a": {
-						"b": 100,
-					},
-				},
-			},
-			r1:       "a",
-			r2:       "b",
-			expected: 100,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, tc.table.CostMultiplier(tc.r1, tc.r2))
-		})
-	}
-}
+	table, err := NewNetworkCostTable(`
+		{"regionPairs": [
+				{"fromRegion": "us-central1", "toRegion": "us-west1", "cost": 10},
+				{"fromRegion": "us-west1", "toRegion": "us-central1", "cost": 20}
+		]}
+	`)
+	require.NoError(t, err)
 
-func TestRegionalCostMultiplierTable_Validate(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+	cost, found := table.Matrix[NetworkPath{
+		FromRegion: "us-central1",
+		ToRegion:   "us-west1",
+	}]
+	require.True(t, found)
+	require.Equal(t, cost, NetworkCost(10))
 
-	for _, tc := range []struct {
-		name  string
-		table *RegionalCostMultiplierTable
-		err   string
-	}{
-		{
-			name:  "nil_matrix",
-			table: &RegionalCostMultiplierTable{},
-		},
-		{
-			name: "nil_inner_matrix",
-			table: &RegionalCostMultiplierTable{
-				Matrix: map[string]map[string]RUMultiplier{
-					"a": nil,
-				},
-			},
-			err: "inner matrix cannot be nil",
-		},
-		{
-			name: "more_rows_than_cols",
-			table: &RegionalCostMultiplierTable{
-				Matrix: map[string]map[string]RUMultiplier{
-					"a": {
-						"b": 100,
-					},
-					"b": {
-						"a": 100,
-					},
-				},
-			},
-			err: "number of rows and columns do not match: rows=2, cols=1",
-		},
-		{
-			name: "more_cols_than_rows",
-			table: &RegionalCostMultiplierTable{
-				Matrix: map[string]map[string]RUMultiplier{
-					"a": {
-						"b": 100,
-						"c": 101,
-					},
-				},
-			},
-			err: "number of rows and columns do not match: rows=1, cols=2",
-		},
-		{
-			name: "not_symmetrical",
-			table: &RegionalCostMultiplierTable{
-				Matrix: map[string]map[string]RUMultiplier{
-					"a": {
-						"a": 10,
-						"b": 100,
-					},
-					"b": {
-						"a": 40,
-						"b": 10,
-					},
-				},
-			},
-			err: "table values are invalid",
-		},
-		{
-			name: "negative_values",
-			table: &RegionalCostMultiplierTable{
-				Matrix: map[string]map[string]RUMultiplier{
-					"a": {
-						"a": -10,
-						"b": 100,
-					},
-					"b": {
-						"a": 100,
-						"b": -20,
-					},
-				},
-			},
-			err: "table values must be non-negative",
-		},
-		{
-			name: "valid",
-			table: &RegionalCostMultiplierTable{
-				Matrix: map[string]map[string]RUMultiplier{
-					"a": {
-						"a": 10,
-						"b": 55,
-						"c": 66,
-					},
-					"b": {
-						"a": 55,
-						"b": 10,
-						"c": 77,
-					},
-					"c": {
-						"a": 66,
-						"b": 77,
-						"c": 10,
-					},
-				},
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.table.Validate()
-			if tc.err != "" {
-				require.EqualError(t, err, tc.err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
+	cost, found = table.Matrix[NetworkPath{
+		FromRegion: "us-west1",
+		ToRegion:   "us-central1",
+	}]
+	require.True(t, found)
+	require.Equal(t, cost, NetworkCost(20))
 
-func TestMakeRegionalCostMultiplierTableFromCompact(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	t.Run("empty", func(t *testing.T) {
-		compact := &RegionalCostMultiplierCompactTable{}
-		require.NoError(t, compact.Validate())
-
-		table := MakeRegionalCostMultiplierTableFromCompact(compact)
-		expectedTable := RegionalCostMultiplierTable{
-			Matrix: map[string]map[string]RUMultiplier{},
-		}
-		require.Equal(t, expectedTable, table)
-		require.NoError(t, table.Validate())
-	})
-
-	t.Run("single region", func(t *testing.T) {
-		compact := &RegionalCostMultiplierCompactTable{
-			Regions: []string{"us-east1"},
-			Matrix:  [][]RUMultiplier{{1.9}},
-		}
-		require.NoError(t, compact.Validate())
-
-		table := MakeRegionalCostMultiplierTableFromCompact(compact)
-		expectedTable := RegionalCostMultiplierTable{
-			Matrix: map[string]map[string]RUMultiplier{
-				"us-east1": {
-					"us-east1": 1.9,
-				},
-			},
-		}
-		require.Equal(t, expectedTable, table)
-		require.NoError(t, table.Validate())
-	})
-
-	t.Run("multiple regions", func(t *testing.T) {
-		compact := &RegionalCostMultiplierCompactTable{
-			Regions: []string{"us-east1", "eu-central1", "asia-southeast1"},
-			Matrix: [][]RUMultiplier{
-				{1, 1.5, 2.6},
-				{1, 3.5},
-				{1},
-			},
-		}
-		require.NoError(t, compact.Validate())
-
-		table := MakeRegionalCostMultiplierTableFromCompact(compact)
-		expectedTable := RegionalCostMultiplierTable{
-			Matrix: map[string]map[string]RUMultiplier{
-				"us-east1": {
-					"us-east1":        1,
-					"eu-central1":     1.5,
-					"asia-southeast1": 2.6,
-				},
-				"eu-central1": {
-					"us-east1":        1.5,
-					"eu-central1":     1,
-					"asia-southeast1": 3.5,
-				},
-				"asia-southeast1": {
-					"us-east1":        2.6,
-					"eu-central1":     3.5,
-					"asia-southeast1": 1,
-				},
-			},
-		}
-		require.Equal(t, expectedTable, table)
-		require.NoError(t, table.Validate())
-	})
-}
-
-func TestMakeRegionalCostMultiplierCompactTableFromExpanded(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	t.Run("empty", func(t *testing.T) {
-		expanded := &RegionalCostMultiplierTable{}
-		require.NoError(t, expanded.Validate())
-
-		table := MakeRegionalCostMultiplierCompactTableFromExpanded(expanded)
-		expectedTable := RegionalCostMultiplierCompactTable{
-			Regions: []string{},
-			Matrix:  [][]RUMultiplier{},
-		}
-		require.Equal(t, expectedTable, table)
-		require.NoError(t, table.Validate())
-	})
-
-	t.Run("single region", func(t *testing.T) {
-		expanded := &RegionalCostMultiplierTable{
-			Matrix: map[string]map[string]RUMultiplier{
-				"eu-central1": {
-					"eu-central1": 42,
-				},
-			},
-		}
-		require.NoError(t, expanded.Validate())
-
-		table := MakeRegionalCostMultiplierCompactTableFromExpanded(expanded)
-		expectedTable := RegionalCostMultiplierCompactTable{
-			Regions: []string{"eu-central1"},
-			Matrix:  [][]RUMultiplier{{42}},
-		}
-		require.Equal(t, expectedTable, table)
-		require.NoError(t, table.Validate())
-	})
-
-	t.Run("multiple regions", func(t *testing.T) {
-		expanded := &RegionalCostMultiplierTable{
-			Matrix: map[string]map[string]RUMultiplier{
-				"us-east1": {
-					"us-east1":        1,
-					"eu-central1":     1.5,
-					"asia-southeast1": 2.6,
-				},
-				"eu-central1": {
-					"us-east1":        1.5,
-					"eu-central1":     1,
-					"asia-southeast1": 3.5,
-				},
-				"asia-southeast1": {
-					"us-east1":        2.6,
-					"eu-central1":     3.5,
-					"asia-southeast1": 1,
-				},
-			},
-		}
-		require.NoError(t, expanded.Validate())
-
-		table := MakeRegionalCostMultiplierCompactTableFromExpanded(expanded)
-		expectedTable := RegionalCostMultiplierCompactTable{
-			Regions: []string{"asia-southeast1", "eu-central1", "us-east1"},
-			Matrix:  [][]RUMultiplier{{1, 3.5, 2.6}, {1, 1.5}, {1}},
-		}
-		require.Equal(t, expectedTable, table)
-		require.NoError(t, table.Validate())
-	})
+	cost = table.Matrix[NetworkPath{
+		FromRegion: "does-not-exist",
+		ToRegion:   "also-does-not-exist",
+	}]
+	require.Equal(t, cost, NetworkCost(0))
 }


### PR DESCRIPTION
Previously the 'tenant_cost_model.region_multiplier_table' allowed configuring the cost of multi-region operations by applying a multiplier to the entire operation cost. There were three problems with this approach that prevented deploying it to production:

1. There was a flat multiplier for reads and writes. Because the fixed overhead of a read is much lower, the cost impact of cross region network traffic is much larger when compared to writes. The break even read multiplier was an order of magnitude higher than the break even write multiplier.
2. The correct multiplier depends heavily on how many bytes are in an operation. Large operations require a larger multiplier to break even than smaller operations. Again the break even multiplier for large operations needed to be an order of magnitude larger than the break even for small operations.
3. The original setting assumed the cost of network traffic was symmetric between two different regions. That assumption is true for some cloud providers, but is not true for all cloud providers.

Now, the 'tenant_cost_model.cross_region_network_cost' setting allows configuring the RU/byte cost of network traffic between region pairs. The cost is computed by the dist sender because computing the network cost requires locality information for the local node, the target replica, and all replica's in the range.

The network cost only applies to logical byte traffic, it does not apply to RPC overhead. This is believed to be okay, because the fixed RU cost of each request and batch is high enough to cover the network cost of the operation overhead.

This only accounts for network traffic incurred by reads or writes between the sql server or the kv server. It does not account for network traffic generated by zone configuration changes, replica rebalancing, or distsql.
- Currently distsql is disabled in production Serverless and will only be reenabled once distsql properly accounts for network traffic. Distsql should use the same byte per RU cost table as sql server <-> kv traffic.
- Zone configuration is expected to generate a small enough amount of the overall network traffic that we do not need to charge for it. We can revise this decision in the future if production data shows that is not true.
- Replica rebalancing is something controlled by CRDB. If rebalancing cost ends up being a problem, we could look into reducing the amount of cross-region rebalancing traffic or we could start charging for rebalancing traffic.

This change is backwards incompatible and will be back ported to 23.1. This is safe because Serverless is the only user of the setting.

Release Note: none

Part of: https://cockroachlabs.atlassian.net/browse/CC-7140