### PR TITLE
kv: read clock before mutex lock in ReplicaLoad.record

### DIFF
--- a/pkg/kv/kvserver/load/replica_load.go
+++ b/pkg/kv/kvserver/load/replica_load.go
@@ -120,10 +120,11 @@ func NewReplicaLoad(clock *hlc.Clock, getNodeLocality replicastats.LocalityOracl
 }
 
 func (rl *ReplicaLoad) record(stat LoadStat, val float64, nodeID roachpb.NodeID) {
+	now := timeutil.Unix(0, rl.clock.PhysicalNow())
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	rl.mu.stats[stat].RecordCount(timeutil.Unix(0, rl.clock.PhysicalNow()), val, nodeID)
+	rl.mu.stats[stat].RecordCount(now, val, nodeID)
 }
 
 // Split will distribute the load from the calling struct, evenly between itself


### PR DESCRIPTION
This commit moves the clock read outside of the mutex in `ReplicaLoad.record`. Doing so avoids mutex contention.

Epic: None
Release note: None