### PR TITLE
sql: initialize job collection for internal planner

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -408,3 +408,46 @@ CREATE TABLE e105393 (a PRIMARY KEY, b) AS TABLE db105393_1.public.t105393;
 
 statement error pq: cross database type references are not supported: db105393_1.public.e105393
 CREATE TABLE e105393 (b) AS SELECT b FROM db105393_1.public.t105393;
+
+# Regression test for #105887
+subtest regression_105887
+
+statement ok
+CREATE TABLE t_105887_job (a INT);
+INSERT INTO t_105887_job values (1);
+
+statement ok
+ALTER TABLE t_105887_job ADD COLUMN b INT NOT NULL DEFAULT 2;
+
+query B
+SELECT count(*) > 0 FROM crdb_internal.jobs WHERE job_type like '%SCHEMA CHANGE%';
+----
+true
+
+statement ok
+CREATE MATERIALIZED VIEW v_105887_1 AS SELECT * FROM [SHOW JOBS];
+CREATE MATERIALIZED VIEW v_105887_2 AS SELECT * FROM crdb_internal.jobs;
+
+query B
+SELECT count(*) > 0 FROM v_105887_1
+----
+true
+
+query B
+SELECT count(*) > 0 FROM v_105887_2
+----
+true
+
+statement ok
+CREATE TABLE t_105887_1 AS SELECT * FROM [SHOW JOBS];
+CREATE TABLE t_105887_2 AS SELECT * FROM crdb_internal.jobs;
+
+query B
+SELECT count(*) > 0 FROM t_105887_1
+----
+true
+
+query B
+SELECT count(*) > 0 FROM t_105887_2
+----
+true

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -544,6 +544,7 @@ func internalExtendedEvalCtx(
 		Descs:           tables,
 		indexUsageStats: indexUsageStats,
 		statsProvider:   sqlStatsProvider,
+		jobs:            newTxnJobsCollection(),
 	}
 	ret.SetDeprecatedContext(ctx)
 	ret.copyFromExecCfg(execCfg)


### PR DESCRIPTION
Previously, we didn't initilize a jobs collection for internal planners. This is inadequate because the jobs collection is used by `crdb_internal.jobs` table and any CTAS statement touching the table would use a nil jobs collection since it uses a internal planner. This commit initialize a collection for that.

Fixes: #105887

Release note (bug fix): this commit fixed a bug where CTAS statement could crash if it queried `crdb_internal.jobs` table.