### PR TITLE
test: improve error messages

### DIFF
--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -59,13 +59,13 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 		"FROM system.public.transaction_activity")
 	err := row.Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, 0, count, "transaction_activity: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "system.transaction_activity: expect:0, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
 		"FROM system.public.statement_activity")
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, 0, count, "statement_activity: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "system.statement_activity: expect:0, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
 		"FROM system.public.jobs WHERE job_type = 'AUTO UPDATE SQL ACTIVITY' and id = 103 ")
@@ -77,13 +77,13 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 		"FROM system.public.transaction_statistics")
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, 0, count, "transaction_statistics: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "system.transaction_statistics: expect:0, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
 		"FROM system.public.statement_statistics")
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, 0, count, "statement_statistics: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "system.statement_statistics: expect:0, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() FROM crdb_internal.transaction_activity")
 	err = row.Scan(&count)
@@ -109,13 +109,13 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 		"FROM system.public.transaction_activity")
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, 0, count, "transaction_activity: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "system.transaction_activity: expect:0, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
 		"FROM system.public.statement_activity")
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, 0, count, "statement_activity: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "system.statement_activity: expect:0, actual:%d", count)
 
 	appName := "TestSqlActivityUpdateJob"
 	_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", appName)
@@ -171,25 +171,25 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 		"FROM system.public.transaction_activity WHERE app_name = $1", appName)
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, count, 1, "transaction_activity after transfer: expect:1, actual:%d", count)
+	require.Equal(t, count, 1, "system.transaction_activity after transfer: expect:1, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
 		"FROM system.public.statement_activity WHERE app_name = $1", appName)
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, count, 1, "statement_activity after transfer: expect:1, actual:%d", count)
+	require.Equal(t, count, 1, "system.statement_activity after transfer: expect:1, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
 		"FROM crdb_internal.transaction_activity WHERE app_name = $1", appName)
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, count, 1, "transaction_activity after transfer: expect:1, actual:%d", count)
+	require.Equal(t, count, 1, "crdb_internal.transaction_activity after transfer: expect:1, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
 		"FROM crdb_internal.statement_activity WHERE app_name = $1", appName)
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, count, 1, "statement_activity after transfer: expect:1, actual:%d", count)
+	require.Equal(t, count, 1, "crdb_internal.statement_activity after transfer: expect:1, actual:%d", count)
 
 	// Reset the stats and verify it's empty
 	_, err = db.ExecContext(ctx, "SELECT crdb_internal.reset_sql_stats()")
@@ -199,25 +199,25 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 		"FROM system.public.transaction_activity")
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Zero(t, count, "transaction_activity after transfer: expect:0, actual:%d", count)
+	require.Zero(t, count, "system.transaction_activity after transfer: expect:0, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
 		"FROM system.public.statement_activity")
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Zero(t, count, "statement_activity after transfer: expect:0, actual:%d", count)
+	require.Zero(t, count, "system.statement_activity after transfer: expect:0, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
 		"FROM crdb_internal.transaction_activity")
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Zero(t, count, "transaction_activity after transfer: expect:0, actual:%d", count)
+	require.Zero(t, count, "crdb_internal.transaction_activity after transfer: expect:0, actual:%d", count)
 
 	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
 		"FROM crdb_internal.statement_activity")
 	err = row.Scan(&count)
 	require.NoError(t, err)
-	require.Zero(t, count, "statement_activity after transfer: expect:0, actual:%d", count)
+	require.Zero(t, count, "crdb_internal.statement_activity after transfer: expect:0, actual:%d", count)
 }
 
 // TestSqlActivityUpdateJob verifies that the


### PR DESCRIPTION
Clarify the tables on the error messages from the test `TestSqlActivityUpdateJob`, so when it fails is a little easier to understand the source.

Part of #104769

Release note: None