### PR TITLE
ui: show requested stmnt diagnostics results on statements page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -398,6 +398,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   onChangeLimit: noop,
   onChangeReqSort: noop,
   onApplySearchCriteria: noop,
+  statementDiagnostics: [],
 };
 
 export const statementsPagePropsWithRequestError: StatementsPageProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -10,7 +10,7 @@
 
 import React from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { flatMap, merge } from "lodash";
+import { flatMap, merge, groupBy } from "lodash";
 import classNames from "classnames/bind";
 import { getValidErrorsList, Loading } from "src/loading";
 import { Delayed } from "src/delayed";
@@ -78,6 +78,7 @@ import {
   InsertStmtDiagnosticRequest,
   StatementDiagnosticsReport,
   SqlStatsResponse,
+  StatementDiagnosticsResponse,
 } from "../api";
 import {
   filteredStatementsData,
@@ -150,6 +151,7 @@ export interface StatementsPageStateProps {
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
   hasAdminRole?: UIConfigState["hasAdminRole"];
   stmtsTotalRuntimeSecs: number;
+  statementDiagnostics: StatementDiagnosticsResponse | null;
 }
 
 export interface StatementsPageState {
@@ -709,10 +711,21 @@ export class StatementsPage extends React.Component<
       refreshStatementDiagnosticsRequests,
       onActivateStatementDiagnostics,
       onDiagnosticsModalOpen,
+      statementDiagnostics,
     } = this.props;
+
+    const diagnosticsByStatement = groupBy(
+      statementDiagnostics,
+      sd => sd.statement_fingerprint,
+    );
 
     const statements = convertRawStmtsToAggregateStatisticsMemoized(
       this.props.statementsResponse?.data?.statements,
+    ).map(
+      (s): AggregateStatistics => ({
+        ...s,
+        diagnosticsReports: diagnosticsByStatement[s.label] || [],
+      }),
     );
 
     const longLoadingMessage = (

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -100,6 +100,7 @@ export const ConnectedStatementsPage = withRouter(
         stmtsTotalRuntimeSecs:
           state.adminUI?.statements?.data?.stmts_total_runtime_secs ?? 0,
         statementsResponse: state.adminUI.statements,
+        statementDiagnostics: state.adminUI.statementDiagnostics?.data,
       },
       activePageProps: mapStateToActiveStatementsPageProps(state),
     }),

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -209,6 +209,11 @@ type DispatchProps = {
 const selectStatements =
   createSelectorForCachedDataField<api.SqlStatsResponse>("statements");
 
+const selectStatementDiagnostics =
+  createSelectorForCachedDataField<api.StatementDiagnosticsResponse>(
+    "statementDiagnosticsReports",
+  );
+
 export default withRouter(
   connect<
     StateProps,
@@ -233,6 +238,7 @@ export default withRouter(
         stmtsTotalRuntimeSecs:
           state.cachedData?.statements?.data?.stmts_total_runtime_secs ?? 0,
         statementsResponse: selectStatements(state),
+        statementDiagnostics: selectStatementDiagnostics(state)?.data,
       },
       activePageProps: mapStateToActiveStatementViewProps(state),
     }),


### PR DESCRIPTION
Before, statements page didnt show the status and results of requested statement diagnostics on Statements page only due to some regression.

This change extends Statements page to accept list of statement diagnostics and provide this data to show per statement diagnostics.

Release note: None

Resolves: #106148

#### Db console
![Screenshot 2023-07-06 at 02 25 42](https://github.com/cockroachdb/cockroach/assets/3106437/869dfa13-416f-4ca6-915d-fbf6611f924d)

#### CC Console
![Screenshot 2023-07-06 at 02 16 34](https://github.com/cockroachdb/cockroach/assets/3106437/9734975a-7475-46e2-b81e-0e1e1de982e9)
