### PR TITLE
kvserver: don't spawn gossip goroutine when acquiring non-liveness lease

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -533,10 +533,16 @@ func (r *Replica) leasePostApplyLocked(
 	// seconds) in any case due to the liveness heartbeats. And the system config
 	// will be gossiped rarely because it falls on a range with an epoch-based
 	// range lease that is only reacquired extremely infrequently.
-	if iAmTheLeaseHolder {
+	//
+	// TODO(erikgrinaker): This and MaybeGossipNodeLivenessRaftMuLocked should
+	// check whether the replica intersects the liveness span rather than contains
+	// the entirety of it.
+	if iAmTheLeaseHolder && kvserverbase.ContainsKeyRange(
+		r.descRLocked(), keys.NodeLivenessSpan.Key, keys.NodeLivenessSpan.EndKey) {
 		// NB: run these in an async task to keep them out of the critical section
 		// (r.mu is held here).
-		_ = r.store.stopper.RunAsyncTask(r.AnnotateCtx(context.Background()), "lease-triggers", func(ctx context.Context) {
+		ctx := r.AnnotateCtx(context.Background())
+		_ = r.store.stopper.RunAsyncTask(ctx, "lease-gossip", func(ctx context.Context) {
 			// Re-acquire the raftMu, as we are now in an async task.
 			r.raftMu.Lock()
 			defer r.raftMu.Unlock()


### PR DESCRIPTION
Spawning this goroutine serves no purpose for ranges that don't contain the liveness range, and may have a non-negligible cost with expiration-based leases on many replicas.

Epic: none
Release note: None