### PR TITLE
asim: passes simulator setting ptr to ticking components

### DIFF
--- a/pkg/kv/kvserver/asim/asim.go
+++ b/pkg/kv/kvserver/asim/asim.go
@@ -134,14 +134,10 @@ func (s *Simulator) StoreAddNotify(storeID state.StoreID, _ state.State) {
 func (s *Simulator) addStore(storeID state.StoreID, tick time.Time) {
 	allocator := s.state.MakeAllocator(storeID)
 	storePool := s.state.StorePool(storeID)
-	// TODO(kvoli): Instead of passing in individual settings to construct
-	// the each ticking component, pass a pointer to the simulation
-	// settings struct. That way, the settings may be adjusted dynamically
-	// during a simulation.
 	s.rqs[storeID] = queue.NewReplicateQueue(
 		storeID,
 		s.changer,
-		s.settings.ReplicaChangeDelayFn(),
+		s.settings,
 		allocator,
 		storePool,
 		tick,
@@ -149,16 +145,12 @@ func (s *Simulator) addStore(storeID state.StoreID, tick time.Time) {
 	s.sqs[storeID] = queue.NewSplitQueue(
 		storeID,
 		s.changer,
-		s.settings.RangeSplitDelayFn(),
-		s.settings.RangeSizeSplitThreshold,
+		s.settings,
 		tick,
 	)
 	s.pacers[storeID] = queue.NewScannerReplicaPacer(
 		s.state.NextReplicasFn(storeID),
-		s.settings.PacerLoopInterval,
-		s.settings.PacerMinIterInterval,
-		s.settings.PacerMaxIterIterval,
-		s.settings.Seed,
+		s.settings,
 	)
 	s.controllers[storeID] = op.NewController(
 		s.changer,

--- a/pkg/kv/kvserver/asim/queue/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/queue/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/kv/kvserver/allocator/allocatorimpl",
         "//pkg/kv/kvserver/allocator/plan",
         "//pkg/kv/kvserver/allocator/storepool",
+        "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/state",
         "//pkg/kv/kvserver/constraint",
         "//pkg/kv/kvserver/kvserverpb",

--- a/pkg/kv/kvserver/asim/queue/pacer_test.go
+++ b/pkg/kv/kvserver/asim/queue/pacer_test.go
@@ -94,14 +94,14 @@ func TestScannerReplicaPacer(t *testing.T) {
 
 	for _, tc := range testCases {
 		nextReplsFn := createNextRepls(tc.replCount)
-
+		testSettings := config.DefaultSimulationSettings()
+		testSettings.PacerLoopInterval = tc.loopInterval
+		testSettings.PacerMinIterInterval = tc.minInterval
+		testSettings.PacerMaxIterIterval = tc.maxInterval
 		t.Run(tc.desc, func(t *testing.T) {
 			pacer := NewScannerReplicaPacer(
 				nextReplsFn,
-				tc.loopInterval,
-				tc.minInterval,
-				tc.maxInterval,
-				config.DefaultSimulationSettings().Seed,
+				testSettings,
 			)
 			results := make([]int, 0, 1)
 			for _, tick := range tc.ticks {

--- a/pkg/kv/kvserver/asim/queue/replicate_queue_test.go
+++ b/pkg/kv/kvserver/asim/queue/replicate_queue_test.go
@@ -368,7 +368,7 @@ func TestReplicateQueue(t *testing.T) {
 			rq := NewReplicateQueue(
 				store.StoreID(),
 				changer,
-				testSettings.ReplicaChangeDelayFn(),
+				testSettings,
 				s.MakeAllocator(store.StoreID()),
 				s.StorePool(store.StoreID()),
 				start,

--- a/pkg/kv/kvserver/asim/queue/split_queue_test.go
+++ b/pkg/kv/kvserver/asim/queue/split_queue_test.go
@@ -142,13 +142,13 @@ func TestSplitQueue(t *testing.T) {
 			)
 			s.SplitRange(endKey)
 
+			testSettings.RangeSizeSplitThreshold = tc.splitThreshold
 			changer := state.NewReplicaChanger()
 			store, _ := s.Store(testingStore)
 			sq := NewSplitQueue(
 				store.StoreID(),
 				changer,
-				testSettings.RangeSplitDelayFn(),
-				tc.splitThreshold,
+				testSettings,
 				start,
 			)
 


### PR DESCRIPTION
Prior to this commit, the allocator simulator passes settings by value to
ticking components, limiting dynamic adjustment of settings during the
simulation. To improve flexibility, this patch passes a pointer to the simulator
setting instead when constructing ticking components. Note that all ticking
components run on the same goroutine, thus race conditions are currently not a
concern.

Epic: None 
Release Note: None