### PR TITLE
kvserver: add raft.replication.latency

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1229,6 +1229,32 @@ metric, which receives datapoints for each sub-batch processed in the process.`,
 		Measurement: "Latency",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	metaRaftReplicationLatency = metric.Metadata{
+		Name: "raft.replication.latency",
+		Help: `The duration elapsed between having evaluated a BatchRequest and it being
+reflected in the proposer's state machine (i.e. having applied fully).
+
+This encompasses time spent in the quota pool, in replication (including
+reproposals), and application, but notably *not* sequencing latency (i.e.
+contention and latch acquisition).
+
+No measurement is recorded for read-only commands as well as read-write commands
+which end up not writing (such as a DeleteRange on an empty span). Commands that
+result in 'above-replication' errors (i.e. txn retries, etc) are similarly
+excluded. Errors that arise while waiting for the in-flight replication result
+or result from application of the command are included.
+
+Note also that usually, clients are signalled at beginning of application, but
+the recorded measurement captures the entirety of log application.
+
+The duration is always measured on the proposer, even if the Raft leader and
+leaseholder are not colocated, or the request is proposed from a follower.
+
+Commands that use async consensus will still cause a measurement that reflects
+the actual replication latency, despite returning early to the client.`,
+		Measurement: "Latency",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaRaftSchedulerLatency = metric.Metadata{
 		Name: "raft.scheduler.latency",
 		Help: `Queueing durations for ranges waiting to be processed by the Raft scheduler.
