### PR TITLE
release-23.1: cluster-ui: bump package version to 23.1.5

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE5OTU2Mjk4ODM=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE5OTU2Mjk4ODM=
@@ -1,6 +1,6 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm_cluster_ui", pnpm_lock = "//pkg/ui/workspaces/cluster-ui:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 pkg/ui/.npmrc.pnpm=1714720514
-pkg/ui/workspaces/cluster-ui/pnpm-lock.yaml=1409758461
+pkg/ui/workspaces/cluster-ui/pnpm-lock.yaml=-216806008
 pkg/ui/workspaces/cluster-ui/yarn.lock=1601010899
-pkg/ui/workspaces/cluster-ui/package.json=745014881
+pkg/ui/workspaces/cluster-ui/package.json=1004843776

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.1.4",
+  "version": "23.1.5",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/pnpm-lock.yaml
+++ b/pkg/ui/workspaces/cluster-ui/pnpm-lock.yaml
@@ -4081,7 +4081,7 @@ packages:
       '@storybook/channels': 6.3.1
       '@storybook/client-logger': 6.3.1
       '@storybook/core-events': 6.3.1
-      core-js: 2.6.12
+      core-js: 3.15.1
       global: 4.4.0
       qs: 6.10.1
       telejson: 5.3.3
@@ -4144,11 +4144,11 @@ packages:
       '@types/overlayscrollbars': 1.12.0
       '@types/react-syntax-highlighter': 11.0.5
       color-convert: 2.0.1
-      core-js: 2.6.12
+      core-js: 3.15.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
       lodash: 4.17.21
-      markdown-to-jsx: 6.11.4(react@16.12.0)
+      markdown-to-jsx: 7.1.3(react@16.12.0)
       memoizerific: 1.11.3
       overlayscrollbars: 1.13.1
       polished: 4.1.3
@@ -4520,7 +4520,7 @@ packages:
       babel-plugin-add-react-displayname: 0.0.5
       babel-plugin-named-asset-import: 0.3.7(@babel/core@7.9.0)
       babel-plugin-react-docgen: 4.2.1
-      core-js: 2.6.12
+      core-js: 3.15.1
       global: 4.4.0
       lodash: 4.17.21
       prop-types: 15.7.2
@@ -4621,7 +4621,7 @@ packages:
       '@storybook/theming': 6.3.1(react-dom@16.12.0)(react@16.12.0)
       '@types/markdown-to-jsx': 6.11.3
       copy-to-clipboard: 3.3.1
-      core-js: 2.6.12
+      core-js: 3.15.1
       core-js-pure: 3.15.1
       downshift: 6.1.3(react@16.12.0)
       emotion-theming: 10.0.27(@emotion/core@10.1.1)(react@16.12.0)
@@ -11548,6 +11548,15 @@ packages:
       prop-types: 15.7.2
       react: 16.12.0
       unquote: 1.1.1
+    dev: true
+
+  /markdown-to-jsx@7.1.3(react@16.12.0):
+    resolution: {integrity: sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      react: '>= 0.14.0'
+    dependencies:
+      react: 16.12.0
     dev: true
 
   /md5.js@1.3.5:


### PR DESCRIPTION
Epic: none

Release note: None

Release justification: low-risk updates