### PR TITLE
changefeedccl: Improve error handling

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/iterutil",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/settings",
         "//pkg/sql/catalog/descpb",
-        "//pkg/sql/catalog/lease",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util",
@@ -28,13 +27,27 @@ go_library(
 
 go_test(
     name = "changefeedbase_test",
-    srcs = ["options_test.go"],
+    srcs = [
+        "errors_test.go",
+        "main_test.go",
+        "options_test.go",
+    ],
     args = ["-test.timeout=295s"],
     embed = [":changefeedbase"],
     tags = ["ccl_test"],
     deps = [
+        "//pkg/ccl",
+        "//pkg/jobs",
+        "//pkg/kv/kvpb",
+        "//pkg/security/securityassets",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/changefeedccl/changefeedbase/errors_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors_test.go
@@ -1,0 +1,76 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedbase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type drainHelper bool
+
+func (h drainHelper) IsDraining() bool {
+	return bool(h)
+}
+
+var nodeIsDraining drainHelper = true
+var nodeIsNotDraining drainHelper = false
+
+func TestAsTerminalError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("context error", func(t *testing.T) {
+		canceledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// Regardless of the state of the node drain, or the type of error,
+		// context error takes precedence.
+		require.Regexp(t, context.Canceled,
+			changefeedbase.AsTerminalError(canceledCtx, nodeIsDraining, errors.New("ignored")))
+		require.Regexp(t, context.Canceled,
+			changefeedbase.AsTerminalError(canceledCtx, nodeIsNotDraining, errors.New("ignored")))
+	})
+
+	t.Run("node drain marked as job retry", func(t *testing.T) {
+		cause := errors.New("some error happened")
+		termErr := changefeedbase.AsTerminalError(context.Background(), nodeIsDraining, cause)
+		require.Regexp(t, cause.Error(), termErr)
+		require.True(t, jobs.IsRetryJobError(termErr))
+	})
+
+	t.Run("terminal errors are terminal", func(t *testing.T) {
+		// Errors explicitly marked as terminal are really terminal
+		cause := changefeedbase.WithTerminalError(
+			changefeedbase.MarkRetryableError(errors.New("confusing error")))
+		termErr := changefeedbase.AsTerminalError(context.Background(), nodeIsNotDraining, cause)
+		require.Regexp(t, cause.Error(), termErr)
+	})
+
+	t.Run("assertion failures are terminal", func(t *testing.T) {
+		// Assertion failures are terminal, even if marked as retry-able.
+		cause := changefeedbase.MarkRetryableError(errors.AssertionFailedf("though shall not pass"))
+		termErr := changefeedbase.AsTerminalError(context.Background(), nodeIsNotDraining, cause)
+		require.Regexp(t, cause.Error(), termErr)
+	})
+
+	t.Run("gc error is terminal", func(t *testing.T) {
+		cause := changefeedbase.MarkRetryableError(&kvpb.BatchTimestampBeforeGCError{})
+		termErr := changefeedbase.AsTerminalError(context.Background(), nodeIsNotDraining, cause)
+		require.Regexp(t, cause.Error(), termErr)
+	})
+}

--- a/pkg/ccl/changefeedccl/changefeedbase/main_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedbase_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	defer ccl.TestingEnableEnterprise()()
+	securityassets.SetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -214,7 +214,7 @@ func (b *blockingBuffer) enqueue(ctx context.Context, e Event) (err error) {
 
 	if b.mu.closed {
 		logcrash.ReportOrPanic(ctx, b.sv, "buffer unexpectedly closed")
-		return errors.AssertionFailedf("buffer unexpectedly closed")
+		return errors.New("buffer unexpectedly closed")
 	}
 
 	b.metrics.BufferEntriesIn.Inc(1)

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -413,8 +413,8 @@ func (f *kvFeed) scanIfShould(
 				}
 			}
 			if !scanTime.Equal(ev.After.GetModificationTime()) {
-				return nil, hlc.Timestamp{}, errors.AssertionFailedf(
-					"found event in shouldScan which did not occur at the scan time %v: %v",
+				return nil, hlc.Timestamp{}, errors.Newf(
+					"found event in scanIfShould which did not occur at the scan time %v: %v",
 					scanTime, ev)
 			}
 		}

--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -34,6 +34,11 @@ func MarkAsRetryJobError(err error) error {
 	return errors.Mark(err, errRetryJobSentinel)
 }
 
+// IsRetryJobError checks whether the given error is a job retry error.
+func IsRetryJobError(err error) bool {
+	return errors.Is(err, errRetryJobSentinel)
+}
+
 // Registry does not retry a job that fails due to a permanent error.
 var errJobPermanentSentinel = errors.New("permanent job error")
 


### PR DESCRIPTION
Two commits to improve error handling behavior:

---
changefeedccl: Treat kv decoding errors as terminal 

Treat key/value decoding errors as terminal.
Produce loud errors when encountering such an error.

Fixes #106384

Release note: None

---
changefeedccl: Audit AssertionFailed uses and treat them as terminal 

Audit the uses of AssertionFailed errors and treat those
errors as terminal changefeed errors.

Fixes #106385

Release note: None
