### PR TITLE
upgrades: fix the write of 'version' to system.tenant_settings

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
@@ -8,10 +8,13 @@ true
 user host-cluster-root
 
 # Ensure that the version is set the same in the system tenant and in the tenant override.
-query I
-select count(*) from system.settings JOIN system.tenant_settings on tenant_settings.name = settings.name where tenant_settings.name = 'version' and tenant_settings.value = settings.value;
+query TI rowsort
+SELECT settings.name, tenant_id
+FROM system.settings
+JOIN system.tenant_settings ON tenant_settings.name = settings.name
+WHERE tenant_settings.name = 'version' AND tenant_settings.value = settings.value;
 ----
-1
+version 0
 
 statement ok
 ALTER TENANT [10] SET CLUSTER SETTING sql.notices.enabled = false

--- a/pkg/server/tenantsettingswatcher/BUILD.bazel
+++ b/pkg/server/tenantsettingswatcher/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     embed = [":tenantsettingswatcher"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv/kvpb",
         "//pkg/roachpb",

--- a/pkg/server/tenantsettingswatcher/watcher_test.go
+++ b/pkg/server/tenantsettingswatcher/watcher_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/tenantsettingswatcher"
@@ -60,6 +61,9 @@ func TestWatcher(t *testing.T) {
 		t.Helper()
 		var vals []string
 		for _, s := range overrides {
+			if s.Name == clusterversion.KeyVersionSetting {
+				continue
+			}
 			vals = append(vals, fmt.Sprintf("%s=%s", s.Name, s.Value.Value))
 		}
 		if actual := strings.Join(vals, " "); actual != expected {

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -415,11 +415,12 @@ EXCEPT SELECT capability_name, capability_value FROM [SHOW TENANT othertenant WI
 ----
 
 # Check that the setting overrides were copied.
-query TTTT
-SELECT variable, value, type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT othertenant]
+query TTTT rowsort
+SELECT variable, IF(variable='version','--',value), type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT othertenant]
 WHERE origin != 'no-override'
 ----
 trace.debug.enable  true  b  per-tenant-override
+version             --    m  all-tenants-override
 
 # Check that the resource usage parameters were copied.
 query IIRRRRI
@@ -463,11 +464,12 @@ EXCEPT SELECT capability_name, capability_value FROM [SHOW TENANT othertenant WI
 ----
 
 # Check the setting overrides were taken over.
-query TTTT
-SELECT variable, value, type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT othertenant]
+query TTTT rowsort
+SELECT variable, IF(variable='version','--',value), type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT othertenant]
 WHERE origin != 'no-override'
 ----
 trace.debug.enable  true  b  per-tenant-override
+version             --    m  all-tenants-override
 
 # Check that the resource usage parameters were copied.
 query IIRRRRI

--- a/pkg/upgrade/upgrades/permanent_upgrades.go
+++ b/pkg/upgrade/upgrades/permanent_upgrades.go
@@ -135,11 +135,12 @@ func populateVersionSetting(
 
 	// Tenant ID 0 indicates that we're overriding the value for all
 	// tenants.
-	tenantID := tree.NewDInt(0)
 	_, err = ie.Exec(
 		ctx,
 		"insert-setting", nil, /* txn */
-		fmt.Sprintf(`INSERT INTO system.tenant_settings (tenant_id, name, value, "last_updated", "value_type") VALUES (%d, 'version', x'%x', now(), 'm') ON CONFLICT(tenant_id, name) DO NOTHING`, tenantID, b),
+		fmt.Sprintf(`
+INSERT INTO system.tenant_settings (tenant_id, name, value, last_updated, value_type)
+VALUES (0, 'version', x'%x', now(), 'm') ON CONFLICT(tenant_id, name) DO NOTHING`, b),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Prior to this patch, a bogus value was written to the tenant_id column for the 'version' override. This patch fixes it.

We also suspect this will help with the multitenant-upgrade roachtest but this will be checked in a later step.

Informs #105858.
Release note: None
Epic: CRDB-26691