### PR TITLE
kvserver/reports: fix index out of bounds in visitRanges

### DIFF
--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -610,8 +610,8 @@ func visitRanges(
 		key = newKey
 		first = false
 
-		for i, v := range visitors {
-			var err error
+		for i := 0; i < len(visitors); {
+			v := visitors[i]
 			if sameZoneAsPrevRange {
 				v.visitSameZone(ctx, &rd)
 			} else {
@@ -626,6 +626,8 @@ func visitRanges(
 				// Remove this visitor; it shouldn't be called any more.
 				visitors = append(visitors[:i], visitors[i+1:]...)
 				visitorErrs = append(visitorErrs, err)
+			} else {
+				i++
 			}
 		}
 	}

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -634,7 +634,11 @@ func TestRangeIteration(t *testing.T) {
 	compiled, err := compileTestCase(schema)
 	require.NoError(t, err)
 	v := recordingRangeVisitor{}
-	require.NoError(t, visitRanges(ctx, &compiled.iter, compiled.cfg, &v))
+	// In addition to the meat of the test, we'll surround v with
+	// error-injecting range visitors as a regression test for index out of
+	// bounds when removing visitors that encountered errors (#104788).
+	var extraVisitor1, extraVisitor2 errorRangeVisitor
+	require.Error(t, visitRanges(ctx, &compiled.iter, compiled.cfg, &extraVisitor1, &v, &extraVisitor2))
 
 	type entry struct {
 		newZone bool
@@ -685,4 +689,26 @@ func (r *recordingRangeVisitor) reset(ctx context.Context) {
 type visitorEntry struct {
 	newZone bool
 	rng     roachpb.RangeDescriptor
+}
+
+// errorRangeVisitor always returns an error on visitNewZone call.
+type errorRangeVisitor struct {
+	errorReturned bool
+}
+
+var _ rangeVisitor = &errorRangeVisitor{}
+
+func (e *errorRangeVisitor) visitNewZone(context.Context, *roachpb.RangeDescriptor) error {
+	e.errorReturned = true
+	return errors.New("an error")
+}
+
+func (e *errorRangeVisitor) visitSameZone(context.Context, *roachpb.RangeDescriptor) {}
+
+func (e *errorRangeVisitor) failed() bool {
+	return e.errorReturned
+}
+
+func (e *errorRangeVisitor) reset(context.Context) {
+	e.errorReturned = false
 }


### PR DESCRIPTION
This commit fixes an index out of bound panic that can occur in `visitRanges` when at least two visitors encounter errors. Previously, the code would update `visitors` slice in-place, but the length of the original slice was captured during the loop instantiation, so when any visitor is removed from the slice, we'd reach out of bounds with the original iteration. This is now fixed by re-evaluating the length of the slice on each iteration.

Fixes: #104788.

Release note: None