### PR TITLE
asim: add a new test case for zone config 

### DIFF
--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -49,7 +49,7 @@ import (
 //     simulation. The default values are: rw_ratio=0 rate=0 min_block=1
 //     max_block=1 min_key=1 max_key=10_000 access_skew=false.
 //
-//   - "ken_cluster" [nodes=<int>] [stores_per_node=<int>]
+//   - "gen_cluster" [nodes=<int>] [stores_per_node=<int>]
 //     Initialize the cluster generator parameters. On the next call to eval,
 //     the cluster generator is called to create the initial state used in the
 //     simulation. The default values are: nodes=3 stores_per_node=1.

--- a/pkg/kv/kvserver/asim/tests/testdata/example_liveness
+++ b/pkg/kv/kvserver/asim/tests/testdata/example_liveness
@@ -20,11 +20,7 @@ set_liveness node=6 liveness=decommissioning delay=3m
 ----
 
 # The number of replicas on the dead store should be 0, assert this.
-assertion type=stat stat=replicas ticks=6 threshold=0 store=7
-----
-
-# The number of replicas on the decommissioning store should be 0, assert this.
-assertion type=stat stat=replicas ticks=6 threshold=0 store=6
+assertion type=stat stat=replicas ticks=6 threshold=0 stores=(6,7)
 ----
 
 eval duration=12m seed=42

--- a/pkg/kv/kvserver/asim/tests/testdata/example_zone_config
+++ b/pkg/kv/kvserver/asim/tests/testdata/example_zone_config
@@ -1,0 +1,78 @@
+# This example configures zone constraints to favor the US_East region. As a
+# result, we are expecting that most replicas will be appropriately rebalanced
+# across stores=(1-12) which are located in the US. Number of replicas assigned
+# to other stores are expected to be approximately zero.
+
+load_cluster config=multi_region
+----
+
+# Create 200 ranges (RF=3) with zone preference set to US_East.
+set_span_config delay=1m
+[0,10000): num_replicas=3 constraints={'+region=US_East'}
+----
+
+assertion type=conformance under=0 violating=0
+----
+
+gen_ranges ranges=200
+----
+
+# Stores=(13-25) should have number of replicas close to zero.
+assertion type=stat stat=replicas ticks=5 threshold=0 stores=(13,14,15,16,17,18,20,21,22,24,26,27,28,29,30)
+----
+
+assertion type=stat stat=replicas ticks=5 threshold=1 stores=(23)
+----
+
+eval duration=10m samples=1 seed=42
+----
+OK
+
+
+topology
+----
+EU
+  EU_1
+  │ └── [25 26 27 28]
+  EU_2
+  │ └── [29 30 31 32]
+  EU_3
+  │ └── [33 34 35 36]
+US_East
+  US_East_1
+  │ └── [1 2 3 4]
+  US_East_2
+  │ └── [5 6 7 8]
+  US_East_3
+  │ └── [9 10 11 12]
+US_West
+  US_West_1
+    └── [13 14 15 16]
+  US_West_2
+    └── [17 18 19 20]
+  US_West_3
+    └── [21 22 23 24]
+
+plot stat=replicas
+----
+----
+
+ 51.00 ┤                ╭─────╭────────────────────────────────────────────────────────
+ 47.60 ┤           ╭╭╭────────╯────────────────────────────────────────────────────────
+ 44.20 ┤           ╭╮│─╯
+ 40.80 ┤          ╭│╰╯
+ 37.40 ┤          ╭╯╯
+ 34.00 ┤         ╭│╯
+ 30.60 ┤        ╭╭╯
+ 27.20 ┤        ╭│╯
+ 23.80 ┤        ╭╯
+ 20.40 ┤        │╯
+ 17.00 ┼────────╮╮╮
+ 13.60 ┤       ╰╰╮─╮╮
+ 10.20 ┤        ╰╰─╮╮
+  6.80 ┤        ╰╰╮╰╮──╮╮
+  3.40 ┤         ╰╰─╰────────╮╮
+  0.00 ┤          ╰╰╰──╰╰╰───╰─────────────────────────────────────────────────────────
+                                            replicas
+----
+----


### PR DESCRIPTION
This patch adds a new test case for the allocator simulator. This test focuses
on testing zone configs by 1. Setting zone configs for specific ranges. 2.
Asserts that replica placements adhere to the defined zone configurations.

Epic: None

Release Note: None