### PR TITLE
ci: install Azure CLI

### DIFF
--- a/build/.bazelbuilderversion
+++ b/build/.bazelbuilderversion
@@ -1,1 +1,1 @@
-cockroachdb/bazel:20230616-060512
+cockroachdb/bazel:20230629-030909

--- a/build/.bazelbuilderversion-fips
+++ b/build/.bazelbuilderversion-fips
@@ -1,1 +1,1 @@
-cockroachdb/bazel-fips:20230616-060512
+cockroachdb/bazel-fips:20230629-030909

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -49,6 +49,7 @@ RUN case ${TARGETPLATFORM} in \
 # git - Upgrade to a more modern version
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev -y && \
+    apt-get clean && \
     curl -fsSL https://github.com/git/git/archive/v2.29.2.zip -o "git-2.29.2.zip" && \
     unzip "git-2.29.2.zip" && \
     cd git-2.29.2 && \
@@ -61,9 +62,14 @@ RUN apt-get update && \
 
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
  && echo 'deb https://packages.cloud.google.com/apt cloud-sdk main' | tee /etc/apt/sources.list.d/gcloud.list \
+ && curl -fsLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | apt-key add - \
+ && echo "deb https://packages.microsoft.com/repos/azure-cli/ focal main" > /etc/apt/sources.list.d/azure-cli.list \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    google-cloud-sdk
+    azure-cli \
+    google-cloud-sdk \
+    google-cloud-cli-gke-gcloud-auth-plugin \
+    && apt-get clean
 
 # chrome is needed for UI tests. Unfortunately it is only distributed for x86_64
 # and not for ARM. Chrome shouldn't need to be installed when we migrate away

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20230622-223455
+version=20230629-033334
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -152,8 +152,11 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
  && curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
  && echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google.list \
  && curl https://bazel.build/bazel-release.pub.gpg | apt-key add - \
+ && curl -fsLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | apt-key add - \
+ && echo "deb https://packages.microsoft.com/repos/azure-cli/ focal main" > /etc/apt/sources.list.d/azure-cli.list \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    azure-cli \
     ccache \
     google-cloud-sdk \
     google-cloud-cli-gke-gcloud-auth-plugin \
@@ -165,7 +168,8 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
     openssh-client \
     yarn \
     google-chrome-stable \
-    unzip
+    unzip \
+&& apt-get clean
 
 # awscli - roachtests
 # NB: we don't use apt-get because we need an up to date version of awscli
@@ -178,6 +182,7 @@ RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip"
 
 # git - Upgrade to a more modern version
 RUN DEBIAN_FRONTEND=noninteractive apt-get install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev -y && \
+    apt-get clean && \
     curl -fsSL https://github.com/git/git/archive/v2.29.2.zip -o "git-2.29.2.zip" && \
     unzip "git-2.29.2.zip" && \
     cd git-2.29.2 && \

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -21,16 +21,23 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0EBFCD88
 cat > /etc/apt/sources.list.d/docker.list <<EOF
 deb https://download.docker.com/linux/ubuntu focal stable
 EOF
+
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+echo 'deb https://packages.cloud.google.com/apt cloud-sdk main' > /etc/apt/sources.list.d/gcloud.list
+
+curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | apt-key add -
+echo "deb https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
+
 # Some images come with apt autoupgrade job running at start, let's give it a few minutes to finish to avoid races.
 echo "Sleeping for 3 minutes to allow apt daily cronjob to finish..."
 sleep 3m
-apt-get update --yes
+apt-get update
 
-# Install the sudo version patched for CVE-2021-3156
-apt-get install --yes sudo
-
+# Installing gnome-keyring prevents the error described in
+# https://github.com/moby/moby/issues/34048
 apt-get install --yes \
   autoconf \
+  azure-cli \
   bison \
   build-essential \
   curl \
@@ -38,6 +45,8 @@ apt-get install --yes \
   docker-compose \
   flex \
   gnome-keyring \
+  google-cloud-sdk \
+  google-cloud-cli-gke-gcloud-auth-plugin \
   gnupg2 \
   git \
   jq \
@@ -45,6 +54,7 @@ apt-get install --yes \
   pass \
   python2 \
   python3 \
+  sudo \
   unzip
 
 # Enable support for executing binaries of all architectures via qemu emulation
@@ -91,22 +101,6 @@ $SHASUM /tmp/bazelisk
 EOF
 chmod +x /tmp/bazelisk
 mv /tmp/bazelisk /usr/bin/bazel
-
-# gcloud won't be automatically installed for ARM machines (which run on AWS).
-if [ $ARCH = aarch64 ]; then
-    curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-377.0.0-linux-arm.tar.gz > /tmp/gcloud.tar.gz
-    sha256sum -c - <<EOF
-42dd29714b052d3460b005b3d09faacdb0818e70edd60c20d447a1594fd6aa83 /tmp/gcloud.tar.gz
-EOF
-    tar -C /usr/local -zxf /tmp/gcloud.tar.gz
-    rm /tmp/gcloud.tar.gz
-    /usr/local/google-cloud-sdk/install.sh -q --usage-reporting false
-    ln -s /usr/local/google-cloud-sdk/bin/gcloud /usr/bin
-    ln -s /usr/local/google-cloud-sdk/bin/gsutil /usr/bin
-fi
-
-# Installing gnome-keyring prevents the error described in
-# https://github.com/moby/moby/issues/34048
 
 # Add a user for the TeamCity agent if it doesn't exist already.
 id -u agent &>/dev/null 2>&1 || adduser agent --disabled-password


### PR DESCRIPTION
Previously, our build images and agents had no `az` installed.

This PR installs Azure CLI and does some other changes:

* Install `google-cloud-cli-gke-gcloud-auth-plugin` alongside with `gcloud-sdk` to address GKE 1.26 auth.
* Unify how we install `gcloud` on linux/arm64 - now it uses the same apt repo as linux/amd64.
* Use `apt-get clean` chained in docker `RUN` commands to not keep the downloaded packages in the layers.

Part of: #105580
Release note: None