### PR TITLE
sql: fix CREATE AS sourcing vtable panics

### DIFF
--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -35,9 +35,6 @@ func TestCreateAsVTable(t *testing.T) {
 	// The map should be empty if all vtables are supported.
 	brokenTables := map[string]struct{}{
 		// TODO(sql-foundations): Fix nil pointer dereference.
-		//  See https://github.com/cockroachdb/cockroach/issues/106166.
-		`pg_catalog.pg_prepared_statements`: {},
-		// TODO(sql-foundations): Fix nil pointer dereference.
 		//  See https://github.com/cockroachdb/cockroach/issues/106167.
 		`pg_catalog.pg_cursors`: {},
 		// TODO(sql-foundations): Fix nil pointer dereference.

--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -33,11 +33,7 @@ func TestCreateAsVTable(t *testing.T) {
 
 	// These are the vtables that need to be fixed.
 	// The map should be empty if all vtables are supported.
-	brokenTables := map[string]struct{}{
-		// TODO(sql-foundations): Fix nil pointer dereference.
-		//  See https://github.com/cockroachdb/cockroach/issues/106168.
-		`"".crdb_internal.create_statements`: {},
-	}
+	brokenTables := map[string]struct{}{}
 
 	ctx := context.Background()
 	testCluster := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{})

--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -31,10 +31,6 @@ import (
 func TestCreateAsVTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// These are the vtables that need to be fixed.
-	// The map should be empty if all vtables are supported.
-	brokenTables := map[string]struct{}{}
-
 	ctx := context.Background()
 	testCluster := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{})
 	defer testCluster.Stopper().Stop(ctx)
@@ -78,10 +74,6 @@ func TestCreateAsVTable(t *testing.T) {
 			}
 
 			fqName := name.FQString()
-			if _, ok := brokenTables[fqName]; ok {
-				continue
-			}
-
 			// Filter by trace_id to prevent error when selecting from
 			// crdb_internal.cluster_inflight_traces:
 			// "pq: a trace_id value needs to be specified".

--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -35,9 +35,6 @@ func TestCreateAsVTable(t *testing.T) {
 	// The map should be empty if all vtables are supported.
 	brokenTables := map[string]struct{}{
 		// TODO(sql-foundations): Fix nil pointer dereference.
-		//  See https://github.com/cockroachdb/cockroach/issues/106167.
-		`pg_catalog.pg_cursors`: {},
-		// TODO(sql-foundations): Fix nil pointer dereference.
 		//  See https://github.com/cockroachdb/cockroach/issues/106168.
 		`"".crdb_internal.create_statements`: {},
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -457,6 +457,7 @@ func newInternalPlanner(
 
 	p.queryCacheSession.Init()
 	p.optPlanningCtx.init(p)
+	p.preparedStatements = emptyPreparedStatements{}
 	p.createdSequences = emptyCreatedSequences{}
 
 	p.schemaResolver.descCollection = p.Descriptors()

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -405,6 +405,7 @@ func newInternalPlanner(
 	p.semaCtx.SearchPath = &sd.SearchPath
 	p.semaCtx.TypeResolver = p
 	p.semaCtx.FunctionResolver = p
+	p.semaCtx.NameResolver = p
 	p.semaCtx.DateStyle = sd.GetDateStyle()
 	p.semaCtx.IntervalStyle = sd.GetIntervalStyle()
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -457,6 +457,7 @@ func newInternalPlanner(
 
 	p.queryCacheSession.Init()
 	p.optPlanningCtx.init(p)
+	p.sqlCursors = emptySqlCursors{}
 	p.preparedStatements = emptyPreparedStatements{}
 	p.createdSequences = emptyCreatedSequences{}
 

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -126,6 +126,27 @@ type preparedStatementsAccessor interface {
 	DeleteAll(ctx context.Context)
 }
 
+// emptyPreparedStatements is the default impl used by the planner when the
+// connExecutor is not available.
+type emptyPreparedStatements struct{}
+
+var _ preparedStatementsAccessor = emptyPreparedStatements{}
+
+func (e emptyPreparedStatements) List() map[string]*PreparedStatement {
+	return nil
+}
+
+func (e emptyPreparedStatements) Get(string, bool) (*PreparedStatement, bool) {
+	return nil, false
+}
+
+func (e emptyPreparedStatements) Delete(context.Context, string) bool {
+	return false
+}
+
+func (e emptyPreparedStatements) DeleteAll(context.Context) {
+}
+
 // PortalPausablity mark if the portal is pausable and the reason. This is
 // needed to give the correct error for usage of multiple active portals.
 type PortalPausablity int64

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -301,6 +301,32 @@ type sqlCursors interface {
 	list() map[tree.Name]*sqlCursor
 }
 
+// emptySqlCursors is the default impl used by the planner when the
+// connExecutor is not available.
+type emptySqlCursors struct{}
+
+var _ sqlCursors = emptySqlCursors{}
+
+func (e emptySqlCursors) closeAll(bool) error {
+	return errors.AssertionFailedf("closeAll not supported in emptySqlCursors")
+}
+
+func (e emptySqlCursors) closeCursor(tree.Name) error {
+	return errors.AssertionFailedf("closeCursor not supported in emptySqlCursors")
+}
+
+func (e emptySqlCursors) getCursor(tree.Name) *sqlCursor {
+	return nil
+}
+
+func (e emptySqlCursors) addCursor(tree.Name, *sqlCursor) error {
+	return errors.AssertionFailedf("addCursor not supported in emptySqlCursors")
+}
+
+func (e emptySqlCursors) list() map[tree.Name]*sqlCursor {
+	return nil
+}
+
 // cursorMap is a sqlCursors that's backed by an actual map.
 type cursorMap struct {
 	cursors map[tree.Name]*sqlCursor


### PR DESCRIPTION
Fixes #106166
Fixes #106167
Fixes #106168
Informs #105895

Fixes panics affects CREATE AS sourcing from vtables. These statements now work properly:
```
CREATE TABLE t AS SELECT * FROM pg_catalog.pg_prepared_statements;
CREATE MATERIALIZED VIEW v AS SELECT * FROM pg_catalog.pg_prepared_statements;
CREATE TABLE t AS SELECT * FROM pg_catalog.pg_cursors;
CREATE MATERIALIZED VIEW v AS SELECT * FROM pg_catalog.pg_cursors;
CREATE TABLE t AS SELECT * FROM crdb_internal.create_statements;
CREATE MATERIALIZED VIEW v AS SELECT * FROM crdb_internal.create_statements;
```