### PR TITLE
backfill: fix possible race in tests

### DIFF
--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -92,6 +92,9 @@ type RowReceiver interface {
 	// and they might not all be aware of the last status returned).
 	//
 	// Implementations of Push() must be thread-safe.
+	// TODO(yuzefovich): some implementations (DistSQLReceiver and
+	// copyingRowReceiver) are not actually thread-safe. Figure out whether we
+	// want to fix them or to update the contract.
 	Push(row rowenc.EncDatumRow, meta *execinfrapb.ProducerMetadata) ConsumerStatus
 }
 


### PR DESCRIPTION
This commit addresses a race when `Push`ing into `execinfra.RowReceiver` which can happen in tests. In particular, when
`PushesProgressEveryChunk` testing knob is set, there is a concurrency between the main waiter goroutine and worker goroutine, so we now add a mutex around that `Push`. In theory, `RowReceiver.Push` claims to be thread-safe, so it shouldn't be necessary, but two implementations (`DistSQLReceiver` and `copyingRowReceiver`) are actually not thread-safe, and fixing that is left as a TODO.

Fixes: #106161.

Release note: None