### PR TITLE
pprofui: add support for collecting goroutines with labels

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3043,10 +3043,11 @@ Support status: [reserved](#support-status)
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| node_id | [string](#cockroach.server.serverpb.ProfileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. node_id translates to a KV node ID on a storage server and SQL instance ID on a SQL only server. | [reserved](#support-status) |
+| node_id | [string](#cockroach.server.serverpb.ProfileRequest-string) |  | node_id is a string so that "local" or "all" can be used to specify that no forwarding is necessary. node_id translates to a KV node ID on a storage server and SQL instance ID on a SQL only server. | [reserved](#support-status) |
 | type | [ProfileRequest.Type](#cockroach.server.serverpb.ProfileRequest-cockroach.server.serverpb.ProfileRequest.Type) |  | The type of profile to retrieve. | [reserved](#support-status) |
 | seconds | [int32](#cockroach.server.serverpb.ProfileRequest-int32) |  | applies only to Type=CPU, defaults to 30 | [reserved](#support-status) |
-| labels | [bool](#cockroach.server.serverpb.ProfileRequest-bool) |  | applies only to Type=CPU, defaults to false | [reserved](#support-status) |
+| labels | [bool](#cockroach.server.serverpb.ProfileRequest-bool) |  | Labels can be specified for Type=CPU or Type=GOROUTINE.<br><br>- If true for CPU profiles, we request a CPU profile with pprof labels.<br><br>- If true for GOROUTINE profiles, we request an aggregated goroutine profile with debug=1. | [reserved](#support-status) |
+| label_filter | [string](#cockroach.server.serverpb.ProfileRequest-string) |  | LabelFilter only applies to Type=GOROUTINE. Only goroutines with a pprof label matching the filter will be returned. | [reserved](#support-status) |
 | sender_server_version | [cockroach.roachpb.Version](#cockroach.server.serverpb.ProfileRequest-cockroach.roachpb.Version) |  | SenderServerVersion is the server version of the node sending the Profile request. If this field is set then the node processing the request will only collect the profile if its server version is equal to the sender's server version.<br><br>Currently, this is only used when collecting profiles that will be merged using pprof.Merge as all the samples must be from the same binary version. | [reserved](#support-status) |
 
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -173,6 +173,7 @@ go_library(
         "//pkg/server/autoconfig",
         "//pkg/server/autoconfig/acprovider",
         "//pkg/server/debug",
+        "//pkg/server/debug/pprofui",
         "//pkg/server/diagnostics",
         "//pkg/server/diagnostics/diagnosticspb",
         "//pkg/server/goroutinedumper",

--- a/pkg/server/debug/pprofui/server_test.go
+++ b/pkg/server/debug/pprofui/server_test.go
@@ -50,11 +50,17 @@ func init() {
 	}
 }
 
+var supportedProfiles = []string{
+	"cpu", "goroutine", "heap", "threadcreate", "block", "mutex", "allocs",
+}
+
 func TestServer(t *testing.T) {
 	expectedNodeID := "local"
+	withLabels := false
 
 	mockProfile := func(ctx context.Context, req *serverpb.ProfileRequest) (*serverpb.JSONResponse, error) {
 		require.Equal(t, expectedNodeID, req.NodeId)
+		require.Equal(t, withLabels, req.Labels)
 		b, err := os.ReadFile(datapathutils.TestDataPath(t, "heap.profile"))
 		require.NoError(t, err)
 		return &serverpb.JSONResponse{Data: b}, nil
@@ -63,26 +69,30 @@ func TestServer(t *testing.T) {
 	storage := NewMemStorage(1, 0)
 	s := NewServer(storage, ProfilerFunc(mockProfile))
 
+	count := 1
 	for i := 0; i < 3; i++ {
-		t.Run(fmt.Sprintf("request local profile %d", i), func(t *testing.T) {
-			r := httptest.NewRequest("GET", "/heap/", nil)
-			w := httptest.NewRecorder()
-			s.ServeHTTP(w, r)
+		for _, profileType := range supportedProfiles {
+			t.Run(fmt.Sprintf("request local profile %s:%d", profileType, i), func(t *testing.T) {
+				r := httptest.NewRequest("GET", fmt.Sprintf("/%s/", profileType), nil)
+				w := httptest.NewRecorder()
+				s.ServeHTTP(w, r)
 
-			require.Equal(t, http.StatusTemporaryRedirect, w.Code)
+				require.Equal(t, http.StatusTemporaryRedirect, w.Code)
 
-			loc := w.Result().Header.Get("Location")
-			require.Equal(t, fmt.Sprintf("/heap/%d/flamegraph", i+1), loc)
+				loc := w.Result().Header.Get("Location")
+				require.Equal(t, fmt.Sprintf("/%s/%d/flamegraph", profileType, count), loc)
+				count++
 
-			r = httptest.NewRequest("GET", loc, nil)
-			w = httptest.NewRecorder()
+				r = httptest.NewRequest("GET", loc, nil)
+				w = httptest.NewRecorder()
 
-			s.ServeHTTP(w, r)
+				s.ServeHTTP(w, r)
 
-			require.Equal(t, http.StatusOK, w.Code)
-			require.Contains(t, w.Body.String(), "pprof</a></h1>")
-		})
-		require.Equal(t, 1, len(storage.getRecords()),
+				require.Equal(t, http.StatusOK, w.Code)
+				require.Contains(t, w.Body.String(), "pprof</a></h1>")
+			})
+		}
+		require.Equal(t, 1, len(storage.GetRecords()),
 			"storage did not expunge records")
 	}
 
@@ -95,7 +105,97 @@ func TestServer(t *testing.T) {
 
 		require.Equal(t, http.StatusTemporaryRedirect, w.Code)
 		loc := w.Result().Header.Get("Location")
-		require.Equal(t, "/heap/4/flamegraph?node=3", loc)
+		require.Equal(t, fmt.Sprintf("/heap/%d/flamegraph?node=3", count), loc)
+	})
+
+	t.Run("request profile with labels", func(t *testing.T) {
+		expectedNodeID = "3"
+		withLabels = true
+		defer func() {
+			withLabels = false
+		}()
+
+		// Labels are only supported for CPU and GOROUTINE profiles.
+		r := httptest.NewRequest("GET", "/heap/?node=3&labels=true", nil)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, r)
+		count++
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		require.Equal(t, "profiling with labels is unsupported for HEAP\n", w.Body.String())
+
+		r = httptest.NewRequest("GET", "/cpu/?node=3&labels=true", nil)
+		w = httptest.NewRecorder()
+		s.ServeHTTP(w, r)
+		count++
+		require.Equal(t, http.StatusTemporaryRedirect, w.Code)
+		loc := w.Result().Header.Get("Location")
+		require.Equal(t, fmt.Sprintf("/cpu/%d/flamegraph?node=3&labels=true", count), loc)
+
+		// A GOROUTINE profile with a label will trigger a download since it is not
+		// generated a Profile protobuf format.
+		r = httptest.NewRequest("GET", "/goroutine/?node=3&labels=true", nil)
+		w = httptest.NewRecorder()
+		s.ServeHTTP(w, r)
+		count++
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "attachment; filename=goroutine_25.txt", w.Header().Get("Content-Disposition"))
+		require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+	})
+
+	t.Run("request cluster-wide profiles", func(t *testing.T) {
+		expectedNodeID = "all"
+
+		// Cluster-wide profiles are only supported for CPU and GOROUTINE profiles.
+		r := httptest.NewRequest("GET", "/heap/?node=all", nil)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, r)
+		count++
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		require.Equal(t, "cluster-wide collection is unsupported for HEAP\n", w.Body.String())
+
+		r = httptest.NewRequest("GET", "/cpu/?node=all", nil)
+		w = httptest.NewRecorder()
+		s.ServeHTTP(w, r)
+		count++
+		require.Equal(t, http.StatusTemporaryRedirect, w.Code)
+		loc := w.Result().Header.Get("Location")
+		require.Equal(t, fmt.Sprintf("/cpu/%d/flamegraph?node=all", count), loc)
+
+		// A GOROUTINE profile with a label will trigger a download since it is not
+		// generated a Profile protobuf format.
+		r = httptest.NewRequest("GET", "/goroutine/?node=all", nil)
+		w = httptest.NewRecorder()
+		s.ServeHTTP(w, r)
+		count++
+		require.Equal(t, http.StatusTemporaryRedirect, w.Code)
+		loc = w.Result().Header.Get("Location")
+		require.Equal(t, fmt.Sprintf("/goroutine/%d/flamegraph?node=all", count), loc)
+	})
+
+	t.Run("request profile with label filters", func(t *testing.T) {
+		expectedNodeID = "3"
+		withLabels = true
+		defer func() {
+			withLabels = false
+		}()
+
+		// Labels are only supported for CPU and GOROUTINE profiles.
+		r := httptest.NewRequest("GET", "/heap/?node=3&labels=true&labelfilter=foo:bar", nil)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, r)
+		count++
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		require.Equal(t, "profiling with labels is unsupported for HEAP\n", w.Body.String())
+
+		// A GOROUTINE profile with a label will trigger a download since it is not
+		// generated a Profile protobuf format.
+		r = httptest.NewRequest("GET", "/goroutine/?node=3&labelfilter=foo:bar", nil)
+		w = httptest.NewRecorder()
+		s.ServeHTTP(w, r)
+		count++
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "attachment; filename=goroutine_30.txt", w.Header().Get("Content-Disposition"))
+		require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
 	})
 }
 
@@ -153,4 +253,81 @@ func TestServerConcurrentAccess(t *testing.T) {
 		go runWorker()
 	}
 	wg.Wait()
+}
+
+func TestFilterStacksWithLabels(t *testing.T) {
+	testStacks := `
+Stacks for node 1:
+
+8 @ 0x4a13d6 0x46b3bb 0x46aef8 0x12fd53f 0xe9bc43 0x12fd478 0x4d3101
+# labels: {"foo":"baz", "bar":"biz"}
+#       0x12fd53e       github.com/cockroachdb/pebble.(*tableCacheShard).releaseLoop.func1+0x9e github.com/cockroachdb/pebble/external/com_github_cockroachdb_pebble/table_cache.go:324
+
+10 @ 0x4a13d6 0x4b131c 0x17969e6 0x4d3101
+#       0x17969e5       github.com/cockroachdb/cockroach/pkg/util/admission.initWorkQueue.func2+0x85    github.com/cockroachdb/cockroach/pkg/util/admission/work_queue.go:388
+
+8 @ 0x4a13d6 0x4b131c 0x1796e96 0x4d3101
+# labels: {"bar":"biz"}
+#       0x1796e95       github.com/cockroachdb/cockroach/pkg/util/admission.(*WorkQueue).startClosingEpochs.func1+0x1d5 github.com/cockroachdb/cockroach/pkg
+/util/admission/work_queue.go:462
+
+1 @ 0x100907fc4 0x100919c8c 0x100919c69 0x1009354d8 0x1009459c0 0x101e2015c 0x101ec4b08 0x101ec4fc8 0x101f0b78c 0x101f0addc 0x1015319fc 0x100939fb4
+# labels: {"range_str":"12419/2:/Table/136/1/"{NHCH-…-PWN-a"}", "n":"1", "rangefeed":"sql-watcher-descriptor-rangefeed"}
+#	0x1009354d7	sync.runtime_Semacquire+0x27									GOROOT/src/runtime/sema.go:62
+
+
+`
+	t.Run("empty filter", func(t *testing.T) {
+		res := FilterStacksWithLabels([]byte(testStacks), "")
+		require.Equal(t, `
+Stacks for node 1:
+
+8 @ 0x4a13d6 0x46b3bb 0x46aef8 0x12fd53f 0xe9bc43 0x12fd478 0x4d3101
+# labels: {"foo":"baz", "bar":"biz"}
+#       0x12fd53e       github.com/cockroachdb/pebble.(*tableCacheShard).releaseLoop.func1+0x9e github.com/cockroachdb/pebble/external/com_github_cockroachdb_pebble/table_cache.go:324
+
+10 @ 0x4a13d6 0x4b131c 0x17969e6 0x4d3101
+#       0x17969e5       github.com/cockroachdb/cockroach/pkg/util/admission.initWorkQueue.func2+0x85    github.com/cockroachdb/cockroach/pkg/util/admission/work_queue.go:388
+
+8 @ 0x4a13d6 0x4b131c 0x1796e96 0x4d3101
+# labels: {"bar":"biz"}
+#       0x1796e95       github.com/cockroachdb/cockroach/pkg/util/admission.(*WorkQueue).startClosingEpochs.func1+0x1d5 github.com/cockroachdb/cockroach/pkg
+/util/admission/work_queue.go:462
+
+1 @ 0x100907fc4 0x100919c8c 0x100919c69 0x1009354d8 0x1009459c0 0x101e2015c 0x101ec4b08 0x101ec4fc8 0x101f0b78c 0x101f0addc 0x1015319fc 0x100939fb4
+# labels: {"range_str":"12419/2:/Table/136/1/"{NHCH-…-PWN-a"}", "n":"1", "rangefeed":"sql-watcher-descriptor-rangefeed"}
+#	0x1009354d7	sync.runtime_Semacquire+0x27									GOROOT/src/runtime/sema.go:62
+
+
+`, string(res))
+	})
+
+	t.Run("bar-biz filter", func(t *testing.T) {
+		res := FilterStacksWithLabels([]byte(testStacks), "\"bar\":\"biz\"")
+		require.Equal(t, `
+Stacks for node 1:
+
+8 @ 0x4a13d6 0x46b3bb 0x46aef8 0x12fd53f 0xe9bc43 0x12fd478 0x4d3101
+# labels: {"foo":"baz", "bar":"biz"}
+#       0x12fd53e       github.com/cockroachdb/pebble.(*tableCacheShard).releaseLoop.func1+0x9e github.com/cockroachdb/pebble/external/com_github_cockroachdb_pebble/table_cache.go:324
+
+8 @ 0x4a13d6 0x4b131c 0x1796e96 0x4d3101
+# labels: {"bar":"biz"}
+#       0x1796e95       github.com/cockroachdb/cockroach/pkg/util/admission.(*WorkQueue).startClosingEpochs.func1+0x1d5 github.com/cockroachdb/cockroach/pkg
+/util/admission/work_queue.go:462
+
+`, string(res))
+	})
+
+	t.Run("filter non-alphanumeric characters", func(t *testing.T) {
+		res := FilterStacksWithLabels([]byte(testStacks), "\"{NHCH")
+		require.Equal(t, `
+Stacks for node 1:
+
+1 @ 0x100907fc4 0x100919c8c 0x100919c69 0x1009354d8 0x1009459c0 0x101e2015c 0x101ec4b08 0x101ec4fc8 0x101f0b78c 0x101f0addc 0x1015319fc 0x100939fb4
+# labels: {"range_str":"12419/2:/Table/136/1/"{NHCH-…-PWN-a"}", "n":"1", "rangefeed":"sql-watcher-descriptor-rangefeed"}
+#	0x1009354d7	sync.runtime_Semacquire+0x27									GOROOT/src/runtime/sema.go:62
+
+`, string(res))
+	})
 }

--- a/pkg/server/debug/pprofui/storage.go
+++ b/pkg/server/debug/pprofui/storage.go
@@ -17,8 +17,12 @@ type Storage interface {
 	// ID generates a unique ID for use in Store.
 	ID() string
 	// Store invokes the passed-in closure with a writer that stores its input.
-	Store(id string, write func(io.Writer) error) error
+	// IsProfileProto determines whether the input will be in the protobuf format
+	// outlined in https://github.com/google/pprof/tree/main/proto#overview.
+	Store(id string, isProfileProto bool, write func(io.Writer) error) error
 	// Get invokes the passed-in closure with a reader for the data at the given id.
 	// An error is returned when no data is found.
-	Get(id string, read func(io.Reader) error) error
+	// The boolean indicates whether the stored record is in protobuf format
+	// outlined in https://github.com/google/pprof/tree/main/proto#overview.
+	Get(id string, read func(bool, io.Reader) error) error
 }

--- a/pkg/server/debug/pprofui/storage_mem.go
+++ b/pkg/server/debug/pprofui/storage_mem.go
@@ -26,7 +26,10 @@ import (
 type record struct {
 	id string
 	t  time.Time
-	b  []byte
+	// isProfileProto is true when the profile record is stored in protobuf format
+	// outlined in https://github.com/google/pprof/tree/main/proto#overview.
+	isProfileProto bool
+	b              []byte
 }
 
 // A MemStorage is a Storage implementation that holds recent profiles in memory.
@@ -40,7 +43,7 @@ type MemStorage struct {
 	keepNumber   int           // zero for disabled
 }
 
-func (s *MemStorage) getRecords() []record {
+func (s *MemStorage) GetRecords() []record {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]record(nil), s.mu.records...)
@@ -78,14 +81,14 @@ func (s *MemStorage) cleanLocked() {
 }
 
 // Store implements Storage.
-func (s *MemStorage) Store(id string, write func(io.Writer) error) error {
+func (s *MemStorage) Store(id string, isProfileProto bool, write func(io.Writer) error) error {
 	var b bytes.Buffer
 	if err := write(&b); err != nil {
 		return err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.mu.records = append(s.mu.records, record{id: id, t: timeutil.Now(), b: b.Bytes()})
+	s.mu.records = append(s.mu.records, record{id: id, t: timeutil.Now(), b: b.Bytes(), isProfileProto: isProfileProto})
 	sort.Slice(s.mu.records, func(i, j int) bool {
 		return s.mu.records[i].t.Before(s.mu.records[j].t)
 	})
@@ -94,12 +97,12 @@ func (s *MemStorage) Store(id string, write func(io.Writer) error) error {
 }
 
 // Get implements Storage.
-func (s *MemStorage) Get(id string, read func(io.Reader) error) error {
+func (s *MemStorage) Get(id string, read func(bool, io.Reader) error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, v := range s.mu.records {
 		if v.id == id {
-			return read(bytes.NewReader(v.b))
+			return read(v.isProfileProto, bytes.NewReader(v.b))
 		}
 	}
 	return errors.Errorf("profile not found; it may have expired, please regenerate the profile.\n" +

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -753,7 +753,7 @@ message GetFilesResponse {
 }
 
 message ProfileRequest {
-  // node_id is a string so that "local" can be used to specify that no
+  // node_id is a string so that "local" or "all" can be used to specify that no
   // forwarding is necessary. node_id translates to a KV node ID on a storage
   // server and SQL instance ID on a SQL only server.
   string node_id = 1;
@@ -771,7 +771,18 @@ message ProfileRequest {
   Type type = 5;
 
   int32 seconds = 6; // applies only to Type=CPU, defaults to 30
-  bool labels = 7; // applies only to Type=CPU, defaults to false
+
+  // Labels can be specified for Type=CPU or Type=GOROUTINE.
+  //
+  // - If true for CPU profiles, we request a CPU profile with pprof labels.
+  //
+  // - If true for GOROUTINE profiles, we request an aggregated goroutine
+  // profile with debug=1.
+  bool labels = 7;
+
+  // LabelFilter only applies to Type=GOROUTINE. Only goroutines with a pprof
+  // label matching the filter will be returned.
+  string label_filter = 9;
 
   // SenderServerVersion is the server version of the node sending the Profile
   // request. If this field is set then the node processing the request will

--- a/pkg/server/status_local_file_retrieval.go
+++ b/pkg/server/status_local_file_retrieval.go
@@ -13,13 +13,16 @@ package server
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
+	"github.com/cockroachdb/cockroach/pkg/server/debug/pprofui"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
@@ -30,7 +33,7 @@ import (
 // profileLocal runs a performance profile of the requested type (heap, cpu etc).
 // on the local node. This method returns a gRPC error to the caller.
 func profileLocal(
-	ctx context.Context, req *serverpb.ProfileRequest, st *cluster.Settings,
+	ctx context.Context, req *serverpb.ProfileRequest, st *cluster.Settings, nodeID roachpb.NodeID,
 ) (*serverpb.JSONResponse, error) {
 	switch req.Type {
 	case serverpb.ProfileRequest_CPU:
@@ -57,6 +60,29 @@ func profileLocal(
 			}
 		}); err != nil {
 			return nil, err
+		}
+		return &serverpb.JSONResponse{Data: buf.Bytes()}, nil
+	case serverpb.ProfileRequest_GOROUTINE:
+		p := pprof.Lookup("goroutine")
+		if p == nil {
+			return nil, status.Error(codes.Internal, "unable to find goroutine profile")
+		}
+		var buf bytes.Buffer
+		if req.Labels {
+			buf.WriteString(fmt.Sprintf("Stacks for node: %d\n\n", nodeID))
+			if err := p.WriteTo(&buf, 1); err != nil {
+				return nil, status.Errorf(codes.Internal, err.Error())
+			}
+			buf.WriteString("\n\n")
+
+			// Now check if we need to filter the goroutines by the provided label filter.
+			if req.LabelFilter != "" {
+				return &serverpb.JSONResponse{Data: pprofui.FilterStacksWithLabels(buf.Bytes(), req.LabelFilter)}, nil
+			}
+		} else {
+			if err := p.WriteTo(&buf, 0); err != nil {
+				return nil, status.Errorf(codes.Internal, err.Error())
+			}
 		}
 		return &serverpb.JSONResponse{Data: buf.Bytes()}, nil
 	default:


### PR DESCRIPTION
This change refactors some of the logic in the pprofui/. Additionally, we add support for collecting cluster-wide goroutine profiles.

These goroutine profiles can be collected with or without labels. When collected without labels we request pprof profiles with debug=0, which generates Profile protobufs on every node and `pprof.Merge`s them before redirecting the client to a flamegraph.

When collected with labels we request pprof profiles with debug=1, which generates a legacy text format with comments translating addresses to function names and line numbers, so that a programmer can read the profile without tools. These profiles cannot be `pprof.Merged` and so we manually stitch them together on a per-node basis before downloading them for the client as txt file.

This change also adds support for filtering the aforementioned goroutines by pprof label. This will be used by the Jobs Profiler to collect cluster-wide stacks relevant to the running job.

Informs: #105440
Release note: None