### PR TITLE
kvserver: unredact allocator error messages

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@io_etcd_go_raft_v3//:raft",
         "@io_etcd_go_raft_v3//tracker",
     ],

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -748,7 +748,7 @@ func (rq *replicateQueue) processOneChangeWithTracing(
 		}
 
 		if err != nil {
-			log.KvDistribution.Infof(ctx, "error processing replica: %v%s", err, traceOutput)
+			log.KvDistribution.Infof(ctx, "error processing replica: %s%s", err, traceOutput)
 		} else if exceededDuration {
 			log.KvDistribution.Infof(ctx, "processing replica took %s, exceeding threshold of %s%s",
 				processDuration, loggingThreshold, traceOutput)


### PR DESCRIPTION
Error messages from the allocator do not contain PII, however they were previously redacted because the allocator error type did not implement `SafeFormatError`. This change fixes this issue, which will help observability into issues when only redacted logs are available. This was particularly noticable in a recent escalation, and should help future similar escalations.

Epic: none

Release note: None