### PR TITLE
sql: implement DELETE BATCH plan

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -77,6 +77,7 @@ go_library(
         "deallocate.go",
         "delayed.go",
         "delete.go",
+        "delete_batch.go",
         "delete_range.go",
         "descriptor.go",
         "discard.go",

--- a/pkg/sql/delete_batch.go
+++ b/pkg/sql/delete_batch.go
@@ -1,0 +1,59 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+type deleteBatchNode struct {
+	delete *tree.Delete
+}
+
+var _ exec.Node = &deleteBatchNode{}
+var _ planNode = &deleteBatchNode{}
+
+func (d deleteBatchNode) startExec(runParams) error {
+	del := d.delete
+	var hasSize bool
+	for i, param := range del.Batch.Params {
+		switch param.(type) {
+		case *tree.SizeBatchParam:
+			if hasSize {
+				return pgerror.Newf(pgcode.Syntax, "invalid parameter at index %d, SIZE already specified", i)
+			}
+			hasSize = true
+		}
+	}
+	if hasSize {
+		// TODO(ecwall): remove when DELETE BATCH is supported
+		return pgerror.Newf(pgcode.Syntax, "DELETE BATCH (SIZE <size>) not implemented")
+	}
+	// TODO(ecwall): remove when DELETE BATCH is supported
+	return pgerror.Newf(pgcode.Syntax, "DELETE BATCH not implemented")
+}
+
+func (d deleteBatchNode) Next(runParams) (bool, error) {
+	return false, nil
+}
+
+func (d deleteBatchNode) Values() tree.Datums {
+	return nil
+}
+
+func (d deleteBatchNode) Close(context.Context) {
+
+}

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1020,6 +1020,10 @@ func (e *distSQLSpecExecFactory) ConstructDelete(
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: delete")
 }
 
+func (e *distSQLSpecExecFactory) ConstructDeleteBatch(*tree.Delete) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: delete")
+}
+
 func (e *distSQLSpecExecFactory) ConstructDeleteRange(
 	table cat.Table,
 	needed exec.TableColumnOrdinalSet,

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -559,6 +559,13 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 	return ep, nil
 }
 
+func (b *Builder) buildDeleteBatch(del *memo.DeleteBatchExpr) (ep execPlan, err error) {
+	ep.root, err = b.factory.ConstructDeleteBatch(
+		del.Syntax,
+	)
+	return
+}
+
 // tryBuildDeleteRange attempts to construct a fast DeleteRange execution for a
 // logical Delete operator, checking all required conditions. See
 // exec.Factory.ConstructDeleteRange.

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -291,6 +291,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.DeleteExpr:
 		ep, err = b.buildDelete(t)
 
+	case *memo.DeleteBatchExpr:
+		ep, err = b.buildDeleteBatch(t)
+
 	case *memo.CreateTableExpr:
 		ep, err = b.buildCreateTable(t)
 

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -36,7 +36,7 @@ import (
 )
 
 func init() {
-	if numOperators != 61 {
+	if numOperators != 62 {
 		// This error occurs when an operator has been added or removed in
 		// pkg/sql/opt/exec/explain/factory.opt. If an operator is added at the
 		// end of factory.opt, simply adjust the hardcoded value above. If an

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -155,6 +155,9 @@ func getResultColumns(
 			a.Passthrough...,
 		), nil
 
+	case deleteBatchOp:
+		return nil, nil
+
 	case opaqueOp:
 		if args.(*opaqueArgs).Metadata != nil {
 			return args.(*opaqueArgs).Metadata.Columns(), nil

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -785,3 +785,8 @@ define LiteralValues {
 define ShowCompletions {
     Command *tree.ShowCompletions
 }
+
+# DeleteBatch implements a DELETE BATCH statement.
+define DeleteBatch {
+    Delete *tree.Delete
+}

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1430,6 +1430,10 @@ func (b *logicalPropsBuilder) buildDeleteProps(del *DeleteExpr, rel *props.Relat
 	b.buildMutationProps(del, rel)
 }
 
+func (b *logicalPropsBuilder) buildDeleteBatchProps(del *DeleteBatchExpr, rel *props.Relational) {
+	b.buildBasicProps(del, opt.ColList{}, rel)
+}
+
 func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Relational) {
 	BuildSharedProps(mutation, &rel.Shared, b.evalCtx)
 

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -357,3 +357,10 @@ define AlterRangeRelocatePrivate {
     # Props stores the required physical properties for the input expression.
     Props PhysProps
 }
+
+# DeleteBatch represents a `DELETE BATCH FROM .. ` statement.
+[Relational]
+define DeleteBatch {
+    # Syntax is the original delete statement.
+    Syntax Delete
+}

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -340,6 +340,9 @@ func (b *Builder) buildStmt(
 		return b.buildSelect(stmt.Select, noRowLocking, desiredTypes, inScope)
 
 	case *tree.Delete:
+		if stmt.Batch != nil {
+			return b.buildDeleteBatch(stmt, inScope)
+		}
 		return b.processWiths(stmt.With, inScope, func(inScope *scope) *scope {
 			return b.buildDelete(stmt, inScope)
 		})

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -251,6 +251,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"Volatility":           {fullName: "volatility.V", passByVal: true},
 		"LiteralRows":          {fullName: "opt.LiteralRows", isExpr: true, isPointer: true},
 		"Distribution":         {fullName: "physical.Distribution", passByVal: true},
+		"Delete":               {fullName: "tree.Delete", isPointer: true, usePointerIntern: true},
 	}
 
 	// Add types of generated op and private structs.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1768,6 +1768,10 @@ func (ef *execFactory) ConstructDelete(
 	return &rowCountNode{source: del}, nil
 }
 
+func (ef *execFactory) ConstructDeleteBatch(del *tree.Delete) (exec.Node, error) {
+	return &deleteBatchNode{delete: del}, nil
+}
+
 func (ef *execFactory) ConstructDeleteRange(
 	table cat.Table,
 	needed exec.TableColumnOrdinalSet,

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -399,6 +399,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&createViewNode{}):                          "create view",
 	reflect.TypeOf(&delayedNode{}):                             "virtual table",
 	reflect.TypeOf(&deleteNode{}):                              "delete",
+	reflect.TypeOf(&deleteBatchNode{}):                         "delete batch",
 	reflect.TypeOf(&deleteRangeNode{}):                         "delete range",
 	reflect.TypeOf(&discardNode{}):                             "discard",
 	reflect.TypeOf(&distinctNode{}):                            "distinct",


### PR DESCRIPTION
Fixes #105729
    
This add the plumbing between the parser output and the sql.planNode where the
job will be started.
    
Pass the original *tree.Delete pointer to the new sql.planNode. It will be
converted into the job input in a separate PR.
    
Release note: None