### PR TITLE
ui: add cluster setting to skip activity tables

### DIFF
--- a/pkg/server/cluster_settings.go
+++ b/pkg/server/cluster_settings.go
@@ -32,3 +32,13 @@ var SQLStatsShowInternal = settings.RegisterBoolSetting(
 		"statistics on the SQL Activity pages",
 	false,
 ).WithPublic()
+
+// StatsActivityUIEnabled controls if the combined statement stats uses
+// the system.statement_activity and system.transaction_activity which
+// acts as a cache storing the top queries from system.statement_statistics
+// and system.transaction_statistics tables.
+var StatsActivityUIEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.stats.activity.ui.enabled",
+	"enable the combined statistics endpoint to get data from the system activity tables",
+	true)

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -100,11 +100,13 @@ func getCombinedStatementStats(
 		activityHasAllData, err = activityTablesHaveFullData(
 			ctx,
 			ie,
+			settings,
 			testingKnobs,
 			reqStartTime,
 			req.Limit,
 			sort,
 		)
+
 		if err != nil {
 			log.Errorf(ctx, "Error on activityTablesHaveFullData: %s", err)
 		}
@@ -182,17 +184,27 @@ func getCombinedStatementStats(
 func activityTablesHaveFullData(
 	ctx context.Context,
 	ie *sql.InternalExecutor,
+	settings *cluster.Settings,
 	testingKnobs *sqlstats.TestingKnobs,
 	reqStartTime *time.Time,
 	limit int64,
 	order serverpb.StatsSortOptions,
 ) (result bool, err error) {
+
+	if !StatsActivityUIEnabled.Get(&settings.SV) {
+		return false, nil
+	}
+
 	if (limit > 0 && !isLimitOnActivityTable(limit)) || !isSortOptionOnActivityTable(order) {
 		return false, nil
 	}
-	var auxDate time.Time
-	dateFormat := "2006-01-02 15:04:05.00"
-	auxDate, err = time.Parse(dateFormat, timeutil.Now().String())
+
+	if reqStartTime == nil {
+		return false, nil
+	}
+
+	// Used to verify the table contained data.
+	zeroDate := time.Time{}
 
 	queryWithPlaceholders := `
 SELECT 
@@ -201,12 +213,13 @@ FROM crdb_internal.statement_activity
 %s
 `
 
+	// Format string "2006-01-02 15:04:05.00" is a golang-specific string
 	it, err := ie.QueryIteratorEx(
 		ctx,
 		"activity-min-ts",
 		nil,
 		sessiondata.NodeUserSessionDataOverride,
-		fmt.Sprintf(queryWithPlaceholders, auxDate.Format(dateFormat), testingKnobs.GetAOSTClause()))
+		fmt.Sprintf(queryWithPlaceholders, zeroDate.Format("2006-01-02 15:04:05.00"), testingKnobs.GetAOSTClause()))
 
 	if err != nil {
 		return false, err
@@ -229,8 +242,8 @@ FROM crdb_internal.statement_activity
 	}()
 
 	minAggregatedTs := tree.MustBeDTimestampTZ(row[0]).Time
-	hasData := !minAggregatedTs.Equal(auxDate) && (reqStartTime.After(minAggregatedTs) || reqStartTime.Equal(minAggregatedTs))
 
+	hasData := !minAggregatedTs.IsZero() && (reqStartTime.After(minAggregatedTs) || reqStartTime.Equal(minAggregatedTs))
 	return hasData, nil
 }
 
@@ -759,9 +772,6 @@ GROUP BY
 
 	var it isql.Rows
 	var err error
-	defer func() {
-		err = closeIterator(it, err)
-	}()
 	if activityTableHasAllData {
 		it, err = getIterator(
 			ctx,
@@ -777,6 +787,10 @@ GROUP BY
 			return nil, serverError(ctx, err)
 		}
 	}
+
+	defer func() {
+		err = closeIterator(it, err)
+	}()
 
 	// If there are no results from the activity table, retrieve the data from the persisted table.
 	if it == nil || !it.HasResults() {
@@ -1053,6 +1067,7 @@ func getStatementDetails(
 		activityHasData, err = activityTablesHaveFullData(
 			ctx,
 			ie,
+			settings,
 			testingKnobs,
 			reqStartTime,
 			1,


### PR DESCRIPTION
1. This cluster setting is being added as a possible mitigation if any issues
    are detected with the cached data in the activity tables.
2. Fixes a possible panic from a nil pointer dereference if requested 
    start time is not passed in
3. Fixes a bug if an error occurred in the activity check the defer would 
    would cause a panic from attempting to close an invalid iterator. The 
    iterator should only be close if the original called did not return an error.
4. Fixes a time parse error. The time is passed into the query and returned
    via `COALESCE` if there are no rows in the activity table. The time parse 
    was always failing, and there was nothing checking the err. This caused 
    the time  to be the default zero date time. I switched the code to just use
    default zero instead. This check is used to verify the table is not empty.

Fixes
Epic: none
closes: #105911

Release note: None