### PR TITLE
server: don't print trace if empty

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1315,8 +1315,11 @@ func (n *Node) batchInternal(
 	// the request was doing at the time it noticed the cancellation.
 	if pErr != nil && ctx.Err() != nil {
 		if sp := tracing.SpanFromContext(ctx); sp != nil && !sp.IsNoop() {
-			log.Infof(ctx, "batch request %s failed with error: %s\ntrace:\n%s", args.String(),
-				pErr.GoError().Error(), sp.GetConfiguredRecording().String())
+			recording := sp.GetConfiguredRecording()
+			if recording.Len() != 0 {
+				log.Infof(ctx, "batch request %s failed with error: %v\ntrace:\n%s", args.String(),
+					pErr.GoError(), recording)
+			}
 		}
 	}
 


### PR DESCRIPTION
This change adds a conditional to only print the
trace of context cancelled request if the trace is not empty. This avoids log spam noticed in #105378.

Fixes: #105378
Release note: None