### PR TITLE
sql: unskip TestCaptureIndexUsageStats

### DIFF
--- a/pkg/sql/scheduledlogging/BUILD.bazel
+++ b/pkg/sql/scheduledlogging/BUILD.bazel
@@ -38,7 +38,6 @@ go_test(
         "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -66,7 +65,6 @@ func (s *stubDurations) getOverlapDuration() time.Duration {
 
 func TestCaptureIndexUsageStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 102732)
 	sc := log.ScopeWithoutShowLogs(t)
 	defer sc.Close(t)
 


### PR DESCRIPTION
Test was unskipped to increase the time buffer for
TestCaptureIndexUsageStats in https://github.com/cockroachdb/cockroach/pull/105771.

Informs: https://github.com/cockroachdb/cockroach/issues/102732

Release note: None