### PR TITLE
kvserver: increase rangelog async task timeout

### DIFF
--- a/pkg/kv/kvserver/range_log.go
+++ b/pkg/kv/kvserver/range_log.go
@@ -238,8 +238,8 @@ func writeToRangeLogTable(
 		// Stop writing when the server shuts down.
 		asyncCtx, stopCancel := stopper.WithCancelOnQuiesce(asyncCtx)
 
-		const perAttemptTimeout = 5 * time.Second
-		const maxAttempts = 5
+		const perAttemptTimeout = 20 * time.Second
+		const maxAttempts = 3
 		retryOpts := base.DefaultRetryOptions()
 		retryOpts.Closer = asyncCtx.Done()
 		retryOpts.MaxRetries = maxAttempts


### PR DESCRIPTION
Previously the rangelog timeout of 5 seconds was often exceeded when the rangelog became briefly unavailable during a leasholder change. Bumping the timeout to 20s should help in these cases but we don't want to spawn too many such long-lived tasks, so this patch also reduces the number of retries to 3.

Fixes: #105413

Release note: None