### PR TITLE
release-22.2: sql: expose whether streamer was used in EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -79,6 +79,8 @@ type KVReader interface {
 	// GetScanStats returns statistics about the scan that happened during the
 	// KV reads. It must be safe for concurrent use.
 	GetScanStats() execstats.ScanStats
+	// UsedStreamer returns whether the Streamer API was used by the KVReader.
+	UsedStreamer() bool
 }
 
 // ZeroInputNode is an execopnode.OpNode with no inputs.

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -176,6 +176,13 @@ func (s *ColBatchScan) GetScanStats() execstats.ScanStats {
 	return execstats.GetScanStats(s.Ctx, nil /* recording */)
 }
 
+// UsedStreamer is part of the colexecop.KVReader interface.
+func (s *ColBatchScan) UsedStreamer() bool {
+	// TODO(yuzefovich): update this when the streamer is used to power the
+	// ColBatchScans (#82164).
+	return false
+}
+
 var colBatchScanPool = sync.Pool{
 	New: func() interface{} {
 		return &ColBatchScan{}

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -404,6 +404,11 @@ func (s *ColIndexJoin) GetCumulativeContentionTime() time.Duration {
 	return execstats.GetCumulativeContentionTime(s.Ctx, nil /* recording */)
 }
 
+// UsedStreamer is part of the colexecop.KVReader interface.
+func (s *ColIndexJoin) UsedStreamer() bool {
+	return s.usesStreamer
+}
+
 // inputBatchSizeLimit is a batch size limit for the number of input rows that
 // will be used to form lookup spans for each scan. This is used as a proxy for
 // result batch size in order to prevent OOMs, because index joins do not limit

--- a/pkg/sql/colflow/stats.go
+++ b/pkg/sql/colflow/stats.go
@@ -247,6 +247,7 @@ func (vsc *vectorizedStatsCollectorImpl) GetStats() *execinfrapb.ComponentStats 
 		s.KV.BytesRead.Set(uint64(vsc.kvReader.GetBytesRead()))
 		s.KV.BatchRequestsIssued.Set(uint64(vsc.kvReader.GetBatchRequestsIssued()))
 		s.KV.ContentionTime.Set(vsc.kvReader.GetCumulativeContentionTime())
+		s.KV.UsedStreamer = vsc.kvReader.UsedStreamer()
 		scanStats := vsc.kvReader.GetScanStats()
 		execstats.PopulateKVMVCCStats(&s.KV, &scanStats)
 		s.Exec.ConsumedRU.Set(scanStats.ConsumedRU)

--- a/pkg/sql/execinfrapb/component_stats.go
+++ b/pkg/sql/execinfrapb/component_stats.go
@@ -74,7 +74,11 @@ const (
 func (s *ComponentStats) StatsForQueryPlan() []string {
 	result := make([]string, 0, 4)
 	s.formatStats(func(key string, value interface{}) {
-		result = append(result, fmt.Sprintf("%s: %v", key, value))
+		if value != nil {
+			result = append(result, fmt.Sprintf("%s: %v", key, value))
+		} else {
+			result = append(result, key)
+		}
 	})
 	return result
 }
@@ -166,6 +170,9 @@ func (s *ComponentStats) formatStats(fn func(suffix string, value interface{})) 
 				humanizeutil.Count(s.KV.NumInterfaceSeeks.Value()),
 				humanizeutil.Count(s.KV.NumInternalSeeks.Value())),
 		)
+	}
+	if s.KV.UsedStreamer {
+		fn("used streamer", nil)
 	}
 
 	// Exec stats.

