### PR TITLE
release-22.2: logictestccl: Fix regional_by_row_query_behavior flake

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs !metamorphic
+# LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 
 # Set the closed timestamp interval to be short to shorten the amount of time
 # we need to wait for the system config to propagate.

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -178,70 +178,83 @@ SET enforce_home_region = true
 ### Regression tests for issue #89875
 
 # Non-DML statements should not error out due to enforce_home_region.
-query T
+query T retry
 SELECT table_name FROM [SHOW CREATE messages_global]
 ----
 messages_global
 
 # Non-DML SHOW RANGES statement on RBR table should succeed.
-query I
+query I retry
 SELECT DISTINCT range_id FROM [SHOW RANGES FROM TABLE messages_rbr]
 ----
 52
 
 # Update does not fail when accessing all rows in messages_rbr because lookup
 # join does not error out the lookup table in phase 1.
+retry
 statement ok
 UPDATE messages_rbt SET account_id = -account_id WHERE account_id NOT IN (SELECT account_id FROM messages_rbr)
 
 # Update should fail accessing all rows in messages_rbr.
+retry
 statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
 UPDATE messages_rbt SET account_id = -account_id WHERE message_id NOT IN (SELECT message_id FROM messages_rbr)
 
 # Update should fail accessing all rows in messages_rbr.
+retry
 statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
 UPDATE messages_rbr SET account_id = -account_id WHERE account_id NOT IN (SELECT account_id FROM messages_rbt)
 
 # Delete does not fail when accessing all rows in messages_rbr because lookup
 # join does not error out the lookup table in phase 1.
+retry
 statement ok
 DELETE FROM messages_rbt WHERE account_id NOT IN (SELECT account_id FROM messages_rbr)
 
 # Delete should fail accessing all rows in messages_rbr.
 # join does not error out the lookup table in phase 1.
+retry
 statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
 DELETE FROM messages_rbt WHERE message_id NOT IN (SELECT message_id FROM messages_rbr)
 
 # Delete of potentially all rows in messages_rbr should fail.
+retry
 statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
 DELETE FROM messages_rbr WHERE account_id NOT IN (SELECT account_id FROM messages_rbt)
 
 # Delete accessing all regions should fail.
+retry
 statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
 DELETE FROM messages_rbr WHERE message = 'Hello World!'
 
 # Insert should fail accessing all rows in messages_rbr.
+retry
 statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
 INSERT INTO messages_rbt SELECT * FROM messages_rbr
 
 # Insert into an RBR table should succeed. New rows are placed in the gateway region.
+retry
 statement ok
 INSERT INTO messages_rbr SELECT * FROM messages_rbt
 
 # Upsert into an RBR table should succeed.
+retry
 statement ok
 UPSERT INTO messages_rbr SELECT * FROM messages_rbt
 
 # Upsert should fail accessing all rows in messages_rbr.
+retry
 statement error pq: Query has no home region\. Try adding a LIMIT clause\.
 UPSERT INTO messages_rbt SELECT * FROM messages_rbr
 
 # Upsert into an RBR table uses locality-optimized lookup join and should
 # succeed.
+retry
 statement ok
 UPSERT INTO messages_rbr SELECT * FROM messages_rbt
 
 # UNION ALL where one branch scans all rows of an RBR table should fail.
+retry
 statement error pq: Query has no home region\. Try adding a LIMIT clause\.
 SELECT * FROM messages_rbr UNION ALL SELECT * FROM messages_rbt
 
@@ -254,6 +267,7 @@ SELECT * FROM (SELECT * FROM messages_rbr LIMIT 1) UNION ALL SELECT * FROM messa
 
 # A join relation with no home region as the left input of lookup join should
 # not be allowed.
+retry
 statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region and/or on key column \(rbr\.account_id\)\.
 SELECT * FROM messages_rbr rbr INNER LOOKUP JOIN messages_global g2 ON rbr.account_id = g2.account_id
   INNER LOOKUP JOIN messages_global g3 ON g2.account_id = g3.account_id
@@ -264,12 +278,14 @@ SELECT c_id FROM child, (SELECT * FROM [VALUES (1)]) v WHERE crdb_region = 'ap-s
 ----
 
 # Joins which may access all regions should error out in phase 1.
+retry
 statement error pq: Query has no home region\. Try adding a filter on p\.crdb_region and/or on key column \(p\.p_id\)\. Try adding a filter on c\.crdb_region and/or on key column \(c\.c_p_id\)\.
 SELECT * FROM parent p, child c WHERE p_id = c_p_id AND
 p.crdb_region = c.crdb_region LIMIT 1
 
 # Locality optimized join is not allowed if the input is a full scan of an RBR
 # table.
+retry
 statement error pq: Query has no home region. Try adding a filter on c\.crdb_region and/or on key column \(c\.c_id\)\.
 SELECT * FROM parent p, child c WHERE p_id = c_p_id LIMIT 1
 
@@ -343,6 +359,7 @@ statement ok
 SET locality_optimized_partitioned_index_scan = false
 
 # This query should error out because it is not locality optimized.
+retry
 statement error pq: Query has no home region\. Try adding a filter on parent\.crdb_region and/or on key column \(parent\.p_id\)\. Try adding a filter on child\.crdb_region and/or on key column \(child\.c_id\)\.
 SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10
 
@@ -367,12 +384,14 @@ locality-optimized-search
 
 # Locality optimized search with lookup join will be supported in phase 2 or 3
 # when we can dynamically determine if the lookup will access a remote region.
+retry
 statement error pq: Query has no home region\. Try adding a filter on o\.crdb_region and/or on key column \(o\.cust_id\)\.
 SELECT * FROM customers c JOIN orders o ON c.id = o.cust_id AND
   (c.crdb_region = o.crdb_region) WHERE c.id = '69a1c2c2-5b18-459e-94d2-079dc53a4dd0'
 
 # A join relation with no home region as the left input of lookup join should
 # not be allowed.
