### PR TITLE
descs: reduce heap usage in getNonVirtualDescriptorID

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -534,8 +534,8 @@ func (desc *immutable) GetRawBytesInStorage() []byte {
 }
 
 // ForEachUDTDependentForHydration implements the catalog.Descriptor interface.
-func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error) error {
-	return nil
+func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error) (error, bool) {
+	return nil, false
 }
 
 // maybeRemoveDroppedSelfEntryFromSchemas removes an entry in the Schemas map corresponding to the

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -255,8 +255,9 @@ type Descriptor interface {
 
 	// ForEachUDTDependentForHydration iterates over all the user-defined types.T
 	// referenced by this descriptor which must be hydrated prior to using it.
-	// iterutil.StopIteration is supported.
-	ForEachUDTDependentForHydration(func(t *types.T) error) error
+	// iterutil.StopIteration is supported. The second return value is true if
+	// a iterutil.StopIteration error was generated.
+	ForEachUDTDependentForHydration(func(t *types.T) error) (error, bool)
 }
 
 // DatabaseDescriptor encapsulates the concept of a database.
@@ -1076,12 +1077,13 @@ func HasConcurrentDeclarativeSchemaChange(desc Descriptor) bool {
 	return desc.GetDeclarativeSchemaChangerState() != nil
 }
 
+func stopIteration(t *types.T) error {
+	return iterutil.StopIteration()
+}
+
 // MaybeRequiresHydration returns false if the descriptor definitely does not
 // depend on any types.T being hydrated.
 func MaybeRequiresHydration(desc Descriptor) (ret bool) {
-	_ = desc.ForEachUDTDependentForHydration(func(t *types.T) error {
-		ret = true
-		return iterutil.StopIteration()
-	})
+	_, ret = desc.ForEachUDTDependentForHydration(stopIteration)
 	return ret
 }

--- a/pkg/sql/catalog/nstree/catalog.go
+++ b/pkg/sql/catalog/nstree/catalog.go
@@ -186,6 +186,24 @@ func (c Catalog) LookupNamespaceEntry(key catalog.NameKey) NamespaceEntry {
 	return e.(NamespaceEntry)
 }
 
+// LookupNameEntryUsingUnwrappedNameKeyFields looks up a descriptor ID by
+// parentID, parentSchemaID and name, the fields of a `catalog.NameKey`. This
+// function is similar to LookupNamespaceEntry, but by accepting non-interface
+// arguments, may prevent the arguments from escaping to heap memory.
+func (c Catalog) LookupNameEntryUsingUnwrappedNameKeyFields(
+	parentID, parentSchemaID descpb.ID, name string,
+) catalog.NameEntry {
+	if !c.IsInitialized() {
+		return nil
+	}
+	got, _ := get(c.byName.t, byNameItem{
+		parentID:       parentID,
+		parentSchemaID: parentSchemaID,
+		name:           name,
+	}.get()).(catalog.NameEntry)
+	return got
+}
+
 // OrderedDescriptors returns the descriptors in an ordered fashion.
 func (c Catalog) OrderedDescriptors() []catalog.Descriptor {
 	if !c.IsInitialized() {

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -78,7 +78,7 @@ func (desc *immutable) GetRawBytesInStorage() []byte {
 }
 
 // ForEachUDTDependentForHydration implements the catalog.Descriptor interface.
-func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error) error {
+func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error) (error, bool) {
 	for _, f := range desc.Functions {
 		for _, sig := range f.Signatures {
 			for _, typ := range sig.ArgTypes {
@@ -86,18 +86,20 @@ func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error
 					continue
 				}
 				if err := fn(typ); err != nil {
-					return iterutil.Map(err)
+					err = iterutil.Map(err)
+					return err, err == nil
 				}
 			}
 			if !catid.IsOIDUserDefined(sig.ReturnType.Oid()) {
 				continue
 			}
 			if err := fn(sig.ReturnType); err != nil {
-				return iterutil.Map(err)
+				err = iterutil.Map(err)
+				return err, err == nil
 			}
 		}
 	}
-	return nil
+	return nil, false
 }
 
 // SafeMessage makes Mutable a SafeMessager.

--- a/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
@@ -140,8 +140,8 @@ func (p synthetic) ForEachFunctionSignature(
 }
 
 // ForEachUDTDependentForHydration implements the catalog.Descriptor interface.
