### PR TITLE
roachtest: move awsdms test ownership to migrations

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -100,3 +100,6 @@ cockroachdb/unowned:
   aliases:
     cockroachdb/rfc-prs: other
   triage_column_id: 0 # TODO
+cockroachdb/migrations:
+  label: T-migrations
+  triage_column_id: 19552034

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -24,6 +24,7 @@ const (
 	OwnerObsInf           Owner = `obs-inf-prs`
 	OwnerServer           Owner = `server` // not currently staffed
 	OwnerSQLFoundations   Owner = `sql-foundations`
+	OwnerMigrations       Owner = `migrations`
 	OwnerSQLQueries       Owner = `sql-queries`
 	OwnerStorage          Owner = `storage`
 	OwnerTestEng          Owner = `test-eng`

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -189,7 +189,7 @@ func dmsDescribeTasksInput(
 func registerAWSDMS(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "awsdms",
-		Owner:   registry.OwnerSQLFoundations, // TODO(otan): add a migrations OWNERS team
+		Owner:   registry.OwnerMigrations,
 		Cluster: r.MakeClusterSpec(1),
 		Leases:  registry.MetamorphicLeases,
 		Tags:    registry.Tags(`default`, `awsdms`, `aws`),


### PR DESCRIPTION
Release note: None

Epic: none