### PR TITLE
server: close net.Conn unconditionally after accepting

### DIFF
--- a/pkg/server/server_controller_sql.go
+++ b/pkg/server/server_controller_sql.go
@@ -50,6 +50,10 @@ func (c *serverController) sqlMux(
 			// The concurrent dispatch gives a chance to the succeeding
 			// servers to see and process the cancel at approximately the
 			// same time as every other.
+			//
+			// Cancel requests are unauthenticated so run the cancel async to prevent
+			// the client from deriving any info about the cancel based on how long it
+			// takes.
 			if err := c.stopper.RunAsyncTask(ctx, "cancel", func(ctx context.Context) {
 				s.handleCancel(ctx, status.CancelKey)
 			}); err != nil {

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -217,7 +217,6 @@ func (s *PreServeConnHandler) SendRoutingError(
 		`Double check your "-ccluster=" connection option or your "cluster:" database name prefix.`)
 
 	_ = s.sendErr(ctx, s.st, conn, err)
-	_ = conn.Close()
 }
 
 // sendErr sends errors to the client during the connection startup
@@ -235,7 +234,6 @@ func (s *PreServeConnHandler) sendErr(
 	// receive error payload are highly correlated with clients
 	// disconnecting abruptly.
 	_ /* err */ = w.writeErr(ctx, err, conn)
-	_ = conn.Close()
 	return err
 }
 
@@ -324,7 +322,7 @@ func (s *PreServeConnHandler) PreServe(
 	case versionCancel:
 		// The cancel message is rather peculiar: it is sent without
 		// authentication, always over an unencrypted channel.
-		if ok, key := readCancelKeyAndCloseConn(ctx, conn, &buf); ok {
+		if ok, key := readCancelKey(ctx, &buf); ok {
 			return conn, PreServeStatus{
 				State:     PreServeCancel,
 				CancelKey: key,
@@ -374,7 +372,7 @@ func (s *PreServeConnHandler) PreServe(
 		// Yet, we've found clients in the wild that send the cancel
 		// after the TLS handshake, for example at
 		// https://github.com/cockroachlabs/support/issues/600.
-		if ok, key := readCancelKeyAndCloseConn(ctx, conn, &buf); ok {
+		if ok, key := readCancelKey(ctx, &buf); ok {
 			return conn, PreServeStatus{
 				State:     PreServeCancel,
 				CancelKey: key,

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -183,6 +183,9 @@ func (s *TCPServer) ServeWith(
 		}
 		tempDelay = 0
 		err := s.stopper.RunAsyncTask(ctx, "tcp-serve", func(ctx context.Context) {
+			defer func() {
+				_ = rw.Close()
+			}()
 			s.addConn(rw)
 			defer s.rmConn(rw)
 			serveConn(ctx, rw)


### PR DESCRIPTION
Informs #105448

Previously after the server accepted a connection, it was closed in multiple paths and in multiple layers after it was done being used. Now it is always closed in the same layer that accepted it after the serveConn callback returns.

Release note: None