### PR TITLE
concurrency: re-introduce exclusive lock strength into the lock table

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -84,7 +84,7 @@ func Get(
 
 	var res result.Result
 	if args.KeyLocking != lock.None && h.Txn != nil && getRes.Value != nil {
-		acq := roachpb.MakeLockAcquisition(h.Txn, args.Key, lock.Unreplicated)
+		acq := roachpb.MakeLockAcquisition(h.Txn, args.Key, lock.Unreplicated, args.KeyLocking)
 		res.Local.AcquiredLocks = []roachpb.LockAcquisition{acq}
 	}
 	res.Local.EncounteredIntents = intents

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -110,7 +110,7 @@ func ReverseScan(
 	}
 
 	if args.KeyLocking != lock.None && h.Txn != nil {
-		err = acquireUnreplicatedLocksOnKeys(&res, h.Txn, args.ScanFormat, &scanRes)
+		err = acquireUnreplicatedLocksOnKeys(&res, h.Txn, args.KeyLocking, args.ScanFormat, &scanRes)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -110,7 +110,7 @@ func Scan(
 	}
 
 	if args.KeyLocking != lock.None && h.Txn != nil {
-		err = acquireUnreplicatedLocksOnKeys(&res, h.Txn, args.ScanFormat, &scanRes)
+		err = acquireUnreplicatedLocksOnKeys(&res, h.Txn, args.KeyLocking, args.ScanFormat, &scanRes)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/intent.go
+++ b/pkg/kv/kvserver/batcheval/intent.go
@@ -109,6 +109,7 @@ func readProvisionalVal(
 func acquireUnreplicatedLocksOnKeys(
 	res *result.Result,
 	txn *roachpb.Transaction,
+	str lock.Strength,
 	scanFmt kvpb.ScanFormat,
 	scanRes *storage.MVCCScanResult,
 ) error {
@@ -117,13 +118,13 @@ func acquireUnreplicatedLocksOnKeys(
 	case kvpb.BATCH_RESPONSE:
 		var i int
 		return storage.MVCCScanDecodeKeyValues(scanRes.KVData, func(key storage.MVCCKey, _ []byte) error {
-			res.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, copyKey(key.Key), lock.Unreplicated)
+			res.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, copyKey(key.Key), lock.Unreplicated, str)
 			i++
 			return nil
 		})
 	case kvpb.KEY_VALUES:
 		for i, row := range scanRes.KVs {
-			res.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, copyKey(row.Key), lock.Unreplicated)
+			res.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, copyKey(row.Key), lock.Unreplicated, str)
 		}
 		return nil
 	case kvpb.COL_BATCH_RESPONSE:

--- a/pkg/kv/kvserver/batcheval/result/intent.go
+++ b/pkg/kv/kvserver/batcheval/result/intent.go
@@ -24,7 +24,7 @@ func FromAcquiredLocks(txn *roachpb.Transaction, keys ...roachpb.Key) Result {
 	}
 	pd.Local.AcquiredLocks = make([]roachpb.LockAcquisition, len(keys))
 	for i := range pd.Local.AcquiredLocks {
-		pd.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, keys[i], lock.Replicated)
+		pd.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, keys[i], lock.Replicated, lock.Intent)
 	}
 	return pd
 }

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -85,7 +85,7 @@ start-waiting: <bool>
  Calls lockTable.ScanOptimistic. The request must not have an existing guard.
  If a guard is returned, stores it for later use.
 
