### PR TITLE
sql: unskip TestSchemaChangeGCJob

### DIFF
--- a/pkg/sql/gcjob_test/BUILD.bazel
+++ b/pkg/sql/gcjob_test/BUILD.bazel
@@ -38,7 +38,6 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",


### PR DESCRIPTION
Informs: #85876
fixes https://github.com/cockroachdb/cockroach/issues/60664

A few assumptions has been changed since the test was skipped. For example, the first user defined table descriptor ID and expected error messages. There was actually also bugs in the error assertion in the test for some reason, that is fixed by this PR too.

Release note: None