### PR TITLE
kvcoord: Deflake TestDistSenderRangeFeedRetryOnTransportErrors test

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
@@ -144,9 +144,9 @@ func TestDistSenderRangeFeedRetryOnTransportErrors(t *testing.T) {
 							client.EXPECT().RangeFeed(gomock.Any(), gomock.Any()).Return(stream, nil)
 						}
 
-						transport.EXPECT().IsExhausted().Return(false)
-						transport.EXPECT().NextReplica().Return(desc.InternalReplicas[0])
-						transport.EXPECT().NextInternalClient(gomock.Any()).Return(client, nil)
+						transport.EXPECT().IsExhausted().Return(false).AnyTimes()
+						transport.EXPECT().NextReplica().Return(desc.InternalReplicas[0]).AnyTimes()
+						transport.EXPECT().NextInternalClient(gomock.Any()).Return(client, nil).AnyTimes()
 						transport.EXPECT().Release().AnyTimes()
 					}
 


### PR DESCRIPTION
Fixes #105742
Verified w/ 300k run.

Release note: None