### PR TITLE
sql: return error for udfs with record input args

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -52,6 +52,9 @@ CREATE FUNCTION f() RETURNS INT IMMUTABLE AS $$ SELECT 1 $$;
 statement error pq: no function body specified
 CREATE FUNCTION f() RETURNS INT IMMUTABLE LANGUAGE SQL;
 
+statement error pq: SQL functions cannot have arguments of type record
+CREATE FUNCTION f(r RECORD) RETURNS INT LANGUAGE SQL AS 'SELECT i'
+
 statement ok
 CREATE FUNCTION a(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT i'
 

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -145,6 +145,10 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateFunction, inScope *scope) (
 		if err != nil {
 			panic(err)
 		}
+		if language == tree.FunctionLangSQL && types.IsRecordType(typ) {
+			panic(pgerror.Newf(pgcode.InvalidFunctionDefinition,
+				"SQL functions cannot have arguments of type record"))
+		}
 
 		// Add the parameter to the base scope of the body.
 		paramColName := funcParamColName(param.Name, i)


### PR DESCRIPTION
Postgres does not support `RECORD` as an input argument type for UDFs with the SQL language, so CRDB should not either.

Epic: none
Fixes: #105120

Release note (bug fix): CRDB now returns an error during UDF creation if an input argument has type `RECORD`.