### PR TITLE
kvtenant: relax the startup synchronization condition

### DIFF
--- a/pkg/kv/kvclient/kvtenant/setting_overrides.go
+++ b/pkg/kv/kvclient/kvtenant/setting_overrides.go
@@ -38,6 +38,16 @@ func (c *connector) runTenantSettingsSubscription(ctx context.Context, startupCh
 			c.tryForgetClient(ctx, client)
 			continue
 		}
+
+		// Reset the sentinel checks. We start a new sequence of messages
+		// from the server every time we (re)connect.
+		func() {
+			c.settingsMu.Lock()
+			defer c.settingsMu.Unlock()
+			c.settingsMu.receivedFirstAllTenantOverrides = false
+			c.settingsMu.receivedFirstSpecificOverrides = false
+		}()
+
 		for {
 			e, err := stream.Recv()
 			if err != nil {

--- a/pkg/kv/kvclient/kvtenant/setting_overrides.go
+++ b/pkg/kv/kvclient/kvtenant/setting_overrides.go
@@ -61,7 +61,8 @@ func (c *connector) runTenantSettingsSubscription(ctx context.Context, startupCh
 			}
 			if e.Error != (errorspb.EncodedError{}) {
 				// Hard logical error. We expect io.EOF next.
-				log.Errorf(ctx, "error consuming TenantSettings RPC: %v", e.Error)
+				err := errors.DecodeError(ctx, e.Error)
+				log.Errorf(ctx, "error consuming TenantSettings RPC: %v", err)
 				continue
 			}
 

--- a/pkg/kv/kvclient/kvtenant/setting_overrides.go
+++ b/pkg/kv/kvclient/kvtenant/setting_overrides.go
@@ -83,18 +83,29 @@ func (c *connector) processSettingsEvent(
 	c.settingsMu.Lock()
 	defer c.settingsMu.Unlock()
 
-	if (!c.settingsMu.receivedFirstAllTenantOverrides || !c.settingsMu.receivedFirstSpecificOverrides) && e.Incremental {
-		return false, errors.Newf("need to receive non-incremental setting events first")
-	}
-
 	var m map[string]settings.EncodedValue
 	switch e.Precedence {
 	case kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES:
+		if !c.settingsMu.receivedFirstAllTenantOverrides && e.Incremental {
+			return false, errors.Newf(
+				"need to receive non-incremental setting event first for precedence %v",
+				e.Precedence,
+			)
+		}
+
 		c.settingsMu.receivedFirstAllTenantOverrides = true
 		m = c.settingsMu.allTenantOverrides
+
 	case kvpb.TenantSettingsEvent_TENANT_SPECIFIC_OVERRIDES:
+		if !c.settingsMu.receivedFirstSpecificOverrides && e.Incremental {
+			return false, errors.Newf(
+				"need to receive non-incremental setting events first for precedence %v",
+				e.Precedence,
+			)
+		}
 		c.settingsMu.receivedFirstSpecificOverrides = true
 		m = c.settingsMu.specificOverrides
+
 	default:
 		return false, errors.Newf("unknown precedence value %d", e.Precedence)
 	}

--- a/pkg/server/settingswatcher/settings_watcher.go
+++ b/pkg/server/settingswatcher/settings_watcher.go
@@ -376,8 +376,9 @@ func (s *SettingsWatcher) updateOverrides(ctx context.Context) (updateCh <-chan 
 		if key == versionSettingKey {
 			var newVersion clusterversion.ClusterVersion
 			if err := protoutil.Unmarshal([]byte(val.Value), &newVersion); err != nil {
-				log.Warningf(ctx, "ignoring invalid cluster version: %newVersion - "+
-					"the lack of a refreshed storage cluster version in a secondary tenant may prevent tenant upgrade", err)
+				log.Warningf(ctx, "ignoring invalid cluster version: %s - %v\n"+
+					"Note: the lack of a refreshed storage cluster version in a secondary tenant may prevent tenant upgrade.",
+					newVersion, err)
 			} else {
 				// We don't want to fully process the override in the case
 				// where we're dealing with the "version" setting, as we want


### PR DESCRIPTION
Fixes #105658.
Epic: CRDB-26691

**Context**

For context, in the original v22.2/v23.1 implementation the tenant
connector *client* would report readiness immediately after
the *first* TenantSettingEvent received.

Additionally, that version contained an assertion that the *first*
event must have `Incremental` set to `false`.

We want to preserve compatibility with that first version client.
This means that in any case the first event must have `Incremental`
set to `false`.

For more context, in that implementation the tenant connector *server*
always sends 2 tenant setting override messages initially (with
`Incremental` set to `false`) to populate the initial values, then
sends more messages when the overrides are updated.

We want to preserve compatibility with that server, i.e. not _require_
more events to be sent than the only 2 that version would send
initially.

**Problem solved here**

In the previous commit in this
area (27249ff) we created a new
synchronization protocol: a tenant connector *client* signals
readiness as soon as the first two setting overrides messages have
been received.

This was the main purpose of that change, and solves the problem
(waiting for all the setting initial values before signaling
readiness).

Sadly, that commit introduced an unwanted restriction: it also
introduced a *new* assertion (which wasn't there before) that
*all* the TenantSettingEvent received must have `Incremental` set to
`false` until a message of each precedence type has been seen.

This assertion is excessive, because it prevents us from introducing a
metadata event type in that initial synchronization handshake.

**What this commit does**

This commit relaxes the assertion, to only require `Incremental` set
to `false` on the first setting update message of each precedence
type. This is more restrictive than the original code (described at
top) but opens the door for a tenant metadata event.

Release note: None