+retry
 statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region and/or on key column \(rbr\.account_id\)\.
 SELECT * FROM messages_rbr rbr INNER LOOKUP JOIN messages_global g2 ON rbr.account_id = g2.account_id
   INNER LOOKUP JOIN messages_global g3 ON g2.account_id = g3.account_id
@@ -486,12 +505,14 @@ inner-join (lookup messages_global [as=g3])
 
 # A join relation with no home region as the left input of lookup join should
 # not be allowed.
+retry
 statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region and/or on key column \(rbr\.account_id\)\.
 SELECT * FROM messages_rbr rbr INNER LOOKUP JOIN messages_global g2 ON rbr.account_id = g2.account_id
   INNER LOOKUP JOIN messages_global g3 ON g2.account_id = g3.account_id
 
 # The explicit REGIONAL BY ROW AS column name should be used in the error
 # message if it differs from the default crdb_region.
+retry
 statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region_alt and/or on key column \(rbr\.account_id\)\.
 SELECT * FROM messages_rbr_alt rbr INNER LOOKUP JOIN messages_global g2 ON rbr.account_id = g2.account_id
   INNER LOOKUP JOIN messages_global g3 ON g2.account_id = g3.account_id
@@ -530,10 +551,12 @@ ALTER TABLE messages_rbt SET LOCALITY REGIONAL BY TABLE IN "us-east-1";
 
 # Regression test for issue #88788
 # A full scan on an RBT table should error out lookup join.
+retry
 statement error pq: Query has no home region\. The home region \('us-east-1'\) of table 'messages_rbt' does not match the home region \('ap-southeast-2'\) of lookup table 'messages_rbr'\.
 SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 1
 
 # Select from REGIONAL BY TABLE should indicate the gateway region to use.
+retry
 statement error pq: Query is not running in its home region. Try running the query from region 'us-east-1'.
 SELECT message from messages_rbt@messages_rbt_pkey
 
@@ -545,6 +568,7 @@ USE multi_region_test_db;
 SELECT message from messages_rbr@msg_idx WHERE crdb_region = 'ca-central-1'
 ----
 
+retry
 query T nodeidx=4
 SET enforce_home_region = true;
 USE multi_region_test_db;
@@ -556,11 +580,13 @@ project
       └── flags: force-index=msg_idx
 
 # Lookup join should detect REGIONAL BY TABLE in the wrong region.
+retry
 statement error pq: Query has no home region\. The home region \('us-east-1'\) of table 'messages_rbt' does not match the home region \('ap-southeast-2'\) of lookup table 'messages_rbr'\.
 SELECT * FROM  messages_rbt rbt inner lookup join messages_rbr rbr ON rbr.account_id = rbt.account_id
 AND rbr.crdb_region = 'ap-southeast-2'
 
 # Lookup join should detect REGIONAL BY TABLE in the wrong region.
+retry
 statement error pq: Query has no home region\. The home region \('ap-southeast-2'\) of table 'messages_rbr' does not match the home region \('us-east-1'\) of lookup table 'messages_rbt'\.
 SELECT * FROM messages_rbr rbr inner lookup join messages_rbt rbt ON rbr.account_id = rbt.account_id
 AND rbr.crdb_region = 'ap-southeast-2'
@@ -612,20 +638,24 @@ statement ok
 SET enforce_home_region = true
 
 # Tables in non-multiregion databases have no home region.
+retry
 statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability.
 SELECT * FROM messages
 
 # If any table in a query has no home region, error out.
+retry
 statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability.
 SELECT * FROM non_multiregion_test_db.messages, multi_region_test_db.messages_global
 
 # Scans from tables in non-multiregion databases with contradictions in
 # predicates are not allowed.
+retry
 statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability.
 SELECT * FROM messages WHERE account_id = 1 AND account_id = 2
 
 # A lookup join from a multiregion table to non-multiregion table is not
 # allowed.
+retry
 statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability.
 SELECT * FROM multi_region_test_db.messages_global mr INNER LOOKUP JOIN non_multiregion_test_db.messages nmr
   ON mr.account_id = nmr.account_id
@@ -637,24 +667,31 @@ statement ok
 USE multi_region_test_db
 
 # Statements which previously succeeded should now fail under REGION survivability.
+retry
 statement error pq: The enforce_home_region setting cannot be combined with REGION survivability. Try accessing only tables in multi-region databases with ZONE survivability.
 SELECT * FROM parent p, child c WHERE c_id = 10 AND p_id = c_p_id
 
+retry
 statement error pq: The enforce_home_region setting cannot be combined with REGION survivability. Try accessing only tables in multi-region databases with ZONE survivability.
 SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10
 
+retry
 statement error pq: The enforce_home_region setting cannot be combined with REGION survivability. Try accessing only tables in multi-region databases with ZONE survivability.
 SELECT * FROM parent LIMIT 1
 
+retry
 statement error pq: The enforce_home_region setting cannot be combined with REGION survivability. Try accessing only tables in multi-region databases with ZONE survivability.
 SELECT * FROM messages_global@messages_global_pkey
 
+retry
 statement error pq: The enforce_home_region setting cannot be combined with REGION survivability. Try accessing only tables in multi-region databases with ZONE survivability.
 SELECT message from messages_rbt@messages_rbt_pkey
 
+retry
 statement error pq: The enforce_home_region setting cannot be combined with REGION survivability. Try accessing only tables in multi-region databases with ZONE survivability.
 SELECT message from messages_rbr@msg_idx WHERE crdb_region = 'ap-southeast-2'
 
+retry
 statement error pq: The enforce_home_region setting cannot be combined with REGION survivability. Try accessing only tables in multi-region databases with ZONE survivability.
 EXECUTE s('ap-southeast-2')
 
@@ -689,6 +726,7 @@ project
            └── t1.j @> t2.j
 
 # Inverted join doing lookup into a REGIONAL BY ROW table is not allowed.
