### PR TITLE
roachprod: fix leaky goroutine in `SyncedCluster.Monitor`

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -638,6 +638,7 @@ func (c *SyncedCluster) Monitor(
 	ch := make(chan NodeMonitorInfo)
 	nodes := c.TargetNodes()
 	var wg sync.WaitGroup
+	monitorCtx, cancel := context.WithCancel(ctx)
 
 	for i := range nodes {
 		wg.Add(1)
@@ -758,9 +759,10 @@ done
 				return
 			}
 
-			// Watch for context cancellation.
+			// Watch for context cancellation, which can happen either if
+			// the test fails, or if the monitor loop exits.
 			go func() {
-				<-ctx.Done()
+				<-monitorCtx.Done()
 				sess.Close()
 			}()
 
@@ -776,6 +778,7 @@ done
 	}
 	go func() {
 		wg.Wait()
+		cancel()
 		close(ch)
 	}()
 


### PR DESCRIPTION
The `Monitor` function would leak a goroutine per node waiting for context cancelation even after the monitor loop had already exited (for example, when a `OneShot` monitor check was requested).

This commit updates that function so that we use a cancelable context derived from the context passed as argument; when the monitor loop exits, we cancel that context, which causes the leaky goroutine to terminate appropriately.

This leaked goroutine shows up in the newly introduced roachtest `leaktest`, where there is one leaked goroutine per node in the cluster created by the test; the monitor is created during the `assertNoDeadNode` post-test assertion.

Epic: none

Release note: None