### PR TITLE
release-22.2: roachprod: add `--gce-use-spot`

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -111,6 +111,13 @@ type jsonVM struct {
 			NatIP string
 		}
 	}
+	Scheduling struct {
+		AutomaticRestart          bool
+		Preemptible               bool
+		OnHostMaintenance         string
+		InstanceTerminationAction string
+		ProvisioningModel         string
+	}
 	MachineType string
 	Zone        string
 }
@@ -154,6 +161,10 @@ func (jsonVM *jsonVM) toVM(project string, opts *ProviderOpts) (ret *vm.VM) {
 			vpc = lastComponent(jsonVM.NetworkInterfaces[0].Network)
 		}
 	}
+	if jsonVM.Scheduling.OnHostMaintenance == "" {
+		// N.B. 'onHostMaintenance' is always non-empty, hence its absense implies a parsing error
+		vmErrors = append(vmErrors, vm.ErrBadScheduling)
+	}
 
 	machineType := lastComponent(jsonVM.MachineType)
 	zone := lastComponent(jsonVM.Zone)
@@ -171,6 +182,7 @@ func (jsonVM *jsonVM) toVM(project string, opts *ProviderOpts) (ret *vm.VM) {
 		Errors:      vmErrors,
 		DNS:         fmt.Sprintf("%s.%s.%s", jsonVM.Name, zone, project),
 		Lifetime:    lifetime,
+		Preemptible: jsonVM.Scheduling.Preemptible,
 		Labels:      jsonVM.Labels,
 		PrivateIP:   privateIP,
 		Provider:    ProviderName,
@@ -206,6 +218,7 @@ func DefaultProviderOpts() *ProviderOpts {
 		TerminateOnMigration: false,
 		useSharedUser:        true,
 		preemptible:          false,
+		useSpot:              false,
 	}
 }
 
@@ -236,6 +249,8 @@ type ProviderOpts struct {
 	useSharedUser bool
 	// use preemptible instances
 	preemptible bool
+	// use spot instances (i.e., latest version of preemptibles which can run > 24 hours)
+	useSpot bool
 }
 
 // Provider is the GCE implementation of the vm.Provider interface.
@@ -334,7 +349,10 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 			"will be repeated N times. If > 1 zone specified, nodes will be geo-distributed\n"+
 			"regardless of geo (default [%s])",
 			strings.Join(defaultZones, ",")))
-	flags.BoolVar(&o.preemptible, ProviderName+"-preemptible", false, "use preemptible GCE instances")
+	flags.BoolVar(&o.preemptible, ProviderName+"-preemptible", false,
+		"use preemptible GCE instances (lifetime cannot exceed 24h)")
+	flags.BoolVar(&o.useSpot, ProviderName+"-use-spot", false,
+		"use spot GCE instances (like preemptible but lifetime can exceed 24h)")
 	flags.BoolVar(&o.TerminateOnMigration, ProviderName+"-terminateOnMigration", false,
 		"use 'TERMINATE' maintenance policy (for GCE live migrations)")
 }
@@ -481,6 +499,8 @@ func (p *Provider) Create(
 		// Preemptible instances require the following arguments set explicitly
 		args = append(args, "--maintenance-policy", "TERMINATE")
 		args = append(args, "--no-restart-on-failure")
+	} else if providerOpts.useSpot {
+		args = append(args, "--provisioning-model", "SPOT")
 	} else {
 		if providerOpts.TerminateOnMigration {
 			args = append(args, "--maintenance-policy", "TERMINATE")

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -72,9 +72,10 @@ type VM struct {
 	CreatedAt time.Time `json:"created_at"`
 	// If non-empty, indicates that some or all of the data in the VM instance
 	// is not present or otherwise invalid.
-	Errors   []error           `json:"errors"`
-	Lifetime time.Duration     `json:"lifetime"`
-	Labels   map[string]string `json:"labels"`
+	Errors      []error           `json:"errors"`
+	Lifetime    time.Duration     `json:"lifetime"`
+	Preemptible bool              `json:"preemptible"`
+	Labels      map[string]string `json:"labels"`
 	// The provider-internal DNS name for the VM instance
 	DNS string `json:"dns"`
 	// The name of the cloud provider that hosts the VM instance
@@ -118,9 +119,10 @@ func Name(cluster string, idx int) string {
 
 // Error values for VM.Error
 var (
-	ErrBadNetwork   = errors.New("could not determine network information")
-	ErrInvalidName  = errors.New("invalid VM name")
-	ErrNoExpiration = errors.New("could not determine expiration")
+	ErrBadNetwork    = errors.New("could not determine network information")
+	ErrBadScheduling = errors.New("could not determine scheduling information")
+	ErrInvalidName   = errors.New("invalid VM name")
+	ErrNoExpiration  = errors.New("could not determine expiration")
 )
 
 var regionRE = regexp.MustCompile(`(.*[^-])-?[a-z]$`)


### PR DESCRIPTION
Backport 1/1 commits from #105470.

/cc @cockroachdb/release

---

Previously, `--gce-preemptible` was available.
This change adds an option to create a GCE spot
instance, whose lifetime can extend 24h; otherwise, it's essentially equivalent to a GCE preemptible.
VM metadata and billing estimator are updated to
handle both preemptible and spot instances.

Epic: none

Release note: None
Release justification: ci/test only change
