### PR TITLE
release-22.1: allocator: expose LeaseRebalanceThreshold as a cluster setting

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -36,6 +36,7 @@
 <tr><td><code>feature.schema_change.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable schema changes, false to disable; default is true</td></tr>
 <tr><td><code>feature.stats.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable CREATE STATISTICS/ANALYZE, false to disable; default is true</td></tr>
 <tr><td><code>jobs.retention_time</code></td><td>duration</td><td><code>336h0m0s</code></td><td>the amount of time to retain records for completed jobs before</td></tr>
+<tr><td><code>kv.allocator.lease_rebalance_threshold</code></td><td>float</td><td><code>0.05</code></td><td>minimum fraction away from the mean a store's lease count can be before it is considered for lease-transfers</td></tr>
 <tr><td><code>kv.allocator.load_based_lease_rebalancing.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to enable rebalancing of range leases based on load and latency</td></tr>
 <tr><td><code>kv.allocator.load_based_rebalancing</code></td><td>enumeration</td><td><code>leases and replicas</code></td><td>whether to rebalance based on the distribution of QPS across stores [off = 0, leases = 1, leases and replicas = 2]</td></tr>
 <tr><td><code>kv.allocator.load_based_rebalancing_interval</code></td><td>duration</td><td><code>1m0s</code></td><td>the rough interval at which each store will check for load-based lease / replica rebalancing opportunities</td></tr>

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -478,6 +478,7 @@ type AllocatorMetrics struct {
 // Allocator tries to spread replicas as evenly as possible across the stores
 // in the cluster.
 type Allocator struct {
+	st            *cluster.Settings
 	storePool     *StorePool
 	nodeLatencyFn func(addr string) (time.Duration, bool)
 	// TODO(aayush): Let's replace this with a *rand.Rand that has a rand.Source
@@ -511,6 +512,7 @@ func makeAllocatorMetrics() AllocatorMetrics {
 
 // MakeAllocator creates a new allocator using the specified StorePool.
 func MakeAllocator(
+	st *cluster.Settings,
 	storePool *StorePool,
 	nodeLatencyFn func(addr string) (time.Duration, bool),
 	knobs *AllocatorTestingKnobs,
@@ -526,6 +528,7 @@ func MakeAllocator(
 		randSource = rand.NewSource(rand.Int63())
 	}
 	allocator := Allocator{
+		st:            st,
 		storePool:     storePool,
 		nodeLatencyFn: nodeLatencyFn,
 		randGen:       makeAllocatorRand(randSource),

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1179,6 +1179,7 @@ func NewStore(
 	}
 	if cfg.RPCContext != nil {
 		s.allocator = MakeAllocator(
+			cfg.Settings,
 			cfg.StorePool,
 			cfg.RPCContext.RemoteClocks.Latency,
 			cfg.TestingKnobs.AllocatorKnobs,
@@ -1186,6 +1187,7 @@ func NewStore(
 		)
 	} else {
 		s.allocator = MakeAllocator(
+			cfg.Settings,
 			cfg.StorePool, func(string) (time.Duration, bool) {
 				return 0, false
 			}, cfg.TestingKnobs.AllocatorKnobs, s.metrics,


### PR DESCRIPTION
Backport 1/1 commits from #105924.

/cc @cockroachdb/release

---

This patch adds a new cluster setting --
`kv.allocator.lease_rebalance_threshold`. This setting controls the minimum
fraction away from the mean a store's lease count can be before it is considered
for lease-transfers. The default setting is 0.05.

Fixes: https://github.com/cockroachdb/cockroach/issues/105909

Release Note (allocator): cluster setting
`kv.allocator.lease_rebalance_threshold` can now be used to control the minimum 
fraction away from the mean a store's lease count before it is considered for
lease-transfers. The default setting is 0.05.

---

Release justification: low risk to the existing functionality
