### PR TITLE
kv: re-organize order of raft environment variables

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -132,7 +132,15 @@ var defaultRaftSchedulerConcurrency = envutil.EnvOrDefaultInt(
 // per CPU core, capped at 128, so 16 is equivalent to 2 CPUs per shard, or a
 // maximum of 8 shards. This significantly relieves contention at high core
 // counts, while also avoiding starvation by excessive sharding.
-var defaultRaftSchedulerShardSize = envutil.EnvOrDefaultInt("COCKROACH_SCHEDULER_SHARD_SIZE", 16)
+var defaultRaftSchedulerShardSize = envutil.EnvOrDefaultInt(
+	"COCKROACH_SCHEDULER_SHARD_SIZE", 16)
+
+// defaultRaftSchedulerPriorityShardSize specifies the default size of the Raft
+// scheduler priority shard, used for certain system ranges. This shard is
+// always fully populated with workers that don't count towards the concurrency
+// limit, and is thus effectively the number of priority workers per store.
+var defaultRaftSchedulerPriorityShardSize = envutil.EnvOrDefaultInt(
+	"COCKROACH_SCHEDULER_PRIORITY_SHARD_SIZE", 2)
 
 // defaultRaftEntryCacheSize is the default size in bytes for a store's Raft
 // entry cache. The Raft entry cache is shared by all Raft groups managed by the
@@ -141,13 +149,6 @@ var defaultRaftSchedulerShardSize = envutil.EnvOrDefaultInt("COCKROACH_SCHEDULER
 // them from the persistent log.
 var defaultRaftEntryCacheSize = envutil.EnvOrDefaultBytes(
 	"COCKROACH_RAFT_ENTRY_CACHE_SIZE", 16<<20 /* 16 MiB */)
-
-// defaultRaftSchedulerPriorityShardSize specifies the default size of the Raft
-// scheduler priority shard, used for certain system ranges. This shard is
-// always fully populated with workers that don't count towards the concurrency
-// limit, and is thus effectively the number of priority workers per store.
-var defaultRaftSchedulerPriorityShardSize = envutil.EnvOrDefaultInt(
-	"COCKROACH_SCHEDULER_PRIORITY_SHARD_SIZE", 2)
 
 var logSSTInfoTicks = envutil.EnvOrDefaultInt(
 	"COCKROACH_LOG_SST_INFO_TICKS_INTERVAL", 60)


### PR DESCRIPTION
This commit cleans up the order of the raft environment variables to ensure that raft scheduler related variables are grouped together. They were unintentionally split by #105799.

Epic: None
Release note: None