### PR TITLE
changefeedccl: Return an error from FilterSpansWithMutation

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -646,9 +646,16 @@ func (ca *changeAggregator) tick() error {
 		a := event.DetachAlloc()
 		a.Release(ca.Ctx())
 		resolved := event.Resolved()
-		if ca.knobs.FilterSpanWithMutation == nil || !ca.knobs.FilterSpanWithMutation(&resolved) {
-			return ca.noteResolvedSpan(resolved)
+		if ca.knobs.FilterSpanWithMutation != nil {
+			shouldFilter, err := ca.knobs.FilterSpanWithMutation(&resolved)
+			if err != nil {
+				return err
+			}
+			if shouldFilter {
+				return nil
+			}
 		}
+		return ca.noteResolvedSpan(resolved)
 	case kvevent.TypeFlush:
 		return ca.flushBufferedEvents()
 	}

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -40,7 +40,7 @@ type TestingKnobs struct {
 	PubsubClientSkipClientCreation bool
 	// FilterSpanWithMutation is a filter returning true if the resolved span event should
 	// be skipped. This method takes a pointer in case resolved spans need to be mutated.
-	FilterSpanWithMutation func(resolved *jobspb.ResolvedSpan) bool
+	FilterSpanWithMutation func(resolved *jobspb.ResolvedSpan) (bool, error)
 	// FeedKnobs are kvfeed testing knobs.
 	FeedKnobs kvfeed.TestingKnobs
 	// NullSinkIsExternalIOAccounted controls whether we record


### PR DESCRIPTION
Modify FilterSpansWithMutation testing knob to return an error in addition to filtering decision.

This is needed since using `require.XXX` or similar calls inside that knob, which runs in the context of changefeed processor, is not safe -- if the require check is false, this would cause changefeed to panic (and in general, it's not safe to panic on another thread -- only the test that owns *testing.T should do that).

Informs #104399

Release note: None