### PR TITLE
sql/sqlstats: avoid heap allocations when using stats iterators

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -678,8 +678,7 @@ func (s *Server) GetUnscrubbedStmtStats(
 		stmtStats = append(stmtStats, *stat)
 		return nil
 	}
-	err :=
-		s.sqlStats.GetLocalMemProvider().IterateStatementStats(ctx, &sqlstats.IteratorOptions{}, stmtStatsVisitor)
+	err := s.sqlStats.GetLocalMemProvider().IterateStatementStats(ctx, sqlstats.IteratorOptions{}, stmtStatsVisitor)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch statement stats")
@@ -698,8 +697,7 @@ func (s *Server) GetUnscrubbedTxnStats(
 		txnStats = append(txnStats, *stat)
 		return nil
 	}
-	err :=
-		s.sqlStats.GetLocalMemProvider().IterateTransactionStats(ctx, &sqlstats.IteratorOptions{}, txnStatsVisitor)
+	err := s.sqlStats.GetLocalMemProvider().IterateTransactionStats(ctx, sqlstats.IteratorOptions{}, txnStatsVisitor)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch statement stats")
@@ -748,8 +746,7 @@ func (s *Server) getScrubbedStmtStats(
 		return nil
 	}
 
-	err :=
-		statsProvider.IterateStatementStats(ctx, &sqlstats.IteratorOptions{}, stmtStatsVisitor)
+	err := statsProvider.IterateStatementStats(ctx, sqlstats.IteratorOptions{}, stmtStatsVisitor)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch scrubbed statement stats")

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1659,7 +1659,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 			return nil
 		}
 
