### PR TITLE
builtins: add repaired_descriptor builtin

### DIFF
--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/config/zonepb",
         "//pkg/geo/geoindex",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",

--- a/pkg/sql/catalog/dbdesc/BUILD.bazel
+++ b/pkg/sql/catalog/dbdesc/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/security/username",
         "//pkg/sql/catalog",
@@ -37,6 +38,7 @@ go_test(
     embed = [":dbdesc"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/jobs/jobspb",
         "//pkg/security/username",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/catalog/dbdesc/database_test.go
+++ b/pkg/sql/catalog/dbdesc/database_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -385,5 +386,48 @@ func TestMaybeConvertIncompatibleDBPrivilegesToDefaultPrivileges(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestStripDanglingBackReferences(t *testing.T) {
+	type testCase struct {
+		input, expectedOutput descpb.DatabaseDescriptor
+		validIDs              catalog.DescriptorIDSet
+	}
+
+	testData := []testCase{
+		{
+			input: descpb.DatabaseDescriptor{
+				Name: "foo",
+				ID:   100,
+				Schemas: map[string]descpb.DatabaseDescriptor_SchemaInfo{
+					"bar": {ID: 101},
+					"baz": {ID: 12345},
+				},
+			},
+			expectedOutput: descpb.DatabaseDescriptor{
+				Name: "foo",
+				ID:   100,
+				Schemas: map[string]descpb.DatabaseDescriptor_SchemaInfo{
+					"bar": {ID: 101},
+				},
+			},
+			validIDs: catalog.MakeDescriptorIDSet(100, 101),
+		},
+	}
+
+	for i, test := range testData {
+		t.Run(fmt.Sprintf("#%02d", i+1), func(t *testing.T) {
+			b := NewBuilder(&test.input)
+			require.NoError(t, b.RunPostDeserializationChanges())
+			out := NewBuilder(&test.expectedOutput)
+			require.NoError(t, out.RunPostDeserializationChanges())
+			require.NoError(t, b.StripDanglingBackReferences(test.validIDs.Contains, func(id jobspb.JobID) bool {
+				return false
+			}))
+			desc := b.BuildCreatedMutableDatabase()
+			require.True(t, desc.GetPostDeserializationChanges().Contains(catalog.StrippedDanglingBackReferences))
+			require.Equal(t, out.BuildCreatedMutableDatabase().DatabaseDesc(), desc.DatabaseDesc())
+		})
 	}
 }

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -791,9 +791,6 @@ type TypeDescriptor interface {
 	// GetReferencingDescriptorID returns the ID of the referencing descriptor at
 	// ordinal refOrdinal.
 	GetReferencingDescriptorID(refOrdinal int) descpb.ID
-	// GetReferencingDescriptorIDs returns IDs of descriptors referencing this
-	// type.
-	GetReferencingDescriptorIDs() []descpb.ID
 
 	// AsEnumTypeDescriptor returns this instance cast to EnumTypeDescriptor
 	// if this type is an enum type, nil otherwise.

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
@@ -92,6 +93,20 @@ type DescriptorBuilder interface {
 	// This is to compensate for the fact that these are not subject to cluster
 	// upgrade migrations
 	RunRestoreChanges(version clusterversion.ClusterVersion, descLookupFn func(id descpb.ID) Descriptor) error
+
+	// StripDanglingBackReferences attempts to remove any back-references in the
+	// descriptor which are known to be dangling references. In other words, if
+	// there is a back-reference to a descriptor or a job and we know that the
+	// ID isn't valid, then this method removes this back-reference.
+	//
+	// Back-references are only ever checked when performing schema changes and
+	// usually aren't needed by the query planner so any corruption there can
+	// remain undetected for a long time. This method provides a mechanism for
+	// brute-force repair.
+	StripDanglingBackReferences(
+		descIDMightExist func(id descpb.ID) bool,
+		nonTerminalJobIDMightExist func(id jobspb.JobID) bool,
+	) error
 
 	// SetRawBytesInStorage sets `rawBytesInStorage` field by deep-copying `rawBytes`.
 	SetRawBytesInStorage(rawBytes []byte)

--- a/pkg/sql/catalog/funcdesc/BUILD.bazel
+++ b/pkg/sql/catalog/funcdesc/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/jobs/jobspb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/catprivilege",
@@ -39,6 +40,7 @@ go_test(
     deps = [
         ":funcdesc",
         "//pkg/clusterversion",
+        "//pkg/jobs/jobspb",
         "//pkg/security/username",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",

--- a/pkg/sql/catalog/funcdesc/func_desc_test.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
@@ -799,6 +800,58 @@ func TestToOverload(t *testing.T) {
 			overload.ReturnType = nil
 			tc.expected.ReturnType = nil
 			require.Equal(t, tc.expected, *overload)
+		})
+	}
+}
+
+func TestStripDanglingBackReferences(t *testing.T) {
+	type testCase struct {
+		input, expectedOutput descpb.FunctionDescriptor
+		validIDs              catalog.DescriptorIDSet
+	}
+
+	testData := []testCase{
+		{
+			input: descpb.FunctionDescriptor{
+				Name: "foo",
+				ID:   105,
+				DependedOnBy: []descpb.FunctionDescriptor_Reference{
+					{
+						ID:        104,
+						ColumnIDs: []descpb.ColumnID{1},
+					},
+					{
+						ID:        12345,
+						ColumnIDs: []descpb.ColumnID{1},
+					},
+				},
+			},
+			expectedOutput: descpb.FunctionDescriptor{
+				Name: "foo",
+				ID:   105,
+				DependedOnBy: []descpb.FunctionDescriptor_Reference{
+					{
+						ID:        104,
+						ColumnIDs: []descpb.ColumnID{1},
+					},
+				},
+			},
+			validIDs: catalog.MakeDescriptorIDSet(104, 105),
+		},
+	}
+
+	for i, test := range testData {
+		t.Run(fmt.Sprintf("#%02d", i+1), func(t *testing.T) {
+			b := funcdesc.NewBuilder(&test.input)
+			require.NoError(t, b.RunPostDeserializationChanges())
+			out := funcdesc.NewBuilder(&test.expectedOutput)
+			require.NoError(t, out.RunPostDeserializationChanges())
+			require.NoError(t, b.StripDanglingBackReferences(test.validIDs.Contains, func(id jobspb.JobID) bool {
+				return false
+			}))
+			desc := b.BuildCreatedMutableFunction()
+			require.True(t, desc.GetPostDeserializationChanges().Contains(catalog.StrippedDanglingBackReferences))
+			require.Equal(t, out.BuildCreatedMutableFunction().FuncDesc(), desc.FuncDesc())
 		})
 	}
 }

--- a/pkg/sql/catalog/post_deserialization_changes.go
+++ b/pkg/sql/catalog/post_deserialization_changes.go
@@ -109,9 +109,13 @@ const (
 
 	// UpgradedDeclarativeSchemaChangerState indicates the declarative schema changer
 	// state was modified.
-	UpgradedDeclarativeSchemaChangerState = 15
+	UpgradedDeclarativeSchemaChangerState
 
 	// SetIndexInvisibility indicates that the invisibility of at least one index
 	// descriptor was updated to a non-zero value.
 	SetIndexInvisibility
+
+	// StrippedDanglingBackReferences indicates that at least one dangling
+	// back-reference was removed from the descriptor.
+	StrippedDanglingBackReferences
 )

--- a/pkg/sql/catalog/schemadesc/BUILD.bazel
+++ b/pkg/sql/catalog/schemadesc/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/catalog/schemadesc/schema_desc_builder.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_builder.go
@@ -12,6 +12,7 @@ package schemadesc
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -125,6 +126,15 @@ func (sdb *schemaDescriptorBuilder) RunRestoreChanges(
 	if scpb.MigrateDescriptorState(version, sdb.maybeModified.DeclarativeSchemaChangerState) {
 		sdb.changes.Add(catalog.UpgradedDeclarativeSchemaChangerState)
 	}
+	return nil
+}
+
+// StripDanglingBackReferences implements the catalog.DescriptorBuilder
+// interface.
+func (sdb *schemaDescriptorBuilder) StripDanglingBackReferences(
+	descIDMightExist func(id descpb.ID) bool, nonTerminalJobIDMightExist func(id jobspb.JobID) bool,
+) error {
+	// There's nothing we can do for schemas here.
 	return nil
 }
 

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/docs",
         "//pkg/geo/geoindex",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/settings",

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -12,6 +12,7 @@ package tabledesc
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
@@ -182,6 +183,80 @@ func (tdb *tableDescriptorBuilder) RunRestoreChanges(
 	}
 
 	return err
+}
+
+// StripDanglingBackReferences implements the catalog.DescriptorBuilder
+// interface.
+func (tdb *tableDescriptorBuilder) StripDanglingBackReferences(
+	descIDMightExist func(id descpb.ID) bool, nonTerminalJobIDMightExist func(id jobspb.JobID) bool,
+) error {
+	// Strip dangling back-references in depended_on_by,
+	{
+		sliceIdx := 0
+		for _, backref := range tdb.maybeModified.DependedOnBy {
+			tdb.maybeModified.DependedOnBy[sliceIdx] = backref
+			if descIDMightExist(backref.ID) {
+				sliceIdx++
+			}
+		}
+		if sliceIdx < len(tdb.maybeModified.DependedOnBy) {
+			tdb.maybeModified.DependedOnBy = tdb.maybeModified.DependedOnBy[:sliceIdx]
+			tdb.changes.Add(catalog.StrippedDanglingBackReferences)
+		}
+	}
+	// ... in inbound foreign keys,
+	{
+		sliceIdx := 0
+		for _, backref := range tdb.maybeModified.InboundFKs {
+			tdb.maybeModified.InboundFKs[sliceIdx] = backref
+			if descIDMightExist(backref.OriginTableID) {
+				sliceIdx++
+			}
+		}
+		if sliceIdx < len(tdb.maybeModified.InboundFKs) {
+			tdb.maybeModified.InboundFKs = tdb.maybeModified.InboundFKs[:sliceIdx]
+			tdb.changes.Add(catalog.StrippedDanglingBackReferences)
+		}
+	}
+	// ... in the replacement_of field,
+	if id := tdb.maybeModified.ReplacementOf.ID; id != descpb.InvalidID && !descIDMightExist(id) {
+		tdb.maybeModified.ReplacementOf.Reset()
+		tdb.changes.Add(catalog.StrippedDanglingBackReferences)
+	}
+	// ... in the drop_job field,
+	if id := tdb.maybeModified.DropJobID; id != jobspb.InvalidJobID && !nonTerminalJobIDMightExist(id) {
+		tdb.maybeModified.DropJobID = jobspb.InvalidJobID
+		tdb.changes.Add(catalog.StrippedDanglingBackReferences)
+	}
+	// ... in the mutation_jobs slice,
+	{
+		sliceIdx := 0
+		for _, backref := range tdb.maybeModified.MutationJobs {
+			tdb.maybeModified.MutationJobs[sliceIdx] = backref
+			if nonTerminalJobIDMightExist(backref.JobID) {
+				sliceIdx++
+			}
+		}
+		if sliceIdx < len(tdb.maybeModified.MutationJobs) {
+			tdb.maybeModified.MutationJobs = tdb.maybeModified.MutationJobs[:sliceIdx]
+			tdb.changes.Add(catalog.StrippedDanglingBackReferences)
+		}
+	}
+	// ... in the row_level_ttl field,
+	if ttl := tdb.maybeModified.RowLevelTTL; ttl != nil {
+		if id := jobspb.JobID(ttl.ScheduleID); id != jobspb.InvalidJobID && !nonTerminalJobIDMightExist(id) {
+			tdb.maybeModified.RowLevelTTL = nil
+			tdb.changes.Add(catalog.StrippedDanglingBackReferences)
+		}
+	}
+	// ... in the sequence ownership field.
+	if seq := tdb.maybeModified.SequenceOpts; seq != nil {
+		if id := seq.SequenceOwner.OwnerTableID; id != descpb.InvalidID && !descIDMightExist(id) {
+			seq.SequenceOwner.Reset()
+			tdb.changes.Add(catalog.StrippedDanglingBackReferences)
+		}
+	}
+	return nil
 }
 
 // SetRawBytesInStorage implements the catalog.DescriptorBuilder interface.

--- a/pkg/sql/catalog/typedesc/BUILD.bazel
+++ b/pkg/sql/catalog/typedesc/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
@@ -48,6 +49,7 @@ go_test(
     deps = [
         ":typedesc",
         "//pkg/clusterversion",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -271,9 +271,6 @@ func (v *tableImplicitRecordType) NumReferencingDescriptors() int { return 0 }
 // GetReferencingDescriptorID implements the catalog.TypeDescriptor interface.
 func (v *tableImplicitRecordType) GetReferencingDescriptorID(_ int) descpb.ID { return 0 }
 
-// GetReferencingDescriptorIDs implements the catalog.TypeDescriptor interface.
-func (v *tableImplicitRecordType) GetReferencingDescriptorIDs() []descpb.ID { return nil }
-
 // GetPostDeserializationChanges implements the catalog.Descriptor interface.
 func (v *tableImplicitRecordType) GetPostDeserializationChanges() catalog.PostDeserializationChanges {
 	return catalog.PostDeserializationChanges{}

--- a/pkg/sql/catalog/typedesc/type_desc_builder.go
+++ b/pkg/sql/catalog/typedesc/type_desc_builder.go
@@ -12,6 +12,7 @@ package typedesc
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -125,6 +126,25 @@ func (tdb *typeDescriptorBuilder) RunRestoreChanges(
 	// Upgrade the declarative schema changer state
 	if scpb.MigrateDescriptorState(version, tdb.maybeModified.DeclarativeSchemaChangerState) {
 		tdb.changes.Add(catalog.UpgradedDeclarativeSchemaChangerState)
+	}
+	return nil
+}
+
+// StripDanglingBackReferences implements the catalog.DescriptorBuilder
+// interface.
+func (tdb *typeDescriptorBuilder) StripDanglingBackReferences(
+	descIDMightExist func(id descpb.ID) bool, nonTerminalJobIDMightExist func(id jobspb.JobID) bool,
+) error {
+	sliceIdx := 0
+	for _, id := range tdb.maybeModified.ReferencingDescriptorIDs {
+		tdb.maybeModified.ReferencingDescriptorIDs[sliceIdx] = id
+		if descIDMightExist(id) {
+			sliceIdx++
+		}
+	}
+	if sliceIdx < len(tdb.maybeModified.ReferencingDescriptorIDs) {
+		tdb.maybeModified.ReferencingDescriptorIDs = tdb.maybeModified.ReferencingDescriptorIDs[:sliceIdx]
+		tdb.changes.Add(catalog.StrippedDanglingBackReferences)
 	}
 	return nil
 }

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -844,6 +845,52 @@ func TestValidateTypeDesc(t *testing.T) {
 		} else if expectedErr != err.Error() {
 			t.Errorf("#%d expected err: %s but found: %s", i, expectedErr, err)
 		}
+	}
+}
+
+func TestStripDanglingBackReferences(t *testing.T) {
+	type testCase struct {
+		input, expectedOutput descpb.TypeDescriptor
+		validIDs              catalog.DescriptorIDSet
+	}
+
+	testData := []testCase{
+		{
+			input: descpb.TypeDescriptor{
+				Name:                     "foo",
+				ID:                       104,
+				ParentID:                 100,
+				ParentSchemaID:           101,
+				ArrayTypeID:              105,
+				Kind:                     descpb.TypeDescriptor_TABLE_IMPLICIT_RECORD_TYPE,
+				ReferencingDescriptorIDs: []descpb.ID{12345, 105, 5678},
+			},
+			expectedOutput: descpb.TypeDescriptor{
+				Name:                     "foo",
+				ID:                       104,
+				ParentID:                 100,
+				ParentSchemaID:           101,
+				ArrayTypeID:              105,
+				Kind:                     descpb.TypeDescriptor_TABLE_IMPLICIT_RECORD_TYPE,
+				ReferencingDescriptorIDs: []descpb.ID{105},
+			},
+			validIDs: catalog.MakeDescriptorIDSet(100, 101, 104, 105),
+		},
+	}
+
+	for i, test := range testData {
+		t.Run(fmt.Sprintf("#%02d", i+1), func(t *testing.T) {
+			b := typedesc.NewBuilder(&test.input)
+			require.NoError(t, b.RunPostDeserializationChanges())
+			out := typedesc.NewBuilder(&test.expectedOutput)
+			require.NoError(t, out.RunPostDeserializationChanges())
+			require.NoError(t, b.StripDanglingBackReferences(test.validIDs.Contains, func(id jobspb.JobID) bool {
+				return false
+			}))
+			desc := b.BuildCreatedMutableType()
+			require.True(t, desc.GetPostDeserializationChanges().Contains(catalog.StrippedDanglingBackReferences))
+			require.Equal(t, out.BuildCreatedMutableType().TypeDesc(), desc.TypeDesc())
+		})
 	}
 }
 

--- a/pkg/sql/create_function_test.go
+++ b/pkg/sql/create_function_test.go
@@ -142,10 +142,8 @@ SELECT nextval(105:::REGCLASS);`,
 		_, typ, err := descs.PrefixAndType(ctx, col.ByNameWithLeased(txn.KV()).Get(), &typn)
 		require.NoError(t, err)
 		require.Equal(t, "notmyworkday", typ.GetName())
-		require.Equal(t,
-			[]descpb.ID{110},
-			typ.GetReferencingDescriptorIDs(),
-		)
+		require.Equal(t, 1, typ.NumReferencingDescriptors())
+		require.Equal(t, 110, typ.GetReferencingDescriptorID(0))
 
 		return nil
 	})
@@ -335,7 +333,8 @@ SELECT nextval(106:::REGCLASS);`,
 		typn := tree.MakeQualifiedTypeName("defaultdb", "public", "notmyworkday")
 		_, typ, err := descs.PrefixAndType(ctx, col.ByNameWithLeased(txn.KV()).Get(), &typn)
 		require.NoError(t, err)
-		require.Equal(t, []descpb.ID{112}, typ.GetReferencingDescriptorIDs())
+		require.Equal(t, 1, typ.NumReferencingDescriptors())
+		require.Equal(t, 112, typ.GetReferencingDescriptorID(0))
 
 		// All objects with "1" suffix should have back references to the function,
 		// "2" should have empty references since it's not used yet.
@@ -378,7 +377,8 @@ SELECT nextval(107:::REGCLASS);`,
 		typn := tree.MakeQualifiedTypeName("defaultdb", "public", "notmyworkday")
 		_, typ, err := descs.PrefixAndType(ctx, col.ByNameWithLeased(txn.KV()).Get(), &typn)
 		require.NoError(t, err)
-		require.Equal(t, []descpb.ID{112}, typ.GetReferencingDescriptorIDs())
+		require.Equal(t, 1, typ.NumReferencingDescriptors())
+		require.Equal(t, 112, typ.GetReferencingDescriptorID(0))
 
 		// Now all objects with "2" suffix in name should have back references "1"
 		// had before, and "1" should have empty references.

--- a/pkg/sql/drop_function_test.go
+++ b/pkg/sql/drop_function_test.go
@@ -133,10 +133,8 @@ SELECT nextval(105:::REGCLASS);`,
 		_, typ, err := descs.PrefixAndType(ctx, col.ByNameWithLeased(txn.KV()).Get(), &typn)
 		require.NoError(t, err)
 		require.Equal(t, "notmyworkday", typ.GetName())
-		require.Equal(t,
-			[]descpb.ID{109},
-			typ.GetReferencingDescriptorIDs(),
-		)
+		require.Equal(t, 1, typ.NumReferencingDescriptors())
+		require.Equal(t, 109, typ.GetReferencingDescriptorID(0))
 
 		return nil
 	})
@@ -176,7 +174,7 @@ SELECT nextval(105:::REGCLASS);`,
 		typn := tree.MakeQualifiedTypeName("defaultdb", "public", "notmyworkday")
 		_, typ, err := descs.PrefixAndType(ctx, col.ByNameWithLeased(txn.KV()).Get(), &typn)
 		require.NoError(t, err)
-		require.Nil(t, typ.GetReferencingDescriptorIDs())
+		require.Zero(t, typ.NumReferencingDescriptors())
 
 		return nil
 	})

--- a/pkg/sql/evalcatalog/BUILD.bazel
+++ b/pkg/sql/evalcatalog/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/geo/geoindex",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/sql/catalog",

--- a/pkg/sql/logictest/testdata/logic_test/schema_repair
+++ b/pkg/sql/logictest/testdata/logic_test/schema_repair
@@ -215,6 +215,32 @@ statement error invalid foreign key backreference
 DROP TABLE corrupt_backref_fk
 
 statement ok
+CREATE FUNCTION repaired(descriptor BYTES) RETURNS BYTES VOLATILE LANGUAGE SQL AS $$
+SELECT crdb_internal.repaired_descriptor(
+  descriptor,
+  (SELECT array_agg(id) AS desc_id_array FROM system.descriptor),
+  (
+    SELECT
+      array_agg(id) AS job_id_array
+    FROM
+      system.jobs
+    WHERE
+      status NOT IN ('failed', 'succeeded', 'canceled', 'revert-failed')
+  )
+)
+$$;
+
+query B
+SELECT crdb_internal.unsafe_upsert_descriptor(id, repaired(descriptor), true)
+FROM system.descriptor
+WHERE id = 'corrupt_backref_fk'::REGCLASS::INT
+----
+true
+
+statement ok
+DROP TABLE corrupt_backref_fk
+
+statement ok
 CREATE TABLE corrupt_backref_view (k INT PRIMARY KEY, v STRING);
 INSERT INTO corrupt_backref_view (k, v) VALUES (1, 'a');
 CREATE VIEW corrupt_view AS SELECT k, v FROM corrupt_backref_view
@@ -236,6 +262,16 @@ SELECT * FROM corrupt_backref_view
 1 a
 
 statement error pgcode XX000 invalid depended-on-by relation back reference
+DROP TABLE corrupt_backref_view
+
+query B
+SELECT crdb_internal.unsafe_upsert_descriptor(id, repaired(descriptor), true)
+FROM system.descriptor
+WHERE id = 'corrupt_backref_view'::REGCLASS::INT
+----
+true
+
+statement ok
 DROP TABLE corrupt_backref_view
 
 statement ok
@@ -261,41 +297,21 @@ a
 statement error pgcode XXUUU referenced descriptor not found
 ALTER TYPE corrupt_backref_typ DROP VALUE 'b'
 
-# This is required to pass the validation tests when the logic test completes.
-subtest cleanup_corrupt_backref
-
 query TB
-SELECT
-  name,
-	crdb_internal.unsafe_delete_descriptor(id, true)
-FROM
-	system.namespace
-WHERE
-	name LIKE '%corrupt_backref_%'
-ORDER BY
-  name
+SELECT ns.name, crdb_internal.unsafe_upsert_descriptor(d.id, repaired(d.descriptor), true)
+FROM system.descriptor d
+INNER JOIN system.namespace ns ON d.id = ns.id
+WHERE ns.name LIKE '%corrupt_backref_typ'
+ORDER BY 1
 ----
-_corrupt_backref_typ  true
-corrupt_backref_fk    true
-corrupt_backref_typ   true
-corrupt_backref_view  true
+_corrupt_backref_typ true
+corrupt_backref_typ true
 
-query TBB
-SELECT
-  name,
-	crdb_internal.force_delete_table_data(id),
-	crdb_internal.unsafe_delete_namespace_entry("parentID", "parentSchemaID", name, id)
-FROM
-	system.namespace
-WHERE
-	name LIKE '%corrupt_backref_%'
-ORDER BY
-  name
-----
-_corrupt_backref_typ  true  true
-corrupt_backref_fk    true  true
-corrupt_backref_typ   true  true
-corrupt_backref_view  true  true
+statement ok
+ALTER TYPE corrupt_backref_typ DROP VALUE 'b'
+
+statement ok
+DROP TYPE corrupt_backref_typ
 
 # Check that `SET descriptor_validation = off ` disables validation.
 # We do so by corrupting a table descriptor and assert on the successful

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2422,6 +2422,7 @@ var builtinOidsArray = []string{
 	2449: `st_asmvtgeom(geometry: geometry, bbox: box2d, extent: int, buffer: int) -> geometry`,
 	2450: `st_asmvtgeom(geometry: geometry, bbox: box2d, extent: int) -> geometry`,
 	2451: `st_asmvtgeom(geometry: geometry, bbox: box2d) -> geometry`,
+	2452: `crdb_internal.repaired_descriptor(descriptor: bytes, valid_descriptor_ids: int[], valid_job_ids: int[]) -> bytes`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -121,11 +122,17 @@ type CatalogBuiltins interface {
 	// redacts its expressions, and re-encodes it.
 	RedactDescriptor(ctx context.Context, encodedDescriptor []byte) ([]byte, error)
 
-	// DescriptorWithPostDeserializationChanges expects an encoded protobuf
-	// descriptor, decodes it, puts it into a catalog.DescriptorBuilder,
-	// calls RunPostDeserializationChanges, and re-encodes it.
-	DescriptorWithPostDeserializationChanges(
-		ctx context.Context, encodedDescriptor []byte,
+	// RepairedDescriptor expects an encoded protobuf descriptor,
+	// decodes it,
+	// puts it into a catalog.DescriptorBuilder,
+	// calls RunPostDeserializationChanges,
+	// calls StripDanglingBackReferences,
+	// and re-encodes it.
+	RepairedDescriptor(
+		ctx context.Context,
+		encodedDescriptor []byte,
+		descIDMightExist func(id descpb.ID) bool,
+		nonTerminalJobIDMightExist func(id jobspb.JobID) bool,
 	) ([]byte, error)
 }
 


### PR DESCRIPTION
This commit adds a new crdb_internal.repaired_descriptor builtin
which makes use of the recently-added StripDanglingBackReferences method
on catalog.MutableDescriptor.

In conjunction with crdb_internal.unsafe_upsert_descriptor, this builtin
makes it possible to repair descriptors corrupted with dangling
back-references (back-references to descriptors or jobs which are
invalid) without needing to craft a descriptor surgery query for each
descriptor. It is therefore possible to repair this whole class of
corruptions in bulk.

This class of descriptor corruptions is particularly insidious in that
it is only caught by validation checks performed when writing new
versions of the descriptor (i.e. schema changes). This is deliberate, in
that we don't want this kind of corruption to interfere with DML queries
because those don't interact with back-references at all. On the other
hand, it defers detection of the corruption until a schema change or
a cluster upgrade is attempted.

Informs #104425.

Release note: None