### PR TITLE
jobs: batch writes when backfilling job_type column in system.jobs

### DIFF
--- a/pkg/upgrade/upgrades/alter_jobs_add_job_type.go
+++ b/pkg/upgrade/upgrades/alter_jobs_add_job_type.go
@@ -12,13 +12,24 @@ package upgrades
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
+
+// JobsBackfillBatchSize_22_2_20 is used to batch writes in the below migration.
+// Batching writes across multiple transactions prevents this upgrade
+// from failing continuously due to contention on system.jobs.
+var JobsBackfillBatchSize_22_2_20 = envutil.EnvOrDefaultInt("COCKROACH_UPGRADE_22_2_20_BACKFILL_BATCH", 100)
 
 const addTypeColumnStmt = `
 ALTER TABLE system.jobs
@@ -32,9 +43,17 @@ ON system.jobs (job_type)
 `
 
 const backfillTypeColumnStmt = `
-UPDATE system.jobs
-SET job_type = crdb_internal.job_payload_type(payload)
-WHERE job_type IS NULL
+WITH ids AS (
+	SELECT id FROM system.jobs
+	WHERE id > $1 AND job_type is NULL
+	ORDER BY id ASC
+	LIMIT $2
+), updated AS (
+	UPDATE system.jobs
+	SET job_type = crdb_internal.job_payload_type(payload)
+	WHERE id IN (SELECT id from ids)
+	RETURNING id
+) SELECT max(id) FROM updated
 `
 
 func alterSystemJobsAddJobType(
@@ -67,10 +86,31 @@ func alterSystemJobsAddJobType(
 func backfillJobTypeColumn(
 	ctx context.Context, cs clusterversion.ClusterVersion, d upgrade.TenantDeps,
 ) error {
-	ie := d.InternalExecutor
-	_, err := ie.Exec(ctx, "backfill-jobs-type-column", nil /* txn */, backfillTypeColumnStmt, username.RootUser)
-	if err != nil {
-		return err
+	resumeAfter := 0
+	for batch, done := 0, false; !done; batch++ {
+		if err := d.DB.KV().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			last, err := d.InternalExecutor.QueryBufferedEx(
+				ctx,
+				fmt.Sprintf("backfill-jobs-type-column-batch-%d", batch),
+				txn,
+				sessiondata.NodeUserSessionDataOverride,
+				backfillTypeColumnStmt,
+				resumeAfter,
+				JobsBackfillBatchSize_22_2_20,
+			)
+			if err != nil {
+				return errors.Wrap(err, "failed to backfill system jobs type column")
+			}
+			if len(last) == 1 && len(last[0]) == 1 && last[0][0] != tree.DNull {
+				resumeAfter = int(tree.MustBeDInt(last[0][0]))
+			} else {
+				done = true
+			}
+			log.Infof(ctx, "backfilling system.jobs job_type column, batch%d done; resume after %d, done %v", batch, resumeAfter, done)
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/upgrade/upgrades/backfill_job_info_table_migration.go
+++ b/pkg/upgrade/upgrades/backfill_job_info_table_migration.go
@@ -25,7 +25,10 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-var jobInfoBackfillBatchSize = envutil.EnvOrDefaultInt("COCKROACH_UPGRADE_JOB_BACKFILL_BATCH", 100)
+// JobsBackfillBatchSize_22_2_78 is used to batch writes in the below migration.
+// Batching writes across multiple transactions prevents this upgrade
+// from failing continuously due to contention on system.jobs.
+var JobsBackfillBatchSize_22_2_78 = envutil.EnvOrDefaultInt("COCKROACH_UPGRADE_22_2_78_BACKFILL_BATCH", 100)
 
 const (
 	backfillJobInfoSharedPrefix = `WITH inserted AS (
@@ -64,7 +67,7 @@ func backfillJobInfoTable(
 					sessiondata.NodeUserSessionDataOverride,
 					stmt,
 					resumeAfter,
-					jobInfoBackfillBatchSize,
+					JobsBackfillBatchSize_22_2_78,
 				)
 
 				if err != nil {


### PR DESCRIPTION
Previously, the migration which backfills the `job_type` column in `system.jobs` could hang indefinately due to contention on the jobs table. This change updates the migration to batch the backfill using multiple transactions.

Informs: https://github.com/cockroachdb/cockroach/issues/105663
Epic: None