### PR TITLE
c2c: prioritize matching src-node pairs with shared localities

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -11,6 +11,8 @@ package streamingest
 import (
 	"context"
 	"fmt"
+	"math"
+	"sort"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -222,11 +224,16 @@ func (p *replicationFlowPlanner) makePlan(
 		if err != nil {
 			return nil, nil, err
 		}
+		destNodeLocalities, err := getDestNodeLocalities(ctx, dsp, sqlInstanceIDs)
+		if err != nil {
+			return nil, nil, err
+		}
 
 		streamIngestionSpecs, streamIngestionFrontierSpec, err := constructStreamIngestionPlanSpecs(
+			ctx,
 			streamingccl.StreamAddress(details.StreamAddress),
 			topology,
-			sqlInstanceIDs,
+			destNodeLocalities,
 			initialScanTimestamp,
 			previousReplicatedTime,
 			checkpoint,
@@ -261,11 +268,6 @@ func (p *replicationFlowPlanner) makePlan(
 		p.AddSingleGroupStage(ctx, gatewayID,
 			execinfrapb.ProcessorCoreUnion{StreamIngestionFrontier: streamIngestionFrontierSpec},
 			execinfrapb.PostProcessSpec{}, streamIngestionResultTypes)
-
-		for src, dst := range streamIngestionFrontierSpec.SubscribingSQLInstances {
-			log.Infof(ctx, "physical replication src-dst pair candidate: %s:%d",
-				src, dst)
-		}
 
 		p.PlanToStreamColMap = []int{0}
 		sql.FinalizePlan(ctx, planCtx, p)
@@ -318,10 +320,128 @@ func measurePlanChange(before, after *sql.PhysicalPlan) float64 {
 	return float64(diff) / float64(oldCount)
 }
 
+type partitionWithCandidates struct {
+	partition          streamclient.PartitionInfo
+	closestDestIDs     []base.SQLInstanceID
+	sharedPrefixLength int
+}
+
+type candidatesByPriority []partitionWithCandidates
+
+func (a candidatesByPriority) Len() int      { return len(a) }
+func (a candidatesByPriority) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a candidatesByPriority) Less(i, j int) bool {
+	return a[i].sharedPrefixLength > a[j].sharedPrefixLength
+}
+
+// nodeMatcher matches each source cluster node to a destination cluster node,
+// given a list of available nodes in each cluster. The matcher has a primary goal
+// to match src-dst nodes that are "close" to each other, i.e. have common
+// locality tags, and a secondary goal to distribute source node assignments
+// evenly across destination nodes. Here's the algorithm:
+//
+// - For each src node, find their closest dst nodes and the number of
+// localities that match, the LocalityMatchCount, via the sql.ClosestInstances()
+// function. Example: Consider Src-A [US,East] which has match candidates Dst-A
+// [US,West], Dst-B [US, Central]. In the example, the LocalityMatchCount is 1,
+// as only US matches with the src node's locality.
+//
+// - Prioritize matching src nodes with a higher locality match count, via the
+// findSourceNodePriority() function.
+//
+// - While we have src nodes left to match, match the highest priority src node
+// to the dst node candidate that has the fewest matches already, via the
+// findMatch() function.
+
+type nodeMatcher struct {
+	destMatchCount     map[base.SQLInstanceID]int
+	destNodesInfo      []sql.InstanceLocality
+	destNodeToLocality map[base.SQLInstanceID]roachpb.Locality
+}
+
+func makeNodeMatcher(destNodesInfo []sql.InstanceLocality) *nodeMatcher {
+	nodeToLocality := make(map[base.SQLInstanceID]roachpb.Locality, len(destNodesInfo))
+	for _, node := range destNodesInfo {
+		nodeToLocality[node.GetInstanceID()] = node.GetLocality()
+	}
+	return &nodeMatcher{
+		destMatchCount:     make(map[base.SQLInstanceID]int, len(destNodesInfo)),
+		destNodesInfo:      destNodesInfo,
+		destNodeToLocality: nodeToLocality,
+	}
+}
+
+func (nm *nodeMatcher) destNodeIDs() []base.SQLInstanceID {
+	allDestNodeIDs := make([]base.SQLInstanceID, 0, len(nm.destNodesInfo))
+	for _, info := range nm.destNodesInfo {
+		allDestNodeIDs = append(allDestNodeIDs, info.GetInstanceID())
+	}
+	return allDestNodeIDs
+}
+
+// findSourceNodePriority finds the closest dest nodes for each source node and
+// returns a list of (source node, dest node match candidates) pairs ordered by
+// matching priority. A source node is earlier (higher priority) in the list if
+// it shares more locality tiers with their destination node match candidates.
+func (nm *nodeMatcher) findSourceNodePriority(topology streamclient.Topology) candidatesByPriority {
+
+	allDestNodeIDs := nm.destNodeIDs()
+	candidates := make(candidatesByPriority, 0, len(topology.Partitions))
+	for _, partition := range topology.Partitions {
+		closestDestIDs, sharedPrefixLength := sql.ClosestInstances(nm.destNodesInfo,
+			partition.SrcLocality)
+		if sharedPrefixLength == 0 {
+			closestDestIDs = allDestNodeIDs
+		}
+		candidate := partitionWithCandidates{
+			partition:          partition,
+			closestDestIDs:     closestDestIDs,
+			sharedPrefixLength: sharedPrefixLength,
+		}
+		candidates = append(candidates, candidate)
+	}
+	sort.Sort(candidates)
+
+	return candidates
+}
+
+// findMatch returns the destination node id with the fewest src node matches from the input list.
+func (nm *nodeMatcher) findMatch(destIDCandidates []base.SQLInstanceID) base.SQLInstanceID {
+	minCount := math.MaxInt
+	currentMatch := base.SQLInstanceID(0)
+
+	for _, destID := range destIDCandidates {
+		currentDestCount := nm.destMatchCount[destID]
+		if currentDestCount < minCount {
+			currentMatch = destID
+			minCount = currentDestCount
+		}
+	}
+	nm.destMatchCount[currentMatch]++
+	return currentMatch
+}
+
+func getDestNodeLocalities(
+	ctx context.Context, dsp *sql.DistSQLPlanner, instanceIDs []base.SQLInstanceID,
+) ([]sql.InstanceLocality, error) {
+
+	instanceInfos := make([]sql.InstanceLocality, 0, len(instanceIDs))
+	for _, id := range instanceIDs {
+		nodeDesc, err := dsp.GetSQLInstanceInfo(id)
+		if err != nil {
+			log.Eventf(ctx, "unable to get node descriptor for sql node %s", id)
+			return nil, err
+		}
+		instanceInfos = append(instanceInfos, sql.MakeInstanceLocality(id, nodeDesc.Locality))
+	}
+	return instanceInfos, nil
+}
+
 func constructStreamIngestionPlanSpecs(
+	ctx context.Context,
 	streamAddress streamingccl.StreamAddress,
 	topology streamclient.Topology,
-	sqlInstanceIDs []base.SQLInstanceID,
+	destSQLInstances []sql.InstanceLocality,
 	initialScanTimestamp hlc.Timestamp,
 	previousReplicatedTimestamp hlc.Timestamp,
 	checkpoint jobspb.StreamIngestionCheckpoint,
@@ -330,41 +450,55 @@ func constructStreamIngestionPlanSpecs(
 	sourceTenantID roachpb.TenantID,
 	destinationTenantID roachpb.TenantID,
 ) ([]*execinfrapb.StreamIngestionDataSpec, *execinfrapb.StreamIngestionFrontierSpec, error) {
-	// For each stream partition in the topology, assign it to a node.
-	streamIngestionSpecs := make([]*execinfrapb.StreamIngestionDataSpec, 0, len(sqlInstanceIDs))
+
+	streamIngestionSpecs := make([]*execinfrapb.StreamIngestionDataSpec, 0, len(destSQLInstances))
+	destSQLInstancesToIdx := make(map[base.SQLInstanceID]int, len(destSQLInstances))
+	for i, id := range destSQLInstances {
+		spec := &execinfrapb.StreamIngestionDataSpec{
+			StreamID:                    uint64(streamID),
+			JobID:                       int64(jobID),
+			PreviousReplicatedTimestamp: previousReplicatedTimestamp,
+			InitialScanTimestamp:        initialScanTimestamp,
+			Checkpoint:                  checkpoint, // TODO: Only forward relevant checkpoint info
+			StreamAddress:               string(streamAddress),
+			PartitionSpecs:              make(map[string]execinfrapb.StreamIngestionPartitionSpec),
+			TenantRekey: execinfrapb.TenantRekey{
+				OldID: sourceTenantID,
+				NewID: destinationTenantID,
+			},
+		}
+		streamIngestionSpecs = append(streamIngestionSpecs, spec)
+		destSQLInstancesToIdx[id.GetInstanceID()] = i
+	}
 
 	trackedSpans := make([]roachpb.Span, 0)
 	subscribingSQLInstances := make(map[string]uint32)
-	for i, partition := range topology.Partitions {
-		// Round robin assign the stream partitions to nodes. Partitions 0 through
-		// len(nodes) - 1 creates the spec. Future partitions just add themselves to
-		// the partition addresses.
-		if i < len(sqlInstanceIDs) {
-			spec := &execinfrapb.StreamIngestionDataSpec{
-				StreamID:                    uint64(streamID),
-				JobID:                       int64(jobID),
-				PreviousReplicatedTimestamp: previousReplicatedTimestamp,
-				InitialScanTimestamp:        initialScanTimestamp,
-				Checkpoint:                  checkpoint, // TODO: Only forward relevant checkpoint info
-				StreamAddress:               string(streamAddress),
-				PartitionSpecs:              make(map[string]execinfrapb.StreamIngestionPartitionSpec),
-				TenantRekey: execinfrapb.TenantRekey{
-					OldID: sourceTenantID,
-					NewID: destinationTenantID,
-				},
-			}
-			streamIngestionSpecs = append(streamIngestionSpecs, spec)
-		}
-		n := i % len(sqlInstanceIDs)
 
-		subscribingSQLInstances[partition.ID] = uint32(sqlInstanceIDs[n])
-		streamIngestionSpecs[n].PartitionSpecs[partition.ID] = execinfrapb.StreamIngestionPartitionSpec{
+	// Update stream ingestion specs with their matched source node.
+	matcher := makeNodeMatcher(destSQLInstances)
+	for _, candidate := range matcher.findSourceNodePriority(topology) {
+		destID := matcher.findMatch(candidate.closestDestIDs)
+		log.Infof(ctx, "physical replication src-dst pair candidate: %s (locality %s) - %d ("+
+			"locality %s)",
+			candidate.partition.ID,
+			candidate.partition.SrcLocality,
+			destID,
+			matcher.destNodeToLocality[destID])
+		partition := candidate.partition
+		subscribingSQLInstances[partition.ID] = uint32(destID)
+
+		specIdx, ok := destSQLInstancesToIdx[destID]
+		if !ok {
+			return nil, nil, errors.AssertionFailedf(
+				"matched destination node id does not contain a stream ingestion spec")
+		}
+		streamIngestionSpecs[specIdx].PartitionSpecs[partition.ID] = execinfrapb.
+			StreamIngestionPartitionSpec{
 			PartitionID:       partition.ID,
 			SubscriptionToken: string(partition.SubscriptionToken),
 			Address:           string(partition.SrcAddr),
 			Spans:             partition.Spans,
 		}
-
 		trackedSpans = append(trackedSpans, partition.Spans...)
 	}
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist_test.go
@@ -9,14 +9,23 @@
 package streamingest
 
 import (
+	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -117,6 +126,193 @@ func TestMeasurePlanChange(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			frac := measurePlanChange(&tc.before, &tc.after)
 			require.Equal(t, tc.frac, frac)
+		})
+	}
+}
+
+func fakeTopology(nls []sql.InstanceLocality) streamclient.Topology {
+	topology := streamclient.Topology{
+		SourceTenantID: roachpb.TenantID{InternalValue: uint64(2)},
+		Partitions:     make([]streamclient.PartitionInfo, 0, len(nls)),
+	}
+	for _, nl := range nls {
+		partition := streamclient.PartitionInfo{
+			ID:          nl.GetInstanceID().String(),
+			SrcLocality: nl.GetLocality(),
+		}
+		topology.Partitions = append(topology.Partitions, partition)
+	}
+	return topology
+}
+
+// TestSourceDestMatching checks for an expected matching on a given src-dest
+// node topology. The matching algorithm prioritizes matching nodes with common
+// localities and tie breaks by distributing load across destination nodes
+// evenly.
+func TestSourceDestMatching(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+
+	rng, seed := randutil.NewTestRand()
+	t.Logf("Random Seed %d", seed)
+
+	nl := func(id int, locality string) sql.InstanceLocality {
+		localityStruct := roachpb.Locality{}
+		require.NoError(t, localityStruct.Set(locality))
+		return sql.MakeInstanceLocality(base.SQLInstanceID(id), localityStruct)
+	}
+
+	nls := func(nodes ...sql.InstanceLocality) []sql.InstanceLocality {
+		for i := len(nodes) - 1; i > 0; i-- {
+			j := rng.Intn(i + 1)
+			nodes[i], nodes[j] = nodes[j], nodes[i]
+		}
+		return nodes
+	}
+	type pair struct {
+		srcID int
+		dstID int
+	}
+
+	// validatePairs tests that src-dst assignments are expected.
+	validatePairs := func(sipSpecs []*execinfrapb.StreamIngestionDataSpec, dstNodes []sql.InstanceLocality,
+		expected map[pair]struct{}) {
+		for i, spec := range sipSpecs {
+
+			// SIPs are created in the order of the destination node ids
+			dstID := dstNodes[i].GetInstanceID()
+			for srcID := range spec.PartitionSpecs {
+				srcIDNum, err := strconv.Atoi(srcID)
+				require.NoError(t, err)
+				_, ok := expected[pair{srcIDNum, int(dstID)}]
+				require.True(t, ok, "Src %s,Dst %d do not match", srcID, dstID)
+			}
+		}
+	}
+
+	// validateEvenDistribution tests that source node assignments were evenly
+	// distributed across destination nodes. This function is only called on test
+	// cases without an expected exact src-dst node match.
+	validateEvenDistribution := func(sipSpecs []*execinfrapb.StreamIngestionDataSpec, dstNodes []sql.InstanceLocality) {
+
+		dstNodeAssignmentCount := make(map[base.SQLInstanceID]int, len(dstNodes))
+		for i, spec := range sipSpecs {
+
+			// SIPs are created in the order of the destination node ids
+			dstID := dstNodes[i].GetInstanceID()
+			for range spec.PartitionSpecs {
+				dstNodeAssignmentCount[dstID]++
+			}
+		}
+
+		var expectedCount int
+		for _, count := range dstNodeAssignmentCount {
+			if expectedCount == 0 {
+				expectedCount = count
+			} else {
+				require.Equal(t, expectedCount, count)
+			}
+		}
+	}
+
+	mkPair := func(srcID int, dstID int) pair {
+		return pair{srcID: srcID, dstID: dstID}
+	}
+
+	pairs := func(pairList ...pair) map[pair]struct{} {
+		pairSet := make(map[pair]struct{}, len(pairList))
+		for _, p := range pairList {
+			pairSet[p] = struct{}{}
+		}
+		return pairSet
+	}
+
+	// For a variety of src dest topologies, ensure the right matching or distribution occurs.
+	for _, tc := range []struct {
+		name          string
+		srcNodes      []sql.InstanceLocality
+		dstNodes      []sql.InstanceLocality
+		expectedPairs map[pair]struct{}
+	}{
+		{
+			name:          "two matched regions",
+			srcNodes:      nls(nl(1, "a=x"), nl(2, "a=y")),
+			dstNodes:      nls(nl(99, "a=x"), nl(98, "a=y")),
+			expectedPairs: pairs(mkPair(1, 99), mkPair(2, 98)),
+		},
+		{
+			name:          "one mismatched region",
+			srcNodes:      nls(nl(1, "a=x"), nl(2, "a=z")),
+			dstNodes:      nls(nl(99, "a=x"), nl(98, "a=y")),
+			expectedPairs: pairs(mkPair(1, 99), mkPair(2, 98)),
+		},
+		{
+			name:          "prioritize region match over even distribution",
+			srcNodes:      nls(nl(1, "a=x"), nl(2, "a=x")),
+			dstNodes:      nls(nl(99, "a=x"), nl(98, "a=y")),
+			expectedPairs: pairs(mkPair(1, 99), mkPair(2, 99)),
+		},
+		{
+			name:          "multi tiered match",
+			srcNodes:      nls(nl(1, "a=x,b=x"), nl(2, "a=x,b=y")),
+			dstNodes:      nls(nl(99, "a=x,b=x"), nl(98, "a=x,b=y")),
+			expectedPairs: pairs(mkPair(1, 99), mkPair(2, 98)),
+		},
+		{
+			name:          "prioritize stronger match",
+			srcNodes:      nls(nl(1, "a=x"), nl(2, "a=x,b=y")),
+			dstNodes:      nls(nl(99, "a=x"), nl(98, "a=x,b=y")),
+			expectedPairs: pairs(mkPair(1, 99), mkPair(2, 98)),
+		},
+		{
+			name:          "prioritize stronger match with fewer locality tiers",
+			srcNodes:      nls(nl(1, "a=x"), nl(2, "a=z,b=y")),
+			dstNodes:      nls(nl(99, "a=x"), nl(98, "a=y,b=y")),
+			expectedPairs: pairs(mkPair(1, 99), mkPair(2, 98)),
+		},
+		{
+			name:     "ensure even distribution within region",
+			srcNodes: nls(nl(1, "a=x"), nl(2, "a=x"), nl(3, "a=x")),
+			dstNodes: nls(nl(99, "a=x"), nl(98, "a=x"), nl(97, "a=x")),
+		},
+		{
+			name:     "ensure even distribution in overloaded destination nodes",
+			srcNodes: nls(nl(1, "a=x"), nl(2, "a=x"), nl(3, "a=x"), nl(4, "a=x")),
+			dstNodes: nls(nl(99, "a=x"), nl(98, "a=x")),
+		},
+		{
+			name:     "ensure even distribution across mismatched regions",
+			srcNodes: nls(nl(1, "a=x"), nl(2, "a=y"), nl(3, "a=z")),
+			dstNodes: nls(nl(99, "a=a"), nl(98, "a=b"), nl(97, "a=c")),
+		},
+		{
+			name:     "ensure even distribution in overloaded mismatched destination nodes",
+			srcNodes: nls(nl(1, "a=x"), nl(2, "a=y"), nl(3, "a=z"), nl(4, "a=x")),
+			dstNodes: nls(nl(99, "a=a"), nl(98, "a=b")),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeStreamAddress := streamingccl.StreamAddress("")
+			sipSpecs, _, err := constructStreamIngestionPlanSpecs(
+				ctx,
+				fakeStreamAddress,
+				fakeTopology(tc.srcNodes),
+				tc.dstNodes,
+				hlc.Timestamp{},
+				hlc.Timestamp{},
+				jobspb.StreamIngestionCheckpoint{},
+				jobspb.InvalidJobID,
+				streampb.StreamID(2),
+				roachpb.TenantID{InternalValue: 2},
+				roachpb.TenantID{InternalValue: 2},
+			)
+			require.NoError(t, err)
+			if len(tc.expectedPairs) > 0 {
+				validatePairs(sipSpecs, tc.dstNodes, tc.expectedPairs)
+			} else {
+				validateEvenDistribution(sipSpecs, tc.dstNodes)
+			}
 		})
 	}
 }

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1465,7 +1465,8 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 			}
 
 			// TODO(dt): Pre-compute / cache this result, e.g. in the instance reader.
-			if closest := closestInstances(instances, nodeDesc.Locality); len(closest) > 0 {
+			if closest, _ := ClosestInstances(instances,
+				nodeDesc.Locality); len(closest) > 0 {
 				return closest[rng.Intn(len(closest))]
 			}
 
@@ -1496,24 +1497,50 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 	return resolver, nil
 }
 
-// closestInstances returns the subset of instances which are closest to the
+type InstanceLocalityGetter interface {
+	sqlinstance.InstanceInfo | InstanceLocality
+	GetInstanceID() base.SQLInstanceID
+	GetLocality() roachpb.Locality
+}
+
+type InstanceLocality struct {
+	id       base.SQLInstanceID
+	locality roachpb.Locality
+}
+
+func MakeInstanceLocality(id base.SQLInstanceID, locality roachpb.Locality) InstanceLocality {
+	return InstanceLocality{id: id, locality: locality}
+}
+
+func (il InstanceLocality) GetInstanceID() base.SQLInstanceID {
+	return il.id
+}
+
+func (ii InstanceLocality) GetLocality() roachpb.Locality {
+	return ii.locality
+}
+
+// ClosestInstances returns the subset of instances which are closest to the
 // passed locality, i.e. those which jointly have the longest shared prefix of
-// at least length 1. Returns nil, rather than the entire input, if no instances
-// have *any* shared locality prefix.
-func closestInstances(
-	instances []sqlinstance.InstanceInfo, loc roachpb.Locality,
-) []base.SQLInstanceID {
+// at least length 1 and the shared prefix length. Returns nil, rather than the
+// entire input, if no instances have *any* shared locality prefix.
+func ClosestInstances[instance InstanceLocalityGetter](
+	instances []instance, loc roachpb.Locality,
+) ([]base.SQLInstanceID, int) {
 	best := 1
 	var res []base.SQLInstanceID
 	for _, i := range instances {
-		if l := i.Locality.SharedPrefix(loc); l > best {
+		if l := i.GetLocality().SharedPrefix(loc); l > best {
 			best = l
-			res = append(res[:0], i.InstanceID)
+			res = append(res[:0], i.GetInstanceID())
 		} else if l == best {
-			res = append(res, i.InstanceID)
+			res = append(res, i.GetInstanceID())
 		}
 	}
-	return res
+	if len(res) == 0 {
+		best = 0
+	}
+	return res, best
 }
 
 // getInstanceIDForScan retrieves the SQL Instance ID where the single table

--- a/pkg/sql/sqlinstance/sqlinstance.go
+++ b/pkg/sql/sqlinstance/sqlinstance.go
@@ -39,6 +39,14 @@ type InstanceInfo struct {
 	BinaryVersion   roachpb.Version
 }
 
+func (ii InstanceInfo) GetInstanceID() base.SQLInstanceID {
+	return ii.InstanceID
+}
+
+func (ii InstanceInfo) GetLocality() roachpb.Locality {
+	return ii.Locality
+}
+
 // SafeFormat implements redact.SafeFormatter.
 func (ii InstanceInfo) SafeFormat(s interfaces.SafePrinter, verb rune) {
 	s.Printf(


### PR DESCRIPTION
During C2C DistSQL planning we currently round robin match source to
destination nodes to be responsible for replicating a set of key spans. We
currently don’t consider node localities. To avoid cross-region traffic, we’d
ideally match a source node to it’s closest possible destination node and
maintain even load across nodes.

This patch implements the following src-node pair matching algorithm:

- For each Src node, find their closest dst nodes and the number of localities
  that match, the LocalityMatchCount. Example: Consider Src-A [US,East] which
has match candidates Dst-A [US,West], Dst-B [US,Central]. In the example, the
LocalityMatchCount is 1, as only US matches with the src nodes.

- Order Src nodes by their LocalityMatchCount. We want to prioritize matching
  src-nodes with a higher locality match count.

- While we have src nodes left to match, match the highest priority Src node to
  the Dst node candidate that has the fewest matches already

Note that this algorithm will nicely match source and destination nodes even if
the clusters have mismatched regions, and doesn’t consider zone configuration
metadata at all.

Fixes #106313

Release note: none