### PR TITLE
kvserver: rm TestProposalNotAcknowledgedOrReproposedAfterApplication

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -516,7 +516,6 @@ go_test(
         "@io_etcd_go_raft_v3//tracker",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//metadata",
-        "@org_golang_x_net//trace",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sync//syncmap",
         "@org_golang_x_time//rate",

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -78,7 +78,6 @@ import (
 	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/raftpb"
 	"go.etcd.io/raft/v3/tracker"
-	"golang.org/x/net/trace"
 )
 
 // allSpans is a SpanSet that covers *everything* for use in tests that don't
@@ -13475,172 +13474,6 @@ func TestSplitSnapshotWarningStr(t *testing.T) {
 	)
 }
 
-// TestProposalNotAcknowledgedOrReproposedAfterApplication exercises a case
-// where a command is reproposed twice at different MaxLeaseIndex values to
-// ultimately fail with an error which cannot be reproposed (say due to a lease
-// transfer or change to the gc threshold). This test works to exercise the
-// invariant that when a proposal has been reproposed at different MaxLeaseIndex
-// values are not additionally reproposed or acknowledged after applying
-// locally. The test verfies this condition by asserting that the
-// span used to trace the execution of the proposal is not used after the
-// proposal has been finished as it would be if the proposal were reproposed
-// after applying locally.
-//
-// The test does the following things:
-//
-//   - Propose cmd at an initial MaxLeaseIndex.
-//   - Refresh that cmd immediately.
-//   - Fail the initial command with an injected error which will lead to a
-//     reproposal at a higher MaxLeaseIndex.
-//   - Simultaneously update the lease sequence number on the replica so all
-//     future commands will fail with NotLeaseHolderError.
-//   - Enable unconditional refreshes of commands after a raft ready so that
-//     higher MaxLeaseIndex commands are refreshed.
-//
-// This order of events ensures that there will be a committed command which
-// experiences the lease mismatch error but does not carry the highest
-// MaxLeaseIndex for the proposal. The test attempts to verify that once a
-// proposal has been acknowledged it will not be reproposed or acknowledged
-// again by asserting that the proposal's context is not reused after it is
-// finished by the waiting client.
-func TestProposalNotAcknowledgedOrReproposedAfterApplication(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 71148, "the test is fooling itself")
-
-	// Set the trace infrastructure to log if a span is used after being finished.
-	defer enableTraceDebugUseAfterFree()()
-
-	tc := testContext{}
-	ctx := context.Background()
-
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-	tc.manualClock = timeutil.NewManualTime(timeutil.Unix(0, 123))
-	cfg := TestStoreConfig(hlc.NewClockForTesting(tc.manualClock))
-	// Set the RaftMaxCommittedSizePerReady so that only a single raft entry is
-	// applied at a time, which makes it easier to line up the timing of reproposals.
-	cfg.RaftMaxCommittedSizePerReady = 1
-	// Set up tracing.
-	tracer := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&cfg.Settings.SV))
-	cfg.AmbientCtx.Tracer = tracer
-
-	// Below we set txnID to the value of the transaction we're going to force to
-	// be proposed multiple times.
-	var txnID uuid.UUID
-	// In the TestingProposalFilter we populater cmdID with the id of the proposal
-	// which corresponds to txnID.
-	var cmdID kvserverbase.CmdIDKey
-	// seen is used to detect the first application of our proposal.
-	var seen bool
-	cfg.TestingKnobs = StoreTestingKnobs{
-		// Constant reproposals are the worst case which this test is trying to
-		// examine.
-		EnableUnconditionalRefreshesInRaftReady: true,
-		// Set the TestingProposalFilter in order to know the CmdIDKey for our
-		// request by detecting its txnID.
-		TestingProposalFilter: func(args kvserverbase.ProposalFilterArgs) *kvpb.Error {
-			if args.Req.Header.Txn != nil && args.Req.Header.Txn.ID == txnID {
-				cmdID = args.CmdID
-			}
-			return nil
-		},
-		// Detect the application of the proposal to repropose it and also
-		// invalidate the lease.
-		TestingApplyCalledTwiceFilter: func(args kvserverbase.ApplyFilterArgs) (retry int, pErr *kvpb.Error) {
-			if seen || args.CmdID != cmdID {
-				return 0, nil
-			}
-			seen = true
-			tc.repl.mu.Lock()
-			defer tc.repl.mu.Unlock()
-
-			// Increase the lease sequence so that future reproposals will fail with
-			// NotLeaseHolderError. This mimics the outcome of a leaseholder change
-			// slipping in between the application of the first proposal and the
-			// reproposals.
-			tc.repl.mu.state.Lease.Sequence++
-			// This return value will force another retry which will carry a yet
-			// higher MaxLeaseIndex. The first reproposal will fail and return to the
-			// client but the second (which hasn't been applied due to the
-			// MaxCommittedSizePerReady setting) will be reproposed again. This test
-			// ensure that it does not reuse the original proposal's context for that
-			// reproposal by ensuring that no event is recorded after the original
-			// proposal has been finished.
-			return int(kvserverbase.ProposalRejectionIllegalLeaseIndex),
-				kvpb.NewErrorf("forced error that can be reproposed at a higher index")
-		},
-	}
-	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
-	key := roachpb.Key("a")
-	st := tc.repl.CurrentLeaseStatus(ctx)
-	txn := newTransaction("test", key, roachpb.NormalUserPriority, tc.Clock())
-	txnID = txn.ID
-	ba := &kvpb.BatchRequest{
-		Header: kvpb.Header{
-			RangeID: tc.repl.RangeID,
-			Txn:     txn,
-		},
-	}
-	ba.Timestamp = txn.ReadTimestamp
-	ba.Add(&kvpb.PutRequest{
-		RequestHeader: kvpb.RequestHeader{
-			Key: key,
-		},
-		Value: roachpb.MakeValueFromBytes([]byte("val")),
-	})
-
-	// Hold the RaftLock to ensure that after evalAndPropose our proposal is in
-	// the proposal map. Entries are only removed from that map underneath raft.
-	tc.repl.RaftLock()
-	_, tok := tc.repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	sp := cfg.AmbientCtx.Tracer.StartSpan("replica send", tracing.WithForceRealSpan())
-	tracedCtx := tracing.ContextWithSpan(ctx, sp)
-	ch, _, _, _, pErr := tc.repl.evalAndPropose(tracedCtx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok)
-	if pErr != nil {
-		t.Fatal(pErr)
-	}
-	errCh := make(chan *kvpb.Error)
-	go func() {
-		res := <-ch
-		sp.Finish()
-		errCh <- res.Err
-	}()
-
-	// While still holding the raftMu, repropose the initial proposal so we know
-	// that there will be two instances
-	func() {
-		tc.repl.mu.Lock()
-		defer tc.repl.mu.Unlock()
-		if err := tc.repl.mu.proposalBuf.flushLocked(ctx); err != nil {
-			t.Fatal(err)
-		}
-		tc.repl.refreshProposalsLocked(ctx, 0 /* refreshAtDelta */, reasonNewLeaderOrConfigChange)
-	}()
-	tc.repl.RaftUnlock()
-
-	if pErr = <-errCh; !testutils.IsPError(pErr, "NotLeaseHolder") {
-		t.Fatal(pErr)
-	}
-
-	// Round trip another proposal through the replica to ensure that previously
-	// committed entries have been applied.
-	if _, pErr := tc.repl.Send(ctx, ba); pErr != nil {
-		t.Fatal(pErr)
-	}
-	log.Flush()
-
-	stopper.Quiesce(ctx)
-	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
-		regexp.MustCompile("net/trace"), log.WithFlattenedSensitiveData)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(entries) > 0 {
-		t.Fatalf("reused span after free: %v", entries)
-	}
-}
-
 // This test ensures that pushes due to closed timestamps are properly recorded
 // into the associated telemetry counter.
 func TestReplicaTelemetryCounterForPushesDueToClosedTimestamp(t *testing.T) {
@@ -13944,12 +13777,6 @@ func TestPrepareChangeReplicasTrigger(t *testing.T) {
 			assert.Equal(t, tc.expTrigger, trigger.String())
 		})
 	}
-}
-
-func enableTraceDebugUseAfterFree() (restore func()) {
-	prev := trace.DebugUseAfterFinish
-	trace.DebugUseAfterFinish = true
-	return func() { trace.DebugUseAfterFinish = prev }
 }
 
 // Test that, depending on the request's ClientRangeInfo, descriptor and lease


### PR DESCRIPTION
This test can't be salvaged and besides, hasn't been run in >1.5 years. We just
merged decent enough coverage in #105272, though.

Closes #71148.

Epic: none
Release note: None
