### PR TITLE
server: remove extra conn.cancelConn() calls

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -1219,8 +1219,7 @@ func (s *Server) serveImpl(
 	// canceled our context and that's how we got here; in that case, this will
 	// be a no-op.
 	c.stmtBuf.Close()
-	// Cancel the processor's context.
-	c.cancelConn()
+
 	// In case the authenticator is blocked on waiting for data from the client,
 	// tell it that there's no more data coming. This is a no-op if authentication
 	// was completed already.


### PR DESCRIPTION
Informs #105448

`conn.cancelConn` is always called in a deferred function after the `conn` is created so it does not need to be called deeper in the stack.

Release note: None