### PR TITLE
release-23.1: server: deflake test hot ranges response

### DIFF
--- a/pkg/kv/kvserver/allocator/range_usage_info.go
+++ b/pkg/kv/kvserver/allocator/range_usage_info.go
@@ -22,7 +22,11 @@ type RangeUsageInfo struct {
 	LogicalBytes             int64
 	QueriesPerSecond         float64
 	WritesPerSecond          float64
+	ReadsPerSecond           float64
+	WriteBytesPerSecond      float64
+	ReadBytesPerSecond       float64
 	RequestCPUNanosPerSecond float64
+	RequestsPerSecond        float64
 	RaftCPUNanosPerSecond    float64
 	RequestLocality          *RangeRequestLocalityInfo
 }

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -2164,8 +2164,12 @@ func RangeUsageInfoForRepl(repl *Replica) allocator.RangeUsageInfo {
 		LogicalBytes:             repl.GetMVCCStats().Total(),
 		QueriesPerSecond:         loadStats.QueriesPerSecond,
 		WritesPerSecond:          loadStats.WriteKeysPerSecond,
+		ReadsPerSecond:           loadStats.ReadKeysPerSecond,
+		WriteBytesPerSecond:      loadStats.WriteBytesPerSecond,
+		ReadBytesPerSecond:       loadStats.ReadBytesPerSecond,
 		RaftCPUNanosPerSecond:    loadStats.RaftCPUNanosPerSecond,
 		RequestCPUNanosPerSecond: loadStats.RequestCPUNanosPerSecond,
+		RequestsPerSecond:        loadStats.RequestsPerSecond,
 		RequestLocality: &allocator.RangeRequestLocalityInfo{
 			Counts:   localityInfo.LocalityCounts,
 			Duration: localityInfo.Duration,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3364,15 +3364,15 @@ func (s *Store) HottestReplicasByTenant(tenantID roachpb.TenantID) []HotReplicaI
 func mapToHotReplicasInfo(repls []CandidateReplica) []HotReplicaInfo {
 	hotRepls := make([]HotReplicaInfo, len(repls))
 	for i := range repls {
-		loadStats := repls[i].Repl().LoadStats()
+		ri := repls[i].RangeUsageInfo()
 		hotRepls[i].Desc = repls[i].Desc()
-		hotRepls[i].QPS = loadStats.QueriesPerSecond
-		hotRepls[i].RequestsPerSecond = loadStats.RequestsPerSecond
-		hotRepls[i].WriteKeysPerSecond = loadStats.WriteKeysPerSecond
-		hotRepls[i].ReadKeysPerSecond = loadStats.ReadKeysPerSecond
-		hotRepls[i].WriteBytesPerSecond = loadStats.WriteBytesPerSecond
-		hotRepls[i].ReadBytesPerSecond = loadStats.ReadBytesPerSecond
-		hotRepls[i].CPUTimePerSecond = loadStats.RaftCPUNanosPerSecond + loadStats.RequestCPUNanosPerSecond
+		hotRepls[i].QPS = ri.QueriesPerSecond
+		hotRepls[i].RequestsPerSecond = ri.RequestsPerSecond
+		hotRepls[i].WriteKeysPerSecond = ri.WritesPerSecond
+		hotRepls[i].ReadKeysPerSecond = ri.ReadsPerSecond
+		hotRepls[i].WriteBytesPerSecond = ri.WriteBytesPerSecond
+		hotRepls[i].ReadBytesPerSecond = ri.ReadBytesPerSecond
+		hotRepls[i].CPUTimePerSecond = ri.RaftCPUNanosPerSecond + ri.RequestCPUNanosPerSecond
 	}
 	return hotRepls
 }

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1031,7 +1031,6 @@ func TestMetricsMetadata(t *testing.T) {
 
 func TestHotRangesResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 98619, "flaky test")
 	defer log.Scope(t).Close(t)
 	ts := startServer(t)
 	defer ts.Stopper().Stop(context.Background())
@@ -1064,9 +1063,9 @@ func TestHotRangesResponse(t *testing.T) {
 					t.Errorf("unexpected empty/unpopulated range descriptor: %+v", r.Desc)
 				}
 				if r.QueriesPerSecond > 0 {
-					if r.ReadsPerSecond == 0 && r.WritesPerSecond == 0 {
-						t.Errorf("qps %.2f > 0, expected either reads=%.2f or writes=%.2f to be non-zero",
-							r.QueriesPerSecond, r.ReadsPerSecond, r.WritesPerSecond)
+					if r.ReadsPerSecond == 0 && r.WritesPerSecond == 0 && r.ReadBytesPerSecond == 0 && r.WriteBytesPerSecond == 0 {
+						t.Errorf("qps %.2f > 0, expected either reads=%.2f, writes=%.2f, readBytes=%.2f or writeBytes=%.2f to be non-zero",
+							r.QueriesPerSecond, r.ReadsPerSecond, r.WritesPerSecond, r.ReadBytesPerSecond, r.WriteBytesPerSecond)
 					}
 					// If the architecture doesn't support sampling CPU, it
 					// will also be zero.
@@ -1088,7 +1087,6 @@ func TestHotRangesResponse(t *testing.T) {
 
 func TestHotRanges2Response(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 98619, "flaky test")
 	defer log.Scope(t).Close(t)
 	ts := startServer(t)
 	defer ts.Stopper().Stop(context.Background())
@@ -1106,9 +1104,9 @@ func TestHotRanges2Response(t *testing.T) {
 			t.Errorf("unexpected empty range id: %d", r.RangeID)
 		}
 		if r.QPS > 0 {
-			if r.ReadsPerSecond == 0 && r.WritesPerSecond == 0 {
-				t.Errorf("qps %.2f > 0, expected either reads=%.2f or writes=%.2f to be non-zero",
-					r.QPS, r.ReadsPerSecond, r.WritesPerSecond)
+			if r.ReadsPerSecond == 0 && r.WritesPerSecond == 0 && r.ReadBytesPerSecond == 0 && r.WriteBytesPerSecond == 0 {
+				t.Errorf("qps %.2f > 0, expected either reads=%.2f, writes=%.2f, readBytes=%.2f or writeBytes=%.2f to be non-zero",
+					r.QPS, r.ReadsPerSecond, r.WritesPerSecond, r.ReadBytesPerSecond, r.WriteBytesPerSecond)
 			}
 			// If the architecture doesn't support sampling CPU, it
 			// will also be zero.


### PR DESCRIPTION
Backport 1/1 commits from #99108.

/cc @cockroachdb/release

---

Flaky tests for HotRanges api were caused after changing source
for getting stats per replica in `mapToHotReplicasInfo` func.
`mapToHotReplicasInfo` func calls `Repl().LoadStats()` that
internally relies on calculates average values per second
in current moment, but values could be recorded earlier.

Now, `mapToHotReplicasInfo` func relies on `RangeUsageInfo()` func
that keeps average stats at the time stats were recorded.

Related change to this fix: https://github.com/cockroachdb/cockroach/pull/99716

Release note: None

Fixes: #98619

Release justification: non-production code changes
