### PR TITLE
release-22.2: roachtest: fix sysbench segfault detection

### DIFF
--- a/pkg/roachprod/errors/errors.go
+++ b/pkg/roachprod/errors/errors.go
@@ -37,6 +37,10 @@ const (
 // code of 255. This could be indicative of an SSH flake.
 var ErrSSH255 = errors.New("SSH error occurred with exit code 255")
 
+const (
+	SegmentationFaultExitCode = 139
+)
+
 // Cmd wraps errors that result from a command run against the cluster.
 type Cmd struct {
 	Err error


### PR DESCRIPTION
Backport 1/1 commits from #105145 and #106111.

/cc @cockroachdb/release

---

Two previous attempts [1, 2] failed at identifying `sysbench` segfaults and properly skipping the associated failures. The latest attempt uses the command's exit code to identify when the command segfaulted: an exit code of `139` indicates a segmentation fault.

However, what that change failed to take into account is that `RunWithDetailsSingleNode` behaves differently from `RunWithDetails`: the former will return `result.Err` as the `error` return result of the function [3], whereas the latter won't -- `err` will be roachprod-related errors.

This fixes the issue by checking for the `RemoteExitStatus` field before checking for `err`, which should properly skip the test on segfault.

Release justification: test-only change.
Release note: None
