### PR TITLE
bazci: don't use `envutil`

### DIFF
--- a/pkg/cmd/bazci/githubpost/BUILD.bazel
+++ b/pkg/cmd/bazci/githubpost/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//pkg/internal/codeowners",
         "//pkg/internal/team",
         "//pkg/roachprod/logger",
-        "//pkg/util/envutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/codeowners"
 	"github.com/cockroachdb/cockroach/pkg/internal/team"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -106,7 +105,7 @@ func getIssueFilerForFormatter(formatterName string) func(ctx context.Context, f
 		if err != nil {
 			return err
 		}
-		if stress := envutil.EnvOrDefaultBool("COCKROACH_NIGHTLY_STRESS", false); stress {
+		if stress := os.Getenv("COCKROACH_NIGHTLY_STRESS"); stress != "" {
 			req.ExtraParams["stress"] = "true"
 		}
 		return issues.Post(ctx, l, fmter, req)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -477,7 +477,11 @@ func TestLint(t *testing.T) {
 			re       string
 			excludes []string
 		}{
-			{re: `\bos\.(Getenv|LookupEnv)\("COCKROACH`},
+			{re: `\bos\.(Getenv|LookupEnv)\("COCKROACH`,
+				excludes: []string{
+					":!cmd/bazci/githubpost",
+				},
+			},
 			{
 				re: `\bos\.(Getenv|LookupEnv)\(`,
 				excludes: []string{


### PR DESCRIPTION
Fix the following error:

```
    panic: environment variable COCKROACH_NIGHTLY_STRESS already used from github.com/cockroachdb/cockroach/pkg/testutils/skip/stress.go
```

Epic: none
Release note: None