### PR TITLE
cmd/internal/issues: fix missing reproduction command in GH issue rep…

### DIFF
--- a/pkg/cmd/internal/issues/formatter_unit.go
+++ b/pkg/cmd/internal/issues/formatter_unit.go
@@ -144,7 +144,6 @@ var UnitTestFormatter = IssueFormatter{
 // renders a reproduction command and helpful links.
 func UnitTestHelpCommand(repro string) func(r *Renderer) {
 	return func(r *Renderer) {
-		ReproductionCommandFromString(repro)
 		r.Escaped("\n") // need this newline or link won't render
 		r.Escaped("See also: ")
 		r.A("How To Investigate a Go Test Failure (internal)", "https://cockroachlabs.atlassian.net/l/c/HgfXfJgM")


### PR DESCRIPTION
…orter

Github issue reporter for failed unit tests contains an
optional `HelpCommand` field which may include a reproduction
command, supplied by `ReproductionCommandFromString`.
The latter was returning a closure instead of being invoked.

Upon further discussion, we decided to remove the call to
`ReproductionCommandFromString` altogether since the
included public wiki [1] already contains a description
on how to reproduce a unit test failure.

[1] https://cockroachlabs.atlassian.net/l/cp/HeeQsi6H
Epic: none

Release note: None