### PR TITLE
configprofiles: emphasize "cluster virtualization"

### DIFF
--- a/pkg/configprofiles/setter.go
+++ b/pkg/configprofiles/setter.go
@@ -107,6 +107,9 @@ var profileHelp = func() string {
 		if _, ok := staticProfiles[a.aliasTarget]; !ok {
 			panic(errors.AssertionFailedf("alias %q refers to non-existent profile %q", name, a.aliasTarget))
 		}
+		if a.hidden {
+			continue
+		}
 		allNames = append(allNames, name)
 	}
 	sort.Strings(allNames)

--- a/pkg/configprofiles/testdata/replication-source
+++ b/pkg/configprofiles/testdata/replication-source
@@ -1,5 +1,5 @@
 profile
 replication-source
 ----
-canonical profile name: multitenant+app+sharedservice+repl
+canonical profile name: virtual+app+sharedservice+repl
 server started

--- a/pkg/configprofiles/testdata/replication-target
+++ b/pkg/configprofiles/testdata/replication-target
@@ -1,5 +1,5 @@
 profile
 replication-target
 ----
-canonical profile name: multitenant+noapp+repl
+canonical profile name: virtual+noapp+repl
 server started

--- a/pkg/configprofiles/testdata/virtual-app
+++ b/pkg/configprofiles/testdata/virtual-app
@@ -1,7 +1,7 @@
 profile
-multitenant+app+sharedservice
+virtual+app+sharedservice
 ----
-canonical profile name: multitenant+app+sharedservice
+canonical profile name: virtual+app+sharedservice
 server started
 
 connect-tenant

--- a/pkg/configprofiles/testdata/virtual-app-repl
+++ b/pkg/configprofiles/testdata/virtual-app-repl
@@ -1,7 +1,7 @@
 profile
-multitenant+app+sharedservice+repl
+virtual+app+sharedservice+repl
 ----
-canonical profile name: multitenant+app+sharedservice+repl
+canonical profile name: virtual+app+sharedservice+repl
 server started
 
 connect-tenant

--- a/pkg/configprofiles/testdata/virtual-noapp
+++ b/pkg/configprofiles/testdata/virtual-noapp
@@ -1,7 +1,7 @@
 profile
-multitenant+noapp
+virtual+noapp
 ----
-canonical profile name: multitenant+noapp
+canonical profile name: virtual+noapp
 server started
 
 system-sql

--- a/pkg/configprofiles/testdata/virtual-noapp-repl
+++ b/pkg/configprofiles/testdata/virtual-noapp-repl
@@ -1,7 +1,7 @@
 profile
-multitenant+noapp+repl
+virtual+noapp+repl
 ----
-canonical profile name: multitenant+noapp+repl
+canonical profile name: virtual+noapp+repl
 server started
 
 system-sql


### PR DESCRIPTION
Informs #106068.
Epic: CRDB-29380

Before this patch:
```
$ cockroach start-single-node --config-profile=help
...
replication-source                  configuration suitable for a replication source cluster (alias for "multitenant+app+sharedservice+repl")
replication-target                  configuration suitable for a replication target cluster (alias for "multitenant+noapp+repl")`
multitenant+app+sharedservice       multi-tenant cluster with one secondary tenant configured to serve SQL application traffic
multitenant+app+sharedservice+repl  multi-tenant cluster with one secondary tenant configured to serve SQL application traffic, with replication enabled
multitenant+noapp                   multi-tenant cluster with no secondary tenant defined yet
multitenant+noapp+repl              multi-tenant cluster with no secondary tenant defined yet, with replication enabled
```

After this patch:
```
replication-source              configuration suitable for a replication source cluster (alias for "virtual+app+sharedservice+repl")
replication-target              configuration suitable for a replication target cluster (alias for "virtual+noapp+repl")
virtual+app+sharedservice       one virtual cluster configured to serve SQL application traffic
virtual+app+sharedservice+repl  one virtual cluster configured to serve SQL application traffic, with replication enabled
virtual+noapp                   virtualization enabled but no virtual cluster defined yet
virtual+noapp+repl              virtualization enabled but no virtual cluster defined yet, with replication enabled
```

Release note: None