### PR TITLE
ui: fix crash on key visualizer

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/keyVisualizer/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/keyVisualizer/index.tsx
@@ -33,11 +33,19 @@ import { RouteComponentProps } from "react-router-dom";
 const EnabledSetting = "keyvisualizer.enabled";
 const IntervalSetting = "keyvisualizer.sample_interval";
 
+export function getRequestsAsNumber(requests: number | Long | null): number {
+  if (typeof requests === "number") {
+    return requests;
+  }
+
+  return requests?.toInt() ?? 0;
+}
+
 function hottestBucket(samples: KeyVisSamplesResponse["samples"]) {
   let highest = 0;
   for (const sample of samples) {
     for (const stat of sample.buckets) {
-      const numRequests = stat.requests?.toInt() || 0;
+      const numRequests = getRequestsAsNumber(stat.requests);
       if (numRequests > highest) {
         highest = numRequests;
       }

--- a/pkg/ui/workspaces/db-console/src/views/keyVisualizer/keyVisualizer.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/keyVisualizer/keyVisualizer.tsx
@@ -23,6 +23,7 @@ import {
   SampleBucket,
 } from "src/views/keyVisualizer/interfaces";
 import { throttle } from "lodash";
+import { getRequestsAsNumber } from ".";
 
 function drawBucket(
   pixels: Uint8ClampedArray,
@@ -296,7 +297,7 @@ export default class KeyVisualizer extends React.PureComponent<
 
           // compute color
           const color = [
-            Math.log(Math.max(bucket.requests.toInt(), 1)) /
+            Math.log(Math.max(getRequestsAsNumber(bucket.requests), 1)) /
               Math.log(this.props.hottestBucket),
             0,
             0,
@@ -400,7 +401,7 @@ export default class KeyVisualizer extends React.PureComponent<
                   y: y,
                   startKey: this.props.keys[bucket.startKeyHex],
                   endKey: this.props.keys[bucket.endKeyHex],
-                  requests: bucket.requests.toNumber(),
+                  requests: getRequestsAsNumber(bucket.requests),
                   epochTime: sample.timestamp.seconds.toNumber(),
                 },
               });


### PR DESCRIPTION
Fixes #106318

The value for requests response could be null, Long or number, and depending on the format it could cause a crash when trying to convert the value to number.
This commit does the correct checks and conversion to number.

Release note (bug fix): Key Visualizer not longer crashes with invalid conversion to int message.