### PR TITLE
sql: add implicit SELECT FOR SHARE locking to FK checks

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -822,6 +822,13 @@ func TestTenantLogic_fk(
 	runLogicTest(t, "fk")
 }
 
+func TestTenantLogic_fk_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "fk_read_committed")
+}
+
 func TestTenantLogic_float(
 	t *testing.T,
 ) {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -627,7 +627,8 @@ func (ex *connExecutor) execStmtInOpenState(
 	if !isPausablePortal() || portal.pauseInfo.execStmtInOpenState.ihWrapper == nil {
 		ctx, needFinish = ih.Setup(
 			ctx, ex.server.cfg, ex.statsCollector, p, ex.stmtDiagnosticsRecorder,
-			stmt.StmtNoConstants, os.ImplicitTxn.Get(), ex.extraTxnState.shouldCollectTxnExecutionStats,
+			stmt.StmtNoConstants, os.ImplicitTxn.Get(), ex.state.priority,
+			ex.extraTxnState.shouldCollectTxnExecutionStats,
 		)
 	} else {
 		ctx = portal.pauseInfo.execStmtInOpenState.ihWrapper.ctx
@@ -2926,7 +2927,11 @@ func (ex *connExecutor) recordTransactionFinish(
 		RowsWritten:             ex.extraTxnState.rowsWritten,
 		BytesRead:               ex.extraTxnState.bytesRead,
 		Priority:                ex.state.priority,
-		SessionData:             ex.sessionData(),
+		// TODO(107318): add isolation level
+		// TODO(107318): add qos
+		// TODO(107318): add asoftime or ishistorical
+		// TODO(107318): add readonly
+		SessionData: ex.sessionData(),
 	}
 
 	if ex.server.cfg.TestingKnobs.OnRecordTxnFinish != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3612,6 +3612,10 @@ func (m *sessionDataMutator) SetOptimizerUseImprovedJoinElimination(val bool) {
 	m.data.OptimizerUseImprovedJoinElimination = val
 }
 
+func (m *sessionDataMutator) SetImplicitFKLockingForSerializable(val bool) {
+	m.data.ImplicitFKLockingForSerializable = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/fk_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/fk_read_committed
@@ -1,0 +1,46 @@
+# LogicTest: !local-mixed-22.2-23.1
+
+# Some foreign key checks are prohibited under weaker isolation levels until we
+# improve locking. See #80683, #100156, #100193.
+
+statement ok
+CREATE TABLE jars (j INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE cookies (c INT PRIMARY KEY, j INT REFERENCES jars (j))
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+statement ok
+INSERT INTO jars VALUES (1), (2)
+
+# Foreign key checks of the parent require durable shared locking under weaker
+# isolation levels, and are not yet supported.
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
+INSERT INTO cookies VALUES (1, 1)
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE
+
+statement ok
+INSERT INTO cookies VALUES (1, 1)
+
+statement ok
+COMMIT
+
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
+UPDATE cookies SET j = 2 WHERE c = 1
+
+# Foreign key checks of the child do not require locking.
+query error violates foreign key constraint
+UPDATE jars SET j = j + 4
+
+query error violates foreign key constraint
+DELETE FROM jars WHERE j = 1
+
+statement ok
+DELETE FROM cookies WHERE c = 1
+
+statement ok
+DELETE FROM jars WHERE j = 1

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5289,6 +5289,7 @@ enable_auto_rehoming                                       off
 enable_create_stats_using_extremes                         off
 enable_drop_enum_value                                     on
 enable_experimental_alter_column_type_general              off
+enable_implicit_fk_locking_for_serializable                off
 enable_implicit_select_for_update                          on
 enable_implicit_transaction_for_batch_statements           on
 enable_insert_fast_path                                    on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2727,6 +2727,7 @@ distsql                                                    off                 N
 enable_auto_rehoming                                       off                 NULL      NULL        NULL        string
 enable_create_stats_using_extremes                         off                 NULL      NULL        NULL        string
 enable_experimental_alter_column_type_general              off                 NULL      NULL        NULL        string
+enable_implicit_fk_locking_for_serializable                off                 NULL      NULL        NULL        string
 enable_implicit_select_for_update                          on                  NULL      NULL        NULL        string
 enable_implicit_transaction_for_batch_statements           on                  NULL      NULL        NULL        string
 enable_insert_fast_path                                    on                  NULL      NULL        NULL        string
@@ -2887,6 +2888,7 @@ distsql                                                    off                 N
 enable_auto_rehoming                                       off                 NULL  user     NULL      off                 off
 enable_create_stats_using_extremes                         off                 NULL  user     NULL      off                 off
 enable_experimental_alter_column_type_general              off                 NULL  user     NULL      off                 off
+enable_implicit_fk_locking_for_serializable                off                 NULL  user     NULL      off                 off
 enable_implicit_select_for_update                          on                  NULL  user     NULL      on                  on
 enable_implicit_transaction_for_batch_statements           on                  NULL  user     NULL      on                  on
 enable_insert_fast_path                                    on                  NULL  user     NULL      on                  on
@@ -3044,6 +3046,7 @@ distsql_workmem                                            NULL    NULL     NULL
 enable_auto_rehoming                                       NULL    NULL     NULL     NULL        NULL
 enable_create_stats_using_extremes                         NULL    NULL     NULL     NULL        NULL
 enable_experimental_alter_column_type_general              NULL    NULL     NULL     NULL        NULL
+enable_implicit_fk_locking_for_serializable                NULL    NULL     NULL     NULL        NULL
 enable_implicit_select_for_update                          NULL    NULL     NULL     NULL        NULL
 enable_implicit_transaction_for_batch_statements           NULL    NULL     NULL     NULL        NULL
 enable_insert_fast_path                                    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/read_committed
@@ -38,7 +38,7 @@ COMMIT
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
 
-query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
 SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE
 
 statement ok
@@ -51,7 +51,7 @@ SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SNAPSHOT
 
-query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under Snapshot isolation
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
 SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE
 
 statement ok
@@ -67,7 +67,7 @@ BEGIN TRANSACTION
 statement ok
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 
-query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
 UPDATE supermarket
   SET aisle = (SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE)
   WHERE person = 'michael'
@@ -82,7 +82,7 @@ BEGIN TRANSACTION
 statement ok
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 
-query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
 WITH s AS
   (SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE)
 SELECT aisle + 1 FROM s
@@ -99,7 +99,7 @@ statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
 
 # But calling that function should fail.
-query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
 INSERT INTO supermarket (person, aisle) VALUES ('grandma', wrangle('matilda'))
 
 statement ok
@@ -116,14 +116,14 @@ statement ok
 PREPARE psa AS SELECT aisle FROM supermarket WHERE person = $1::STRING FOR UPDATE
 
 # But execution should fail.
-query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
 EXECUTE psa('matilda')
 
 statement ok
 DEALLOCATE psa
 
 # SELECT FOR UPDATE using a lookup join should also fail.
-query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
 WITH names AS MATERIALIZED
   (SELECT 'matilda' AS person)
 SELECT aisle
@@ -132,14 +132,14 @@ SELECT aisle
   FOR UPDATE
 
 # SELECT FOR UPDATE using an index join should also fail.
-query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
 SELECT aisle
   FROM supermarket@supermarket_starts_with_idx
   WHERE starts_with = 'm'
   FOR UPDATE
 
 # SELECT FOR UPDATE using a zigzag join should also fail.
-query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
+query error pgcode 0A000 guaranteed-durable locking not yet implemented
 SELECT aisle
   FROM supermarket@{FORCE_ZIGZAG}
   WHERE starts_with = 'm' AND ends_with = 'lda'

--- a/pkg/sql/logictest/testdata/logic_test/read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/read_committed
@@ -3,7 +3,7 @@
 subtest select_for_update
 
 # SELECT FOR UPDATE is prohibited under weaker isolation levels until we improve
-# locking. See #57031, #75457, #100144.
+# locking. See #57031, #75457, #100144, #100193.
 
 statement ok
 CREATE TABLE supermarket (

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -62,6 +62,7 @@ distsql                                                    off
 enable_auto_rehoming                                       off
 enable_create_stats_using_extremes                         off
 enable_experimental_alter_column_type_general              off
+enable_implicit_fk_locking_for_serializable                off
 enable_implicit_select_for_update                          on
 enable_implicit_transaction_for_batch_statements           on
 enable_insert_fast_path                                    on

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -793,6 +793,13 @@ func TestLogic_fk(
 	runLogicTest(t, "fk")
 }
 
+func TestLogic_fk_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "fk_read_committed")
+}
+
 func TestLogic_float(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -793,6 +793,13 @@ func TestLogic_fk(
 	runLogicTest(t, "fk")
 }
 
+func TestLogic_fk_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "fk_read_committed")
+}
+
 func TestLogic_float(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -793,6 +793,13 @@ func TestLogic_fk(
 	runLogicTest(t, "fk")
 }
 
+func TestLogic_fk_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "fk_read_committed")
+}
+
 func TestLogic_float(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -779,6 +779,13 @@ func TestLogic_fk(
 	runLogicTest(t, "fk")
 }
 
+func TestLogic_fk_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "fk_read_committed")
+}
+
 func TestLogic_float(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -800,6 +800,13 @@ func TestLogic_fk(
 	runLogicTest(t, "fk")
 }
 
+func TestLogic_fk_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "fk_read_committed")
+}
+
 func TestLogic_float(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -828,6 +828,13 @@ func TestLogic_fk(
 	runLogicTest(t, "fk")
 }
 
+func TestLogic_fk_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "fk_read_committed")
+}
+
 func TestLogic_float(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -17,7 +17,6 @@ import (
 	"math"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -2901,11 +2900,9 @@ func (b *Builder) buildLocking(locking opt.Locking) (opt.Locking, error) {
 				"cannot execute %s in a read-only transaction", locking.Strength.String(),
 			)
 		}
-		if locking.Durability == tree.LockDurabilityGuaranteed &&
-			b.evalCtx.TxnIsoLevel != isolation.Serializable {
+		if locking.Durability == tree.LockDurabilityGuaranteed {
 			return opt.Locking{}, unimplemented.NewWithIssuef(
-				100144, "cannot execute SELECT FOR UPDATE statements under %s isolation",
-				b.evalCtx.TxnIsoLevel,
+				100193, "guaranteed-durable locking not yet implemented",
 			)
 		}
 		b.ContainsNonDefaultKeyLocking = true

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
@@ -60,6 +60,9 @@ rows decoded from KV: 5 (40 B, 10 KVs, 5 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • group (scalar)
 │ nodes: <hidden>
@@ -94,6 +97,9 @@ rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • merge join
 │ nodes: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -109,6 +109,9 @@ rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • create statistics
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -2227,6 +2227,9 @@ vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • values
   nodes: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -13,6 +13,9 @@ vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • scan
   nodes: <hidden>
@@ -42,6 +45,47 @@ rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  nodes: <hidden>
+  regions: <hidden>
+  actual row count: 3
+  KV time: 0µs
+  KV contention time: 0µs
+  KV rows decoded: 3
+  KV pairs read: 6
+  KV bytes read: 24 B
+  KV gRPC calls: 3
+  estimated max memory allocated: 0 B
+  missing stats
+  table: kv@kv_pkey
+  spans: [/2 - ]
+
+# Test that non-default isolation level, priority, and QoS are correct.
+
+statement ok
+SET default_transaction_quality_of_service = background
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED PRIORITY LOW
+
+query T
+EXPLAIN ANALYZE (PLAN) SELECT * FROM kv WHERE k >= 2
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: read committed
+priority: low
+quality of service: background
 ·
 • scan
   nodes: <hidden>
@@ -59,6 +103,12 @@ regions: <hidden>
   spans: [/2 - ]
 
 statement ok
+ROLLBACK
+
+statement ok
+RESET default_transaction_quality_of_service
+
+statement ok
 CREATE TABLE ab (a INT PRIMARY KEY, b INT);
 INSERT INTO ab VALUES (10,100), (40,400), (50,500);
 
@@ -73,6 +123,9 @@ rows decoded from KV: 7 (56 B, 14 KVs, 7 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • hash join (inner)
 │ columns: (k, v, a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -69,6 +69,9 @@ rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • group (streaming)
 │ nodes: <hidden>
@@ -131,6 +134,9 @@ rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • sort
 │ nodes: <hidden>
@@ -201,6 +207,9 @@ rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • cross join
 │ nodes: <hidden>
@@ -284,6 +293,9 @@ rows decoded from KV: 5 (40 B, 10 KVs, 5 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • window
 │ nodes: <hidden>
@@ -321,6 +333,9 @@ vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • scan
   nodes: <hidden>
@@ -355,6 +370,9 @@ rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • root
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -42,6 +42,44 @@ vectorized: true
                   estimated row count: 2
                   label: buffer 1
 
+# Try again with implicit locking of the parent row.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN INSERT INTO child VALUES (1,1), (2,2)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: child(c, p)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 2 columns, 2 rows
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
+            │ equality: (column2) = (p)
+            │ equality cols are key
+            │ locking strength: for share
+            │
+            └── • scan buffer
+                  estimated row count: 2
+                  label: buffer 1
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
+
 # Use data from a different table as input.
 statement ok
 CREATE TABLE xy (x INT, y INT)
@@ -81,6 +119,49 @@ vectorized: true
                   table: parent@parent_pkey
                   spans: FULL SCAN
 
+# Try again with implicit locking of the parent row.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN INSERT INTO child SELECT x,y FROM xy
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: child(c, p)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: xy@xy_pkey
+│             spans: FULL SCAN
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (anti)
+            │ equality: (y) = (p)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: parent@parent_pkey
+                  spans: FULL SCAN
+                  locking strength: for share
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
+
 statement ok
 CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p), INDEX (p));
 
@@ -119,6 +200,48 @@ vectorized: true
                 └── • scan buffer
                       estimated row count: 2
                       label: buffer 1
+
+# Try again with implicit locking of the parent row.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN INSERT INTO child_nullable VALUES (100, 1), (200, NULL)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: child_nullable(c, p)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 2 columns, 2 rows
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
+            │ equality: (column2) = (p)
+            │ equality cols are key
+            │ locking strength: for share
+            │
+            └── • filter
+                │ estimated row count: 1
+                │ filter: column2 IS NOT NULL
+                │
+                └── • scan buffer
+                      estimated row count: 2
+                      label: buffer 1
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
 
 # Tests with multicolumn FKs.
 statement ok
@@ -290,6 +413,55 @@ vectorized: true
             └── • scan buffer
                   label: buffer 1
 
+# Even with implicit locking enabled, we should not acquire any shared locks
+# when checking a delete from the parent.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN DELETE FROM parent WHERE p = 3
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • delete
+│   │ from: parent
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: parent@parent_pkey
+│             spans: [/3 - /3]
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: child@child_p_idx
+│           │ equality: (p) = (p)
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: child_nullable@child_nullable_p_idx
+            │ equality: (p) = (p)
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
+
 statement ok
 CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other), INDEX (p))
 
@@ -428,6 +600,53 @@ vectorized: true
                   table: parent@parent_pkey
                   spans: FULL SCAN
 
+# Try again with implicit locking of the parent row.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN UPDATE child SET p = 4
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@child_pkey
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • merge join (anti)
+            │ equality: (p_new) = (p)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: parent@parent_pkey
+                  spans: FULL SCAN
+                  locking strength: for share
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
+
 query T
 EXPLAIN UPDATE child SET p = 4 WHERE c = 10
 ----
@@ -462,6 +681,49 @@ vectorized: true
             │
             └── • scan buffer
                   label: buffer 1
+
+# Try again with implicit locking of the parent row.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN UPDATE child SET p = 4 WHERE c = 10
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@child_pkey
+│                 spans: [/10 - /10]
+│                 locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
+            │ equality: (p_new) = (p)
+            │ equality cols are key
+            │ locking strength: for share
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
 
 query T
 EXPLAIN UPDATE parent SET p = p+1
@@ -644,6 +906,63 @@ vectorized: true
                       table: grandchild@grandchild_pkey
                       spans: FULL SCAN
 
+# Even with implicit locking enabled, we should not acquire any shared locks
+# when checking an update of the parent (in this case the child is parent of the
+# grandchild).
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN UPDATE child SET c = 4
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: c
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@child_pkey
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join
+            │ equality: (c) = (c)
+            │ left cols are key
+            │ right cols are key
+            │
+            ├── • except all
+            │   │
+            │   ├── • scan buffer
+            │   │     label: buffer 1
+            │   │
+            │   └── • scan buffer
+            │         label: buffer 1
+            │
+            └── • distinct
+                │ distinct on: c
+                │
+                └── • scan
+                      missing stats
+                      table: grandchild@grandchild_pkey
+                      spans: FULL SCAN
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
+
 # This update shouldn't emit checks for c, since it's unchanged.
 query T
 EXPLAIN UPDATE child SET p = 4
@@ -683,6 +1002,53 @@ vectorized: true
                   missing stats
                   table: parent@parent_pkey
                   spans: FULL SCAN
+
+# Try again with implicit locking of the parent row.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN UPDATE child SET p = 4
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@child_pkey
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • merge join (anti)
+            │ equality: (p_new) = (p)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: parent@parent_pkey
+                  spans: FULL SCAN
+                  locking strength: for share
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
 
 query T
 EXPLAIN UPDATE child SET p = p
@@ -785,6 +1151,78 @@ vectorized: true
                       table: grandchild@grandchild_pkey
                       spans: FULL SCAN
 
+# Try again with implicit locking of the parent row.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN UPDATE child SET p = p+1, c = c+1
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: c, p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@child_pkey
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (anti)
+│           │ equality: (p_new) = (p)
+│           │ right cols are key
+│           │
+│           ├── • scan buffer
+│           │     label: buffer 1
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: parent@parent_pkey
+│                 spans: FULL SCAN
+│                 locking strength: for share
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join
+            │ equality: (c) = (c)
+            │ left cols are key
+            │ right cols are key
+            │
+            ├── • except all
+            │   │
+            │   ├── • scan buffer
+            │   │     label: buffer 1
+            │   │
+            │   └── • scan buffer
+            │         label: buffer 1
+            │
+            └── • distinct
+                │ distinct on: c
+                │
+                └── • scan
+                      missing stats
+                      table: grandchild@grandchild_pkey
+                      spans: FULL SCAN
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
+
 # Multiple grandchild tables
 statement ok
 CREATE TABLE grandchild2 (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
@@ -870,6 +1308,53 @@ vectorized: true
                   table: self@self_pkey
                   spans: FULL SCAN
 
+# Try again with implicit locking of the parent row.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN UPDATE self SET y = 3
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: self
+│   │ set: y
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: self@self_pkey
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • merge join (anti)
+            │ equality: (y_new) = (x)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: self@self_pkey
+                  spans: FULL SCAN
+                  locking strength: for share
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
+
 query T
 EXPLAIN UPDATE self SET x = 3
 ----
@@ -918,6 +1403,62 @@ vectorized: true
                       table: self@self_pkey
                       spans: FULL SCAN
 
+# Even with implicit locking enabled, we should not acquire any shared locks
+# when checking an update of the parent.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN UPDATE self SET x = 3
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: self
+│   │ set: x
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: self@self_pkey
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join
+            │ equality: (x) = (y)
+            │ left cols are key
+            │ right cols are key
+            │
+            ├── • except all
+            │   │
+            │   ├── • scan buffer
+            │   │     label: buffer 1
+            │   │
+            │   └── • scan buffer
+            │         label: buffer 1
+            │
+            └── • distinct
+                │ distinct on: y
+                │
+                └── • scan
+                      missing stats
+                      table: self@self_pkey
+                      spans: FULL SCAN
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
+
 # Tests for the insert fast path.
 statement ok
 SET enable_insert_fast_path = true
@@ -940,6 +1481,32 @@ vectorized: true
   row 0, expr 1: 1
   row 1, expr 0: 2
   row 1, expr 1: 2
+
+# Try again with implicit locking of the parent row.
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN (VERBOSE) INSERT INTO child VALUES (1,1), (2,2)
+----
+distribution: local
+vectorized: true
+·
+• insert fast path
+  columns: ()
+  estimated row count: 0 (missing stats)
+  into: child(c, p)
+  auto commit
+  FK check: parent@parent_pkey
+  FK check locking strength: for share
+  size: 2 columns, 2 rows
+  row 0, expr 0: 1
+  row 0, expr 1: 1
+  row 1, expr 0: 2
+  row 1, expr 1: 2
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
 
 # We shouldn't use the fast path if the VALUES columns are not in order.
 query B

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_read_committed
@@ -1,0 +1,119 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE jars (j INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE cookies (c INT PRIMARY KEY, j INT REFERENCES jars (j))
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+# Foreign key checks of the parent require durable shared locking under weaker
+# isolation levels.
+query T
+EXPLAIN (OPT) INSERT INTO cookies VALUES (1, 1)
+----
+insert cookies
+ ├── values
+ │    └── (1, 1)
+ └── f-k-checks
+      └── f-k-checks-item: cookies(j) -> jars(j)
+           └── anti-join (lookup jars)
+                ├── lookup columns are key
+                ├── locking: for-share,durability-guaranteed
+                ├── with-scan &1
+                └── filters (true)
+
+# Under serializable isolation, locking is not required, unless
+# enable_implicit_fk_locking_for_serializable is true.
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE
+
+query T
+EXPLAIN (OPT) INSERT INTO cookies VALUES (1, 1)
+----
+insert cookies
+ ├── values
+ │    └── (1, 1)
+ └── f-k-checks
+      └── f-k-checks-item: cookies(j) -> jars(j)
+           └── anti-join (lookup jars)
+                ├── lookup columns are key
+                ├── with-scan &1
+                └── filters (true)
+
+statement ok
+SET enable_implicit_fk_locking_for_serializable = true
+
+query T
+EXPLAIN (OPT) INSERT INTO cookies VALUES (1, 1)
+----
+insert cookies
+ ├── values
+ │    └── (1, 1)
+ └── f-k-checks
+      └── f-k-checks-item: cookies(j) -> jars(j)
+           └── anti-join (lookup jars)
+                ├── lookup columns are key
+                ├── locking: for-share
+                ├── with-scan &1
+                └── filters (true)
+
+statement ok
+RESET enable_implicit_fk_locking_for_serializable
+
+statement ok
+COMMIT
+
+query T
+EXPLAIN (OPT) UPDATE cookies SET j = 2 WHERE c = 1
+----
+update cookies
+ ├── project
+ │    ├── scan cookies
+ │    │    └── constraint: /5: [/1 - /1]
+ │    └── projections
+ │         └── 2
+ └── f-k-checks
+      └── f-k-checks-item: cookies(j) -> jars(j)
+           └── anti-join (lookup jars)
+                ├── lookup columns are key
+                ├── locking: for-share,durability-guaranteed
+                ├── with-scan &1
+                └── filters (true)
+
+# Foreign key checks of the child do not require locking.
+query T
+EXPLAIN (OPT) UPDATE jars SET j = j + 4
+----
+update jars
+ ├── project
+ │    ├── scan jars
+ │    └── projections
+ │         └── jars.j + 4
+ └── f-k-checks
+      └── f-k-checks-item: cookies(j) -> jars(j)
+           └── project
+                └── inner-join (hash)
+                     ├── except-all
+                     │    ├── with-scan &1
+                     │    └── with-scan &1
+                     ├── distinct-on
+                     │    └── scan cookies
+                     └── filters
+                          └── j = cookies.j
+
+query T
+EXPLAIN (OPT) DELETE FROM jars WHERE j = 1
+----
+delete jars
+ ├── scan jars
+ │    └── constraint: /4: [/1 - /1]
+ └── f-k-checks
+      └── f-k-checks-item: cookies(j) -> jars(j)
+           └── semi-join (hash)
+                ├── with-scan &1
+                ├── scan cookies
+                └── filters
+                     └── j = cookies.j

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
@@ -30,6 +30,9 @@ rows decoded from KV: 6 (48 B, 12 KVs, 6 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • sort
 │ nodes: <hidden>
@@ -119,6 +122,9 @@ rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • sort
 │ nodes: <hidden>
@@ -192,6 +198,9 @@ rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • sort
 │ nodes: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -84,6 +84,9 @@ rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • limit
 │ count: 1
@@ -165,6 +168,9 @@ rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • limit
 │ count: 1
@@ -319,6 +325,9 @@ rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • limit
 │ count: 1
@@ -411,6 +420,9 @@ rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • limit
 │ count: 2

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -119,6 +119,9 @@ rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • scan
   nodes: <hidden>
@@ -145,6 +148,9 @@ vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • scan
   nodes: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -28,7 +28,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE
@@ -42,7 +41,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for no key update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE
@@ -56,7 +54,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for share
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE
@@ -70,7 +67,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for key share
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE
@@ -84,7 +80,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for share
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
@@ -98,7 +93,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for no key update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
@@ -112,7 +106,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t
@@ -126,7 +119,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2
@@ -147,7 +139,6 @@ vectorized: true
       table: t@t_pkey
       spans: FULL SCAN
       locking strength: for update
-      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE
@@ -161,7 +152,6 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE
@@ -175,7 +165,6 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for no key update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE
@@ -189,7 +178,6 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for share
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE
@@ -203,7 +191,6 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for key share
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE
@@ -217,7 +204,6 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for share
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
@@ -231,7 +217,6 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for no key update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
@@ -245,7 +230,6 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t
@@ -259,7 +243,6 @@ vectorized: true
   table: t@t_pkey
   spans: /1/0
   locking strength: for update
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2
@@ -280,7 +263,6 @@ vectorized: true
       table: t@t_pkey
       spans: /1/0
       locking strength: for update
-      locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with table aliases.
@@ -298,7 +280,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 FOR UPDATE OF t
@@ -315,7 +296,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM [$t_id AS t] FOR UPDATE
@@ -329,7 +309,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM [$t_id AS t] FOR UPDATE OF t
@@ -343,7 +322,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM [$t_id AS t] FOR UPDATE OF t2
@@ -364,7 +342,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF v
@@ -378,7 +355,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "v2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF v2
@@ -405,7 +381,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "v" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM v AS v2 FOR UPDATE OF v
@@ -422,7 +397,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with subqueries.
@@ -444,7 +418,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE)
@@ -458,7 +431,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
@@ -472,7 +444,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for no key update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
@@ -486,7 +457,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for no key update
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) FOR UPDATE OF t
@@ -503,7 +473,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
@@ -517,7 +486,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
@@ -531,7 +499,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE OF t
@@ -548,7 +515,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) FOR UPDATE
@@ -608,7 +574,6 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
-              locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) FOR UPDATE OF t
@@ -642,7 +607,6 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
-              locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) AS r FOR UPDATE
@@ -702,7 +666,6 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
-              locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) AS r FOR UPDATE OF t
@@ -736,7 +699,6 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
-              locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE
@@ -750,7 +712,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE)
@@ -776,7 +737,6 @@ vectorized: true
   table: t@t_pkey
   spans: FULL SCAN
   locking strength: for update
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE OF t)
@@ -806,7 +766,6 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
-    │ locking durability: guaranteed
     │
     └── • distinct
         │ columns: (b)
