### PR TITLE
kvserver: deflake TestProtectedTimestamps

### DIFF
--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -47,7 +47,6 @@ import (
 func TestProtectedTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 93497, "flaky test")
 	ctx := context.Background()
 
 	// This test is too slow to run with race.
@@ -59,7 +58,7 @@ func TestProtectedTimestamps(t *testing.T) {
 		DisableGCQueue:            true,
 		DisableLastProcessedCheck: true,
 	}
-	tc := testcluster.StartTestCluster(t, 3, args)
+	tc := testcluster.StartTestCluster(t, 1, args)
 	defer tc.Stopper().Stop(ctx)
 	s0 := tc.Server(0)
 
@@ -73,7 +72,7 @@ func TestProtectedTimestamps(t *testing.T) {
 	_, err = conn.Exec("SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'") // speeds up the test
 	require.NoError(t, err)
 
-	const tableRangeMaxBytes = 1 << 18
+	const tableRangeMaxBytes = 64 << 20
 	_, err = conn.Exec("ALTER TABLE foo CONFIGURE ZONE USING "+
 		"gc.ttlseconds = 1, range_max_bytes = $1, range_min_bytes = 1<<10;", tableRangeMaxBytes)
 	require.NoError(t, err)


### PR DESCRIPTION
This patch fixes a few (hopefully all) issues with TestProtectedTimestamps. In particular,

- The range max bytes used by the test was broken after the lower bound was bumped in a37e053173ebf069b12ef6a2c38a03dd984992e2. We up the value.
- There was flakiness at various points in the test as a result of lease transfers. We change the test to run on a single node test cluster to get around this.

Fixes: #93497

Release note: None