### PR TITLE
storage: avoid allocating in EngineKey.Validate

### DIFF
--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -769,6 +769,7 @@ func TestLockTableKeyEncodeDecode(t *testing.T) {
 			k, err := DecodeLockTableSingleKey(ltKey)
 			require.NoError(t, err)
 			require.Equal(t, test.key, k)
+			require.NoError(t, ValidateLockTableSingleKey(ltKey))
 		})
 	}
 }
@@ -793,6 +794,7 @@ func TestLockTableSingleKeyNext_Equivalent(t *testing.T) {
 
 			k, err := DecodeLockTableSingleKey(got)
 			require.NoError(t, err)
+			require.NoError(t, ValidateLockTableSingleKey(got))
 			require.Equal(t, next, k)
 		})
 	}

--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -188,12 +188,11 @@ func (k EngineKey) ToLockTableKey() (LockTableKey, error) {
 
 // Validate checks if the EngineKey is a valid MVCCKey or LockTableKey.
 func (k EngineKey) Validate() error {
-	_, errMVCC := k.ToMVCCKey()
-	_, errLock := k.ToLockTableKey()
-	if errMVCC != nil && errLock != nil {
-		return errors.Newf("key %s is neither an MVCCKey or LockTableKey", k)
+	if k.IsLockTableKey() {
+		return keys.ValidateLockTableSingleKey(k.Key)
 	}
-	return nil
+	_, errMVCC := k.ToMVCCKey()
+	return errMVCC
 }
 
 // DecodeEngineKey decodes the given bytes as an EngineKey. If the caller


### PR DESCRIPTION
This function previously allocated unnecessarily, because it validated through decoding the key as both a MVCCKey and a LockTableKey and ensuring that one succeeded. If the key was a LockTableKey, `ToMVCCKey` would allocate an error (including stack traces, etc) and `ToLockTableKey` would allocate during decoding. If the key was a MVCCKey, `ToLockTableKey` would allocate an error (including stack traces, etc).

Now, Validate never allocates for valid keys and a randomized unit test ensures this.

Fix #106464.

Epic: none
Release note: none