### PR TITLE
release-23.1: sql,server,upgrades: simpler sending of version to tenant servers

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
@@ -7,15 +7,6 @@ true
 
 user host-cluster-root
 
-# Ensure that the version is set the same in the system tenant and in the tenant override.
-query TI rowsort
-SELECT settings.name, tenant_id
-FROM system.settings
-JOIN system.tenant_settings ON tenant_settings.name = settings.name
-WHERE tenant_settings.name = 'version' AND tenant_settings.value = settings.value;
-----
-version 0
-
 statement ok
 ALTER TENANT [10] SET CLUSTER SETTING sql.notices.enabled = false
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/pprofutil"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/startup"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -271,6 +272,14 @@ type Node struct {
 
 	// Used to collect samples for the key visualizer.
 	spanStatsCollector *spanstatscollector.SpanStatsCollector
+
+	// versionUpdateMu is used by the TenantSettings endpoint
+	// to inform tenant servers of storage version changes.
+	versionUpdateMu struct {
+		syncutil.Mutex
+		encodedVersion string
+		updateCh       chan struct{}
+	}
 }
 
 var _ kvpb.InternalServer = &Node{}
@@ -438,6 +447,7 @@ func NewNode(
 		kvAdmissionQ, elasticCPUGrantCoord, storeGrantCoords, cfg.Settings,
 	)
 	n.storeCfg.SchedulerLatencyListener = elasticCPUGrantCoord.SchedulerLatencyListener
+	n.versionUpdateMu.updateCh = make(chan struct{})
 	n.perReplicaServer = kvserver.MakeServer(&n.Descriptor, n.stores)
 	return n
 }
@@ -500,6 +510,11 @@ func (n *Node) start(
 		StartedAt:       n.startedAt,
 		HTTPAddress:     util.MakeUnresolvedAddr(httpAddr.Network(), httpAddr.String()),
 	}
+
+	// Track changes to the version setting to inform the tenant connector.
+	n.storeCfg.Settings.Version.SetOnChange(n.notifyClusterVersionChange)
+	// Also update the encoded copy immediately.
+	n.notifyClusterVersionChange(ctx, n.storeCfg.Settings.Version.ActiveVersion(ctx))
 
 	// Gossip the node descriptor to make this node addressable by node ID.
 	n.storeCfg.Gossip.NodeID.Set(ctx, n.Descriptor.NodeID)
@@ -1889,11 +1904,11 @@ func (n *Node) TenantSettings(
 		})
 	}
 