@@ -846,7 +805,6 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
-              locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE OF t
@@ -864,7 +822,6 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
-    │ locking durability: guaranteed
     │
     └── • distinct
         │ columns: (b)
@@ -904,7 +861,6 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
-              locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with common-table expressions.
@@ -978,7 +934,6 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
-              locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
@@ -1009,7 +964,6 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
-              locking durability: guaranteed
 
 # Verify that the unused CTE doesn't get eliminated.
 # TODO(radu): we should at least not buffer the rows in this case.
@@ -1044,7 +998,6 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
               locking strength: for update
-              locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with joins.
@@ -1074,7 +1027,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1083,7 +1035,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
-          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
@@ -1109,7 +1060,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1149,7 +1099,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
-          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
@@ -1175,7 +1124,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1184,7 +1132,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
-          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
@@ -1210,7 +1157,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1219,7 +1165,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for share
-          locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
@@ -1248,7 +1193,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1257,7 +1201,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for share
-          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
@@ -1283,7 +1226,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1292,7 +1234,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
-          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
@@ -1318,7 +1259,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for no key update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1327,7 +1267,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for key share
-          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UPDATE OF u
@@ -1353,7 +1292,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for no key update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1362,7 +1300,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
-          locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with joins of aliased tables and aliased joins.
@@ -1392,7 +1329,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1401,7 +1337,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
-          locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t
@@ -1436,7 +1371,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1476,7 +1410,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
-          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
@@ -1502,7 +1435,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1511,7 +1443,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
-          locking durability: guaranteed
 
 # Postgres doesn't support applying locking clauses to joins. The following
 # queries all return the error: "FOR UPDATE cannot be applied to a join".
