### PR TITLE
release-23.1: roachtest: Fix npgsql test

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -774,6 +774,7 @@ var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.CopyTests(Multiplexing).Text_import(False)`:                                              "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Text_import(True)`:                                               "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Text_import_empty`:                                               "flaky",
+	`Npgsql.Tests.CopyTests(Multiplexing).Undefined_table_throws`:                                          "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Write_null_values`:                                               "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Write_column_out_of_bounds_throws`:                               "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Wrong_table_definition_binary_export`:                            "flaky",


### PR DESCRIPTION
This PR adds a flaky test to the npgsql ignorelist to fix the npgsql roachtest.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/106381
Release note: None
Release justification: Test only change