### PR TITLE
release-23.1: sql/schemachanger: avoid assertions when columns are missing

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -4164,3 +4164,14 @@ query I
 SELECT count(*) FROM child80828
 ----
 0
+
+# See #104546 which was a regression when an invalid column name was specified,
+# when adding a FK reference.
+subtest unknown_column_name
+
+statement ok
+create table t104546 (a int primary key);
+create table t104546_fk_src (a int primary key, b int);
+
+statement error pgcode 42703 column "b" does not exist
+alter table t104546 add constraint con foreign key (b) references t104546_fk_src(b);

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_not_null.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_not_null.go
@@ -22,7 +22,7 @@ func alterTableSetNotNull(
 	b BuildCtx, tn *tree.TableName, tbl *scpb.Table, t *tree.AlterTableSetNotNull,
 ) {
 	alterColumnPreChecks(b, tn, tbl, t.Column)
-	columnID := mustGetColumnIDFromColumnName(b, tbl.TableID, t.Column)
+	columnID := getColumnIDFromColumnName(b, tbl.TableID, t.Column, true /*required */)
 	if isColNotNull(b, tbl.TableID, columnID) {
 		return
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -564,10 +564,7 @@ func addColumnsForSecondaryIndex(
 				expressionTelemtryCounted = true
 			}
 		}
-		colID := getColumnIDFromColumnName(b, tableID, colName)
-		if colID == 0 {
-			panic(colinfo.NewUndefinedColumnError(string(colName)))
-		}
+		colID := getColumnIDFromColumnName(b, tableID, colName, true /* required */)
 		columnTypeElem := mustRetrieveColumnTypeElem(b, tableID, colID)
 		columnElem := mustRetrieveColumnElem(b, tableID, colID)
 		// Column should be accessible.


### PR DESCRIPTION
Backport 1/1 commits from #104841.

/cc @cockroachdb/release

---

Previously, the declarative schema changer, when resolving columns would assert if a column name was undefined. This is incorrect behaviour and a regression. To address this, this patch will generate the appropriate missing column error.

Fixes: #104546

Release note (bug fix): Adding a foreign key or setting a column to not null with a non-existent column produced an assertion error, instead of the proper pgcode in the declarative schema changer.

Release justification: low risk and fixes an incorrect error message