+retry
 statement error pq: Query has no home region\. Try adding a filter on t1\.crdb_region and/or on key column \(t1\.j_inverted_key\)\.
 SELECT t1.k FROM json_arr2_rbt AS t2 INNER INVERTED JOIN json_arr1_rbr AS t1 ON t1.j @> t2.j
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -1,4 +1,4 @@
-# LogicTest: 5node !metamorphic
+# LogicTest: 5node !metamorphic-batch-sizes
 
 statement ok
 SET experimental_enable_implicit_column_partitioning = true;

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -34,7 +34,7 @@ CREATE TABLE t_child_partitioned (
    PARTITION us_east VALUES IN (('new york'))
 );
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_child VALUES (123, 321);
 ----
 distribution: local
@@ -86,7 +86,7 @@ vectorized: true
                               estimated row count: 1
                               label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_child_partitioned VALUES (123, 321, 'seattle');
 ----
 distribution: local
@@ -178,7 +178,7 @@ CREATE TABLE t_gen_random_uuid (
    PARTITION us_east VALUES IN (('new york'))
 );
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val, part) VALUES (4321, 'seattle');
 ----
 distribution: local
@@ -213,7 +213,7 @@ vectorized: true
               row 0, expr 1: '4321'
               row 0, expr 2: gen_random_uuid()
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val, part) VALUES (4321, 'seattle') ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -266,7 +266,7 @@ vectorized: true
                           row 0, expr 1: '4321'
                           row 0, expr 2: gen_random_uuid()
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -338,7 +338,7 @@ CREATE TABLE t_unique_hash_pk (
   PARTITION us_east VALUES IN (('new york'))
 );
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle');
 ----
 distribution: local
@@ -403,7 +403,7 @@ vectorized: true
                                   table: t_unique_hash_pk@t_unique_hash_pk_pkey
                                   spans: /"new york"/9/4321/0
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -442,7 +442,7 @@ vectorized: true
               spans: /"new york"/9/4321/0 /"seattle"/9/4321/0
               parallel
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -488,7 +488,7 @@ vectorized: true
                       row 1, expr 0: 8765
                       row 1, expr 1: 'new york'
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT (id) DO NOTHING;
 ----
 distribution: local
@@ -527,7 +527,7 @@ vectorized: true
               spans: /"new york"/9/4321/0 /"seattle"/9/4321/0
               parallel
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT (id) DO NOTHING;
 ----
 distribution: local
@@ -573,7 +573,7 @@ vectorized: true
                       row 1, expr 0: 8765
                       row 1, expr 1: 'new york'
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT (id) DO UPDATE SET id = excluded.id
 ----
 distribution: local
@@ -669,7 +669,7 @@ vectorized: true
                                   estimated row count: 1 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT (id) DO UPDATE SET id = excluded.id
 ----
 distribution: local
@@ -772,7 +772,7 @@ vectorized: true
                                   estimated row count: 2 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle');
 ----
 distribution: local
@@ -818,7 +818,7 @@ vectorized: true
                   parallel
                   locking strength: for update
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york');
 ----
 distribution: local
@@ -871,7 +871,7 @@ vectorized: true
                           row 1, expr 0: 8765
                           row 1, expr 1: 'new york'
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_pk SET id = 1234 WHERE id = 4321;
 ----
 distribution: local
@@ -956,7 +956,7 @@ CREATE TABLE t_unique_hash_sec_key (
 statement ok
 CREATE UNIQUE INDEX idx_uniq_hash_email ON t_unique_hash_sec_key (email) USING HASH;
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle');
 ----
 distribution: local
@@ -1052,7 +1052,7 @@ vectorized: true
                                   table: t_unique_hash_sec_key@idx_uniq_hash_email
                                   spans: /"new york"/13/"some_email"/0
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle') ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -1114,7 +1114,7 @@ vectorized: true
                               spans: /"new york"/4321/0 /"seattle"/4321/0
                               parallel
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -1178,7 +1178,7 @@ vectorized: true
                               row 1, expr 1: 'another_email'
                               row 1, expr 2: 'new york'
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle') ON CONFLICT (email) DO NOTHING;
 ----
 distribution: local
@@ -1248,7 +1248,7 @@ vectorized: true
                       spans: /"new york"/4321/0
                       limit: 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT (email) DO NOTHING;
 ----
 distribution: local
@@ -1327,7 +1327,7 @@ vectorized: true
                           estimated row count: 0 (missing stats)
                           label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
 ----
 distribution: local
@@ -1463,7 +1463,7 @@ vectorized: true
                                   estimated row count: 1 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
 ----
 distribution: local
@@ -1616,7 +1616,7 @@ vectorized: true
                                   estimated row count: 2 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1', 'seattle');
 ----
 distribution: local
@@ -1711,7 +1711,7 @@ vectorized: true
                                   estimated row count: 1 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1', 'seattle'), (8765, 'email2', 'new york');
 ----
 distribution: local
@@ -1816,7 +1816,7 @@ vectorized: true
                                   estimated row count: 2 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_sec_key SET email = 'email1' WHERE id = 2;
 ----
 distribution: local

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs !metamorphic
+# LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -95,7 +95,7 @@ vectorized: true
                                   estimated row count: 1
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_child_regional VALUES (123, 321)
 ----
 distribution: local
@@ -190,7 +190,7 @@ CREATE TABLE t_gen_random_uuid (
   FAMILY fam_0 (user_id, val)
 ) LOCALITY REGIONAL BY ROW;
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val) VALUES (4321);
 ----
 distribution: local
@@ -225,7 +225,7 @@ vectorized: true
               row 0, expr 1: gen_random_uuid()
               row 0, expr 2: 'ap-southeast-2'
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val) VALUES (4321) ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -285,7 +285,7 @@ vectorized: true
                               row 0, expr 1: gen_random_uuid()
                               row 0, expr 2: 'ap-southeast-2'
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val) VALUES (4321), (8765) ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -357,7 +357,7 @@ CREATE TABLE t_unique_hash_pk (
   id INT PRIMARY KEY USING HASH
 ) LOCALITY REGIONAL BY ROW;
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321);
 ----
 distribution: local
