### PR TITLE
sqlproxyccl: fix deadlock risk in test directory server

### DIFF
--- a/pkg/ccl/cliccl/mt_test_directory.go
+++ b/pkg/ccl/cliccl/mt_test_directory.go
@@ -9,14 +9,23 @@
 package cliccl
 
 import (
+	"bufio"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
 	"github.com/cockroachdb/cockroach/pkg/cli"
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +62,9 @@ func runDirectorySvr(cmd *cobra.Command, args []string) (returnErr error) {
 	}
 	defer stopper.Stop(ctx)
 
-	tds, err := tenantdirsvr.New(stopper, args...)
+	tds, err := tenantdirsvr.New(stopper, func(ctx context.Context, stopper *stop.Stopper, tenantID uint64) (string, error) {
+		return startTenant(ctx, stopper, tenantID, args)
+	})
 	if err != nil {
 		return err
 	}
@@ -67,3 +78,95 @@ func runDirectorySvr(cmd *cobra.Command, args []string) (returnErr error) {
 	stopper.AddCloser(stop.CloserFn(func() { _ = listenPort.Close() }))
 	return tds.Serve(listenPort)
 }
+
+func startTenant(
+	ctx context.Context, stopper *stop.Stopper, tenantID uint64, args []string,
+) (sqlAddress string, err error) {
+	// A hackish way to have the sql tenant process listen on known ports.
+	sqlListener, err := net.Listen("tcp", "")
+	if err != nil {
+		return "", err
+	}
+	httpListener, err := net.Listen("tcp", "")
+	if err != nil {
+		return "", err
+	}
+
+	if len(args) == 0 {
+		cockroachExecutable, err := os.Executable()
+		if err != nil {
+			return "", err
+		}
+		args = []string{
+			cockroachExecutable, "mt", "start-sql", "--kv-addrs=:26257", "--insecure",
+		}
+	}
+	args = append(args,
+		fmt.Sprintf("--sql-addr=%s", sqlListener.Addr().String()),
+		fmt.Sprintf("--http-addr=%s", httpListener.Addr().String()),
+		fmt.Sprintf("--tenant-id=%d", tenantID),
+	)
+	if err = sqlListener.Close(); err != nil {
+		return "", err
+	}
+	if err = httpListener.Close(); err != nil {
+		return "", err
+	}
+
+	c := exec.Command(args[0], args[1:]...)
+	c.Env = append(os.Environ(), "COCKROACH_TRUST_CLIENT_PROVIDED_SQL_REMOTE_ADDR=true")
+	var f writerFunc = func(p []byte) (int, error) {
+		sc := bufio.NewScanner(strings.NewReader(string(p)))
+		for sc.Scan() {
+			log.Infof(ctx, "%s", sc.Text())
+		}
+		return len(p), nil
+	}
+	c.Stdout = f
+	c.Stderr = f
+	err = c.Start()
+	if err != nil {
+		return "", err
+	}
+	stopper.AddCloser(stop.CloserFn(func() {
+		_ = c.Process.Kill()
+	}))
+	err = stopper.RunAsyncTask(ctx, "cmd-wait", func(ctx context.Context) {
+		if err := c.Wait(); err != nil {
+			log.Infof(ctx, "finished %s with err %s", c.Args, err)
+			return
+		}
+		log.Infof(ctx, "finished %s with success", c.Args)
+		stopper.Stop(ctx)
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Wait for the tenant to show healthy
+	start := timeutil.Now()
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: transport}
+	for {
+		time.Sleep(300 * time.Millisecond)
+		resp, err := client.Get(fmt.Sprintf("https://%s/health", httpListener.Addr().String()))
+		waitTime := timeutil.Since(start)
+		if err == nil {
+			resp.Body.Close()
+			log.Infof(ctx, "tenant is healthy")
+			break
+		}
+		if waitTime > 5*time.Second {
+			log.Infof(ctx, "waited more than 5 sec for the tenant to get healthy and it still isn't")
+			break
+		}
+		log.Infof(ctx, "waiting %s for healthy tenant: %s", waitTime, err)
+	}
+	return sqlAddress, nil
+}
+
+type writerFunc func(p []byte) (int, error)
+
+func (wf writerFunc) Write(p []byte) (int, error) { return wf(p) }


### PR DESCRIPTION
Previously, TestResume was flakey when run under the deadlock detector. The root cause appears to be the fact that stopper close functions can be run synchronously if the stopper is already closed. The test directory server added a closer that required a lock while holding the same lock.

This change refactors the TestDirectoryServer to simplify the server's state management and it avoids registering the closer that interacts with the TestDirectoryServer while holding the TestDirectoryServer's lock.

Fixes: #100981
Release note: None