### PR TITLE
release-23.1: bazel: update to bazel 5.4.1

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,1 @@
-cockroachdb/5.1.0
+cockroachdb/5.4.0

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,1 @@
-cockroachdb/5.4.0
+cockroachdb/5.4.1


### PR DESCRIPTION
Release note: None
Epic: none

Backport:
  * 1/1 commits from "bazel: upgrade to bazel 5.4.0" (#100312)
  * 1/1 commits from "bazel: update to 5.4.1" (#102012)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: Build-only code change
