### PR TITLE
colexec: close disk resources in tests

### DIFF
--- a/pkg/sql/colcontainer/partitionedqueue_test.go
+++ b/pkg/sql/colcontainer/partitionedqueue_test.go
@@ -310,5 +310,8 @@ func TestPartitionedDiskQueueSimulatedExternal(t *testing.T) {
 		}
 
 		joinRepartition(0, 0, numRepartitions, 0)
+
+		require.NoError(t, p.Close(ctx))
+		countingFS.assertOpenFDs(t, sem, 0, 0)
 	})
 }

--- a/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
@@ -122,6 +122,7 @@ func TestSpillingBuffer(t *testing.T) {
 			spillingQueueUnlimitedAllocator, memoryLimit, queueCfg,
 			colexecop.NewTestingSemaphore(2), typs, testDiskAcc, testMemAcc, colsToStore...,
 		)
+		defer buf.Close(ctx)
 		if setInMemTuplesLimit {
 			buf.testingKnobs.maxTuplesStoredInMemory = numBatches * inputBatchSize / 2
 		}


### PR DESCRIPTION
Fixes: #106119

**colcontainer: close PDQ during TestPartitionedDiskQueueSimulatedExternal**

Close the `PartitionedDiskQueue` at the end of `TestPartitionedDiskQueueSimulatedExternal/HashJoin`.

Release note: None

---

**colexecutils: close SpillingBuffer during TestSpillingBuffer**

Release note: None

---

**colexec: make some operators implement colexecop.Closer interface**

This commit makes the following adjustments that fix "leaked files" in
the disk-spilling tests:
- `orderedDistinct` now implements `colexecop.Closer` (needed for
`TestExternalDistinct`)
- `orderedAggregator` and `distinctChainOps` now implement
`colexecop.Closer` (needed for `TestExternalHashAggregator`)
- `TestCrossJoiner` is adjusted to explicitly close all closers when
non-empty ON expression is used (in this case we have selection and
projection operators on top of the cross joiner which currently don't
implement the `Closer` interface).

Release note: None