### PR TITLE
lease: unskip TestDescriptorRefreshOnRetry

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -890,8 +890,6 @@ CREATE TABLE t.foo (v INT);
 func TestDescriptorRefreshOnRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	skip.WithIssue(t, 50037)
-
 	params := createTestServerParams()
 
 	fooAcquiredCount := int32(0)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/50037

Miraculously, this is now passing after 3 years of being skipped. Ran under stress for 10 minutes.

Release note: None