### PR TITLE
storage: unskip unskip TestCreateCheckpoint_SpanConstrained

### DIFF
--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1033,7 +1032,6 @@ func TestCreateCheckpoint(t *testing.T) {
 func TestCreateCheckpoint_SpanConstrained(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 100935)
 	ctx := context.Background()
 
 	rng, _ := randutil.NewTestRand()


### PR DESCRIPTION
The reason for skipping the test was fixed and backported. Details in https://github.com/cockroachdb/cockroach/issues/100935.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/105739
Release note: None