### PR TITLE
obsservice: remove unused Protobuf import

### DIFF
--- a/pkg/obsservice/obspb/BUILD.bazel
+++ b/pkg/obsservice/obspb/BUILD.bazel
@@ -23,7 +23,6 @@ proto_library(
         "//pkg/obsservice/obspb/opentelemetry-proto/logs/v1:v1_proto",
         "//pkg/obsservice/obspb/opentelemetry-proto/resource/v1:v1_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
-        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/pkg/obsservice/obspb/obsservice.proto
+++ b/pkg/obsservice/obspb/obsservice.proto
@@ -15,7 +15,6 @@ import "gogoproto/gogo.proto";
 import "obsservice/obspb/opentelemetry-proto/logs/v1/logs.proto";
 import "obsservice/obspb/opentelemetry-proto/common/v1/common.proto";
 import "obsservice/obspb/opentelemetry-proto/resource/v1/resource.proto";
-import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/cockroachdb/cockroach/pkg/obsservice/obspb";
 


### PR DESCRIPTION
Fixes this build warning:

```
obsservice/obspb/obsservice.proto:18:1: warning: Import google/protobuf/timestamp.proto but not used.
```

Epic: none
Release note: None