### PR TITLE
asim: add exact_bound, upper_bound, lower_bound to CmdArgs

### DIFF
--- a/pkg/kv/kvserver/asim/tests/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/tests/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "tests_test",
-    srcs = ["datadriven_simulation_test.go"],
+    srcs = [
+        "datadriven_simulation_test.go",
+        "helpers_test.go",
+    ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":tests"],

--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -510,36 +509,4 @@ func TestDataDriven(t *testing.T) {
 			}
 		})
 	})
-}
-
-// TODO(kvoli): Upstream the scan implementations for the float64 and
-// time.Duration types to the datadriven testing repository.
-func scanArg(t *testing.T, d *datadriven.TestData, key string, dest interface{}) {
-	var tmp string
-	var err error
-	switch dest := dest.(type) {
-	case *time.Duration:
-		d.ScanArgs(t, key, &tmp)
-		*dest, err = time.ParseDuration(tmp)
-		require.NoError(t, err)
-	case *float64:
-		d.ScanArgs(t, key, &tmp)
-		*dest, err = strconv.ParseFloat(tmp, 64)
-		require.NoError(t, err)
-	case *[]int, *string, *int, *int64, *uint64, *bool:
-		d.ScanArgs(t, key, dest)
-	default:
-		require.Fail(t, "unsupported type %T", dest)
-	}
-}
-
-// scanIfExists looks up the first arg in CmdArgs array that matches the
-// provided firstKey. If found, it scans the value into dest and returns true;
-// Otherwise, it does nothing and returns false.
-func scanIfExists(t *testing.T, d *datadriven.TestData, key string, dest interface{}) bool {
-	if d.HasArg(key) {
-		scanArg(t, d, key, dest)
-		return true
-	}
-	return false
 }

--- a/pkg/kv/kvserver/asim/tests/helpers_test.go
+++ b/pkg/kv/kvserver/asim/tests/helpers_test.go
@@ -50,3 +50,23 @@ func scanIfExists(t *testing.T, d *datadriven.TestData, key string, dest interfa
 	}
 	return false
 }
+
+// scanThreshold looks up the first arg that matches with  "exact_bound",
+// "upper_bound", or "lower_bound" in the CmdArgs array. If found, it creates a
+// threshold struct from the located key-value pair. If no keys are found, a
+// fatal error is triggered. Note that only one key should be specified at a
+// time. If multiple keys are specified, the precedence order is exact_bound >
+// upper_bound > lower_bound.
+func scanThreshold(t *testing.T, d *datadriven.TestData) (th threshold) {
+	if scanIfExists(t, d, "exact_bound", &th.value) {
+		th.thresholdType = exactBound
+		return th
+	}
+	if scanIfExists(t, d, "upper_bound", &th.value) {
+		th.thresholdType = upperBound
+		return th
+	}
+	scanArg(t, d, "lower_bound", &th.value)
+	th.thresholdType = lowerBound
+	return th
+}

--- a/pkg/kv/kvserver/asim/tests/helpers_test.go
+++ b/pkg/kv/kvserver/asim/tests/helpers_test.go
@@ -1,0 +1,52 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO(kvoli): Upstream the scan implementations for the float64 and
+// time.Duration types to the datadriven testing repository.
+func scanArg(t *testing.T, d *datadriven.TestData, key string, dest interface{}) {
+	var tmp string
+	var err error
+	switch dest := dest.(type) {
+	case *time.Duration:
+		d.ScanArgs(t, key, &tmp)
+		*dest, err = time.ParseDuration(tmp)
+		require.NoError(t, err)
+	case *float64:
+		d.ScanArgs(t, key, &tmp)
+		*dest, err = strconv.ParseFloat(tmp, 64)
+		require.NoError(t, err)
+	case *[]int, *string, *int, *int64, *uint64, *bool:
+		d.ScanArgs(t, key, dest)
+	default:
+		require.Fail(t, "unsupported type %T", dest)
+	}
+}
+
+// scanIfExists looks up the first arg in CmdArgs array that matches the
+// provided firstKey. If found, it scans the value into dest and returns true;
+// Otherwise, it does nothing and returns false.
+func scanIfExists(t *testing.T, d *datadriven.TestData, key string, dest interface{}) bool {
+	if d.HasArg(key) {
+		scanArg(t, d, key, dest)
+		return true
+	}
+	return false
+}

--- a/pkg/kv/kvserver/asim/tests/testdata/example_add_node
+++ b/pkg/kv/kvserver/asim/tests/testdata/example_add_node
@@ -17,7 +17,7 @@ add_node
 ----
 
 # Assert that the replica counts balance within 5% of each other among stores.
-assertion type=balance stat=replicas ticks=6 threshold=1.05
+assertion type=balance stat=replicas ticks=6 upper_bound=1.05
 ----
 
 # Update the replication factor for the keyspace to be 3, instead of the

