### PR TITLE
release-22.2: roachtest: Fix gopg and pgjdbc tests

### DIFF
--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -92,12 +92,13 @@ var gopgIgnoreList21_1 = gopgIgnoreList20_2
 var gopgIgnoreList20_2 = blocklist{
 	// These "fetching" tests assume a particular order when ORDER BY clause is
 	// omitted from the query by the ORM itself.
-	"pg | ORM slice model | fetches Book relations":       "41690",
-	"pg | ORM slice model | fetches Genre relations":      "41690",
-	"pg | ORM slice model | fetches Translation relation": "41690",
-	"pg | ORM struct model | fetches Author relations":    "41690",
-	"pg | ORM struct model | fetches Book relations":      "41690",
-	"pg | ORM struct model | fetches Genre relations":     "41690",
+	"pg | ORM | fetches Book relations works when there are no results": "unknown",
+	"pg | ORM slice model | fetches Book relations":                     "41690",
+	"pg | ORM slice model | fetches Genre relations":                    "41690",
+	"pg | ORM slice model | fetches Translation relation":               "41690",
+	"pg | ORM struct model | fetches Author relations":                  "41690",
+	"pg | ORM struct model | fetches Book relations":                    "41690",
+	"pg | ORM struct model | fetches Genre relations":                   "41690",
 	// Different error message for context cancellation timeout.
 	"pg | OnConnect | does not panic on timeout": "41690",
 	// These tests assume different transaction isolation level (READ COMMITTED).

--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -945,4 +945,5 @@ var pgjdbcIgnoreList = blocklist{
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testBadUTF8Decode":                                                                              "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testTruncatedUTF8Decode":                                                                        "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testUTF8Decode":                                                                                 "54477",
+	"org.postgresql.test.jdbc2.StatementTest.testShortQueryTimeout":                                                                                 "unknown",
 }


### PR DESCRIPTION
This PR adds some flaky tests to the ignorelist for the pgjdbc and gopg roachtests.

Release note: None
Epic: None
Release justification: Test only change
Fixes: https://github.com/cockroachdb/cockroach/issues/106139, https://github.com/cockroachdb/cockroach/issues/94292