@@ -1541,7 +1472,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1550,7 +1480,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
-          locking durability: guaranteed
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF t
@@ -1585,7 +1514,6 @@ vectorized: true
     │     table: t@t_pkey
     │     spans: FULL SCAN
     │     locking strength: for update
-    │     locking durability: guaranteed
     │
     └── • scan
           columns: (a, b, c)
@@ -1594,7 +1522,6 @@ vectorized: true
           table: u@u_pkey
           spans: FULL SCAN
           locking strength: for update
-          locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with lateral joins.
@@ -1616,7 +1543,6 @@ vectorized: true
 │     table: t@t_pkey
 │     spans: FULL SCAN
 │     locking strength: for update
-│     locking durability: guaranteed
 │
 └── • scan
       columns: (a, b, c)
@@ -1624,7 +1550,6 @@ vectorized: true
       table: u@u_pkey
       spans: FULL SCAN
       locking strength: for update
-      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t, u FOR UPDATE OF t
@@ -1642,7 +1567,6 @@ vectorized: true
 │     table: t@t_pkey
 │     spans: FULL SCAN
 │     locking strength: for update
-│     locking durability: guaranteed
 │
 └── • scan
       columns: (a, b, c)
@@ -1666,7 +1590,6 @@ vectorized: true
 │     table: t@t_pkey
 │     spans: FULL SCAN
 │     locking strength: for share
