### PR TITLE
protoutil: prefer MarshalToSizedBuffer over MarshalTo where possible

### DIFF
--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -126,7 +126,7 @@ func MaybeSideloadEntries(
 		{
 			data := make([]byte, raftlog.RaftCommandPrefixLen+e.Cmd.Size())
 			raftlog.EncodeRaftCommandPrefix(data[:raftlog.RaftCommandPrefixLen], typ, e.ID)
-			_, err := protoutil.MarshalTo(&e.Cmd, data[raftlog.RaftCommandPrefixLen:])
+			_, err := protoutil.MarshalToSizedBuffer(&e.Cmd, data[raftlog.RaftCommandPrefixLen:])
 			if err != nil {
 				return nil, 0, 0, 0, errors.Wrap(err, "while marshaling stripped sideloaded command")
 			}
@@ -215,7 +215,7 @@ func MaybeInlineSideloadedRaftCommand(
 	{
 		data := make([]byte, raftlog.RaftCommandPrefixLen+e.Cmd.Size())
 		raftlog.EncodeRaftCommandPrefix(data[:raftlog.RaftCommandPrefixLen], typ, e.ID)
-		_, err := protoutil.MarshalTo(&e.Cmd, data[raftlog.RaftCommandPrefixLen:])
+		_, err := protoutil.MarshalToSizedBuffer(&e.Cmd, data[raftlog.RaftCommandPrefixLen:])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kv/kvserver/raftlog/payload.go
+++ b/pkg/kv/kvserver/raftlog/payload.go
@@ -93,7 +93,7 @@ func EncodeCommand(
 				return nil, errors.AssertionFailedf("missing origin node for flow token returns")
 			}
 		}
-		if _, err := protoutil.MarshalTo(
+		if _, err := protoutil.MarshalToSizedBuffer(
 			raftAdmissionMeta,
 			data[preLen:preLen+admissionMetaLen],
 		); err != nil {
@@ -112,7 +112,7 @@ func EncodeCommand(
 	}
 
 	// Encode the rest of the command.
-	if _, err := protoutil.MarshalTo(command, data[preLen+admissionMetaLen:]); err != nil {
+	if _, err := protoutil.MarshalToSizedBuffer(command, data[preLen+admissionMetaLen:]); err != nil {
 		return nil, err
 	}
 	return data, nil

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -543,7 +543,7 @@ func CalcReplicaDigest(
 		} else {
 			timestampBuf = timestampBuf[:size]
 		}
-		if _, err := protoutil.MarshalTo(&legacyTimestamp, timestampBuf); err != nil {
+		if _, err := protoutil.MarshalToSizedBuffer(&legacyTimestamp, timestampBuf); err != nil {
 			return err
 		}
 		if _, err := hasher.Write(timestampBuf); err != nil {
@@ -585,7 +585,7 @@ func CalcReplicaDigest(
 		} else {
 			timestampBuf = timestampBuf[:size]
 		}
-		if _, err := protoutil.MarshalTo(&legacyTimestamp, timestampBuf); err != nil {
+		if _, err := protoutil.MarshalToSizedBuffer(&legacyTimestamp, timestampBuf); err != nil {
 			return err
 		}
 		if _, err := hasher.Write(timestampBuf); err != nil {

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -951,7 +951,7 @@ func (b *propBuf) marshallLAIAndClosedTimestampToProposalLocked(
 	// capacity for this footer.
 	preLen := len(p.encodedCommand)
 	p.encodedCommand = p.encodedCommand[:preLen+buf.Size()]
-	_, err := protoutil.MarshalTo(buf, p.encodedCommand[preLen:])
+	_, err := protoutil.MarshalToSizedBuffer(buf, p.encodedCommand[preLen:])
 	return err
 }
 

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -321,7 +321,7 @@ func (pc proposalCreator) encodeProposal(p *ProposalData) []byte {
 	data := make([]byte, raftlog.RaftCommandPrefixLen, needed)
 	raftlog.EncodeRaftCommandPrefix(data, raftlog.EntryEncodingStandardWithoutAC, p.idKey)
 	data = data[:raftlog.RaftCommandPrefixLen+p.command.Size()]
-	if _, err := protoutil.MarshalTo(p.command, data[raftlog.RaftCommandPrefixLen:]); err != nil {
+	if _, err := protoutil.MarshalToSizedBuffer(p.command, data[raftlog.RaftCommandPrefixLen:]); err != nil {
 		panic(err)
 	}
 	return data

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -497,7 +497,7 @@ func (v *Value) SetProto(msg protoutil.Message) error {
 	// directly into the Value.RawBytes field instead of allocating a separate
 	// []byte and copying.
 	v.ensureRawBytes(headerSize + msg.Size())
-	if _, err := protoutil.MarshalTo(msg, v.RawBytes[headerSize:]); err != nil {
+	if _, err := protoutil.MarshalToSizedBuffer(msg, v.RawBytes[headerSize:]); err != nil {
 		return err
 	}
 	// Special handling for timeseries data.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1430,7 +1430,7 @@ func (b *putBuffer) marshalMeta(meta *enginepb.MVCCMetadata) (_ []byte, err erro
 	} else {
 		data = data[:size]
 	}
-	n, err := protoutil.MarshalTo(meta, data)
+	n, err := protoutil.MarshalToSizedBuffer(meta, data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/protoutil/BUILD.bazel
+++ b/pkg/util/protoutil/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/protoutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/buildutil",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//jsonpb",

--- a/pkg/util/protoutil/marshal.go
+++ b/pkg/util/protoutil/marshal.go
@@ -10,7 +10,12 @@
 
 package protoutil
 
-import "github.com/gogo/protobuf/proto"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/gogo/protobuf/proto"
+)
 
 // Message extends the proto.Message interface with the MarshalTo and Size
 // methods we tell gogoproto to generate for us.
@@ -22,7 +27,7 @@ type Message interface {
 	Size() int
 }
 
-// Marshal encodes pb into the wire format.
+// Marshal encodes pb into the wire format and returns the resulting byte slice.
 func Marshal(pb Message) ([]byte, error) {
 	dest := make([]byte, pb.Size())
 	if _, err := MarshalToSizedBuffer(pb, dest); err != nil {
@@ -31,13 +36,31 @@ func Marshal(pb Message) ([]byte, error) {
 	return dest, nil
 }
 
-// MarshalTo encodes pb into the wire format.
+// MarshalTo encodes pb into the wire format and writes the result into the
+// provided byte slice, returning the number of bytes written.
+//
+// dest is required to have a capacity of at least pb.Size() bytes.
 func MarshalTo(pb Message, dest []byte) (int, error) {
+	if buildutil.CrdbTestBuild {
+		if pb.Size() > cap(dest) {
+			panic(fmt.Sprintf("MarshalTo called for %T with slice with insufficient "+
+				"capacity: pb.Size()=%d, cap(dest)=%d", pb, pb.Size(), cap(dest)))
+		}
+	}
 	return pb.MarshalTo(dest)
 }
 
-// MarshalToSizedBuffer encodes pb into the wire format.
+// MarshalToSizedBuffer encodes pb into the wire format and writes the result
+// into the provided byte slice, returning the number of bytes written.
+//
+// dest is required to have a length of exactly pb.Size() bytes.
 func MarshalToSizedBuffer(pb Message, dest []byte) (int, error) {
+	if buildutil.CrdbTestBuild {
+		if pb.Size() != len(dest) {
+			panic(fmt.Sprintf("MarshalToSizedBuffer called for %T with slice with "+
+				"incorrect length: pb.Size()=%d, len(dest)=%d", pb, pb.Size(), len(dest)))
+		}
+	}
 	return pb.MarshalToSizedBuffer(dest)
 }
 


### PR DESCRIPTION
This commit switches a number of callers of `protoutil.MarshalTo` over to `protoutil.MarshalToSizedBuffer`. The latter function is more strict in that it requires the the destination buffer to have a length of exactly `pb.Size()` bytes, as opposed to only requiring it to have a capacity of at least `pb.Size()` bytes. In return, it avoids a call to `pb.Size()`.

The three performance-sensitive callers that are changes here are:
- `roachpb.Value.SetProto`
- `raftlog.EncodeCommand`
- `storage.putBuffer.marshalMeta`

The commit also adds some testing-only assertions to verify that callers are using the functions correctly.

Epic: None
Release note: None