### PR TITLE
sql: fix nil pointer dereference in crdb_internal.transaction_contention_events

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -8011,7 +8011,7 @@ func getContentionEventInfo(
 	if err != nil {
 		schName = "[dropped schema]"
 	}
-	if dbDesc != nil {
+	if schemaDesc != nil {
 		schName = schemaDesc.GetName()
 	}
 


### PR DESCRIPTION
`schemaDesc` was not checked for a nil pointer before dereferencing it. `schemaDesc` can be nil under the following conditions:

1. A schema descriptor can be deleted, in which case all of its tables would be deleted too.

2. The transaction used to retrieve the descriptor fails.

Given the structure of `getContentionEventInfo`, this nil pointer dereference is only possible under scenario 2: If a schema and its tables are deleted, a nil table descriptor would force an early return, and this code path would not execute.

Fixes: #104406
Epic: none
Release note: None