### PR TITLE
release-23.1: roachtest: Fix npgsql test

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -789,6 +789,7 @@ var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Write_null_values`:                                            "flaky",
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Wrong_format_binary_export`:                                   "flaky",
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Wrong_format_binary_import`:                                   "flaky",
+	`Npgsql.Tests.CopyTests(NonMultiplexing).Wrong_format_raw_binary_copy`:                                 "flaky",
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Wrong_format_text_import`:                                     "flaky",
 	`Npgsql.Tests.ReaderTests(Multiplexing,SequentialAccess).Cleans_up_ok_with_dispose_calls(NotPrepared)`: "flaky",
 	`Npgsql.Tests.TransactionTests(NonMultiplexing).CommitAsync(Prepared)`:                                 "flaky",


### PR DESCRIPTION
This PR adds another flaky test that was detected
over the weekend to the npgsql ignorelist. This will ensure the roachtest passes in subsequent runs.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/103252
Release justification: Test only change