-│     locking durability: guaranteed
 │
 └── • scan
       columns: (a, b, c)
@@ -1674,7 +1597,6 @@ vectorized: true
       table: u@u_pkey
       spans: FULL SCAN
       locking strength: for update
-      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
@@ -1692,7 +1614,6 @@ vectorized: true
 │     table: t@t_pkey
 │     spans: FULL SCAN
 │     locking strength: for update
-│     locking durability: guaranteed
 │
 └── • scan
       columns: (a, b, c)
@@ -1700,7 +1621,6 @@ vectorized: true
       table: u@u_pkey
       spans: FULL SCAN
       locking strength: for update
-      locking durability: guaranteed
 
 query error pgcode 42P01 relation "u" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF u
@@ -1727,7 +1647,6 @@ vectorized: true
       table: u@u_pkey
       spans: FULL SCAN
       locking strength: for update
-      locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with index joins.
@@ -1753,7 +1672,6 @@ vectorized: true
 │ table: indexed@indexed_pkey
 │ key columns: a
 │ locking strength: for update
-│ locking durability: guaranteed
 │
 └── • scan
       columns: (a, b)
@@ -1761,7 +1679,6 @@ vectorized: true
       table: indexed@b_idx
       spans: /2-/3
       locking strength: for update
-      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM indexed WHERE b BETWEEN 2 AND 10 FOR UPDATE
@@ -1775,7 +1692,6 @@ vectorized: true
 │ table: indexed@indexed_pkey
 │ key columns: a
 │ locking strength: for update
-│ locking durability: guaranteed
 │
 └── • scan
       columns: (a, b)
@@ -1783,7 +1699,6 @@ vectorized: true
       table: indexed@b_idx
       spans: /2-/11
       locking strength: for update
-      locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with lookup joins.
@@ -1805,7 +1720,6 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
-    │ locking durability: guaranteed
     │
     └── • scan
           columns: (a, b)
@@ -1813,7 +1727,6 @@ vectorized: true
           table: t@t_pkey
           spans: /2/0
           locking strength: for update
-          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a BETWEEN 2 AND 10 FOR UPDATE
@@ -1831,7 +1744,6 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
-    │ locking durability: guaranteed
     │
     └── • scan
           columns: (a, b)
@@ -1840,7 +1752,6 @@ vectorized: true
           spans: /2-/11
           parallel
           locking strength: for update
-          locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN indexed ON t.b = indexed.b WHERE t.a = 2 FOR UPDATE
@@ -1855,7 +1766,6 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
-│ locking durability: guaranteed
 │
 └── • lookup join (inner)
     │ columns: (a, b, a, b)
@@ -1863,7 +1773,6 @@ vectorized: true
     │ table: indexed@b_idx
     │ equality: (b) = (b)
     │ locking strength: for update
-    │ locking durability: guaranteed
     │
     └── • scan
           columns: (a, b)
@@ -1871,7 +1780,6 @@ vectorized: true
           table: t@t_pkey
           spans: /2/0
           locking strength: for update
-          locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with inverted filters and joins.
@@ -1898,7 +1806,6 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
-│ locking durability: guaranteed
 │
 └── • project
     │ columns: (a)
@@ -1910,12 +1817,10 @@ vectorized: true
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
           left locking strength: for update
-          left locking durability: guaranteed
           right table: inverted@b_inv
           right columns: (a, b_inverted_key)
           right fixed values: 1 column
           right locking strength: for update
-          right locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM inverted WHERE b <@ '{1, 2}' FOR UPDATE
@@ -1934,7 +1839,6 @@ vectorized: true
     │ table: inverted@inverted_pkey
     │ key columns: a
     │ locking strength: for update
-    │ locking durability: guaranteed
     │
     └── • project
         │ columns: (a)
@@ -1951,7 +1855,6 @@ vectorized: true
                   table: inverted@b_inv
                   spans: /[]-/"D" /1-/3
                   locking strength: for update
-                  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM inverted@b_inv AS i1, inverted AS i2 WHERE i1.b @> i2.b FOR UPDATE
@@ -1970,7 +1873,6 @@ vectorized: true
     │ equality cols are key
     │ pred: b @> b
     │ locking strength: for update
-    │ locking durability: guaranteed
     │
     └── • project
         │ columns: (a, b, c, a)
@@ -1981,7 +1883,6 @@ vectorized: true
             │ table: inverted@b_inv
             │ inverted expr: b_inverted_key @> b
             │ locking strength: for update
-            │ locking durability: guaranteed
             │
             └── • scan
                   columns: (a, b, c)
@@ -1989,7 +1890,6 @@ vectorized: true
                   table: inverted@inverted_pkey
                   spans: FULL SCAN
                   locking strength: for update
-                  locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with zigzag joins.
@@ -2023,12 +1923,10 @@ vectorized: true
       left columns: (a, b)
       left fixed values: 1 column
       left locking strength: for update
-      left locking durability: guaranteed
       right table: zigzag@c_idx
       right columns: (a, c)
       right fixed values: 1 column
       right locking strength: for update
-      right locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * from zigzag where d @> '{"a": {"b": "c"}, "f": "g"}' FOR UPDATE
@@ -2043,7 +1941,6 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
-│ locking durability: guaranteed
 │
 └── • project
     │ columns: (a)
