### PR TITLE
storage: ensure no filesystem use after close in test builds

### DIFF
--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -337,6 +337,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 
 	// Write some arbitrary data only to store on n2. Inconsistent key "e"!
 	s2 := tc.GetFirstStoreFromServer(t, 1)
+	s2AuxDir := s2.TODOEngine().GetAuxiliaryDir()
 	var val roachpb.Value
 	val.SetInt(42)
 	// Put an inconsistent key "e" to s2, and have s1 and s3 still agree.
@@ -411,9 +412,10 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	assert.Equal(t, hashes[0], hashes[2])    // s1 and s3 agree
 	assert.NotEqual(t, hashes[0], hashes[1]) // s2 diverged
 
-	// A death rattle should have been written on s2.
-	eng := s2.TODOEngine()
-	f, err := eng.Open(base.PreventedStartupFile(eng.GetAuxiliaryDir()))
+	// A death rattle should have been written on s2. Note that the VFSes are
+	// zero-indexed whereas store IDs are one-indexed.
+	fs := stickyVFSRegistry.Get("1")
+	f, err := fs.Open(base.PreventedStartupFile(s2AuxDir))
 	require.NoError(t, err)
 	b, err := io.ReadAll(f)
 	require.NoError(t, err)

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1238,6 +1238,7 @@ func TestEngineFS(t *testing.T) {
 		"8c: f.close",
 		"8d: f = open /bar",
 		"8e: f.read 3 == ghe",
+		"8f: f.close",
 		"9a: create-dir /dir1",
 		"9b: create /dir1/bar",
 		"9c: list-dir /dir1 == bar",


### PR DESCRIPTION
In test builds, panic if any of the VFS filesystem facilities are used after the Engine is closed.

Epic: none
Informs #106119.
Resolves #110293.
Release note: None