### PR TITLE
sql: fix `SHOW SCHEMAS` database name resolution bug

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
@@ -58,7 +58,7 @@ SHOW CREATE DATABASE multi_region_test_placement_restricted_db
 database_name                                     create_statement
 multi_region_test_placement_restricted_db         CREATE DATABASE multi_region_test_placement_restricted_db PRIMARY REGION "ap-southeast-2" REGIONS = "ap-southeast-2", "ca-central-1", "us-east-1" SURVIVE ZONE FAILURE PLACEMENT RESTRICTED
 
-statement error target database or schema does not exist
+statement error database "foo" does not exist
 SHOW CREATE DATABASE foo
 
 # Test that showing localities works for databases and schemas with weird

--- a/pkg/sql/delegate/show_schemas.go
+++ b/pkg/sql/delegate/show_schemas.go
@@ -62,18 +62,6 @@ func (d *delegator) delegateShowCreateAllSchemas() (tree.Statement, error) {
 // Returns an error if there is no current database, or if the specified
 // database doesn't exist.
 func (d *delegator) getSpecifiedOrCurrentDatabase(specifiedDB tree.Name) (tree.Name, error) {
-	var name cat.SchemaName
-	if specifiedDB != "" {
-		// Note: the schema name may be interpreted as database name,
-		// see name_resolution.go.
-		name.SchemaName = specifiedDB
-		name.ExplicitSchema = true
-	}
-
 	flags := cat.Flags{AvoidDescriptorCaches: true}
-	_, resName, err := d.catalog.ResolveSchema(d.ctx, flags, &name)
-	if err != nil {
-		return "", err
-	}
-	return resName.CatalogName, nil
+	return d.catalog.LookupDatabaseName(d.ctx, flags, string(specifiedDB))
 }

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -309,6 +309,11 @@ CREATE TABLE db69713.s.pg_constraintdef_test (
 statement ok
 DROP DATABASE db69713;
 
+statement ok
+RESET DATABASE;
+
+subtest end
+
 # Ensure user must exist to create with owner.
 statement error role/user "fake_user" does not exist
 CREATE DATABASE aa with owner fake_user
@@ -359,5 +364,75 @@ SELECT * FROM [SHOW DATABASES] WHERE database_name = 'ifnotexistsownerdb'
 ----
 database_name       owner     primary_region  secondary_region  regions  survival_goal
 ifnotexistsownerdb  testuser  NULL            NULL              {}       NULL
+
+subtest end
+
+subtest regression_105906
+
+statement ok
+CREATE SCHEMA regression_105906
+
+statement ok
+CREATE DATABASE regression_105906
+
+query TT colnames,rowsort
+SHOW SCHEMAS
+----
+schema_name         owner
+crdb_internal       NULL
+information_schema  NULL
+pg_catalog          NULL
+pg_extension        NULL
+public              admin
+regression_105906   root
+
+# Note: regression_105906 should not appear in the list of schemas below
+query TT colnames,rowsort
+SHOW SCHEMAS FROM regression_105906
+----
+schema_name         owner
+crdb_internal       NULL
+information_schema  NULL
+pg_catalog          NULL
+pg_extension        NULL
+public              admin
+
+statement ok
+DROP DATABASE regression_105906
+
+statement ok
+DROP SCHEMA regression_105906
+
+statement ok
+CREATE SCHEMA "rEgReSsIoN 105906"
+
+statement ok
+CREATE DATABASE "rEgReSsIoN 105906"
+
+query T rowsort
+SELECT schema_name FROM [SHOW SCHEMAS]
+----
+public
+rEgReSsIoN 105906
+crdb_internal
+information_schema
+pg_catalog
+pg_extension
+
+# Note: "rEgReSsIoN 105906" should not appear in the list of schemas below
+query T rowsort
+SELECT schema_name FROM [SHOW SCHEMAS FROM "rEgReSsIoN 105906"]
+----
+public
+crdb_internal
+information_schema
+pg_catalog
+pg_extension
+
+statement ok
+DROP SCHEMA "rEgReSsIoN 105906"
+
+statement ok
+DROP DATABASE "rEgReSsIoN 105906"
 
 subtest end

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -83,6 +83,14 @@ type Flags struct {
 // returned by the Resolve methods (schemas and data sources) *must* be
 // immutable after construction, and therefore also thread-safe.
 type Catalog interface {
+	// LookupDatabaseName locates a database with the given name and returns
+	// the name if found. If no name is provided, it will return the name of
+	// the current database. An error is returned if no database with the given
+	// name exists or in the case of an empty name, there is no current database.
+	// TODO(yang): This function can be extended if needed in the future
+	// to return a new cat.Database type similar to ResolveSchema.
+	LookupDatabaseName(ctx context.Context, flags Flags, name string) (tree.Name, error)
+
 	// ResolveSchema locates a schema with the given name and returns it along
 	// with the resolved SchemaName (which has all components filled in).
 	// If the SchemaName is empty, returns the current database/schema (if one is

--- a/pkg/sql/opt/testutils/testcat/BUILD.bazel
+++ b/pkg/sql/opt/testutils/testcat/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/sql/sem/tree/treecmp",
         "//pkg/sql/sem/volatility",
         "//pkg/sql/sessiondatapb",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/stats",
         "//pkg/sql/types",
         "//pkg/sql/vtable",

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
@@ -75,6 +76,15 @@ func New() *Catalog {
 			dataSources: make(map[string]dataSource),
 		},
 	}
+}
+
+func (tc *Catalog) LookupDatabaseName(
+	_ context.Context, _ cat.Flags, name string,
+) (tree.Name, error) {
+	if name != testDB {
+		return "", sqlerrors.NewUndefinedDatabaseError(name)
+	}
+	return tree.Name(name), nil
 }
 
 // ResolveSchema is part of the cat.Catalog interface.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -160,6 +160,25 @@ func (os *optSchema) getDescriptorForPermissionsCheck() catalog.Descriptor {
 	return os.database
 }
 
+// LookupDatabaseName implements the cat.Catalog interface.
+func (oc *optCatalog) LookupDatabaseName(
+	ctx context.Context, flags cat.Flags, name string,
+) (tree.Name, error) {
+	if flags.AvoidDescriptorCaches {
+		defer func(prev bool) {
+			oc.planner.skipDescriptorCache = prev
+		}(oc.planner.skipDescriptorCache)
+		oc.planner.skipDescriptorCache = true
+	}
+	if name == "" {
+		name = oc.planner.CurrentDatabase()
+	}
+	if err := oc.planner.LookupDatabase(ctx, name); err != nil {
+		return "", err
+	}
+	return tree.Name(name), nil
+}
+
 // ResolveSchema is part of the cat.Catalog interface.
 func (oc *optCatalog) ResolveSchema(
 	ctx context.Context, flags cat.Flags, name *cat.SchemaName,

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -200,6 +200,15 @@ func (sr *schemaResolver) LookupSchema(
 	return true, catalog.ResolvedObjectPrefix{Database: db, Schema: sc}, nil
 }
 
+func (sr *schemaResolver) LookupDatabase(ctx context.Context, dbName string) error {
+	g := sr.byNameGetterBuilder().Get()
+	_, err := g.Database(ctx, dbName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // CurrentDatabase implements the tree.QualifiedNameResolver interface.
 func (sr *schemaResolver) CurrentDatabase() string {
 	return sr.sessionDataStack.Top().Database


### PR DESCRIPTION
This patch fixes a bug in the `SHOW SCHEMAS FROM db_name` logic where a schema with the name `db_name` in the current database would result in the current database's schemas being erroneously returned instead. The logic will now simply look up the database name instead of using the schema lookup logic.

Fixes #105906 

Release note (bug fix): `SHOW SCHEMAS FROM db_name` will no longer incorrectly show schemas from the current database when the current database has a schema named `db_name`.