-		return sqlStats.GetLocalMemProvider().IterateStatementStats(ctx, &sqlstats.IteratorOptions{
+		return sqlStats.GetLocalMemProvider().IterateStatementStats(ctx, sqlstats.IteratorOptions{
 			SortedAppNames: true,
 			SortedKey:      true,
 		}, statementVisitor)
@@ -1817,7 +1817,7 @@ CREATE TABLE crdb_internal.node_transaction_statistics (
 			return nil
 		}
 
-		return sqlStats.GetLocalMemProvider().IterateTransactionStats(ctx, &sqlstats.IteratorOptions{
+		return sqlStats.GetLocalMemProvider().IterateTransactionStats(ctx, sqlstats.IteratorOptions{
 			SortedAppNames: true,
 			SortedKey:      true,
 		}, transactionVisitor)
@@ -1857,7 +1857,7 @@ CREATE TABLE crdb_internal.node_txn_stats (
 			)
 		}
 
-		return sqlStats.IterateAggregatedTransactionStats(ctx, &sqlstats.IteratorOptions{
+		return sqlStats.IterateAggregatedTransactionStats(ctx, sqlstats.IteratorOptions{
 			SortedAppNames: true,
 		}, appTxnStatsVisitor)
 	},
@@ -6396,7 +6396,7 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
 
 		row := make(tree.Datums, 9 /* number of columns for this virtual table */)
 		worker := func(ctx context.Context, pusher rowPusher) error {
-			return memSQLStats.IterateStatementStats(ctx, &sqlstats.IteratorOptions{
+			return memSQLStats.IterateStatementStats(ctx, sqlstats.IteratorOptions{
 				SortedAppNames: true,
 				SortedKey:      true,
 			}, func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
@@ -6798,7 +6798,7 @@ CREATE TABLE crdb_internal.cluster_transaction_statistics (
 
 		row := make(tree.Datums, 5 /* number of columns for this virtual table */)
 		worker := func(ctx context.Context, pusher rowPusher) error {
-			return memSQLStats.IterateTransactionStats(ctx, &sqlstats.IteratorOptions{
+			return memSQLStats.IterateTransactionStats(ctx, sqlstats.IteratorOptions{
 				SortedAppNames: true,
 				SortedKey:      true,
 			}, func(

--- a/pkg/sql/instrumentation_test.go
+++ b/pkg/sql/instrumentation_test.go
@@ -60,7 +60,7 @@ func TestSampledStatsCollection(t *testing.T) {
 				GetLocalMemProvider().
 				IterateStatementStats(
 					ctx,
-					&sqlstats.IteratorOptions{},
+					sqlstats.IteratorOptions{},
 					func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
 						if statistics.Key.Query == key.Query &&
 							statistics.Key.ImplicitTxn == key.ImplicitTxn &&
@@ -89,7 +89,7 @@ func TestSampledStatsCollection(t *testing.T) {
 			GetLocalMemProvider().
 			IterateTransactionStats(
 				ctx,
-				&sqlstats.IteratorOptions{},
+				sqlstats.IteratorOptions{},
 				func(ctx context.Context, statistics *appstatspb.CollectedTransactionStatistics) error {
 					if statistics.TransactionFingerprintID == key {
 						stats = statistics

--- a/pkg/sql/sqlstats/persistedsqlstats/combined_iterator.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/combined_iterator.go
@@ -29,7 +29,7 @@ type CombinedStmtStatsIterator struct {
 	mem struct {
 		canBeAdvanced bool
 		paused        bool
-		it            *memStmtStatsIterator
+		it            memStmtStatsIterator
 	}
 
 	disk struct {
@@ -42,9 +42,9 @@ type CombinedStmtStatsIterator struct {
 // NewCombinedStmtStatsIterator returns a new instance of
 // CombinedStmtStatsIterator.
 func NewCombinedStmtStatsIterator(
-	memIter *memStmtStatsIterator, diskIter isql.Rows, expectedColCnt int,
-) *CombinedStmtStatsIterator {
-	c := &CombinedStmtStatsIterator{
+	memIter memStmtStatsIterator, diskIter isql.Rows, expectedColCnt int,
+) CombinedStmtStatsIterator {
+	c := CombinedStmtStatsIterator{
 		expectedColCnt: expectedColCnt,
 	}
 
@@ -215,7 +215,7 @@ type CombinedTxnStatsIterator struct {
 	mem struct {
 		canBeAdvanced bool
 		paused        bool
-		it            *memTxnStatsIterator
+		it            memTxnStatsIterator
 	}
 
 	disk struct {
@@ -228,9 +228,9 @@ type CombinedTxnStatsIterator struct {
 // NewCombinedTxnStatsIterator returns a new instance of
 // CombinedTxnStatsIterator.
 func NewCombinedTxnStatsIterator(
-	memIter *memTxnStatsIterator, diskIter isql.Rows, expectedColCnt int,
-) *CombinedTxnStatsIterator {
-	c := &CombinedTxnStatsIterator{
+	memIter memTxnStatsIterator, diskIter isql.Rows, expectedColCnt int,
+) CombinedTxnStatsIterator {
+	c := CombinedTxnStatsIterator{
 		expectedColCnt: expectedColCnt,
 	}
 

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -145,7 +145,7 @@ FROM
 func (s *PersistedSQLStats) flushStmtStats(ctx context.Context, aggregatedTs time.Time) {
 	// s.doFlush directly logs errors if they are encountered. Therefore,
 	// no error is returned here.
-	_ = s.SQLStats.IterateStatementStats(ctx, &sqlstats.IteratorOptions{},
+	_ = s.SQLStats.IterateStatementStats(ctx, sqlstats.IteratorOptions{},
 		func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
 			s.doFlush(ctx, func() error {
 				return s.doFlushSingleStmtStats(ctx, statistics, aggregatedTs)
@@ -160,7 +160,7 @@ func (s *PersistedSQLStats) flushStmtStats(ctx context.Context, aggregatedTs tim
 }
 
 func (s *PersistedSQLStats) flushTxnStats(ctx context.Context, aggregatedTs time.Time) {
-	_ = s.SQLStats.IterateTransactionStats(ctx, &sqlstats.IteratorOptions{},
+	_ = s.SQLStats.IterateTransactionStats(ctx, sqlstats.IteratorOptions{},
 		func(ctx context.Context, statistics *appstatspb.CollectedTransactionStatistics) error {
 			s.doFlush(ctx, func() error {
 				return s.doFlushSingleTxnStats(ctx, statistics, aggregatedTs)

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -651,7 +651,7 @@ func verifyInMemoryStatsCorrectness(
 	t *testing.T, tcs []testCase, statsProvider *persistedsqlstats.PersistedSQLStats,
 ) {
 	for _, tc := range tcs {
-		err := statsProvider.SQLStats.IterateStatementStats(context.Background(), &sqlstats.IteratorOptions{}, func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
+		err := statsProvider.SQLStats.IterateStatementStats(context.Background(), sqlstats.IteratorOptions{}, func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
 			if tc.fingerprint == statistics.Key.Query {
 				require.Equal(t, tc.count, statistics.Stats.Count, "fingerprint: %s", tc.fingerprint)
 			}
@@ -678,7 +678,7 @@ func verifyInMemoryStatsEmpty(
 	t *testing.T, tcs []testCase, statsProvider *persistedsqlstats.PersistedSQLStats,
 ) {
 	for _, tc := range tcs {
-		err := statsProvider.SQLStats.IterateStatementStats(context.Background(), &sqlstats.IteratorOptions{}, func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
+		err := statsProvider.SQLStats.IterateStatementStats(context.Background(), sqlstats.IteratorOptions{}, func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
 			if tc.fingerprint == statistics.Key.Query {
 				require.Equal(t, 0 /* expected */, statistics.Stats.Count, "fingerprint: %s", tc.fingerprint)
 			}

--- a/pkg/sql/sqlstats/persistedsqlstats/mem_iterator.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/mem_iterator.go
@@ -32,7 +32,7 @@ type memStmtStatsIterator struct {
 
 func newMemStmtStatsIterator(
 	stats *sslocal.SQLStats,
-	options *sqlstats.IteratorOptions,
+	options sqlstats.IteratorOptions,
 	aggregatedTS time.Time,
 	aggInterval time.Duration,
 ) memStmtStatsIterator {
@@ -66,7 +66,7 @@ type memTxnStatsIterator struct {
 
 func newMemTxnStatsIterator(
 	stats *sslocal.SQLStats,
-	options *sqlstats.IteratorOptions,
+	options sqlstats.IteratorOptions,
 	aggregatedTS time.Time,
 	aggInterval time.Duration,
 ) memTxnStatsIterator {

--- a/pkg/sql/sqlstats/persistedsqlstats/mem_iterator.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/mem_iterator.go
@@ -25,7 +25,7 @@ import (
 // and aggregation_interval fields on the returning
 // appstatspb.CollectedStatementStatistics.
 type memStmtStatsIterator struct {
-	*sslocal.StmtStatsIterator
+	sslocal.StmtStatsIterator
 	aggregatedTs time.Time
 	aggInterval  time.Duration
 }
@@ -35,8 +35,8 @@ func newMemStmtStatsIterator(
 	options *sqlstats.IteratorOptions,
 	aggregatedTS time.Time,
 	aggInterval time.Duration,
-) *memStmtStatsIterator {
-	return &memStmtStatsIterator{
+) memStmtStatsIterator {
+	return memStmtStatsIterator{
 		StmtStatsIterator: stats.StmtStatsIterator(options),
 		aggregatedTs:      aggregatedTS,
 		aggInterval:       aggInterval,
@@ -59,7 +59,7 @@ func (m *memStmtStatsIterator) Cur() *appstatspb.CollectedStatementStatistics {
 // aggregatoin_interval fields fields on the returning
 // appstatspb.CollectedTransactionStatistics.
 type memTxnStatsIterator struct {
-	*sslocal.TxnStatsIterator
+	sslocal.TxnStatsIterator
 	aggregatedTs time.Time
 	aggInterval  time.Duration
 }
@@ -69,8 +69,8 @@ func newMemTxnStatsIterator(
 	options *sqlstats.IteratorOptions,
 	aggregatedTS time.Time,
 	aggInterval time.Duration,
-) *memTxnStatsIterator {
-	return &memTxnStatsIterator{
+) memTxnStatsIterator {
+	return memTxnStatsIterator{
 		TxnStatsIterator: stats.TxnStatsIterator(options),
 		aggregatedTs:     aggregatedTS,
 		aggInterval:      aggInterval,

--- a/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
@@ -93,7 +93,7 @@ func TestPersistedSQLStatsRead(t *testing.T) {
 		require.NoError(t,
 			sqlStats.IterateStatementStats(
 				context.Background(),
-				&sqlstats.IteratorOptions{
+				sqlstats.IteratorOptions{
 					SortedKey:      true,
 					SortedAppNames: true,
 				},
@@ -115,7 +115,7 @@ func TestPersistedSQLStatsRead(t *testing.T) {
 		require.NoError(t,
 			sqlStats.IterateTransactionStats(
 				context.Background(),
-				&sqlstats.IteratorOptions{},
+				sqlstats.IteratorOptions{},
 				func(
 					ctx context.Context,
 					statistics *appstatspb.CollectedTransactionStatistics,
@@ -215,7 +215,7 @@ func verifyStoredStmtFingerprints(
 	require.NoError(t,
 		sqlStats.IterateStatementStats(
 			context.Background(),
-			&sqlstats.IteratorOptions{},
+			sqlstats.IteratorOptions{},
 			func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
 				if expectedExecCount, ok := expectedStmtFingerprints[statistics.Key.Query]; ok {
 					foundQueries[statistics.Key.Query] = struct{}{}
@@ -228,7 +228,7 @@ func verifyStoredStmtFingerprints(
 	require.NoError(t,
 		sqlStats.IterateTransactionStats(
 			context.Background(),
-			&sqlstats.IteratorOptions{},
+			sqlstats.IteratorOptions{},
 			func(
 				ctx context.Context,
 				statistics *appstatspb.CollectedTransactionStatistics,

--- a/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
@@ -28,7 +28,7 @@ import (
 
 // IterateStatementStats implements sqlstats.Provider interface.
 func (s *PersistedSQLStats) IterateStatementStats(
-	ctx context.Context, options *sqlstats.IteratorOptions, visitor sqlstats.StatementVisitor,
+	ctx context.Context, options sqlstats.IteratorOptions, visitor sqlstats.StatementVisitor,
 ) (err error) {
 	// We override the sorting options since otherwise we would need to implement
 	// sorted and unsorted merge separately. We can revisit this decision if
@@ -79,7 +79,7 @@ func (s *PersistedSQLStats) IterateStatementStats(
 }
 
 func (s *PersistedSQLStats) persistedStmtStatsIter(
-	ctx context.Context, options *sqlstats.IteratorOptions,
+	ctx context.Context, options sqlstats.IteratorOptions,
 ) (iter isql.Rows, expectedColCnt int, err error) {
 	query, expectedColCnt := s.getFetchQueryForStmtStatsTable(ctx, options)
 
@@ -99,7 +99,7 @@ func (s *PersistedSQLStats) persistedStmtStatsIter(
 }
 
 func (s *PersistedSQLStats) getFetchQueryForStmtStatsTable(
-	ctx context.Context, options *sqlstats.IteratorOptions,
+	ctx context.Context, options sqlstats.IteratorOptions,
 ) (query string, colCnt int) {
 	selectedColumns := []string{
 		"aggregated_ts",

--- a/pkg/sql/sqlstats/persistedsqlstats/txn_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/txn_reader.go
@@ -27,7 +27,7 @@ import (
 
 // IterateTransactionStats implements sqlstats.Provider interface.
 func (s *PersistedSQLStats) IterateTransactionStats(
-	ctx context.Context, options *sqlstats.IteratorOptions, visitor sqlstats.TransactionVisitor,
+	ctx context.Context, options sqlstats.IteratorOptions, visitor sqlstats.TransactionVisitor,
 ) (err error) {
 	// We override the sorting options since otherwise we would need to implement
 	// sorted and unsorted merge separately. We can revisit this decision if
@@ -78,7 +78,7 @@ func (s *PersistedSQLStats) IterateTransactionStats(
 }
 
 func (s *PersistedSQLStats) persistedTxnStatsIter(
-	ctx context.Context, options *sqlstats.IteratorOptions,
+	ctx context.Context, options sqlstats.IteratorOptions,
 ) (iter isql.Rows, expectedColCnt int, err error) {
 	query, expectedColCnt := s.getFetchQueryForTxnStatsTable(options)
 	exec := s.cfg.DB.Executor()
@@ -96,7 +96,7 @@ func (s *PersistedSQLStats) persistedTxnStatsIter(
 }
 
 func (s *PersistedSQLStats) getFetchQueryForTxnStatsTable(
-	options *sqlstats.IteratorOptions,
+	options sqlstats.IteratorOptions,
 ) (query string, colCnt int) {
 	selectedColumns := []string{
 		"aggregated_ts",

--- a/pkg/sql/sqlstats/sslocal/iterator_test.go
+++ b/pkg/sql/sqlstats/sslocal/iterator_test.go
@@ -51,7 +51,7 @@ func TestSQLStatsIteratorWithTelemetryFlush(t *testing.T) {
 	// transaction stats later.
 	fingerprintIDs := make(map[appstatspb.StmtFingerprintID]struct{})
 	require.NoError(t,
-		sqlStats.IterateStatementStats(ctx, &sqlstats.IteratorOptions{},
+		sqlStats.IterateStatementStats(ctx, sqlstats.IteratorOptions{},
 			func(_ context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
 				fingerprintIDs[statistics.ID] = struct{}{}
 				return nil
@@ -61,7 +61,7 @@ func TestSQLStatsIteratorWithTelemetryFlush(t *testing.T) {
 		require.NoError(t,
 			sqlStats.IterateStatementStats(
 				ctx,
-				&sqlstats.IteratorOptions{},
+				sqlstats.IteratorOptions{},
 				func(_ context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
 					require.NotNil(t, statistics)
 					// If we are running our test case, we reset the SQL Stats. The iterator
@@ -80,7 +80,7 @@ func TestSQLStatsIteratorWithTelemetryFlush(t *testing.T) {
 		require.NoError(t,
 			sqlStats.IterateTransactionStats(
 				ctx,
-				&sqlstats.IteratorOptions{},
+				sqlstats.IteratorOptions{},
 				func(
 					ctx context.Context,
 					statistics *appstatspb.CollectedTransactionStatistics,

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -77,7 +77,7 @@ func TestStmtStatsBulkIngestWithRandomMetadata(t *testing.T) {
 	require.NoError(t,
 		sqlStats.IterateStatementStats(
 			context.Background(),
-			&sqlstats.IteratorOptions{},
+			sqlstats.IteratorOptions{},
 			func(
 				ctx context.Context,
 				statistics *appstatspb.CollectedStatementStatistics,
@@ -196,7 +196,7 @@ func TestSQLStatsStmtStatsBulkIngest(t *testing.T) {
 	require.NoError(t,
 		sqlStats.IterateStatementStats(
 			context.Background(),
-			&sqlstats.IteratorOptions{},
+			sqlstats.IteratorOptions{},
 			func(
 				ctx context.Context,
 				statistics *appstatspb.CollectedStatementStatistics,
@@ -294,7 +294,7 @@ func TestSQLStatsTxnStatsBulkIngest(t *testing.T) {
 	require.NoError(t,
 		sqlStats.IterateTransactionStats(
 			context.Background(),
-			&sqlstats.IteratorOptions{},
+			sqlstats.IteratorOptions{},
 			func(
 				ctx context.Context,
 				statistics *appstatspb.CollectedTransactionStatistics,
@@ -621,7 +621,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			var stats []*appstatspb.CollectedStatementStatistics
 			err = statsCollector.IterateStatementStats(
 				ctx,
-				&sqlstats.IteratorOptions{},
+				sqlstats.IteratorOptions{},
 				func(_ context.Context, s *appstatspb.CollectedStatementStatistics) error {
 					stats = append(stats, s)
 					return nil

--- a/pkg/sql/sqlstats/sslocal/sslocal_iterator.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_iterator.go
@@ -27,14 +27,14 @@ type baseIterator struct {
 // statement statistics stored in SQLStats.
 type StmtStatsIterator struct {
 	baseIterator
-	curIter *ssmemstorage.StmtStatsIterator
+	curIter ssmemstorage.StmtStatsIterator
 }
 
 // NewStmtStatsIterator returns a new instance of the StmtStatsIterator.
-func NewStmtStatsIterator(s *SQLStats, options *sqlstats.IteratorOptions) *StmtStatsIterator {
+func NewStmtStatsIterator(s *SQLStats, options *sqlstats.IteratorOptions) StmtStatsIterator {
 	appNames := s.getAppNames(options.SortedAppNames)
 
-	return &StmtStatsIterator{
+	return StmtStatsIterator{
 		baseIterator: baseIterator{
 			sqlStats: s,
 			idx:      -1,
@@ -53,7 +53,7 @@ func NewStmtStatsIterator(s *SQLStats, options *sqlstats.IteratorOptions) *StmtS
 func (s *StmtStatsIterator) Next() bool {
 	// If we haven't called Next() for the first time or our current child
 	// iterator has finished iterator, then we increment s.idx.
-	if s.curIter == nil || !s.curIter.Next() {
+	if !s.curIter.Initialized() || !s.curIter.Next() {
 		s.idx++
 		if s.idx >= len(s.appNames) {
 			return false
@@ -78,14 +78,14 @@ func (s *StmtStatsIterator) Cur() *appstatspb.CollectedStatementStatistics {
 // statement statistics stored in SQLStats.
 type TxnStatsIterator struct {
 	baseIterator
-	curIter *ssmemstorage.TxnStatsIterator
+	curIter ssmemstorage.TxnStatsIterator
 }
 
 // NewTxnStatsIterator returns a new instance of the TxnStatsIterator.
-func NewTxnStatsIterator(s *SQLStats, options *sqlstats.IteratorOptions) *TxnStatsIterator {
+func NewTxnStatsIterator(s *SQLStats, options *sqlstats.IteratorOptions) TxnStatsIterator {
 	appNames := s.getAppNames(options.SortedAppNames)
 
-	return &TxnStatsIterator{
+	return TxnStatsIterator{
 		baseIterator: baseIterator{
 			sqlStats: s,
 			idx:      -1,
@@ -104,7 +104,7 @@ func NewTxnStatsIterator(s *SQLStats, options *sqlstats.IteratorOptions) *TxnSta
 func (t *TxnStatsIterator) Next() bool {
 	// If we haven't called Next() for the first time or our current child
 	// iterator has finished iterator, then we increment s.idx.
-	if t.curIter == nil || !t.curIter.Next() {
+	if !t.curIter.Initialized() || !t.curIter.Next() {
 		t.idx++
 		if t.idx >= len(t.appNames) {
 			return false

--- a/pkg/sql/sqlstats/sslocal/sslocal_iterator.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_iterator.go
@@ -20,7 +20,7 @@ type baseIterator struct {
 	sqlStats *SQLStats
 	idx      int
 	appNames []string
-	options  *sqlstats.IteratorOptions
+	options  sqlstats.IteratorOptions
 }
 
 // StmtStatsIterator is an iterator that can be used to iterate over the
@@ -31,7 +31,7 @@ type StmtStatsIterator struct {
 }
 
 // NewStmtStatsIterator returns a new instance of the StmtStatsIterator.
-func NewStmtStatsIterator(s *SQLStats, options *sqlstats.IteratorOptions) StmtStatsIterator {
+func NewStmtStatsIterator(s *SQLStats, options sqlstats.IteratorOptions) StmtStatsIterator {
 	appNames := s.getAppNames(options.SortedAppNames)
 
 	return StmtStatsIterator{
@@ -82,7 +82,7 @@ type TxnStatsIterator struct {
 }
 
 // NewTxnStatsIterator returns a new instance of the TxnStatsIterator.
-func NewTxnStatsIterator(s *SQLStats, options *sqlstats.IteratorOptions) TxnStatsIterator {
+func NewTxnStatsIterator(s *SQLStats, options sqlstats.IteratorOptions) TxnStatsIterator {
 	appNames := s.getAppNames(options.SortedAppNames)
 
 	return TxnStatsIterator{

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -130,7 +130,7 @@ func (s *SQLStats) GetLastReset() time.Time {
 
 // IterateStatementStats implements sqlstats.Provider interface.
 func (s *SQLStats) IterateStatementStats(
-	ctx context.Context, options *sqlstats.IteratorOptions, visitor sqlstats.StatementVisitor,
+	ctx context.Context, options sqlstats.IteratorOptions, visitor sqlstats.StatementVisitor,
 ) error {
 	iter := s.StmtStatsIterator(options)
 
@@ -145,13 +145,13 @@ func (s *SQLStats) IterateStatementStats(
 
 // StmtStatsIterator returns an instance of sslocal.StmtStatsIterator for
 // the current SQLStats.
-func (s *SQLStats) StmtStatsIterator(options *sqlstats.IteratorOptions) StmtStatsIterator {
+func (s *SQLStats) StmtStatsIterator(options sqlstats.IteratorOptions) StmtStatsIterator {
 	return NewStmtStatsIterator(s, options)
 }
 
 // IterateTransactionStats implements sqlstats.Provider interface.
 func (s *SQLStats) IterateTransactionStats(
-	ctx context.Context, options *sqlstats.IteratorOptions, visitor sqlstats.TransactionVisitor,
+	ctx context.Context, options sqlstats.IteratorOptions, visitor sqlstats.TransactionVisitor,
 ) error {
 	iter := s.TxnStatsIterator(options)
 
@@ -167,14 +167,14 @@ func (s *SQLStats) IterateTransactionStats(
 
 // TxnStatsIterator returns an instance of sslocal.TxnStatsIterator for
 // the current SQLStats.
-func (s *SQLStats) TxnStatsIterator(options *sqlstats.IteratorOptions) TxnStatsIterator {
+func (s *SQLStats) TxnStatsIterator(options sqlstats.IteratorOptions) TxnStatsIterator {
 	return NewTxnStatsIterator(s, options)
 }
 
 // IterateAggregatedTransactionStats implements sqlstats.Provider interface.
 func (s *SQLStats) IterateAggregatedTransactionStats(
 	ctx context.Context,
-	options *sqlstats.IteratorOptions,
+	options sqlstats.IteratorOptions,
 	visitor sqlstats.AggregatedTransactionVisitor,
 ) error {
 	appNames := s.getAppNames(options.SortedAppNames)

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -145,7 +145,7 @@ func (s *SQLStats) IterateStatementStats(
 
 // StmtStatsIterator returns an instance of sslocal.StmtStatsIterator for
 // the current SQLStats.
-func (s *SQLStats) StmtStatsIterator(options *sqlstats.IteratorOptions) *StmtStatsIterator {
+func (s *SQLStats) StmtStatsIterator(options *sqlstats.IteratorOptions) StmtStatsIterator {
 	return NewStmtStatsIterator(s, options)
 }
 
@@ -167,7 +167,7 @@ func (s *SQLStats) IterateTransactionStats(
 
 // TxnStatsIterator returns an instance of sslocal.TxnStatsIterator for
 // the current SQLStats.
-func (s *SQLStats) TxnStatsIterator(options *sqlstats.IteratorOptions) *TxnStatsIterator {
+func (s *SQLStats) TxnStatsIterator(options *sqlstats.IteratorOptions) TxnStatsIterator {
 	return NewTxnStatsIterator(s, options)
 }
 

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -134,7 +134,7 @@ func (s *StatsCollector) ShouldSample(
 
 // UpgradeImplicitTxn implements sqlstats.StatsCollector interface.
 func (s *StatsCollector) UpgradeImplicitTxn(ctx context.Context) error {
-	err := s.ApplicationStats.IterateStatementStats(ctx, &sqlstats.IteratorOptions{},
+	err := s.ApplicationStats.IterateStatementStats(ctx, sqlstats.IteratorOptions{},
 		func(_ context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
 			statistics.Key.ImplicitTxn = false
 			return nil

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
@@ -33,7 +33,7 @@ type StmtStatsIterator struct {
 // NewStmtStatsIterator returns a StmtStatsIterator.
 func NewStmtStatsIterator(
 	container *Container, options *sqlstats.IteratorOptions,
-) *StmtStatsIterator {
+) StmtStatsIterator {
 	var stmtKeys stmtList
 	container.mu.Lock()
 	for k := range container.mu.stmts {
@@ -44,13 +44,18 @@ func NewStmtStatsIterator(
 		sort.Sort(stmtKeys)
 	}
 
-	return &StmtStatsIterator{
+	return StmtStatsIterator{
 		baseIterator: baseIterator{
 			container: container,
 			idx:       -1,
 		},
 		stmtKeys: stmtKeys,
 	}
+}
+
+// Initialized returns true if the iterator has been initialized, false otherwise.
+func (s *StmtStatsIterator) Initialized() bool {
+	return s.container != nil
 }
 
 // Next updates the current value returned by the subsequent Cur() call. Next()
@@ -119,9 +124,7 @@ type TxnStatsIterator struct {
 }
 
 // NewTxnStatsIterator returns a new instance of TxnStatsIterator.
-func NewTxnStatsIterator(
-	container *Container, options *sqlstats.IteratorOptions,
-) *TxnStatsIterator {
+func NewTxnStatsIterator(container *Container, options *sqlstats.IteratorOptions) TxnStatsIterator {
 	var txnKeys txnList
 	container.mu.Lock()
 	for k := range container.mu.txns {
@@ -132,13 +135,18 @@ func NewTxnStatsIterator(
 		sort.Sort(txnKeys)
 	}
 
-	return &TxnStatsIterator{
+	return TxnStatsIterator{
 		baseIterator: baseIterator{
 			container: container,
 			idx:       -1,
 		},
 		txnKeys: txnKeys,
 	}
+}
+
+// Initialized returns true if the iterator has been initialized, false otherwise.
+func (t *TxnStatsIterator) Initialized() bool {
+	return t.container != nil
 }
 
 // Next updates the current value returned by the subsequent Cur() call. Next()

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
@@ -32,7 +32,7 @@ type StmtStatsIterator struct {
 
 // NewStmtStatsIterator returns a StmtStatsIterator.
 func NewStmtStatsIterator(
-	container *Container, options *sqlstats.IteratorOptions,
+	container *Container, options sqlstats.IteratorOptions,
 ) StmtStatsIterator {
 	var stmtKeys stmtList
 	container.mu.Lock()
@@ -124,7 +124,7 @@ type TxnStatsIterator struct {
 }
 
 // NewTxnStatsIterator returns a new instance of TxnStatsIterator.
-func NewTxnStatsIterator(container *Container, options *sqlstats.IteratorOptions) TxnStatsIterator {
+func NewTxnStatsIterator(container *Container, options sqlstats.IteratorOptions) TxnStatsIterator {
 	var txnKeys txnList
 	container.mu.Lock()
 	for k := range container.mu.txns {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -167,7 +167,7 @@ func New(
 // IterateAggregatedTransactionStats implements sqlstats.ApplicationStats
 // interface.
 func (s *Container) IterateAggregatedTransactionStats(
-	_ context.Context, _ *sqlstats.IteratorOptions, visitor sqlstats.AggregatedTransactionVisitor,
+	_ context.Context, _ sqlstats.IteratorOptions, visitor sqlstats.AggregatedTransactionVisitor,
 ) error {
 	txnStat := func() appstatspb.TxnStats {
 		s.txnCounts.mu.Lock()
@@ -184,18 +184,18 @@ func (s *Container) IterateAggregatedTransactionStats(
 }
 
 // StmtStatsIterator returns an instance of StmtStatsIterator.
-func (s *Container) StmtStatsIterator(options *sqlstats.IteratorOptions) StmtStatsIterator {
+func (s *Container) StmtStatsIterator(options sqlstats.IteratorOptions) StmtStatsIterator {
 	return NewStmtStatsIterator(s, options)
 }
 
 // TxnStatsIterator returns an instance of TxnStatsIterator.
-func (s *Container) TxnStatsIterator(options *sqlstats.IteratorOptions) TxnStatsIterator {
+func (s *Container) TxnStatsIterator(options sqlstats.IteratorOptions) TxnStatsIterator {
 	return NewTxnStatsIterator(s, options)
 }
 
 // IterateStatementStats implements sqlstats.Provider interface.
 func (s *Container) IterateStatementStats(
-	ctx context.Context, options *sqlstats.IteratorOptions, visitor sqlstats.StatementVisitor,
+	ctx context.Context, options sqlstats.IteratorOptions, visitor sqlstats.StatementVisitor,
 ) error {
 	iter := s.StmtStatsIterator(options)
 
@@ -210,7 +210,7 @@ func (s *Container) IterateStatementStats(
 
 // IterateTransactionStats implements sqlstats.Provider interface.
 func (s *Container) IterateTransactionStats(
-	ctx context.Context, options *sqlstats.IteratorOptions, visitor sqlstats.TransactionVisitor,
+	ctx context.Context, options sqlstats.IteratorOptions, visitor sqlstats.TransactionVisitor,
 ) error {
 	iter := s.TxnStatsIterator(options)
 
@@ -686,7 +686,7 @@ func (s *Container) MergeApplicationStatementStats(
 ) (discardedStats uint64) {
 	if err := other.IterateStatementStats(
 		ctx,
-		&sqlstats.IteratorOptions{},
+		sqlstats.IteratorOptions{},
 		func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
 			if transformer != nil {
 				transformer(statistics)
@@ -737,7 +737,7 @@ func (s *Container) MergeApplicationTransactionStats(
 ) (discardedStats uint64) {
 	if err := other.IterateTransactionStats(
 		ctx,
-		&sqlstats.IteratorOptions{},
+		sqlstats.IteratorOptions{},
 		func(ctx context.Context, statistics *appstatspb.CollectedTransactionStatistics) error {
 			txnStats, _, throttled :=
 				s.getStatsForTxnWithKey(

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -184,12 +184,12 @@ func (s *Container) IterateAggregatedTransactionStats(
 }
 
 // StmtStatsIterator returns an instance of StmtStatsIterator.
-func (s *Container) StmtStatsIterator(options *sqlstats.IteratorOptions) *StmtStatsIterator {
+func (s *Container) StmtStatsIterator(options *sqlstats.IteratorOptions) StmtStatsIterator {
 	return NewStmtStatsIterator(s, options)
 }
 
 // TxnStatsIterator returns an instance of TxnStatsIterator.
-func (s *Container) TxnStatsIterator(options *sqlstats.IteratorOptions) *TxnStatsIterator {
+func (s *Container) TxnStatsIterator(options *sqlstats.IteratorOptions) TxnStatsIterator {
 	return NewTxnStatsIterator(s, options)
 }
 

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -56,16 +56,16 @@ type Reader interface {
 	// as ordering, through IteratorOptions argument. StatementVisitor can return
 	// error, if an error is returned after the execution of the visitor, the
 	// iteration is aborted.
-	IterateStatementStats(context.Context, *IteratorOptions, StatementVisitor) error
+	IterateStatementStats(context.Context, IteratorOptions, StatementVisitor) error
 
 	// IterateTransactionStats iterates through all the collected transaction
 	// statistics by using TransactionVisitor. It behaves similarly to
 	// IterateStatementStats.
-	IterateTransactionStats(context.Context, *IteratorOptions, TransactionVisitor) error
+	IterateTransactionStats(context.Context, IteratorOptions, TransactionVisitor) error
 
 	// IterateAggregatedTransactionStats iterates through all the collected app-level
 	// transactions statistics. It behaves similarly to IterateStatementStats.
-	IterateAggregatedTransactionStats(context.Context, *IteratorOptions, AggregatedTransactionVisitor) error
+	IterateAggregatedTransactionStats(context.Context, IteratorOptions, AggregatedTransactionVisitor) error
 }
 
 // ApplicationStats is an interface to read from or write to the statistics


### PR DESCRIPTION
This PR contains two changes that each avoid per-transaction heap allocations in the `sqlstats` package.

### sql/sqlstats: return iterators by value from constructors

This commit switches to returning sqlstats iterations by value from their constructors, instead of by pointer. This avoids causing the iterators to escape and needing to allocate on the heap. Instead, they can be kept on the stack, avoiding heap allocations in methods like `IterateStatementStats`.

```sh
➜ benchdiff --run='BenchmarkKV/./SQL/rows=1$$' --count=25 ./pkg/sql/tests

name                     old time/op    new time/op    delta
KV/Insert/SQL/rows=1-10     173µs ±13%     172µs ±15%    ~     (p=0.939 n=25+25)
KV/Update/SQL/rows=1-10     285µs ±16%     280µs ±11%    ~     (p=0.356 n=25+23)
KV/Delete/SQL/rows=1-10     212µs ±25%     221µs ±19%    ~     (p=0.345 n=25+25)
KV/Scan/SQL/rows=1-10       127µs ±11%     127µs ±11%    ~     (p=0.878 n=25+24)

name                     old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-10      32.2kB ± 1%    32.0kB ± 1%  -0.36%  (p=0.006 n=24+24)
KV/Insert/SQL/rows=1-10    59.0kB ± 1%    58.9kB ± 1%    ~     (p=0.140 n=25+25)
KV/Update/SQL/rows=1-10    70.6kB ± 1%    70.4kB ± 1%    ~     (p=0.050 n=24+24)
KV/Delete/SQL/rows=1-10    84.9kB ± 1%    84.9kB ± 1%    ~     (p=0.859 n=25+25)

name                     old allocs/op  new allocs/op  delta
KV/Scan/SQL/rows=1-10         368 ± 1%       366 ± 1%  -0.62%  (p=0.001 n=24+24)
KV/Update/SQL/rows=1-10       726 ± 1%       723 ± 2%  -0.45%  (p=0.013 n=23+24)
KV/Insert/SQL/rows=1-10       492 ± 2%       490 ± 1%  -0.41%  (p=0.044 n=25+25)
KV/Delete/SQL/rows=1-10       613 ± 3%       613 ± 3%    ~     (p=0.179 n=25+25)
```

### sql/sqlstats: pass `sqlstats.IteratorOptions` by value, not pointer

This commit switches from passing the `sqlstats.IteratorOptions` around by pointer to passing it by value. The struct is 2 bytes large (8 when padded), so there's little benefit to passing it around by pointer. Meanwhile, passing the object by pointer through interface methods prevents escape analysis from keeping it on the stack, forcing a heap allocation.

```
➜ benchdiff --run='BenchmarkKV/./SQL/rows=1$$' --count=25 ./pkg/sql/tests

name                     old time/op    new time/op    delta
KV/Insert/SQL/rows=1-10     169µs ±13%     168µs ±17%    ~     (p=0.603 n=25+25)
KV/Update/SQL/rows=1-10     282µs ± 9%     282µs ± 8%    ~     (p=0.788 n=25+25)
KV/Delete/SQL/rows=1-10     227µs ±26%     206µs ±27%    ~     (p=0.074 n=25+25)
KV/Scan/SQL/rows=1-10       126µs ±12%     127µs ±16%    ~     (p=0.908 n=25+25)

name                     old alloc/op   new alloc/op   delta
KV/Delete/SQL/rows=1-10    84.9kB ± 1%    84.5kB ± 1%  -0.50%  (p=0.008 n=25+21)
KV/Insert/SQL/rows=1-10    58.9kB ± 1%    58.7kB ± 1%  -0.23%  (p=0.020 n=25+23)
KV/Update/SQL/rows=1-10    70.5kB ± 1%    70.5kB ± 1%    ~     (p=0.894 n=24+24)
KV/Scan/SQL/rows=1-10      32.0kB ± 1%    32.0kB ± 1%    ~     (p=0.631 n=25+24)

name                     old allocs/op  new allocs/op  delta
KV/Delete/SQL/rows=1-10       613 ± 3%       604 ± 1%  -1.52%  (p=0.000 n=25+21)
KV/Insert/SQL/rows=1-10       489 ± 1%       486 ± 1%  -0.69%  (p=0.001 n=25+23)
KV/Scan/SQL/rows=1-10         365 ± 1%       363 ± 1%  -0.42%  (p=0.024 n=25+25)
KV/Update/SQL/rows=1-10       724 ± 2%       722 ± 2%    ~     (p=0.302 n=25+24)
```

Epic: None
Release note: None