### PR TITLE
roachtest: fix sysbench segfault detection one more time

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -123,9 +123,6 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 		t.Status("running workload")
 		cmd := opts.cmd(true /* haproxy */) + " run"
 		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), loadNode, cmd)
-		if err != nil {
-			return err
-		}
 
 		// Sysbench occasionally segfaults. When that happens, don't fail the
 		// test.
@@ -134,7 +131,11 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 			return nil
 		}
 
-		return result.Err
+		if err != nil {
+			return err
+		}
+
+		return nil
 	})
 	m.Wait()
 }


### PR DESCRIPTION
Two previous attempts [1, 2] failed at identifying `sysbench` segfaults and properly skipping the associated failures. The latest attempt uses the command's exit code to identify when the command segfaulted: an exit code of `139` indicates a segmentation fault.

However, what that change failed to take into account is that `RunWithDetailsSingleNode` behaves differently from `RunWithDetails`: the former will return `result.Err` as the `error` return result of the function [3], whereas the latter won't -- `err` will be roachprod-related errors.

This fixes the issue by checking for the `RemoteExitStatus` field before checking for `err`, which should properly skip the test on segfault.

Fixes: #106064

[1] #103549
[2] #105145
[3] https://github.com/cockroachdb/cockroach/blob/b467125dac87e5821363a84c9c6765fbf7584c0a/pkg/cmd/roachtest/cluster.go#L2341

Release note: None