### PR TITLE
auditloggingccl: fix TestRoleBasedAuditEnterpriseGated

### DIFF
--- a/pkg/ccl/auditloggingccl/audit_logging_test.go
+++ b/pkg/ccl/auditloggingccl/audit_logging_test.go
@@ -95,7 +95,7 @@ func TestRoleBasedAuditEnterpriseGated(t *testing.T) {
 		0,
 		math.MaxInt64,
 		10000,
-		regexp.MustCompile(`"EventType":"role_based_audit_event"`),
+		regexp.MustCompile(`"Statement":"SHOW CLUSTER SETTING \\"sql.log.user_audit\\""`),
 		log.WithMarkedSensitiveData,
 	)
 


### PR DESCRIPTION
Resolves: #105749

Prior to this change, this test could flake when stressed due to unrelated running queries (i.e. outside of this test)  getting caught in the audit logs.  This change makes the regexp log filter more specific to ensure that the number of expected logs for a particular statement is as expected.

Release note: None