### PR TITLE
changefeedccl: Fix cluster ID check logic

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -264,6 +264,7 @@ go_test(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/flowinfra",
         "//pkg/sql/importer",
+        "//pkg/sql/isql",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1097,13 +1097,39 @@ func (b *changefeedResumer) Resume(ctx context.Context, execCtx interface{}) err
 	details := b.job.Details().(jobspb.ChangefeedDetails)
 	progress := b.job.Progress()
 
-	if createdBy := b.job.Payload().CreationClusterID; !jobExec.ExtendedEvalContext().ClusterID.Equal(createdBy) {
-		return errors.Newf("this changefeed was orignally created by cluster %s; it must be recreated on this cluster if this cluster is now expected to emit to the same destination", createdBy)
+	if err := b.ensureClusterIDMatches(ctx, jobExec.ExtendedEvalContext().ClusterID); err != nil {
+		return err
 	}
 
 	err := b.resumeWithRetries(ctx, jobExec, jobID, details, progress, execCfg)
 	if err != nil {
 		return b.handleChangefeedError(ctx, err, details, jobExec)
+	}
+	return nil
+}
+
+// ensureClusterIDMatches verifies that this job record matches
+// the cluster ID of this cluster.
+// This check ensures that if the job has been restored from the
+// full backup, or from streaming replication, then we will fail
+// this changefeed since resuming changefeed, from potentially
+// long "sleep", and attempting to write to existing bucket/topic,
+// is more undesirable and dangerous than just failing this job.
+func (b *changefeedResumer) ensureClusterIDMatches(ctx context.Context, clusterID uuid.UUID) error {
+	if createdBy := b.job.Payload().CreationClusterID; createdBy == uuid.Nil {
+		// This cluster was upgraded from a version that did not set clusterID
+		// in the job record -- rectify this issue.
+		if err := b.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			md.Payload.CreationClusterID = clusterID
+			ju.UpdatePayload(md.Payload)
+			return nil
+		}); err != nil {
+			return jobs.MarkAsRetryJobError(err)
+		}
+	} else if clusterID != createdBy {
+		return errors.Newf("this changefeed was originally created by cluster %s; "+
+			"it must be recreated on this cluster if this cluster is now expected "+
+			"to emit to the same destination", createdBy)
 	}
 	return nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -68,6 +68,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -94,6 +95,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/dustin/go-humanize"
 	"github.com/lib/pq"
@@ -1366,6 +1368,53 @@ func TestChangefeedProjectionDelete(t *testing.T) {
 		})
 	}
 	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
+}
+
+// Regression test for https://github.com/cockroachdb/cockroach/issues/106358
+// Ensure that changefeeds upgraded from the version that did not set job record
+// cluster ID continue functioning.
+func TestChangefeedCanResumeWhenClusterIDMissing(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		sqlDB.Exec(t, `CREATE TABLE foo (id int primary key, a string)`)
+		sqlDB.Exec(t, `INSERT INTO foo values (0, 'a')`)
+		foo := feed(t, f, `CREATE CHANGEFEED WITH envelope='wrapped' AS SELECT * FROM foo`)
+		defer closeFeed(t, foo)
+		assertPayloads(t, foo, []string{`foo: [0]->{"after": {"a": "a", "id": 0}}`})
+		jobFeed := foo.(cdctest.EnterpriseTestFeed)
+
+		// Pause the job and delete the row.
+		require.NoError(t, jobFeed.Pause())
+		sqlDB.Exec(t, `DELETE FROM foo WHERE id = 0`)
+
+		// clear out creation cluster id.
+		jobRegistry := s.Server.JobRegistry().(*jobs.Registry)
+		require.NoError(t, func() error {
+			job, err := jobRegistry.LoadJob(context.Background(), jobFeed.JobID())
+			if err != nil {
+				return err
+			}
+			return job.NoTxn().Update(context.Background(), func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+				md.Payload.CreationClusterID = uuid.Nil
+				ju.UpdatePayload(md.Payload)
+				return nil
+			})
+		}())
+
+		// Resume; we expect to see deleted row.
+		require.NoError(t, jobFeed.Resume())
+		assertPayloads(t, foo, []string{
+			`foo: [0]->{"after": null}`,
+		})
+
+		// The job payload now has clusterID set.
+		job, err := jobRegistry.LoadJob(context.Background(), jobFeed.JobID())
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, job.Payload().CreationClusterID)
+	}
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
 }
 
 // If we drop columns which are not targeted by the changefeed, it should not backfill.


### PR DESCRIPTION
Changefeeds created prior to
https://github.com/cockroachdb/cockroach/pull/99841 do not have cluster ID field set in their job record.  As a result, when upgrading to 23.1.x version, changefeeds created prior to that version will fail with an error message introduced by the above PR.

Fix the cluster ID checking logic to handle this case.
Fixes #106358

Release note (enterprise change): Changefeeds should no longer fail when upgrading to version 23.1.5.