### PR TITLE
backupccl: unskip TestBackupRestoreNegativePrimaryKey

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -942,8 +942,8 @@ func TestBackupRestoreEmpty(t *testing.T) {
 // for tables with negative primary key data caused AdminSplit to fail.
 func TestBackupRestoreNegativePrimaryKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 68127, "flaky test")
 	defer log.Scope(t).Close(t)
+	skip.UnderStressRace(t, "test is too slow to run under race, presumably because of the multiple splits")
 
 	const numAccounts = 1000
 


### PR DESCRIPTION
This test was skipped but stressing for an hour reveals nothing. It is possible that the changes we made to restore and how it issued splits changed the behaviour of this test.

The test is too slow to run under stressrace so this change selectively skips it under those conditions.

Fixes: #68127
Release note: None