### PR TITLE
admission: avoid recursive grant chain

### DIFF
--- a/pkg/kv/kvserver/testdata/flow_control_integration/granter_admit_one_by_one
+++ b/pkg/kv/kvserver/testdata/flow_control_integration/granter_admit_one_by_one
@@ -1,0 +1,58 @@
+echo
+----
+----
+-- (Issuing regular 1024*1KiB, 3x replicated writes that are not admitted.)
+
+
+-- Flow token metrics from n1 after issuing 1024KiB, i.e. 1MiB 3x replicated writes
+-- that are yet to get admitted. We see 3*1MiB=3MiB deductions of
+-- {regular,elastic} tokens with no corresponding returns.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvadmission%tokens%'
+ORDER BY name ASC;
+
+  kvadmission.flow_controller.elastic_tokens_available   | 21 MiB   
+  kvadmission.flow_controller.elastic_tokens_deducted    | 3.0 MiB  
+  kvadmission.flow_controller.elastic_tokens_returned    | 0 B      
+  kvadmission.flow_controller.elastic_tokens_unaccounted | 0 B      
+  kvadmission.flow_controller.regular_tokens_available   | 45 MiB   
+  kvadmission.flow_controller.regular_tokens_deducted    | 3.0 MiB  
+  kvadmission.flow_controller.regular_tokens_returned    | 0 B      
+  kvadmission.flow_controller.regular_tokens_unaccounted | 0 B      
+
+
+-- Observe the total tracked tokens per-stream on n1.
+SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles
+
+  range_id | store_id | total_tracked_tokens  
+-----------+----------+-----------------------
+  64       | 1        | 1.0 MiB               
+  64       | 2        | 1.0 MiB               
+  64       | 3        | 1.0 MiB               
+
+
+-- (Allow below-raft admission to proceed.)
+
+
+-- Flow token metrics from n1 after work gets admitted. We see 3MiB returns of
+-- {regular,elastic} tokens, and the available capacities going back to what
+-- they were. In #105185, by now we would've observed panics.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvadmission%tokens%'
+ORDER BY name ASC;
+
+  kvadmission.flow_controller.elastic_tokens_available   | 24 MiB   
+  kvadmission.flow_controller.elastic_tokens_deducted    | 3.0 MiB  
+  kvadmission.flow_controller.elastic_tokens_returned    | 3.0 MiB  
+  kvadmission.flow_controller.elastic_tokens_unaccounted | 0 B      
+  kvadmission.flow_controller.regular_tokens_available   | 48 MiB   
+  kvadmission.flow_controller.regular_tokens_deducted    | 3.0 MiB  
+  kvadmission.flow_controller.regular_tokens_returned    | 3.0 MiB  
+  kvadmission.flow_controller.regular_tokens_unaccounted | 0 B      
+----
+----
+
+# vim:ft=sql

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -143,6 +143,7 @@ func TestGranterBasic(t *testing.T) {
 				kvIOTotalTokensTaken:            metrics.KVIOTotalTokensTaken,
 				workQueueMetrics:                workQueueMetrics,
 				disableTickerForTesting:         true,
+				knobs:                           &TestingKnobs{},
 			}
 			var metricsProvider testMetricsProvider
 			metricsProvider.setMetricsForStores([]int32{1}, pebble.Metrics{})

--- a/pkg/util/admission/testing_knobs.go
+++ b/pkg/util/admission/testing_knobs.go
@@ -38,6 +38,10 @@ type TestingKnobs struct {
 	// DisableWorkQueueGranting disables the work queue from granting admission
 	// to waiting work.
 	DisableWorkQueueGranting func() bool
+
+	// AlwaysTryGrantWhenAdmitted causes the granter to unconditionally try
+	// admitting another request when admitting one.
+	AlwaysTryGrantWhenAdmitted bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Fixes #105185.
Fixes #105613.

In #97599 we introduced a non-blocking admission interface for below-raft, replication admission control. When doing so, we unintentionally violated the 'requester' interface -- when 'requester.granted()' is invoked, the granter expects to admit a single queued request. The code layering made it so that after granting one, when doing post-hoc token adjustments, if we observed the granter was exhausted but now no longer was so, we'd try to grant again. This resulted in admitting work recursively, with a callstack as deep as the admit chain.

Not only is that undesirable design-wise, it also triggered panics in the granter that wasn't expecting more than one request being admitted. Recursively we were incrementing the grant chain index, which overflowed (it was in int8, so happened readily with long enough admit chains), after which we panic-ed when using a negative index to access an array.

We add a test that fails without the changes. The failure can also be triggered by applying the diff below (which reverts to the older, buggy behavior):
```
dev test pkg/kv/kvserver -f TestFlowControlGranterAdmitOneByOne -v --show-logs
```

```diff
diff --git i/pkg/util/admission/granter.go w/pkg/util/admission/granter.go
index ba42213c375..7c526fbb3d8 100644
--- i/pkg/util/admission/granter.go
+++ w/pkg/util/admission/granter.go
@@ -374,7 +374,7 @@ func (cg *kvStoreTokenChildGranter) storeWriteDone(
 func (cg *kvStoreTokenChildGranter) storeReplicatedWorkAdmittedLocked(
        originalTokens int64, admittedInfo storeReplicatedWorkAdmittedInfo,
 ) (additionalTokens int64) {
-       return cg.parent.storeReplicatedWorkAdmittedLocked(cg.workClass, originalTokens, admittedInfo, false /* canGrantAnother */)
+       return cg.parent.storeReplicatedWorkAdmittedLocked(cg.workClass, originalTokens, admittedInfo, true /* canGrantAnother */)
 }
```
Release note: None