### PR TITLE
roachtest: restart-one-node to use explicit addrs

### DIFF
--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -434,7 +434,8 @@ SELECT count(replicas)
 		` ./cockroach start --insecure --background --store={store-dir} `+
 			`--log-dir={log-dir} --cache=10% --max-sql-memory=10% `+
 			`--listen-addr=:$[{pgport:1}+10000] --http-port=$[{pgport:1}+1] `+
-			`--join={pghost:1}:{pgport:1}`+
+			`--join={pghost:1}:{pgport:1} `+
+			`--advertise-addr={pghost:1}:$[{pgport:1}+10000] `+
 			`> {log-dir}/cockroach.stdout 2> {log-dir}/cockroach.stderr`)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Test is restarting one node with modified start params. It was not passing advertise-addr option which lead to hostname picked being unaccessible from other cluster nodes. This commit changes test to provide explicit address upon restart.

Fixes #105972

Release note: None