### PR TITLE
kv: add contending txn_meta for refresh failures

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4287,3 +4287,66 @@ func BenchmarkReturnOnRangeBoundary(b *testing.B) {
 		require.NoError(b, txn.Commit(ctx))
 	}
 }
+
+func TestRefreshFailureIncludesConflictingTxn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunTrueAndFalse(t, "committed", func(t *testing.T, committed bool) {
+		testutils.RunTrueAndFalse(t, "range-refresh", func(t *testing.T, rangeRefresh bool) {
+			ctx := context.Background()
+			s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+			defer s.Stopper().Stop(ctx)
+
+			keyA := "a"
+			endRangeA := "a2"
+			keyB := "b"
+
+			err := db.Put(ctx, keyA, "put")
+			require.NoError(t, err)
+
+			txn1 := db.NewTxn(ctx, "original txn")
+			txn2 := db.NewTxn(ctx, "contending txn")
+
+			if rangeRefresh {
+				_, err = txn1.Scan(ctx, keyA, endRangeA, 10)
+				require.NoError(t, err)
+			} else {
+				_, err = txn1.Get(ctx, keyA)
+				require.NoError(t, err)
+			}
+
+			// This bumps the timestamp cache on keyB so that the next put from txn1
+			// causes its write timestamp to skew, thereby forcing a refresh.
+			_, err = txn2.Get(ctx, keyB)
+			require.NoError(t, err)
+
+			err = txn2.Put(ctx, keyA, "put")
+			require.NoError(t, err)
+
+			if committed {
+				require.NoError(t, txn2.Commit(ctx))
+				// Force intent clean up.
+				_, err = db.Get(ctx, keyA)
+				require.NoError(t, err)
+			}
+
+			err = txn1.Put(ctx, keyB, "put")
+			require.NoError(t, err)
+
+			err = txn1.Commit(ctx)
+			require.Error(t, err)
+
+			tErr := (*kvpb.TransactionRetryWithProtoRefreshError)(nil)
+			require.ErrorAs(t, err, &tErr)
+
+			if committed {
+				require.Nil(t, tErr.ConflictingTxn)
+			} else {
+				require.NotNil(t, tErr.ConflictingTxn)
+				require.Equal(t, txn2.ID(), tErr.ConflictingTxn.ID)
+				require.Equal(t, int32(1), tErr.ConflictingTxn.CoordinatorNodeID)
+			}
+		})
+	})
+}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -264,10 +265,7 @@ func (sr *txnSpanRefresher) sendLockedWithRefreshAttempts(
 		// chances that the refresh fails.
 		bumpedTxn := br.Txn.Clone()
 		bumpedTxn.WriteTooOld = false
-		pErr = kvpb.NewErrorWithTxn(
-			kvpb.NewTransactionRetryError(kvpb.RETRY_WRITE_TOO_OLD,
-				"WriteTooOld flag converted to WriteTooOldError"),
-			bumpedTxn)
+		pErr = kvpb.NewErrorWithTxn(kvpb.NewTransactionRetryError(kvpb.RETRY_WRITE_TOO_OLD, "WriteTooOld flag converted to WriteTooOldError"), bumpedTxn)
 		br = nil
 	}
 	if pErr != nil {
@@ -525,16 +523,22 @@ func newRetryErrorOnFailedPreemptiveRefresh(
 	if txn.WriteTooOld {
 		reason = kvpb.RETRY_WRITE_TOO_OLD
 	}
+	var conflictingTxn *enginepb.TxnMeta
 	msg := redact.StringBuilder{}
 	msg.SafeString("failed preemptive refresh")
 	if refreshErr != nil {
 		if refreshErr, ok := refreshErr.GetDetail().(*kvpb.RefreshFailedError); ok {
-			msg.Printf(" due to a conflict: %s on key %s", refreshErr.FailureReason(), refreshErr.Key)
+			if refreshErr.ConflictingTxn != nil {
+				conflictingTxn = refreshErr.ConflictingTxn
+				msg.Printf(" due to a conflict: %s on key %s with conflicting txn %s", refreshErr.FailureReason(), refreshErr.Key, refreshErr.ConflictingTxn.Short())
+			} else {
+				msg.Printf(" due to a conflict: %s on key %s", refreshErr.FailureReason(), refreshErr.Key)
+			}
 		} else {
 			msg.Printf(" - unknown error: %s", refreshErr)
 		}
 	}
-	retryErr := kvpb.NewTransactionRetryError(reason, msg.RedactableString())
+	retryErr := kvpb.NewTransactionRetryError(reason, msg.RedactableString(), kvpb.WithConflictingTxn(conflictingTxn))
 	return kvpb.NewErrorWithTxn(retryErr, txn)
 }
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
@@ -625,8 +625,7 @@ func TestTxnSpanRefresherPreemptiveRefresh(t *testing.T) {
 		require.Equal(t, scanArgs.Span(), refReq.Span())
 		require.Equal(t, origReadTs, refReq.RefreshFrom)
 
-		return nil, kvpb.NewError(kvpb.NewRefreshFailedError(
-			kvpb.RefreshFailedError_REASON_COMMITTED_VALUE, roachpb.Key("a"), hlc.Timestamp{WallTime: 1}))
+		return nil, kvpb.NewError(kvpb.NewRefreshFailedError(ctx, kvpb.RefreshFailedError_REASON_COMMITTED_VALUE, roachpb.Key("a"), hlc.Timestamp{WallTime: 1}))
 	}
 	unexpected := func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		require.Fail(t, "unexpected")

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -29,6 +29,7 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvpb";
 import "errorspb/errors.proto";
 import "roachpb/data.proto";
 import "roachpb/metadata.proto";
+import "storage/enginepb/mvcc3.proto";
 import "util/hlc/timestamp.proto";
 import "gogoproto/gogo.proto";
 
@@ -263,6 +264,12 @@ message TransactionRetryError {
   // TODO(davidh): Remove in 23.2
   optional string extra_msg = 2 [(gogoproto.nullable) = false];
   optional string extra_msg_redactable = 3 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];
+  // The conflicting transaction's TxnMeta. This is bubbled up from a
+  // RefreshFailedError. This field is only set if the retry error is
+  // constructed in response to a RefreshFailedError. In all other cases, or if
+  // the RefreshFailedError does not contain conflicting transaction
+  // information, this field is unset.
+  optional storage.enginepb.TxnMeta conflicting_txn = 4;
 }
 
 // A TransactionStatusError indicates that the transaction status is
