### PR TITLE
cloud,backupccl: path does not contain a completed latest backup (emp…

### DIFF
--- a/pkg/ccl/backupccl/backupdest/backup_destination.go
+++ b/pkg/ccl/backupccl/backupdest/backup_destination.go
@@ -311,9 +311,16 @@ func FindLatestFile(
 	// in the base directory if the first attempt fails.
 
 	// We name files such that the most recent latest file will always
-	// be at the top, so just grab the first filename.
+	// be at the top, so just grab the first filename _unless_ it's the
+	// empty object with a trailing '/'. The latter is never created by our code
+	// but can be created by other tools, e.g., AWS DataSync to transfer an existing backup to
+	// another bucket. (See https://github.com/cockroachdb/cockroach/issues/106070.)
 	err := exportStore.List(ctx, backupbase.LatestHistoryDirectory, "", func(p string) error {
 		p = strings.TrimPrefix(p, "/")
+		if p == "" {
+			// N.B. skip the empty object with a trailing '/', created by a third-party tool.
+			return nil
+		}
 		latestFile = p
 		latestFileFound = true
 		// We only want the first latest file so return an error that it is


### PR DESCRIPTION
…ty objects ending with /)

Third-party services, e.g., AWS DataSync insert empty objects with a trailing `/` (to denote folders). Thus, a bucket containing backups which was transferred via AWS DataSync cannot be restored.
Previously, restore would fail with the follwing
error message, `read LATEST path: path does not contain a completed latest backup: NoSuchKey`.

This change skips over the empty object while enumerating the objects in the `LatestHistoryDirectory`.

Epic: none
Fixes: #106070

Release note (bug fix): cloud buckets containing backups can now be copied via AWS DataSync and other third-party services which insert empty object with a trailing `/`. Previously, restore would fail with the follwing error message, `read LATEST path: path does not contain a completed latest backup: NoSuchKey`.