### PR TITLE
opt/exec: add passthrough cols to DELETE USING result cols in explain

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -337,3 +337,47 @@ vectorized: true
               estimated row count: 990 (missing stats)
               table: xyz@xyz_y_idx
               spans: /1-/1000 /2001-/3000
+
+# Testcase for issue 105803.
+
+statement ok
+CREATE TABLE b (b INT PRIMARY KEY)
+
+query T
+EXPLAIN (TYPES) DELETE FROM a USING b WHERE b > 1 RETURNING a, b, NULL
+----
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a int, b int, "?column?" unknown)
+│ render ?column?: (NULL)[unknown]
+│ render a: (a)[int]
+│ render b: (b)[int]
+│
+└── • delete
+    │ columns: (a int, b int)
+    │ estimated row count: 1,000 (missing stats)
+    │ from: a
+    │ auto commit
+    │
+    └── • distinct
+        │ columns: (a int, b int)
+        │ estimated row count: 1,000 (missing stats)
+        │ distinct on: a
+        │
+        └── • cross join (inner)
+            │ columns: (a int, b int)
+            │ estimated row count: 333,333 (missing stats)
+            │
+            ├── • scan
+            │     columns: (a int)
+            │     estimated row count: 1,000 (missing stats)
+            │     table: a@a_pkey
+            │     spans: FULL SCAN
+            │
+            └── • scan
+                  columns: (b int)
+                  estimated row count: 333 (missing stats)
+                  table: b@b_pkey
+                  spans: /2-

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -150,7 +150,10 @@ func getResultColumns(
 
 	case deleteOp:
 		a := args.(*deleteArgs)
-		return tableColumns(a.Table, a.ReturnCols), nil
+		return appendColumns(
+			tableColumns(a.Table, a.ReturnCols),
+			a.Passthrough...,
+		), nil
 
 	case opaqueOp:
 		if args.(*opaqueArgs).Metadata != nil {


### PR DESCRIPTION
Now that we support `DELETE USING`, delete nodes can have passthrough columns. Add these to the result columns used by `EXPLAIN (TYPES)`.

Fixes: #105803

Release note (sql change): Fix an internal error when using `EXPLAIN (TYPES)` on a `DELETE FROM ... USING ... RETURNING` statement.