@@ -519,6 +526,14 @@ message TransactionRetryWithProtoRefreshError {
 
   // A user-readable message containing redaction markers.
   optional string msg_redactable = 4 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];
+
+  // The conflicting transaction's TxnMeta. This field is bubbled up from a
+  // RefreshFailedError. This field is only set when a
+  // TransactionRetryWithProtoRefreshError is constructed in response to a
+  // RefreshFailedError which includes information about the conflicting
+  // transaction that caused the refresh to fail. In all other cases this field
+  // is unset
+  optional storage.enginepb.TxnMeta conflicting_txn = 6;
 }
 
 // TxnAlreadyEncounteredErrorError indicates that an operation tried to use a
@@ -649,6 +664,12 @@ message RefreshFailedError {
 
   // The timestamp the key was last updated.
   optional util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
+  
+  // The conflicting transaction's TxnMeta, if available. This field is used
+  // when the refresh fails with REASON_INTENT and is bubbled up for
+  // observability purposes to track the conflicting transaction. This field is
+  // not set if the refresh fails because of REASON_COMMITTED_VALUE.
+  optional storage.enginepb.TxnMeta conflicting_txn = 4;
 }
 
 // ErrorDetail is a union type containing all available errors.

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -12,6 +12,7 @@ package kvpb
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -355,11 +356,19 @@ func TestErrorGRPCStatus(t *testing.T) {
 }
 
 func TestRefreshSpanError(t *testing.T) {
-	e1 := NewRefreshFailedError(RefreshFailedError_REASON_COMMITTED_VALUE, roachpb.Key("foo"), hlc.Timestamp{WallTime: 3})
+	ctx := context.Background()
+	txn := &enginepb.TxnMeta{
+		ID:             uuid.UUID{2},
+		Key:            roachpb.Key("foo"),
+		WriteTimestamp: hlc.Timestamp{WallTime: 3},
+		MinTimestamp:   hlc.Timestamp{WallTime: 4},
+	}
+	e1 := NewRefreshFailedError(ctx, RefreshFailedError_REASON_COMMITTED_VALUE, roachpb.Key("foo"), hlc.Timestamp{WallTime: 3})
 	require.Equal(t, "encountered recently written committed value \"foo\" @0.000000003,0", e1.Error())
 
-	e2 := NewRefreshFailedError(RefreshFailedError_REASON_INTENT, roachpb.Key("bar"), hlc.Timestamp{WallTime: 4})
+	e2 := NewRefreshFailedError(ctx, RefreshFailedError_REASON_INTENT, roachpb.Key("bar"), hlc.Timestamp{WallTime: 4}, WithConflictingTxn(txn))
 	require.Equal(t, "encountered recently written intent \"bar\" @0.000000004,0", e2.Error())
+	require.Equal(t, txn, e2.ConflictingTxn)
 }
 
 func TestNotLeaseholderError(t *testing.T) {

--- a/pkg/kv/kvserver/batcheval/cmd_refresh.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh.go
@@ -64,15 +64,14 @@ func Refresh(
 	} else if res.Value != nil {
 		if ts := res.Value.Timestamp; refreshFrom.Less(ts) {
 			return result.Result{},
-				kvpb.NewRefreshFailedError(kvpb.RefreshFailedError_REASON_COMMITTED_VALUE, args.Key, ts)
+				kvpb.NewRefreshFailedError(ctx, kvpb.RefreshFailedError_REASON_COMMITTED_VALUE, args.Key, ts)
 		}
 	}
 
 	// Check if an intent which is not owned by this transaction was written
 	// at or beneath the refresh timestamp.
 	if res.Intent != nil && res.Intent.Txn.ID != h.Txn.ID {
-		return result.Result{}, kvpb.NewRefreshFailedError(kvpb.RefreshFailedError_REASON_INTENT,
-			res.Intent.Key, res.Intent.Txn.WriteTimestamp)
+		return result.Result{}, kvpb.NewRefreshFailedError(ctx, kvpb.RefreshFailedError_REASON_INTENT, res.Intent.Key, res.Intent.Txn.WriteTimestamp, kvpb.WithConflictingTxn(&res.Intent.Txn))
 	}
 
 	return result.Result{}, nil


### PR DESCRIPTION
This patch introduces a new field in the error protos for the
transaction retry failures. When a refresh fails due to a write intent
present from another transaction, we now capture its `TxnMeta` and
propagate it up in the `ConflictingTxn` field of the error protos. In
the case of a refresh failure due to a committed value, this field will
be nil, since we clean up write intents after a transaction commits.

This field can be extracted from error messages returned from a
transaction commit operation for observability purposes to identify
the transaction that caused a `RETRY_SERIALIZABLE` error.

Epic: CRDB-26480

Release note: None