### PR TITLE
kv: unskip TestSystemZoneConfigs

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2690,8 +2690,6 @@ func TestSystemZoneConfigs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 98905)
-
 	// This test is relatively slow and resource intensive. When run under
 	// stressrace on a loaded machine (as in the nightly tests), sometimes the
 	// SucceedsSoon conditions below take longer than the allotted time (#25273).


### PR DESCRIPTION
TestSystemZoneConfigs was part of a batch of skipped tests [1]. It appears several tests in that batch flaked due to a "slow quiesce" issue. The root cause for TestSystemZoneConfigs flaking during that time remains unknown, yet the other tests in the same batch have since been unskipped.

After stress-testing via,

```
./dev test pkg/kv/kvserver -f=TestSystemZoneConfigs --stress --stress-args '-maxruns 10000 -p 23' --timeout=10m
```
we surmise this test might have been indirectly deflaked. Thus, we unskip it.

[1] https://github.com/cockroachdb/cockroach/pull/99121

Epic: none
Fixes: #98905

Release note: None