### PR TITLE
release-23.1: kv, server: rewrite hot ranges stats collection per tenant

### DIFF
--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
+	aload "github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/load"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
@@ -2618,6 +2619,53 @@ func TestStoreBadRequests(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStore_HottestReplicasByTenant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	store, _ := createTestStore(ctx, t, testStoreOpts{createSystemRanges: true}, stopper)
+
+	type testData struct {
+		tenantID uint64
+		qps      float64
+	}
+
+	td := []testData{{1, 2}, {1, 3}, {1, 4}, {1, 5},
+		{2, 1}, {2, 2}, {2, 3}, {2, 4}}
+
+	acc := NewTenantReplicaAccumulator(aload.Queries)
+
+	for i, c := range td {
+		cr := candidateReplica{
+			Replica: &Replica{RangeID: roachpb.RangeID(i)},
+			usage:   allocator.RangeUsageInfo{QueriesPerSecond: c.qps},
+		}
+		cr.mu.tenantID = roachpb.MustMakeTenantID(c.tenantID)
+		acc.AddReplica(cr)
+	}
+
+	store.replRankingsByTenant.Update(acc)
+
+	hotReplicas := store.HottestReplicasByTenant(roachpb.MustMakeTenantID(1))
+	require.NotNil(t, hotReplicas)
+	require.Equal(t, 4, len(hotReplicas))
+
+	// Test requesting hottest replicas asynchronously to detect data race.
+	iterationsNum := 100
+	wg := sync.WaitGroup{}
+	wg.Add(iterationsNum)
+	for i := 0; i < iterationsNum; i++ {
+		go func() {
+			require.NotNil(t, store.HottestReplicasByTenant(roachpb.MustMakeTenantID(1)))
+			require.NotNil(t, store.HottestReplicasByTenant(roachpb.MustMakeTenantID(2)))
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }
 
 // fakeRangeQueue implements the rangeQueue interface and


### PR DESCRIPTION
Backport 1/1 commits from #102766.

/cc @cockroachdb/release

This patch includes following changes
- refactor RRAccumulatorByTenant and ReplicaRankingMap to follow the
same pattern as RRAccumulator and RRAccumulator accumulator respectively;
- collect hottest replicas per tenant and per QPS and CPU rebalance objectives;
- resolve data race issues

---

Resolves: #104767

Release note: None

Release justification: fixes for high-priority or high-severity bugs in existing functionality