@@ -2334,6 +2360,7 @@ type StoreMetrics struct {
 	RaftCommandCommitLatency   metric.IHistogram
 	RaftHandleReadyLatency     metric.IHistogram
 	RaftApplyCommittedLatency  metric.IHistogram
+	RaftReplicationLatency     metric.IHistogram
 	RaftSchedulerLatency       metric.IHistogram
 	RaftTimeoutCampaign        *metric.Counter
 	RaftStorageReadBytes       *metric.Counter
@@ -2996,6 +3023,12 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 			Metadata: metaRaftApplyCommittedLatency,
 			Duration: histogramWindow,
 			Buckets:  metric.IOLatencyBuckets,
+		}),
+		RaftReplicationLatency: metric.NewHistogram(metric.HistogramOptions{
+			Mode:     metric.HistogramModePrometheus,
+			Metadata: metaRaftReplicationLatency,
+			Duration: histogramWindow,
+			Buckets:  metric.IOLatencyBuckets, // because NetworkLatencyBuckets tops out at 1s
 		}),
 		RaftSchedulerLatency: metric.NewHistogram(metric.HistogramOptions{
 			Mode:     metric.HistogramModePreferHdrLatency,

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -336,7 +336,7 @@ func (r *Replica) tryReproposeWithNewLeaseIndexV2(
 	newEC := origP.ec
 	defer func() {
 		if success {
-			origP.ec = endCmds{}
+			origP.ec = makeEmptyEndCmds()
 		}
 	}()
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -135,7 +135,7 @@ func (r *Replica) evalAndPropose(
 
 	// Attach the endCmds to the proposal and assume responsibility for
 	// releasing the concurrency guard if the proposal makes it to Raft.
-	proposal.ec = endCmds{repl: r, g: g, st: *st}
+	proposal.ec = makeEndCmds(r, g, *st)
 
 	// Pull out proposal channel to return. proposal.doneCh may be set to
 	// nil if it is signaled in this function.

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -170,7 +170,7 @@ func (r *Replica) evalAndPropose(
 
 	// Make it a truly replicated proposal. We measure the replication latency
 	// from this point on.
-	proposal.ec = makeReplicatedEndCmds(r, g, *st)
+	proposal.ec = makeReplicatedEndCmds(r, g, *st, timeutil.Now())
 
 	log.VEventf(proposal.ctx, 2,
 		"proposing command to write %d new keys, %d new values, %d new intents, "+

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -157,7 +157,7 @@ func (r *Replica) evalAndPropose(
 		// example, discovered intents should be pushed to make sure they get
 		// dealt with proactively rather than waiting for a future command to
 		// find them.
-		proposal.ec = makeEndCmds(r, g, *st)
+		proposal.ec = makeUnreplicatedEndCmds(r, g, *st)
 		pr := proposalResult{
 			Reply:              proposal.Local.Reply,
 			Err:                pErr,
@@ -168,8 +168,9 @@ func (r *Replica) evalAndPropose(
 		return proposalCh, func() {}, "", nil, nil
 	}
 
-	// Make it a truly replicated proposal.
-	proposal.ec = makeEndCmds(r, g, *st)
+	// Make it a truly replicated proposal. We measure the replication latency
+	// from this point on.
+	proposal.ec = makeReplicatedEndCmds(r, g, *st)
 
 	log.VEventf(proposal.ctx, 2,
 		"proposing command to write %d new keys, %d new values, %d new intents, "+

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -244,7 +244,7 @@ func (r *Replica) updateTimestampCacheAndDropLatches(
 	pErr *kvpb.Error,
 	st kvserverpb.LeaseStatus,
 ) {
-	ec := endCmds{repl: r, g: g, st: st}
+	ec := makeEndCmds(r, g, st)
 	ec.done(ctx, ba, br, pErr)
 }
 

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -244,7 +244,7 @@ func (r *Replica) updateTimestampCacheAndDropLatches(
 	pErr *kvpb.Error,
 	st kvserverpb.LeaseStatus,
 ) {
-	ec := makeEndCmds(r, g, st)
+	ec := makeUnreplicatedEndCmds(r, g, st)
 	ec.done(ctx, ba, br, pErr)
 }
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -1267,12 +1267,18 @@ type endCmds struct {
 	replicatingSince time.Time
 }
 
+// makeUnreplicatedEndCmds sets up an endCmds to track an unreplicated,
+// that is, read-only, command.
 func makeUnreplicatedEndCmds(
 	repl *Replica, g *concurrency.Guard, st kvserverpb.LeaseStatus,
 ) endCmds {
 	return makeReplicatedEndCmds(repl, g, st, time.Time{})
 }
 
+// makeReplicatedEndCmds initializes an endCmds representing a command that
+// needs to undergo replication. This is not used for read-only commands
+// (including read-write commands that end up not queueing any mutations to the
+// state machine).
 func makeReplicatedEndCmds(
 	repl *Replica, g *concurrency.Guard, st kvserverpb.LeaseStatus, replicatingSince time.Time,
 ) endCmds {

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -1264,11 +1264,19 @@ type endCmds struct {
 	st   kvserverpb.LeaseStatus // empty for follower reads
 }
 
+func makeEndCmds(repl *Replica, g *concurrency.Guard, st kvserverpb.LeaseStatus) endCmds {
+	return endCmds{repl: repl, g: g, st: st}
+}
+
+func makeEmptyEndCmds() endCmds {
+	return endCmds{}
+}
+
 // move moves the endCmds into the return value, clearing and making a call to
 // done on the receiver a no-op.
 func (ec *endCmds) move() endCmds {
 	res := *ec
-	*ec = endCmds{}
+	*ec = makeEmptyEndCmds()
 	return res
 }
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"reflect"
 	"runtime/pprof"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -34,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -1259,19 +1261,22 @@ func (r *Replica) collectSpans(
 // either after a write request has achieved consensus and been applied to Raft
 // or after a read-only request has finished evaluation.
 type endCmds struct {
-	repl *Replica
-	g    *concurrency.Guard
-	st   kvserverpb.LeaseStatus // empty for follower reads
+	repl             *Replica
+	g                *concurrency.Guard
+	st               kvserverpb.LeaseStatus // empty for follower reads
+	replicatingSince time.Time
 }
 
 func makeUnreplicatedEndCmds(
 	repl *Replica, g *concurrency.Guard, st kvserverpb.LeaseStatus,
 ) endCmds {
-	return makeReplicatedEndCmds(repl, g, st)
+	return makeReplicatedEndCmds(repl, g, st, time.Time{})
 }
 
-func makeReplicatedEndCmds(repl *Replica, g *concurrency.Guard, st kvserverpb.LeaseStatus) endCmds {
-	return endCmds{repl: repl, g: g, st: st}
+func makeReplicatedEndCmds(
+	repl *Replica, g *concurrency.Guard, st kvserverpb.LeaseStatus, replicatingSince time.Time,
+) endCmds {
+	return endCmds{repl: repl, g: g, st: st, replicatingSince: replicatingSince}
 }
 
 func makeEmptyEndCmds() endCmds {
@@ -1318,9 +1323,18 @@ func (ec *endCmds) done(
 		ec.repl.updateTimestampCache(ctx, &ec.st, ba, br, pErr)
 	}
 
-	// Release the latches acquired by the request and exit lock wait-queues.
-	// Must be done AFTER the timestamp cache is updated. ec.g is only set when
-	// the Raft proposal has assumed responsibility for the request.
+	if ts := ec.replicatingSince; !ts.IsZero() {
+		ec.repl.store.metrics.RaftReplicationLatency.RecordValue(timeutil.Since(ts).Nanoseconds())
+	}
+
+	// Release the latches acquired by the request and exit lock wait-queues. Must
+	// be done AFTER the timestamp cache is updated. ec.g is set both for reads
+	// and for writes. For writes, it is set only when the Raft proposal has
+	// assumed responsibility for the request.
+	//
+	// TODO(replication): at the time of writing, there is no code path in which
+	// this method is called and the Guard is not set. Consider removing this
+	// check and upgrading the previous observation to an invariant.
 	if ec.g != nil {
 		ec.repl.concMgr.FinishReq(ec.g)
 	}

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -1264,7 +1264,13 @@ type endCmds struct {
 	st   kvserverpb.LeaseStatus // empty for follower reads
 }
 
-func makeEndCmds(repl *Replica, g *concurrency.Guard, st kvserverpb.LeaseStatus) endCmds {
+func makeUnreplicatedEndCmds(
+	repl *Replica, g *concurrency.Guard, st kvserverpb.LeaseStatus,
+) endCmds {
+	return makeReplicatedEndCmds(repl, g, st)
+}
+
+func makeReplicatedEndCmds(repl *Replica, g *concurrency.Guard, st kvserverpb.LeaseStatus) endCmds {
 	return endCmds{repl: repl, g: g, st: st}
 }
 


### PR DESCRIPTION
The help text says it all:

----

The duration elapsed between having evaluated a BatchRequest and it being
reflected in the proposer's state machine (i.e. having applied fully).

This encompasses time spent in the quota pool, in replication (including
reproposals), and application, but notably *not* sequencing latency (i.e.
contention and latch acquisition).

No measurement is recorded for read-only commands as well as read-write commands
which end up not writing (such as a DeleteRange on an empty span). Commands that
result in 'above-replication' errors (i.e. txn retries, etc) are similarly
excluded. Errors that arise while waiting for the in-flight replication result
or result from application of the command are included.

Note also that usually, clients are signalled at beginning of application, but
the recorded measurement captures the entirety of log application.

Commands that use async consensus will still cause a measurement that reflects
the actual replication latency, despite returning early to the client.

----

Fixes cockroachdb#83262.

Epic: CRDB-25287
Release note (ops change): a histogram metric raft.replication.latency was added.
It tracks the time between evaluation and application of the command. This includes
time spent in the quota pool, in replication (including reproposals) as well as log
application, but notably *not* sequencing latency, i.e. contention and latch
acquisition.


