### PR TITLE
geo: fix nan handling in bounding box comparison

### DIFF
--- a/pkg/geo/bbox.go
+++ b/pkg/geo/bbox.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/errors"
 	"github.com/golang/geo/s2"
-	"github.com/twpayne/go-geom"
+	geom "github.com/twpayne/go-geom"
 )
 
 // CartesianBoundingBox is the cartesian BoundingBox representation,
@@ -71,28 +71,30 @@ func ParseCartesianBoundingBox(s string) (CartesianBoundingBox, error) {
 
 // Compare returns the comparison between two bounding boxes.
 // Compare lower dimensions before higher ones, i.e. X, then Y.
+// In SQL, NaN is treated as less than all other float values. In Go, any
+// comparison with NaN returns false.
 func (b *CartesianBoundingBox) Compare(o *CartesianBoundingBox) int {
-	if b.LoX < o.LoX {
+	if b.LoX < o.LoX || (math.IsNaN(b.LoX) && !math.IsNaN(o.LoX)) {
 		return -1
-	} else if b.LoX > o.LoX {
+	} else if b.LoX > o.LoX || (!math.IsNaN(b.LoX) && math.IsNaN(o.LoX)) {
 		return 1
 	}
 
-	if b.HiX < o.HiX {
+	if b.HiX < o.HiX || (math.IsNaN(b.HiX) && !math.IsNaN(o.HiX)) {
 		return -1
-	} else if b.HiX > o.HiX {
+	} else if b.HiX > o.HiX || (!math.IsNaN(b.HiX) && math.IsNaN(o.HiX)) {
 		return 1
 	}
 
-	if b.LoY < o.LoY {
+	if b.LoY < o.LoY || (math.IsNaN(b.LoY) && !math.IsNaN(o.LoY)) {
 		return -1
-	} else if b.LoY > o.LoY {
+	} else if b.LoY > o.LoY || (!math.IsNaN(b.LoY) && math.IsNaN(o.LoY)) {
 		return 1
 	}
 
-	if b.HiY < o.HiY {
+	if b.HiY < o.HiY || (math.IsNaN(b.HiY) && !math.IsNaN(o.HiY)) {
 		return -1
-	} else if b.HiY > o.HiY {
+	} else if b.HiY > o.HiY || (!math.IsNaN(b.HiY) && math.IsNaN(o.HiY)) {
 		return 1
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_bbox
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_bbox
@@ -293,3 +293,19 @@ query T
 SELECT ST_Box2DFromGeoHash(NULL, NULL)::BOX2D;
 ----
 NULL
+
+subtest regression_93541
+
+statement ok
+CREATE TABLE bbox_units (d INT PRIMARY KEY, f FLOAT4);
+
+statement ok
+INSERT INTO bbox_units VALUES (1, 1.0), (2, 'NaN');
+
+query I
+SELECT count(*) FROM bbox_units
+WHERE 'BOX(-10 -10,10 10)'::BOX2D IN (
+  SELECT st_expand('BOX(1 -1, 1 -1)'::BOX2D, t2.f) FROM bbox_units t2
+);
+----
+0


### PR DESCRIPTION
Go always returns false when comparing float NaNs, but SQL expects NaNs to be less than any other float value. Before this change, the geo package's `CartesianBoundingBox` did not have special handling for NaNs, so it implemented the go behavior, which is incorrect for our use case.

This change adds correct NaN comparison behavior to bounding boxes.

Epic: None
Fixes: #93541
Fixes: #102661

Release note (bug fix): Fixes a bug in the geospatial cartesian bounding box type that had incorrect behavior when comparing boxes with NaN values.