### PR TITLE
server: use HTTP query parameter `cluster` for manual selection

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -1928,8 +1928,8 @@ func (c *transientCluster) ListDemoNodes(w, ew io.Writer, justOne, verbose bool)
 		if !c.demoCtx.Multitenant || verbose {
 			// Connection parameters for the system tenant follow.
 			uiURL := s.Cfg.AdminURL()
-			if q := uiURL.Query(); c.demoCtx.Multitenant && !c.demoCtx.DisableServerController && !q.Has(server.TenantNameParamInQueryURL) {
-				q.Add(server.TenantNameParamInQueryURL, catconstants.SystemTenantName)
+			if q := uiURL.Query(); c.demoCtx.Multitenant && !c.demoCtx.DisableServerController && !q.Has(server.ClusterNameParamInQueryURL) {
+				q.Add(server.ClusterNameParamInQueryURL, catconstants.SystemTenantName)
 				uiURL.RawQuery = q.Encode()
 			}
 
@@ -2011,7 +2011,7 @@ func (c *transientCluster) addDemoLoginToURL(uiURL *url.URL, includeTenantName b
 	}
 
 	if !includeTenantName {
-		q.Del(server.TenantNameParamInQueryURL)
+		q.Del(server.ClusterNameParamInQueryURL)
 	}
 
 	uiURL.RawQuery = q.Encode()

--- a/pkg/cli/interactive_tests/test_demo_cli_integration.tcl
+++ b/pkg/cli/interactive_tests/test_demo_cli_integration.tcl
@@ -167,7 +167,7 @@ eexpect ":/# "
 # Check that the cookies work.
 set pyfile [file join [file dirname $argv0] test_auth_cookie.py]
 
-send "$python $pyfile cookie_system.txt 'http://localhost:8080/_admin/v1/users?tenant_name=system'\r"
+send "$python $pyfile cookie_system.txt 'http://localhost:8080/_admin/v1/users?cluster=system'\r"
 eexpect "username"
 eexpect "demo"
 # No tenant name specified -> use default tenant.
@@ -190,7 +190,7 @@ eexpect "defaultdb>"
 
 set spawn_id $shell_spawn_id
 
-send "$python $pyfile cookie_system.txt 'http://localhost:8080/_admin/v1/users?tenant_name=system'\r"
+send "$python $pyfile cookie_system.txt 'http://localhost:8080/_admin/v1/users?cluster=system'\r"
 eexpect "username"
 eexpect "demo"
 # No tenant name specified -> use default tenant.

--- a/pkg/server/server_controller_http.go
+++ b/pkg/server/server_controller_http.go
@@ -28,8 +28,9 @@ const (
 	// TenantSelectHeader is the HTTP header used to select a particular tenant.
 	TenantSelectHeader = `X-Cockroach-Tenant`
 
-	// TenantNameParamInQueryURL is the HTTP query URL parameter used to select a particular tenant.
-	TenantNameParamInQueryURL = "tenant_name"
+	// ClusterNameParamInQueryURL is the HTTP query URL parameter used
+	// to select a particular virtual cluster.
+	ClusterNameParamInQueryURL = "cluster"
 
 	// TenantSelectCookieName is the name of the HTTP cookie used to select a particular tenant,
 	// if the custom header is not specified.
@@ -109,7 +110,7 @@ func (c *serverController) httpMux(w http.ResponseWriter, r *http.Request) {
 
 func getTenantNameFromHTTPRequest(st *cluster.Settings, r *http.Request) roachpb.TenantName {
 	// Highest priority is manual override on the URL query parameters.
-	if tenantName := r.URL.Query().Get(TenantNameParamInQueryURL); tenantName != "" {
+	if tenantName := r.URL.Query().Get(ClusterNameParamInQueryURL); tenantName != "" {
 		return roachpb.TenantName(tenantName)
 	}
 

--- a/pkg/server/testserver_http.go
+++ b/pkg/server/testserver_http.go
@@ -68,7 +68,7 @@ func (ts *httpTestServer) AdminURL() string {
 	u := ts.t.sqlServer.execCfg.RPCContext.Config.AdminURL()
 	if ts.t.tenantName != "" {
 		q := u.Query()
-		q.Add(TenantNameParamInQueryURL, string(ts.t.tenantName))
+		q.Add(ClusterNameParamInQueryURL, string(ts.t.tenantName))
 		u.RawQuery = q.Encode()
 	}
 	return u.String()


### PR DESCRIPTION
Informs #106068.
Epic: CRDB-29380

Prior to this patch, there was a debug-only way to manually force a HTTP request to be routed to a particular virtual cluster through the server controller. This was achieved via the query parameter `tenant_name`.

This patch renames the paramater to `cluster`, for a better UX coherence with the option of the same name in `cockroach sql`.

Release note: None