### PR TITLE
roachtest: Delete scbench randomload test

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -29,13 +29,6 @@ const (
 	txnLogFile = "transactions.ndjson"
 )
 
-type randomLoadBenchSpec struct {
-	Nodes       int
-	Ops         int
-	Concurrency int
-	Tags        map[string]struct{}
-}
-
 func registerSchemaChangeRandomLoad(r registry.Registry) {
 	geoZones := []string{"us-east1-b", "us-west1-b", "europe-west2-b"}
 	if r.MakeClusterSpec(1).Cloud == spec.AWS {
@@ -62,47 +55,6 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 			}
 			runSchemaChangeRandomLoad(ctx, t, c, maxOps, concurrency)
 		},
-	})
-
-	// Run a few representative scbench specs in CI.
-	registerRandomLoadBenchSpec(r, randomLoadBenchSpec{
-		Nodes:       3,
-		Ops:         2000,
-		Concurrency: 1,
-		Tags:        registry.Tags("aws"),
-	})
-
-	registerRandomLoadBenchSpec(r, randomLoadBenchSpec{
-		Nodes:       3,
-		Ops:         10000,
-		Concurrency: 20,
-	})
-}
-
-func registerRandomLoadBenchSpec(r registry.Registry, b randomLoadBenchSpec) {
-	nameParts := []string{
-		"scbench",
-		"randomload",
-		fmt.Sprintf("nodes=%d", b.Nodes),
-		fmt.Sprintf("ops=%d", b.Ops),
-		fmt.Sprintf("conc=%d", b.Concurrency),
-	}
-	name := strings.Join(nameParts, "/")
-
-	r.Add(registry.TestSpec{
-		Name:       name,
-		Owner:      registry.OwnerSQLFoundations,
-		Benchmark:  true,
-		Cluster:    r.MakeClusterSpec(b.Nodes),
-		NativeLibs: registry.LibGEOS,
-		Skip:       "https://github.com/cockroachdb/cockroach/issues/56230",
-		// This is set while development is still happening on the workload and we
-		// fix (or bypass) minor schema change bugs that are discovered.
-		NonReleaseBlocker: true,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runSchemaChangeRandomLoad(ctx, t, c, b.Ops, b.Concurrency)
-		},
-		Tags: b.Tags,
 	})
 }
 


### PR DESCRIPTION
This test has been skipped for a year and based
on the history of the test hasn't been providing
much value. We can delete it now. Random
schema change testing is covered by schemachange/randomload.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/56230
Release note: None