### PR TITLE
server: de-flake a decommission test race condition

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -481,6 +481,9 @@ const (
 // of the provided transaction, using the provided internal executor.
 //
 // This converts to a call to insertEventRecords() with just 1 entry.
+//
+// Note: it is not safe to pass the same entry references to multiple
+// subsequent calls (it causes a race condition).
 func InsertEventRecords(
 	ctx context.Context, execCfg *ExecutorConfig, dst LogEventDestination, info ...logpb.EventPayload,
 ) {
@@ -516,6 +519,9 @@ func InsertEventRecords(
 //   - if there's at txn, after the txn commit time (i.e. we don't log
 //     if the txn ends up aborting), using a txn commit trigger.
 //   - otherwise (no txn), immediately.
+//
+// Note: it is not safe to pass the same entry references to multiple
+// subsequent calls (it causes a race condition).
 func insertEventRecords(
 	ctx context.Context,
 	execCfg *ExecutorConfig,


### PR DESCRIPTION
Informs #103698 (will fix when backported to 23.1).
Epic: CRDB-28893

When a Decommission request is sent that addresses multiple nodes simultaneously, a race condition existed in the code that logs the decommission event to the event log.

This is because the `sql.InsertEventRecords` API expects to take ownership over the events. The `Decommission` handler was violating the expectation by passing the same event references to multiple subsequent calls.

This was not visible in practice however, because the racy writes were always overwriting the same value to the same field.

This patch fixes it by allocating a new event for each subsequent node decommission.

Release note: None