### PR TITLE
roachtest: preserve certs in multitenant_tpch

### DIFF
--- a/pkg/cmd/roachtest/tests/cancel.go
+++ b/pkg/cmd/roachtest/tests/cancel.go
@@ -54,7 +54,7 @@ func registerCancel(r registry.Registry) {
 
 			t.Status("restoring TPCH dataset for Scale Factor 1")
 			if err := loadTPCHDataset(
-				ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false, /* disableMergeQueue */
+				ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false /* disableMergeQueue */, false, /* secure */
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -42,6 +42,7 @@ func loadTPCHDataset(
 	m cluster.Monitor,
 	roachNodes option.NodeListOption,
 	disableMergeQueue bool,
+	secure bool,
 ) (retErr error) {
 	if c.Spec().Cloud != spec.GCE {
 		t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
@@ -93,7 +94,7 @@ func loadTPCHDataset(
 		// If the scale factor was smaller than the required scale factor, wipe the
 		// cluster and restore.
 		m.ExpectDeaths(int32(c.Spec().NodeCount))
-		c.Wipe(ctx, false /* preserveCerts */, roachNodes)
+		c.Wipe(ctx, secure, roachNodes)
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
 		m.ResetDeaths()
 	} else if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) &&

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -46,7 +46,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 
 		if err := loadTPCHDataset(
 			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx, c.Range(1, numNodes-1)),
-			c.Range(1, numNodes-1), true, /* disableMergeQueue */
+			c.Range(1, numNodes-1), true /* disableMergeQueue */, false, /* secure */
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -76,7 +76,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 
 		t.Status("setting up dataset")
 		err := loadTPCHDataset(
-			ctx, t, c, conn, b.ScaleFactor, m, roachNodes, true, /* disableMergeQueue */
+			ctx, t, c, conn, b.ScaleFactor, m, roachNodes, true /* disableMergeQueue */, false, /* secure */
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -609,7 +609,7 @@ func runTPCHVec(
 
 	t.Status("restoring TPCH dataset for Scale Factor 1")
 	if err := loadTPCHDataset(
-		ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), disableMergeQueue,
+		ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), disableMergeQueue, false, /* secure */
 	); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The `loadTPCHDataset` function was unconditionally removing certs when the cluster was wiped. In this commit, we add a parameter to that function to indicate if the cluster being used is `secure`; if so, we preserve the certs when wiping.

Fixes: #105880

Release note: None