-acquire r=<name> k=<key> durability=r|u [ignored-seqs=<int>[-<int>][,<int>[-<int>]]]
+acquire r=<name> k=<key> durability=r|u [ignored-seqs=<int>[-<int>][,<int>[-<int>]] strength=<strength>
 ----
 <error string>
 
@@ -381,7 +381,8 @@ func TestLockTableBasic(t *testing.T) {
 				if s[0] == 'r' {
 					durability = lock.Replicated
 				}
-				acq := roachpb.MakeLockAcquisition(req.Txn, roachpb.Key(key), durability)
+				strength := ScanLockStrength(t, d)
+				acq := roachpb.MakeLockAcquisition(req.Txn, roachpb.Key(key), durability, strength)
 				var ignored []enginepb.IgnoredSeqNumRange
 				if d.HasArg("ignored-seqs") {
 					ignored = scanIgnoredSeqNumbers(t, d)
@@ -706,6 +707,8 @@ func scanSpans(
 		case lock.None:
 			sa = spanset.SpanReadOnly
 		case lock.Intent:
+			sa = spanset.SpanReadWrite
+		case lock.Exclusive:
 			sa = spanset.SpanReadWrite
 		default:
 			d.Fatalf(t, "unsupported lock strength: %s", str)
@@ -1201,7 +1204,7 @@ func newWorkLoadExecutor(items []workloadItem, concurrency int) *workloadExecuto
 }
 
 func (e *workloadExecutor) acquireLock(txn *roachpb.Transaction, k roachpb.Key) error {
-	acq := roachpb.MakeLockAcquisition(txn, k, lock.Unreplicated)
+	acq := roachpb.MakeLockAcquisition(txn, k, lock.Unreplicated, lock.Exclusive)
 	err := e.lt.AcquireLock(&acq)
 	if err != nil {
 		return err
@@ -1630,7 +1633,7 @@ func doBenchWork(item *benchWorkItem, env benchEnv, doneCh chan<- error) {
 		}
 	}
 	for _, k := range item.locksToAcquire {
-		acq := roachpb.MakeLockAcquisition(item.Txn, k, lock.Unreplicated)
+		acq := roachpb.MakeLockAcquisition(item.Txn, k, lock.Unreplicated, lock.Exclusive)
 		if err = env.lt.AcquireLock(&acq); err != nil {
 			doneCh <- err
 			return
@@ -1827,7 +1830,7 @@ func BenchmarkLockTableMetrics(b *testing.B) {
 			}
 			for i := 0; i < locks; i++ {
 				k := roachpb.Key(fmt.Sprintf("%03d", i))
-				acq := roachpb.MakeLockAcquisition(txn, k, lock.Unreplicated)
+				acq := roachpb.MakeLockAcquisition(txn, k, lock.Unreplicated, lock.Exclusive)
 				err := lt.AcquireLock(&acq)
 				if err != nil {
 					b.Fatal(err)

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
@@ -14,14 +14,14 @@ new-lock-table maxlocks=10000
 new-txn txn=txn1 ts=10,1 epoch=0 seq=1
 ----
 
-new-request r=req1 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 scan r=req1
 ----
 start-waiting: false
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -36,14 +36,14 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=2
 ----
 
-new-request r=req2 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req2 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 scan r=req2
 ----
 start-waiting: false
 
-acquire r=req2 k=a durability=u
+acquire r=req2 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -58,14 +58,14 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=4
 ----
 
-new-request r=req3 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req3 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 scan r=req3
 ----
 start-waiting: false
 
-acquire r=req3 k=a durability=u
+acquire r=req3 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -84,14 +84,14 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=4
 ----
 
-new-request r=req3 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req3 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 scan r=req3
 ----
 start-waiting: false
 
-acquire r=req3 k=a durability=u
+acquire r=req3 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -110,14 +110,14 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=2
 ----
 
-new-request r=req4 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req4 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 scan r=req4
 ----
 start-waiting: false
 
-acquire r=req4 k=a durability=u
+acquire r=req4 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -138,14 +138,14 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=3
 ----
 
-new-request r=req5 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req5 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 scan r=req5
 ----
 start-waiting: false
 
-acquire r=req5 k=a durability=u
+acquire r=req5 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -164,14 +164,14 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=5
 ----
 
-new-request r=req6 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req6 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 scan r=req6
 ----
 start-waiting: false
 
-acquire r=req6 k=a durability=u
+acquire r=req6 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
@@ -8,19 +8,19 @@ new-lock-table maxlocks=10000
 new-txn txn=txn1 ts=10,1 epoch=0 seq=1
 ----
 
-new-request r=req1 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 new-txn txn=txn1 ts=10,1 epoch=0 seq=2
 ----
 
-new-request r=req2 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req2 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 new-txn txn=txn1 ts=10,1 epoch=0 seq=3
 ----
 
-new-request r=req3 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req3 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 scan r=req1
@@ -31,19 +31,19 @@ scan r=req2
 ----
 start-waiting: false
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1]
 
-acquire r=req2 k=a durability=u
+acquire r=req2 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [1, 2]
 
-acquire r=req3 k=a durability=u
+acquire r=req3 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -58,10 +58,10 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=5
 ----
 
-new-request r=req4 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req4 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
-acquire r=req4 k=a durability=u ignored-seqs=1,3
+acquire r=req4 k=a durability=u ignored-seqs=1,3 strength=exclusive
 ----
 num=1
  lock: "a"
@@ -75,10 +75,10 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=8
 ----
 
-new-request r=req5 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req5 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
-acquire r=req5 k=a durability=u ignored-seqs=4
+acquire r=req5 k=a durability=u ignored-seqs=4 strength=exclusive
 ----
 num=1
  lock: "a"
@@ -111,7 +111,7 @@ new-request r=req7 txn=txn1 ts=10,1 spans=intent@a
 # Because the lock is being acquired as a replicated lock nothing in the
 # unreplicated sequence number tracking gets pruned.
 
-acquire r=req7 k=a durability=r ignored-seqs=8
+acquire r=req7 k=a durability=r ignored-seqs=8 strength=intent
 ----
 num=1
  lock: "a"
@@ -122,7 +122,10 @@ num=1
 
 # However, unreplicated lock acquisition with the same ignored sequence number
 # (8) will result in the list of sequence numbers getting pruned.
-acquire r=req7 k=a durability=u ignored-seqs=8
+new-request r=req8 txn=txn1 ts=10,1 spans=exclusive@a
+----
+
+acquire r=req8 k=a durability=u ignored-seqs=8 strength=exclusive
 ----
 num=1
  lock: "a"
@@ -139,13 +142,13 @@ num=1
 new-txn txn=txn1 ts=10,1 epoch=0 seq=11
 ----
 
-new-request r=req8 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req9 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 # Note that 9 is held as both replicated and unreplicated; however it won't be
 # removed from the replicated list.
 
-acquire r=req8 k=a durability=u ignored-seqs=2-5,9
+acquire r=req9 k=a durability=u ignored-seqs=2-5,9 strength=exclusive
 ----
 num=1
  lock: "a"
@@ -164,10 +167,10 @@ num=1
 new-txn txn=txn1 ts=11,1 epoch=1 seq=12
 ----
 
-new-request r=req9 txn=txn1 ts=11,1 spans=intent@a
+new-request r=req10 txn=txn1 ts=11,1 spans=intent@a
 ----
 
-acquire r=req9 k=a durability=r
+acquire r=req10 k=a durability=r strength=intent
 ----
 num=1
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
@@ -31,14 +31,14 @@ new-txn txn=txn2 ts=10 epoch=0
 new-txn txn=txn3 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 scan r=req1
 ----
 start-waiting: false
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -6,7 +6,7 @@ new-txn txn=txn1 ts=10,1 epoch=0
 
 # req1 will acquire locks for txn1
 
-new-request r=req1 txn=txn1 ts=10,1 spans=none@a,b+intent@c,f
+new-request r=req1 txn=txn1 ts=10,1 spans=none@a,b+exclusive@c,f
 ----
 
 scan r=req1
@@ -19,18 +19,17 @@ new: state=doneWaiting
 
 # Acquire lock on c both replicated and unreplicated. Just to trigger corner cases and since
 # uncontended replicated locks are not tracked by lockTable.
-acquire r=req1 k=c durability=r
+acquire r=req1 k=c durability=r strength=intent
 ----
 num=0
 
-acquire r=req1 k=c durability=u
+acquire r=req1 k=c durability=u strength=exclusive
 ----
 num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
-acquire r=req1 k=e durability=u
-----
+acquire r=req1 k=e durability=u strength=exclusive
 num=2
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
@@ -51,14 +50,14 @@ time-tick ms=200
 
 # req2 is also for txn1 and will not wait for locks that are held by self.
 
-new-request r=req2 txn=txn1 ts=10,2 spans=intent@b,d+none@d,g
+new-request r=req2 txn=txn1 ts=10,2 spans=exclusive@b,d+none@d,g
 ----
 
 scan r=req2
 ----
 start-waiting: false
 
-acquire r=req2 k=b durability=u
+acquire r=req2 k=b durability=u strength=exclusive
 ----
 num=3
  lock: "b"
@@ -114,7 +113,7 @@ time-tick ms=200
 # req4 from txn2 will conflict with locks on b, c since wants to write to [a, d). But does
 # not conflict with lock on e since wants to read there and the read is at a lower timestamp
 # than the lock.
-new-request r=req4 txn=txn2 ts=8,12 spans=intent@a,d+none@d,g
+new-request r=req4 txn=txn2 ts=8,12 spans=exclusive@a,d+none@d,g
 ----
 
 scan r=req4
@@ -123,7 +122,7 @@ start-waiting: true
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Exclusive
 
 # 3s passes while req4 is waiting on locks on b,c
 time-tick s=3
@@ -146,7 +145,7 @@ num=3
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Exclusive
 
 # 1s passes while req4 continues to wait on c (and only has reservation on b)
 time-tick s=1
@@ -248,7 +247,7 @@ time-tick s=2
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn3 key="a" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn3 key="a" held=true guard-strength=Exclusive
 
 print
 ----
@@ -948,7 +947,7 @@ scan r=req4
 ----
 start-waiting: false
 
-acquire r=req4 k=b durability=r
+acquire r=req4 k=b durability=r strength=intent
 ----
 num=4
  lock: "a"
@@ -967,7 +966,7 @@ num=4
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
-acquire r=req4 k=c durability=r
+acquire r=req4 k=c durability=r strength=intent
 ----
 num=4
  lock: "a"
@@ -1586,14 +1585,14 @@ topklocksbywaitduration:
 # All requests have been retired and the lock table is empty.
 # The following tests multiple requests from the same transaction.
 
-new-request r=req9 txn=txn1 ts=10,1 spans=intent@c
+new-request r=req9 txn=txn1 ts=10,1 spans=exclusive@c
 ----
 
 scan r=req9
 ----
 start-waiting: false
 
-acquire r=req9 k=c durability=u
+acquire r=req9 k=c durability=u strength=exclusive
 ----
 num=1
  lock: "c"
@@ -1699,7 +1698,7 @@ topklocksbywaitduration:
   waitdurationnanos: 0
   maxwaitdurationnanos: 0
 
-new-request r=req10 txn=txn2 ts=8,12 spans=intent@c
+new-request r=req10 txn=txn2 ts=8,12 spans=exclusive@c
 ----
 
 scan r=req10
@@ -1708,7 +1707,7 @@ start-waiting: true
 
 guard-state r=req10
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Exclusive
 
 new-request r=req11 txn=txn3 ts=6 spans=intent@c
 ----
@@ -1958,7 +1957,7 @@ topklocksbywaitduration:
   waitdurationnanos: 0
   maxwaitdurationnanos: 0
 
-acquire r=req10 k=c durability=u
+acquire r=req10 k=c durability=u strength=exclusive
 ----
 num=1
  lock: "c"
@@ -2084,7 +2083,7 @@ num=1
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
 
-acquire r=req12 k=c durability=r
+acquire r=req12 k=c durability=r strength=intent
 ----
 num=1
  lock: "c"
@@ -2220,14 +2219,14 @@ num=0
 # Tests with non-transactional requests that triggered nil pointer
 # dereference bugs.
 
-new-request r=req13 txn=txn2 ts=8,12 spans=intent@c
+new-request r=req13 txn=txn2 ts=8,12 spans=exclusive@c
 ----
 
 scan r=req13
 ----
 start-waiting: false
 
-acquire r=req13 k=c durability=u
+acquire r=req13 k=c durability=u strength=exclusive
 ----
 num=1
  lock: "c"
@@ -2371,20 +2370,20 @@ topklocksbywaitduration:
 # transaction that eventually grabs a reservation. Triggered a bug
 # in not replacing the distinguished waiter.
 
-new-request r=req17 txn=txn1 ts=9,0 spans=intent@c+intent@d
+new-request r=req17 txn=txn1 ts=9,0 spans=exclusive@c+exclusive@d
 ----
 
 scan r=req17
 ----
 start-waiting: false
 
-acquire r=req17 k=c durability=u
+acquire r=req17 k=c durability=u strength=exclusive
 ----
 num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req17 k=d durability=u
+acquire r=req17 k=d durability=u strength=exclusive
 ----
 num=2
  lock: "c"
@@ -2400,14 +2399,14 @@ num=2
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 9.000000000,0, info: unrepl seqs: [0]
 
-new-request r=req18 txn=txn2 ts=10,0 spans=intent@c+intent@d
+new-request r=req18 txn=txn2 ts=10,0 spans=exclusive@c+exclusive@d
 ----
 
 scan r=req18
 ----
 start-waiting: true
 
-new-request r=req19 txn=txn2 ts=10,0 spans=intent@d
+new-request r=req19 txn=txn2 ts=10,0 spans=exclusive@d
 ----
 
 scan r=req19
@@ -2535,7 +2534,7 @@ num=2
 
 guard-state r=req18
 ----
-new: state=waitFor txn=txn1 key="d" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="d" held=true guard-strength=Exclusive
 
 print
 ----
@@ -2657,7 +2656,7 @@ scan r=req18
 ----
 start-waiting: false
 
-acquire r=req18 k=d durability=u
+acquire r=req18 k=d durability=u strength=exclusive
 ----
 num=2
  lock: "c"
@@ -2693,14 +2692,14 @@ num=0
 # Reservation can be broken while holding latches because a different
 # lock is released
 
-new-request r=req20 txn=txn1 ts=10 spans=intent@c
+new-request r=req20 txn=txn1 ts=10 spans=exclusive@c
 ----
 
 scan r=req20
 ----
 start-waiting: false
 
-acquire r=req20 k=c durability=u
+acquire r=req20 k=c durability=u strength=exclusive
 ----
 num=1
  lock: "c"
@@ -2712,14 +2711,14 @@ num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-new-request r=req21 txn=txn1 ts=10 spans=intent@d
+new-request r=req21 txn=txn1 ts=10 spans=exclusive@d
 ----
 
 scan r=req21
 ----
 start-waiting: false
 
-acquire r=req21 k=d durability=u
+acquire r=req21 k=d durability=u strength=exclusive
 ----
 num=2
  lock: "c"
@@ -2844,7 +2843,7 @@ topklocksbywaitduration:
   waitdurationnanos: 0
   maxwaitdurationnanos: 0
 
-new-request r=req23 txn=txn3 ts=10 spans=intent@d
+new-request r=req23 txn=txn3 ts=10 spans=exclusive@d
 ----
 
 scan r=req23
@@ -2992,7 +2991,7 @@ topklocksbywaitduration:
   waitdurationnanos: 0
   maxwaitdurationnanos: 0
 
-acquire r=req23 k=d durability=u
+acquire r=req23 k=d durability=u strength=exclusive
 ----
 num=2
  lock: "c"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
@@ -14,7 +14,7 @@ new-txn txn=txn3 ts=12,1 epoch=0
 
 # txn1 acquires unreplicated exclusive locks at a and b.
 
-new-request r=req1 txn=txn1 ts=10,1 spans=intent@a+intent@b
+new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@a+exclusive@b
 ----
 
 scan r=req1
@@ -25,13 +25,13 @@ guard-state r=req1
 ----
 new: state=doneWaiting
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
-acquire r=req1 k=b durability=u
+acquire r=req1 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -33,10 +33,10 @@ new-txn txn=txn8 ts=11,1 epoch=0
 # req1 to finish scanning. It needs to resolve the locks held by txn2, txn3.
 # -----------------------------------------------------------------------------
 
-new-request r=req1 txn=txn1 ts=10,1 spans=intent@a+intent@b+intent@c+intent@d+intent@e
+new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@a+exclusive@b+exclusive@c+exclusive@d+exclusive@e
 ----
 
-new-request r=req2 txn=txn4 ts=11,1 spans=intent@c
+new-request r=req2 txn=txn4 ts=11,1 spans=exclusive@c
 ----
 
 scan r=req1
@@ -103,7 +103,7 @@ scan r=req2
 ----
 start-waiting: false
 
-acquire r=req2 k=c durability=u
+acquire r=req2 k=c durability=u strength=exclusive
 ----
 num=5
  lock: "a"
@@ -183,7 +183,7 @@ start-waiting: true
 
 guard-state r=req1
 ----
-new: state=waitForDistinguished txn=txn4 key="c" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn4 key="c" held=true guard-strength=Exclusive
 
 print
 ----
@@ -281,10 +281,10 @@ num=0
 # replicated and unreplicated locks.
 # -----------------------------------------------------------------------------
 
-new-request r=req3 txn=txn1 ts=10,1 spans=intent@a+intent@b+intent@c
+new-request r=req3 txn=txn1 ts=10,1 spans=exclusive@a+exclusive@b+exclusive@c
 ----
 
-new-request r=req4 txn=txn2 ts=11,1 spans=intent@b
+new-request r=req4 txn=txn2 ts=11,1 spans=exclusive@b
 ----
 
 scan r=req3
@@ -315,7 +315,7 @@ scan r=req4
 ----
 start-waiting: false
 
-acquire r=req4 k=b durability=u
+acquire r=req4 k=b durability=u strength=exclusive
 ----
 num=3
  lock: "a"
@@ -384,10 +384,10 @@ num=0
 # req5 notices the finalization (via pushing) and scans again and resolves.
 # -----------------------------------------------------------------------------
 
-new-request r=req5 txn=txn1 ts=12,1 spans=intent@a+intent@b
+new-request r=req5 txn=txn1 ts=12,1 spans=exclusive@a+exclusive@b
 ----
 
-new-request r=req6 txn=txn3 ts=12,1 spans=intent@a
+new-request r=req6 txn=txn3 ts=12,1 spans=exclusive@a
 ----
 
 scan r=req5
@@ -440,11 +440,11 @@ start-waiting: true
 
 guard-state r=req6
 ----
-new: state=waitFor txn=txn2 key="a" held=true guard-strength=Intent
+new: state=waitFor txn=txn2 key="a" held=true guard-strength=Exclusive
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Exclusive
 
 print
 ----
@@ -475,7 +475,7 @@ num=2
 
 guard-state r=req6
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=false guard-strength=Intent
+new: state=waitForDistinguished txn=txn1 key="a" held=false guard-strength=Exclusive
 
 guard-state r=req5
 ----
@@ -516,7 +516,7 @@ num=0
 # reader.
 # -----------------------------------------------------------------------------
 
-new-request r=req7 txn=txn1 ts=12,1 spans=intent@a+intent@b
+new-request r=req7 txn=txn1 ts=12,1 spans=exclusive@a+exclusive@b
 ----
 
 new-request r=req8 txn=txn3 ts=12,1 spans=none@a+none@b
@@ -552,7 +552,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Exclusive
 
 print
 ----
@@ -722,7 +722,7 @@ num=0
 # waiters.
 # -----------------------------------------------------------------------------
 
-new-request r=req11 txn=none ts=12,1 spans=intent@a
+new-request r=req11 txn=none ts=12,1 spans=exclusive@a
 ----
 
 scan r=req11
@@ -818,11 +818,11 @@ num=0
 # -----------------------------------------------------------------------------
 
 # Acquire 6 locks, 1 each for each request types we care about.
-new-request r=req13 txn=txn6 ts=11,0 spans=intent@a+intent@b+intent@c+intent@d+intent@e+intent@f
+new-request r=req13 txn=txn6 ts=11,0 spans=exclusive@a+exclusive@b+exclusive@c+exclusive@d+exclusive@e+exclusive@f
 ----
 
 # Locking, transactional request.
-new-request r=req14 txn=txn5 ts=11,0 spans=intent@a+intent@b
+new-request r=req14 txn=txn5 ts=11,0 spans=exclusive@a+exclusive@b
 ----
 
 # Non-locking, transactional request
@@ -830,16 +830,16 @@ new-request r=req15 txn=txn5 ts=11,0 spans=none@c+none@d
 ----
 
 # Non-locking, transactional request
-new-request r=req16 txn=none ts=11,0 spans=intent@e+intent@f
+new-request r=req16 txn=none ts=11,0 spans=exclusive@e+exclusive@f
 ----
 
-acquire r=req13 k=a durability=u
+acquire r=req13 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req13 k=b durability=u
+acquire r=req13 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"
@@ -847,7 +847,7 @@ num=2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req13 k=c durability=u
+acquire r=req13 k=c durability=u strength=exclusive
 ----
 num=3
  lock: "a"
@@ -857,7 +857,7 @@ num=3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req13 k=d durability=u
+acquire r=req13 k=d durability=u strength=exclusive
 ----
 num=4
  lock: "a"
@@ -869,7 +869,7 @@ num=4
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req13 k=e durability=u
+acquire r=req13 k=e durability=u strength=exclusive
 ----
 num=5
  lock: "a"
@@ -883,7 +883,7 @@ num=5
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, ts: 11.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req13 k=f durability=u
+acquire r=req13 k=f durability=u strength=exclusive
 ----
 num=6
  lock: "a"
@@ -994,7 +994,7 @@ clear
 ----
 num=0
 
-new-request r=req17 txn=txn5 ts=11,0 spans=intent@a+intent@b
+new-request r=req17 txn=txn5 ts=11,0 spans=exclusive@a+exclusive@b
 ----
 
 scan r=req17
@@ -1047,7 +1047,7 @@ start-waiting: true
 
 guard-state r=req17
 ----
-new: state=waitForDistinguished txn=txn8 key="b" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn8 key="b" held=true guard-strength=Exclusive
 
 # Now that req17 is able to wait on lock "b", and claim the lock on "a", it should
 # no longer be the distinguished waiter on lock "a" anymore.
@@ -1064,7 +1064,7 @@ num=2
     active: true req: 16, txn: 00000000-0000-0000-0000-000000000005
    distinguished req: 16
 
-new-request r=req18 txn=txn8 ts=11,0 spans=intent@a
+new-request r=req18 txn=txn8 ts=11,0 spans=exclusive@a
 ----
 
 scan r=req18

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
@@ -19,7 +19,7 @@ clear disable
 ----
 num=0
 
-new-request r=req1 txn=txn1 ts=10,1 spans=intent@a+intent@c
+new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@a+exclusive@c
 ----
 
 scan r=req1
@@ -43,7 +43,7 @@ scan r=req1
 ----
 start-waiting: false
 
-acquire r=req1 k=c durability=u
+acquire r=req1 k=c durability=u strength=exclusive
 ----
 num=0
 
@@ -58,7 +58,7 @@ num=0
 enable
 ----
 
-new-request r=req2 txn=txn1 ts=10,1 spans=intent@a+intent@c
+new-request r=req2 txn=txn1 ts=10,1 spans=exclusive@a+exclusive@c
 ----
 
 scan r=req2
@@ -83,7 +83,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Exclusive
 
 release txn=txn2 span=a
 ----
@@ -96,7 +96,7 @@ guard-state r=req2
 ----
 new: state=doneWaiting
 
-acquire r=req2 k=c durability=u
+acquire r=req2 k=c durability=u strength=exclusive
 ----
 num=2
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
@@ -17,14 +17,14 @@ new-txn txn=txn2 ts=10 epoch=0
 new-txn txn=txn3 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=intent@a+intent@b+intent@c
+new-request r=req1 txn=txn1 ts=10 spans=exclusive@a+exclusive@b+exclusive@c
 ----
 
 scan r=req1
 ----
 start-waiting: false
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -76,20 +76,20 @@ num=0
 # broken, but ignores "b" when encounters it as reader.
 # ---------------------------------------------------------------------------------
 
-new-request r=req3 txn=txn1 ts=10 spans=intent@a+intent@b+intent@c
+new-request r=req3 txn=txn1 ts=10 spans=exclusive@a+exclusive@b+exclusive@c
 ----
 
 scan r=req3
 ----
 start-waiting: false
 
-acquire r=req3 k=a durability=u
+acquire r=req3 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req3 k=b durability=u
+acquire r=req3 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"
@@ -97,7 +97,7 @@ num=2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req3 k=c durability=u
+acquire r=req3 k=c durability=u strength=exclusive
 ----
 num=3
  lock: "a"
@@ -293,20 +293,20 @@ num=0
 # previous test.
 # ---------------------------------------------------------------------------------
 
-new-request r=req6 txn=txn1 ts=10 spans=intent@a+intent@b+intent@c
+new-request r=req6 txn=txn1 ts=10 spans=exclusive@a+exclusive@b+exclusive@c
 ----
 
 scan r=req6
 ----
 start-waiting: false
 
-acquire r=req6 k=a durability=u
+acquire r=req6 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req6 k=b durability=u
+acquire r=req6 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"
@@ -314,7 +314,7 @@ num=2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req6 k=c durability=u
+acquire r=req6 k=c durability=u strength=exclusive strength=exclusive
 ----
 num=3
  lock: "a"
@@ -334,7 +334,7 @@ num=3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-new-request r=req7 txn=txn2 ts=10 spans=intent@a+intent@b
+new-request r=req7 txn=txn2 ts=10 spans=exclusive@a+exclusive@b
 ----
 
 scan r=req7
@@ -343,7 +343,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Exclusive
 
 new-request r=req8 txn=none ts=10 spans=intent@b+intent@c+none@b
 ----
@@ -465,7 +465,7 @@ scan r=req7
 ----
 start-waiting: false
 
-acquire r=req7 k=b durability=u
+acquire r=req7 k=b durability=u strength=exclusive
 ----
 num=3
  lock: "a"
@@ -530,20 +530,20 @@ num=0
 # it ignores the lock at "b".
 # ---------------------------------------------------------------------------------
 
-new-request r=req10 txn=txn1 ts=10 spans=intent@a+intent@b
+new-request r=req10 txn=txn1 ts=10 spans=exclusive@a+exclusive@b
 ----
 
 scan r=req10
 ----
 start-waiting: false
 
-acquire r=req10 k=a durability=u
+acquire r=req10 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req10 k=b durability=u
+acquire r=req10 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"
@@ -559,7 +559,7 @@ num=2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-new-request r=req11 txn=txn2 ts=10 spans=intent@a+intent@b
+new-request r=req11 txn=txn2 ts=10 spans=exclusive@a+exclusive@b
 ----
 
 scan r=req11
@@ -568,7 +568,7 @@ start-waiting: true
 
 guard-state r=req11
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Exclusive
 
 new-request r=req12 txn=txn3 ts=10 spans=intent@b+none@b
 ----
@@ -640,7 +640,7 @@ scan r=req11
 ----
 start-waiting: false
 
-acquire r=req11 k=b durability=u
+acquire r=req11 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -13,10 +13,10 @@ new-txn txn=txn1 ts=10 epoch=0 seq=2
 new-txn txn=txn2 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=intent@a
+new-request r=req1 txn=txn1 ts=10 spans=exclusive@a
 ----
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -37,10 +37,10 @@ num=1
 new-txn txn=txn1 ts=8 epoch=0 seq=3
 ----
 
-new-request r=req2 txn=txn1 ts=8 spans=intent@a
+new-request r=req2 txn=txn1 ts=8 spans=exclusive@a+intent@a
 ----
 
-acquire r=req2 k=a durability=u
+acquire r=req2 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -62,7 +62,7 @@ scan r=reqContend
 ----
 start-waiting: true
 
-acquire r=req2 k=a durability=r
+acquire r=req2 k=a durability=r strength=intent
 ----
 num=1
  lock: "a"
@@ -84,10 +84,10 @@ num=1
 new-txn txn=txn1 ts=10 epoch=1 seq=1
 ----
 
-new-request r=req3 txn=txn1 ts=10 spans=intent@a
+new-request r=req3 txn=txn1 ts=10 spans=exclusive@a
 ----
 
-acquire r=req3 k=a durability=u
+acquire r=req3 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -102,10 +102,10 @@ num=1
 new-txn txn=txn1 ts=6 epoch=2 seq=0
 ----
 
-new-request r=req4 txn=txn1 ts=6 spans=intent@a
+new-request r=req4 txn=txn1 ts=6 spans=exclusive@a
 ----
 
-acquire r=req4 k=a durability=u
+acquire r=req4 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -138,10 +138,10 @@ num=1
 new-txn txn=txn1 ts=14 epoch=2 seq=1
 ----
 
-new-request r=req6 txn=txn1 ts=14 spans=intent@a
+new-request r=req6 txn=txn1 ts=14 spans=intent@a+exclusive@a
 ----
 
-acquire r=req6 k=a durability=r
+acquire r=req6 k=a durability=r strength=intent
 ----
 num=1
  lock: "a"
@@ -154,7 +154,7 @@ guard-state r=req5
 ----
 old: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
-acquire r=req6 k=a durability=u
+acquire r=req6 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -214,14 +214,13 @@ num=1
 new-txn txn=txn1 ts=14 epoch=1 seq=1
 ----
 
-new-request r=req8 txn=txn1 ts=14 spans=none@a
+new-request r=req8 txn=txn1 ts=14 spans=exclusive@a
 ----
 
 scan r=req8
 ----
 start-waiting: false
 
-acquire r=req8 k=a durability=u
+acquire r=req8 k=a durability=u strength=exclusive
 ----
 locking request with epoch 1 came after lock(unreplicated) had already been acquired at epoch 2 in txn 00000000-0000-0000-0000-000000000001
-

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
@@ -10,10 +10,10 @@ new-lock-table maxlocks=10000
 new-txn txn=txn1 ts=10 epoch=0 seq=2
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=intent@a
+new-request r=req1 txn=txn1 ts=10 spans=intent@a+exclusive@a
 ----
 
-acquire r=req1 k=a durability=r
+acquire r=req1 k=a durability=r strength=intent
 ----
 num=0
 
@@ -22,13 +22,13 @@ num=0
 # lock to be dropped.
 # ---------------------------------------------------------------------------------
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [2]
 
-acquire r=req1 k=a durability=r
+acquire r=req1 k=a durability=r strength=intent
 ----
 num=0
 
@@ -40,7 +40,7 @@ num=0
 new-request r=reqContendReader txn=none ts=10 spans=none@a
 ----
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -59,7 +59,7 @@ num=1
     req: 1, txn: none
    distinguished req: 1
 
-acquire r=req1 k=a durability=r
+acquire r=req1 k=a durability=r strength=intent
 ----
 num=0
 
@@ -75,7 +75,7 @@ new: state=doneWaiting
 new-request r=reqContendWriter txn=none ts=10 spans=intent@a
 ----
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -100,7 +100,7 @@ num=1
     active: true req: 2, txn: none
    distinguished req: 1
 
-acquire r=req1 k=a durability=r
+acquire r=req1 k=a durability=r strength=intent
 ----
 num=1
  lock: "a"
@@ -135,7 +135,7 @@ num=0
 # stall indefinitely.
 # ---------------------------------------------------------------------------------
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -144,10 +144,10 @@ num=1
 new-txn txn=txn2 ts=10 epoch=0 seq=0
 ----
 
-new-request r=req2 txn=txn2 ts=10 spans=intent@b
+new-request r=req2 txn=txn2 ts=10 spans=exclusive@b+intent@b
 ----
 
-acquire r=req2 k=b durability=u
+acquire r=req2 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"
@@ -166,7 +166,7 @@ guard-state r=req3
 ----
 new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
-acquire r=req2 k=b durability=r
+acquire r=req2 k=b durability=r strength=intent
 ----
 num=1
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
@@ -11,20 +11,20 @@ new-txn txn=txn3 ts=10 epoch=0
 ----
 
 # First locks at a, b, c are acquired by txn1
-new-request r=req1 txn=txn1 ts=10 spans=intent@a+intent@b+intent@c
+new-request r=req1 txn=txn1 ts=10 spans=exclusive@a+exclusive@b+exclusive@c
 ----
 
 scan r=req1
 ----
 start-waiting: false
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req1 k=b durability=u
+acquire r=req1 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"
@@ -32,7 +32,7 @@ num=2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req1 k=c durability=u
+acquire r=req1 k=c durability=u strength=exclusive
 ----
 num=3
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/optimistic
@@ -9,7 +9,7 @@ new-txn txn=txn2 ts=11,1 epoch=0
 
 # req1 will acquire locks for txn1
 
-new-request r=req1 txn=txn1 ts=10,1 spans=intent@c,h
+new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@c,h
 ----
 
 scan r=req1
@@ -20,13 +20,13 @@ should-wait r=req1
 ----
 false
 
-acquire r=req1 k=c durability=u
+acquire r=req1 k=c durability=u strength=exclusive
 ----
 num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
-acquire r=req1 k=g durability=u
+acquire r=req1 k=g durability=u strength=exclusive
 ----
 num=2
  lock: "c"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/query
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/query
@@ -6,7 +6,7 @@ new-txn txn=txn1 ts=10,1 epoch=0
 
 # req1 will acquire locks for txn1
 
-new-request r=req1 txn=txn1 ts=10,1 spans=none@a,b+intent@c,f
+new-request r=req1 txn=txn1 ts=10,1 spans=none@a,b+exclusive@c,f
 ----
 
 scan r=req1
@@ -17,13 +17,13 @@ guard-state r=req1
 ----
 new: state=doneWaiting
 
-acquire r=req1 k=c durability=u
+acquire r=req1 k=c durability=u strength=exclusive
 ----
 num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
-acquire r=req1 k=e durability=u
+acquire r=req1 k=e durability=u strength=exclusive
 ----
 num=2
  lock: "c"
@@ -51,14 +51,14 @@ num locks: 1, bytes returned: 41, resume reason: RESUME_UNKNOWN, resume span: <n
 
 # req2 is also for txn1 and will not wait for locks that are held by self.
 
-new-request r=req2 txn=txn1 ts=10,2 spans=intent@b,d+none@d,g
+new-request r=req2 txn=txn1 ts=10,2 spans=exclusive@b,d+none@d,g
 ----
 
 scan r=req2
 ----
 start-waiting: false
 
-acquire r=req2 k=b durability=u
+acquire r=req2 k=b durability=u strength=exclusive
 ----
 num=3
  lock: "b"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
@@ -10,7 +10,7 @@ new-txn txn=txn2 ts=10 epoch=0
 new-txn txn=txn3 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=intent@a
+new-request r=req1 txn=txn1 ts=10 spans=exclusive@a
 ----
 
 new-request r=req2 txn=txn2 ts=10 spans=intent@a
@@ -23,7 +23,7 @@ scan r=req1
 ----
 start-waiting: false
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -188,14 +188,14 @@ num=1
 new-txn txn=txn6 ts=10 epoch=0
 ----
 
-new-request r=req9 txn=txn6 ts=10 spans=intent@b
+new-request r=req9 txn=txn6 ts=10 spans=exclusive@b
 ----
 
 scan r=req9
 ----
 start-waiting: false
 
-acquire r=req9 k=b durability=u
+acquire r=req9 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
@@ -46,14 +46,14 @@ num=2
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
 
-new-request r=reqLock txn=txn2 ts=10,1 spans=intent@a+intent@b+intent@c+intent@d
+new-request r=reqLock txn=txn2 ts=10,1 spans=exclusive@a+exclusive@b+exclusive@c+exclusive@d
 ----
 
 scan r=reqLock
 ----
 start-waiting: false
 
-acquire r=reqLock k=a durability=u
+acquire r=reqLock k=a durability=u strength=exclusive
 ----
 num=3
  lock: "a"
@@ -63,7 +63,7 @@ num=3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, ts: 10.000000000,1, info: repl
 
-acquire r=reqLock k=b durability=u
+acquire r=reqLock k=b durability=u strength=exclusive
 ----
 num=3
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
@@ -15,20 +15,20 @@ new-txn txn=txn1 ts=10 epoch=0
 new-txn txn=txn2 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=intent@a,e
+new-request r=req1 txn=txn1 ts=10 spans=exclusive@a,e+intent@c
 ----
 
 scan r=req1
 ----
 start-waiting: false
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,0, info: unrepl seqs: [0]
 
-acquire r=req1 k=b durability=u
+acquire r=req1 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"
@@ -43,7 +43,7 @@ num=2
 # uncontended replicated locks. When that behavior changes with the
 # segregated lock table, we can remove this unreplicated lock
 # acquisition and queued writer.
-acquire r=req1 k=c durability=u
+acquire r=req1 k=c durability=u strength=exclusive
 ----
 num=3
  lock: "a"
@@ -60,7 +60,7 @@ scan r=reqContend
 ----
 start-waiting: true
 
-acquire r=req1 k=c durability=r
+acquire r=req1 k=c durability=r strength=intent
 ----
 num=3
  lock: "a"
@@ -213,7 +213,7 @@ num=4
    queued writers:
     active: false req: 8, txn: 00000000-0000-0000-0000-000000000002
 
-new-request r=req8 txn=txn2 ts=10 spans=intent@e
+new-request r=req8 txn=txn2 ts=10 spans=exclusive@e
 ----
 
 scan r=req8
@@ -222,7 +222,7 @@ start-waiting: false
 
 # The lock table hits its size limit at this acquisition, and clears all
 # locks except "d" which is the discovered lock with no active waiter.
-acquire r=req8 k=e durability=u
+acquire r=req8 k=e durability=u strength=exclusive
 ----
 num=1
  lock: "d"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -15,7 +15,7 @@ new-txn txn=txn2 ts=9,1 epoch=0
 #  e: unlocked
 #  f: reservation by txn1
 
-new-request r=req1 txn=txn1 ts=10,1 spans=intent@b,d
+new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@b,d
 ----
 
 scan r=req1
@@ -26,13 +26,13 @@ should-wait r=req1
 ----
 false
 
-acquire r=req1 k=b durability=u
+acquire r=req1 k=b durability=u strength=exclusive
 ----
 num=1
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
-acquire r=req1 k=d durability=u
+acquire r=req1 k=d durability=u strength=exclusive
 ----
 num=2
  lock: "b"
@@ -48,7 +48,7 @@ num=2
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
-new-request r=req2 txn=txn2 ts=9,1 spans=intent@c+intent@f
+new-request r=req2 txn=txn2 ts=9,1 spans=exclusive@c+exclusive@f
 ----
 
 scan r=req2
@@ -59,7 +59,7 @@ should-wait r=req2
 ----
 false
 
-acquire r=req2 k=c durability=u
+acquire r=req2 k=c durability=u strength=exclusive
 ----
 num=3
  lock: "b"
@@ -69,7 +69,7 @@ num=3
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, ts: 10.000000000,1, info: unrepl seqs: [0]
 
-acquire r=req2 k=f durability=u
+acquire r=req2 k=f durability=u strength=exclusive
 ----
 num=4
  lock: "b"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -14,7 +14,7 @@ new-txn txn=txn3 ts=14,1 epoch=0
 # Acquire a lock on key a at timestamp 10,1
 # -------------------------------------------------------------
 
-new-request r=req1 txn=txn1 ts=10,1 spans=intent@a
+new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
 scan r=req1
@@ -25,7 +25,7 @@ guard-state r=req1
 ----
 new: state=doneWaiting
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -386,10 +386,10 @@ new-lock-table maxlocks=10000
 new-txn txn=txn1 ts=10 epoch=1 seq=1
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=intent@a
+new-request r=req1 txn=txn1 ts=10 spans=exclusive@a
 ----
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -398,10 +398,10 @@ num=1
 new-txn txn=txn1 ts=10 epoch=1 seq=5
 ----
 
-new-request r=req2 txn=txn1 ts=10 spans=intent@a
+new-request r=req2 txn=txn1 ts=10 spans=exclusive@a
 ----
 
-acquire r=req2 k=a durability=u
+acquire r=req2 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -410,10 +410,10 @@ num=1
 new-txn txn=txn1 ts=10 epoch=1 seq=7
 ----
 
-new-request r=req3 txn=txn1 ts=10 spans=intent@a
+new-request r=req3 txn=txn1 ts=10 spans=exclusive@a
 ----
 
-acquire r=req3 k=a durability=u
+acquire r=req3 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -422,10 +422,10 @@ num=1
 new-txn txn=txn1 ts=10 epoch=1 seq=10
 ----
 
-new-request r=req4 txn=txn1 ts=10 spans=intent@a
+new-request r=req4 txn=txn1 ts=10 spans=exclusive@a
 ----
 
-acquire r=req4 k=a durability=u
+acquire r=req4 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
@@ -17,23 +17,23 @@ new-txn txn=txn2 ts=10 epoch=0
 new-txn txn=txn3 ts=10 epoch=0
 ----
 
-new-request r=req1 txn=txn1 ts=10 spans=intent@a
+new-request r=req1 txn=txn1 ts=10 spans=exclusive@a
 ----
 
-new-request r=req2 txn=txn2 ts=10 spans=intent@a
+new-request r=req2 txn=txn2 ts=10 spans=exclusive@a
 ----
 
 new-request r=req3 txn=txn3 ts=10 spans=intent@a
 ----
 
-new-request r=req4 txn=txn2 ts=10 spans=intent@a
+new-request r=req4 txn=txn2 ts=10 spans=exclusive@a
 ----
 
 scan r=req1
 ----
 start-waiting: false
 
-acquire r=req1 k=a durability=u
+acquire r=req1 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -59,7 +59,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Exclusive
 
 guard-state r=req3
 ----
@@ -67,7 +67,7 @@ new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 guard-state r=req4
 ----
-new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Exclusive
 
 print
 ----
@@ -122,11 +122,11 @@ guard-state r=req4
 new: state=waitSelf
 
 # ---------------------------------------------------------------------------------
-# req4 is waiting on reserved "a", and req2 from the same txn acquires the
-# lock. req4 stops waiting
+# req4 is waiting on claimed "a", and req2 from the same txn acquires the
+# lock. req4 stops waiting.
 # ---------------------------------------------------------------------------------
 
-acquire r=req2 k=a durability=u
+acquire r=req2 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
@@ -146,3 +146,4 @@ new: state=doneWaiting
 scan r=req4
 ----
 start-waiting: false
+

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10813,7 +10813,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				expTS = ba.Txn.WriteTimestamp
 
 				scan := scanArgs(roachpb.Key("lscan"), roachpb.Key("lscan\x00"))
-				scan.KeyLocking = lock.Update
+				scan.KeyLocking = lock.Exclusive
 				ba.Add(scan)
 				return
 			},

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1979,16 +1979,15 @@ func AsIntents(txn *enginepb.TxnMeta, keys []Key) []Intent {
 }
 
 // MakeLockAcquisition makes a lock acquisition message from the given
-// txn, key, and durability level.
-func MakeLockAcquisition(txn *Transaction, key Key, dur lock.Durability) LockAcquisition {
+// txn, key, durability level, and lock strength.
+func MakeLockAcquisition(
+	txn *Transaction, key Key, dur lock.Durability, str lock.Strength,
+) LockAcquisition {
 	return LockAcquisition{
-		Span:       Span{Key: key},
-		Txn:        txn.TxnMeta,
-		Durability: dur,
-		// TODO(arul): The lock table only supports/expects locks with Intent lock
-		// strength. This will change once we generalize the lock table for
-		// different strengths.
-		Strength:       lock.Intent,
+		Span:           Span{Key: key},
+		Txn:            txn.TxnMeta,
+		Durability:     dur,
+		Strength:       str,
 		IgnoredSeqNums: txn.IgnoredSeqNums,
 	}
 }


### PR DESCRIPTION
First 6 commits from https://github.com/cockroachdb/cockroach/pull/105474

This patch re-introduces exclusive lock strength into the lock table.
Now, unreplicated locks are considered to have exclusive lock strength
whereas replicated locks have intent lock strength. The testing diff
follows from this mapping.

This distinction between exclusive lock strength and intent lock
strength is not meaningful for serializable transactions by default.
As such, this patch doesn't change anything functionally. However, once
we plumb in the isolation level of a request in all the right places,
this change will be useful. In particular, it'll allow non-locking reads
from read committed transactions to not block on exclusive locks.

Informs https://github.com/cockroachdb/cockroach/issues/94729

Release note: None