### PR TITLE
changefeedccl: Fix incorrect skip usage

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3627,7 +3627,7 @@ func TestChangefeedStopOnSchemaChange(t *testing.T) {
 			// any schema changes. Dropping a column in the declarative schema
 			// changer means that an extra error will occur.
 			if _, isSinkless := f.(*sinklessFeedFactory); isSinkless {
-				skip.WithIssue(t, 84511)
+				return
 			}
 			sqlDB.Exec(t, `CREATE TABLE drop_column (a INT PRIMARY KEY, b INT)`)
 			defer sqlDB.Exec(t, `DROP TABLE drop_column`)


### PR DESCRIPTION
Remove skip.WithIssue in sinkelss "drop column" test. It's not an appropriate use of skip -- we should just return.

Fixes  #84511
Release note: None