### PR TITLE
sql: return unimplemented error for plpgsql udfs with record input

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
+++ b/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
@@ -552,3 +552,10 @@ $$ LANGUAGE PLpgSQL;
 
 statement error control reached end of function without RETURN
 SELECT f(1, 2);
+
+statement error PL/pgSQL functions with RECORD input arguments are not yet supported
+CREATE FUNCTION f_err(p1 RECORD) RETURNS RECORD AS $$
+  BEGIN
+   RETURN p1;
+ END
+$$ LANGUAGE PLpgSQL;

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -145,9 +145,16 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateFunction, inScope *scope) (
 		if err != nil {
 			panic(err)
 		}
-		if language == tree.FunctionLangSQL && types.IsRecordType(typ) {
-			panic(pgerror.Newf(pgcode.InvalidFunctionDefinition,
-				"SQL functions cannot have arguments of type record"))
+		if types.IsRecordType(typ) {
+			if language == tree.FunctionLangSQL {
+				panic(pgerror.Newf(pgcode.InvalidFunctionDefinition,
+					"SQL functions cannot have arguments of type record"))
+			} else if language == tree.FunctionLangPLpgSQL {
+				panic(unimplemented.NewWithIssueDetail(105713,
+					"PL/pgSQL functions with RECORD input arguments",
+					"PL/pgSQL functions with RECORD input arguments are not yet supported",
+				))
+			}
 		}
 
 		// Add the parameter to the base scope of the body.


### PR DESCRIPTION
PLpgSQL UDFs should support `RECORD` argument types as input, but there are currently issues with assignment of underlying tuple types in `RECORD`s that prevent CRDB from supporting them. We explicitly note this feature as unsupported until the issues are resolved.

Epic: None
Informs: #105713

Release note: None