### PR TITLE
server: unskip TestStatusEngineStatsJson

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -262,7 +262,6 @@ func TestStatusGossipJson(t *testing.T) {
 // stats contains the required fields.
 func TestStatusEngineStatsJson(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 99261, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	dir, cleanupFn := testutils.TempDir(t)


### PR DESCRIPTION
Fixes #99261.

We have fixed the issue that caused the skip in #103764.

Release note: None