### PR TITLE
 sql: increase time buffer for TestCaptureIndexUsageStats

### DIFF
--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -80,7 +80,7 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	stubLoggingDelay := 0 * time.Second
 
 	// timeBuffer is a short time buffer to account for non-determinism in the logging timings.
-	const timeBuffer = 3 * time.Second
+	const timeBuffer = 4 * time.Second
 
 	settings := cluster.MakeTestingClusterSettings()
 	// Configure capture index usage statistics to be disabled. This is to test


### PR DESCRIPTION
Note to reviewers: this builds on top of #105755, please only consider the second commit.

Previously, the `pkg/sql/scheduleslogging/TestCaptureIndexUsageStats`
test failed on CI, despire passing locally. This commit increases the
time buffer from 3s to 4s to give a larger tolerance for
non-determinism.

Fixes https://github.com/cockroachdb/cockroach/issues/102980
Release note: None