### PR TITLE
cluster-ui: update cluster-ui publish steps in README

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/README.md
+++ b/pkg/ui/workspaces/cluster-ui/README.md
@@ -185,18 +185,32 @@ here: https://storybook.js.org/docs/react/api/csf in order to
 facilitate writing unit tests with the storybook components.
 
 ## Publishing Cluster UI package to npm
-Publishing Cluster UI pre-release versions from the master branch to npm is done
-by a Github Action workflow called "Publish Cluster UI Pre-release". This workflow
-will publish to npm anytime a version of Cluster UI is merged to master that is
-unpublished (by comparing the version in the `package.json` to versions of
-`@cockroachlabs/cluster-ui` on npm). To change the version of Cluster UI, you can
-run the command `yarn bump` from `pkg/ui/workspaces/cluster-ui`.
+### Automatic Publishing with Github Actions
+Publishing Cluster UI versions to npm is done by Github Action workflows that run
+on master and release branches. "Publish Cluster UI Pre-release" runs on master,
+and "Publish Cluster UI Release" for commits merged to release branches. These
+workflows will publish to npm anytime a version of Cluster UI is merged to the branch
+that is unpublished (by comparing the version in the `package.json` to versions of
+`@cockroachlabs/cluster-ui` on npm).
 
-To publish a version from a release branch, a manual publish is still required.
-The steps below can be followed to manually publish to npm. Github Workflows are
-being worked on for release branches, and this README will be updated when they
-are available.
+Follow the steps below on your feature branch:
 
+### 1. Bump Cluster UI Version
+Run `yarn bump` from `pkg/ui/workspaces/cluster-ui`, or change the version manually
+in `package.json`.
+
+### 2. Run `yarn build` without errors 
+Ensure the pkg can be built without errors by running `yarn build` in the `cluster-ui`
+directory.
+
+### 3. Merge PR and verify publish action was successful
+Once your PR is merged to the desired branch, check that the workflow ran
+successfully. Go to the 'Actions' tab in the cockroachdb repo and select the
+action corresponding to either master (Publish Cluster UI Pre-release) or a
+release branch (Publish Cluster UI Release). If there were any errors, address
+in a new PR and merge (no need to bump the version as the publish was unsuccessful).
+
+### Manual Publishing
 ### 1. Change the version in package.json
 CockroachDB uses a form of [calver](https://calver.org/) versioning where the major part
 is a *Short Year* and the minor part is an iterative number.The micro part (in


### PR DESCRIPTION
Update the steps to publish cluster-ui pkg in README.

Epic: none

Release note: None