### PR TITLE
release-23.1: ui: fix job details refresh when executing job

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -191,7 +191,9 @@ export class JobDetails extends React.Component<JobDetailsProps> {
   };
 
   render(): React.ReactElement {
-    const isLoading = !this.props.job || this.props.jobLoading;
+    const isLoading =
+      (this.props.job === undefined && this.props.jobLoading) ||
+      (this.props.jobLoading === undefined && this.props.job === undefined);
     const error = this.props.jobError;
     return (
       <div className={jobCx("job-details")}>


### PR DESCRIPTION
Backport 1/1 commits from #104981.

/cc @cockroachdb/release

---

Fixes: #103206

Previously, when a job was still executing, the job details page for that job would keep refreshing and the loading animation would interrupt the page, causing flickers. This commit fixes this bug to only show the loading animation when the `jobRequest` does not have data to show.

Loom: https://www.loom.com/share/498f5cfd236e4bb6aeaf9f27e9e5409b.

Release note (bug fix): fix bug where the job details page would flicker between the job details and a loading animation when a job is still executing.

---

Release justification: bug fix
