### PR TITLE
sql: only skip import worker failure under race,stress,deadlock

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5422,7 +5422,9 @@ func TestImportWorkerFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 102839, "flaky test")
+	skip.UnderStressWithIssue(t, 102839, "flaky test")
+	skip.UnderDeadlockWithIssue(t, 102839, "flaky test")
+	skip.UnderRaceWithIssue(t, 102839, "flaky test")
 
 	allowResponse := make(chan struct{})
 	params := base.TestClusterArgs{}


### PR DESCRIPTION
Better to have the test running some of the time to catch regressions.

Informs: #102839
Epic: None
Release note: None
