### PR TITLE
pg_class: populate pg_class.relreplident

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -657,38 +657,38 @@ t6_expr_idx1       false      i        1         0          false       false
 mv1                false      m        2         0          false       true
 mv1_pkey           false      i        1         0          false       false
 
-query TBBBITT colnames,rowsort
-SELECT relname, relhasrules, relhastriggers, relhassubclass, relfrozenxid, relacl, reloptions
+query TBBBITTT colnames,rowsort
+SELECT relname, relhasrules, relhastriggers, relhassubclass, relfrozenxid, relacl, reloptions, relreplident
 FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-relname            relhasrules  relhastriggers  relhassubclass  relfrozenxid  relacl  reloptions
-t1                 false        false           false           0             NULL    NULL
-t1_pkey            false        false           false           0             NULL    NULL
-t1_a_key           false        false           false           0             NULL    NULL
-index_key          false        false           false           0             NULL    NULL
-t1_m_seq           false        false           false           0             NULL    NULL
-t1_n_seq           false        false           false           0             NULL    NULL
-t2                 false        false           false           0             NULL    NULL
-t2_pkey            false        false           false           0             NULL    NULL
-t2_t1_id_idx       false        false           false           0             NULL    NULL
-t3                 false        false           false           0             NULL    NULL
-t3_pkey            false        false           false           0             NULL    NULL
-t3_a_b_idx         false        false           false           0             NULL    NULL
-v1                 false        false           false           0             NULL    NULL
-t4                 false        false           false           0             NULL    NULL
-t4_pkey            false        false           false           0             NULL    NULL
-t5                 false        false           false           0             NULL    NULL
-t5_pkey            false        false           false           0             NULL    NULL
-t6                 false        false           false           0             NULL    NULL
-t6_pkey            false        false           false           0             NULL    NULL
-t6_expr_idx        false        false           false           0             NULL    NULL
-t6_expr_expr1_idx  false        false           false           0             NULL    NULL
-t6_expr_key        false        false           false           0             NULL    NULL
-t6_expr_idx1       false        false           false           0             NULL    NULL
-mv1                false        false           false           0             NULL    NULL
-mv1_pkey           false        false           false           0             NULL    NULL
+relname            relhasrules  relhastriggers  relhassubclass  relfrozenxid  relacl  reloptions  relreplident
+t1                 false        false           false           0             NULL    NULL        d
+t1_pkey            false        false           false           0             NULL    NULL        n
+t1_a_key           false        false           false           0             NULL    NULL        n
+index_key          false        false           false           0             NULL    NULL        n
+t1_m_seq           false        false           false           0             NULL    NULL        n
+t1_n_seq           false        false           false           0             NULL    NULL        n
+t2                 false        false           false           0             NULL    NULL        d
+t2_pkey            false        false           false           0             NULL    NULL        n
+t2_t1_id_idx       false        false           false           0             NULL    NULL        n
+t3                 false        false           false           0             NULL    NULL        d
+t3_pkey            false        false           false           0             NULL    NULL        n
+t3_a_b_idx         false        false           false           0             NULL    NULL        n
+v1                 false        false           false           0             NULL    NULL        n
+t4                 false        false           false           0             NULL    NULL        d
+t4_pkey            false        false           false           0             NULL    NULL        n
+t5                 false        false           false           0             NULL    NULL        d
+t5_pkey            false        false           false           0             NULL    NULL        n
+t6                 false        false           false           0             NULL    NULL        d
+t6_pkey            false        false           false           0             NULL    NULL        n
+t6_expr_idx        false        false           false           0             NULL    NULL        n
+t6_expr_expr1_idx  false        false           false           0             NULL    NULL        n
+t6_expr_key        false        false           false           0             NULL    NULL        n
+t6_expr_idx1       false        false           false           0             NULL    NULL        n
+mv1                false        false           false           0             NULL    NULL        d
+mv1_pkey           false        false           false           0             NULL    NULL        n
 
 ## pg_catalog.pg_attribute
 
@@ -924,20 +924,20 @@ CREATE MATERIALIZED VIEW mv_test AS SELECT 1
 statement ok
 CREATE SEQUENCE seq_test
 
-query TT
-SELECT relname, relkind
+query TTT
+SELECT relname, relkind, relreplident
 FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ORDER BY relname
 ----
-mv_test         m
-mv_test_pkey    i
-seq_test        S
-tbl_test        r
-tbl_test_pkey   i
-tbl_test_v_idx  i
-view_test       v
+mv_test         m  d
+mv_test_pkey    i  n
+seq_test        S  n
+tbl_test        r  d
+tbl_test_pkey   i  n
+tbl_test_v_idx  i  n
+view_test       v  n
 
 statement ok
 DROP DATABASE relkinds

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -664,15 +664,19 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 		// The only difference between tables, views and sequences are the relkind and relam columns.
 		relKind := relKindTable
 		relAm := forwardIndexOid
+		replIdent := "d" // default;
 		if table.IsView() {
 			relKind = relKindView
 			if table.MaterializedView() {
 				relKind = relKindMaterializedView
+			} else {
+				replIdent = "n"
 			}
 			relAm = oidZero
 		} else if table.IsSequence() {
 			relKind = relKindSequence
 			relAm = oidZero
+			replIdent = "n"
 		}
 		relPersistence := relPersistencePermanent
 		if table.IsTemporary() {
@@ -724,13 +728,13 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 			tree.DNull,      // relacl
 			relOptions,      // reloptions
 			// These columns were automatically created by pg_catalog_test's missing column generator.
-			tree.DNull, // relforcerowsecurity
-			tree.DNull, // relispartition
-			tree.DNull, // relispopulated
-			tree.DNull, // relreplident
-			tree.DNull, // relrewrite
-			tree.DNull, // relrowsecurity
-			tree.DNull, // relpartbound
+			tree.DNull,                 // relforcerowsecurity
+			tree.DNull,                 // relispartition
+			tree.DNull,                 // relispopulated
+			tree.NewDString(replIdent), // relreplident
+			tree.DNull,                 // relrewrite
+			tree.DNull,                 // relrowsecurity
+			tree.DNull,                 // relpartbound
 			// These columns were automatically created by pg_catalog_test's missing column generator.
 			tree.DNull, // relminmxid
 		); err != nil {
@@ -784,13 +788,13 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 				tree.DNull,      // relacl
 				tree.DNull,      // reloptions
 				// These columns were automatically created by pg_catalog_test's missing column generator.
-				tree.DNull, // relforcerowsecurity
-				tree.DNull, // relispartition
-				tree.DNull, // relispopulated
-				tree.DNull, // relreplident
-				tree.DNull, // relrewrite
-				tree.DNull, // relrowsecurity
-				tree.DNull, // relpartbound
+				tree.DNull,           // relforcerowsecurity
+				tree.DNull,           // relispartition
+				tree.DNull,           // relispopulated
+				tree.NewDString("n"), // relreplident
+				tree.DNull,           // relrewrite
+				tree.DNull,           // relrowsecurity
+				tree.DNull,           // relpartbound
 				// These columns were automatically created by pg_catalog_test's missing column generator.
 				tree.DNull, // relminmxid
 			)


### PR DESCRIPTION
Release note (sql change): pg_class's relreplident field was previously unpopulated. It is now populated with `d` for all tables (as each table has a primary key) and n otherwise.

Informs: #84505