### PR TITLE
kvserver: improve server-side trace print on ctx cancellation

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1313,7 +1313,7 @@ func (n *Node) batchInternal(
 	// replica to notice the cancellation and return a response. For this reason,
 	// we log the server-side trace of the cancelled request to help debug what
 	// the request was doing at the time it noticed the cancellation.
-	if pErr != nil && errors.IsAny(pErr.GoError(), context.Canceled, context.DeadlineExceeded) {
+	if pErr != nil && ctx.Err() != nil {
 		if sp := tracing.SpanFromContext(ctx); sp != nil && !sp.IsNoop() {
 			log.Infof(ctx, "batch request %s failed with error: %s\ntrace:\n%s", args.String(),
 				pErr.GoError().Error(), sp.GetConfiguredRecording().String())


### PR DESCRIPTION
Noticed in passing. When a replica circuit breaker trips, the error will
typically wrap `context.Canceled` but this will have nothing to do with the
client's `ctx` (and the logs will be spammed). If we try to be sensitive to
client ctx cancellation, we ought to look at the client's ctx.

Epic: none
Release note: None
