### PR TITLE
kvserver: deflake `TestLeaderAfterSplit`

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2185,24 +2185,34 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 	}
 }
 
-// TestLeaderAfterSplit verifies that a raft group created by a split
-// elects a leader without waiting for an election timeout.
+// TestLeaderAfterSplit verifies that a raft group created by a split elects a
+// leader without waiting for an election timeout. It also tests that we don't
+// get an election tie, because we only allow the leaseholder to campaign if
+// there is a valid lease.
 func TestLeaderAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 3,
-		base.TestClusterArgs{
-			ReplicationMode: base.ReplicationManual,
-			ServerArgs: base.TestServerArgs{
-				RaftConfig: base.RaftConfig{
-					RaftElectionTimeoutTicks: 1000000,
-				},
+	// Timing-sensitive test, disable under deadlock and stressrace.
+	skip.UnderDeadlock(t)
+	skip.UnderStressRace(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // time out early
+	defer cancel()
+
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			RaftConfig: base.RaftConfig{
+				RangeLeaseDuration:       time.Hour, // don't expire leases
+				RaftElectionTimeoutTicks: 1000000,   // disable elections
 			},
-		})
+		},
+	})
 	defer tc.Stopper().Stop(ctx)
+
 	store := tc.GetFirstStoreFromServer(t, 0)
+	sender := tc.Servers[0].DistSender()
 
 	leftKey := roachpb.Key("a")
 	splitKey := roachpb.Key("m")
@@ -2212,20 +2222,17 @@ func TestLeaderAfterSplit(t *testing.T) {
 	require.NotNil(t, repl)
 	tc.AddVotersOrFatal(t, repl.Desc().StartKey.AsRawKey(), tc.Targets(1, 2)...)
 
-	splitArgs := adminSplitArgs(splitKey)
-	if _, pErr := kv.SendWrapped(ctx, tc.Servers[0].DistSender(), splitArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
+	// Split the range.
+	_, pErr := kv.SendWrapped(ctx, sender, adminSplitArgs(splitKey))
+	require.NoError(t, pErr.GoError())
 
-	incArgs := incrementArgs(leftKey, 1)
-	if _, pErr := kv.SendWrapped(ctx, tc.Servers[0].DistSender(), incArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
+	// Make sure both the LHS and RHS can replicate a write request. This will
+	// time out if the RHS can't elect a Raft leader.
+	_, pErr = kv.SendWrapped(ctx, sender, incrementArgs(leftKey, 1))
+	require.NoError(t, pErr.GoError())
 
-	incArgs = incrementArgs(rightKey, 2)
-	if _, pErr := kv.SendWrapped(ctx, tc.Servers[0].DistSender(), incArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
+	_, pErr = kv.SendWrapped(ctx, sender, incrementArgs(rightKey, 1))
+	require.NoError(t, pErr.GoError())
 }
 
 func BenchmarkStoreRangeSplit(b *testing.B) {


### PR DESCRIPTION
Under slow tests (deadlock and stressrace), it was possible for an expiration-based lease to expire before the RHS replicas considered campaigning. If there is no valid leaseholder, then all replicas will attempt to campaign, which can result in an election tie.

This patch deflakes the test by ensuring leases won't expire. It also disables the test under deadlock and stressrace, since it is timing-sensitive.

Resolves #101605.
Epic: none

Release note: None