### PR TITLE
kvserver: transfer lease when acquiring lease outside preferences

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2827,7 +2827,7 @@ func (a Allocator) PreferredLeaseholders(
 			if !ok {
 				continue
 			}
-			if constraint.ConjunctionsCheck(storeDesc, preference.Constraints) {
+			if constraint.CheckStoreConjunction(storeDesc, preference.Constraints) {
 				preferred = append(preferred, repl)
 			}
 		}

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -2010,7 +2010,7 @@ func allocateConstraintsCheck(
 	}
 
 	for i, constraints := range analyzed.Constraints {
-		if constraintsOK := constraint.ConjunctionsCheck(
+		if constraintsOK := constraint.CheckStoreConjunction(
 			store, constraints.Constraints,
 		); constraintsOK {
 			valid = true
@@ -2050,9 +2050,7 @@ func replaceConstraintsCheck(
 	for i, constraints := range analyzed.Constraints {
 		matchingStores := analyzed.SatisfiedBy[i]
 		satisfiedByExistingStore := containsStore(matchingStores, existingStore.StoreID)
-		satisfiedByCandidateStore := constraint.ConjunctionsCheck(
-			store, constraints.Constraints,
-		)
+		satisfiedByCandidateStore := constraint.CheckStoreConjunction(store, constraints.Constraints)
 		if satisfiedByCandidateStore {
 			valid = true
 		}
@@ -2147,7 +2145,7 @@ func rebalanceFromConstraintsCheck(
 	// satisfied by existing replicas or that is only fully satisfied because of
 	// fromStoreID, then it's necessary.
 	for i, constraints := range analyzed.Constraints {
-		if constraintsOK := constraint.ConjunctionsCheck(
+		if constraintsOK := constraint.CheckStoreConjunction(
 			store, constraints.Constraints,
 		); constraintsOK {
 			valid = true

--- a/pkg/kv/kvserver/allocator/base.go
+++ b/pkg/kv/kvserver/allocator/base.go
@@ -76,7 +76,7 @@ func IsStoreValid(
 		return true
 	}
 	for _, subConstraints := range constraints {
-		if constraintsOK := constraint.ConjunctionsCheck(
+		if constraintsOK := constraint.CheckStoreConjunction(
 			store, subConstraints.Constraints,
 		); constraintsOK {
 			return true

--- a/pkg/kv/kvserver/asim/queue/allocator_replica.go
+++ b/pkg/kv/kvserver/asim/queue/allocator_replica.go
@@ -96,7 +96,7 @@ func (sr *SimulatorReplica) LeaseViolatesPreferences(context.Context) bool {
 		return false
 	}
 	for _, preference := range conf.LeasePreferences {
-		if constraint.ConjunctionsCheck(storeDesc, preference.Constraints) {
+		if constraint.CheckStoreConjunction(storeDesc, preference.Constraints) {
 			return false
 		}
 	}

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -550,6 +550,19 @@ func (r *Replica) leasePostApplyLocked(
 		})
 	}
 
+	// If we acquired a new lease, and it violates the lease preferences, enqueue
+	// it in the replicate queue.
+	if leaseChangingHands && iAmTheLeaseHolder {
+		violatesPreferences := leaseViolatesPreferences(st, r.store.StoreID(), r.store.Attrs(),
+			r.store.nodeDesc.Attrs, r.store.nodeDesc.Locality, r.mu.conf.LeasePreferences)
+		if violatesPreferences {
+			log.VEventf(ctx, 2,
+				"acquired lease violates lease preferences, enqueueing for transfer [lease=%s preferences=%s]",
+				newLease, r.mu.conf.LeasePreferences)
+			r.store.replicateQueue.AddAsync(ctx, r, replicateQueuePriorityHigh)
+		}
+	}
+
 	// Inform the store of this lease.
 	if iAmTheLeaseHolder {
 		r.store.registerLeaseholder(ctx, r, newLease.Sequence)

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1540,25 +1540,42 @@ func (r *Replica) hasCorrectLeaseTypeRLocked(lease roachpb.Lease) bool {
 	return hasExpirationLease == r.shouldUseExpirationLeaseRLocked()
 }
 
-// LeaseViolatesPreferences checks if current replica owns the lease and if it
-// violates the lease preferences defined in the span config. If there is an
-// error or no preferences defined then it will return false and consider that
-// to be in-conformance.
+// LeaseViolatesPreferences checks if this replica owns the lease and if it
+// violates the lease preferences defined in the span config. If no preferences
+// are defined then it will return false and consider it to be in conformance.
 func (r *Replica) LeaseViolatesPreferences(ctx context.Context) bool {
-	storeDesc, err := r.store.Descriptor(ctx, true /* useCached */)
-	if err != nil {
-		log.Infof(ctx, "Unable to load the descriptor %v: cannot check if lease violates preference", err)
+	storeID := r.store.StoreID()
+	storeAttrs := r.store.Attrs()
+	nodeAttrs := r.store.nodeDesc.Attrs
+	nodeLocality := r.store.nodeDesc.Locality
+	now := r.Clock().NowAsClockTimestamp()
+	r.mu.RLock()
+	leaseStatus := r.leaseStatusAtRLocked(ctx, now)
+	preferences := r.mu.conf.LeasePreferences
+	r.mu.RUnlock()
+	return leaseViolatesPreferences(
+		leaseStatus, storeID, storeAttrs, nodeAttrs, nodeLocality, preferences)
+}
+
+// leaseViolatesPreferences returns true if the given lease is valid, owned by
+// the given store, and does not satisfy the lease preferences.
+func leaseViolatesPreferences(
+	leaseStatus kvserverpb.LeaseStatus,
+	storeID roachpb.StoreID,
+	storeAttrs, nodeAttrs roachpb.Attributes,
+	nodeLocality roachpb.Locality,
+	preferences []roachpb.LeasePreference,
+) bool {
+	if !leaseStatus.IsValid() || !leaseStatus.Lease.OwnedBy(storeID) {
 		return false
 	}
-	conf := r.SpanConfig()
-	if len(conf.LeasePreferences) == 0 {
+	if len(preferences) == 0 {
 		return false
 	}
-	for _, preference := range conf.LeasePreferences {
-		if constraint.CheckStoreConjunction(*storeDesc, preference.Constraints) {
+	for _, preference := range preferences {
+		if constraint.CheckConjunction(storeAttrs, nodeAttrs, nodeLocality, preference.Constraints) {
 			return false
 		}
 	}
-	// We have at lease one preference set up, but we don't satisfy any.
 	return true
 }

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1555,7 +1555,7 @@ func (r *Replica) LeaseViolatesPreferences(ctx context.Context) bool {
 		return false
 	}
 	for _, preference := range conf.LeasePreferences {
-		if constraint.ConjunctionsCheck(*storeDesc, preference.Constraints) {
+		if constraint.CheckStoreConjunction(*storeDesc, preference.Constraints) {
 			return false
 		}
 	}

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -80,6 +80,8 @@ const (
 	// replicateQueueTimerDuration is the duration between replication of queued
 	// replicas.
 	replicateQueueTimerDuration = 0 // zero duration to process replication greedily
+
+	replicateQueuePriorityHigh = 1000 // see AllocatorAction.Priority
 )
 
 // MinLeaseTransferInterval controls how frequently leases can be transferred

--- a/pkg/roachpb/span_config.go
+++ b/pkg/roachpb/span_config.go
@@ -18,12 +18,12 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// StoreMatchesConstraint returns whether a store's attributes or node's
-// locality match the constraint's spec. It notably ignores whether the
-// constraint is required, prohibited, positive, or otherwise.
-func StoreMatchesConstraint(store StoreDescriptor, c Constraint) bool {
+// MatchesConstraint return whether the given attributes and locality tags match
+// the constraint's spec. It ignores whether the constraint is required,
+// prohibited, positive, or otherwise.
+func MatchesConstraint(storeAttrs, nodeAttrs Attributes, nodeLocality Locality, c Constraint) bool {
 	if c.Key == "" {
-		for _, attrs := range []Attributes{store.Attrs, store.Node.Attrs} {
+		for _, attrs := range []Attributes{storeAttrs, nodeAttrs} {
 			for _, attr := range attrs.Attrs {
 				if attr == c.Value {
 					return true
@@ -32,7 +32,7 @@ func StoreMatchesConstraint(store StoreDescriptor, c Constraint) bool {
 		}
 		return false
 	}
-	for _, tier := range store.Node.Locality.Tiers {
+	for _, tier := range nodeLocality.Tiers {
 		if c.Key == tier.Key && c.Value == tier.Value {
 			return true
 		}


### PR DESCRIPTION
When a leaseholder is lost, any surviving replica may acquire the lease, even if it violates lease preferences. There are two main reasons for this: we need to elect a new Raft leader who will acquire the lease, which is agnostic to lease preferences, and there may not even be any surviving replicas that satisfy the lease preferences at all, so we don't want to keep the range unavailable while we try to figure this out (considering e.g. network timeouts can delay this for many seconds).

However, after acquiring a lease, we rely on the replicate queue to transfer the lease back to a replica that conforms with the preferences, which can take several minutes. In multi-region clusters, this can cause severe latency degradation if the lease is acquired in a remote region.

This patch will detect lease preference violations when a replica acquires a new lease, and eagerly enqueue it in the replicate queue for transfer (if possible).

Resolves #106100.
Epic: none

Release note (bug fix): When losing a leaseholder and using lease preferences, the lease can be acquired by any other replica (regardless of lease preferences) in order to restore availability as soon as possible. The new leaseholder will now immediately check if it violates the lease preferences, and attempt to transfer the lease to a replica that satisfies the preferences if possible.