@@ -423,7 +423,7 @@ vectorized: true
                                   table: t_unique_hash_pk@t_unique_hash_pk_pkey
                                   spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -473,7 +473,7 @@ vectorized: true
                   spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
                   parallel
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765) ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -524,7 +524,7 @@ vectorized: true
                           row 0, expr 0: 4321
                           row 1, expr 0: 8765
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT (id) DO NOTHING;
 ----
 distribution: local
@@ -574,7 +574,7 @@ vectorized: true
                   spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
                   parallel
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765) ON CONFLICT (id) DO NOTHING;
 ----
 distribution: local
@@ -625,7 +625,7 @@ vectorized: true
                           row 0, expr 0: 4321
                           row 1, expr 0: 8765
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT (id) DO UPDATE SET id = excluded.id
 ----
 distribution: local
@@ -731,7 +731,7 @@ vectorized: true
                                   estimated row count: 1 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765) ON CONFLICT (id) DO UPDATE SET id = excluded.id
 ----
 distribution: local
@@ -833,7 +833,7 @@ vectorized: true
                                   estimated row count: 2 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id) VALUES (4321);
 ----
 distribution: local
@@ -884,7 +884,7 @@ vectorized: true
                   spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
                   parallel
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765);
 ----
 distribution: local
@@ -931,7 +931,7 @@ vectorized: true
                       row 0, expr 0: 4321
                       row 1, expr 0: 8765
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_pk SET id = 1234 WHERE id = 4321;
 ----
 distribution: local
@@ -1022,7 +1022,7 @@ CREATE TABLE t_unique_hash_sec_key (
 statement ok
 CREATE UNIQUE INDEX idx_uniq_hash_email ON t_unique_hash_sec_key (email) USING HASH;
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email');
 ----
 distribution: local
@@ -1129,7 +1129,7 @@ vectorized: true
                                   table: t_unique_hash_sec_key@idx_uniq_hash_email
                                   spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -1202,7 +1202,7 @@ vectorized: true
                                   spans: /"\x80"/4321/0 /"\xc0"/4321/0
                                   parallel
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT DO NOTHING;
 ----
 distribution: local
@@ -1271,7 +1271,7 @@ vectorized: true
                                   row 1, expr 0: 8765
                                   row 1, expr 1: 'another_email'
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT (email) DO NOTHING;
 ----
 distribution: local
@@ -1352,7 +1352,7 @@ vectorized: true
                       spans: /"\x80"/4321/0 /"\xc0"/4321/0
                       limit: 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT (email) DO NOTHING;
 ----
 distribution: local
@@ -1436,7 +1436,7 @@ vectorized: true
                           estimated row count: 0 (missing stats)
                           label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
 ----
 distribution: local
@@ -1583,7 +1583,7 @@ vectorized: true
                                   estimated row count: 1 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
 ----
 distribution: local
@@ -1735,7 +1735,7 @@ vectorized: true
                                   estimated row count: 2 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1');
 ----
 distribution: local
@@ -1841,7 +1841,7 @@ vectorized: true
                                   estimated row count: 1 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1'), (8765, 'email2');
 ----
 distribution: local
@@ -1945,7 +1945,7 @@ vectorized: true
                                   estimated row count: 2 (missing stats)
                                   label: buffer 1
 
-query T
+query T retry
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_sec_key SET email = 'email1' WHERE id = 2;
 ----
 distribution: local

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs !metamorphic
+# LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant and/or revert
 # the commit that split these changes out.
 
@@ -290,7 +290,7 @@ pk  pk2  a   b   j
 
 
 # Test that a limited, ordered scan is efficient.
-query T
+query T retry
 SELECT * FROM [EXPLAIN (VERBOSE) SELECT * FROM regional_by_row_table
 ORDER BY pk LIMIT 5] OFFSET 2
 ----
@@ -335,7 +335,7 @@ ORDER BY pk LIMIT 5] OFFSET 2
 
 # Test that the synthesized UNIQUE WITHOUT INDEX constraints do not cause
 # lookups into redundant arbiters.
-query T
+query T retry
 SELECT * FROM [
   EXPLAIN INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b)
   VALUES ('ca-central-1', 7, 7, 8, 9) ON CONFLICT DO NOTHING
@@ -455,7 +455,7 @@ SET locality_optimized_partitioned_index_scan = true
 statement ok
 SET vectorize=on
 
-query T
+query T retry
 SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 2
 ----
 ·
@@ -490,7 +490,7 @@ EXPLAIN (VEC) SELECT * FROM regional_by_row_table WHERE pk = 1
 statement ok
 SET vectorize=off
 
-query T
+query T retry
 SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM regional_by_row_table WHERE pk = 1] AS temp(a) WHERE a LIKE '%Diagram%'
 ----
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy8keFr1EAQxb_7VwwDpa2sJBu_SEBoaSMG47VeDhR64di7Hc71kt11d4MtR_53uUQ4IxdBBT_Oe_Mm75fdo_9aY4plVmQ3C3gOb-Z37-Eh-3RfXOczuLjNy0X5obiE8YKjrTJa1Kv108qZb6sg1jXBx7fZPAO7g9fAK7guIVBj4UJc_nAEFPm7DM7PbpXYOtGcnSNDbSTNREMe0wfkWDG0zmzIe-MO0r5fyOUjpjFDpW0bDnLFcGMcYbrHoEJNmOLi0GFOQpKLYmQoKQhV92dP1r06qa7sjp6Q4Y2p20b7FOyOgd0lDASDNYMvyLC04uBES1wuH1_FS4x4FIPQEjiY8JkcVh1D04ZjWR_EljDlHfs7IP6fgK4GmEmAZBLg2NuTU6KGVhsnyZEcVa-6E6Qz88LYKBkzFqpRAfhklfhP_uWcvDXa0y9dpi5XDEluaeDypnUbundm039mGO_6XC9I8mFwk2HIdW_1j_1zmP9LOPlt-OUoHHdV9-x7AAAA__-eCkLr
@@ -556,7 +556,7 @@ RESET vectorize
 
 # The local region for this query is ca-central-1, so that span should be
 # scanned in the first child of the limited union all.