@@ -2055,12 +1952,10 @@ vectorized: true
           left columns: (a, d_inverted_key)
           left fixed values: 1 column
           left locking strength: for update
-          left locking durability: guaranteed
           right table: zigzag@d_idx
           right columns: (a, d_inverted_key)
           right fixed values: 1 column
           right locking strength: for update
-          right locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with the NOWAIT lock wait policy.
@@ -2079,7 +1974,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE NOWAIT
@@ -2094,7 +1988,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for no key update
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE NOWAIT
@@ -2109,7 +2002,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for share
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE NOWAIT
@@ -2124,7 +2016,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for key share
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
@@ -2139,7 +2030,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for share
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
@@ -2154,7 +2044,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for no key update
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
@@ -2169,7 +2058,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t NOWAIT
@@ -2184,7 +2072,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2 NOWAIT
@@ -2206,7 +2093,6 @@ vectorized: true
       spans: FULL SCAN
       locking strength: for update
       locking wait policy: nowait
-      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE NOWAIT
@@ -2221,7 +2107,6 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE NOWAIT
@@ -2236,7 +2121,6 @@ vectorized: true
   spans: /1/0
   locking strength: for no key update
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE NOWAIT
@@ -2251,7 +2135,6 @@ vectorized: true
   spans: /1/0
   locking strength: for share
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE NOWAIT
@@ -2266,7 +2149,6 @@ vectorized: true
   spans: /1/0
   locking strength: for key share
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE NOWAIT
@@ -2281,7 +2163,6 @@ vectorized: true
   spans: /1/0
   locking strength: for share
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE NOWAIT
@@ -2296,7 +2177,6 @@ vectorized: true
   spans: /1/0
   locking strength: for no key update
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE NOWAIT
@@ -2311,7 +2191,6 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t NOWAIT
@@ -2326,7 +2205,6 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: nowait
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2 NOWAIT
@@ -2348,7 +2226,6 @@ vectorized: true
       spans: /1/0
       locking strength: for update
       locking wait policy: nowait
-      locking durability: guaranteed
 
 # ------------------------------------------------------------------------------
 # Tests with the SKIP LOCKED lock wait policy.
@@ -2367,7 +2244,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
@@ -2382,7 +2258,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for no key update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE SKIP LOCKED
@@ -2397,7 +2272,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for share
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE SKIP LOCKED
@@ -2412,7 +2286,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for key share
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
@@ -2427,7 +2300,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for share
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
@@ -2442,7 +2314,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for no key update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
@@ -2457,7 +2328,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
@@ -2472,7 +2342,6 @@ vectorized: true
   spans: FULL SCAN
   locking strength: for update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2 SKIP LOCKED
@@ -2494,7 +2363,6 @@ vectorized: true
       spans: FULL SCAN
       locking strength: for update
       locking wait policy: skip locked
-      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE SKIP LOCKED
@@ -2509,7 +2377,6 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE SKIP LOCKED
@@ -2524,7 +2391,6 @@ vectorized: true
   spans: /1/0
   locking strength: for no key update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE SKIP LOCKED
@@ -2539,7 +2405,6 @@ vectorized: true
   spans: /1/0
   locking strength: for share
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE SKIP LOCKED
@@ -2554,7 +2419,6 @@ vectorized: true
   spans: /1/0
   locking strength: for key share
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE SKIP LOCKED
@@ -2569,7 +2433,6 @@ vectorized: true
   spans: /1/0
   locking strength: for share
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE SKIP LOCKED
@@ -2584,7 +2447,6 @@ vectorized: true
   spans: /1/0
   locking strength: for no key update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
@@ -2599,7 +2461,6 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t SKIP LOCKED
@@ -2614,7 +2475,6 @@ vectorized: true
   spans: /1/0
   locking strength: for update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2 SKIP LOCKED
@@ -2636,7 +2496,6 @@ vectorized: true
       spans: /1/0
       locking strength: for update
       locking wait policy: skip locked
-      locking durability: guaranteed
 
 # Tests with a secondary index.
 
@@ -2653,7 +2512,6 @@ vectorized: true
   spans: /2-/3
   locking strength: for update
   locking wait policy: skip locked
-  locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM u WHERE b = 2 FOR UPDATE SKIP LOCKED
@@ -2668,7 +2526,6 @@ vectorized: true
 │ key columns: a
 │ locking strength: for update
 │ locking wait policy: skip locked
-│ locking durability: guaranteed
 │
 └── • scan
       columns: (a, b)
@@ -2677,7 +2534,6 @@ vectorized: true
       spans: /2-/3
       locking strength: for update
       locking wait policy: skip locked
-      locking durability: guaranteed
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM u WHERE b = 2 LIMIT 1 FOR UPDATE SKIP LOCKED
@@ -2696,7 +2552,6 @@ vectorized: true
     │ key columns: a
     │ locking strength: for update
     │ locking wait policy: skip locked
-    │ locking durability: guaranteed
     │
     └── • scan
           columns: (a, b)
@@ -2705,4 +2560,3 @@ vectorized: true
           spans: /2-/3
           locking strength: for update
           locking wait policy: skip locked
