### PR TITLE
release-23.1: kvserver: don't put a timeout on circuit breaker probes

### DIFF
--- a/pkg/kv/kvserver/replica_circuit_breaker.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/circuit"
-	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -185,6 +184,8 @@ func (br *replicaCircuitBreaker) asyncProbe(report func(error), done func()) {
 	bgCtx := br.ambCtx.AnnotateCtx(context.Background())
 	if err := br.stopper.RunAsyncTask(bgCtx, "replica-probe", func(ctx context.Context) {
 		defer done()
+		ctx, cancel := br.stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
 
 		if !br.enabled() {
 			report(nil)
@@ -225,17 +226,13 @@ func sendProbe(ctx context.Context, r replicaInCircuitBreaker) error {
 	probeReq := &kvpb.ProbeRequest{}
 	probeReq.Key = desc.StartKey.AsRawKey()
 	ba.Add(probeReq)
-	thresh, ok := r.slowReplicationThreshold(ba)
+	_, ok := r.slowReplicationThreshold(ba)
 	if !ok {
 		// Breakers are disabled now.
 		return nil
 	}
-	if err := contextutil.RunWithTimeout(ctx, "probe", thresh,
-		func(ctx context.Context) error {
-			_, pErr := r.Send(ctx, ba)
-			return pErr.GoError()
-		},
-	); err != nil {
+	_, pErr := r.Send(ctx, ba)
+	if err := pErr.GoError(); err != nil {
 		return r.replicaUnavailableError(err)
 	}
 	return nil


### PR DESCRIPTION
Backport 1/1 commits from #105896.

Going to let this bake for a week or two, just in case.

Release justification: stability fix coming out of a post-mortem

/cc @cockroachdb/release

---

Before this commit, replica circuit breaker probes used a timeout. This was
done as a safeguard: even if there were some bug in reproposal code, we could
conceivably end up with an eternally stuck probe even though new commands would
go through.

In reality though, well-intended is often the opposite of well done. Under
longer outages, these probe attempts piled up in the `r.mu.proposals` map,
where they wouldn't get removed even if the probe got canceled - because we
remove a proposal only when it applies (this is necessary for commands that
hold latches, though probes don't hold latches and thus could be treated
differently).

This led to memory build-up on nodes with affected replicas, but another effect
of having many probe proposals is that they would all put new entries into the
raft log every couple of seconds. A constant arrival rate of requests (given by
the probes) plus the regular duplication of everything that is inflight implies
quadratic growth of the number of entries in the log. Since we currently don't
have an effective limit on the memory usage in the replication layer, these
large raft logs could have a profoundly destabilizing effect on clusters once
they started to recover, and in extreme cases would lead into a metaunstable
regime.

This commit removes the timeout from the probe, meaning that unless the node
is restarted, it will send ~one probe per replica and block until this probe
returns. Under the hood, the replication layer will still re-add this probe
to the log periodically, however this only results in linear growth.

Follow-up work can then reduce this linear growth further.

Touches #103908. I'm leaving the issue since the goal should be to not even
have linear growth in this case; will re-title.

----

To verify these changes, I ran a three-node local roachprod cluster with and
without the changes[^1]. After initial up-replication, I stopped nodes 2 and 3 and
had a coffee. Upon returning, I looked at the ranges endpoint for the remaining
node and found a range that had the circuit breaker tripped, noting its
rangeID. I then stopped the node, and dumped the raft log for that rangeID.
Unsurprisingly, this confirmed that we were only seeing reproposals of a single
probe in the log with this PR, and multiple separate probes being reproposed
multiple times without this PR. In other words, we were seeing linear and not
quadratic growth with this PR.

[^1]: and disabled CheckQuorum which independently fixes this bug, however
this PR is intended to be backported.

Epic: CRDB-25287
Release note (bug fix): under prolonged unavailability (such as loss of
quorum), affected ranges would exhibit raft log growth that was quadratic as a
function of the duration of the outage. Now this growth is approximately linear
instead.