-query T nodeidx=3
+query T nodeidx=3 retry
 USE multi_region_test_db; SET locality_optimized_partitioned_index_scan = true;
 SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 2
 ----
@@ -576,7 +576,7 @@ SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 
 
 
 # Query with more than one key.
-query T
+query T retry
 SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table WHERE pk IN (1, 4)] OFFSET 2
 ----
 ·
@@ -777,7 +777,7 @@ statement ok
 SET locality_optimized_partitioned_index_scan = true
 
 # Anti join with locality optimized search enabled.
-query T
+query T retry
 SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 2
 ----
 ·
@@ -858,7 +858,7 @@ Scan /Table/111/1/"\x80"/20/0, /Table/111/1/"\xc0"/20/0
 fetched: /parent/parent_pkey/'ca-central-1'/20 -> <undecoded>
 
 # Semi join with locality optimized search enabled.
-query T
+query T retry
 SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 2
 ----
 ·
@@ -936,7 +936,7 @@ fetched: /parent/parent_pkey/'ca-central-1'/20 -> <undecoded>
 output row: [20 20]
 
 # Inner join with locality optimized search enabled.
-query T
+query T retry
 SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child INNER JOIN parent ON p_id = c_p_id WHERE c_id = 10] OFFSET 2
 ----
 ·
@@ -1014,7 +1014,7 @@ fetched: /parent/parent_pkey/'ca-central-1'/20 -> <undecoded>
 output row: [20 20 20]
 
 # Left join with locality optimized search enabled.
-query T
+query T retry
 SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child LEFT JOIN parent ON p_id = c_p_id WHERE c_id = 10] OFFSET 2
 ----
 ·
@@ -1091,7 +1091,7 @@ Scan /Table/111/1/"\x80"/20/0, /Table/111/1/"\xc0"/20/0
 fetched: /parent/parent_pkey/'ca-central-1'/20 -> <undecoded>
 output row: [20 20 20]
 
-query T
+query T retry
 SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
 ----
 ·
@@ -1141,7 +1141,7 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
 
 # Non-constant insert values cannot be inlined in uniqueness check, and all
 # regions must be searched for duplicates.
-query T
+query T retry
 SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 2
 ----
 ·
@@ -1189,7 +1189,7 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 2
                       estimated row count: 2
                       label: buffer 1
 
-query T
+query T retry
 SELECT * FROM [EXPLAIN UPSERT INTO child VALUES (1, 1)] OFFSET 2
 ----
 ·
@@ -1311,7 +1311,7 @@ ALTER TABLE t56201 INJECT STATISTICS '[
 statement ok
 ALTER TABLE t56201 ADD CONSTRAINT key_a_b UNIQUE (a, b);
 
-query T
+query T retry
 SELECT * FROM [EXPLAIN (VERBOSE) SELECT a, b
 FROM t56201
 WHERE a IS NOT NULL AND b IS NOT NULL
@@ -1391,7 +1391,7 @@ LIMIT 1] OFFSET 2
 statement ok
 CREATE UNIQUE INDEX key_b_partial ON t56201 (b) WHERE a > 0;
 
-query T
+query T retry
 SELECT * FROM [EXPLAIN (VERBOSE) SELECT b
 FROM t56201@key_b_partial
 WHERE b IS NOT NULL AND a > 0
@@ -1457,7 +1457,7 @@ LIMIT 1] OFFSET 2
 statement ok
 CREATE UNIQUE INDEX key_c_partial ON t56201 (c) WHERE a = 1;
 
-query T
+query T retry
 SELECT * FROM [EXPLAIN (VERBOSE) SELECT c
 FROM t56201
 WHERE c IS NOT NULL AND a = 1
@@ -1521,7 +1521,7 @@ ALTER TABLE regional_by_row_table ADD CONSTRAINT unique_b_a UNIQUE(b, a)
 
 # We should plan uniqueness checks for all unique indexes in
 # REGIONAL BY ROW tables.
-query T
+query T retry
 SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1, 1, 1, 1)] OFFSET 2
 ----
 ·
@@ -1639,7 +1639,7 @@ INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-
 # TODO(treilly): The constraint check for uniq_idx should use uniq_idx but due
 # to stats issues w/ empty stats, partial indexes and multicol stats its not.
 # Hopefully fixing #67583 (and possibly #67479) will resolve this.
-query T
+query T retry
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 2, 3, 2, 3)] OFFSET 2
 ----
 ·
@@ -1714,7 +1714,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, 
 # TODO(treilly): The constraint check for uniq_idx should use uniq_idx but due
 # to stats issues w/ empty stats, partial indexes and multicol stats its not.
 # Hopefully fixing #67583 (and possibly #67479) will resolve this.
-query T
+query T retry
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b)
 VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)] OFFSET 2
 ----
@@ -1888,7 +1888,7 @@ pk  a     b     crdb_region_col
 
 # We do not need uniqueness checks on pk since uniqueness can be inferred
 # through the functional dependency between pk and the computed region column.
-query T
+query T retry
 SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
 ----
 ·
@@ -1961,7 +1961,7 @@ CREATE TABLE regional_by_row_table_virt (
 ) LOCALITY REGIONAL BY ROW
 
 # Uniqueness checks for virtual columns should be efficient.
-query T
+query T retry
 SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
 ----
 ·
@@ -2034,7 +2034,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
                                   table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
                                   spans: [/'ap-southeast-2'/11 - /'ap-southeast-2'/11] [/'ca-central-1'/11 - /'ca-central-1'/11] [/'us-east-1'/11 - /'us-east-1'/11]
 
-query T
+query T retry
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
 ----
 ·
@@ -2123,7 +2123,7 @@ CREATE TABLE regional_by_row_table_virt_partial (
 ) LOCALITY REGIONAL BY ROW
 
 # Uniqueness checks for virtual columns should be efficient.
-query T
+query T retry
 SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
 ----
 ·
