### PR TITLE
debugutil,scpb: add debugutil package, adopt in scpb

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2221,6 +2221,7 @@ GO_TARGETS = [
     "//pkg/util/ctxlog:ctxlog_test",
     "//pkg/util/ctxutil:ctxutil",
     "//pkg/util/ctxutil:ctxutil_test",
+    "//pkg/util/debugutil:debugutil",
     "//pkg/util/duration:duration",
     "//pkg/util/duration:duration_test",
     "//pkg/util/encoding/csv:csv",

--- a/pkg/sql/schemachanger/scpb/BUILD.bazel
+++ b/pkg/sql/schemachanger/scpb/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/privilege",  # keep
         "//pkg/sql/sem/catid",  # keep
         "//pkg/sql/sem/tree",  # keep
+        "//pkg/util/debugutil",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/util/debugutil/BUILD.bazel
+++ b/pkg/util/debugutil/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "debugutil",
+    srcs = ["debugutil.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/debugutil",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_elastic_gosigar//:gosigar"],
+)

--- a/pkg/util/debugutil/debugutil.go
+++ b/pkg/util/debugutil/debugutil.go
@@ -1,0 +1,50 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package debugutil
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/elastic/gosigar"
+)
+
+// IsLaunchedByDebugger returns true in cases where the delve debugger
+// was used to launch the cockroach process.
+func IsLaunchedByDebugger() bool {
+	return isLaunchedByDebugger.Load()
+}
+
+var isLaunchedByDebugger atomic.Bool
+
+func init() {
+	isLaunchedByDebugger.Store(func(maybeDelvePID int) bool {
+		// We loop in case there were intermediary processes like the gopls
+		// language server.
+		for maybeDelvePID != 0 {
+			var exe gosigar.ProcExe
+			if err := exe.Get(maybeDelvePID); err != nil {
+				break
+			}
+			switch filepath.Base(exe.Name) {
+			case "dlv":
+				return true
+			}
+			var state gosigar.ProcState
+			if err := state.Get(maybeDelvePID); err != nil {
+				break
+			}
+			maybeDelvePID = state.Ppid
+		}
+		return false
+	}(os.Getppid()))
+}


### PR DESCRIPTION
This commit adds a debugutil package which exposes a flag which is set when the cockroach process is spawned by the delve debugger.

This functionality is used by the scpb package to decorate data structures with useful but expensive debugging information on an as-needed basis.

Release note: None

Epic: CRDB-27601