### PR TITLE
opt/colexec: allow NULLS LAST in window frame with RANGE with offsets

### DIFF
--- a/pkg/sql/colexec/colexecwindow/window_framer.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_framer.eg.go
@@ -1288,7 +1288,16 @@ func (b *windowFramerBase) handleOffsets(
 	// For RANGE mode with an offset, there is a single ordering column. The
 	// offset type depends on the ordering column type. In addition, the ordering
 	// column must be stored.
-	if len(ordering.Columns) != 1 {
+	switch len(ordering.Columns) {
+	case 1:
+		// Fall through; no further handling needed.
+	case 2:
+		// An additional boolean ordering column was added to handle NULLS LAST;
+		// it is safe to truncate this because rangeOffsetHandler will correctly
+		// handle NULLS whether they are ordered first or last. The extra ordering
+		// column will be at position 0.
+		ordering.Columns = ordering.Columns[1:]
+	default:
 		colexecerror.InternalError(
 			errors.AssertionFailedf("expected exactly one ordering column for RANGE mode with offset"))
 	}

--- a/pkg/sql/colexec/colexecwindow/window_framer_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_framer_tmpl.go
@@ -394,7 +394,16 @@ func (b *windowFramerBase) handleOffsets(
 	// For RANGE mode with an offset, there is a single ordering column. The
 	// offset type depends on the ordering column type. In addition, the ordering
 	// column must be stored.
-	if len(ordering.Columns) != 1 {
+	switch len(ordering.Columns) {
+	case 1:
+		// Fall through; no further handling needed.
+	case 2:
+		// An additional boolean ordering column was added to handle NULLS LAST;
+		// it is safe to truncate this because rangeOffsetHandler will correctly
+		// handle NULLS whether they are ordered first or last. The extra ordering
+		// column will be at position 0.
+		ordering.Columns = ordering.Columns[1:]
+	default:
 		colexecerror.InternalError(
 			errors.AssertionFailedf("expected exactly one ordering column for RANGE mode with offset"))
 	}

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -4393,3 +4393,44 @@ NULL  4  4
 
 statement ok
 RESET null_ordered_last
+
+# Regression test for NULLS in the ORDER BY clause of a window function
+# operating in RANGE mode (#94032).
+query III
+SELECT
+  id,
+  first_value(id) OVER (ORDER BY id),
+  first_value(id) OVER (ORDER BY id NULLS LAST)
+FROM nulls_last_test
+ORDER BY id;
+----
+NULL  NULL  1
+1     NULL  1
+2     NULL  1
+3     NULL  1
+
+query III
+SELECT
+  id,
+  first_value(id) OVER (ORDER BY id RANGE 1 PRECEDING),
+  first_value(id) OVER (ORDER BY id NULLS LAST RANGE 1 PRECEDING)
+FROM nulls_last_test
+ORDER BY id;
+----
+NULL  NULL  NULL
+1     1     1
+2     1     1
+3     2     2
+
+query III
+SELECT
+  id,
+  first_value(id) OVER (ORDER BY id RANGE BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING),
+  first_value(id) OVER (ORDER BY id NULLS LAST RANGE BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM nulls_last_test
+ORDER BY id;
+----
+NULL  NULL  NULL
+1     2     2
+2     3     3
+3     NULL  NULL

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -99,14 +99,12 @@ func (b *Builder) buildWindow(outScope *scope, inScope *scope) {
 		// Build appropriate partitions.
 		partitions[i] = b.buildWindowPartition(def.Partitions, i, w.def.Name, inScope, argScope)
 
-		var isRangeModeWithOffsets bool
 		if def.Frame != nil {
 			windowFrames[i] = *def.Frame
-			isRangeModeWithOffsets = windowFrames[i].Mode == treewindow.RANGE && def.Frame.Bounds.HasOffset()
 		}
 
 		// Build appropriate orderings.
-		ord := b.buildWindowOrdering(def.OrderBy, i, w.def.Name, inScope, argScope, isRangeModeWithOffsets)
+		ord := b.buildWindowOrdering(def.OrderBy, i, w.def.Name, inScope, argScope)
 		orderings[i].FromOrdering(ord)
 
 		if w.Filter != nil {
@@ -271,7 +269,7 @@ func (b *Builder) buildAggregationAsWindow(
 
 		// Build appropriate orderings.
 		if !agg.isCommutative() {
-			ord := b.buildWindowOrdering(agg.OrderBy, i, agg.def.Name, fromScope, g.aggInScope, false /* isRangeModeWithOffsets */)
+			ord := b.buildWindowOrdering(agg.OrderBy, i, agg.def.Name, fromScope, g.aggInScope)
 			orderings[i].FromOrdering(ord)
 		}
 
@@ -416,11 +414,7 @@ func (b *Builder) buildWindowPartition(
 
 // buildWindowOrdering builds the appropriate orderings for window functions.
 func (b *Builder) buildWindowOrdering(
-	orderBy tree.OrderBy,
-	windowIndex int,
-	funcName string,
-	inScope, outScope *scope,
-	isRangeModeWithOffsets bool,
+	orderBy tree.OrderBy, windowIndex int, funcName string, inScope, outScope *scope,
 ) opt.Ordering {
 	ord := make(opt.Ordering, 0, len(orderBy))
 	for j, t := range orderBy {
@@ -434,11 +428,6 @@ func (b *Builder) buildWindowOrdering(
 				expr := tree.NewTypedIsNullExpr(e)
 				col := outScope.findExistingCol(expr, false /* allowSideEffects */)
 				if col == nil {
-					if isRangeModeWithOffsets {
-						// TODO(yuzefovich): teach the execution engine to
-						// support this special case (#94032).
-						panic(errors.New("NULLS LAST with RANGE mode with OFFSET is currently unsupported"))
-					}
 					// Use an anonymous name because the column cannot be referenced
 					// in other expressions.
 					colName := scopeColName("").WithMetadataName(


### PR DESCRIPTION
In order to support ordering with `NULLS LAST`, the optbuilder adds an `ordCol IS NULL` ordering column to the user-supplied ordering. The window-function execution logic only supports ordering on a single column for RANGE with an offset, so window frames like the following were disallowed: `(ORDER BY col NULLS LAST RANGE 0 PRECEDING)`.

The execution logic in the `rangeOffsetHandler` is agnostic to whether NULLS are ordered first or last. This patch removes the `IS NULL` ordering column when building the `rangeOffsetHandler`, but keeps it when sorting the input. This allows `RANGE` with offsets to use an ordering column with `NULLS LAST`.

Fixes #94032

Release note (sql change): Implemented `NULLS LAST` ordering for window functions in RANGE mode with offsets.