### PR TITLE
sql: increase test timeout

### DIFF
--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -332,7 +332,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 			}
 			require.Equal(t, stmtAggTs, txnAggTs)
 			return nil
-		}, 30*time.Second)
+		}, 1*time.Minute)
 
 		// The max number of queries is number of top columns * max number of
 		// queries per a column (6*3=18 for this test, 6*500=3000 default). Most of


### PR DESCRIPTION
Updating the activity top tables can be slow, and the average time of this tests is 15 seconds, with some cases of timing out after 30s. This commits increases the timeout for this test.

Fixes #106375

Release note: None