### PR TITLE
ci: don't do retries on tests in CI on master, release branches

### DIFF
--- a/build/teamcity/cockroach/ci/tests/unit_tests_ccl_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_ccl_impl.sh
@@ -10,7 +10,7 @@ bazel build //pkg/cmd/bazci --config=ci
 
 EXTRA_PARAMS=""
 
-if tc_release_branch || tc_bors_branch; then
+if tc_bors_branch; then
   # enable up to 1 retry (2 attempts, worst-case) per test executable to report flakes but only on release branches and staging.
   EXTRA_PARAMS=" --flaky_test_attempts=2"
 fi

--- a/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
@@ -10,7 +10,7 @@ bazel build //pkg/cmd/bazci --config=ci
 
 EXTRA_PARAMS=""
 
-if tc_release_branch || tc_bors_branch; then
+if tc_bors_branch; then
   # enable up to 1 retry (2 attempts, worst-case) per test executable to report flakes but only on release branches and staging.
   EXTRA_PARAMS=" --flaky_test_attempts=2"
 fi


### PR DESCRIPTION
First of all, test retries don't even have the correct behavior: https://github.com/cockroachdb/cockroach/issues/103042
This means that a successfully-retried test tramples the logs of
previously-failed tests, which is very confusing and erases your ability
to debug the test.

Also, we are focusing on quality and wiping out flaky and skipped tests.
This to me suggests we should not be retrying tests to let already-flaky
tests through. Rather, we should be surfacing real failures immediately.

For both of these reasons I turn off test retries for unit tests on
`master` and release branches.

We keep it for `staging` so `bors` is unaffected.

Epic: none
Release note: None