### PR TITLE
sql: don't allocate createdSequences map on each transaction

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1098,7 +1098,6 @@ func (s *Server) newConnExecutor(
 	ex.transitionCtx.sessionTracing = &ex.sessionTracing
 
 	ex.extraTxnState.hasAdminRoleCache = HasAdminRoleCache{}
-	ex.extraTxnState.createdSequences = make(map[descpb.ID]struct{})
 
 	if postSetupFn != nil {
 		postSetupFn(ex)
@@ -1920,6 +1919,7 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) {
 	ex.extraTxnState.numDDL = 0
 	ex.extraTxnState.firstStmtExecuted = false
 	ex.extraTxnState.hasAdminRoleCache = HasAdminRoleCache{}
+	ex.extraTxnState.createdSequences = nil
 
 	if ex.extraTxnState.fromOuterTxn {
 		if ex.extraTxnState.shouldResetSyntheticDescriptors {
@@ -1945,8 +1945,6 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) {
 	if err := ex.extraTxnState.sqlCursors.closeAll(false /* errorOnWithHold */); err != nil {
 		log.Warningf(ctx, "error closing cursors: %v", err)
 	}
-
-	ex.extraTxnState.createdSequences = make(map[descpb.ID]struct{})
 
 	switch ev.eventType {
 	case txnCommit, txnRollback:

--- a/pkg/sql/created_sequence.go
+++ b/pkg/sql/created_sequence.go
@@ -29,6 +29,10 @@ type connExCreatedSequencesAccessor struct {
 }
 
 func (c connExCreatedSequencesAccessor) addCreatedSequence(id descpb.ID) error {
+	if c.ex.extraTxnState.createdSequences == nil {
+		// Lazily allocate.
+		c.ex.extraTxnState.createdSequences = make(map[descpb.ID]struct{})
+	}
 	c.ex.extraTxnState.createdSequences[id] = struct{}{}
 	return nil
 }


### PR DESCRIPTION
Previously, `connExecutor.resetExtraTxnState` would re-allocate the `extraTxnState.createdSequences` hash map on each transaction. This commit changes the map to be lazily allocated on the transaction's first call to `addCreatedSequence`. This avoids the allocation in the common case.

```sh
➜ benchdiff --run='BenchmarkKV/./SQL/rows=1$$' --count=25 ./pkg/sql/tests

name                     old time/op    new time/op    delta
KV/Update/SQL/rows=1-10     267µs ± 3%     263µs ± 2%  -1.42%  (p=0.000 n=25+21)
KV/Delete/SQL/rows=1-10     181µs ± 1%     180µs ± 1%  -0.56%  (p=0.003 n=24+24)
KV/Scan/SQL/rows=1-10       113µs ± 2%     113µs ± 1%  -0.41%  (p=0.049 n=22+23)
KV/Insert/SQL/rows=1-10     155µs ± 1%     155µs ± 2%  -0.32%  (p=0.045 n=23+23)

name                     old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-10      31.8kB ± 0%    31.7kB ± 0%  -0.22%  (p=0.000 n=25+21)
KV/Insert/SQL/rows=1-10    58.7kB ± 0%    58.7kB ± 1%    ~     (p=0.649 n=25+23)
KV/Update/SQL/rows=1-10    70.3kB ± 1%    70.3kB ± 0%    ~     (p=0.670 n=24+23)
KV/Delete/SQL/rows=1-10    84.3kB ± 0%    84.2kB ± 0%    ~     (p=0.056 n=24+25)

name                     old allocs/op  new allocs/op  delta
KV/Scan/SQL/rows=1-10         359 ± 0%       357 ± 0%  -0.40%  (p=0.000 n=25+23)
KV/Delete/SQL/rows=1-10       603 ± 0%       602 ± 0%  -0.21%  (p=0.000 n=24+25)
KV/Insert/SQL/rows=1-10       485 ± 0%       484 ± 0%  -0.21%  (p=0.000 n=21+18)
KV/Update/SQL/rows=1-10       721 ± 1%       720 ± 1%    ~     (p=0.060 n=23+23)
```

Epic: None
Release note: None