--- a/pkg/kv/kvserver/asim/tests/testdata/example_io_overload
+++ b/pkg/kv/kvserver/asim/tests/testdata/example_io_overload
@@ -7,7 +7,7 @@ gen_ranges ranges=500 placement_skew=true
 set_capacity store=5 io_threshold=1
 ----
 
-assertion type=stat stat=replicas stores=(5) threshold=0 ticks=5
+assertion type=stat stat=replicas stores=(5) exact_bound=0 ticks=5
 ----
 
 eval duration=10m seed=42

--- a/pkg/kv/kvserver/asim/tests/testdata/example_liveness
+++ b/pkg/kv/kvserver/asim/tests/testdata/example_liveness
@@ -21,7 +21,7 @@ set_liveness node=6 liveness=decommissioning delay=3m
 
 # The number of replicas on the dead and decommissioning stores should be 0,
 # assert this.
-assertion type=stat stat=replicas ticks=6 threshold=0 stores=(6,7)
+assertion type=stat stat=replicas ticks=6 exact_bound=0 stores=(6,7)
 ----
 
 eval duration=12m seed=42

--- a/pkg/kv/kvserver/asim/tests/testdata/example_multi_store
+++ b/pkg/kv/kvserver/asim/tests/testdata/example_multi_store
@@ -11,10 +11,10 @@ gen_ranges ranges=14 placement_skew=true
 gen_load rate=7000
 ----
 
-assertion stat=leases type=balance ticks=6 threshold=1
+assertion stat=leases type=balance ticks=6 upper_bound=1
 ----
 
-assertion stat=leases type=steady ticks=6 threshold=0
+assertion stat=leases type=steady ticks=6 upper_bound=0
 ----
 
 eval duration=5m seed=42

--- a/pkg/kv/kvserver/asim/tests/testdata/example_rebalancing
+++ b/pkg/kv/kvserver/asim/tests/testdata/example_rebalancing
@@ -16,14 +16,14 @@ gen_load rate=7000 rw_ratio=0.95 access_skew=false min_block=128 max_block=256
 # Add two assertions, the first is a balance assertion. The balance assertion
 # requires that when simulation is evaluated that during last 6 ticks (60
 # seconds) the max/mean QPS of the cluster does not exceed 1.15.
-assertion stat=qps type=balance ticks=6 threshold=1.15
+assertion stat=qps type=balance ticks=6 upper_bound=1.15
 ----
 
 # The second is a steady state assertion. The steady state assertion requires
 # that during the last 6 ticks (60 seconds), the value of QPS per-store doesn't
 # increase or decrease by more than 5% of the mean. This type of assertion is
 # useful when a stat is balanced but not necessarily stable.
-assertion stat=qps type=steady ticks=6 threshold=0.05
+assertion stat=qps type=steady ticks=6 upper_bound=0.05
 ----
 
 # The generators are then called and 2 simulation runs, named samples are
@@ -76,7 +76,7 @@ setting gossip_delay=20s
 eval duration=5m samples=2 seed=42
 ----
 failed assertion sample 2
-  balance stat=qps threshold=1.15 ticks=6
+  balance stat=qps threshold=(<1.15) ticks=6
 	max/mean=2.00 tick=0
 	max/mean=2.00 tick=1
 	max/mean=2.00 tick=2

--- a/pkg/kv/kvserver/asim/tests/testdata/example_splitting
+++ b/pkg/kv/kvserver/asim/tests/testdata/example_splitting
@@ -17,7 +17,7 @@ setting split_qps_threshold=2500
 
 # Assert that the number of replicas should not change at all during the last 6
 # ticks of the simulation.
-assertion stat=replicas type=steady ticks=6 threshold=0.00
+assertion stat=replicas type=steady ticks=6 upper_bound=0.00
 ----
 
 eval duration=5m samples=2 seed=42


### PR DESCRIPTION
**asim: move sim helper functions to helpers_test.go**

This patch moves helper functions for scanning and parsing arguments from
`datadriven_simulation_test.go` to `helpers_test.go`.

Note that this commit does not change any existing functionality.

Epic: None

Release Note: None

---

**asim: add exact_bound, upper_bound, lower_bound to CmdArgs**

Previously, the allocator simulator's assertions were limited to accepting only
a single threshold value for type=balance, type=steady, and type=stat
assertions. This single threshold functioned as an upper limit for balance and
steady and as an exact limit for stat. This is less ideal as there are instances
where different types of bounds need to be asserted. To improve this, this patch
replaces the argument `threshold=` with 
`exact_bound=, upper_bound=, and lower_bound=`. Note that only one 
argument should be specified at a time. If multiple are specified, the expected 
precedence order is exact_bound > upper_bound > lower_bound.

Note that this commit does not change any existing functionality.

Epic: None

Release Note: None