### PR TITLE
c2c: skip TestStreamingAutoReplan

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -714,6 +714,8 @@ func TestStreamingAutoReplan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 106451)
+
 	skip.UnderStressRace(t, "c2c multi node unit tests flake under stress race. see #106194")
 
 	ctx := context.Background()

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -40,7 +40,7 @@ var replanThreshold = settings.RegisterFloatSetting(
 	"stream_replication.replan_flow_threshold",
 	"fraction of nodes in the producer or consumer job that would need to change to refresh the"+
 		" physical execution plan. If set to 0, the physical plan will not automatically refresh.",
-	0.1,
+	0,
 	settings.NonNegativeFloatWithMaximum(1),
 )
 

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1361,7 +1361,8 @@ func srcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
 
 func destClusterSettings(t test.Test, db *sqlutils.SQLRunner, additionalDuration time.Duration) {
 	db.ExecMultiple(t, `SET CLUSTER SETTING cross_cluster_replication.enabled = true;`,
-		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`)
+		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
+		`SET CLUSTER SETTING stream_replication.replan_flow_threshold = 0.1;`)
 
 	if additionalDuration != 0 {
 		replanFrequency := additionalDuration / 2


### PR DESCRIPTION
This patch also switches AutoReplanning default off.

Informs #106451

Release note: None