### PR TITLE
asim: add stores to assertion type=stat CmdArgs

### DIFF
--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -112,9 +112,9 @@ import (
 //     assertion applies per-store, over 'ticks' duration.
 //
 //     For type=stat assertions, if the stat (e.g. stat=replicas) value of the
-//     last ticks (e.g. ticks=5) duration is not exactly equal to threshold,
-//     the assertion fails. This applies for a specified store which must be
-//     provided with store=storeID.
+//     last ticks (e.g. ticks=5) duration is not exactly equal to threshold, the
+//     assertion fails. This applies for specified stores which must be provided
+//     with stores=(storeID,...).
 //
 //     For type=conformance assertions, you may assert on the number of
 //     replicas that you expect to be underreplicated (under),
@@ -443,17 +443,16 @@ func TestDataDriven(t *testing.T) {
 						threshold: threshold,
 					})
 				case "stat":
-					var store int
+					var stores []int
 					scanArg(t, d, "stat", &stat)
 					scanArg(t, d, "ticks", &ticks)
 					scanArg(t, d, "threshold", &threshold)
-					scanArg(t, d, "store", &store)
+					scanArg(t, d, "stores", &stores)
 					assertions = append(assertions, storeStatAssertion{
 						ticks:         ticks,
 						stat:          stat,
 						acceptedValue: threshold,
-						// TODO(kvoli): support setting multiple stores.
-						stores: []int{store},
+						stores:        stores,
 					})
 				case "conformance":
 					var under, over, unavailable, violating int
@@ -527,15 +526,20 @@ func scanArg(t *testing.T, d *datadriven.TestData, key string, dest interface{})
 		d.ScanArgs(t, key, &tmp)
 		*dest, err = strconv.ParseFloat(tmp, 64)
 		require.NoError(t, err)
-	case *string, *int, *int64, *uint64, *bool:
+	case *[]int, *string, *int, *int64, *uint64, *bool:
 		d.ScanArgs(t, key, dest)
 	default:
 		require.Fail(t, "unsupported type %T", dest)
 	}
 }
 
-func scanIfExists(t *testing.T, d *datadriven.TestData, key string, dest interface{}) {
+// scanIfExists looks up the first arg in CmdArgs array that matches the
+// provided firstKey. If found, it scans the value into dest and returns true;
+// Otherwise, it does nothing and returns false.
+func scanIfExists(t *testing.T, d *datadriven.TestData, key string, dest interface{}) bool {
 	if d.HasArg(key) {
 		scanArg(t, d, key, dest)
+		return true
 	}
+	return false
 }

--- a/pkg/kv/kvserver/asim/tests/testdata/example_io_overload
+++ b/pkg/kv/kvserver/asim/tests/testdata/example_io_overload
@@ -7,7 +7,7 @@ gen_ranges ranges=500 placement_skew=true
 set_capacity store=5 io_threshold=1
 ----
 
-assertion type=stat stat=replicas store=5 threshold=0 ticks=5
+assertion type=stat stat=replicas stores=(5) threshold=0 ticks=5
 ----
 
 eval duration=10m seed=42

--- a/pkg/kv/kvserver/asim/tests/testdata/example_liveness
+++ b/pkg/kv/kvserver/asim/tests/testdata/example_liveness
@@ -19,12 +19,9 @@ set_liveness node=7 liveness=dead
 set_liveness node=6 liveness=decommissioning delay=3m
 ----
 
-# The number of replicas on the dead store should be 0, assert this.
-assertion type=stat stat=replicas ticks=6 threshold=0 store=7
-----
-
-# The number of replicas on the decommissioning store should be 0, assert this.
-assertion type=stat stat=replicas ticks=6 threshold=0 store=6
+# The number of replicas on the dead and decommissioning stores should be 0,
+# assert this.
+assertion type=stat stat=replicas ticks=6 threshold=0 stores=(6,7)
 ----
 
 eval duration=12m seed=42


### PR DESCRIPTION
Prior to this commit, the allocator simulator was limited to taking a single
storeID as an argument  for the assertion type=stat. This is less ideal since it
would require the use of multiple statements to check for multiple stores. To
improve this, this patch extends the arguments to take in stores instead of
store. The expected format is `assertion type=stat stores=(1,2)`.

Epic: None

Release Note: None