### PR TITLE
release-23.1: ui: add details to generic error message

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -877,9 +877,7 @@ export class DatabaseDetailsPage extends React.Component<
             renderError={() =>
               LoadingError({
                 statsType: "databases",
-                timeout: this.props.lastError?.name
-                  ?.toLowerCase()
-                  .includes("timeout"),
+                error: this.props.lastError,
               })
             }
           />
@@ -892,9 +890,6 @@ export class DatabaseDetailsPage extends React.Component<
               renderError={() =>
                 LoadingError({
                   statsType: "part of the information",
-                  timeout: this.state.lastDetailsError?.name
-                    ?.toLowerCase()
-                    .includes("timeout"),
                   error: this.state.lastDetailsError,
                 })
               }

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -594,9 +594,7 @@ export class DatabaseTablePage extends React.Component<
                 renderError={() =>
                   LoadingError({
                     statsType: "databases",
-                    timeout: this.props.details.lastError?.name
-                      ?.toLowerCase()
-                      .includes("timeout"),
+                    error: this.props.details.lastError,
                   })
                 }
               />
@@ -619,9 +617,7 @@ export class DatabaseTablePage extends React.Component<
                 renderError={() =>
                   LoadingError({
                     statsType: "databases",
-                    timeout: this.props.details.lastError?.name
-                      ?.toLowerCase()
-                      .includes("timeout"),
+                    error: this.props.details.lastError,
                   })
                 }
               />

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePageConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePageConnected.ts
@@ -64,7 +64,6 @@ export const mapStateToProps = (
   );
   const nodeRegions = nodeRegionsByIDSelector(state);
   const isTenant = selectIsTenant(state);
