### PR TITLE
sql/catalog: lazily allocate hash maps in `*descs.Collection`

### DIFF
--- a/pkg/sql/catalog/descs/uncommitted_metadata.go
+++ b/pkg/sql/catalog/descs/uncommitted_metadata.go
@@ -26,15 +26,18 @@ type uncommittedComments struct {
 }
 
 func makeUncommittedComments() uncommittedComments {
-	return uncommittedComments{
-		uncommitted: make(map[catalogkeys.CommentKey]string),
-		cachedKeys:  make(map[catalogkeys.CommentKey]struct{}),
-	}
+	return uncommittedComments{}
 }
 
 func (uc *uncommittedComments) reset() {
-	uc.uncommitted = make(map[catalogkeys.CommentKey]string)
-	uc.cachedKeys = make(map[catalogkeys.CommentKey]struct{})
+	*uc = uncommittedComments{}
+}
+
+func (uc *uncommittedComments) lazyInitMaps() {
+	if uc.uncommitted == nil {
+		uc.uncommitted = make(map[catalogkeys.CommentKey]string)
+		uc.cachedKeys = make(map[catalogkeys.CommentKey]struct{})
+	}
 }
 
 func (uc *uncommittedComments) getUncommitted(
@@ -50,11 +53,13 @@ func (uc *uncommittedComments) getUncommitted(
 
 // markNoComment lets the cache know that the comment for this key is dropped.
 func (uc *uncommittedComments) markNoComment(key catalogkeys.CommentKey) {
+	uc.lazyInitMaps()
 	delete(uc.uncommitted, key)
 	uc.cachedKeys[key] = struct{}{}
 }
 
 func (uc *uncommittedComments) markTableDeleted(tblID descpb.ID) {
+	// NOTE: lazyInitMaps() not needed, maps can remain nil.
 	var keysToDel []catalogkeys.CommentKey
 	for k := range uc.uncommitted {
 		if k.ObjectID == uint32(tblID) {
@@ -67,6 +72,7 @@ func (uc *uncommittedComments) markTableDeleted(tblID descpb.ID) {
 }
 
 func (uc *uncommittedComments) upsert(key catalogkeys.CommentKey, cmt string) {
+	uc.lazyInitMaps()
 	uc.cachedKeys[key] = struct{}{}
 	uc.uncommitted[key] = cmt
 }
@@ -86,15 +92,18 @@ type uncommittedZoneConfigs struct {
 }
 
 func makeUncommittedZoneConfigs() uncommittedZoneConfigs {
-	return uncommittedZoneConfigs{
-		uncommitted: make(map[descpb.ID]catalog.ZoneConfig),
-		cachedDescs: make(map[descpb.ID]struct{}),
-	}
+	return uncommittedZoneConfigs{}
 }
 
 func (uc *uncommittedZoneConfigs) reset() {
-	uc.uncommitted = make(map[descpb.ID]catalog.ZoneConfig)
-	uc.cachedDescs = make(map[descpb.ID]struct{})
+	*uc = uncommittedZoneConfigs{}
+}
+
+func (uc *uncommittedZoneConfigs) lazyInitMaps() {
+	if uc.uncommitted == nil {
+		uc.uncommitted = make(map[descpb.ID]catalog.ZoneConfig)
+		uc.cachedDescs = make(map[descpb.ID]struct{})
+	}
 }
 
 func (uc *uncommittedZoneConfigs) getUncommitted(
@@ -107,11 +116,13 @@ func (uc *uncommittedZoneConfigs) getUncommitted(
 }
 
 func (uc *uncommittedZoneConfigs) markNoZoneConfig(id descpb.ID) {
+	uc.lazyInitMaps()
 	delete(uc.uncommitted, id)
 	uc.cachedDescs[id] = struct{}{}
 }
 
 func (uc *uncommittedZoneConfigs) upsert(id descpb.ID, zc *zonepb.ZoneConfig) error {
+	uc.lazyInitMaps()
 	uc.cachedDescs[id] = struct{}{}
 	var val roachpb.Value
 	if err := val.SetProto(zc); err != nil {


### PR DESCRIPTION
We call `(*descs.Collection).ResetUncommitted` after each transaction from `(*connExecutor).resetExtraTxnState`. Previously, the method would re-allocate four different hash maps each time it was called.

This commit changes the `uncommittedComments` and `uncommittedZoneConfigs` structs to lazily initialize their hash maps, which avoids allocating the maps when they are not needed. Doing so eliminates the four map allocations per txn.

```sh
➜ benchdiff --run='BenchmarkKV/./SQL/rows=1$$' --count=25 ./pkg/sql/tests

name                     old time/op    new time/op    delta
KV/Scan/SQL/rows=1-10       118µs ± 5%     116µs ± 4%  -1.10%  (p=0.048 n=24+22)
KV/Insert/SQL/rows=1-10     162µs ± 8%     160µs ± 4%    ~     (p=0.208 n=24+22)
KV/Update/SQL/rows=1-10     270µs ± 4%     271µs ± 7%    ~     (p=0.907 n=21+23)
KV/Delete/SQL/rows=1-10     189µs ± 9%     189µs ±10%    ~     (p=0.120 n=23+23)

name                     old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-10      32.0kB ± 0%    31.8kB ± 0%  -0.75%  (p=0.000 n=24+22)
KV/Insert/SQL/rows=1-10    58.9kB ± 0%    58.7kB ± 1%  -0.38%  (p=0.000 n=25+24)
KV/Delete/SQL/rows=1-10    84.6kB ± 1%    84.3kB ± 1%  -0.29%  (p=0.000 n=24+22)
KV/Update/SQL/rows=1-10    70.4kB ± 1%    70.2kB ± 0%  -0.22%  (p=0.006 n=24+23)

name                     old allocs/op  new allocs/op  delta
KV/Scan/SQL/rows=1-10         365 ± 0%       361 ± 1%  -1.20%  (p=0.000 n=24+23)
KV/Delete/SQL/rows=1-10       610 ± 1%       605 ± 0%  -0.75%  (p=0.000 n=20+20)
KV/Insert/SQL/rows=1-10       493 ± 0%       489 ± 1%  -0.72%  (p=0.000 n=25+23)
KV/Update/SQL/rows=1-10       724 ± 1%       721 ± 1%  -0.44%  (p=0.000 n=24+24)
```

Epic: None
Release note: None