### PR TITLE
kvserver: fix off-by-one in FlushLockedWithRaftGroup

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -548,7 +548,7 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 			}
 
 			ents = ents[len(ents):]
-			firstProp, nextProp = i, i
+			firstProp, nextProp = i+1, i+1
 			admitHandles = admitHandles[len(admitHandles):]
 
 			confChangeCtx := kvserverpb.ConfChangeContext{

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -66,6 +66,9 @@ type testProposer struct {
 	onRejectProposalWithLeaseTransferRejectedLocked func(
 		lease *roachpb.Lease, reason raftutil.ReplicaNeedsSnapshotStatus)
 	onRejectProposalWithErrLocked func(*ProposalData, *kvpb.Error)
+	onProposalsDropped            func(
+		ents []raftpb.Entry, proposalData []*ProposalData, stateType raft.StateType,
+	)
 	// validLease is returned by ownsValidLease()
 	validLease bool
 	// leaderNotLive is returned from shouldCampaignOnRedirect().
@@ -92,7 +95,7 @@ type testProposerRaft struct {
 	// proposals are the commands that the propBuf flushed (i.e. passed to the
 	// Raft group) and have not yet been consumed with consumeProposals().
 	proposals  []kvserverpb.RaftCommand
-	onProp     func(raftpb.Message) // invoked on Step with MsgProp
+	onProp     func(raftpb.Message) error // invoked on Step with MsgProp
 	campaigned bool
 }
 
@@ -103,7 +106,9 @@ func (t *testProposerRaft) Step(msg raftpb.Message) error {
 		return nil
 	}
 	if t.onProp != nil {
-		t.onProp(msg)
+		if err := t.onProp(msg); err != nil {
+			return err
+		}
 	}
 	// Decode and save all the commands.
 	for _, e := range msg.Entries {
@@ -186,7 +191,14 @@ func (t *testProposer) withGroupLocked(fn func(proposerRaft) error) error {
 	return fn(t.raftGroup)
 }
 
-func (rp *testProposer) onErrProposalDropped(ents []raftpb.Entry, stateType raft.StateType) {}
+func (rp *testProposer) onErrProposalDropped(
+	ents []raftpb.Entry, props []*ProposalData, typ raft.StateType,
+) {
+	if rp.onProposalsDropped == nil {
+		return
+	}
+	rp.onProposalsDropped(ents, props, typ)
+}
 
 func (t *testProposer) leaseDebugRLocked() string {
 	return ""
@@ -820,6 +832,92 @@ func TestProposalBufferRejectUnsafeLeaseTransfer(t *testing.T) {
 	}
 }
 
+func TestProposalBufferLinesUpEntriesAndProposals(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	proposer := uint64(1)
+	proposerFirstIndex := kvpb.RaftIndex(5)
+
+	var matchingDroppedProposalsSeen int
+	p := testProposer{
+		onProposalsDropped: func(ents []raftpb.Entry, props []*ProposalData, _ raft.StateType) {
+			require.Equal(t, len(ents), len(props))
+			for i := range ents {
+				if ents[i].Type == raftpb.EntryNormal {
+					require.Nil(t, props[i].command.ReplicatedEvalResult.ChangeReplicas)
+				} else {
+					require.NotNil(t, props[i].command.ReplicatedEvalResult.ChangeReplicas)
+				}
+				matchingDroppedProposalsSeen++
+			}
+		},
+	}
+	var pc proposalCreator
+	require.Equal(t, proposer, uint64(p.getReplicaID()))
+
+	// Drop all proposals, since then we'll see the (ents,props) pair in
+	// onErrProposalDropped.
+	r := &testProposerRaft{onProp: func(msg raftpb.Message) error {
+		return raft.ErrProposalDropped
+	}}
+	p.raftGroup = r
+	p.fi = proposerFirstIndex
+
+	var b propBuf
+	// Make the proposal buffer large so that all the proposals we're putting in
+	// get flushed together. (At the time of writing, default size is 4).
+	b.arr.adjustSize(100)
+	clock := hlc.NewClockForTesting(nil)
+	tr := tracker.NewLockfreeTracker()
+	b.Init(&p, tr, clock, cluster.MakeTestingClusterSettings())
+
+	now := clock.Now()
+
+	// Make seven proposals:
+	// [put, put, put, confchange, put, put, put].
+	var pds []*ProposalData
+
+	for i := 0; i < 3; i++ {
+		pds = append(pds, pc.newPutProposal(now))
+	}
+
+	{
+		k := keys.LocalMax // unimportant
+		var ba kvpb.BatchRequest
+		ba.Add(&kvpb.EndTxnRequest{
+			RequestHeader: kvpb.RequestHeader{
+				Key: k,
+			},
+			Commit: true,
+			InternalCommitTrigger: &roachpb.InternalCommitTrigger{
+				ChangeReplicasTrigger: &roachpb.ChangeReplicasTrigger{
+					Desc: roachpb.NewRangeDescriptor(1, roachpb.RKeyMin, roachpb.RKeyMax,
+						roachpb.MakeReplicaSet([]roachpb.ReplicaDescriptor{{NodeID: 1, StoreID: 1, ReplicaID: 1}}),
+					),
+				},
+			},
+		})
+		pds = append(pds, pc.newProposal(&ba))
+	}
+
+	for i := 0; i < 3; i++ {
+		pds = append(pds, pc.newPutProposal(now))
+	}
+
+	for _, pd := range pds {
+		_, tok := b.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
+		require.NoError(t, b.Insert(ctx, pd, tok.Move(ctx)))
+	}
+	require.NoError(t, b.flushLocked(ctx))
+	// The ConfChange doesn't go through proposeBatch, so we only see the
+	// six puts.
+	//
+	// TODO(tbg): fix that. We should handle everything the same.
+	require.Equal(t, len(pds)-1, matchingDroppedProposalsSeen)
+}
+
 // TestProposalBufferRejectStaleChangeReplicasConfChange is a regression test
 // for [1]. See also TestInvalidConfChangeRejection for an end-to-end test.
 //
@@ -843,7 +941,7 @@ func TestProposalBufferRejectStaleChangeReplicasConfChange(t *testing.T) {
 	}
 
 	r := &testProposerRaft{
-		onProp: func(msg raftpb.Message) {
+		onProp: func(msg raftpb.Message) error {
 			// Mimic what RawNode does when it gets a conf change that isn't
 			// compatible with its active config: proposing an empty entry instead. In
 			// practice, because the config is set when applying commands, this can
@@ -854,6 +952,7 @@ func TestProposalBufferRejectStaleChangeReplicasConfChange(t *testing.T) {
 			if msg.Entries[0].Type == raftpb.EntryConfChangeV2 {
 				msg.Entries[0] = raftpb.Entry{Type: raftpb.EntryNormal}
 			}
+			return nil
 		},
 	}
 	p.raftGroup = r

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -911,11 +911,7 @@ func TestProposalBufferLinesUpEntriesAndProposals(t *testing.T) {
 		require.NoError(t, b.Insert(ctx, pd, tok.Move(ctx)))
 	}
 	require.NoError(t, b.flushLocked(ctx))
-	// The ConfChange doesn't go through proposeBatch, so we only see the
-	// six puts.
-	//
-	// TODO(tbg): fix that. We should handle everything the same.
-	require.Equal(t, len(pds)-1, matchingDroppedProposalsSeen)
+	require.Equal(t, len(pds), matchingDroppedProposalsSeen)
 }
 
 // TestProposalBufferRejectStaleChangeReplicasConfChange is a regression test


### PR DESCRIPTION
We need to skip the conf change itself. The result of this bug was that
proposals and entries wouldn't be lined up correctly if there was a conf change
in the batch.

Luckily, the impact of that is limited, since all the proposals are used for in
`proposeBatch` was to log an event to the context. Still, good to fix and improve
test coverage.

Epic: CRDB-25287
Release note: None