### PR TITLE
future: Fix a small race in the test

### DIFF
--- a/pkg/util/future/BUILD.bazel
+++ b/pkg/util/future/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     deps = [
         ":future",
         "//pkg/testutils",
+        "//pkg/util",
         "//pkg/util/ctxgroup",
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/util/future/future_test.go
+++ b/pkg/util/future/future_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/future"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -60,10 +61,14 @@ func TestFuture(t *testing.T) {
 	}()
 
 	mustBeReady := func(ch chan struct{}) error {
+		soon := 5 * time.Second
+		if util.RaceEnabled {
+			soon *= 5
+		}
 		select {
 		case <-ch:
 			return nil
-		default:
+		case <-time.After(soon):
 			return errors.New("channel not ready")
 		}
 	}


### PR DESCRIPTION
Fix a test which was racy because awaitable future may be completed immediately, while the previously arranged `WhenDone` callbacks have not finished running yet.

Fixes #99019
Fixes #99804
Fixes #102080

Release note: None