@@ -2212,7 +2212,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
                           table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
                           spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
 
-query T
+query T retry
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
 ----
 ·
@@ -2399,7 +2399,7 @@ statement ok
 SET database = multi_region_test_db
 
 # LIMIT clause enables locality optimized scan on a REGIONAL BY ROW table
-query T
+query T retry
 SELECT * FROM [
 EXPLAIN SELECT
     pk, pk2, a, b, crdb_region
@@ -2460,7 +2460,37 @@ FROM
 statement ok
 SET vectorize = "on"
 
-statement ok nodeidx=0
+query T retry
+EXPLAIN(OPT) SELECT
+    count(*)
+FROM
+    (
+        SELECT
+            *
+        FROM
+            regional_by_row_table_as4@a_idx
+        WHERE
+            a BETWEEN 1 AND 100
+        LIMIT
+            10
+    )
+----
+scalar-group-by
+ ├── locality-optimized-search
+ │    ├── scan regional_by_row_table_as4@a_idx
+ │    │    ├── constraint: /10/9/8: [/'ap-southeast-2'/1 - /'ap-southeast-2'/100]
+ │    │    ├── limit: 10
+ │    │    └── flags: force-index=a_idx
+ │    └── scan regional_by_row_table_as4@a_idx
+ │         ├── constraint: /15/14/13
+ │         │    ├── [/'ca-central-1'/1 - /'ca-central-1'/100]
+ │         │    └── [/'us-east-1'/1 - /'us-east-1'/100]
+ │         ├── limit: 10
+ │         └── flags: force-index=a_idx
+ └── aggregations
+      └── count-rows
+
+statement ok
 SET database = multi_region_test_db;
 SET TRACING = "on", kv, results;
 SELECT
@@ -2552,7 +2582,7 @@ statement ok
 SET vectorize = "on"
 
 # Locality optimized scan with an IN list
-query T
+query T retry
 SELECT
     *
 FROM
@@ -2705,7 +2735,7 @@ statement ok
 SET vectorize = "on"
 
 # Locality optimized scan with multiple range predicates
-query T
+query T retry
 SELECT
     *
 FROM
@@ -2872,7 +2902,7 @@ statement ok
 INSERT INTO regional_by_row_table_as1 (pk) VALUES (1), (2), (3), (10), (20)
 
 # An extra crdb_region check constraint should still allow locality optimized scan.
-query T
+query T retry
 SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table_as1 LIMIT 3] OFFSET 2
 ----
 ·
@@ -2912,7 +2942,7 @@ CREATE TABLE users (
 ) LOCALITY REGIONAL BY ROW
 
 # Check that we don't recommend indexes that already exist.
-query T
+query T retry
 EXPLAIN INSERT INTO users (name, email)
 VALUES ('Craig Roacher', 'craig@cockroachlabs.com')
 ----
