### PR TITLE
release-23.1: builtins: create function to aggregate aggregated stmt metadata

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -323,6 +323,8 @@
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="cardinality"></a><code>cardinality(input: anyelement[]) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of elements contained in <code>input</code></p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="crdb_internal.merge_aggregated_stmt_metadata"></a><code>crdb_internal.merge_aggregated_stmt_metadata(input: jsonb[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Merge an array of AggregatedStatementMetadata into a single JSONB object</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="crdb_internal.merge_statement_stats"></a><code>crdb_internal.merge_statement_stats(input: jsonb[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Merge an array of appstatspb.StatementStatistics into a single JSONB object</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="crdb_internal.merge_stats_metadata"></a><code>crdb_internal.merge_stats_metadata(input: jsonb[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Merge an array of StmtStatsMetadata into a single JSONB object</p>

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -329,7 +329,7 @@ FROM %s
 		}
 		// If there are no results from the activity table, retrieve the data from the persisted table.
 		if stmtsRuntime == 0 {
-			stmtsRuntime, err = getRuntime(fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix))
+			stmtsRuntime, err = getRuntime("crdb_internal.statement_statistics_persisted" + tableSuffix)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -354,7 +354,7 @@ FROM %s
 		}
 		// If there are no results from the activity table, retrieve the data from the persisted table.
 		if txnsRuntime == 0 {
-			txnsRuntime, err = getRuntime(fmt.Sprintf("crdb_internal.transaction_statistics_persisted%s", tableSuffix))
+			txnsRuntime, err = getRuntime("crdb_internal.transaction_statistics_persisted" + tableSuffix)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -620,7 +620,7 @@ GROUP BY
 			ctx,
 			ie,
 			queryFormat,
-			fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix),
+			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			"combined-stmts-persisted-by-interval",
 			whereClause,
 			args,
@@ -801,7 +801,7 @@ GROUP BY
 			ctx,
 			ie,
 			queryFormat,
-			fmt.Sprintf("crdb_internal.transaction_statistics_persisted%s", tableSuffix),
+			"crdb_internal.transaction_statistics_persisted"+tableSuffix,
 			"combined-txns-persisted-by-interval",
 			whereClause,
 			args,
@@ -935,7 +935,7 @@ GROUP BY
 		}
 		query = fmt.Sprintf(
 			queryFormat,
-			fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix),
+			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			whereClause)
 		it, err = ie.QueryIteratorEx(ctx, "stmts-persisted-for-txn", nil,
 			sessiondata.NodeUserSessionDataOverride, query, args...)
@@ -1226,7 +1226,7 @@ func getTotalStatementDetails(
 	if row == nil || row.Len() == 0 {
 		query = fmt.Sprintf(
 			queryFormat,
-			fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix),
+			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			whereClause)
 		row, err = ie.QueryRowEx(ctx, "combined-stmts-persisted-details-total", nil,
 			sessiondata.NodeUserSessionDataOverride, query, args...)
@@ -1339,7 +1339,7 @@ func getStatementDetailsPerAggregatedTs(
 		}
 		query = fmt.Sprintf(
 			queryFormat,
-			fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix),
+			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			whereClause,
 			len(args))
 
@@ -1523,7 +1523,7 @@ func getStatementDetailsPerPlanHash(
 		}
 		query = fmt.Sprintf(
 			queryFormat,
-			fmt.Sprintf("crdb_internal.statement_statistics_persisted%s", tableSuffix),
+			"crdb_internal.statement_statistics_persisted"+tableSuffix,
 			whereClause,
 			len(args))
 		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-persisted-details-by-plan-hash", nil,

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -206,7 +206,7 @@ func activityTablesHaveFullData(
 	// Used to verify the table contained data.
 	zeroDate := time.Time{}
 
-	queryWithPlaceholders := `
+	const queryWithPlaceholders = `
 SELECT 
     COALESCE(min(aggregated_ts), '%s')
 FROM crdb_internal.statement_activity 
@@ -275,26 +275,20 @@ func getTotalRuntimeSecs(
 
 	whereClause := buffer.String()
 
-	queryWithPlaceholders := `
-SELECT
-COALESCE(
-  sum(
-    (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT *
-    (statistics-> 'statistics' ->> 'cnt')::FLOAT
-  )
-, 0)
-FROM %s
-%s
-`
-
 	getRuntime := func(table string) (float32, error) {
 		it, err := ie.QueryIteratorEx(
 			ctx,
 			fmt.Sprintf(`%s-total-runtime`, table),
 			nil,
 			sessiondata.NodeUserSessionDataOverride,
-			fmt.Sprintf(queryWithPlaceholders, table, whereClause),
-			args...)
+			fmt.Sprintf(`
+SELECT COALESCE(
+          sum(
+             (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT *
+             (statistics -> 'statistics' ->> 'cnt')::FLOAT
+          ),
+       0)
+FROM %s %s`, table, whereClause), args...)
 
 		defer func() {
 			err = closeIterator(it, err)
@@ -573,20 +567,18 @@ func collectCombinedStatements(
 ) ([]serverpb.StatementsResponse_CollectedStatementStatistics, error) {
 	aostClause := testingKnobs.GetAOSTClause()
 	const expectedNumDatums = 6
-	queryFormat := `
-SELECT * FROM (
-SELECT
-    fingerprint_id,
-    array_agg(distinct transaction_fingerprint_id),
-    app_name,
-    max(aggregated_ts) as aggregated_ts,
-    crdb_internal.merge_stats_metadata(array_agg(metadata)) as metadata,
-    crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
-FROM %s %s
-GROUP BY
-    fingerprint_id,
-    app_name
-) %s
+	const queryFormat = `
+SELECT *
+FROM (SELECT fingerprint_id,
+             array_agg(distinct transaction_fingerprint_id),
+             app_name,
+             max(aggregated_ts)                                         AS aggregated_ts,
+             crdb_internal.merge_stats_metadata(array_agg(metadata))    AS metadata,
+             crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
+      FROM %s %s
+      GROUP BY
+          fingerprint_id,
+          app_name) %s
 %s`
 
 	var it isql.Rows
@@ -755,19 +747,17 @@ func collectCombinedTransactions(
 ) ([]serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics, error) {
 	aostClause := testingKnobs.GetAOSTClause()
 	const expectedNumDatums = 5
-	queryFormat := `
-SELECT * FROM (
-SELECT
-    app_name,
-    max(aggregated_ts) as aggregated_ts,
-    fingerprint_id,
-    max(metadata),
-    crdb_internal.merge_transaction_stats(array_agg(statistics)) AS statistics
-FROM %s %s
-GROUP BY
-    app_name,
-    fingerprint_id
-) %s
+	const queryFormat = `
+SELECT *
+FROM (SELECT app_name,
+             max(aggregated_ts)                                           AS aggregated_ts,
+             fingerprint_id,
+             max(metadata),
+             crdb_internal.merge_transaction_stats(array_agg(statistics)) AS statistics
+      FROM %s %s
+      GROUP BY
+          app_name,
+          fingerprint_id) %s
 %s`
 
 	var it isql.Rows
@@ -894,13 +884,12 @@ func collectStmtsForTxns(
 
 	whereClause, args := buildWhereClauseForStmtsByTxn(req, transactions, testingKnobs)
 
-	queryFormat := `
-SELECT
-    fingerprint_id,
-    transaction_fingerprint_id,
-    crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
-    crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
-    app_name
+	const queryFormat = `
+SELECT fingerprint_id,
+       transaction_fingerprint_id,
+       crdb_internal.merge_stats_metadata(array_agg(metadata))    AS metadata,
+       crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
+       app_name
 FROM %s %s
 GROUP BY
     fingerprint_id,
@@ -1201,15 +1190,16 @@ func getTotalStatementDetails(
 ) (serverpb.StatementDetailsResponse_CollectedStatementSummary, error) {
 	const expectedNumDatums = 4
 	var statement serverpb.StatementDetailsResponse_CollectedStatementSummary
-	queryFormat := `SELECT
-				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
-				array_agg(app_name) as app_names,
-				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
-				encode(fingerprint_id, 'hex') as fingerprint_id
-		FROM %s %s
-		GROUP BY
-				fingerprint_id
-		LIMIT 1`
+	const queryFormat = `
+SELECT crdb_internal.merge_stats_metadata(array_agg(metadata))    AS metadata,
+       array_agg(app_name)                                        AS app_names,
+       crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
+       encode(fingerprint_id, 'hex')                              AS fingerprint_id
+FROM %s %s
+GROUP BY
+    fingerprint_id
+LIMIT 1`
+
 	var row tree.Datums
 	var err error
 	var query string
@@ -1299,15 +1289,16 @@ func getStatementDetailsPerAggregatedTs(
 	tableSuffix string,
 ) ([]serverpb.StatementDetailsResponse_CollectedStatementGroupedByAggregatedTs, error) {
 	const expectedNumDatums = 3
-	queryFormat := `SELECT
-				aggregated_ts,
-				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
-				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
-		FROM %s %s
-		GROUP BY
-				aggregated_ts
-		ORDER BY aggregated_ts ASC
-		LIMIT $%d`
+
+	const queryFormat = `
+SELECT aggregated_ts,
+       crdb_internal.merge_stats_metadata(array_agg(metadata))    AS metadata,
+       crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
+FROM %s %s
+GROUP BY
+    aggregated_ts
+ORDER BY aggregated_ts ASC
+LIMIT $%d`
 
 	var it isql.Rows
 	var err error
@@ -1409,7 +1400,7 @@ func getExplainPlanFromGist(ctx context.Context, ie *sql.InternalExecutor, planG
 	planError := "Error collecting Explain Plan."
 	var args []interface{}
 
-	query := `SELECT crdb_internal.decode_plan_gist($1)`
+	const query = `SELECT crdb_internal.decode_plan_gist($1)`
 	args = append(args, planGist)
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-details-get-explain-plan", nil,
@@ -1454,9 +1445,11 @@ func getIdxAndTableName(ctx context.Context, ie *sql.InternalExecutor, indexInfo
 	args = append(args, tableID)
 	args = append(args, indexID)
 
-	row, err := ie.QueryRowEx(ctx, "combined-stmts-details-get-index-and-table-names", nil,
-		sessiondata.NodeUserSessionDataOverride, `SELECT descriptor_name, index_name FROM crdb_internal.table_indexes 
-    WHERE descriptor_id =$1 AND index_id=$2`, args...)
+	row, err := ie.QueryRowEx(ctx,
+		"combined-stmts-details-get-index-and-table-names", nil,
+		sessiondata.NodeUserSessionDataOverride,
+		`SELECT descriptor_name, index_name FROM crdb_internal.table_indexes WHERE descriptor_id = $1 AND index_id = $2`,
+		args...)
 	if err != nil {
 		return indexInfo
 	}
@@ -1482,18 +1475,18 @@ func getStatementDetailsPerPlanHash(
 	tableSuffix string,
 ) ([]serverpb.StatementDetailsResponse_CollectedStatementGroupedByPlanHash, error) {
 	expectedNumDatums := 5
-	queryFormat := `SELECT
-				plan_hash,
-				(statistics -> 'statistics' -> 'planGists'->>0) as plan_gist,
-				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
-				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
-				index_recommendations
-		FROM %s %s
-		GROUP BY
-				plan_hash,
-				plan_gist,
-				index_recommendations
-		LIMIT $%d`
+	const queryFormat = `
+SELECT plan_hash,
+       (statistics - > 'statistics' - > 'planGists' ->>0)         AS plan_gist,
+       crdb_internal.merge_stats_metadata(array_agg(metadata))    AS metadata,
+       crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
+       index_recommendations
+FROM %s %s
+GROUP BY
+    plan_hash,
+    plan_gist,
+    index_recommendations
+LIMIT $%d`
 	args = append(args, limit)
 
 	var it isql.Rows

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4011,3 +4011,27 @@ statement ok
 CREATE TABLE conscheckresult AS (SELECT * FROM crdb_internal.check_consistency(false, '', ''));
 
 subtest end
+
+subtest merge_aggregated_stmts_metadata
+
+query T
+SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[ '{ "db": [ "defaultdb", "movr" ], "distSQLCount": 1, "failedCount": 2, "fullScanCount": 0, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 33, "vecCount": 0 }'::JSON, '{ "db": ["tpcc"], "distSQLCount": 1, "failedCount": 2, "fullScanCount": 0, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 85, "vecCount": 2 }'::JSON ])
+----
+{"appNames": [], "db": ["defaultdb", "movr", "tpcc"], "distSQLCount": 2, "failedCount": 4, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 0, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 118, "vecCount": 2}
+
+query T
+SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[])
+----
+{"appNames": [], "db": [], "distSQLCount": 0, "failedCount": 0, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 0, "implicitTxn": false, "query": "", "querySummary": "", "stmtType": "", "totalCount": 0, "vecCount": 0}
+
+query T
+SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[ '{ "db": [ "defaultdb", "tpcc" ], "distSQLCount": 1, "failedCount": 2, "fullScanCount": 0, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 33, "vecCount": 0 }'::JSON, '{ "db": ["tpcc"], "distSQLCount": 23, "failedCount": 0, "fullScanCount": 99, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 3, "vecCount": 2 }'::JSON, '{"hello": "world"}'::JSON ])
+----
+{"appNames": [], "db": ["defaultdb", "tpcc"], "distSQLCount": 47, "failedCount": 2, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 198, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 39, "vecCount": 4}
+
+query T
+SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[ '{"aMalformedMetadaObj": 123}'::JSON, '{"key": "value"}'::JSON ])
+----
+{"appNames": [], "db": [], "distSQLCount": 0, "failedCount": 0, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 0, "implicitTxn": false, "query": "", "querySummary": "", "stmtType": "", "totalCount": 0, "vecCount": 0}
+
+subtest end

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2384,6 +2384,7 @@ var builtinOidsArray = []string{
 	2452: `crdb_internal.repaired_descriptor(descriptor: bytes, valid_descriptor_ids: int[], valid_job_ids: int[]) -> bytes`,
 	2453: `crdb_internal.reset_activity_tables() -> bool`,
 	2455: `crdb_internal.repair_catalog_corruption(descriptor_id: int, corruption: string) -> bool`,
+	2456: `crdb_internal.merge_aggregated_stmt_metadata(input: jsonb[]) -> jsonb`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
## server: prefer string concat over str format where possible
A number of places in the combined stats api were using string
format where a string concatenation would have worked.

Release note: None

Epic: noneBackport 3/3 commits from #105351.

/cc @cockroachdb/release

---

## server: prefer string concat over str format where possible

A number of places in the combined stats api were using string
format where a string concatenation would have worked.

Release note: None

Epic: none

## server: format sql activity queries

Reformat queries for consistency and readability.

Epic: none

Release note: None


## builtins: create function to aggregate aggregated stmt metadata
The statement activity table used to cache aggregated stmt stats for the sql activity page stores aggregated metadata. Previously we used the same query as the one used for system.statement_statistics, which stores unaggregated metadata, on the activity table. Using the aggregate function for unaggregated metadata on aggregated metadata was nto valid, leading to incorrect JSON fields being produced. This commit introduces the builtin `crdb_internal.combine_aggregated_stmt_metadata` which can be used to correctly aggregate the  metadata column on the stmt activity table.

Fixes: #103895

Release note (bug fix): On the UI, selecting a database filter from the filters menu in the sql activity page should function as expected. This fixes a preivous bug where the filter would break and not show any results when the results were retrieved from the stmt activity table instead of the persisted table.

Release justification: bug fix