### PR TITLE
roachtest: skip c2c/BulkOps and add the new c2c/BulkOps/SingleImport

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -83,6 +83,8 @@ type c2cSetup struct {
 
 const maxExpectedLatencyDefault = 2 * time.Minute
 
+const maxCutoverTimeoutDefault = 5 * time.Minute
+
 var c2cPromMetrics = map[string]clusterstats.ClusterStat{
 	"LogicalMegabytes": {
 		LabelName: "node",
@@ -270,6 +272,11 @@ func (kv replicateKV) runDriver(
 }
 
 type replicateBulkOps struct {
+	// short uses less data during the import and rollback steps. Also only runs one rollback.
+	short bool
+
+	// debugSkipRollback skips all rollback steps during the test.
+	debugSkipRollback bool
 }
 
 func (bo replicateBulkOps) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
@@ -286,6 +293,8 @@ func (bo replicateBulkOps) runDriver(
 	runBackupMVCCRangeTombstones(workloadCtx, t, c, mvccRangeTombstoneConfig{
 		skipBackupRestore: true,
 		skipClusterSetup:  true,
+		short:             bo.short,
+		debugSkipRollback: bo.debugSkipRollback,
 		tenantName:        setup.src.name})
 	return nil
 }
@@ -323,6 +332,9 @@ type replicationSpec struct {
 
 	// timeout specifies when the roachtest should fail due to timeout.
 	timeout time.Duration
+
+	// cutoverTimeout specifies how long we expect cutover to take.
+	cutoverTimeout time.Duration
 
 	expectedNodeDeaths int32
 
@@ -552,7 +564,7 @@ func (rd *replicationDriver) stopReplicationStream(
 	ctx context.Context, ingestionJob int, cutoverTime time.Time,
 ) {
 	rd.setup.dst.sysSQL.Exec(rd.t, `ALTER TENANT $1 COMPLETE REPLICATION TO SYSTEM TIME $2::string`, rd.setup.dst.name, cutoverTime)
-	err := retry.ForDuration(time.Minute*5, func() error {
+	err := retry.ForDuration(rd.rs.cutoverTimeout, func() error {
 		var status string
 		var payloadBytes []byte
 		res := rd.setup.dst.sysSQL.DB.QueryRowContext(ctx, `SELECT status, payload FROM crdb_internal.system_jobs WHERE id = $1`, ingestionJob)
@@ -665,6 +677,11 @@ func (rd *replicationDriver) main(ctx context.Context) {
 	if rd.rs.maxAcceptedLatency != 0 {
 		maxExpectedLatency = rd.rs.maxAcceptedLatency
 	}
+
+	if rd.rs.cutoverTimeout == 0 {
+		rd.rs.cutoverTimeout = maxCutoverTimeoutDefault
+	}
+
 	lv := makeLatencyVerifier("stream-ingestion", 0, maxExpectedLatency, rd.t.L(),
 		getStreamIngestionJobInfo, rd.t.Status, rd.rs.expectedNodeDeaths > 0)
 	defer lv.maybeLogLatencyHist()
@@ -822,15 +839,32 @@ func registerClusterToCluster(r registry.Registry) {
 			skip:               "for local ad hoc testing",
 		},
 		{
-			name:               "c2c/BulkOps",
+			name:               "c2c/BulkOps/full",
 			srcNodes:           4,
 			dstNodes:           4,
 			cpus:               8,
-			pdSize:             500,
+			pdSize:             100,
 			workload:           replicateBulkOps{},
-			timeout:            4 * time.Hour,
+			timeout:            2 * time.Hour,
+			cutoverTimeout:     1 * time.Hour,
 			additionalDuration: 0,
 			cutover:            5 * time.Minute,
+			maxAcceptedLatency: 1 * time.Hour,
+			skip:               "Reveals a bad bug related to replicating an import. See https://github.com/cockroachdb/cockroach/issues/105676 ",
+		},
+		{
+			name:               "c2c/BulkOps/singleImport",
+			srcNodes:           4,
+			dstNodes:           4,
+			cpus:               8,
+			pdSize:             100,
+			workload:           replicateBulkOps{short: true, debugSkipRollback: true},
+			timeout:            2 * time.Hour,
+			cutoverTimeout:     1 * time.Hour,
+			additionalDuration: 0,
+			cutover:            1 * time.Minute,
+			maxAcceptedLatency: 1 * time.Hour,
+			skip:               "Reveals a bad bug related to replicating an import. See https://github.com/cockroachdb/cockroach/issues/105676 ",
 		},
 	} {
 		sp := sp


### PR DESCRIPTION
The roachtest c2c/BulkOps has been failing every night since it merged to
master due to c2c's inability to keep up with the foreground source cluster
workload. We had hoped to deflake the test with general c2c
performance improvements, but have yet to get there.

This patch skips the test and adds the c2c/BulkOps/SingleImport roachtest which
reduces the complexity of the workload.  In the original test, 2 ~30 GB imports
would run + 2 import rollbacks after total ingestion, taking about an hour.
This patch changes the workload to a single ~10GB import which takes about 3
minutes. Even with the simpler workload, the replication stream cannot catch up
to the src tenant after an hour. To avoid nightly roachtest failures, both the
original and new test will be skipped and the performance issues will get
tracked in https://github.com/cockroachdb/cockroach/issues/105676.

Fixes https://github.com/cockroachdb/cockroach/issues/98669
Informs https://github.com/cockroachdb/cockroach/issues/105676

Release note: None