@@ -2981,7 +3011,7 @@ CREATE TABLE user_settings_cascades (
 #   users.id = user_settings.user_id AND users.crdb_region = user_settings.crdb_region
 # This would allow the optimizer to plan a lookup join between users and user_settings
 # and avoid visiting all regions. See #69617.
-query T
+query T retry
 EXPLAIN SELECT users.crdb_region AS user_region, user_settings.crdb_region AS user_settings_region, *
   FROM users JOIN user_settings ON users.id = user_settings.user_id AND users.id = '5ebfedee-0dcf-41e6-a315-5fa0b51b9882';
 ----
@@ -3038,7 +3068,7 @@ vectorized: true
   FK check: users@users_pkey
   size: 5 columns, 1 row
 
-query T
+query T retry
 EXPLAIN DELETE FROM users WHERE id = '5ebfedee-0dcf-41e6-a315-5fa0b51b9882'
 ----
 distribution: local

--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -78,6 +78,9 @@ type Batch interface {
 
 var _ Batch = &MemBatch{}
 
+// DefaultColdataBatchSize is the default value of coldata-batch-size.
+const DefaultColdataBatchSize = 1024
+
 // defaultBatchSize is the size of batches that is used in the non-test setting.
 // Initially, 1024 was picked based on MonetDB/X100 paper and was later
 // confirmed to be very good using tpchvec/bench benchmark on TPC-H queries
@@ -85,7 +88,7 @@ var _ Batch = &MemBatch{}
 // better, so we decided to keep 1024 as it is a power of 2).
 var defaultBatchSize = int64(util.ConstantWithMetamorphicTestRange(
 	"coldata-batch-size",
-	1024, /* defaultValue */
+	DefaultColdataBatchSize, /* defaultValue */
 	// min is set to 3 to match colexec's minBatchSize setting.
 	3, /* min */
 	MaxBatchSize,

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -418,8 +418,8 @@ func (s *SystemConfig) GetZoneConfigForObject(
 // requested. Note, this function is only intended to be called during test
 // execution, such as logic tests.
 func (s *SystemConfig) PurgeZoneConfigCache() {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if len(s.mu.zoneCache) != 0 {
 		s.mu.zoneCache = map[ObjectID]zoneEntry{}
 	}

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -412,6 +412,22 @@ func (s *SystemConfig) GetZoneConfigForObject(
 	return entry.combined, nil
 }
 
+// PurgeZoneConfigCache allocates a new zone config cache in this system config
+// so that tables with stale zone config information could have this info
+// looked up from using the most up-to-date zone config the next time it's
+// requested. Note, this function is only intended to be called during test
+// execution, such as logic tests.
+func (s *SystemConfig) PurgeZoneConfigCache() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.mu.zoneCache) != 0 {
+		s.mu.zoneCache = map[ObjectID]zoneEntry{}
+	}
+	if len(s.mu.shouldSplitCache) != 0 {
+		s.mu.shouldSplitCache = map[ObjectID]bool{}
+	}
+}
+
 // getZoneEntry returns the zone entry for the given system-tenant
 // object ID. In the fast path, the zone is already in the cache, and is
 // directly returned. Otherwise, getZoneEntry will hydrate new

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/base",
         "//pkg/cloud/externalconn/providers",
         "//pkg/clusterversion",
+        "//pkg/col/coldata",
         "//pkg/kv/kvclient/rangefeed",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvserverbase",

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2304,7 +2304,9 @@ func (t *logicTest) purgeZoneConfig() {
 	for i := 0; i < t.cluster.NumServers(); i++ {
 		sysconfigProvider := t.cluster.Server(i).SystemConfigProvider()
 		sysconfig := sysconfigProvider.GetSystemConfig()
-		sysconfig.PurgeZoneConfigCache()
+		if sysconfig != nil {
+			sysconfig.PurgeZoneConfigCache()
+		}
 	}
 }
 

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/externalconn/providers" // imported to register ExternalConnection providers
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -150,9 +151,9 @@ import (
 // A link to the issue will be printed out if the -print-blocklist-issues flag
 // is specified.
 //
-// There is a special directive '!metamorphic' that adjusts the server to force
-// the usage of production values for some constants that might change via the
-// metamorphic testing.
+// There is a special directive '!metamorphic-batch-sizes' that adjusts the
+// server to force the usage of production values related for some constants,
+// mostly related to batch sizes, that might change via metamorphic testing.
 //
 //
 // ###########################################################
@@ -2299,6 +2300,14 @@ func fetchSubtests(path string) ([]subtestDetails, error) {
 	return subtests, nil
 }
 
+func (t *logicTest) purgeZoneConfig() {
+	for i := 0; i < t.cluster.NumServers(); i++ {
+		sysconfigProvider := t.cluster.Server(i).SystemConfigProvider()
+		sysconfig := sysconfigProvider.GetSystemConfig()
+		sysconfig.PurgeZoneConfigCache()
+	}
+}
+
 func (t *logicTest) processSubtest(
 	subtest subtestDetails, path string, config logictestbase.TestClusterConfig, rng *rand.Rand,
 ) error {
@@ -2752,12 +2761,14 @@ func (t *logicTest) processSubtest(
 				for i := 0; i < repeat; i++ {
 					if query.retry && !*rewriteResultsInTestfiles {
 						if err := testutils.SucceedsSoonError(func() error {
+							t.purgeZoneConfig()
 							return t.execQuery(query)
 						}); err != nil {
 							t.Error(err)
 						}
 					} else {
 						if query.retry && *rewriteResultsInTestfiles {
+							t.purgeZoneConfig()
 							// The presence of the retry flag indicates that we expect this
 							// query may need some time to succeed. If we are rewriting, wait
 							// 500ms before executing the query.
@@ -3899,7 +3910,8 @@ func RunLogicTest(
 	}
 
 	// Check whether the test can only be run in non-metamorphic mode.
-	_, onlyNonMetamorphic := logictestbase.ReadTestFileConfigs(t, path, logictestbase.ConfigSet{configIdx})
+	_, nonMetamorphicBatchSizes :=
+		logictestbase.ReadTestFileConfigs(t, path, logictestbase.ConfigSet{configIdx})
 	config := logictestbase.LogicTestConfigs[configIdx]
 
 	// The tests below are likely to run concurrently; `log` is shared
@@ -3951,7 +3963,12 @@ func RunLogicTest(
 	}
 	// Each test needs a copy because of Parallel
 	serverArgsCopy := serverArgs
-	serverArgsCopy.ForceProductionValues = serverArgs.ForceProductionValues || onlyNonMetamorphic
+	serverArgsCopy.ForceProductionValues = serverArgs.ForceProductionValues || nonMetamorphicBatchSizes
+	if serverArgsCopy.ForceProductionValues {
+		if err := coldata.SetBatchSizeForTests(coldata.DefaultColdataBatchSize); err != nil {
+			panic(errors.Wrapf(err, "could not set batch size for test"))
+		}
+	}
 	lt.setup(
 		config, serverArgsCopy, readClusterOptions(t, path), readKnobOptions(t, path), readTenantClusterSettingOverrideArgs(t, path),
 	)

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2301,6 +2301,10 @@ func fetchSubtests(path string) ([]subtestDetails, error) {
 }
 
 func (t *logicTest) purgeZoneConfig() {
+	if t.cluster == nil {
+		// We can only purge zone configs for in-memory test clusters.
+		return
+	}
 	for i := 0; i < t.cluster.NumServers(); i++ {
 		sysconfigProvider := t.cluster.Server(i).SystemConfigProvider()
 		sysconfig := sysconfigProvider.GetSystemConfig()

--- a/pkg/sql/logictest/logictestbase/BUILD.bazel
+++ b/pkg/sql/logictest/logictestbase/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     deps = [
         "//pkg/build",
         "//pkg/roachpb",
-        "//pkg/util",
     ],
 )
 

--- a/pkg/sql/logictest/logictestbase/logictestbase.go
+++ b/pkg/sql/logictest/logictestbase/logictestbase.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 var (
@@ -580,7 +579,7 @@ func (l stdlogger) Logf(format string, args ...interface{}) {
 // If the file doesn't contain a directive, the default config is returned.
 func ReadTestFileConfigs(
 	t logger, path string, defaults ConfigSet,
-) (_ ConfigSet, onlyNonMetamorphic bool) {
+) (_ ConfigSet, nonMetamorphicBatchSizes bool) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, false
@@ -604,8 +603,8 @@ func ReadTestFileConfigs(
 			if len(fields) == 2 {
 				t.Fatalf("%s: empty LogicTest directive", path)
 			}
-			cs, onlyNonMetamorphic := processConfigs(t, path, defaults, fields[2:])
-			return cs, onlyNonMetamorphic
+			cs, nonMetamorphicBatchSizes := processConfigs(t, path, defaults, fields[2:])
+			return cs, nonMetamorphicBatchSizes
 		}
 	}
 	// No directive found, return the default config.
@@ -631,10 +630,11 @@ func getBlocklistIssueNo(blocklistDirective string) (string, int) {
 
 // processConfigs, given a list of configNames, returns the list of
 // corresponding logicTestConfigIdxs as well as a boolean indicating whether
-// the test works only in non-metamorphic setting.
+// metamorphic settings related to batch sizes should be overridden with default
+// production values.
 func processConfigs(
 	t logger, path string, defaults ConfigSet, configNames []string,
-) (_ ConfigSet, onlyNonMetamorphic bool) {
+) (_ ConfigSet, nonMetamorphicBatchSizes bool) {
 	const blocklistChar = '!'
 	// blocklist is a map from a blocked config to a corresponding issue number.
 	// If 0, there is no associated issue.
@@ -662,12 +662,12 @@ func processConfigs(
 		}
 	}
 
-	if _, ok := blocklist["metamorphic"]; ok && util.IsMetamorphicBuild() {
-		onlyNonMetamorphic = true
+	if _, ok := blocklist["metamorphic-batch-sizes"]; ok {
+		nonMetamorphicBatchSizes = true
 	}
 	if len(blocklist) != 0 && allConfigNamesAreBlocklistDirectives {
 		// No configs specified, this blocklist applies to the default configs.
-		return applyBlocklistToConfigs(defaults, blocklist), onlyNonMetamorphic
+		return applyBlocklistToConfigs(defaults, blocklist), nonMetamorphicBatchSizes
 	}
 
 	var configs ConfigSet
@@ -696,7 +696,7 @@ func processConfigs(
 		}
 	}
 
-	return configs, onlyNonMetamorphic
+	return configs, nonMetamorphicBatchSizes
 }
 
 // applyBlocklistToConfigs applies the given blocklist to configs, returning the

--- a/pkg/sql/logictest/testdata/logic_test/create_as_non_metamorphic
+++ b/pkg/sql/logictest/testdata/logic_test/create_as_non_metamorphic
@@ -1,4 +1,4 @@
-# LogicTest: !metamorphic
+# LogicTest: !metamorphic-batch-sizes
 # Disabled to allow us to validate create as with large batch sizes.
 
 # Regression test for #81554, where tried to do gigantic batches for CTAS in

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -1,4 +1,4 @@
-# LogicTest: !metamorphic
+# LogicTest: !metamorphic-batch-sizes
 
 # Disable automatic stats
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join_local
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join_local
@@ -1,4 +1,4 @@
-# LogicTest: local !metamorphic
+# LogicTest: local !metamorphic-batch-sizes
 
 # This test verifies that the row container used by the join reader spills to
 # disk in order to make room for the non-spillable internal state of the

--- a/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
+++ b/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
@@ -1,4 +1,4 @@
-# LogicTest: !metamorphic
+# LogicTest: !metamorphic-batch-sizes
 
 # Regression test for UPSERT batching logic not respecting footprint-based
 # limiting (#102472).

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_env
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_env
@@ -1,4 +1,4 @@
-# LogicTest: local !metamorphic
+# LogicTest: local !metamorphic-batch-sizes
 # We must turn off metamorphic variables because some are included in
 # EXPLAIN (OPT, ENV) output.
 

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -268,7 +268,9 @@ func StartNewTestCluster(
 	for i := 0; i < cluster.NumServers(); i++ {
 		sysconfigProvider := cluster.Server(i).SystemConfigProvider()
 		sysconfig := sysconfigProvider.GetSystemConfig()
-		sysconfig.PurgeZoneConfigCache()
+		if sysconfig != nil {
+			sysconfig.PurgeZoneConfigCache()
+		}
 	}
 	return cluster
 }

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -265,6 +265,11 @@ func StartNewTestCluster(
 ) TestClusterInterface {
 	cluster := NewTestCluster(t, numNodes, args)
 	cluster.Start(t)
+	for i := 0; i < cluster.NumServers(); i++ {
+		sysconfigProvider := cluster.Server(i).SystemConfigProvider()
+		sysconfig := sysconfigProvider.GetSystemConfig()
+		sysconfig.PurgeZoneConfigCache()
+	}
 	return cluster
 }
 


### PR DESCRIPTION
Backport:
  * 1/1 commits from "logictestccl: Fix regional_by_row_query_behavior flake" (#87391)
  * 1/1 commits from "logictest: check for nil SystemConfig before purging zone config cache" (#90802)
  * 1/1 commits from "config: acquire write lock when overwriting the map" (#92606)

Please see individual PRs for details.

/cc @cockroachdb/release

----
logictest: only purge zone configs for in-memory test clusters

This commit backports code needed to fix #104466.

Informs: #104466

Release note: None

----

logictest: retry support for "statement" and "query" commands
This adds a retry command to logic tests which may be issued on a
separate line preceding either a "statement" or "query" command.
It causes the statement to be retried with exponential backoff up
to some maximum duration, e.g.
```
retry
statement error column "non_exist" does not exist
ALTER TABLE created_as_global SET LOCALITY REGIONAL BY ROW AS "non_exist"
```
This has the same effect as the retry option of the query command, but
now also supports "statement ok", "statement error" and "query error"
commands.

Retry of a query command may be specified by the standalone retry
command, the retry option of the query command, or both.

Fixes: https://github.com/cockroachdb/cockroach/issues/95668

Epic: [CRDB-20535](https://cockroachlabs.atlassian.net/browse/CRDB-20535)

Release note: None

----
logictest: retry support for "statement" and "query" commands

This adds a retry command to logic tests which may be issued on a
separate line preceding either a "statement" or "query" command.
It causes the statement to be retried with exponential backoff up
to some maximum duration, e.g.
```
retry
statement error column "non_exist" does not exist
ALTER TABLE created_as_global SET LOCALITY REGIONAL BY ROW AS "non_exist"
```
This has the same effect as the retry option of the query command, but
now also supports "statement ok", "statement error" and "query error"
commands.

Retry of a query command may be specified by the standalone retry
command, the retry option of the query command, or both.

Fixes: #95668

Epic: CRDB-20535

Release note: None

----
logictestccl: add more retries to logic tests

This commit adds more retries to multiregion logic tests.

Fixes #104466

Release note: None

----
Release justification: Fix #104466