### PR TITLE
sql: version gate JSON columns on inverted indexes

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -326,6 +326,7 @@ func checkIndexColumns(
 	version clusterversion.ClusterVersion,
 ) error {
 	for i, colDef := range columns {
+		lastCol := i == len(columns)-1
 		col, err := catalog.MustFindColumnByTreeName(desc, colDef.Column)
 		if err != nil {
 			return errors.Wrapf(err, "finding column %d", i)
@@ -342,7 +343,7 @@ func checkIndexColumns(
 		}
 
 		// Checking if JSON Columns can be forward indexed for a given cluster version.
-		if col.GetType().Family() == types.JsonFamily && !inverted && !version.IsActive(clusterversion.V23_2) {
+		if col.GetType().Family() == types.JsonFamily && (!inverted || !lastCol) && !version.IsActive(clusterversion.V23_2) {
 			return errors.WithHint(
 				pgerror.Newf(
 					pgcode.InvalidTableDefinition,

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -323,12 +323,24 @@ SELECT * FROM backfill_d@idx WHERE i IN (1, 2, 3, 4) AND s = 'bar' AND j @> '7':
 
 # Test selecting, inserting, updating, and deleting on a table with a
 # multi-column JSON inverted index.
+skipif config local-mixed-22.2-23.1
 statement ok
 CREATE TABLE d (
   id INT PRIMARY KEY,
   foo JSONB,
   bar JSONB,
   INVERTED INDEX idx (foo, bar)
+);
+
+# On 22.2 these inverted indexes could not be created, so skip this
+# test by making a normal index
+onlyif config local-mixed-22.2-23.1
+statement ok
+CREATE TABLE d (
+  id INT PRIMARY KEY,
+  foo JSONB,
+  bar JSONB,
+  INDEX idx (id)
 );
 
 # Testing inserting
@@ -394,15 +406,18 @@ INSERT into d VALUES
     (8, '"backfilling"', '[[0], [1], [2], []]')
 
 
+skipif config local-mixed-22.2-23.1
 statement ok
 CREATE INVERTED INDEX idx on d (foo, bar)
 
+skipif config local-mixed-22.2-23.1
 query ITT
 SELECT id, foo, bar FROM d@idx where foo = '"backfilling"' AND bar->2 @> '2' ORDER BY id
 ----
 6  "backfilling"  [[0], [1], 2, 3]
 8  "backfilling"  [[0], [1], [2], []]
 
+skipif config local-mixed-22.2-23.1
 query ITT
 SELECT id, foo, bar FROM d@idx where foo = '"foo"' AND bar->0 = '7' ORDER BY id
 ----

--- a/pkg/upgrade/upgrades/json_forward_indexes_test.go
+++ b/pkg/upgrade/upgrades/json_forward_indexes_test.go
@@ -132,6 +132,14 @@ func TestJSONForwardingIndexes(t *testing.T) {
 	)`)
 	require.Error(t, err)
 
+	// Creating a table with an inverted index with a JSON column should result in an error.
+	_, err = db.Exec(`CREATE TABLE test.tbl_json_secondary_unique(
+    s GEOGRAPHY,
+    j JSONB,
+    INVERTED INDEX tbl_json_secondary_uidx (j, s)
+)`)
+	require.Error(t, err)
+
 	// Setting a cluster version that supports forward indexes on JSON
 	// columns and expecting success when creating forward indexes.
 	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
@@ -157,5 +165,14 @@ func TestJSONForwardingIndexes(t *testing.T) {
 	_, err = db.Exec(`CREATE TABLE test.tbl_json_primary (
 	   key JSONB PRIMARY KEY
 	)`)
+	require.NoError(t, err)
+
+	// Creating a table with an inverted index with a JSON column should not result
+	// in an error once inverted indexes are supported.
+	_, err = db.Exec(`CREATE TABLE test.tbl_json_secondary_unique(
+    s GEOGRAPHY,
+    j JSONB,
+    INVERTED INDEX tbl_json_secondary_uidx (j, s)
+)`)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Previously, our version gate for forward JSON indexes did not correctly handle the case when they are used in inverted indexes. When these columns are not the last column in an inverted index they need to be forward indexable, requiring a similar version gate. This patch fixes version gate logic for this scenario.

Fixes: #104178, Fixes #104707
Release note: None