### PR TITLE
release-23.1: Revert "kvtenant,settingswatcher: ensure overrides are applied during…

### DIFF
--- a/pkg/kv/kvclient/kvtenant/setting_overrides.go
+++ b/pkg/kv/kvclient/kvtenant/setting_overrides.go
@@ -115,10 +115,13 @@ func (c *connector) processSettingsEvent(
 		}
 	}
 
-	// Notify watchers if any.
-	close(c.settingsMu.notifyCh)
-	// Define a new notification channel for subsequent watchers.
-	c.settingsMu.notifyCh = make(chan struct{})
+	// Do a non-blocking send on the notification channel (if it is not nil). This
+	// is a buffered channel and if it already contains a message, there's no
+	// point in sending a duplicate notification.
+	select {
+	case c.settingsMu.notifyCh <- struct{}{}:
+	default:
+	}
 
 	// The protocol defines that the server sends one initial
 	// non-incremental message for both precedences.
@@ -126,13 +129,28 @@ func (c *connector) processSettingsEvent(
 	return settingsReady, nil
 }
 
-// Overrides is part of the settingswatcher.OverridesMonitor interface.
-func (c *connector) Overrides() (map[string]settings.EncodedValue, <-chan struct{}) {
+// RegisterOverridesChannel is part of the settingswatcher.OverridesMonitor
+// interface.
+func (c *connector) RegisterOverridesChannel() <-chan struct{} {
 	c.settingsMu.Lock()
 	defer c.settingsMu.Unlock()
+	if c.settingsMu.notifyCh != nil {
+		panic(errors.AssertionFailedf("multiple calls not supported"))
+	}
+	ch := make(chan struct{}, 1)
+	// Send an initial message on the channel.
+	ch <- struct{}{}
+	c.settingsMu.notifyCh = ch
+	return ch
+}
 
-	res := make(map[string]settings.EncodedValue, len(c.settingsMu.allTenantOverrides)+len(c.settingsMu.specificOverrides))
-
+// Overrides is part of the settingswatcher.OverridesMonitor interface.
+func (c *connector) Overrides() map[string]settings.EncodedValue {
+	// We could be more efficient here, but we expect this function to be called
+	// only when there are changes (which should be rare).
+	res := make(map[string]settings.EncodedValue)
+	c.settingsMu.Lock()
+	defer c.settingsMu.Unlock()
 	// First copy the all-tenant overrides.
 	for name, val := range c.settingsMu.allTenantOverrides {
 		res[name] = val
@@ -142,5 +160,5 @@ func (c *connector) Overrides() (map[string]settings.EncodedValue, <-chan struct
 	for name, val := range c.settingsMu.specificOverrides {
 		res[name] = val
 	}
-	return res, c.settingsMu.notifyCh
+	return res
 }

--- a/pkg/server/settingswatcher/overrides.go
+++ b/pkg/server/settingswatcher/overrides.go
@@ -10,21 +10,22 @@
 
 package settingswatcher
 
-import (
-	"context"
-
-	"github.com/cockroachdb/cockroach/pkg/settings"
-)
+import "github.com/cockroachdb/cockroach/pkg/settings"
 
 // OverridesMonitor is an interface through which the settings watcher can
 // receive setting overrides. Used for non-system tenants.
+//
+// The expected usage is to listen for a message on NotifyCh(), and use
+// Current() to retrieve the updated list of overrides when a message is
+// received.
 type OverridesMonitor interface {
-	// WaitForStart waits until the overrides are ready for consumption.
-	WaitForStart(ctx context.Context) error
+	// RegisterOverridesChannel returns a channel that receives a message
+	// any time the current set of overrides changes.
+	// The channel receives an initial event immediately.
+	RegisterOverridesChannel() <-chan struct{}
 
-	// Overrides retrieves the current set of setting overrides, as a
-	// map from setting key to EncodedValue. Any settings that are
-	// present must be set to the overridden value. It also returns a
-	// channel that will be closed when the overrides are updated.
-	Overrides() (map[string]settings.EncodedValue, <-chan struct{})
+	// Overrides retrieves the current set of setting overrides, as a map from
+	// setting key to EncodedValue. Any settings that are present must be set to
+	// the overridden value.
+	Overrides() map[string]settings.EncodedValue
 }


### PR DESCRIPTION
PR #105602 has introduced a restriction which, if included in a patch release, would paint us in a corner.

See issue #105658 for details

So we need to revert #105602 until I prepare a patch to lift the restriction.

Epic: CRDB-26691

Release justification: avoid getting stuck in a next PR