### PR TITLE
sql: deflake TestParallel

### DIFF
--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -195,6 +195,8 @@ func (t *parallelTest) setup(ctx context.Context, spec *parTestSpec) {
 		sql.DistSQLClusterExecMode.Override(ctx, &st.SV, int64(mode))
 		// Disable automatic stats - they can interfere with the test shutdown.
 		stats.AutomaticStatisticsClusterMode.Override(ctx, &st.SV, false)
+		stats.UseStatisticsOnSystemTables.Override(ctx, &st.SV, false)
+		stats.AutomaticStatisticsOnSystemTables.Override(ctx, &st.SV, false)
 	}
 
 	t.clients = make([][]*gosql.DB, spec.ClusterSize)

--- a/pkg/sql/logictest/testdata/parallel_test/create_stats/test.yaml
+++ b/pkg/sql/logictest/testdata/parallel_test/create_stats/test.yaml
@@ -3,7 +3,7 @@
 
 cluster_size: 3
 
-range_split_size: 32768
+range_split_size: 67108864
 
 run:
    # First run setup


### PR DESCRIPTION
This change is attempt to fix flakiness of TestParallel test with following updates:
- increased `range max bytes` setting as it was increased in a37e053173ebf069b12ef6a2c38a03dd984992e2.
- disabled automatic stats collection for system tables, it has be done in addition to already disabled `stats.AutomaticStatisticsClusterMode`
 setting.

Resolves: #101614

Release note: None