-          locking durability: guaranteed

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
@@ -1,0 +1,117 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE supermarket (
+  person STRING PRIMARY KEY,
+  aisle INT NOT NULL,
+  starts_with STRING GENERATED ALWAYS AS (left(person, 1)) STORED,
+  ends_with STRING GENERATED ALWAYS AS (right(person, 3)) STORED,
+  INDEX (starts_with),
+  INDEX (ends_with)
+)
+
+statement ok
+INSERT INTO supermarket (person, aisle)
+  VALUES ('abbie', 1), ('gideon', 2), ('matilda', 3), ('michael', 4)
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+query T
+EXPLAIN (OPT) SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE
+----
+project
+ └── scan supermarket
+      ├── constraint: /1: [/'matilda' - /'matilda']
+      └── locking: for-update,durability-guaranteed
+
+query T
+EXPLAIN (OPT)
+UPDATE supermarket
+  SET aisle = (SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE)
+  WHERE person = 'michael'
+----
+update supermarket
+ └── project
+      ├── scan supermarket
+      │    └── constraint: /7: [/'michael' - /'michael']
+      └── projections
+           └── subquery
+                └── project
+                     └── scan supermarket
+                          ├── constraint: /13: [/'matilda' - /'matilda']
+                          └── locking: for-update,durability-guaranteed
+
+query T
+EXPLAIN (OPT)
+WITH s AS
+  (SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE)
+SELECT aisle + 1 FROM s
+----
+with &1 (s)
+ ├── project
+ │    └── scan supermarket
+ │         ├── constraint: /1: [/'matilda' - /'matilda']
+ │         └── locking: for-update,durability-guaranteed
+ └── project
+      ├── with-scan &1 (s)
+      └── projections
+           └── aisle + 1
+
+query T
+EXPLAIN (OPT)
+WITH names AS MATERIALIZED
+  (SELECT 'matilda' AS person)
+SELECT aisle
+  FROM names
+  NATURAL INNER LOOKUP JOIN supermarket
+  FOR UPDATE
+----
+with &1 (names)
+ ├── materialized
+ ├── values
+ │    └── ('matilda',)
+ └── project
+      └── inner-join (lookup supermarket)
+           ├── flags: force lookup join (into right side)
+           ├── lookup columns are key
+           ├── locking: for-update,durability-guaranteed
+           ├── with-scan &1 (names)
+           └── filters (true)
+
+query T
+EXPLAIN (OPT)
+SELECT aisle
+  FROM supermarket@supermarket_starts_with_idx
+  WHERE starts_with = 'm'
+  FOR UPDATE
+----
+project
+ └── index-join supermarket
+      ├── locking: for-update,durability-guaranteed
+      └── scan supermarket@supermarket_starts_with_idx
+           ├── constraint: /3/1: [/'m' - /'m']
+           ├── flags: force-index=supermarket_starts_with_idx
+           └── locking: for-update,durability-guaranteed
+
+query T
+EXPLAIN (OPT)
+SELECT aisle
+  FROM supermarket@{FORCE_ZIGZAG}
+  WHERE starts_with = 'm' AND ends_with = 'lda'
+  FOR UPDATE
+----
+project
+ └── inner-join (lookup supermarket)
+      ├── lookup columns are key
+      ├── locking: for-update,durability-guaranteed
+      ├── inner-join (zigzag supermarket@supermarket_starts_with_idx supermarket@supermarket_ends_with_idx)
+      │    ├── left locking: for-update,durability-guaranteed
+      │    ├── right locking: for-update,durability-guaranteed
+      │    └── filters
+      │         ├── starts_with = 'm'
+      │         └── ends_with = 'lda'
+      └── filters (true)
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -46,6 +46,9 @@ rows decoded from KV: 2,001 (16 KiB, 4,002 KVs, 2,001 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • scan
   nodes: <hidden>
@@ -75,6 +78,9 @@ rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • lookup join (streamer)
 │ nodes: <hidden>
@@ -156,6 +162,9 @@ rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
 ·
 • merge join
 │ nodes: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -490,6 +490,13 @@ func TestExecBuild_select_for_update(
 	runExecBuildLogicTest(t, "select_for_update")
 }
 
+func TestExecBuild_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestExecBuild_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -217,6 +217,13 @@ func TestExecBuild_fk(
 	runExecBuildLogicTest(t, "fk")
 }
 
+func TestExecBuild_fk_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "fk_read_committed")
+}
+
 func TestExecBuild_forecast(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     # Pin the dependencies used in auto-generated code.
     deps = [
         "//pkg/geo/geoindex",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/sql/appstatspb",
         "//pkg/sql/catalog/colinfo",
@@ -31,6 +32,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondatapb",
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/errorutil",

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -865,6 +865,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 			ob.Attr(
 				"FK check", fmt.Sprintf("%s@%s", fk.ReferencedTable.Name(), fk.ReferencedIndex.Name()),
 			)
+			e.emitLockingPolicyWithPrefix("FK check ", fk.Locking)
 		}
 		if len(a.Rows) > 0 {
 			e.emitTuples(tree.RawRows(a.Rows), len(a.Rows[0]))

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -16,9 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 	"github.com/cockroachdb/errors"
@@ -402,6 +405,16 @@ func (ob *OutputBuilder) AddRegionsStats(regions []string) {
 		"regions",
 		strings.Join(regions, ", "),
 	)
+}
+
+// AddTxnInfo adds top-level fields for information about the query's
+// transaction.
+func (ob *OutputBuilder) AddTxnInfo(
+	txnIsoLevel isolation.Level, txnPriority roachpb.UserPriority, txnQoSLevel sessiondatapb.QoSLevel,
+) {
+	ob.AddTopLevelField("isolation level", txnIsoLevel.StringLower())
+	ob.AddTopLevelField("priority", txnPriority.String())
+	ob.AddTopLevelField("quality of service", txnQoSLevel.String())
 }
 
 // AddWarning adds the provided string to the list of warnings. Warnings will be

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -524,7 +524,6 @@ explain(shape):
               table: abc@abc_b_idx
               spans: FULL SCAN
               locking strength: for update
-              locking durability: guaranteed
 explain(gist):
 • root
 │

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -263,6 +263,9 @@ type InsertFastPathFKCheck struct {
 
 	MatchMethod tree.CompositeKeyMatchMethod
 
+	// Row-level locking properties of the check.
+	Locking opt.Locking
+
 	// MkErr is called when a violation is detected (i.e. the index has no entries
 	// for a given inserted row). The values passed correspond to InsertCols
 	// above.

--- a/pkg/sql/opt/locking.go
+++ b/pkg/sql/opt/locking.go
@@ -46,10 +46,11 @@ type Locking struct {
 
 	// The third property is the durability of the locking. A guaranteed-durable
 	// lock always persists until commit time, while a best-effort lock may
-	// sometimes be lost before commit. We currently only require
-	// guaranteed-durable locks for SELECT FOR UPDATE statements under SNAPSHOT
-	// and READ COMMITTED isolation. Other locking statements, such as UPDATE,
-	// rely on the durability of intents for correctness, rather than the
+	// sometimes be lost before commit (for example, during a lease transfer). We
+	// currently only require guaranteed-durable locks for SELECT FOR UPDATE
+	// statements and system-maintained constraint checks (e.g. FK checks) under
+	// SNAPSHOT and READ COMMITTED isolation. Other locking statements, such as
+	// UPDATE, rely on the durability of intents for correctness, rather than the
 	// durability of locks.
 	Durability tree.LockingDurability
 }

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/geo/geoindex",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/inverted",
@@ -78,6 +79,7 @@ go_test(
     ],
     embed = [":memo"],
     deps = [
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/settings/cluster",
         "//pkg/sql/inverted",
         "//pkg/sql/opt",

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1556,7 +1556,15 @@ func (f *ExprFmtCtx) formatLockingWithPrefix(
 	default:
 		panic(errors.AssertionFailedf("unexpected wait policy"))
 	}
-	tp.Childf("%slocking: %s%s", labelPrefix, strength, wait)
+	durability := ""
+	switch locking.Durability {
+	case tree.LockDurabilityBestEffort:
+	case tree.LockDurabilityGuaranteed:
+		durability = ",durability-guaranteed"
+	default:
+		panic(errors.AssertionFailedf("unexpected durability"))
+	}
+	tp.Childf("%slocking: %s%s%s", labelPrefix, strength, wait, durability)
 }
 
 // formatDependencies adds a new treeprinter child for schema dependencies.

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -169,6 +169,7 @@ type Memo struct {
 	hoistUncorrelatedEqualitySubqueries        bool
 	useImprovedComputedColumnFiltersDerivation bool
 	useImprovedJoinElimination                 bool
+	implicitFKLockingForSerializable           bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -236,6 +237,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		hoistUncorrelatedEqualitySubqueries:        evalCtx.SessionData().OptimizerHoistUncorrelatedEqualitySubqueries,
 		useImprovedComputedColumnFiltersDerivation: evalCtx.SessionData().OptimizerUseImprovedComputedColumnFiltersDerivation,
 		useImprovedJoinElimination:                 evalCtx.SessionData().OptimizerUseImprovedJoinElimination,
+		implicitFKLockingForSerializable:           evalCtx.SessionData().ImplicitFKLockingForSerializable,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -383,6 +385,7 @@ func (m *Memo) IsStale(
 		m.hoistUncorrelatedEqualitySubqueries != evalCtx.SessionData().OptimizerHoistUncorrelatedEqualitySubqueries ||
 		m.useImprovedComputedColumnFiltersDerivation != evalCtx.SessionData().OptimizerUseImprovedComputedColumnFiltersDerivation ||
 		m.useImprovedJoinElimination != evalCtx.SessionData().OptimizerUseImprovedJoinElimination ||
+		m.implicitFKLockingForSerializable != evalCtx.SessionData().ImplicitFKLockingForSerializable ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -380,6 +380,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseImprovedJoinElimination = false
 	notStale()
 
+	// Stale enable_implicit_fk_locking_for_serializable.
+	evalCtx.SessionData().ImplicitFKLockingForSerializable = true
+	stale()
+	evalCtx.SessionData().ImplicitFKLockingForSerializable = false
+	notStale()
+
 	// Stale txn isolation level.
 	evalCtx.TxnIsoLevel = isolation.ReadCommitted
 	stale()

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
@@ -377,6 +378,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseImprovedJoinElimination = true
 	stale()
 	evalCtx.SessionData().OptimizerUseImprovedJoinElimination = false
+	notStale()
+
+	// Stale txn isolation level.
+	evalCtx.TxnIsoLevel = isolation.ReadCommitted
+	stale()
+	evalCtx.TxnIsoLevel = isolation.Serializable
 	notStale()
 
 	// User no longer has access to view.

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/opt/optbuilder/locking.go
+++ b/pkg/sql/opt/optbuilder/locking.go
@@ -78,12 +78,6 @@ func (lm lockingSpec) get() opt.Locking {
 		return opt.Locking{
 			Strength:   spec.Strength,
 			WaitPolicy: spec.WaitPolicy,
-			// We use fully-durable locks for all SELECT FOR UPDATE statements,
-			// regardless of locking strength and wait policy. Unlike mutation
-			// statements, SELECT FOR UPDATE statements do not lay down intents, so we
-			// cannot rely on the durability of intents to guarantee exclusion until
-			// commit as we do for mutation statements.
-			Durability: tree.LockDurabilityGuaranteed,
 		}
 	}
 	return opt.Locking{}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -696,6 +697,18 @@ func (b *Builder) buildScan(
 	}
 	if locking.isSet() {
 		private.Locking = locking.get()
+		if b.evalCtx.TxnIsoLevel != isolation.Serializable {
+			// Under weaker isolation levels we use fully-durable locks for SELECT FOR
+			// UPDATE statements, SELECT FOR SHARE statements, and all other locked
+			// scans (e.g. FK checks), regardless of locking strength and wait
+			// policy. Unlike mutation statements, SELECT FOR UPDATE statements do not
+			// lay down intents, so we cannot rely on the durability of intents to
+			// guarantee exclusion until commit as we do for mutation statements. And
+			// unlike serializable isolation, weaker isolation levels do not perform
+			// read refreshing, so we cannot rely on read refreshing to guarantee
+			// exclusion.
+			private.Locking.Durability = tree.LockDurabilityGuaranteed
+		}
 		if private.Locking.WaitPolicy == tree.LockWaitSkipLocked && tab.FamilyCount() > 1 {
 			// TODO(rytaft): We may be able to support this if enough columns are
 			// pruned that only a single family is scanned.

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
@@ -180,3 +180,43 @@ delete parent
                 │    └── flags: disabled not visible index feature
                 └── filters
                      └── other:16 = child2.p:18
+
+# Verify that we do *not* lock the child, even with implicit FK locking.
+build set=enable_implicit_fk_locking_for_serializable=true
+DELETE FROM parent WHERE p = 3
+----
+delete parent
+ ├── columns: <none>
+ ├── fetch columns: x:6 parent.p:7 parent.other:8
+ ├── input binding: &1
+ ├── select
+ │    ├── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    ├── scan parent
+ │    │    └── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    └── filters
+ │         └── parent.p:7 = 3
+ └── f-k-checks
+      ├── f-k-checks-item: child(p) -> parent(p)
+      │    └── semi-join (hash)
+      │         ├── columns: p:11!null
+      │         ├── with-scan &1
+      │         │    ├── columns: p:11!null
+      │         │    └── mapping:
+      │         │         └──  parent.p:7 => p:11
+      │         ├── scan child
+      │         │    ├── columns: child.p:13!null
+      │         │    └── flags: disabled not visible index feature
+      │         └── filters
+      │              └── p:11 = child.p:13
+      └── f-k-checks-item: child2(p) -> parent(other)
+           └── semi-join (hash)
+                ├── columns: other:16
+                ├── with-scan &1
+                │    ├── columns: other:16
+                │    └── mapping:
+                │         └──  parent.other:8 => other:16
+                ├── scan child2
+                │    ├── columns: child2.p:18!null
+                │    └── flags: disabled not visible index feature
+                └── filters
+                     └── other:16 = child2.p:18

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -684,3 +684,32 @@ insert child
                 │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8
+
+# Verify that we lock the parent when necessary.
+build set=enable_implicit_fk_locking_for_serializable=true
+INSERT INTO child VALUES (100, 1), (200, 1)
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => c:1
+ │    └── column2:6 => child.p:2
+ ├── input binding: &1
+ ├── values
+ │    ├── columns: column1:5!null column2:6!null
+ │    ├── (100, 1)
+ │    └── (200, 1)
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: p:7!null
+                ├── with-scan &1
+                │    ├── columns: p:7!null
+                │    └── mapping:
+                │         └──  column2:6 => p:7
+                ├── scan parent
+                │    ├── columns: parent.p:8!null
+                │    ├── flags: disabled not visible index feature
+                │    └── locking: for-share
+                └── filters
+                     └── p:7 = parent.p:8

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-update
@@ -570,3 +570,143 @@ update child
                 │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:12
+
+# Verify that we lock the parent when necessary.
+build set=enable_implicit_fk_locking_for_serializable=true
+UPDATE child SET p = p+1, c = c+1
+----
+update child
+ ├── columns: <none>
+ ├── fetch columns: child.c:5 child.p:6
+ ├── update-mapping:
+ │    ├── c_new:10 => child.c:1
+ │    └── p_new:9 => child.p:2
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: p_new:9!null c_new:10!null child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    ├── scan child
+ │    │    └── columns: child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    └── projections
+ │         ├── child.p:6 + 1 [as=p_new:9]
+ │         └── child.c:5 + 1 [as=c_new:10]
+ └── f-k-checks
+      ├── f-k-checks-item: child(p) -> parent(p)
+      │    └── anti-join (hash)
+      │         ├── columns: p:11!null
+      │         ├── with-scan &1
+      │         │    ├── columns: p:11!null
+      │         │    └── mapping:
+      │         │         └──  p_new:9 => p:11
+      │         ├── scan parent
+      │         │    ├── columns: parent.p:13!null
+      │         │    ├── flags: disabled not visible index feature
+      │         │    └── locking: for-share
+      │         └── filters
+      │              └── p:11 = parent.p:13
+      ├── f-k-checks-item: grandchild(c) -> child(c)
+      │    └── semi-join (hash)
+      │         ├── columns: c:17!null
+      │         ├── except
+      │         │    ├── columns: c:17!null
+      │         │    ├── left columns: c:17!null
+      │         │    ├── right columns: c:18
+      │         │    ├── with-scan &1
+      │         │    │    ├── columns: c:17!null
+      │         │    │    └── mapping:
+      │         │    │         └──  child.c:5 => c:17
+      │         │    └── with-scan &1
+      │         │         ├── columns: c:18!null
+      │         │         └── mapping:
+      │         │              └──  c_new:10 => c:18
+      │         ├── scan grandchild
+      │         │    ├── columns: grandchild.c:20!null
+      │         │    └── flags: disabled not visible index feature
+      │         └── filters
+      │              └── c:17 = grandchild.c:20
+      └── f-k-checks-item: grandchild2(c) -> child(c)
+           └── semi-join (hash)
+                ├── columns: c:23!null
+                ├── except
+                │    ├── columns: c:23!null
+                │    ├── left columns: c:23!null
+                │    ├── right columns: c:24
+                │    ├── with-scan &1
+                │    │    ├── columns: c:23!null
+                │    │    └── mapping:
+                │    │         └──  child.c:5 => c:23
+                │    └── with-scan &1
+                │         ├── columns: c:24!null
+                │         └── mapping:
+                │              └──  c_new:10 => c:24
+                ├── scan grandchild2
+                │    ├── columns: grandchild2.c:26!null
+                │    └── flags: disabled not visible index feature
+                └── filters
+                     └── c:23 = grandchild2.c:26
+
+build set=enable_implicit_fk_locking_for_serializable=true
+UPDATE self SET y = 3
+----
+update self
+ ├── columns: <none>
+ ├── fetch columns: x:5 self.y:6
+ ├── update-mapping:
+ │    └── y_new:9 => self.y:2
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: y_new:9!null x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    ├── scan self
+ │    │    └── columns: x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    └── projections
+ │         └── 3 [as=y_new:9]
+ └── f-k-checks
+      └── f-k-checks-item: self(y) -> self(x)
+           └── anti-join (hash)
+                ├── columns: y:10!null
+                ├── with-scan &1
+                │    ├── columns: y:10!null
+                │    └── mapping:
+                │         └──  y_new:9 => y:10
+                ├── scan self
+                │    ├── columns: x:11!null
+                │    ├── flags: disabled not visible index feature
+                │    └── locking: for-share
+                └── filters
+                     └── y:10 = x:11
+
+build set=enable_implicit_fk_locking_for_serializable=true
+UPDATE self SET x = 3
+----
+update self
+ ├── columns: <none>
+ ├── fetch columns: self.x:5 y:6
+ ├── update-mapping:
+ │    └── x_new:9 => self.x:1
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: x_new:9!null self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    ├── scan self
+ │    │    └── columns: self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    └── projections
+ │         └── 3 [as=x_new:9]
+ └── f-k-checks
+      └── f-k-checks-item: self(y) -> self(x)
+           └── semi-join (hash)
+                ├── columns: x:10!null
+                ├── except
+                │    ├── columns: x:10!null
+                │    ├── left columns: x:10!null
+                │    ├── right columns: x:11
+                │    ├── with-scan &1
+                │    │    ├── columns: x:10!null
+                │    │    └── mapping:
+                │    │         └──  self.x:5 => x:10
+                │    └── with-scan &1
+                │         ├── columns: x:11!null
+                │         └── mapping:
+                │              └──  x_new:9 => x:11
+                ├── scan self
+                │    ├── columns: y:13!null
+                │    └── flags: disabled not visible index feature
+                └── filters
+                     └── x:10 = y:13

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -280,7 +280,7 @@ func newTxnKVFetcherInternal(args newTxnKVFetcherArgs) *txnKVFetcher {
 		scanFormat:                 kvpb.BATCH_RESPONSE,
 		reverse:                    args.reverse,
 		lockStrength:               GetKeyLockingStrength(args.lockStrength),
-		lockWaitPolicy:             getWaitPolicy(args.lockWaitPolicy),
+		lockWaitPolicy:             GetWaitPolicy(args.lockWaitPolicy),
 		lockTimeout:                args.lockTimeout,
 		acc:                        args.acc,
 		forceProductionKVBatchSize: args.forceProductionKVBatchSize,
@@ -804,6 +804,7 @@ func spansToRequests(
 				// single key fetch, which can be served using a GetRequest.
 				gets[curGet].req.Key = spans[i].Key
 				gets[curGet].req.KeyLocking = keyLocking
+				// TODO(michae2): Once #100193 is finished, also include locking durability.
 				gets[curGet].union.Get = &gets[curGet].req
 				reqs[i].Value = &gets[curGet].union
 				curGet++
@@ -813,6 +814,7 @@ func spansToRequests(
 			scans[curScan].req.SetSpan(spans[i])
 			scans[curScan].req.ScanFormat = scanFormat
 			scans[curScan].req.KeyLocking = keyLocking
+			// TODO(michae2): Once #100193 is finished, also include locking durability.
 			scans[curScan].union.ReverseScan = &scans[curScan].req
 			reqs[i].Value = &scans[curScan].union
 		}
@@ -827,6 +829,7 @@ func spansToRequests(
 				// single key fetch, which can be served using a GetRequest.
 				gets[curGet].req.Key = spans[i].Key
 				gets[curGet].req.KeyLocking = keyLocking
+				// TODO(michae2): Once #100193 is finished, also include locking durability.
 				gets[curGet].union.Get = &gets[curGet].req
 				reqs[i].Value = &gets[curGet].union
 				curGet++
@@ -836,6 +839,7 @@ func spansToRequests(
 			scans[curScan].req.SetSpan(spans[i])
 			scans[curScan].req.ScanFormat = scanFormat
 			scans[curScan].req.KeyLocking = keyLocking
+			// TODO(michae2): Once #100193 is finished, also include locking durability.
 			scans[curScan].union.Scan = &scans[curScan].req
 			reqs[i].Value = &scans[curScan].union
 		}

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -185,7 +185,7 @@ func NewStreamingKVFetcher(
 		stopper,
 		txn,
 		st,
-		getWaitPolicy(lockWaitPolicy),
+		GetWaitPolicy(lockWaitPolicy),
 		streamerBudgetLimit,
 		streamerBudgetAcc,
 		&kvPairsRead,

--- a/pkg/sql/row/locking.go
+++ b/pkg/sql/row/locking.go
@@ -44,9 +44,9 @@ func GetKeyLockingStrength(lockStrength descpb.ScanLockingStrength) lock.Strengt
 	}
 }
 
-// getWaitPolicy returns the configured lock wait policy to use for key-value
+// GetWaitPolicy returns the configured lock wait policy to use for key-value
 // scans.
-func getWaitPolicy(lockWaitPolicy descpb.ScanLockingWaitPolicy) lock.WaitPolicy {
+func GetWaitPolicy(lockWaitPolicy descpb.ScanLockingWaitPolicy) lock.WaitPolicy {
 	switch lockWaitPolicy {
 	case descpb.ScanLockingWaitPolicy_BLOCK:
 		return lock.WaitPolicy_Block

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -1210,14 +1210,14 @@ const (
 	// on the leaseholder of the locked row. Best-effort locks do not propagate
 	// via Raft to other nodes, and are therefore much faster to acquire than
 	// guaranteed-durable locks. For this reason we prefer to use best-effort
-	// locks when possible (i.e. when locking is used as an optimization rather
-	// than as a guarantor of exclusion).
+	// locks when possible (i.e. whenever locking is used as an optimization
+	// rather than as a guarantor of exclusion).
 	LockDurabilityBestEffort LockingDurability = iota
 
 	// LockDurabilityGuaranteed guarantees that if the transaction commits, the
 	// lock was held until commit, even in the face of lease transfers, range
 	// splits, range merges, node failures, memory limits, etc. Guaranteed-durable
-	// locks *must* be used when correctness depends on locking.
+	// locks *must* be used whenever correctness depends on locking.
 	LockDurabilityGuaranteed
 )
 

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -409,6 +409,14 @@ message LocalOnlySessionData {
   // eliminate joins in more cases by remapping columns from the eliminated
   // input of the join to equivalent columns from the preserved input.
   bool optimizer_use_improved_join_elimination = 107;
+  // ImplicitFKLockingForSerializable is true if FOR SHARE locking may be used
+  // while checking the referenced table during an insert or update to a table
+  // with a foreign key under serializable isolation. (Under weaker isolation
+  // levels foreign key checks of the parent table always use FOR SHARE
+  // locking.)
+  bool implicit_fk_locking_for_serializable = 108 [
+    (gogoproto.customname) = "ImplicitFKLockingForSerializable"
+  ];
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -13,6 +13,9 @@ distribution: local
 vectorized: false
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
+isolation level: serializable
+priority: normal
+quality of service: regular
 
 • scan
   columns: (oid int)
@@ -45,6 +48,9 @@ distribution: local
 vectorized: false
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
+isolation level: serializable
+priority: normal
+quality of service: regular
 
 • scan
   columns: (cid int, date date, value decimal)
@@ -77,6 +83,9 @@ distribution: local
 vectorized: false
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
+isolation level: serializable
+priority: normal
+quality of service: regular
 
 • project
 │ columns: (cid int, sum decimal)
@@ -156,6 +165,9 @@ distribution: local
 vectorized: false
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
+isolation level: serializable
+priority: normal
+quality of service: regular
 
 • scan
   columns: (value decimal)
@@ -188,6 +200,9 @@ distribution: local
 vectorized: false
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
+isolation level: serializable
+priority: normal
+quality of service: regular
 
 • project
 │ columns: (cid int, date date, value decimal)
@@ -277,6 +292,9 @@ distribution: local
 vectorized: false
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
+isolation level: serializable
+priority: normal
+quality of service: regular
 
 • root
 │ columns: (movie_id int, title string, name string)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -872,7 +872,7 @@ var varGen = map[string]sessionVar{
 	`enable_implicit_select_for_update`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`enable_implicit_select_for_update`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {
-			b, err := paramparse.ParseBoolVar("enabled_implicit_select_for_update", s)
+			b, err := paramparse.ParseBoolVar("enable_implicit_select_for_update", s)
 			if err != nil {
 				return err
 			}
@@ -2816,6 +2816,23 @@ var varGen = map[string]sessionVar{
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseImprovedJoinElimination), nil
 		},
 		GlobalDefault: globalTrue,
+	},
+
+	// CockroachDB extension.
+	`enable_implicit_fk_locking_for_serializable`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`enable_implicit_fk_locking_for_serializable`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("enable_implicit_fk_locking_for_serializable", s)
+			if err != nil {
+				return err
+			}
+			m.SetImplicitFKLockingForSerializable(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().ImplicitFKLockingForSerializable), nil
+		},
+		GlobalDefault: globalFalse,
 	},
 }
 


### PR DESCRIPTION
**explain: add transaction information to EXPLAIN ANALYZE**

Add transaction isolation, priority, and quality-of-service to the
output of `EXPLAIN ANALYZE`.

Release note (sql change): `EXPLAIN ANALYZE` output now includes:
- the isolation level of the statement's transaction
- the priority of the statement's transaction
- the quality of service level of the statement's transaction

---

**opt: do not use LockDurabilityGuaranteed under serializable isolation**

This is a follow-up from https://github.com/cockroachdb/cockroach/pull/103734.

We do not want to use guaranteed-durable (a.k.a. replicated) locking
under serializable isolation, because it prevents pipelining and other
optimizations, and is unnecessary for correctness. This commit amends
8cbc6d1360d46e3485e4828c4e9a9a85ac3d8a19 to only set durability for
`SELECT FOR UPDATE` locking under weaker isolation levels.

This means that query plans will be slightly different under different
isolation levels, and so we must add isolation level to the optimizer
memo staleness calculation.

Furthermore, this commit changes the error message added by
e633d5edb47b54a08905ae92d842625ba7805000 to be about guaranteed-durable
locking rather than `SELECT FOR UPDATE`, because in a later commit this
specific error will also be triggered by foreign key checks under weaker
isolation levels.

Informs: #100144, #100156, #100193, #100194

Release note: None

---

**opt: show locking durability in EXPLAIN (OPT) output**

Because the "guaranteed-durable locking not yet implemented" error
condition is checked in execbuilder, it prevents not only execution but
also `EXPLAIN` of queries using guaranteed-durable locking. Thankfully
`EXPLAIN (OPT)` bypasses execbuilder, and hence still works, so use this
for now to verify that we are enabling durable locking for `SELECT FOR
UPDATE` under read committed isolation.

(Note that we have not yet fixed the `SELECT FOR UPDATE` plans to use
more precise locking, that will come in a later PR.)

Informs: #100194

Release note: None

---

**sql: add implicit SELECT FOR SHARE locking to FK parent checks**

Add SELECT FOR SHARE locking to FK parent checks. Under serializable
isolation, this locking is only used when
`enable_implicit_fk_locking_for_serializable` is set. Under weaker
isolation levels (snapshot and read committed) this locking is always
used.

We only need to lock during the insertion-side FK checks, which verify
the existence of a parent row. Deletion-side FK checks verify the
non-existence of a child row, and these do not need to lock. Instead, to
prevent concurrent inserts or updates to the child that would violate
the FK constraint, we rely on the intent(s) created by the deletion
conflicting with the FK locking of those concurrent inserts or updates.

Fixes: #80683
Informs: #100156

Epic: CRDB-25322

Release note (sql change): Add a new session variable,
`enable_implicit_fk_locking_for_serializable`, which controls locking
during foreign key checks under serializable isolation. With this set to
true, foreign key checks of the referenced (parent) table, such as those
performed during an INSERT or UPDATE of the referencing (child) table,
will lock the referenced row using SELECT FOR SHARE locking. (This is
somewhat analogous to the existing `enable_implicit_select_for_update`
variable but applies to the foreign key checks of a mutation statement
instead of the initial row fetch.)

Under weaker isolation levels such as read committed, SELECT FOR SHARE
locking will always be used to ensure the database maintains the foreign
key constraint, regardless of the current setting of
`enable_implicit_fk_locking_for_serializable`.