### PR TITLE
persistedsqlstats: skip TestSQLStatsPersistedLimitReached

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -459,7 +459,7 @@ func TestSQLStatsGatewayNodeSetting(t *testing.T) {
 }
 
 func TestSQLStatsPersistedLimitReached(t *testing.T) {
-	skip.UnderStressWithIssue(t, 97488)
+	skip.WithIssue(t, 97488)
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 


### PR DESCRIPTION
Flakes in Bazel essential CI.
Reverts https://github.com/cockroachdb/cockroach/pull/105770

Informs #105846, #97488
Epic: none
Release note: None