### PR TITLE
buildutil: Add RunningUnderTest function

### DIFF
--- a/pkg/util/buildutil/BUILD.bazel
+++ b/pkg/util/buildutil/BUILD.bazel
@@ -7,8 +7,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "buildutil",
     srcs = select({
-        "//build/toolchains:crdb_test": [":gen-crdb-test-on"],
-        "//conditions:default": [":gen-crdb-test-off"],
+        "//build/toolchains:crdb_test": [
+            "util.go",
+            ":gen-crdb-test-on",
+        ],
+        "//conditions:default": [
+            "util.go",
+            ":gen-crdb-test-off",
+        ],
     }),
     importpath = "github.com/cockroachdb/cockroach/pkg/util/buildutil",
     visibility = ["//visibility:public"],

--- a/pkg/util/buildutil/crdb_test_test.go
+++ b/pkg/util/buildutil/crdb_test_test.go
@@ -23,4 +23,7 @@ func TestCrdbTestOn(t *testing.T) {
 	if bazel.BuiltWithBazel() {
 		require.True(t, CrdbTestBuild)
 	}
+
+	require.True(t, likelyRunningUnderTest)
+	require.True(t, RunningUnderTest())
 }

--- a/pkg/util/buildutil/util.go
+++ b/pkg/util/buildutil/util.go
@@ -1,0 +1,31 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package buildutil
+
+import (
+	"os"
+	"strings"
+)
+
+// RunningUnderTest returns true if we are executing a test binary.
+// Use this function instead of direct CrdbTestBuild constant
+// to work with tests that do not set appropriate tags explicitly
+// (for example when executing test directly using "go test" or when running
+// tests from an IDE)
+func RunningUnderTest() bool {
+	return CrdbTestBuild || likelyRunningUnderTest
+}
+
+var likelyRunningUnderTest bool
+
+func init() {
+	likelyRunningUnderTest = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], "test")
+}


### PR DESCRIPTION
`buildutil.CrdbTest` constant is used in many places to determine if the code is running under test.
This conditionally compiled constant may not be sufficient since some tests -- e.g. those that run by an IDE -- may not set appropriate tags.

Add a `buildutil.RunningUnderTest` function that
does a bit more work to determine if the code
is running under test.

Epic: None

Release note: None