-	send := func(precedence kvpb.TenantSettingsEvent_Precedence, overrides []kvpb.TenantSetting) error {
-		log.VInfof(ctx, 1, "sending precedence %d: %v", precedence, overrides)
+	send := func(precedence kvpb.TenantSettingsEvent_Precedence, overrides []kvpb.TenantSetting, incremental bool) error {
+		log.VInfof(ctx, 1, "sending precedence %d (incremental=%v): %v", precedence, overrides, incremental)
 		return stream.Send(&kvpb.TenantSettingsEvent{
 			Precedence:  precedence,
-			Incremental: false,
+			Incremental: incremental,
 			Overrides:   overrides,
 		})
 	}
@@ -1911,26 +1926,40 @@ func (n *Node) TenantSettings(
 	// The protocol defines that there is one initial response per
 	// precedence value, with Incremental set to false. This is important:
 	// the client waits for at least one non-incremental message
-	// for each predecende before continuing.
+	// for each precedence before continuing.
 
 	allOverrides, allCh := w.GetAllTenantOverrides()
-	if err := send(kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES, allOverrides); err != nil {
+
+	// Inject the current storage logical version as an override; as the
+	// tenant server needs this to start up.
+	verSetting, versionUpdateCh := n.getVersionSettingWithUpdateCh(ctx)
+	allOverrides = append(allOverrides, verSetting)
+	if err := send(kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES, allOverrides, false /* incremental */); err != nil {
 		return err
 	}
 
 	tenantOverrides, tenantCh := w.GetTenantOverrides(args.TenantID)
-	if err := send(kvpb.TenantSettingsEvent_TENANT_SPECIFIC_OVERRIDES, tenantOverrides); err != nil {
+	if err := send(kvpb.TenantSettingsEvent_TENANT_SPECIFIC_OVERRIDES, tenantOverrides, false /* incremental */); err != nil {
 		return err
 	}
 
 	for {
 		select {
+		case <-versionUpdateCh:
+			// The storage version has changed, send it again.
+			verSetting, versionUpdateCh = n.getVersionSettingWithUpdateCh(ctx)
+			if err := send(kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES,
+				[]kvpb.TenantSetting{verSetting},
+				true /* incremental */); err != nil {
+				return err
+			}
+
 		case <-allCh:
 			// All-tenant overrides have changed, send them again.
 			// TODO(multitenant): We can optimize this by only sending the delta since the last
 			// update, with Incremental set to true.
 			allOverrides, allCh = w.GetAllTenantOverrides()
-			if err := send(kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES, allOverrides); err != nil {
+			if err := send(kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES, allOverrides, false /* incremental */); err != nil {
 				return err
 			}
 
@@ -1939,7 +1968,7 @@ func (n *Node) TenantSettings(
 			// TODO(multitenant): We can optimize this by only sending the delta since the last
 			// update, with Incremental set to true.
 			tenantOverrides, tenantCh = w.GetTenantOverrides(args.TenantID)
-			if err := send(kvpb.TenantSettingsEvent_TENANT_SPECIFIC_OVERRIDES, tenantOverrides); err != nil {
+			if err := send(kvpb.TenantSettingsEvent_TENANT_SPECIFIC_OVERRIDES, tenantOverrides, false /* incremental */); err != nil {
 				return err
 			}
 
@@ -1950,6 +1979,43 @@ func (n *Node) TenantSettings(
 			return stop.ErrUnavailable
 		}
 	}
+}
+
+// getVersionSettingWithUpdateCh returns the current encoded cluster
+// version as a TenantSetting, and a channel that is closed whenever
+// the version changes.
+func (n *Node) getVersionSettingWithUpdateCh(
+	ctx context.Context,
+) (kvpb.TenantSetting, <-chan struct{}) {
+	n.versionUpdateMu.Lock()
+	defer n.versionUpdateMu.Unlock()
+
+	setting := kvpb.TenantSetting{
+		Name: clusterversion.KeyVersionSetting,
+		Value: settings.EncodedValue{
+			Type:  settings.VersionSettingValueType,
+			Value: n.versionUpdateMu.encodedVersion,
+		},
+	}
+
+	return setting, n.versionUpdateMu.updateCh
+}
+
+func (n *Node) notifyClusterVersionChange(
+	ctx context.Context, activeVersion clusterversion.ClusterVersion,
+) {
+	n.versionUpdateMu.Lock()
+	defer n.versionUpdateMu.Unlock()
+
+	encodedVersion, err := protoutil.Marshal(&activeVersion)
+	if err != nil {
+		logcrash.ReportOrPanic(ctx, &n.execCfg.Settings.SV, "%w", err)
+		return
+	}
+	n.versionUpdateMu.encodedVersion = string(encodedVersion)
+	// Notify listeners.
+	close(n.versionUpdateMu.updateCh)
+	n.versionUpdateMu.updateCh = make(chan struct{})
 }
 
 // Join implements the kvpb.InternalServer service. This is the

--- a/pkg/settings/version.go
+++ b/pkg/settings/version.go
@@ -103,8 +103,12 @@ func (v *VersionSetting) SettingsListDefault() string {
 // Typ is part of the Setting interface.
 func (*VersionSetting) Typ() string {
 	// This is named "m" (instead of "v") for backwards compatibility reasons.
-	return "m"
+	return VersionSettingValueType
 }
+
+// VersionSettingValueType is the value type string (m originally for
+// "migration") used in the system.settings table.
+const VersionSettingValueType = "m"
 
 // String is part of the Setting interface.
 func (v *VersionSetting) String(sv *Values) string {

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -415,11 +415,10 @@ EXCEPT SELECT capability_name, capability_value FROM [SHOW TENANT othertenant WI
 
 # Check that the setting overrides were copied.
 query TTTT rowsort
-SELECT variable, IF(variable='version','--',value), type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT othertenant]
+SELECT variable, value, type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT othertenant]
 WHERE origin != 'no-override'
 ----
 trace.debug.enable  true  b  per-tenant-override
-version             --    m  all-tenants-override
 
 # Check that the resource usage parameters were copied.
 query IIRRRRI
@@ -464,11 +463,10 @@ EXCEPT SELECT capability_name, capability_value FROM [SHOW TENANT othertenant WI
 
 # Check the setting overrides were taken over.
 query TTTT rowsort
-SELECT variable, IF(variable='version','--',value), type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT othertenant]
+SELECT variable, value, type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT othertenant]
 WHERE origin != 'no-override'
 ----
 trace.debug.enable  true  b  per-tenant-override
-version             --    m  all-tenants-override
 
 # Check that the resource usage parameters were copied.
 query IIRRRRI

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -585,19 +585,6 @@ func setVersionSetting(
 				return err
 			}
 
-			// If we're the system tenant, also send an override to each tenant
-			// to ensure that they know about the new cluster version.
-			if forSystemTenant {
-				if _, err = txn.ExecEx(
-					ctx, "update-setting", txn.KV(),
-					sessiondata.RootUserSessionDataOverride,
-					`UPSERT INTO system.tenant_settings (tenant_id, name, value, "last_updated", "value_type") VALUES ($1, $2, $3, now(), $4)`,
-					tree.NewDInt(0), name, string(rawValue), setting.Typ(),
-				); err != nil {
-					return err
-				}
-			}
-
 			// Perform any necessary post-setting validation. This is used in
 			// the tenant upgrade interlock to ensure that the set of sql
 			// servers present at the time of the settings update, matches the

--- a/pkg/upgrade/upgrades/permanent_upgrades.go
+++ b/pkg/upgrade/upgrades/permanent_upgrades.go
@@ -129,24 +129,7 @@ func populateVersionSetting(
 		ctx, "insert-setting", nil, /* txn */
 		fmt.Sprintf(`INSERT INTO system.settings (name, value, "lastUpdated", "valueType") VALUES ('version', x'%x', now(), 'm') ON CONFLICT(name) DO NOTHING`, b),
 	)
-	if err != nil {
-		return err
-	}
-
-	// Tenant ID 0 indicates that we're overriding the value for all
-	// tenants.
-	_, err = ie.Exec(
-		ctx,
-		"insert-setting", nil, /* txn */
-		fmt.Sprintf(`
-INSERT INTO system.tenant_settings (tenant_id, name, value, last_updated, value_type)
-VALUES (0, 'version', x'%x', now(), 'm') ON CONFLICT(tenant_id, name) DO NOTHING`, b),
-	)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func initializeClusterSecret(


### PR DESCRIPTION
Backport:

- 1/1 commits from #106037.

/cc @cockroachdb/release

---

Epic: CRDB-26691

Release justification: avoids test flakes
