### PR TITLE
kvserver: skip `TestReliableIntentCleanup`

### DIFF
--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -190,6 +190,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 66895)
 	skip.UnderShort(t) // takes 294s
 	skip.UnderRace(t, "timing-sensitive test")
 	skip.UnderDeadlock(t, "timing-sensitive test")


### PR DESCRIPTION
Still flaky.

Epic: none
Release note: None