### PR TITLE
logictest: deflake udf tracing test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2178,7 +2178,7 @@ statement ok
 SET tracing = off
 
 query T rowsort
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message ~ 'udf'
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message ~ '^=== SPAN START: udf-stmt-trace_fn'
 ----
 === SPAN START: udf-stmt-trace_fn-1 ===
 === SPAN START: udf-stmt-trace_fn-2 ===


### PR DESCRIPTION
This commit tightens up a regex filter in a UDF tracing test to ensure
that the filter won't match random DistSQL diagram URLs that exist in
`SHOW TRACE FOR SESSION`.

Fixes #106361

Release note: None