-func (p synthetic) ForEachUDTDependentForHydration(fn func(t *types.T) error) error {
-	return nil
+func (p synthetic) ForEachUDTDependentForHydration(fn func(t *types.T) error) (error, bool) {
+	return nil, false
 }
 
 func (p synthetic) GetRawBytesInStorage() []byte {

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -605,13 +605,14 @@ func (desc *wrapper) GetInProgressImportStartTime() int64 {
 }
 
 // ForEachUDTDependentForHydration implements the catalog.Descriptor interface.
-func (desc *wrapper) ForEachUDTDependentForHydration(fn func(t *types.T) error) error {
+func (desc *wrapper) ForEachUDTDependentForHydration(fn func(t *types.T) error) (error, bool) {
 	for _, c := range desc.UserDefinedTypeColumns() {
 		if err := fn(c.GetType()); err != nil {
-			return iterutil.Map(err)
+			err = iterutil.Map(err)
+			return err, err == nil
 		}
 	}
-	return nil
+	return nil, false
 }
 
 // IsSchemaLocked implements the TableDescriptor interface.

--- a/pkg/sql/catalog/typedesc/hydrate.go
+++ b/pkg/sql/catalog/typedesc/hydrate.go
@@ -20,14 +20,23 @@ import (
 	"github.com/lib/pq/oid"
 )
 
+func forEachUDTDependentForHydration(
+	iterFunc func(t *types.T) error, desc catalog.Descriptor,
+) error {
+	err, _ := desc.ForEachUDTDependentForHydration(iterFunc)
+	return err
+}
+
 // HydrateTypesInDescriptor ensures that all types that the descriptor is
 // depending on are hydrated.
 func HydrateTypesInDescriptor(
 	ctx context.Context, desc catalog.Descriptor, res catalog.TypeDescriptorResolver,
 ) error {
-	return desc.ForEachUDTDependentForHydration(func(t *types.T) error {
+	return forEachUDTDependentForHydration(func(t *types.T) error {
 		return EnsureTypeIsHydrated(ctx, t, res)
-	})
+	},
+		desc,
+	)
 }
 
 // ResolveHydratedTByOID is a convenience function which delegates to

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -188,8 +188,10 @@ func (v *tableImplicitRecordType) GetRawBytesInStorage() []byte {
 }
 
 // ForEachUDTDependentForHydration implements the catalog.Descriptor interface.
-func (v *tableImplicitRecordType) ForEachUDTDependentForHydration(_ func(t *types.T) error) error {
-	return nil
+func (v *tableImplicitRecordType) ForEachUDTDependentForHydration(
+	_ func(t *types.T) error,
+) (error, bool) {
+	return nil, false
 }
 
 // TypeDesc implements the catalog.TypeDescriptor interface.

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -883,24 +883,26 @@ func (desc *immutable) GetRawBytesInStorage() []byte {
 }
 
 // ForEachUDTDependentForHydration implements the catalog.Descriptor interface.
-func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error) error {
+func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error) (error, bool) {
 	if desc.Alias != nil && catid.IsOIDUserDefined(desc.Alias.Oid()) {
 		if err := fn(desc.Alias); err != nil {
-			return iterutil.Map(err)
+			err = iterutil.Map(err)
+			return err, err == nil
 		}
 	}
 	if desc.Composite == nil {
-		return nil
+		return nil, false
 	}
 	for _, e := range desc.Composite.Elements {
 		if !catid.IsOIDUserDefined(e.ElementType.Oid()) {
 			continue
 		}
 		if err := fn(e.ElementType); err != nil {
-			return iterutil.Map(err)
+			err = iterutil.Map(err)
+			return err, err == nil
 		}
 	}
-	return nil
+	return nil, false
 }
 
 // GetIDClosure implements the TypeDescriptor interface.

--- a/pkg/sql/regions/region_provider_test.go
+++ b/pkg/sql/regions/region_provider_test.go
@@ -234,8 +234,8 @@ func (d fakeSystemDatabase) GetID() descpb.ID           { return keys.SystemData
 func (d fakeSystemDatabase) Dropped() bool              { return false }
 func (d fakeSystemDatabase) IsUncommittedVersion() bool { return false }
 func (d fakeSystemDatabase) Adding() bool               { return false }
-func (d fakeSystemDatabase) ForEachUDTDependentForHydration(func(t *types.T) error) error {
-	return nil
+func (d fakeSystemDatabase) ForEachUDTDependentForHydration(func(t *types.T) error) (error, bool) {
+	return nil, false
 }
 
 type fakeLeasedDescriptor struct {
@@ -277,8 +277,10 @@ func (f fakeRegionEnum) SkipNamespace() bool        { return true }
 func (d fakeRegionEnum) Dropped() bool              { return false }
 func (d fakeRegionEnum) IsUncommittedVersion() bool { return false }
 func (d fakeRegionEnum) Adding() bool               { return false }
-func (d fakeRegionEnum) ForEachUDTDependentForHydration(func(t *types.T) error) error {
-	return nil
+func (d fakeRegionEnum) ForEachUDTDependentForHydration(
+	func(t *types.T) error,
+) (err error, ret bool) {
+	return nil, false
 }
 func (d fakeRegionEnum) AsEnumTypeDescriptor() catalog.EnumTypeDescriptor {
 	if d.isNotEnum {


### PR DESCRIPTION
The Go compiler is not able to use stack memory in the
`lookupStoreCacheID` closure, even if the functions calls within it are
changed to pass the locally-built `descpb.NameInfo` by value, resulting
in hundreds of MiB of allocated space for tests which look up a table
thousands of times.

The solution is to refactor the code to call the inner functions
directly, preventing the `descpb.NameInfo` argument from leaking
to the heap.

**Benchmark Results**
```
dev bench //pkg/sql/catalog/descs -f='BenchmarkDescriptorCache' --bench-mem \
          --ignore-cache --stream-output --count 10 -v --bench-time=3s
```
**without fix:**
```
BenchmarkDescriptorCache/immutable_table_descriptor
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 3689557	       966.8 ns/op	     167 B/op	      11 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 3713419	       968.9 ns/op	     164 B/op	      11 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 3696469	       965.9 ns/op	     167 B/op	      11 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 3708067	       967.7 ns/op	     164 B/op	      11 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 3700088	       966.2 ns/op	     172 B/op	      11 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 3724609	       969.4 ns/op	     164 B/op	      11 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 3712176	       988.4 ns/op	     172 B/op	      11 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 3321098	      1019 ns/op	     164 B/op	      11 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 3717261	       966.6 ns/op	     172 B/op	      11 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 3699794	       964.6 ns/op	     164 B/op	      11 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2013207	      1781 ns/op	    1065 B/op	      20 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2011074	      1776 ns/op	    1050 B/op	      20 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2025692	      1816 ns/op	    1326 B/op	      21 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2012298	      1788 ns/op	    1050 B/op	      20 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2017578	      1773 ns/op	    1050 B/op	      20 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2009506	      1777 ns/op	    1050 B/op	      20 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2025168	      1769 ns/op	    1050 B/op	      20 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2029318	      1793 ns/op	    1058 B/op	      20 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2013554	      1781 ns/op	    1051 B/op	      20 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2030397	      1772 ns/op	    1063 B/op	      20 allocs/op
```
**with fix:**
```
BenchmarkDescriptorCache/immutable_table_descriptor
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4082704	       876.3 ns/op	      70 B/op	       7 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4107186	       880.0 ns/op	      68 B/op	       7 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4112974	       874.7 ns/op	      68 B/op	       7 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4124313	       867.7 ns/op	      68 B/op	       7 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4128722	       869.9 ns/op	      80 B/op	       7 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4130685	       871.0 ns/op	      69 B/op	       7 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4094190	       876.8 ns/op	      75 B/op	       7 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4120947	       870.4 ns/op	      68 B/op	       7 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4100317	       873.1 ns/op	      75 B/op	       7 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4103818	       868.9 ns/op	      68 B/op	       7 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2380312	      1515 ns/op	     966 B/op	      16 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2351344	      1524 ns/op	     954 B/op	      16 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2367862	      1550 ns/op	    1109 B/op	      17 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2311496	      1514 ns/op	     954 B/op	      16 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2354755	      1543 ns/op	     968 B/op	      16 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2339215	      1514 ns/op	     954 B/op	      16 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2367279	      1512 ns/op	     966 B/op	      16 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2380909	      1508 ns/op	     954 B/op	      16 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2380462	      1513 ns/op	     967 B/op	      16 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2373717	      1514 ns/op	     954 B/op	      16 allocs/op
```
**benchstat:**
```
                                              │ without_fix │              with_fix               │
                                              │   sec/op    │   sec/op     vs base                │
DescriptorCache/immutable_table_descriptor-10   967.2n ± 2%   872.0n ± 1%   -9.84% (p=0.000 n=10)
DescriptorCache/mutable_table_descriptor-10     1.779µ ± 1%   1.514µ ± 2%  -14.90% (p=0.000 n=10)
geomean                                         1.312µ        1.149µ       -12.41%

                                              │ without_fix │              with_fix              │
                                              │    B/op     │    B/op     vs base                │
DescriptorCache/immutable_table_descriptor-10   165.50 ± 4%   68.50 ± 9%  -58.61% (p=0.000 n=10)
DescriptorCache/mutable_table_descriptor-10     1050.5 ± 1%   960.0 ± 1%   -8.61% (p=0.001 n=10)
geomean                                          417.0        256.4       -38.50%

                                              │ without_fix │              with_fix              │
                                              │  allocs/op  │ allocs/op   vs base                │
DescriptorCache/immutable_table_descriptor-10   11.000 ± 0%   7.000 ± 0%  -36.36% (p=0.000 n=10)
DescriptorCache/mutable_table_descriptor-10      20.00 ± 0%   16.00 ± 0%  -20.00% (p=0.000 n=10)
geomean                                          14.83        10.58       -28.65%
```

Informs #105867

Release note (performance improvement): This patch optimizes memory
usage when performing cached table descriptor lookups, which could
speed up workloads with many point queries.

----
catalog: eliminate allocations in MaybeRequiresHydration

This commit eliminates heap allocations in function
`MaybeRequiresHydration`  when looking up descriptors by name by
changing the closure, passed as a function argument, into a function.

**Benchmark Results**
```
dev bench //pkg/sql/catalog/descs -f='BenchmarkDescriptorCache' --bench-mem \
          --ignore-cache --stream-output --count 10 -v --bench-time=3s
```
```
BenchmarkDescriptorCache/immutable_table_descriptor
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4515679	       795.9 ns/op	      19 B/op	       1 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4551014	       794.1 ns/op	      17 B/op	       1 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4512546	       796.8 ns/op	      16 B/op	       1 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4493860	       794.5 ns/op	      16 B/op	       1 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4513683	       793.7 ns/op	      23 B/op	       1 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4428988	       797.5 ns/op	      18 B/op	       1 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4505838	       791.3 ns/op	      23 B/op	       1 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4539226	       791.8 ns/op	      16 B/op	       1 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4539788	       792.4 ns/op	      23 B/op	       1 allocs/op
BenchmarkDescriptorCache/immutable_table_descriptor-10         	 4510224	       792.2 ns/op	      16 B/op	       1 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2504500	      1436 ns/op	     902 B/op	      10 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2501647	      1431 ns/op	     902 B/op	      10 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2516917	      1444 ns/op	     902 B/op	      10 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2395996	      1441 ns/op	     940 B/op	      10 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2505079	      1430 ns/op	     901 B/op	      10 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2502846	      1429 ns/op	     902 B/op	      10 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2512407	      1430 ns/op	     914 B/op	      10 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2501658	      1428 ns/op	     902 B/op	      10 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2507274	      1437 ns/op	     912 B/op	      10 allocs/op
BenchmarkDescriptorCache/mutable_table_descriptor-10           	 2505388	      1433 ns/op	     902 B/op	      10 allocs/op
```
**benchstat results compared to the first commit**
```
                                              │ getNonVirtualDescriptorID_fix │ maybe_requires_hydration_plus_getNonVirtualDescriptorID_fix │
                                              │            sec/op             │                sec/op                 vs base               │
DescriptorCache/immutable_table_descriptor-10                     872.0n ± 1%                            793.9n ± 0%  -8.96% (p=0.000 n=10)
DescriptorCache/mutable_table_descriptor-10                       1.514µ ± 2%                            1.432µ ± 1%  -5.42% (p=0.000 n=10)
geomean                                                           1.149µ                                 1.066µ       -7.21%

                                              │ getNonVirtualDescriptorID_fix │ maybe_requires_hydration_plus_getNonVirtualDescriptorID_fix │
                                              │             B/op              │                B/op                  vs base                │
DescriptorCache/immutable_table_descriptor-10                      68.50 ± 9%                           17.50 ± 31%  -74.45% (p=0.000 n=10)
DescriptorCache/mutable_table_descriptor-10                        960.0 ± 1%                           902.0 ±  1%   -6.04% (p=0.000 n=10)
geomean                                                            256.4                                125.6        -51.01%

                                              │ getNonVirtualDescriptorID_fix │ maybe_requires_hydration_plus_getNonVirtualDescriptorID_fix │
                                              │           allocs/op           │              allocs/op               vs base                │
DescriptorCache/immutable_table_descriptor-10                      7.000 ± 0%                            1.000 ± 0%  -85.71% (p=0.000 n=10)
DescriptorCache/mutable_table_descriptor-10                        16.00 ± 0%                            10.00 ± 0%  -37.50% (p=0.000 n=10)
geomean                                                            10.58                                 3.162       -70.12%
```

Informs #105867

Release note (performance improvement): This patch optimizes memory
usage when performing table descriptor lookups, which could speed up
workloads with many point queries.