### PR TITLE
TEAMS.yaml: change triage column id for migrations

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -109,4 +109,4 @@ cockroachdb/unowned:
   triage_column_id: 0 # TODO
 cockroachdb/migrations:
   label: T-migrations
-  triage_column_id: 19552034
+  triage_column_id: 18330909


### PR DESCRIPTION
Using https://github.com/orgs/cockroachdb/projects/29#column-18330909 instead.

Epic: None
Release note: None