### PR TITLE
colexecwindow: add cancel-checking for vectorized window functions

### DIFF
--- a/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
@@ -198,6 +198,21 @@ func (a *bool_OP_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 	return f
 }
 
+// {{if eq "_AGGKIND" "Window"}}
+
+// Remove implements the slidingWindowAggregateFunc interface (see
+// window_aggregator_tmpl.go). This allows bool_and and bool_or operators to be
+// used when the window frame only grows. For the case when the window frame can
+// shrink, the default quadratic-scaling implementation is necessary.
+func (*bool_OP_TYPE_AGGKINDAgg) Remove(
+	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+) {
+	colexecerror.InternalError(
+		errors.AssertionFailedf("Remove called on bool_OP_TYPE_AGGKINDAgg"),
+	)
+}
+
+// {{end}}
 // {{end}}
 
 // {{/*

--- a/pkg/sql/colexec/colexecagg/window_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_bool_and_or_agg.eg.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/errors"
 )
 
 // Remove unused warning.
@@ -118,6 +119,18 @@ func (a *boolAndWindowAggAlloc) newAggFunc() AggregateFunc {
 	return f
 }
 
+// Remove implements the slidingWindowAggregateFunc interface (see
+// window_aggregator_tmpl.go). This allows bool_and and bool_or operators to be
+// used when the window frame only grows. For the case when the window frame can
+// shrink, the default quadratic-scaling implementation is necessary.
+func (*boolAndWindowAgg) Remove(
+	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+) {
+	colexecerror.InternalError(
+		errors.AssertionFailedf("Remove called on boolAndWindowAgg"),
+	)
+}
+
 func newBoolOrWindowAggAlloc(
 	allocator *colmem.Allocator, allocSize int64,
 ) aggregateFuncAlloc {
@@ -212,4 +225,16 @@ func (a *boolOrWindowAggAlloc) newAggFunc() AggregateFunc {
 	f.Reset()
 	a.aggFuncs = a.aggFuncs[1:]
 	return f
+}
+
+// Remove implements the slidingWindowAggregateFunc interface (see
+// window_aggregator_tmpl.go). This allows bool_and and bool_or operators to be
+// used when the window frame only grows. For the case when the window frame can
+// shrink, the default quadratic-scaling implementation is necessary.
+func (*boolOrWindowAgg) Remove(
+	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
+) {
+	colexecerror.InternalError(
+		errors.AssertionFailedf("Remove called on boolOrWindowAgg"),
+	)
 }

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -162,6 +162,7 @@ type windowInitFields struct {
 type bufferedWindowOp struct {
 	colexecop.CloserHelper
 	windowInitFields
+	cancelChecker colexecutils.CancelChecker
 
 	// windower houses the fields and logic specific to the window function being
 	// calculated.
@@ -198,6 +199,7 @@ func (b *bufferedWindowOp) Init(ctx context.Context) {
 	if !b.InitHelper.Init(ctx) {
 		return
 	}
+	b.cancelChecker.Init(b.Ctx)
 	b.Input.Init(b.Ctx)
 	b.windower.Init(b.Ctx)
 	b.state = windowLoading
@@ -220,6 +222,7 @@ var _ colexecop.ClosableOperator = &bufferedWindowOp{}
 func (b *bufferedWindowOp) Next() coldata.Batch {
 	var err error
 	for {
+		b.cancelChecker.CheckEveryCall()
 		switch b.state {
 		case windowLoading:
 			batch := b.Input.Next()

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
@@ -56,9 +56,10 @@ const (
 type minMaxRemovableAggBase struct {
 	partitionSeekerBase
 	colexecop.CloserHelper
-	allocator    *colmem.Allocator
-	outputColIdx int
-	framer       windowFramer
+	cancelChecker colexecutils.CancelChecker
+	allocator     *colmem.Allocator
+	outputColIdx  int
+	framer        windowFramer
 
 	// A partial deque of indices into the current partition ordered by the value
 	// of the input column at each index. It contains only indices that are part
@@ -82,6 +83,7 @@ type minMaxRemovableAggBase struct {
 // Init implements the bufferedWindower interface.
 func (b *minMaxRemovableAggBase) Init(ctx context.Context) {
 	b.InitHelper.Init(ctx)
+	b.cancelChecker.Init(b.Ctx)
 }
 
 // transitionToProcessing implements the bufferedWindower interface.
@@ -254,6 +256,7 @@ func (a *minBoolAggregator) aggregateOverIntervals(intervals []windowInterval) {
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -423,6 +426,7 @@ func (a *minBytesAggregator) aggregateOverIntervals(intervals []windowInterval) 
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -578,6 +582,7 @@ func (a *minDecimalAggregator) aggregateOverIntervals(intervals []windowInterval
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -733,6 +738,7 @@ func (a *minInt16Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -910,6 +916,7 @@ func (a *minInt32Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -1087,6 +1094,7 @@ func (a *minInt64Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -1264,6 +1272,7 @@ func (a *minFloat64Aggregator) aggregateOverIntervals(intervals []windowInterval
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -1457,6 +1466,7 @@ func (a *minTimestampAggregator) aggregateOverIntervals(intervals []windowInterv
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -1626,6 +1636,7 @@ func (a *minIntervalAggregator) aggregateOverIntervals(intervals []windowInterva
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -1790,6 +1801,7 @@ func (a *minJSONAggregator) aggregateOverIntervals(intervals []windowInterval) {
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -1979,6 +1991,7 @@ func (a *minDatumAggregator) aggregateOverIntervals(intervals []windowInterval) 
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -2221,6 +2234,7 @@ func (a *maxBoolAggregator) aggregateOverIntervals(intervals []windowInterval) {
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -2390,6 +2404,7 @@ func (a *maxBytesAggregator) aggregateOverIntervals(intervals []windowInterval) 
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -2545,6 +2560,7 @@ func (a *maxDecimalAggregator) aggregateOverIntervals(intervals []windowInterval
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -2700,6 +2716,7 @@ func (a *maxInt16Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -2877,6 +2894,7 @@ func (a *maxInt32Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -3054,6 +3072,7 @@ func (a *maxInt64Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -3231,6 +3250,7 @@ func (a *maxFloat64Aggregator) aggregateOverIntervals(intervals []windowInterval
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -3424,6 +3444,7 @@ func (a *maxTimestampAggregator) aggregateOverIntervals(intervals []windowInterv
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -3593,6 +3614,7 @@ func (a *maxIntervalAggregator) aggregateOverIntervals(intervals []windowInterva
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -3757,6 +3779,7 @@ func (a *maxJSONAggregator) aggregateOverIntervals(intervals []windowInterval) {
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()
@@ -3946,6 +3969,7 @@ func (a *maxDatumAggregator) aggregateOverIntervals(intervals []windowInterval) 
 	for _, interval := range intervals {
 		var cmp bool
 		for j := interval.start; j < interval.end; j++ {
+			a.cancelChecker.Check()
 			idxToAdd := uint32(j)
 			vec, idx, _ := a.buffer.GetVecWithTuple(a.Ctx, argColIdx, j)
 			nulls := vec.Nulls()

--- a/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
@@ -114,6 +114,20 @@ func NewWindowAggregatorOperator(
 				agg:                  agg.(slidingWindowAggregateFunc),
 			}
 		}
+	case execinfrapb.BoolAnd, execinfrapb.BoolOr:
+		if WindowFrameCanShrink(frame, ordering) {
+			// TODO(drewk): add optimized implementations that can handle a shrinking
+			// window by tracking counts of true, false, null values instead of just
+			// the final aggregate value.
+			windower = &windowAggregator{windowAggregatorBase: base, agg: agg}
+		} else {
+			// These aggregates can only be used in a sliding-window context if the
+			// window does not shrink.
+			windower = &slidingWindowAggregator{
+				windowAggregatorBase: base,
+				agg:                  agg.(slidingWindowAggregateFunc),
+			}
+		}
 	default:
 		if slidingWindowAgg, ok := agg.(slidingWindowAggregateFunc); ok {
 			windower = &slidingWindowAggregator{windowAggregatorBase: base, agg: slidingWindowAgg}


### PR DESCRIPTION
#### colexecwindow: use sliding-window for bool_and/bool_or execution

This patch enables sliding-window execution for `bool_and` and `bool_or`
operators in the case when the window never shrinks. This allows the
`bool_and` and `bool_or` aggregates to achieve linear (vs quadratic)
scaling despite not implementing the `Remove` method needed to handle
a shrinking window.

Informs #98432

Release note (performance improvement): `bool_and` and `bool_or`
aggregates will now scale linearly instead of quadratically when used
as a window function with a non-shrinking window,

#### colexecwindow: add cancel-checking to vectorized window functions

This patch adds cancel checking in two places for the vectorized
window functions:
1. The state machine for `bufferedWindowOp`, so that cancellation is
   checked roughly every input and output batch.
2. The `aggregateOverIntervals` loop for aggregate window functions.
   This is necessary beyond (1) because aggregate window functions
   can perform arbitrary amounts of work for each row, not limited to
   the size of a batch.
This will ensure that even expensive executions are responsive to
query cancellation.

Fixes #98432

Release note: None