### PR TITLE
opt/xform: increase timeout of xform_test

### DIFF
--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -61,7 +61,7 @@ go_library(
 
 go_test(
     name = "xform_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "coster_test.go",
         "general_funcs_test.go",
@@ -70,7 +70,7 @@ go_test(
         "optimizer_test.go",
         "physical_props_test.go",
     ],
-    args = ["-test.timeout=55s"],
+    args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]) + [
         "//c-deps:libgeos",
         "//pkg/sql/opt/testutils/opttester:testfixtures",


### PR DESCRIPTION
We've seen `TestExternal` timeout occasionally, so increase the timeout of xform_test from 55s to 295s.

Fixes: #103511

Release note: None