-
   return {
     databaseName: database,
     name: table,

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -736,9 +736,7 @@ export class DatabasesPage extends React.Component<
             renderError={() =>
               LoadingError({
                 statsType: "databases",
-                timeout: this.props.lastError?.name
-                  ?.toLowerCase()
-                  .includes("timeout"),
+                error: this.props.lastError,
               })
             }
           />
@@ -751,9 +749,6 @@ export class DatabasesPage extends React.Component<
               renderError={() =>
                 LoadingError({
                   statsType: "part of the information",
-                  timeout: this.state.lastDetailsError?.name
-                    ?.toLowerCase()
-                    .includes("timeout"),
                   error: this.state.lastDetailsError,
                 })
               }

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -625,9 +625,7 @@ export class IndexDetailsPage extends React.Component<
                     renderError={() =>
                       LoadingError({
                         statsType: "statements",
-                        timeout: this.state.lastStatementsError?.message
-                          ?.toLowerCase()
-                          .includes("timeout"),
+                        error: this.state.lastStatementsError,
                       })
                     }
                   >

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -213,6 +213,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
             renderError={() =>
               LoadingError({
                 statsType: "sessions",
+                error: this.props.sessionError,
               })
             }
           />

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -21,7 +21,7 @@ import {
 import { RouteComponentProps } from "react-router-dom";
 import classNames from "classnames/bind";
 
-import LoadingError from "../sqlActivity/errorComponent";
+import LoadingError, { mergeErrors } from "../sqlActivity/errorComponent";
 import { Pagination } from "src/pagination";
 import {
   SortSetting,
@@ -459,6 +459,7 @@ export class SessionsPage extends React.Component<
           renderError={() =>
             LoadingError({
               statsType: "sessions",
+              error: mergeErrors(this.props.sessionsError),
             })
           }
         />

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
@@ -11,36 +11,93 @@
 import React from "react";
 import classNames from "classnames/bind";
 import styles from "./sqlActivity.module.scss";
+import moment, { Moment } from "moment-timezone";
 
 const cx = classNames.bind(styles);
 
 interface SQLActivityErrorProps {
   statsType: string;
-  timeout?: boolean;
-  error?: Error;
+  error: Error;
+}
+
+export function mergeErrors(errs: Error | Error[]): Error {
+  if (!errs) {
+    return null;
+  }
+
+  if (!Array.isArray(errs)) {
+    // Put single Error into a list to simplify logic in main Loading component.
+    return errs;
+  }
+
+  const errors: Error[] = errs as Error[];
+
+  if (!errors) {
+    return null;
+  }
+
+  if (errors.length === 0) {
+    return null;
+  }
+
+  if (errors.length === 1) {
+    return errors[0];
+  }
+
+  const mergedError: Error = {
+    name: "Multiple errors: ",
+    message: "Multiple errors: ",
+  };
+
+  errors.forEach(
+    (x, i, arr) => (
+      (mergedError.name += ` ${i}: ${x.name};`),
+      (mergedError.message += ` ${i}: ${x.message};`)
+    ),
+  );
+  return mergedError;
 }
 
 const LoadingError: React.FC<SQLActivityErrorProps> = props => {
+  const url = window.location.href;
   if (props.error && props.error.name === "GetDatabaseInfoError") {
     return (
       <div className={cx("row")}>
         <span>{props.error.message}</span>
+        <br />
+        <span>{`Debug information: ${moment
+          .utc()
+          .format("YYYY.MM.DD HH:mm:ss")} utc; URL: ${url}`}</span>
       </div>
     );
   }
-  const error = props.timeout ? "a timeout" : "an unexpected error";
+
+  const error = props.error?.name?.toLowerCase().includes("timeout")
+    ? "a timeout"
+    : "an unexpected error";
+
   return (
-    <div className={cx("row")}>
-      <span>{`This page had ${error} while loading ${props.statsType}.`}</span>
-      &nbsp;
-      <a
-        className={cx("action")}
-        onClick={() => {
-          window.location.reload();
-        }}
-      >
-        Reload this page
-      </a>
+    <div>
+      <div className={cx("row")}>
+        <span>{`This page had ${error} while loading ${props.statsType}.`}</span>
+        &nbsp;
+        <a
+          className={cx("action")}
+          onClick={() => {
+            window.location.reload();
+          }}
+        >
+          Reload this page
+        </a>
+      </div>
+      <div className={cx("row-small")}>
+        <br />
+        <span>{`Debug information: ${moment
+          .utc()
+          .format("YYYY.MM.DD HH:mm:ss")} utc; Error message: ${
+          props?.error?.message
+        }; URL: ${url};`}</span>
+      </div>
     </div>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/sqlActivity.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/sqlActivity.module.scss
@@ -18,3 +18,12 @@
   display: flex;
   flex-direction: row;
 }
+
+.row-small {
+  display: flex;
+  flex-direction: row;
+  font-size:xx-small;
+  color:$colors--neutral-5;
+  max-width: 450px;
+  line-height: 15px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetails.tsx
@@ -174,9 +174,7 @@ export const RecentStatementDetails: React.FC<RecentStatementDetailsProps> = ({
                   renderError={() =>
                     LoadingError({
                       statsType: "explain plan",
-                      timeout: explainPlanState.error?.name
-                        ?.toLowerCase()
-                        .includes("timeout"),
+                      error: explainPlanState.error,
                     })
                   }
                 >

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -430,6 +430,7 @@ export class StatementDetails extends React.Component<
             renderError={() =>
               LoadingError({
                 statsType: "statements",
+                error: error,
               })
             }
           />
@@ -534,7 +535,7 @@ export class StatementDetails extends React.Component<
             intent="danger"
             title={LoadingError({
               statsType: "statements",
-              timeout: true,
+              error: this.props.statementsError,
             })}
           />
         )}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsView.tsx
@@ -219,6 +219,7 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
           renderError={() =>
             LoadingError({
               statsType: "statements",
+              error: sessionsError,
             })
           }
         >

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -764,9 +764,7 @@ export class StatementsPage extends React.Component<
             renderError={() =>
               LoadingError({
                 statsType: "statements",
-                timeout: this.props.statementsError?.name
-                  ?.toLowerCase()
-                  .includes("timeout"),
+                error: this.props.statementsError,
               })
             }
           />

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -597,6 +597,7 @@ export class TransactionDetails extends React.Component<
           renderError={() =>
             LoadingError({
               statsType: "transactions",
+              error: error,
             })
           }
         />

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/recentTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/recentTransactionsView.tsx
@@ -216,6 +216,7 @@ export const RecentTransactionsView: React.FC<RecentTransactionsViewProps> = ({
           renderError={() =>
             LoadingError({
               statsType: "transactions",
+              error: sessionsError,
             })
           }
         >

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -687,9 +687,7 @@ export class TransactionsPage extends React.Component<
             renderError={() =>
               LoadingError({
                 statsType: "transactions",
-                timeout: this.props?.error?.name
-                  ?.toLowerCase()
-                  .includes("timeout"),
+                error: this.props?.error,
               })
             }
           />


### PR DESCRIPTION
Backport 1/1 commits from #105550.

/cc @cockroachdb/release

---

When a user encounters an error they only get a generic error message. Users need to go to the dev console and try to find and share the actual error message. If the issue doesn't reproduce, it's not possible to root cause the problem.

This commit adds the current date, error message, and the current URL to the error component so when a user shares a screen shot we have the necessary info without the need for them to go to the dev console.

This commit also refactors the check for the timeout logic into the error component which removes the duplicate logic.


<img width="1018" alt="Screenshot 2023-06-28 at 1 15 51 PM" src="https://github.com/cockroachdb/cockroach/assets/8868107/503cd28d-f749-4d16-b256-0505bdbb3c93">



Fixes: #105549

Release note (ui change): The generic error message now includes details about the actual error, and other context to make it easier to root cause.

Release Justification: Improved troubleshooting experience

