### PR TITLE
roachtest: deflake change replicas mixed version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -91,6 +91,20 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 	// TABLE RELOCATE via a random gateway node.
 	changeReplicasRelocateFromNodeStep := func(table string, nodeID int) versionStep {
 		return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+			enqueueRangeInReplicateQueue := func(rangeID int) {
+				for n := 1; n <= nodeCount; n++ {
+					conn := u.c.Conn(ctx, t.L(), n)
+					defer conn.Close()
+					// Enqueue on every node, only the leaseholder node will process the
+					// range.
+					_, err = conn.ExecContext(ctx, fmt.Sprintf(
+						`SELECT crdb_internal.kv_enqueue_replica(%d, 'replicate', true)`,
+						rangeID))
+					if err != nil {
+						t.L().Printf("kv_enqueue_replica failed: %s", err)
+					}
+				}
+			}
 
 			// Disable the replicate queue, but re-enable it when we're done.
 			setReplicateQueueEnabled := func(enabled bool) {
@@ -158,6 +172,13 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 					// changes by the replicate queue, so we re-enable it and let it run
 					// for a bit before the next retry.
 					setReplicateQueueEnabled(true)
+					// Additionally, any ranges which had errors are manually enqueued
+					// into the replicate queue. This will speed up resolving conflicts
+					// and intermediate states such as left over learners or joint
+					// configurations.
+					for rangeID := range rangeErrors {
+						enqueueRangeInReplicateQueue(rangeID)
+					}
 				}
 
 				if len(rangeErrors) > 0 {


### PR DESCRIPTION
It was possible for `change-replicas/mixed-version` roachtests to flake due to learner replicas never being removed. Whilst the replicate queue should clean up learner replicas and leftover joint configurations, it can be slow and is not guaranteed to process the replica in time.

Manually enqueue ranges into the replicate queue whenever they return an error during the ALTER TABLE RELOCATE test step.

Fixes: #101414

Release note: None