### PR TITLE
testcat: remove leftover Println for RBT tables

### DIFF
--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -83,7 +83,6 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	if stmt.Locality != nil {
 		isRbr = stmt.Locality.LocalityLevel == tree.LocalityLevelRow
 		isRbt = stmt.Locality.LocalityLevel == tree.LocalityLevelTable
-		fmt.Println(isRbt)
 	}
 	tab := &Table{TabID: tc.nextStableID(), TabName: stmt.Table, Catalog: tc}
 


### PR DESCRIPTION
This removes a Println statement which was originally added for testing support of REGIONAL BY TABLE tables in the test catalog.

Epic: none

Release note: None