### PR TITLE
cli/zip: Use "cluster" to identify the logical cluster instead of "tenant"

### DIFF
--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization
@@ -124,157 +124,157 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
 [cluster] establishing RPC connection to ...
 [cluster] using SQL address: ...
-[cluster] requesting data for debug/virtual/test-tenant/events... received response... writing JSON output: debug/virtual/test-tenant/events.json... done
-[cluster] requesting data for debug/virtual/test-tenant/rangelog... received response... writing JSON output: debug/virtual/test-tenant/rangelog.json... done
-[cluster] requesting data for debug/virtual/test-tenant/settings... received response... writing JSON output: debug/virtual/test-tenant/settings.json... done
-[cluster] requesting data for debug/virtual/test-tenant/reports/problemranges... received response...
-[cluster] requesting data for debug/virtual/test-tenant/reports/problemranges: last request failed: rpc error: ...
-[cluster] requesting data for debug/virtual/test-tenant/reports/problemranges: creating error output: debug/virtual/test-tenant/reports/problemranges.json.err.txt... done
-[cluster] retrieving SQL data for "".crdb_internal.create_function_statements... writing output: debug/virtual/test-tenant/crdb_internal.create_function_statements.json... done
-[cluster] retrieving SQL data for "".crdb_internal.create_schema_statements... writing output: debug/virtual/test-tenant/crdb_internal.create_schema_statements.json... done
-[cluster] retrieving SQL data for "".crdb_internal.create_statements... writing output: debug/virtual/test-tenant/crdb_internal.create_statements.json... done
-[cluster] retrieving SQL data for "".crdb_internal.create_type_statements... writing output: debug/virtual/test-tenant/crdb_internal.create_type_statements.json... done
-[cluster] retrieving SQL data for crdb_internal.cluster_contention_events... writing output: debug/virtual/test-tenant/crdb_internal.cluster_contention_events.json... done
-[cluster] retrieving SQL data for crdb_internal.cluster_database_privileges... writing output: debug/virtual/test-tenant/crdb_internal.cluster_database_privileges.json... done
-[cluster] retrieving SQL data for crdb_internal.cluster_distsql_flows... writing output: debug/virtual/test-tenant/crdb_internal.cluster_distsql_flows.json... done
-[cluster] retrieving SQL data for crdb_internal.cluster_execution_insights... writing output: debug/virtual/test-tenant/crdb_internal.cluster_execution_insights.json... done
-[cluster] retrieving SQL data for crdb_internal.cluster_locks... writing output: debug/virtual/test-tenant/crdb_internal.cluster_locks.json... done
-[cluster] retrieving SQL data for crdb_internal.cluster_queries... writing output: debug/virtual/test-tenant/crdb_internal.cluster_queries.json... done
-[cluster] retrieving SQL data for crdb_internal.cluster_sessions... writing output: debug/virtual/test-tenant/crdb_internal.cluster_sessions.json... done
-[cluster] retrieving SQL data for crdb_internal.cluster_settings... writing output: debug/virtual/test-tenant/crdb_internal.cluster_settings.json... done
-[cluster] retrieving SQL data for crdb_internal.cluster_transactions... writing output: debug/virtual/test-tenant/crdb_internal.cluster_transactions.json... done
-[cluster] retrieving SQL data for crdb_internal.cluster_txn_execution_insights... writing output: debug/virtual/test-tenant/crdb_internal.cluster_txn_execution_insights.json... done
-[cluster] retrieving SQL data for crdb_internal.default_privileges... writing output: debug/virtual/test-tenant/crdb_internal.default_privileges.json... done
-[cluster] retrieving SQL data for crdb_internal.index_usage_statistics... writing output: debug/virtual/test-tenant/crdb_internal.index_usage_statistics.json... done
-[cluster] retrieving SQL data for crdb_internal.invalid_objects... writing output: debug/virtual/test-tenant/crdb_internal.invalid_objects.json... done
-[cluster] retrieving SQL data for crdb_internal.jobs... writing output: debug/virtual/test-tenant/crdb_internal.jobs.json... done
-[cluster] retrieving SQL data for crdb_internal.kv_node_liveness... writing output: debug/virtual/test-tenant/crdb_internal.kv_node_liveness.json...
+[cluster] requesting data for debug/cluster/test-tenant/events... received response... writing JSON output: debug/cluster/test-tenant/events.json... done
+[cluster] requesting data for debug/cluster/test-tenant/rangelog... received response... writing JSON output: debug/cluster/test-tenant/rangelog.json... done
+[cluster] requesting data for debug/cluster/test-tenant/settings... received response... writing JSON output: debug/cluster/test-tenant/settings.json... done
+[cluster] requesting data for debug/cluster/test-tenant/reports/problemranges... received response...
+[cluster] requesting data for debug/cluster/test-tenant/reports/problemranges: last request failed: rpc error: ...
+[cluster] requesting data for debug/cluster/test-tenant/reports/problemranges: creating error output: debug/cluster/test-tenant/reports/problemranges.json.err.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_function_statements... writing output: debug/cluster/test-tenant/crdb_internal.create_function_statements.json... done
+[cluster] retrieving SQL data for "".crdb_internal.create_schema_statements... writing output: debug/cluster/test-tenant/crdb_internal.create_schema_statements.json... done
+[cluster] retrieving SQL data for "".crdb_internal.create_statements... writing output: debug/cluster/test-tenant/crdb_internal.create_statements.json... done
+[cluster] retrieving SQL data for "".crdb_internal.create_type_statements... writing output: debug/cluster/test-tenant/crdb_internal.create_type_statements.json... done
+[cluster] retrieving SQL data for crdb_internal.cluster_contention_events... writing output: debug/cluster/test-tenant/crdb_internal.cluster_contention_events.json... done
+[cluster] retrieving SQL data for crdb_internal.cluster_database_privileges... writing output: debug/cluster/test-tenant/crdb_internal.cluster_database_privileges.json... done
+[cluster] retrieving SQL data for crdb_internal.cluster_distsql_flows... writing output: debug/cluster/test-tenant/crdb_internal.cluster_distsql_flows.json... done
+[cluster] retrieving SQL data for crdb_internal.cluster_execution_insights... writing output: debug/cluster/test-tenant/crdb_internal.cluster_execution_insights.json... done
+[cluster] retrieving SQL data for crdb_internal.cluster_locks... writing output: debug/cluster/test-tenant/crdb_internal.cluster_locks.json... done
+[cluster] retrieving SQL data for crdb_internal.cluster_queries... writing output: debug/cluster/test-tenant/crdb_internal.cluster_queries.json... done
+[cluster] retrieving SQL data for crdb_internal.cluster_sessions... writing output: debug/cluster/test-tenant/crdb_internal.cluster_sessions.json... done
+[cluster] retrieving SQL data for crdb_internal.cluster_settings... writing output: debug/cluster/test-tenant/crdb_internal.cluster_settings.json... done
+[cluster] retrieving SQL data for crdb_internal.cluster_transactions... writing output: debug/cluster/test-tenant/crdb_internal.cluster_transactions.json... done
+[cluster] retrieving SQL data for crdb_internal.cluster_txn_execution_insights... writing output: debug/cluster/test-tenant/crdb_internal.cluster_txn_execution_insights.json... done
+[cluster] retrieving SQL data for crdb_internal.default_privileges... writing output: debug/cluster/test-tenant/crdb_internal.default_privileges.json... done
+[cluster] retrieving SQL data for crdb_internal.index_usage_statistics... writing output: debug/cluster/test-tenant/crdb_internal.index_usage_statistics.json... done
+[cluster] retrieving SQL data for crdb_internal.invalid_objects... writing output: debug/cluster/test-tenant/crdb_internal.invalid_objects.json... done
+[cluster] retrieving SQL data for crdb_internal.jobs... writing output: debug/cluster/test-tenant/crdb_internal.jobs.json... done
+[cluster] retrieving SQL data for crdb_internal.kv_node_liveness... writing output: debug/cluster/test-tenant/crdb_internal.kv_node_liveness.json...
 [cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
-[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: creating error output: debug/virtual/test-tenant/crdb_internal.kv_node_liveness.json.err.txt... done
-[cluster] retrieving SQL data for crdb_internal.kv_node_status... writing output: debug/virtual/test-tenant/crdb_internal.kv_node_status.json...
+[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: creating error output: debug/cluster/test-tenant/crdb_internal.kv_node_liveness.json.err.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_node_status... writing output: debug/cluster/test-tenant/crdb_internal.kv_node_status.json...
 [cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
-[cluster] retrieving SQL data for crdb_internal.kv_node_status: creating error output: debug/virtual/test-tenant/crdb_internal.kv_node_status.json.err.txt... done
-[cluster] retrieving SQL data for crdb_internal.kv_store_status... writing output: debug/virtual/test-tenant/crdb_internal.kv_store_status.json...
+[cluster] retrieving SQL data for crdb_internal.kv_node_status: creating error output: debug/cluster/test-tenant/crdb_internal.kv_node_status.json.err.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_store_status... writing output: debug/cluster/test-tenant/crdb_internal.kv_store_status.json...
 [cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
-[cluster] retrieving SQL data for crdb_internal.kv_store_status: creating error output: debug/virtual/test-tenant/crdb_internal.kv_store_status.json.err.txt... done
-[cluster] retrieving SQL data for crdb_internal.kv_system_privileges... writing output: debug/virtual/test-tenant/crdb_internal.kv_system_privileges.json... done
-[cluster] retrieving SQL data for crdb_internal.partitions... writing output: debug/virtual/test-tenant/crdb_internal.partitions.json... done
-[cluster] retrieving SQL data for crdb_internal.regions... writing output: debug/virtual/test-tenant/crdb_internal.regions.json... done
-[cluster] retrieving SQL data for crdb_internal.schema_changes... writing output: debug/virtual/test-tenant/crdb_internal.schema_changes.json... done
-[cluster] retrieving SQL data for crdb_internal.super_regions... writing output: debug/virtual/test-tenant/crdb_internal.super_regions.json... done
-[cluster] retrieving SQL data for crdb_internal.system_jobs... writing output: debug/virtual/test-tenant/crdb_internal.system_jobs.json... done
-[cluster] retrieving SQL data for crdb_internal.table_indexes... writing output: debug/virtual/test-tenant/crdb_internal.table_indexes.json... done
-[cluster] retrieving SQL data for crdb_internal.transaction_contention_events... writing output: debug/virtual/test-tenant/crdb_internal.transaction_contention_events.json... done
-[cluster] retrieving SQL data for crdb_internal.zones... writing output: debug/virtual/test-tenant/crdb_internal.zones.json... done
-[cluster] retrieving SQL data for system.database_role_settings... writing output: debug/virtual/test-tenant/system.database_role_settings.json... done
-[cluster] retrieving SQL data for system.descriptor... writing output: debug/virtual/test-tenant/system.descriptor.json... done
-[cluster] retrieving SQL data for system.eventlog... writing output: debug/virtual/test-tenant/system.eventlog.json... done
-[cluster] retrieving SQL data for system.external_connections... writing output: debug/virtual/test-tenant/system.external_connections.json... done
-[cluster] retrieving SQL data for system.job_info... writing output: debug/virtual/test-tenant/system.job_info.json... done
-[cluster] retrieving SQL data for system.jobs... writing output: debug/virtual/test-tenant/system.jobs.json... done
-[cluster] retrieving SQL data for system.lease... writing output: debug/virtual/test-tenant/system.lease.json... done
-[cluster] retrieving SQL data for system.locations... writing output: debug/virtual/test-tenant/system.locations.json... done
-[cluster] retrieving SQL data for system.migrations... writing output: debug/virtual/test-tenant/system.migrations.json... done
-[cluster] retrieving SQL data for system.namespace... writing output: debug/virtual/test-tenant/system.namespace.json... done
-[cluster] retrieving SQL data for system.privileges... writing output: debug/virtual/test-tenant/system.privileges.json... done
-[cluster] retrieving SQL data for system.protected_ts_meta... writing output: debug/virtual/test-tenant/system.protected_ts_meta.json... done
-[cluster] retrieving SQL data for system.protected_ts_records... writing output: debug/virtual/test-tenant/system.protected_ts_records.json... done
-[cluster] retrieving SQL data for system.rangelog... writing output: debug/virtual/test-tenant/system.rangelog.json... done
-[cluster] retrieving SQL data for system.replication_constraint_stats... writing output: debug/virtual/test-tenant/system.replication_constraint_stats.json... done
-[cluster] retrieving SQL data for system.replication_critical_localities... writing output: debug/virtual/test-tenant/system.replication_critical_localities.json... done
-[cluster] retrieving SQL data for system.replication_stats... writing output: debug/virtual/test-tenant/system.replication_stats.json... done
-[cluster] retrieving SQL data for system.reports_meta... writing output: debug/virtual/test-tenant/system.reports_meta.json... done
-[cluster] retrieving SQL data for system.role_id_seq... writing output: debug/virtual/test-tenant/system.role_id_seq.json... done
-[cluster] retrieving SQL data for system.role_members... writing output: debug/virtual/test-tenant/system.role_members.json... done
-[cluster] retrieving SQL data for system.role_options... writing output: debug/virtual/test-tenant/system.role_options.json... done
-[cluster] retrieving SQL data for system.scheduled_jobs... writing output: debug/virtual/test-tenant/system.scheduled_jobs.json... done
-[cluster] retrieving SQL data for system.settings... writing output: debug/virtual/test-tenant/system.settings.json... done
-[cluster] retrieving SQL data for system.span_configurations... writing output: debug/virtual/test-tenant/system.span_configurations.json...
+[cluster] retrieving SQL data for crdb_internal.kv_store_status: creating error output: debug/cluster/test-tenant/crdb_internal.kv_store_status.json.err.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_system_privileges... writing output: debug/cluster/test-tenant/crdb_internal.kv_system_privileges.json... done
+[cluster] retrieving SQL data for crdb_internal.partitions... writing output: debug/cluster/test-tenant/crdb_internal.partitions.json... done
+[cluster] retrieving SQL data for crdb_internal.regions... writing output: debug/cluster/test-tenant/crdb_internal.regions.json... done
+[cluster] retrieving SQL data for crdb_internal.schema_changes... writing output: debug/cluster/test-tenant/crdb_internal.schema_changes.json... done
+[cluster] retrieving SQL data for crdb_internal.super_regions... writing output: debug/cluster/test-tenant/crdb_internal.super_regions.json... done
+[cluster] retrieving SQL data for crdb_internal.system_jobs... writing output: debug/cluster/test-tenant/crdb_internal.system_jobs.json... done
+[cluster] retrieving SQL data for crdb_internal.table_indexes... writing output: debug/cluster/test-tenant/crdb_internal.table_indexes.json... done
+[cluster] retrieving SQL data for crdb_internal.transaction_contention_events... writing output: debug/cluster/test-tenant/crdb_internal.transaction_contention_events.json... done
+[cluster] retrieving SQL data for crdb_internal.zones... writing output: debug/cluster/test-tenant/crdb_internal.zones.json... done
+[cluster] retrieving SQL data for system.database_role_settings... writing output: debug/cluster/test-tenant/system.database_role_settings.json... done
+[cluster] retrieving SQL data for system.descriptor... writing output: debug/cluster/test-tenant/system.descriptor.json... done
+[cluster] retrieving SQL data for system.eventlog... writing output: debug/cluster/test-tenant/system.eventlog.json... done
+[cluster] retrieving SQL data for system.external_connections... writing output: debug/cluster/test-tenant/system.external_connections.json... done
+[cluster] retrieving SQL data for system.job_info... writing output: debug/cluster/test-tenant/system.job_info.json... done
+[cluster] retrieving SQL data for system.jobs... writing output: debug/cluster/test-tenant/system.jobs.json... done
+[cluster] retrieving SQL data for system.lease... writing output: debug/cluster/test-tenant/system.lease.json... done
+[cluster] retrieving SQL data for system.locations... writing output: debug/cluster/test-tenant/system.locations.json... done
+[cluster] retrieving SQL data for system.migrations... writing output: debug/cluster/test-tenant/system.migrations.json... done
+[cluster] retrieving SQL data for system.namespace... writing output: debug/cluster/test-tenant/system.namespace.json... done
+[cluster] retrieving SQL data for system.privileges... writing output: debug/cluster/test-tenant/system.privileges.json... done
+[cluster] retrieving SQL data for system.protected_ts_meta... writing output: debug/cluster/test-tenant/system.protected_ts_meta.json... done
+[cluster] retrieving SQL data for system.protected_ts_records... writing output: debug/cluster/test-tenant/system.protected_ts_records.json... done
+[cluster] retrieving SQL data for system.rangelog... writing output: debug/cluster/test-tenant/system.rangelog.json... done
+[cluster] retrieving SQL data for system.replication_constraint_stats... writing output: debug/cluster/test-tenant/system.replication_constraint_stats.json... done
+[cluster] retrieving SQL data for system.replication_critical_localities... writing output: debug/cluster/test-tenant/system.replication_critical_localities.json... done
+[cluster] retrieving SQL data for system.replication_stats... writing output: debug/cluster/test-tenant/system.replication_stats.json... done
+[cluster] retrieving SQL data for system.reports_meta... writing output: debug/cluster/test-tenant/system.reports_meta.json... done
+[cluster] retrieving SQL data for system.role_id_seq... writing output: debug/cluster/test-tenant/system.role_id_seq.json... done
+[cluster] retrieving SQL data for system.role_members... writing output: debug/cluster/test-tenant/system.role_members.json... done
+[cluster] retrieving SQL data for system.role_options... writing output: debug/cluster/test-tenant/system.role_options.json... done
+[cluster] retrieving SQL data for system.scheduled_jobs... writing output: debug/cluster/test-tenant/system.scheduled_jobs.json... done
+[cluster] retrieving SQL data for system.settings... writing output: debug/cluster/test-tenant/system.settings.json... done
+[cluster] retrieving SQL data for system.span_configurations... writing output: debug/cluster/test-tenant/system.span_configurations.json...
 [cluster] retrieving SQL data for system.span_configurations: last request failed: ERROR: relation "system.span_configurations" does not exist (SQLSTATE 42P01)
-[cluster] retrieving SQL data for system.span_configurations: creating error output: debug/virtual/test-tenant/system.span_configurations.json.err.txt... done
-[cluster] retrieving SQL data for system.sql_instances... writing output: debug/virtual/test-tenant/system.sql_instances.json... done
-[cluster] retrieving SQL data for system.sqlliveness... writing output: debug/virtual/test-tenant/system.sqlliveness.json... done
-[cluster] retrieving SQL data for system.statement_diagnostics... writing output: debug/virtual/test-tenant/system.statement_diagnostics.json... done
-[cluster] retrieving SQL data for system.statement_diagnostics_requests... writing output: debug/virtual/test-tenant/system.statement_diagnostics_requests.json... done
-[cluster] retrieving SQL data for system.table_statistics... writing output: debug/virtual/test-tenant/system.table_statistics.json... done
-[cluster] retrieving SQL data for system.task_payloads... writing output: debug/virtual/test-tenant/system.task_payloads.json...
+[cluster] retrieving SQL data for system.span_configurations: creating error output: debug/cluster/test-tenant/system.span_configurations.json.err.txt... done
+[cluster] retrieving SQL data for system.sql_instances... writing output: debug/cluster/test-tenant/system.sql_instances.json... done
+[cluster] retrieving SQL data for system.sqlliveness... writing output: debug/cluster/test-tenant/system.sqlliveness.json... done
+[cluster] retrieving SQL data for system.statement_diagnostics... writing output: debug/cluster/test-tenant/system.statement_diagnostics.json... done
+[cluster] retrieving SQL data for system.statement_diagnostics_requests... writing output: debug/cluster/test-tenant/system.statement_diagnostics_requests.json... done
+[cluster] retrieving SQL data for system.table_statistics... writing output: debug/cluster/test-tenant/system.table_statistics.json... done
+[cluster] retrieving SQL data for system.task_payloads... writing output: debug/cluster/test-tenant/system.task_payloads.json...
 [cluster] retrieving SQL data for system.task_payloads: last request failed: ERROR: relation "system.task_payloads" does not exist (SQLSTATE 42P01)
-[cluster] retrieving SQL data for system.task_payloads: creating error output: debug/virtual/test-tenant/system.task_payloads.json.err.txt... done
-[cluster] retrieving SQL data for system.tenant_settings... writing output: debug/virtual/test-tenant/system.tenant_settings.json...
+[cluster] retrieving SQL data for system.task_payloads: creating error output: debug/cluster/test-tenant/system.task_payloads.json.err.txt... done
+[cluster] retrieving SQL data for system.tenant_settings... writing output: debug/cluster/test-tenant/system.tenant_settings.json...
 [cluster] retrieving SQL data for system.tenant_settings: last request failed: ERROR: relation "system.tenant_settings" does not exist (SQLSTATE 42P01)
-[cluster] retrieving SQL data for system.tenant_settings: creating error output: debug/virtual/test-tenant/system.tenant_settings.json.err.txt... done
-[cluster] retrieving SQL data for system.tenant_tasks... writing output: debug/virtual/test-tenant/system.tenant_tasks.json...
+[cluster] retrieving SQL data for system.tenant_settings: creating error output: debug/cluster/test-tenant/system.tenant_settings.json.err.txt... done
+[cluster] retrieving SQL data for system.tenant_tasks... writing output: debug/cluster/test-tenant/system.tenant_tasks.json...
 [cluster] retrieving SQL data for system.tenant_tasks: last request failed: ERROR: relation "system.tenant_tasks" does not exist (SQLSTATE 42P01)
-[cluster] retrieving SQL data for system.tenant_tasks: creating error output: debug/virtual/test-tenant/system.tenant_tasks.json.err.txt... done
-[cluster] retrieving SQL data for system.tenant_usage... writing output: debug/virtual/test-tenant/system.tenant_usage.json...
+[cluster] retrieving SQL data for system.tenant_tasks: creating error output: debug/cluster/test-tenant/system.tenant_tasks.json.err.txt... done
+[cluster] retrieving SQL data for system.tenant_usage... writing output: debug/cluster/test-tenant/system.tenant_usage.json...
 [cluster] retrieving SQL data for system.tenant_usage: last request failed: ERROR: relation "system.tenant_usage" does not exist (SQLSTATE 42P01)
-[cluster] retrieving SQL data for system.tenant_usage: creating error output: debug/virtual/test-tenant/system.tenant_usage.json.err.txt... done
-[cluster] retrieving SQL data for system.tenants... writing output: debug/virtual/test-tenant/system.tenants.json...
+[cluster] retrieving SQL data for system.tenant_usage: creating error output: debug/cluster/test-tenant/system.tenant_usage.json.err.txt... done
+[cluster] retrieving SQL data for system.tenants... writing output: debug/cluster/test-tenant/system.tenants.json...
 [cluster] retrieving SQL data for system.tenants: last request failed: ERROR: relation "system.tenants" does not exist (SQLSTATE 42P01)
-[cluster] retrieving SQL data for system.tenants: creating error output: debug/virtual/test-tenant/system.tenants.json.err.txt... done
+[cluster] retrieving SQL data for system.tenants: creating error output: debug/cluster/test-tenant/system.tenants.json.err.txt... done
 [cluster] requesting nodes... received response...
 [cluster] requesting nodes: last request failed: rpc error: ...
 [cluster] requesting nodes: creating error output: debug/nodes.json.err.txt... done
-[cluster] requesting liveness... received response... writing JSON output: debug/virtual/test-tenant/liveness.json... done
+[cluster] requesting liveness... received response... writing JSON output: debug/cluster/test-tenant/liveness.json... done
 [cluster] requesting tenant ranges... received response...
 [cluster] requesting tenant ranges: last request failed: rpc error: ...
-[cluster] requesting tenant ranges: creating error output: debug/virtual/test-tenant/tenant_ranges.err.txt... done
+[cluster] requesting tenant ranges: creating error output: debug/cluster/test-tenant/tenant_ranges.err.txt... done
 [cluster] requesting CPU profiles
 [cluster] profiles generated
-[cluster] profile for node 1... writing binary output: debug/virtual/test-tenant/nodes/1/cpu.pprof... done
-[node 1] node status... writing JSON output: debug/virtual/test-tenant/nodes/1/status.json... done
+[cluster] profile for node 1... writing binary output: debug/cluster/test-tenant/nodes/1/cpu.pprof... done
+[node 1] node status... writing JSON output: debug/cluster/test-tenant/nodes/1/status.json... done
 [node 1] using SQL connection URL: postgresql://...
-[node 1] retrieving SQL data for crdb_internal.active_range_feeds... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.active_range_feeds.json... done
-[node 1] retrieving SQL data for crdb_internal.feature_usage... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.feature_usage.json... done
-[node 1] retrieving SQL data for crdb_internal.gossip_alerts... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.gossip_alerts.json...
+[node 1] retrieving SQL data for crdb_internal.active_range_feeds... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.active_range_feeds.json... done
+[node 1] retrieving SQL data for crdb_internal.feature_usage... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.feature_usage.json... done
+[node 1] retrieving SQL data for crdb_internal.gossip_alerts... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_alerts.json...
 [node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
-[node 1] retrieving SQL data for crdb_internal.gossip_alerts: creating error output: debug/virtual/test-tenant/nodes/1/crdb_internal.gossip_alerts.json.err.txt... done
-[node 1] retrieving SQL data for crdb_internal.gossip_liveness... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.gossip_liveness.json...
+[node 1] retrieving SQL data for crdb_internal.gossip_alerts: creating error output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_alerts.json.err.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_liveness... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_liveness.json...
 [node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
-[node 1] retrieving SQL data for crdb_internal.gossip_liveness: creating error output: debug/virtual/test-tenant/nodes/1/crdb_internal.gossip_liveness.json.err.txt... done
-[node 1] retrieving SQL data for crdb_internal.gossip_nodes... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.gossip_nodes.json...
+[node 1] retrieving SQL data for crdb_internal.gossip_liveness: creating error output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_liveness.json.err.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_nodes... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_nodes.json...
 [node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
-[node 1] retrieving SQL data for crdb_internal.gossip_nodes: creating error output: debug/virtual/test-tenant/nodes/1/crdb_internal.gossip_nodes.json.err.txt... done
-[node 1] retrieving SQL data for crdb_internal.leases... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.leases.json... done
-[node 1] retrieving SQL data for crdb_internal.node_build_info... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_build_info.json... done
-[node 1] retrieving SQL data for crdb_internal.node_contention_events... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_contention_events.json... done
-[node 1] retrieving SQL data for crdb_internal.node_distsql_flows... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_distsql_flows.json... done
-[node 1] retrieving SQL data for crdb_internal.node_execution_insights... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_execution_insights.json... done
-[node 1] retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_inflight_trace_spans.json... done
-[node 1] retrieving SQL data for crdb_internal.node_memory_monitors... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_memory_monitors.json... done
-[node 1] retrieving SQL data for crdb_internal.node_metrics... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_metrics.json... done
-[node 1] retrieving SQL data for crdb_internal.node_queries... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_queries.json... done
-[node 1] retrieving SQL data for crdb_internal.node_runtime_info... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_runtime_info.json... done
-[node 1] retrieving SQL data for crdb_internal.node_sessions... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_sessions.json... done
-[node 1] retrieving SQL data for crdb_internal.node_statement_statistics... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_statement_statistics.json... done
-[node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_tenant_capabilities_cache.json...
+[node 1] retrieving SQL data for crdb_internal.gossip_nodes: creating error output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_nodes.json.err.txt... done
+[node 1] retrieving SQL data for crdb_internal.leases... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.leases.json... done
+[node 1] retrieving SQL data for crdb_internal.node_build_info... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_build_info.json... done
+[node 1] retrieving SQL data for crdb_internal.node_contention_events... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_contention_events.json... done
+[node 1] retrieving SQL data for crdb_internal.node_distsql_flows... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_distsql_flows.json... done
+[node 1] retrieving SQL data for crdb_internal.node_execution_insights... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_execution_insights.json... done
+[node 1] retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_inflight_trace_spans.json... done
+[node 1] retrieving SQL data for crdb_internal.node_memory_monitors... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_memory_monitors.json... done
+[node 1] retrieving SQL data for crdb_internal.node_metrics... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_metrics.json... done
+[node 1] retrieving SQL data for crdb_internal.node_queries... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_queries.json... done
+[node 1] retrieving SQL data for crdb_internal.node_runtime_info... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_runtime_info.json... done
+[node 1] retrieving SQL data for crdb_internal.node_sessions... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_sessions.json... done
+[node 1] retrieving SQL data for crdb_internal.node_statement_statistics... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_statement_statistics.json... done
+[node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_tenant_capabilities_cache.json...
 [node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: last request failed: ERROR: operation node_tenant_capabilities_cache supported only by system tenant (SQLSTATE XXUUU)
-[node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: creating error output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_tenant_capabilities_cache.json.err.txt... done
-[node 1] retrieving SQL data for crdb_internal.node_transaction_statistics... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_transaction_statistics.json... done
-[node 1] retrieving SQL data for crdb_internal.node_transactions... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_transactions.json... done
-[node 1] retrieving SQL data for crdb_internal.node_txn_execution_insights... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_txn_execution_insights.json... done
-[node 1] retrieving SQL data for crdb_internal.node_txn_stats... writing output: debug/virtual/test-tenant/nodes/1/crdb_internal.node_txn_stats.json... done
-[node 1] requesting data for debug/virtual/test-tenant/nodes/1/details... received response... writing JSON output: debug/virtual/test-tenant/nodes/1/details.json... done
-[node 1] requesting data for debug/virtual/test-tenant/nodes/1/gossip... received response...
-[node 1] requesting data for debug/virtual/test-tenant/nodes/1/gossip: last request failed: rpc error: ...
-[node 1] requesting data for debug/virtual/test-tenant/nodes/1/gossip: creating error output: debug/virtual/test-tenant/nodes/1/gossip.json.err.txt... done
-[node 1] requesting data for debug/virtual/test-tenant/nodes/1/enginestats... received response...
-[node 1] requesting data for debug/virtual/test-tenant/nodes/1/enginestats: last request failed: rpc error: ...
-[node 1] requesting data for debug/virtual/test-tenant/nodes/1/enginestats: creating error output: debug/virtual/test-tenant/nodes/1/enginestats.json.err.txt... done
-[node 1] requesting stacks... received response... writing binary output: debug/virtual/test-tenant/nodes/1/stacks.txt... done
-[node 1] requesting stacks with labels... received response... writing binary output: debug/virtual/test-tenant/nodes/1/stacks_with_labels.txt... done
-[node 1] requesting heap profile... received response... writing binary output: debug/virtual/test-tenant/nodes/1/heap.pprof... done
+[node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: creating error output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_tenant_capabilities_cache.json.err.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_transaction_statistics... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_transaction_statistics.json... done
+[node 1] retrieving SQL data for crdb_internal.node_transactions... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_transactions.json... done
+[node 1] retrieving SQL data for crdb_internal.node_txn_execution_insights... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_txn_execution_insights.json... done
+[node 1] retrieving SQL data for crdb_internal.node_txn_stats... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_txn_stats.json... done
+[node 1] requesting data for debug/cluster/test-tenant/nodes/1/details... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/details.json... done
+[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip... received response...
+[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip: last request failed: rpc error: ...
+[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip: creating error output: debug/cluster/test-tenant/nodes/1/gossip.json.err.txt... done
+[node 1] requesting data for debug/cluster/test-tenant/nodes/1/enginestats... received response...
+[node 1] requesting data for debug/cluster/test-tenant/nodes/1/enginestats: last request failed: rpc error: ...
+[node 1] requesting data for debug/cluster/test-tenant/nodes/1/enginestats: creating error output: debug/cluster/test-tenant/nodes/1/enginestats.json.err.txt... done
+[node 1] requesting stacks... received response... writing binary output: debug/cluster/test-tenant/nodes/1/stacks.txt... done
+[node 1] requesting stacks with labels... received response... writing binary output: debug/cluster/test-tenant/nodes/1/stacks_with_labels.txt... done
+[node 1] requesting heap profile... received response... writing binary output: debug/cluster/test-tenant/nodes/1/heap.pprof... done
 [node 1] requesting heap file list... received response...
 [node 1] requesting heap file list: last request failed: rpc error: ...
-[node 1] requesting heap file list: creating error output: debug/virtual/test-tenant/nodes/1/heapprof.err.txt... done
+[node 1] requesting heap file list: creating error output: debug/cluster/test-tenant/nodes/1/heapprof.err.txt... done
 [node 1] requesting goroutine dump list... received response...
 [node 1] requesting goroutine dump list: last request failed: rpc error: ...
-[node 1] requesting goroutine dump list: creating error output: debug/virtual/test-tenant/nodes/1/goroutines.err.txt... done
+[node 1] requesting goroutine dump list: creating error output: debug/cluster/test-tenant/nodes/1/goroutines.err.txt... done
 [node 1] requesting log files list... received response... done
 [node ?] ? log files found
 [node 1] requesting ranges... received response...
 [node 1] requesting ranges: last request failed: rpc error: ...
-[node 1] requesting ranges: creating error output: debug/virtual/test-tenant/nodes/1/ranges.err.txt... done
-[cluster] pprof summary script... writing binary output: debug/virtual/test-tenant/pprof-summary.sh... done
-[cluster] hot range summary script... writing binary output: debug/virtual/test-tenant/hot-ranges.sh... done
-[cluster] tenant hot range summary script... writing binary output: debug/virtual/test-tenant/hot-ranges-tenant.sh... done
+[node 1] requesting ranges: creating error output: debug/cluster/test-tenant/nodes/1/ranges.err.txt... done
+[cluster] pprof summary script... writing binary output: debug/cluster/test-tenant/pprof-summary.sh... done
+[cluster] hot range summary script... writing binary output: debug/cluster/test-tenant/hot-ranges.sh... done
+[cluster] tenant hot range summary script... writing binary output: debug/cluster/test-tenant/hot-ranges-tenant.sh... done

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -267,7 +267,7 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 			// Only add tenant prefix for non system tenants.
 			var prefix string
 			if tenant.TenantId.ToUint64() != roachpb.SystemTenantID.ToUint64() {
-				prefix = fmt.Sprintf("/virtual/%s", tenant.TenantName)
+				prefix = fmt.Sprintf("/cluster/%s", tenant.TenantName)
 			}
 
 			zc := debugZipContext{


### PR DESCRIPTION
Informs #106068.
Epic: CRDB-29380

Requested by Abbey Russell in replacement of #106117.

Release note (cluster virtualization): This patch renames the
subdirectory inside the output of `cockroach debug zip` when pointed
to a cluster with virtualization enabled to be `cluster`, which brings
the UX in coherence with the parameter of the same name in `cockroach
sql` and the HTTP API parameter in the same name.