### PR TITLE
xform: compute distribution of a lookup join with a lookup join as input

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -247,6 +247,9 @@ CREATE TABLE customers (
 ) LOCALITY REGIONAL BY ROW;
 
 statement ok
+INSERT INTO customers VALUES ('69a1c2c2-5b18-459e-94d2-079dc53a4dd0', 'ACME Sprockets')
+
+statement ok
 ALTER TABLE customers INJECT STATISTICS '[
   {
     "columns": ["id"],
@@ -276,6 +279,9 @@ CREATE TABLE orders (
     INDEX (cust_id),
     FOREIGN KEY (cust_id, crdb_region) REFERENCES customers (id, crdb_region) ON UPDATE CASCADE
 ) LOCALITY REGIONAL BY ROW;
+
+statement ok
+INSERT INTO orders VALUES ('69a1c2c2-5b18-459e-94d2-079dc53a4dd0', '69a1c2c2-5b18-459e-94d2-079dc53a4dd0', 'Super Deluxe Sprocket')
 
 statement ok
 ALTER TABLE orders INJECT STATISTICS '[
@@ -636,11 +642,33 @@ locality-optimized-search
       ├── constraint: /11/10: [/'ca-central-1' - /'us-east-1']
       └── limit: 1
 
-# Locality optimized search with lookup join will be supported in phase 2 or 3
-# when we can dynamically determine if the lookup will access a remote region.
-retry
+# Static checking should not error this query out, because we now generate a
+# plan with a home region for it.
+query T retry
+EXPLAIN (OPT) SELECT * FROM customers c JOIN orders o ON c.id = o.cust_id AND
+  (c.crdb_region = o.crdb_region) WHERE c.id = '69a1c2c2-5b18-459e-94d2-079dc53a4dd0'
+----
+project
+ └── inner-join (lookup orders [as=o])
+      ├── lookup columns are key
+      ├── inner-join (lookup orders@orders_cust_id_idx [as=o])
+      │    ├── locality-optimized-search
+      │    │    ├── scan customers [as=c]
+      │    │    │    └── constraint: /15/13: [/'ap-southeast-2'/'69a1c2c2-5b18-459e-94d2-079dc53a4dd0' - /'ap-southeast-2'/'69a1c2c2-5b18-459e-94d2-079dc53a4dd0']
+      │    │    └── scan customers [as=c]
+      │    │         └── constraint: /20/18
+      │    │              ├── [/'ca-central-1'/'69a1c2c2-5b18-459e-94d2-079dc53a4dd0' - /'ca-central-1'/'69a1c2c2-5b18-459e-94d2-079dc53a4dd0']
+      │    │              └── [/'us-east-1'/'69a1c2c2-5b18-459e-94d2-079dc53a4dd0' - /'us-east-1'/'69a1c2c2-5b18-459e-94d2-079dc53a4dd0']
+      │    └── filters
+      │         └── cust_id = '69a1c2c2-5b18-459e-94d2-079dc53a4dd0'
+      └── filters (true)
+
+# This query should error out dynamically during execution, but
+# `GetLookupJoinLookupTableDistribution` doesn't currently work in
+# the execbuilder phase because `Optimizer.stateMap` is empty.
+# TODO(msirek): Fix this test case to not error out statically.
 statement error pq: Query has no home region\. Try adding a filter on o\.crdb_region and/or on key column \(o\.cust_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
-SELECT * FROM customers c JOIN orders o ON c.id = o.cust_id AND
+SELECT 'a' FROM customers c JOIN orders o ON c.id = o.cust_id AND
   (c.crdb_region = o.crdb_region) WHERE c.id = '69a1c2c2-5b18-459e-94d2-079dc53a4dd0'
 
 # Locality optimized lookup join is allowed.

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -1080,6 +1080,7 @@ project
       │    ├── fd: ()-->(11), (7)-->(9)
       │    ├── limit hint: 1.00
       │    ├── distribution: ap-southeast-2
+      │    ├── lookup table distribution: ap-southeast-2
       │    ├── prune: (7)
       │    ├── inner-join (inverted json_arr1_rbr@j_idx [as=t1])
       │    │    ├── columns: t2.j:3 t1.k:18 crdb_region:22

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -639,7 +639,7 @@ locality-optimized-search
 # Locality optimized search with lookup join will be supported in phase 2 or 3
 # when we can dynamically determine if the lookup will access a remote region.
 retry
-statement error pq: Query has no home region\. Try adding a filter on o\.crdb_region and/or on key column \(o\.id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+statement error pq: Query has no home region\. Try adding a filter on o\.crdb_region and/or on key column \(o\.cust_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM customers c JOIN orders o ON c.id = o.cust_id AND
   (c.crdb_region = o.crdb_region) WHERE c.id = '69a1c2c2-5b18-459e-94d2-079dc53a4dd0'
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3554,3 +3554,91 @@ EXPLAIN (VEC) SELECT * FROM child LEFT JOIN parent ON p_id = c_p_id WHERE c_id =
 
 statement ok
 RESET vectorize
+
+statement ok
+CREATE TABLE abc (
+  id UUID PRIMARY KEY,
+  id1 UUID NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  id2 UUID NULL,
+  INDEX (id1 ASC, id2 ASC)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE xyz (
+  id UUID PRIMARY KEY,
+  str STRING NOT NULL,
+  abc_id UUID NOT NULL,
+  id2 UUID NULL,
+  FOREIGN KEY (abc_id) REFERENCES abc(id) ON DELETE CASCADE,
+  INDEX (abc_id ASC, id2 ASC),
+  INDEX (id2 ASC, str ASC, abc_id ASC)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+ALTER TABLE abc INJECT STATISTICS '[
+  {
+    "avg_size": 3000,
+    "columns": ["id"],
+    "distinct_count": 100,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  }
+]';
+
+statement ok
+ALTER TABLE xyz INJECT STATISTICS '[
+  {
+    "avg_size": 3000,
+    "columns": ["id"],
+    "distinct_count": 100,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  }
+]';
+
+# Regression test for #105942
+# The following should produce 2 lookup joins with a local distribution.
+query T retry
+EXPLAIN SELECT
+  xyz.str,
+  abc.id,
+  abc.id1,
+  abc.id2,
+  abc.created_at,
+  abc.updated_at
+FROM
+  abc JOIN xyz ON
+    xyz.abc_id = abc.id
+    AND xyz.id2 = abc.id2
+    AND xyz.crdb_region = abc.crdb_region
+WHERE
+  abc.id1 = '6da4f356-e526-4b78-b9f9-bbb1a7fc12d6'
+  AND abc.id2 = '68088706-02c6-47d1-b993-a421cd761f2b'
+  AND abc.crdb_region = 'ap-southeast-2'
+  AND xyz.crdb_region = 'ap-southeast-2';
+----
+distribution: local
+vectorized: true
+·
+• lookup join
+│ estimated row count: 1
+│ table: abc@abc_pkey
+│ equality: (crdb_region, id) = (crdb_region,id)
+│ equality cols are key
+│
+└── • lookup join
+    │ estimated row count: 0
+    │ table: abc@abc_id1_id2_idx
+    │ equality: (crdb_region, lookup_join_const_col_@2, id2, abc_id) = (crdb_region,id1,id2,id)
+    │ equality cols are key
+    │ pred: (id2 = '68088706-02c6-47d1-b993-a421cd761f2b') AND (crdb_region = 'ap-southeast-2')
+    │
+    └── • render
+        │
+        └── • scan
+              estimated row count: 4 (3.7% of the table; stats collected <hidden> ago)
+              table: xyz@xyz_id2_str_abc_id_idx
+              spans: [/'ap-southeast-2'/'68088706-02c6-47d1-b993-a421cd761f2b' - /'ap-southeast-2'/'68088706-02c6-47d1-b993-a421cd761f2b']
+

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3642,3 +3642,113 @@ vectorized: true
               table: xyz@xyz_id2_str_abc_id_idx
               spans: [/'ap-southeast-2'/'68088706-02c6-47d1-b993-a421cd761f2b' - /'ap-southeast-2'/'68088706-02c6-47d1-b993-a421cd761f2b']
 
+# The following should use a string of 4 lookup joins with a cost under 200.
+query T retry
+EXPLAIN(opt,verbose) SELECT
+  x.str,
+  a.id1,
+  a.id2,
+  a.created_at,
+  a.updated_at,
+  b.id1,
+  b.id2,
+  b.created_at,
+  b.updated_at
+FROM
+  abc a
+  INNER JOIN xyz x ON
+    x.abc_id = a.id
+    AND x.id2 = a.id2
+    AND x.crdb_region = a.crdb_region
+  INNER JOIN abc b ON
+    x.abc_id = b.id
+    AND x.id2 = b.id2
+    AND x.crdb_region = b.crdb_region
+WHERE
+  a.id1 = '6da4f356-e526-4b78-b9f9-bbb1a7fc12d6'
+  AND a.id2 = '68088706-02c6-47d1-b993-a421cd761f2b'
+  AND a.crdb_region = 'ap-southeast-2'
+  AND b.id1 = '6da4f356-e526-4b78-b9f9-bbb1a7fc12d6'
+  AND b.id2 = '68088706-02c6-47d1-b993-a421cd761f2b'
+  AND b.crdb_region = 'ap-southeast-2'
+  AND x.crdb_region = 'ap-southeast-2';
+----
+project
+ ├── columns: str:10 id1:2 id2:5 created_at:3 updated_at:4 id1:17 id2:20 created_at:18 updated_at:19
+ ├── immutable
+ ├── stats: [rows=1.031997]
+ ├── cost: 112.377461
+ ├── fd: ()-->(2,5,17,20), (2)==(17), (17)==(2), (3)==(18), (18)==(3), (4)==(19), (19)==(4)
+ ├── distribution: ap-southeast-2
+ ├── prune: (2-5,10,17-20)
+ └── inner-join (lookup abc [as=a])
+      ├── columns: a.id:1 a.id1:2 a.created_at:3 a.updated_at:4 a.id2:5 a.crdb_region:6 str:10 abc_id:11 x.id2:12 x.crdb_region:13 b.id:16 b.id1:17 b.created_at:18 b.updated_at:19 b.id2:20 b.crdb_region:21
+      ├── key columns: [6 1] = [6 1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── stats: [rows=1.031997, distinct(11)=0.936667, null(11)=0, distinct(12)=0.936667, null(12)=0, distinct(13)=0.936667, null(13)=0, distinct(16)=0.936667, null(16)=0, distinct(20)=0.936667, null(20)=0, distinct(21)=0.936667, null(21)=0]
+      ├── cost: 112.347141
+      ├── fd: ()-->(2,5,6,12,13,17,20,21), (1)-->(3,4), (1)==(11,16), (11)==(1,16), (5)==(12,20), (12)==(5,20), (6)==(13,21), (13)==(6,21), (16)-->(18,19), (16)==(1,11), (20)==(5,12), (21)==(6,13), (2)==(17), (17)==(2), (3)==(18), (18)==(3), (4)==(19), (19)==(4)
+      ├── distribution: ap-southeast-2
+      ├── inner-join (lookup abc@abc_id1_id2_idx [as=a])
+      │    ├── columns: a.id:1 a.id1:2 a.id2:5 a.crdb_region:6 str:10 abc_id:11 x.id2:12 x.crdb_region:13 b.id:16 b.id1:17 b.created_at:18 b.updated_at:19 b.id2:20 b.crdb_region:21
+      │    ├── key columns: [13 17 12 11] = [6 2 5 1]
+      │    ├── lookup columns are key
+      │    ├── immutable
+      │    ├── stats: [rows=0.01031997, distinct(1)=0.01032, null(1)=0, distinct(2)=0.01032, null(2)=0, distinct(5)=0.01032, null(5)=0, distinct(6)=0.01032, null(6)=0, distinct(10)=0.0102714, null(10)=0, distinct(11)=0.01032, null(11)=0, distinct(12)=0.01032, null(12)=0, distinct(13)=0.01032, null(13)=0, distinct(16)=0.0102638, null(16)=0, distinct(17)=0.01032, null(17)=0, distinct(18)=0.010244, null(18)=0, distinct(19)=0.010244, null(19)=0, distinct(20)=0.0102638, null(20)=0, distinct(21)=0.0102638, null(21)=0, distinct(2,5,6)=0.01032, null(2,5,6)=0]
+      │    ├── cost: 112.088874
+      │    ├── fd: ()-->(2,5,6,12,13,17,20,21), (16)-->(18,19), (11)==(1,16), (16)==(1,11), (12)==(5,20), (20)==(5,12), (13)==(6,21), (21)==(6,13), (6)==(13,21), (2)==(17), (17)==(2), (5)==(12,20), (1)==(11,16)
+      │    ├── distribution: ap-southeast-2
+      │    ├── inner-join (lookup abc [as=b])
+      │    │    ├── columns: str:10 abc_id:11 x.id2:12 x.crdb_region:13 b.id:16 b.id1:17 b.created_at:18 b.updated_at:19 b.id2:20 b.crdb_region:21
+      │    │    ├── key columns: [21 16] = [21 16]
+      │    │    ├── lookup columns are key
+      │    │    ├── immutable
+      │    │    ├── stats: [rows=1.101776, distinct(10)=1.08174, null(10)=0, distinct(11)=0.936667, null(11)=0, distinct(12)=0.936667, null(12)=0, distinct(13)=0.936667, null(13)=0, distinct(16)=0.936667, null(16)=0, distinct(17)=0.709904, null(17)=0, distinct(18)=0.693547, null(18)=0, distinct(19)=0.693547, null(19)=0, distinct(20)=0.936667, null(20)=0, distinct(21)=0.936667, null(21)=0]
+      │    │    ├── cost: 107.514948
+      │    │    ├── fd: ()-->(12,13,17,20,21), (16)-->(18,19), (11)==(16), (16)==(11), (12)==(20), (20)==(12), (13)==(21), (21)==(13)
+      │    │    ├── distribution: ap-southeast-2
+      │    │    ├── interesting orderings: (+11 opt(12,13)) (+10,+11 opt(12,13)) (+16 opt(17,20,21))
+      │    │    ├── inner-join (lookup abc@abc_id1_id2_idx [as=b])
+      │    │    │    ├── columns: str:10 abc_id:11 x.id2:12 x.crdb_region:13 b.id:16 b.id1:17 b.id2:20 b.crdb_region:21
+      │    │    │    ├── key columns: [13 28 12 11] = [21 17 20 16]
+      │    │    │    ├── lookup columns are key
+      │    │    │    ├── immutable
+      │    │    │    ├── stats: [rows=0.03434444, distinct(11)=0.0343444, null(11)=0, distinct(12)=0.0343444, null(12)=0, distinct(13)=0.0343444, null(13)=0, distinct(16)=0.0343444, null(16)=0, distinct(17)=0.0343444, null(17)=0, distinct(20)=0.0343444, null(20)=0, distinct(21)=0.0343444, null(21)=0, distinct(28)=0.0343444, null(28)=0, distinct(17,20,21)=0.0343444, null(17,20,21)=0]
+      │    │    │    ├── cost: 88.4621065
+      │    │    │    ├── fd: ()-->(12,13,17,20,21), (13)==(21), (21)==(13), (12)==(20), (20)==(12), (11)==(16), (16)==(11)
+      │    │    │    ├── distribution: ap-southeast-2
+      │    │    │    ├── interesting orderings: (+(11|16) opt(12,13,17,20,21,28)) (+10,+(11|16) opt(12,13,17,20,21,28))
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: "lookup_join_const_col_@17":28 str:10 abc_id:11 x.id2:12 x.crdb_region:13
+      │    │    │    │    ├── immutable
+      │    │    │    │    ├── stats: [rows=3.666667, distinct(10)=3.11719, null(10)=0, distinct(11)=3.11719, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(28)=1, null(28)=0]
+      │    │    │    │    ├── cost: 73.3666668
+      │    │    │    │    ├── fd: ()-->(12,13,28)
+      │    │    │    │    ├── distribution: ap-southeast-2
+      │    │    │    │    ├── interesting orderings: (+11 opt(12,13,28)) (+10,+11 opt(12,13,28))
+      │    │    │    │    ├── scan xyz@xyz_id2_str_abc_id_idx [as=x]
+      │    │    │    │    │    ├── columns: str:10 abc_id:11 x.id2:12 x.crdb_region:13
+      │    │    │    │    │    ├── constraint: /13/12/10/11/9: [/'ap-southeast-2'/'68088706-02c6-47d1-b993-a421cd761f2b' - /'ap-southeast-2'/'68088706-02c6-47d1-b993-a421cd761f2b']
+      │    │    │    │    │    ├── immutable
+      │    │    │    │    │    ├── stats: [rows=3.666667, distinct(10)=3.11719, null(10)=0, distinct(11)=3.11719, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(12,13)=1, null(12,13)=0]
+      │    │    │    │    │    │   histogram(13)=  0       3.6667
+      │    │    │    │    │    │                 <--- 'ap-southeast-2'
+      │    │    │    │    │    ├── cost: 73.2733335
+      │    │    │    │    │    ├── fd: ()-->(12,13)
+      │    │    │    │    │    ├── distribution: ap-southeast-2
+      │    │    │    │    │    ├── prune: (10,11)
+      │    │    │    │    │    └── interesting orderings: (+11 opt(12,13)) (+10,+11 opt(12,13))
+      │    │    │    │    └── projections
+      │    │    │    │         └── '6da4f356-e526-4b78-b9f9-bbb1a7fc12d6' [as="lookup_join_const_col_@17":28]
+      │    │    │    └── filters
+      │    │    │         ├── b.id2:20 = '68088706-02c6-47d1-b993-a421cd761f2b' [outer=(20), constraints=(/20: [/'68088706-02c6-47d1-b993-a421cd761f2b' - /'68088706-02c6-47d1-b993-a421cd761f2b']; tight), fd=()-->(20)]
+      │    │    │         └── b.crdb_region:21 = 'ap-southeast-2' [outer=(21), immutable, constraints=(/21: [/'ap-southeast-2' - /'ap-southeast-2']; tight), fd=()-->(21)]
+      │    │    └── filters (true)
+      │    └── filters
+      │         ├── a.id2:5 = '68088706-02c6-47d1-b993-a421cd761f2b' [outer=(5), constraints=(/5: [/'68088706-02c6-47d1-b993-a421cd761f2b' - /'68088706-02c6-47d1-b993-a421cd761f2b']; tight), fd=()-->(5)]
+      │         ├── a.crdb_region:6 = 'ap-southeast-2' [outer=(6), immutable, constraints=(/6: [/'ap-southeast-2' - /'ap-southeast-2']; tight), fd=()-->(6)]
+      │         └── a.id1:2 = '6da4f356-e526-4b78-b9f9-bbb1a7fc12d6' [outer=(2), constraints=(/2: [/'6da4f356-e526-4b78-b9f9-bbb1a7fc12d6' - /'6da4f356-e526-4b78-b9f9-bbb1a7fc12d6']; tight), fd=()-->(2)]
+      └── filters
+           ├── a.created_at:3 = b.created_at:18 [outer=(3,18), constraints=(/3: (/NULL - ]; /18: (/NULL - ]), fd=(3)==(18), (18)==(3)]
+           └── a.updated_at:4 = b.updated_at:19 [outer=(4,19), constraints=(/4: (/NULL - ]; /19: (/NULL - ]), fd=(4)==(19), (19)==(4)]

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3690,6 +3690,7 @@ project
       ├── cost: 112.347141
       ├── fd: ()-->(2,5,6,12,13,17,20,21), (1)-->(3,4), (1)==(11,16), (11)==(1,16), (5)==(12,20), (12)==(5,20), (6)==(13,21), (13)==(6,21), (16)-->(18,19), (16)==(1,11), (20)==(5,12), (21)==(6,13), (2)==(17), (17)==(2), (3)==(18), (18)==(3), (4)==(19), (19)==(4)
       ├── distribution: ap-southeast-2
+      ├── lookup table distribution: ap-southeast-2,ca-central-1,us-east-1
       ├── inner-join (lookup abc@abc_id1_id2_idx [as=a])
       │    ├── columns: a.id:1 a.id1:2 a.id2:5 a.crdb_region:6 str:10 abc_id:11 x.id2:12 x.crdb_region:13 b.id:16 b.id1:17 b.created_at:18 b.updated_at:19 b.id2:20 b.crdb_region:21
       │    ├── key columns: [13 17 12 11] = [6 2 5 1]
@@ -3699,6 +3700,7 @@ project
       │    ├── cost: 112.088874
       │    ├── fd: ()-->(2,5,6,12,13,17,20,21), (16)-->(18,19), (11)==(1,16), (16)==(1,11), (12)==(5,20), (20)==(5,12), (13)==(6,21), (21)==(6,13), (6)==(13,21), (2)==(17), (17)==(2), (5)==(12,20), (1)==(11,16)
       │    ├── distribution: ap-southeast-2
+      │    ├── lookup table distribution: ap-southeast-2,ca-central-1,us-east-1
       │    ├── inner-join (lookup abc [as=b])
       │    │    ├── columns: str:10 abc_id:11 x.id2:12 x.crdb_region:13 b.id:16 b.id1:17 b.created_at:18 b.updated_at:19 b.id2:20 b.crdb_region:21
       │    │    ├── key columns: [21 16] = [21 16]
@@ -3708,6 +3710,7 @@ project
       │    │    ├── cost: 107.514948
       │    │    ├── fd: ()-->(12,13,17,20,21), (16)-->(18,19), (11)==(16), (16)==(11), (12)==(20), (20)==(12), (13)==(21), (21)==(13)
       │    │    ├── distribution: ap-southeast-2
+      │    │    ├── lookup table distribution: ap-southeast-2,ca-central-1,us-east-1
       │    │    ├── interesting orderings: (+11 opt(12,13)) (+10,+11 opt(12,13)) (+16 opt(17,20,21))
       │    │    ├── inner-join (lookup abc@abc_id1_id2_idx [as=b])
       │    │    │    ├── columns: str:10 abc_id:11 x.id2:12 x.crdb_region:13 b.id:16 b.id1:17 b.id2:20 b.crdb_region:21
@@ -3718,6 +3721,7 @@ project
       │    │    │    ├── cost: 88.4621065
       │    │    │    ├── fd: ()-->(12,13,17,20,21), (13)==(21), (21)==(13), (12)==(20), (20)==(12), (11)==(16), (16)==(11)
       │    │    │    ├── distribution: ap-southeast-2
+      │    │    │    ├── lookup table distribution: ap-southeast-2,ca-central-1,us-east-1
       │    │    │    ├── interesting orderings: (+(11|16) opt(12,13,17,20,21,28)) (+10,+(11|16) opt(12,13,17,20,21,28))
       │    │    │    ├── project
       │    │    │    │    ├── columns: "lookup_join_const_col_@17":28 str:10 abc_id:11 x.id2:12 x.crdb_region:13

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -327,6 +327,11 @@ func (*DummyEvalPlanner) ExecutorConfig() interface{} {
 	return nil
 }
 
+// Optimizer is part of the cat.Catalog interface.
+func (*DummyEvalPlanner) Optimizer() interface{} {
+	return nil
+}
+
 var _ eval.Planner = &DummyEvalPlanner{}
 
 var errEvalPlanner = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -200,4 +200,8 @@ type Catalog interface {
 
 	// RoleExists returns true if the role exists.
 	RoleExists(ctx context.Context, role username.SQLUsername) (bool, error)
+
+	// Optimizer returns the query Optimizer used to optimize SQL statements
+	// referencing objects in this catalog, if any.
+	Optimizer() interface{}
 }

--- a/pkg/sql/opt/distribution/distribution.go
+++ b/pkg/sql/opt/distribution/distribution.go
@@ -149,22 +149,111 @@ func GetDEnumAsStringFromConstantExpr(expr opt.Expr) (enumAsString string, ok bo
 	return "", false
 }
 
-// BuildLookupJoinLookupTableDistribution builds the Distribution that results
-// from performing lookups of a LookupJoin, if that distribution can be
-// statically determined. If crdbRegionColID is non-zero, it is the column ID
-// of the input REGIONAL BY ROW table holding the crdb_region column, and
-// inputDistribution is the distribution of the operation on that table
-// (Scan or LocalityOptimizedSearch).
-// The distribution of the lookup join is returned, plus the first lookup index
-// column, as matched in the lookup with crdbRegionColID (if it can be
-// determined, otherwise zero).
+// getCRBDRegionColSetFromInput finds the set of column ids in the input to a
+// lookup join which are known to all be `crdb_region` columns, either in a Scan
+// or by being a `crdb_region` lookup table key column in a lookup join or chain
+// of lookup joins, all connected by `crdb_region` key column lookups. This
+// column set plus the distribution of the lookup join's input relation is
+// returned.
+func getCRBDRegionColSetFromInput(
+	ctx context.Context,
+	evalCtx *eval.Context,
+	join *memo.LookupJoinExpr,
+	required *physical.Required,
+	maybeGetBestCostRelation func(grp memo.RelExpr, required *physical.Required) (best memo.RelExpr, ok bool),
+) (crdbRegionColSet opt.ColSet, inputDistribution physical.Distribution) {
+	var needRemap bool
+	var setOpCols opt.ColSet
+
+	if bestCostInputRel, ok := maybeGetBestCostRelation(join.Input, required); ok {
+		maybeScan := bestCostInputRel
+		var projectExpr *memo.ProjectExpr
+		if projectExpr, ok = maybeScan.(*memo.ProjectExpr); ok {
+			maybeScan, ok = maybeGetBestCostRelation(projectExpr.Input, required)
+			if !ok {
+				return crdbRegionColSet, physical.Distribution{}
+			}
+		}
+		if selectExpr, ok := maybeScan.(*memo.SelectExpr); ok {
+			maybeScan, ok = maybeGetBestCostRelation(selectExpr.Input, required)
+			if !ok {
+				return crdbRegionColSet, physical.Distribution{}
+			}
+		}
+		if indexJoinExpr, ok := maybeScan.(*memo.IndexJoinExpr); ok {
+			maybeScan, ok = maybeGetBestCostRelation(indexJoinExpr.Input, required)
+			if !ok {
+				return crdbRegionColSet, physical.Distribution{}
+			}
+		}
+		if lookupJoinExpr, ok := maybeScan.(*memo.LookupJoinExpr); ok {
+			crdbRegionColSet, inputDistribution =
+				BuildLookupJoinLookupTableDistribution(
+					ctx, evalCtx, lookupJoinExpr, required, maybeGetBestCostRelation)
+			return crdbRegionColSet, inputDistribution
+		}
+		if localityOptimizedScan, ok := maybeScan.(*memo.LocalityOptimizedSearchExpr); ok {
+			maybeScan = localityOptimizedScan.Local
+			needRemap = true
+			setOpCols = localityOptimizedScan.Relational().OutputCols
+		}
+		scanExpr, ok := maybeScan.(*memo.ScanExpr)
+		if !ok {
+			return crdbRegionColSet, physical.Distribution{}
+		}
+		tab := maybeScan.Memo().Metadata().Table(scanExpr.Table)
+		if !tab.IsRegionalByRow() {
+			return crdbRegionColSet, physical.Distribution{}
+		}
+		inputDistribution =
+			BuildProvided(ctx, evalCtx, scanExpr, &required.Distribution)
+		index := tab.Index(scanExpr.Index)
+		crdbRegionColID := scanExpr.Table.IndexColumnID(index, 0)
+		if needRemap {
+			scanCols := scanExpr.Relational().OutputCols
+			if scanCols.Len() == setOpCols.Len() {
+				destCol, _ := setOpCols.Next(0)
+				for srcCol, ok := scanCols.Next(0); ok; srcCol, ok = scanCols.Next(srcCol + 1) {
+					if srcCol == crdbRegionColID {
+						crdbRegionColID = destCol
+						break
+					}
+					destCol, _ = setOpCols.Next(destCol + 1)
+				}
+			}
+		}
+		if projectExpr != nil {
+			if !projectExpr.Passthrough.Contains(crdbRegionColID) {
+				return crdbRegionColSet, physical.Distribution{}
+			}
+		}
+		crdbRegionColSet.Add(crdbRegionColID)
+	}
+	return crdbRegionColSet, inputDistribution
+}
+
+// BuildLookupJoinLookupTableDistribution builds and returns the Distribution of
+// a lookup table in a lookup join if that distribution can be statically
+// determined. It also finds the set of column ids in the input to the lookup
+// join which are known to all be `crdb_region` columns, either in a Scan or by
+// being a `crdb_region` lookup table key column in a lookup join or chain of
+// lookup joins, all connected by `crdb_region` key column lookups. This column
+// set plus the distribution of the lookup join's lookup table is returned.
+// Parameter `maybeGetBestCostRelation` is expected to be a function that looks
+// up the best cost relation in the `grp` relation's memo group. Typically this
+// is `xform.Coster.MaybeGetBestCostRelation`. It's passed as a function since
+// `BuildLookupJoinLookupTableDistribution` may be called from packages not
+// allowed to import the `xform` package due to import cycles.
 func BuildLookupJoinLookupTableDistribution(
 	ctx context.Context,
 	evalCtx *eval.Context,
 	lookupJoin *memo.LookupJoinExpr,
-	crdbRegionColID opt.ColumnID,
-	inputDistribution physical.Distribution,
-) (firstLookupIndexCol opt.ColumnID, provided physical.Distribution) {
+	required *physical.Required,
+	maybeGetBestCostRelation func(grp memo.RelExpr, required *physical.Required) (best memo.RelExpr, ok bool),
+) (crdbRegionColSet opt.ColSet, provided physical.Distribution) {
+	localCrdbRegionColSet, inputDistribution :=
+		getCRBDRegionColSetFromInput(ctx, evalCtx, lookupJoin, required, maybeGetBestCostRelation)
+
 	lookupTableMeta := lookupJoin.Memo().Metadata().TableMeta(lookupJoin.Table)
 	lookupTable := lookupTableMeta.Table
 
@@ -175,13 +264,13 @@ func BuildLookupJoinLookupTableDistribution(
 
 	if lookupJoin.LocalityOptimized || lookupJoin.ChildOfLocalityOptimizedSearch {
 		provided.FromLocality(evalCtx.Locality)
-		return 0 /* firstLookupIndexCol */, provided
+		return crdbRegionColSet, provided
 	} else if lookupTable.IsGlobalTable() {
 		provided.FromLocality(evalCtx.Locality)
-		return 0 /* firstLookupIndexCol */, provided
+		return crdbRegionColSet, provided
 	} else if homeRegion, ok := lookupTable.HomeRegion(); ok {
 		provided.Regions = []string{homeRegion}
-		return 0 /* firstLookupIndexCol */, provided
+		return crdbRegionColSet, provided
 	} else if lookupTable.IsRegionalByRow() {
 		if len(lookupJoin.KeyCols) > 0 {
 			inputExpr := lookupJoin.Input
@@ -190,23 +279,29 @@ func BuildLookupJoinLookupTableDistribution(
 				if filterExpr, ok := invertedJoinExpr.GetConstExprFromFilter(firstKeyColID); ok {
 					if homeRegion, ok = GetDEnumAsStringFromConstantExpr(filterExpr); ok {
 						provided.Regions = []string{homeRegion}
-						return colIDOfFirstLookupIndexColumn, provided
+						crdbRegionColSet.UnionWith(localCrdbRegionColSet)
+						crdbRegionColSet.Add(colIDOfFirstLookupIndexColumn)
+						return crdbRegionColSet, provided
 					}
 				}
 			} else if projectExpr, ok := inputExpr.(*memo.ProjectExpr); ok {
 				regionName := projectExpr.GetProjectedEnumConstant(firstKeyColID)
 				if regionName != "" {
 					provided.Regions = []string{regionName}
-					return colIDOfFirstLookupIndexColumn, provided
+					crdbRegionColSet.UnionWith(localCrdbRegionColSet)
+					crdbRegionColSet.Add(colIDOfFirstLookupIndexColumn)
+					return crdbRegionColSet, provided
 				}
 			}
-			if crdbRegionColID == firstKeyColID {
+			if localCrdbRegionColSet.Contains(firstKeyColID) {
 				provided.FromIndexScan(ctx, evalCtx, lookupTableMeta, lookupJoin.Index, nil)
 				if !inputDistribution.Any() &&
 					(provided.Any() || len(provided.Regions) > len(inputDistribution.Regions)) {
-					return colIDOfFirstLookupIndexColumn, inputDistribution
+					crdbRegionColSet.UnionWith(localCrdbRegionColSet)
+					crdbRegionColSet.Add(colIDOfFirstLookupIndexColumn)
+					return crdbRegionColSet, inputDistribution
 				}
-				return 0 /* firstLookupIndexCol */, provided
+				return crdbRegionColSet, provided
 			}
 		} else if len(lookupJoin.LookupJoinPrivate.LookupExpr) > 0 {
 			if filterIdx, ok := lookupJoin.GetConstPrefixFilter(lookupJoin.Memo().Metadata()); ok {
@@ -214,22 +309,26 @@ func BuildLookupJoinLookupTableDistribution(
 				if firstIndexColEqExpr.Op() == opt.EqOp {
 					if regionName, ok := GetDEnumAsStringFromConstantExpr(firstIndexColEqExpr.Child(1)); ok {
 						provided.Regions = []string{regionName}
-						return colIDOfFirstLookupIndexColumn, provided
+						crdbRegionColSet.UnionWith(localCrdbRegionColSet)
+						crdbRegionColSet.Add(colIDOfFirstLookupIndexColumn)
+						return crdbRegionColSet, provided
 					}
 				}
-			} else if lookupJoin.ColIsEquivalentWithLookupIndexPrefix(lookupJoin.Memo().Metadata(), crdbRegionColID) {
+			} else if lookupJoin.LookupIndexPrefixIsEquatedWithColInColSet(lookupJoin.Memo().Metadata(), localCrdbRegionColSet) {
 				// We have a `crdb_region = crdb_region` term in `LookupJoinPrivate.LookupExpr`.
 				provided.FromIndexScan(ctx, evalCtx, lookupTableMeta, lookupJoin.Index, nil)
 				if !inputDistribution.Any() &&
 					(provided.Any() || len(provided.Regions) > len(inputDistribution.Regions)) {
-					return colIDOfFirstLookupIndexColumn, inputDistribution
+					crdbRegionColSet.UnionWith(localCrdbRegionColSet)
+					crdbRegionColSet.Add(colIDOfFirstLookupIndexColumn)
+					return crdbRegionColSet, inputDistribution
 				}
-				return 0 /* firstLookupIndexCol */, provided
+				return crdbRegionColSet, provided
 			}
 		}
 	}
 	provided.FromIndexScan(ctx, evalCtx, lookupTableMeta, lookupJoin.Index, nil)
-	return 0 /* firstLookupIndexCol */, provided
+	return crdbRegionColSet, provided
 }
 
 // BuildInvertedJoinLookupTableDistribution builds the Distribution that results

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2311,7 +2311,8 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 	if lookupTable.IsGlobalTable() || join.LocalityOptimized || join.ChildOfLocalityOptimizedSearch {
 		// HomeRegion() does not automatically fill in the home region of a global
 		// table as the gateway region, so let's manually set it here.
-		// Locality optimized joins are considered local in phase 1.
+		// Locality optimized joins are considered local for static
+		// enforce_home_region checks.
 		homeRegion = gatewayRegion
 	} else {
 		homeRegion, _ = lookupTable.HomeRegion()
@@ -2343,7 +2344,19 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 			}
 		}
 	}
-
+	// If the specialized methods of setting the home region above don't succeed,
+	// see if `GetLookupJoinLookupTableDistribution` can find the lookup table's
+	// distribution.
+	// TODO(msirek): Check if the specialized methods above are even needed any
+	// more.
+	if homeRegion == "" && b.optimizer != nil && b.optimizer.Coster() != nil {
+		_, physicalDistribution := distribution.BuildLookupJoinLookupTableDistribution(
+			b.ctx, b.evalCtx, join, join.RequiredPhysical(), b.optimizer.MaybeGetBestCostRelation,
+		)
+		if len(physicalDistribution.Regions) == 1 {
+			homeRegion = physicalDistribution.Regions[0]
+		}
+	}
 	if homeRegion != "" {
 		if foundLocalRegion {
 			if queryHasHomeRegion {

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -920,24 +920,22 @@ func (lj *LookupJoinPrivate) GetConstPrefixFilter(md *opt.Metadata) (pos int, ok
 	return 0, false
 }
 
-// ColIsEquivalentWithLookupIndexPrefix returns true if there is a term in
-// `LookupExpr` equating the first column in the lookup index with `col`.
-func (lj *LookupJoinPrivate) ColIsEquivalentWithLookupIndexPrefix(
-	md *opt.Metadata, col opt.ColumnID,
+// LookupIndexPrefixIsEquatedWithColInColSet returns true if there is a term in
+// `LookupExpr` equating the first column in the lookup index with a column in
+// `colSet`.
+func (lj *LookupJoinPrivate) LookupIndexPrefixIsEquatedWithColInColSet(
+	md *opt.Metadata, colSet opt.ColSet,
 ) bool {
 	lookupTable := md.Table(lj.Table)
 	lookupIndex := lookupTable.Index(lj.Index)
 
 	idxCol := lj.Table.IndexColumnID(lookupIndex, 0)
-	var desiredEquivalentCols opt.ColSet
-	desiredEquivalentCols.Add(idxCol)
-	desiredEquivalentCols.Add(col)
 
 	for i := range lj.LookupExpr {
 		props := lj.LookupExpr[i].ScalarProps()
 
 		equivCols := props.FuncDeps.ComputeEquivGroup(idxCol)
-		if desiredEquivalentCols.SubsetOf(equivCols) {
+		if colSet.Intersects(equivCols) {
 			return true
 		}
 	}

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -865,6 +865,19 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if !required.Distribution.Any() {
 			tp.Childf("distribution: %s", required.Distribution.String())
 		}
+		// Show the lookup table distribution of a lookup join, if it has been set.
+		if lookupJoinExpr, ok := e.(*LookupJoinExpr); ok && f.Catalog != nil {
+			if optimizer := f.Catalog.Optimizer(); optimizer != nil {
+				providedDistribution := GetLookupJoinLookupTableDistribution(
+					lookupJoinExpr,
+					lookupJoinExpr.RequiredPhysical(),
+					optimizer,
+				)
+				if !providedDistribution.Any() {
+					tp.Childf("lookup table distribution: %s", providedDistribution.String())
+				}
+			}
+		}
 		if distribute, ok := e.(*DistributeExpr); ok {
 			tp.Childf("input distribution: %s", distribute.Input.ProvidedPhysical().Distribution.String())
 		}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -580,3 +580,11 @@ func (l *LiteralValuesExpr) ColList() opt.ColList {
 func (l *LiteralValuesExpr) Len() int {
 	return l.Rows.Rows.NumRows()
 }
+
+// GetLookupJoinLookupTableDistribution returns the Distribution of a lookup
+// table in a lookup join if that distribution can be statically determined.
+var GetLookupJoinLookupTableDistribution func(
+	lookupJoin *LookupJoinExpr,
+	required *physical.Required,
+	optimizer interface{},
+) (physicalDistribution physical.Distribution)

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -541,3 +541,8 @@ func (ep *fakeGetMultiregionConfigPlanner) GetRangeDescByID(
 ) (rangeDesc roachpb.RangeDescriptor, err error) {
 	return
 }
+
+// Optimizer is part of the cat.Catalog interface.
+func (ep *fakeGetMultiregionConfigPlanner) Optimizer() interface{} {
+	return nil
+}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -316,6 +316,11 @@ func (tc *Catalog) RoleExists(ctx context.Context, role username.SQLUsername) (b
 	return true, nil
 }
 
+// Optimizer is part of the cat.Catalog interface.
+func (tc *Catalog) Optimizer() interface{} {
+	return nil
+}
+
 func (tc *Catalog) resolveSchema(toResolve *cat.SchemaName) (cat.Schema, cat.SchemaName, error) {
 	if string(toResolve.CatalogName) != testDB {
 		return nil, cat.SchemaName{}, pgerror.Newf(pgcode.InvalidSchemaName,

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1032,82 +1032,6 @@ func (c *coster) computeIndexJoinCost(
 	)
 }
 
-// getCRBDRegionColFromInput examines the input to a lookup join. If it is a
-// Scan or LocalityOptimizedSearch from a REGIONAL BY ROW table, the column id
-// of the crdb_region column and Distribution of the operation are returned.
-// Otherwise, 0 and an empty Distribution are returned.
-func (c *coster) getCRBDRegionColFromInput(
-	join *memo.LookupJoinExpr, required *physical.Required,
-) (crdbRegionColID opt.ColumnID, inputDistribution physical.Distribution) {
-	var needRemap bool
-	var setOpCols opt.ColSet
-	if bestCostInputRel, ok := c.MaybeGetBestCostRelation(join.Input, required); ok {
-		maybeScan := bestCostInputRel
-		var projectExpr *memo.ProjectExpr
-		if projectExpr, ok = maybeScan.(*memo.ProjectExpr); ok {
-			maybeScan, ok = c.MaybeGetBestCostRelation(projectExpr.Input, required)
-			if !ok {
-				return 0, physical.Distribution{}
-			}
-		}
-		if selectExpr, ok := maybeScan.(*memo.SelectExpr); ok {
-			maybeScan, ok = c.MaybeGetBestCostRelation(selectExpr.Input, required)
-			if !ok {
-				return 0, physical.Distribution{}
-			}
-		}
-		if indexJoinExpr, ok := maybeScan.(*memo.IndexJoinExpr); ok {
-			maybeScan, ok = c.MaybeGetBestCostRelation(indexJoinExpr.Input, required)
-			if !ok {
-				return 0, physical.Distribution{}
-			}
-		}
-		if lookupJoinExpr, ok := maybeScan.(*memo.LookupJoinExpr); ok {
-			crdbRegionColID, inputDistribution = c.getCRBDRegionColFromInput(lookupJoinExpr, required)
-			crdbRegionColID, inputDistribution =
-				distribution.BuildLookupJoinLookupTableDistribution(
-					c.ctx, c.evalCtx, lookupJoinExpr, crdbRegionColID, inputDistribution)
-			return crdbRegionColID, inputDistribution
-		}
-		if localityOptimizedScan, ok := maybeScan.(*memo.LocalityOptimizedSearchExpr); ok {
-			maybeScan = localityOptimizedScan.Local
-			needRemap = true
-			setOpCols = localityOptimizedScan.Relational().OutputCols
-		}
-		scanExpr, ok := maybeScan.(*memo.ScanExpr)
-		if !ok {
-			return 0, physical.Distribution{}
-		}
-		tab := maybeScan.Memo().Metadata().Table(scanExpr.Table)
-		if !tab.IsRegionalByRow() {
-			return 0, physical.Distribution{}
-		}
-		inputDistribution =
-			distribution.BuildProvided(c.ctx, c.evalCtx, scanExpr, &required.Distribution)
-		index := tab.Index(scanExpr.Index)
-		crdbRegionColID = scanExpr.Table.IndexColumnID(index, 0)
-		if needRemap {
-			scanCols := scanExpr.Relational().OutputCols
-			if scanCols.Len() == setOpCols.Len() {
-				destCol, _ := setOpCols.Next(0)
-				for srcCol, ok := scanCols.Next(0); ok; srcCol, ok = scanCols.Next(srcCol + 1) {
-					if srcCol == crdbRegionColID {
-						crdbRegionColID = destCol
-						break
-					}
-					destCol, _ = setOpCols.Next(destCol + 1)
-				}
-			}
-		}
-		if projectExpr != nil {
-			if !projectExpr.Passthrough.Contains(crdbRegionColID) {
-				return 0, physical.Distribution{}
-			}
-		}
-	}
-	return crdbRegionColID, inputDistribution
-}
-
 func (c *coster) computeLookupJoinCost(
 	join *memo.LookupJoinExpr, required *physical.Required,
 ) memo.Cost {
@@ -1125,9 +1049,8 @@ func (c *coster) computeLookupJoinCost(
 		join.Flags,
 		join.LocalityOptimized,
 	)
-	crdbRegionColID, inputDistribution := c.getCRBDRegionColFromInput(join, required)
 	_, provided := distribution.BuildLookupJoinLookupTableDistribution(
-		c.ctx, c.evalCtx, join, crdbRegionColID, inputDistribution)
+		c.ctx, c.evalCtx, join, required, c.MaybeGetBestCostRelation)
 	extraCost := c.distributionCost(provided)
 	cost += extraCost
 	return cost

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1062,6 +1062,13 @@ func (c *coster) getCRBDRegionColFromInput(
 				return 0, physical.Distribution{}
 			}
 		}
+		if lookupJoinExpr, ok := maybeScan.(*memo.LookupJoinExpr); ok {
+			crdbRegionColID, inputDistribution = c.getCRBDRegionColFromInput(lookupJoinExpr, required)
+			crdbRegionColID, inputDistribution =
+				distribution.BuildLookupJoinLookupTableDistribution(
+					c.ctx, c.evalCtx, lookupJoinExpr, crdbRegionColID, inputDistribution)
+			return crdbRegionColID, inputDistribution
+		}
 		if localityOptimizedScan, ok := maybeScan.(*memo.LocalityOptimizedSearchExpr); ok {
 			maybeScan = localityOptimizedScan.Local
 			needRemap = true
@@ -1119,7 +1126,8 @@ func (c *coster) computeLookupJoinCost(
 		join.LocalityOptimized,
 	)
 	crdbRegionColID, inputDistribution := c.getCRBDRegionColFromInput(join, required)
-	provided := distribution.BuildLookupJoinLookupTableDistribution(c.ctx, c.evalCtx, join, crdbRegionColID, inputDistribution)
+	_, provided := distribution.BuildLookupJoinLookupTableDistribution(
+		c.ctx, c.evalCtx, join, crdbRegionColID, inputDistribution)
 	extraCost := c.distributionCost(provided)
 	cost += extraCost
 	return cost

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1888,9 +1888,10 @@ func (c *CustomFuncs) CanMaybeGenerateLocalityOptimizedSearchOfLookupJoins(
 
 // LookupsAreLocal returns true if the lookups done by the given lookup join
 // are done in the local region.
-func (c *CustomFuncs) LookupsAreLocal(lookupJoinExpr *memo.LookupJoinExpr) bool {
-	var inputDistribution physical.Distribution
-	_, provided := distribution.BuildLookupJoinLookupTableDistribution(c.e.ctx, c.e.f.EvalContext(), lookupJoinExpr, 0, inputDistribution)
+func (c *CustomFuncs) LookupsAreLocal(
+	lookupJoinExpr *memo.LookupJoinExpr, required *physical.Required,
+) bool {
+	_, provided := distribution.BuildLookupJoinLookupTableDistribution(c.e.ctx, c.e.f.EvalContext(), lookupJoinExpr, required, c.e.o.MaybeGetBestCostRelation)
 	if provided.Any() || len(provided.Regions) != 1 {
 		return false
 	}
@@ -2115,6 +2116,9 @@ func (c *CustomFuncs) GenerateLocalityOptimizedSearchLOJ(
 	inputScan *memo.ScanExpr,
 	inputFilters memo.FiltersExpr,
 ) {
+	if !c.LookupsAreLocal(lookupJoinExpr, required) {
+		return
+	}
 	c.GenerateLocalityOptimizedSearchOfLookupJoins(grp, required, lookupJoinExpr, inputScan, inputFilters, nil)
 }
 

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1890,7 +1890,7 @@ func (c *CustomFuncs) CanMaybeGenerateLocalityOptimizedSearchOfLookupJoins(
 // are done in the local region.
 func (c *CustomFuncs) LookupsAreLocal(lookupJoinExpr *memo.LookupJoinExpr) bool {
 	var inputDistribution physical.Distribution
-	provided := distribution.BuildLookupJoinLookupTableDistribution(c.e.ctx, c.e.f.EvalContext(), lookupJoinExpr, 0, inputDistribution)
+	_, provided := distribution.BuildLookupJoinLookupTableDistribution(c.e.ctx, c.e.f.EvalContext(), lookupJoinExpr, 0, inputDistribution)
 	if provided.Any() || len(provided.Regions) != 1 {
 		return false
 	}

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -298,3 +298,26 @@ func BuildChildPhysicalPropsScalar(mem *memo.Memo, parent opt.Expr, nth int) *ph
 	}
 	return mem.InternPhysicalProps(&childProps)
 }
+
+func init() {
+	memo.GetLookupJoinLookupTableDistribution = func(
+		lookupJoin *memo.LookupJoinExpr,
+		required *physical.Required,
+		optimizer interface{},
+	) (physicalDistribution physical.Distribution) {
+		if optimizer == nil {
+			return physicalDistribution
+		}
+		o, ok := optimizer.(*Optimizer)
+		if !ok {
+			return physicalDistribution
+		}
+		if o.evalCtx == nil {
+			return physicalDistribution
+		}
+		_, physicalDistribution = distribution.BuildLookupJoinLookupTableDistribution(
+			o.ctx, o.evalCtx, lookupJoin, required, o.MaybeGetBestCostRelation,
+		)
+		return physicalDistribution
+	}
+}

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -897,8 +897,7 @@
 (LookupJoin
     $input:* &
         (IsRegionalByRowTableScanOrSelect $input) &
-        (IsCardinalityAboveMaxForLocalityOptimizedScan $input) &
-        (LookupsAreLocal (Root))
+        (IsCardinalityAboveMaxForLocalityOptimizedScan $input)
     *
     $private:* &
         ^(IsAntiJoin $private) &

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
@@ -487,6 +488,15 @@ func (oc *optCatalog) fullyQualifiedNameWithTxn(
 // RoleExists is part of the cat.Catalog interface.
 func (oc *optCatalog) RoleExists(ctx context.Context, role username.SQLUsername) (bool, error) {
 	return RoleExists(ctx, oc.planner.InternalSQLTxn(), role)
+}
+
+// Optimizer is part of the cat.Catalog interface.
+func (oc *optCatalog) Optimizer() interface{} {
+	if oc.planner == nil {
+		return nil
+	}
+	plannerInterface := eval.Planner(oc.planner)
+	return plannerInterface.Optimizer()
 }
 
 // dataSourceForDesc returns a data source wrapper for the given descriptor.

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -811,3 +811,8 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(
 
 	return indexRecs, nil
 }
+
+// Optimizer returns the Optimizer associated with this planning context.
+func (opc *optPlanningCtx) Optimizer() interface{} {
+	return &opc.optimizer
+}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -975,3 +975,8 @@ func (p *planner) MaybeReallocateAnnotations(numAnnotations tree.AnnotationIdx) 
 	p.SemaCtx().Annotations = tree.MakeAnnotations(numAnnotations)
 	p.ExtendedEvalContext().Annotations = &p.SemaCtx().Annotations
 }
+
+// Optimizer is part of the eval.Planner interface.
+func (p *planner) Optimizer() interface{} {
+	return p.optPlanningCtx.Optimizer()
+}

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -437,6 +437,11 @@ func (p *fakePlannerWithMonitor) EnforceHomeRegion() bool {
 func (p *fakePlannerWithMonitor) MaybeReallocateAnnotations(numAnnotations tree.AnnotationIdx) {
 }
 
+// Optimizer is part of the cat.Catalog interface.
+func (p *fakePlannerWithMonitor) Optimizer() interface{} {
+	return nil
+}
+
 type fakeStreamManagerFactory struct {
 	StreamManagerFactory
 }

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -401,6 +401,9 @@ type Planner interface {
 	// less than numAnnotations entries. If updated, the annotations in the eval
 	// context held in the planner is also updated.
 	MaybeReallocateAnnotations(numAnnotations tree.AnnotationIdx)
+
+	// Optimizer returns the optimizer associated with this Planner, if any.
+	Optimizer() interface{}
 }
 
 // InternalRows is an iterator interface that's exposed by the internal


### PR DESCRIPTION
The adjustment to optimizer costing of lookup joins, added in v23.1,
to account for non-local input relation distribution (among the regions
in a multiregion database) did not account for the case where the
input to the lookup join is itself a lookup join. This resulted in an
extra distribution cost being added to some best-cost lookup joins,
causing the optimizer to no longer select them.

The issue is in function `getCRBDRegionColFromInput`, which only looks
for scan and locality-optimized scan operations as inputs. It is now
updated with a recursive call to itself plus a call to
`BuildLookupJoinLookupTableDistribution`, so the proper distribution
of a chain of lookup joins, plus the associated `crdb_region` column
in the lookup table can be determined. Function
`BuildLookupJoinLookupTableDistribution` is updated to return the
first lookup index column, when it is matched with the input's
crdb_region column, to facilitate this behavior.

Fixes: #105942

Release note (bug fix): This patch fixes an optimizer costing bug
introduced in v23.1 which may cause a query involving 2 or more
joins with REGIONAL BY ROW tables to not pick the most optimal
lookup joins.

----
xform: improve detection of local lookup joins with RBR tables

This commit improves the optimizer's ability to detect the proper
distribution of a string of lookup joins involving REGIONAL BY ROW
tables by updating the interfaces which match on the `crdb_region`
key column of the join to use a `ColSet` which holds all of the
`crdb_region` column ids which have been equated with eachother.

Informs: #105942

Release note (bug fix): This patch fixes an optimizer costing bug
introduced in v23.1 which may cause a query whose best-cost query
plan is a string of lookup joins with REGIONAL BY ROW tables, one
after the other in sequence, to not pick the most optimal join plan.

----
execbuilder: use lookup join lookup table distribution in home region checking

This commit updates enforce_home_region checking to build the lookup
join lookup table's distribution the same as is done in the coster.
This can prevent some lookup joins with a home region from being
errored out as not having a home region.

Informs: #105942

Release note: None

----

memo: print lookup table distribution in EXPLAIN output

This commit adds the distribution of the lookup table of lookup join to
the EXPLAIN output when it is not empty.

Informs: #105942

Release note: None