### PR TITLE
persistedsqlstats: skip TestSQLStatsPersistedLimitReached under stress

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -459,7 +459,7 @@ func TestSQLStatsGatewayNodeSetting(t *testing.T) {
 }
 
 func TestSQLStatsPersistedLimitReached(t *testing.T) {
-	skip.WithIssue(t, 97488)
+	skip.UnderStressWithIssue(t, 97488)
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 


### PR DESCRIPTION
TestSQLStatsPersistedLimitReached succeeds under 'normal' testing conditions. We can and should get this test coverage when we can.

Informs #97488
Epic: none
Release note: None