### PR TITLE
kvflowhandle: fix mutex leak

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/kvflowhandle.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/kvflowhandle.go
@@ -97,6 +97,7 @@ func (h *Handle) Admit(ctx context.Context, pri admissionpb.WorkPriority, ct tim
 
 	h.mu.Lock()
 	if h.mu.closed {
+		h.mu.Unlock()
 		log.Errorf(ctx, "operating on a closed handle")
 		return nil
 	}


### PR DESCRIPTION
Fixes #106078.

We were forgetting to unlock the mutex on the error path.

Release note: None