### PR TITLE
kvserver: remove unnecessary condition

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -603,13 +603,7 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 
 			// We don't want deduct flow tokens for reproposed commands, and of
 			// course for proposals that didn't integrate with kvflowcontrol.
-			//
-			// TODO(tbg): with useReproposalsV2, we make new proposals in
-			// tryReproposeWithNewLeaseIndex that will have createdAtTicks ==
-			// proposedAtTicks. They will have !reproposal but raftAdmissionMeta=nil.
-			// What is createdAtTicks==proposedAtTicks even good for? The !reproposal
-			// condition already handles the case in which it isn't.
-			shouldAdmit := p.createdAtTicks == p.proposedAtTicks && !reproposal && p.raftAdmissionMeta != nil
+			shouldAdmit := !reproposal && p.raftAdmissionMeta != nil
 			if !shouldAdmit {
 				admitHandles = append(admitHandles, admitEntHandle{})
 			} else {


### PR DESCRIPTION
The `!reproposal` condition already captures whether this is the
first time the proposal is seen in that method. The other condition
added only fear, uncertainty, and doubt.

Epic: CRDB-25287
Release note: None
