### PR TITLE
sql: TestValidationWithProtectedTS is skipped 

### DIFF
--- a/pkg/sql/schemachanger/scdeps/sctestdeps/backfill.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/backfill.go
@@ -13,6 +13,7 @@ package sctestdeps
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
@@ -85,6 +86,7 @@ func (s *testBackfiller) BackfillIndexes(
 	_ context.Context,
 	progress scexec.BackfillProgress,
 	_ scexec.BackfillerProgressWriter,
+	_ *jobs.Job,
 	tbl catalog.TableDescriptor,
 ) error {
 	s.s.LogSideEffectf(
@@ -106,6 +108,7 @@ var _ scexec.Merger = (*testBackfiller)(nil)
 // MergeIndexes implements the scexec.Merger interface.
 func (s *testBackfiller) MergeIndexes(
 	_ context.Context,
+	job *jobs.Job,
 	progress scexec.MergeProgress,
 	_ scexec.BackfillerProgressWriter,
 	tbl catalog.TableDescriptor,

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -173,6 +173,7 @@ type Backfiller interface {
 		context.Context,
 		BackfillProgress,
 		BackfillerProgressWriter,
+		*jobs.Job,
 		catalog.TableDescriptor,
 	) error
 }
@@ -184,12 +185,7 @@ type Merger interface {
 
 	// MergeIndexes will merge the specified indexes in the table, from each
 	// temporary index into each adding index.
-	MergeIndexes(
-		context.Context,
-		MergeProgress,
-		BackfillerProgressWriter,
-		catalog.TableDescriptor,
-	) error
+	MergeIndexes(context.Context, *jobs.Job, MergeProgress, BackfillerProgressWriter, catalog.TableDescriptor) error
 }
 
 // Validator provides interfaces that allow indexes and check constraints to be validated.

--- a/pkg/sql/schemachanger/scexec/exec_backfill_test.go
+++ b/pkg/sql/schemachanger/scexec/exec_backfill_test.go
@@ -160,7 +160,7 @@ func TestExecBackfiller(t *testing.T) {
 				FlushCheckpoint(gomock.Any()).
 				After(setProgress)
 			backfillCall := bf.EXPECT().
-				BackfillIndexes(gomock.Any(), scanned, bt, desc).
+				BackfillIndexes(gomock.Any(), scanned, bt, deps.TransactionalJobRegistry().CurrentJob(), desc).
 				After(flushAfterScan)
 			bt.EXPECT().
 				FlushCheckpoint(gomock.Any()).
@@ -245,10 +245,10 @@ func TestExecBackfiller(t *testing.T) {
 					FlushCheckpoint(gomock.Any()).
 					After(setProgress)
 				backfillBarCall := bf.EXPECT().
-					BackfillIndexes(gomock.Any(), scannedBar, bt, bar).
+					BackfillIndexes(gomock.Any(), scannedBar, bt, deps.TransactionalJobRegistry().CurrentJob(), bar).
 					After(flushAfterScan)
 				backfillFooCall := bf.EXPECT().
-					BackfillIndexes(gomock.Any(), progressFoo, bt, foo).
+					BackfillIndexes(gomock.Any(), progressFoo, bt, deps.TransactionalJobRegistry().CurrentJob(), foo).
 					After(flushAfterScan)
 				bt.EXPECT().
 					FlushCheckpoint(gomock.Any()).
@@ -306,7 +306,7 @@ func TestExecBackfiller(t *testing.T) {
 				GetMergeProgress(gomock.Any(), merge).
 				Return(progress, nil)
 			mergeCall := m.EXPECT().
-				MergeIndexes(gomock.Any(), progress, bt, desc).
+				MergeIndexes(gomock.Any(), deps.CurrentJob(), progress, bt, desc).
 				After(getProgress)
 			bt.EXPECT().
 				FlushCheckpoint(gomock.Any()).

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -412,6 +412,7 @@ func (n noopBackfiller) BackfillIndexes(
 	ctx context.Context,
 	progress scexec.BackfillProgress,
 	writer scexec.BackfillerProgressWriter,
+	job *jobs.Job,
 	descriptor catalog.TableDescriptor,
 ) error {
 	return nil
@@ -441,6 +442,7 @@ var _ scexec.Merger = (*noopMerger)(nil)
 
 func (n noopMerger) MergeIndexes(
 	ctx context.Context,
+	job *jobs.Job,
 	progress scexec.MergeProgress,
 	writer scexec.BackfillerProgressWriter,
 	descriptor catalog.TableDescriptor,

--- a/pkg/sql/schemachanger/scexec/mocks_generated_test.go
+++ b/pkg/sql/schemachanger/scexec/mocks_generated_test.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	jobs "github.com/cockroachdb/cockroach/pkg/jobs"
 	username "github.com/cockroachdb/cockroach/pkg/security/username"
 	cluster "github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	catalog "github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -503,17 +504,17 @@ func (m *MockBackfiller) EXPECT() *MockBackfillerMockRecorder {
 }
 
 // BackfillIndexes mocks base method.
-func (m *MockBackfiller) BackfillIndexes(arg0 context.Context, arg1 scexec.BackfillProgress, arg2 scexec.BackfillerProgressWriter, arg3 catalog.TableDescriptor) error {
+func (m *MockBackfiller) BackfillIndexes(arg0 context.Context, arg1 scexec.BackfillProgress, arg2 scexec.BackfillerProgressWriter, arg3 *jobs.Job, arg4 catalog.TableDescriptor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BackfillIndexes", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "BackfillIndexes", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // BackfillIndexes indicates an expected call of BackfillIndexes.
-func (mr *MockBackfillerMockRecorder) BackfillIndexes(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockBackfillerMockRecorder) BackfillIndexes(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackfillIndexes", reflect.TypeOf((*MockBackfiller)(nil).BackfillIndexes), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackfillIndexes", reflect.TypeOf((*MockBackfiller)(nil).BackfillIndexes), arg0, arg1, arg2, arg3, arg4)
 }
 
 // MaybePrepareDestIndexesForBackfill mocks base method.
@@ -555,17 +556,17 @@ func (m *MockMerger) EXPECT() *MockMergerMockRecorder {
 }
 
 // MergeIndexes mocks base method.
-func (m *MockMerger) MergeIndexes(arg0 context.Context, arg1 scexec.MergeProgress, arg2 scexec.BackfillerProgressWriter, arg3 catalog.TableDescriptor) error {
+func (m *MockMerger) MergeIndexes(arg0 context.Context, arg1 *jobs.Job, arg2 scexec.MergeProgress, arg3 scexec.BackfillerProgressWriter, arg4 catalog.TableDescriptor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MergeIndexes", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "MergeIndexes", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MergeIndexes indicates an expected call of MergeIndexes.
-func (mr *MockMergerMockRecorder) MergeIndexes(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockMergerMockRecorder) MergeIndexes(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeIndexes", reflect.TypeOf((*MockMerger)(nil).MergeIndexes), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeIndexes", reflect.TypeOf((*MockMerger)(nil).MergeIndexes), arg0, arg1, arg2, arg3, arg4)
 }
 
 // MockBackfillerTracker is a mock of BackfillerTracker interface.


### PR DESCRIPTION
This patch does the following to address a flaky test:

1. TestValidationWithProtectedTS is re-enabled, and the logic for detecting errors is updated to prevent the test from hanging and handling transaction retry errors.
2. The index backfiller is updated to add a protected timestamp, since it's possible in this test to encounter hangs where we get stuck in retry loops because of short GC interval

Fixes: https://github.com/cockroachdb/cockroach/issues/90879