### PR TITLE
release-23.1: cluster-ui: fix tables page story, bump cluster-ui

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE5OTU2Mjk4ODM=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE5OTU2Mjk4ODM=
@@ -3,4 +3,4 @@
 pkg/ui/.npmrc.pnpm=1714720514
 pkg/ui/workspaces/cluster-ui/pnpm-lock.yaml=-216806008
 pkg/ui/workspaces/cluster-ui/yarn.lock=1601010899
-pkg/ui/workspaces/cluster-ui/package.json=1004843776
+pkg/ui/workspaces/cluster-ui/package.json=1264672671

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.1.5",
+  "version": "23.1.6",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -30,9 +30,6 @@ const withLoadingIndicator: DatabaseTablePageProps = {
   indexUsageStatsEnabled: false,
   showIndexRecommendations: false,
   automaticStatsCollectionEnabled: true,
-  schemaName: randomName(),
-  indexUsageStatsEnabled: false,
-  showIndexRecommendations: false,
   details: {
     loading: true,
     loaded: false,
@@ -79,9 +76,6 @@ const withData: DatabaseTablePageProps = {
   indexUsageStatsEnabled: true,
   showIndexRecommendations: true,
   automaticStatsCollectionEnabled: true,
-  schemaName: randomName(),
-  indexUsageStatsEnabled: true,
-  showIndexRecommendations: true,
   details: {
     loading: false,
     loaded: true,


### PR DESCRIPTION
The db tables page story file was broken, causing automatic cluster-ui publishing to fail. This commit fixes the story file, allowing the package to build. The cluster-ui version is bumped to 23.1.6 to allow for publishing.

Epic: none

Release note: None

Release justification: low-risk updates (bumping cluster-ui version will publish UI changes to cloud clusters)

-----
Verified the package can build with `yarn build`.