### PR TITLE
sql: turn copy fatal error into assertion error

### DIFF
--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -1129,7 +1129,7 @@ func (c *copyMachine) insertRowsInternal(ctx context.Context, finalBatch bool) (
 	}
 
 	if rows := res.RowsAffected(); rows != numRows {
-		log.Fatalf(ctx, "didn't insert all buffered rows and yet no error was reported. "+
+		return errors.AssertionFailedf("COPY didn't insert all buffered rows and yet no error was reported. "+
 			"Inserted %d out of %d rows.", rows, numRows)
 	}
 	c.insertedRows += numRows


### PR DESCRIPTION
If we don't get an error but COPY doesn't insert the number of rows we
expect we currently do a fatal log and bring down the node. Not only
is it bad to crash the node its unhelpful because we never log the
COPY query and don't know the query or table involved. Better to just
return an assertion failed error which will put the query into the log
and we can observe the failing query.

Informs: #104662
Release note: None
Epic: None
