### PR TITLE
changefeedccl: surface errors when job fails in alter changefeed tests

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -688,6 +688,19 @@ func expectNotice(t *testing.T, s serverutils.TestTenantInterface, sql string, e
 	require.Equal(t, expected, actual)
 }
 
+func loadProgress(
+	t *testing.T, jobFeed cdctest.EnterpriseTestFeed, jobRegistry *jobs.Registry,
+) jobspb.Progress {
+	t.Helper()
+	jobID := jobFeed.JobID()
+	job, err := jobRegistry.LoadJob(context.Background(), jobID)
+	require.NoError(t, err)
+	if job.Status().Terminal() {
+		t.Errorf("tried to load progress for job %v but it has reached terminal status %s with error %s", job, job.Status(), jobFeed.FetchTerminalJobErr())
+	}
+	return job.Progress()
+}
+
 func feed(
 	t testing.TB, f cdctest.TestFeedFactory, create string, args ...interface{},
 ) cdctest.TestFeed {


### PR DESCRIPTION
Alter changefeed tests use SucceedsSoon around checking various things to do with a job's progress, which leads to an unhelpful hardcoded error message if the job has actually failed entirely. This commit extracts the logic into a test helper and makes it surface job errors.

Fixes: #102760