--- a/pkg/sql/execinfrapb/component_stats.proto
+++ b/pkg/sql/execinfrapb/component_stats.proto
@@ -140,6 +140,10 @@ message KVStats {
   optional util.optional.Uint num_gets = 21 [(gogoproto.nullable) = false];
   optional util.optional.Uint num_scans = 22 [(gogoproto.nullable) = false];
   optional util.optional.Uint num_reverse_scans = 23 [(gogoproto.nullable) = false];
+
+  // UsedStreamer indicates whether the Streamer API was used to perform KV
+  // operations.
+  optional bool used_streamer = 25 [(gogoproto.nullable) = false];
 }
 
 // ExecStats contains statistics about the execution of a component.

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -693,6 +693,7 @@ func (m execNodeTraceMetadata) annotateExplain(
 				nodeStats.KVBytesRead.MaybeAdd(stats.KV.BytesRead)
 				nodeStats.KVRowsRead.MaybeAdd(stats.KV.TuplesRead)
 				nodeStats.KVBatchRequestsIssued.MaybeAdd(stats.KV.BatchRequestsIssued)
+				nodeStats.UsedStreamer = stats.KV.UsedStreamer
 				nodeStats.StepCount.MaybeAdd(stats.KV.NumInterfaceSteps)
 				nodeStats.InternalStepCount.MaybeAdd(stats.KV.NumInternalSteps)
 				nodeStats.SeekCount.MaybeAdd(stats.KV.NumInterfaceSeeks)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
@@ -45,7 +45,7 @@ regions: <hidden>
     │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
-    └── • index join
+    └── • index join (streamer)
         │ nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 2
@@ -81,7 +81,7 @@ regions: <hidden>
                   table: geo_table@geom_index
                   spans: 31 spans
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzMVeFu2zYQ_r-nONyfJJgGk5LiuRwGeHHVzdtSB0rQoZiMgJFurmCJVElqUxDksfYCe7JBYlLETaPWHQrMP2Tfd_dRx_v40Tdo31Yo8Dz5NVlcwBZepKtT2JC-dPKqIvjtpyRNwLrLUjkylnJnDw_O0-Xz78PpMz777my1fHlxGDPGWATDF4uODoT4MVmdJhfp66Bfqz6CVfo8SeHkNWwxQKULeilrsih-R47rABujc7JWmx66GQqWRYeCBViqpnU9vA4w14ZQ3KArXUUo8KLvMSVZkJkwDLAgJ8tqWPbdFuZ9A5elKqjDABe6amtlBWx9ZxjgeSN7YJLhSZZ1fxRZ1nGWZR372AO_2ZfDMwSpCogYaPeGjMUAf3kFrqxJAPvn77s418qRcqVWj1JG_2XBkCwExB65unZ0D0UhnHh0k54tIJdVZX3h6avFAqyjBnLdKgeH1LlJqdyRADaMzhcQbZ8qqGUHNdXaXIOsKp1LR4UANrzwSrr8DVnQrWtaJ6CvHzq9B2Jc3wboozstrZMbQsFvg0_Xe6n-JOOoeFFWjgyZCd8V_T6fdI0BrWDOBdheXrBOGicGuaJvj7OMhSzLGPvYA4FUsS-tV_mRzKt-DPO-32GDg5BeGh9bJ6tqV27qKG8fn4IxIfqcfVuBo7qBorRbaK3c0CfrFD6pU7iPTj_rUt3ZMhyxpf912Wzp-sPW_GxvhI-9wacf8kb4xb3x5SSJ9pHknWWiXUE8Lt6_4hlnvL_MQxZOp8_Yw89i-gOfxdwHMzbjszhOYn4gHt768_DoyUMffsah_w9jivcZ07k2jswk3h3SnH_9f_Pj8T67Ssk2Wlna2dVTK7PbdYBUbMj_F1vdmpzOjM6H1_hwNfAGoCDrfJb7YKl8qm_wIZmPksNxcjhKjsbJ0Sg5HifHo-Tj98jr26_-DQAA___vrPo-
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzMVeFu2zYQ_r-nONyfJJgGk5LiuRwGeHHVzdtSB0rQoZiMgJFurmCJVElqUxDksfYCe7JBYlLETaPW3YDNP2Tfd_dRd_f5k27Qvq1Q4Hnyc7K4gC28SFensCF96eRVRfDLD0magHWXpXJkLOXOHh6cp8vn34bTZ3z2zdlq-fLiMGaMsQiGLxYdHQjxfbI6TS7S10F_Vn0Eq_R5ksLJa9higEoX9FLWZFH8ihzXATZG52StNj10MxQsiw4FC7BUTet6eB1grg2huEFXuopQ4EXfY0qyIDNhGGBBTpbVcOy7EeZ9A5elKqjDABe6amtlBWx9ZxjgeSN7YJLhSZZ1vxVZ1nGWZR372AW_2pfDMwSpCogYaPeGjMUAf3oFrqxJAPvrz7s418qRcqVWj1JG_2HBkCwExB65unZ0D0UhnHh0k54tIJdVZX3h6avFAqyjBnLdKgeH1LlJqdyRADaszhcQbZ8qqGUHNdXaXIOsKp1LR4UANtzwSrr8DVnQrWtaJ6CvHzq9B2Jc3wboozstrZMbQsFvg0_Xe6l-J-OoeFFWjgyZCd8V_T6fdI0BrWDOBdheXrBOGicGuaKvj7OMhSzLGPvYBYFUsS-tV_mRzKt-DfO-32HAQUgvjY-tk1W1Kzd1lLeP_wVjQvQ5-7YCR3UDRWm30Fq5oU_WKXxSp3AfnX7UpbqzZThiS__rstnS9Yet-dneCB97g08_5I3wX_FGa6kA6wzJmsx_JlG0j0TvLBTtCuRx8f4jn3HG-4d7yMLp9Bl7-FlMv-OzmPtgxmZ8FsdJzA_Ew7fAPDx60gThZ5jgH6wp3mdN59o4MpN4d0lz_uX_zZ_H-0yVkm20srQz1VMns9t1gFRsyL-brW5NTmdG58NtfLgaeANQkHU-y32wVD7VN_iQzEfJ4Tg5HCVH4-RolByPk-NR8vF75PXtF38HAAD__4Oe_-I=
 
 statement ok
 DROP TABLE geo_table
@@ -132,7 +132,7 @@ regions: <hidden>
     │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
-    └── • index join
+    └── • index join (streamer)
         │ nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 2
@@ -168,7 +168,7 @@ regions: <hidden>
                   table: geo_table@geom_index
                   spans: 31 spans
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzclf9u2zYQx__fUxzunySYBpOS4rkcBnhx1c3bUgdK0KGYjYCRbq5gmVRJalMQ-LH2AnuygWJSxM2qzVgHDPUftO_HlzreR0ffoX1bo8DL7MdsdgUbeJEvzmFN-trJm5rgp--yPAPrrivlyFgqnD0-usznz7-Ox8_45KuLxfzl1XHKGGMJ9F8sOTkS4ttscZ5d5a8jv9f2BBb58yyHs9ewwQiVLuml3JJF8TNyXEXYGF2Qtdp4112fMC87FCzCSjWt8-5VhIU2hOIOXeVqQoFXvsacZElmxDDCkpys6n7bd0eY-gKuK1VShxHOdN1ulRWwCZVhhJeN9I7REs-Wy-6XcrnsWOIX9jcLfnGohi8RpCohYaDdGzIWI_zhFbhqSwLYH7_f24VWjpSrtHoSMvo3C4ZkKSAOnptbRw8uPoaz4F3nFzMoZF3bkHj-ajYD66iBQrfKwTF1blQpdyKA9a0LCUSbDyVsZQdb2mpzC7KudSEdlQJY_8Ab6Yo3ZEG3rmmdAJ_fV_rgiHG1izBY9yytk2tCwXfRP-c9V7-ScVS-qGpHhsyI70N_iGddY0ArmHIB1uMF66RxoseVfHm6XDKPi3kqgwsCqfJQmaf8BPPCt2Hq6-0P2IMMaIJtnazrfdzUUdE-fQuGQPiYfVuDo20DZWU30Fq5po_AKT6E0_e6UvdjGQ-MZfh13Wzo9q9H81OYjf8OSXIIkncjk-wDCX7x_hXPOOP-Mo9ZPB4_Y48_s_E3fJLyYEzYhE_SNEv5kXh860_jk4_60v-LNqWHtOlSG0dmlO43aco__7_N4-khp8rJNlpZ2jvVh3Zmu1WEVK4p_Bdb3ZqCLowu-scEc9HrekdJ1oUoD8ZchZAv8LGYD4rjYXE8KE6GxcmgOB0Wp4Pi0_fEq91nfwYAAP__9CH6Pg==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlf9u2zYQx__fUxzunySYBpOS4rkcBnhx1c3bUgdK0KGYjYCRbq5giVRJanMQ-LH2AnuygWJSxM2qzViBrf6D9v34Usf7-MQ7tG9rFHiZ_ZjNrmADL_LFOaxJXzt5UxP89F2WZ2DddaUcGUuFs8dHl_n8-dfx-BmffHWxmL-8Ok4ZYyyB_oslJ0dCfJstzrOr_HXk92pOYJE_z3I4ew0bjFDpkl7KhiyKn5HjKsLW6IKs1ca77vqEeblFwSKsVNs5715FWGhDKO7QVa4mFHjla8xJlmRGDCMsycmq7rd9d4SpL-C6UiVtMcKZrrtGWQGbUBlGeNlK7xgt8Wy53P5SLpdblviF_c2CXxyq4UsEqUpIGGj3hozFCH94Ba5qSAD74_d7u9DKkXKVVk9CRv9mwZAsBcTBc3Pr6MHFx3AWvOv8YgaFrGsbEs9fzWZgHbVQ6E45OKatG1XKnQhgfetCAtHmQwmN3EJDjTa3IOtaF9JRKYD1D7yRrnhDFnTn2s4J8Pl9pQ-OGFe7CIN1z9I6uSYUfBf9c95z9SsZR-WLqnZkyIz4PvSHeLZtDWgFUy7AerxgnTRO9LiSL0-XS-ZxMU9lcEEgVR4q85SfYF74Nkx9vf0Be5ABTbCtk3W9j5u2VHRP_wVDIHzMvq3BUdNCWdkNdFau6SNwig_h9L2u1P1YxgNjGX5dtxu6_evR_FRmo7NUgnWGZEPmP0OUHILo3Qgl-4CCX7z_ymeccf9yj1k8Hj9jjz-z8Td8kvJgTNiET9I0S_mReHwLTOOTjzoE_6JN6SFtutTGkRml-02a8s__b_N5esipcrKtVpb2TvWhndluFSGVawp3s9WdKejC6KJ_TDAXva53lGRdiPJgzFUI-QIfi_mgOB4Wx4PiZFicDIrTYXE6KD59T7zaffZnAAAA__-IE__i
 
 # Also works when creating an index.
 statement ok
@@ -203,7 +203,7 @@ regions: <hidden>
     │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
-    └── • index join
+    └── • index join (streamer)
         │ nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 2
@@ -239,4 +239,4 @@ regions: <hidden>
                   table: geo_table@geom_index
                   spans: 31 spans
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzclf9u2zYQx__fUxzunySYBpOS4rkcBnhx1c3bUgdK0KGYjYCRbq5gmVRJalMQ-LH2AnuygWJSxM2qzVgHDPUftO_HlzreR0ffoX1bo8DL7MdsdgUbeJEvzmFN-trJm5rgp--yPAPrrivlyFgqnD0-usznz7-Ox8_45KuLxfzl1XHKGGMJ9F8sOTkS4ttscZ5d5a8jv9f2BBb58yyHs9ewwQiVLuml3JJF8TNyXEXYGF2Qtdp4112fMC87FCzCSjWt8-5VhIU2hOIOXeVqQoFXvsacZElmxDDCkpys6n7bd0eY-gKuK1VShxHOdN1ulRWwCZVhhJeN9I7REs-Wy-6XcrnsWOIX9jcLfnGohi8RpCohYaDdGzIWI_zhFbhqSwLYH7_f24VWjpSrtHoSMvo3C4ZkKSAOnptbRw8uPoaz4F3nFzMoZF3bkHj-ajYD66iBQrfKwTF1blQpdyKA9a0LCUSbDyVsZQdb2mpzC7KudSEdlQJY_8Ab6Yo3ZEG3rmmdAJ_fV_rgiHG1izBY9yytk2tCwXfRP-c9V7-ScVS-qGpHhsyI70N_iGddY0ArmHIB1uMF66RxoseVfHm6XDKPi3kqgwsCqfJQmaf8BPPCt2Hq6-0P2IMMaIJtnazrfdzUUdE-fQuGQPiYfVuDo20DZWU30Fq5po_AKT6E0_e6UvdjGQ-MZfh13Wzo9q9H81OYjf8OSXIIkncjk-wDCX7x_hXPOOP-Mo9ZPB4_Y48_s_E3fJLyYEzYhE_SNEv5kXh860_jk4_60v-LNqWHtOlSG0dmlO43aco__7_N4-khp8rJNlpZ2jvVh3Zmu1WEVK4p_Bdb3ZqCLowu-scEc9HrekdJ1oUoD8ZchZAv8LGYD4rjYXE8KE6GxcmgOB0Wp4Pi0_fEq91nfwYAAP__9CH6Pg==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlf9u2zYQx__fUxzunySYBpOS4rkcBnhx1c3bUgdK0KGYjYCRbq5giVRJanMQ-LH2AnuygWJSxM2qzViBrf6D9v34Usf7-MQ7tG9rFHiZ_ZjNrmADL_LFOaxJXzt5UxP89F2WZ2DddaUcGUuFs8dHl_n8-dfx-BmffHWxmL-8Ok4ZYyyB_oslJ0dCfJstzrOr_HXk92pOYJE_z3I4ew0bjFDpkl7KhiyKn5HjKsLW6IKs1ca77vqEeblFwSKsVNs5715FWGhDKO7QVa4mFHjla8xJlmRGDCMsycmq7rd9d4SpL-C6UiVtMcKZrrtGWQGbUBlGeNlK7xgt8Wy53P5SLpdblviF_c2CXxyq4UsEqUpIGGj3hozFCH94Ba5qSAD74_d7u9DKkXKVVk9CRv9mwZAsBcTBc3Pr6MHFx3AWvOv8YgaFrGsbEs9fzWZgHbVQ6E45OKatG1XKnQhgfetCAtHmQwmN3EJDjTa3IOtaF9JRKYD1D7yRrnhDFnTn2s4J8Pl9pQ-OGFe7CIN1z9I6uSYUfBf9c95z9SsZR-WLqnZkyIz4PvSHeLZtDWgFUy7AerxgnTRO9LiSL0-XS-ZxMU9lcEEgVR4q85SfYF74Nkx9vf0Be5ABTbCtk3W9j5u2VHRP_wVDIHzMvq3BUdNCWdkNdFau6SNwig_h9L2u1P1YxgNjGX5dtxu6_evR_FRmo7NUgnWGZEPmP0OUHILo3Qgl-4CCX7z_ymeccf9yj1k8Hj9jjz-z8Td8kvJgTNiET9I0S_mReHwLTOOTjzoE_6JN6SFtutTGkRml-02a8s__b_N5esipcrKtVpb2TvWhndluFSGVawp3s9WdKejC6KJ_TDAXva53lGRdiPJgzFUI-QIfi_mgOB4Wx4PiZFicDIrTYXE6KD59T7zaffZnAAAA__-IE__i

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -93,7 +93,7 @@ regions: <hidden>
     │ regions: <hidden>
     │ actual row count: 1
     │
-    ├── • index join
+    ├── • index join (streamer)
     │   │ nodes: <hidden>
     │   │ regions: <hidden>
     │   │ actual row count: 1
@@ -120,7 +120,7 @@ regions: <hidden>
     │         table: a@a_y_idx
     │         spans: [/1 - /1]
     │
-    └── • index join
+    └── • index join (streamer)
         │ nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
@@ -172,7 +172,7 @@ regions: <hidden>
     │ regions: <hidden>
     │ actual row count: 1
     │
-    ├── • index join
+    ├── • index join (streamer)
     │   │ nodes: <hidden>
     │   │ regions: <hidden>
     │   │ actual row count: 1
@@ -197,7 +197,7 @@ regions: <hidden>
     │         table: a@a_y_idx
     │         spans: [/1 - /1]
     │
-    └── • index join
+    └── • index join (streamer)
         │ nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
@@ -319,7 +319,7 @@ regions: <hidden>
 • limit
 │ count: 1
 │
-└── • lookup join
+└── • lookup join (streamer)
     │ nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 1
@@ -409,7 +409,7 @@ regions: <hidden>
 • limit
 │ count: 2
 │
-└── • lookup join
+└── • lookup join (streamer)
     │ nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -75,7 +75,7 @@ maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
 ·
-• lookup join
+• lookup join (streamer)
 │ nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
@@ -102,7 +102,7 @@ regions: <hidden>
       table: c@sec
       spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0U9Fq1EAUffcrLvdJYdwmeRAZEBZDha3tpmxLXyTIZOayxp3MjZkJ7rLsZ_kDfplkpoXWtaJiH8-Zc-89nMPs0X-xKPHq9Py0vAY9U_BuVV2AhrNqsQQD1RLMrIE3oGcNCnRsaKk68ig_YI61wH5gTd7zMFH7KFiYLcpMYOv6MUx0LVDzQCj3GNpgCSVeq8bSipSh4SRDgYaCam1cq-eeNAos2Y6d8xKUgOn2Va8m9BIFvr-B0HYkIfv-zSes2QVyoWV39DTwVw8DKSOhSEyzC3RH5a_gbWLXq8sStLLWJ-HFTVmCD9SD5tEFeE7bcNK68EJCFk0nAdHmMUGnttBRx8MOlLWsVSAjIYsHGxX0J_LAY-jHIGHSR6d3RIH1QWBCtyn6oNaEMj-IP0_6jFt3G3T-MGgzNx_7De1Q4DnzZuzhM7cO2EmYF_cLmNKvJkvzaUM8FkNNMSXsg7L2KPp_ayk_bun1r0rK_0tJtCU9Hlt6ou6Kv-luRb5n5-lBb49tzg61QDJrSj_R8zhouhxYxzMJVnEuEoZ8SK95AguXniaD94fz3w4XPw3Xh2c_AgAA__-952K3
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0U9FqE0EUffcrLvdJYUx38yAyIARDhdQ2KWnpiwSZnbnENbNz15m7mBDyWf6AXya700JrrKjYx3Pm3HsP5zB7TF88arw6PT-dXoMdGXi3XFyAhbPFbA4OFnNwowregB1VqDCwo7lpKKH-gCWuFLaRLaXEsaf2g2DmtqgLhXVoO-nplULLkVDvUWrxhBqvTeVpScZRPClQoSMxtR_W2kkiiwqn7LsmJA1GQX_7qjU9eokK39-A1A1pKL5_SxlbDkJBag5HT5G_JohknIZxZqqd0B1VvoK3mV0vL6dgjfcpCy9uplNIQi1Y7oLAc9rKSR3khYZiMJ0FRJvHBI3ZQkMNxx0Y79kaIaehGA5WRuwnSsCdtJ1o6PWD0ztijKuDwoxuU0xi1oS6PKg_T_qM63AbdPkwaDdxH9sN7VDhOfOma-Ez1wE4aJiM7xfQp7_oLU36DcOxIdQcU8ZJjPdH0f9bS-VxS69_VVL5X0rqEjlIEsk0FFEhbcl2xxafqMvx33S5pNRySPSgx8c2F4eVQnJryj8zcRctXUa2w5kMF8PcQDhKkl_LDGYhP_UG7w-Xvx0e_zS8Ojz7EQAA__9vVGhb
 
 query T
 EXPLAIN (OPT, VERBOSE) SELECT c.a FROM c INNER MERGE JOIN d ON c.a = d.b

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -176,7 +176,15 @@ func makeEmitter(ob *OutputBuilder, spanFormatFn SpanFormatFn) emitter {
 	return emitter{ob: ob, spanFormatFn: spanFormatFn}
 }
 
-func (e *emitter) nodeName(n *Node) (string, error) {
+func (e *emitter) nodeName(n *Node) (name string, _ error) {
+	defer func() {
+		if stats, ok := n.annotations[exec.ExecutionStatsID]; ok && !omitStats(n) {
+			if stats.(*exec.ExecutionStats).UsedStreamer {
+				name += " (streamer)"
+			}
+		}
+	}()
+
 	switch n.op {
 	case scanOp:
 		a := n.args.(*scanArgs)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -336,6 +336,7 @@ type ExecutionStats struct {
 	KVBytesRead           optional.Uint
 	KVRowsRead            optional.Uint
 	KVBatchRequestsIssued optional.Uint
+	UsedStreamer          bool
 
 	StepCount         optional.Uint
 	InternalStepCount optional.Uint

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1178,6 +1178,7 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 			KVTime:              fis.WaitTime,
 			ContentionTime:      optional.MakeTimeValue(execstats.GetCumulativeContentionTime(jr.Ctx(), jr.ExecStatsTrace)),
 			BatchRequestsIssued: optional.MakeUint(uint64(jr.fetcher.GetBatchRequestsIssued())),
+			UsedStreamer:        jr.usesStreamer,
 		},
 		Output: jr.OutputHelper.Stats(),
 	}


### PR DESCRIPTION
Backport 1/1 commits from #105865.

/cc @cockroachdb/release

---

This commit extends EXPLAIN ANALYZE for index and lookup joins to indicate whether the streamer API was used internally. Currently, to use the streamer or not is decided at the execution time, so it's only available in EXPLAIN ANALYZE flavors of EXPLAIN. Previously, this information could only be deduced from the trace and required non-trivial knowledge of what to look for.

This should make it easier to debug things, and the primary audience of this information are CRDB devs, thus, I omitted the release note.

Epic: None

Release note: None

Release justification: low-risk observability improvement.