### PR TITLE
kv,sql: randomly inject retriable errors 

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -827,11 +827,9 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 			}
 			codec := execCfg.Codec
 			dummyTable := systemschema.SettingsTable
-			err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-				id, err := execCfg.DescIDGenerator.GenerateUniqueDescID(ctx)
-				if err != nil {
-					return err
-				}
+			id, err := execCfg.DescIDGenerator.GenerateUniqueDescID(ctx)
+			require.NoError(t, err)
+			err = db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 				mut := dummyTable.NewBuilder().BuildCreatedMutable().(*tabledesc.Mutable)
 				mut.ID = id
 				mut.Name = fmt.Sprintf("%s_%d", "crdb_internal_copy", id)

--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -142,6 +142,7 @@ type clusterCfg struct {
 	beforeVersion     string
 	testingKnobCfg    string
 	defaultTestTenant base.DefaultTestTenantOptions
+	randomTxnRetries  bool
 }
 
 func (d *datadrivenTestState) addCluster(t *testing.T, cfg clusterCfg) error {
@@ -155,6 +156,9 @@ func (d *datadrivenTestState) addCluster(t *testing.T, cfg clusterCfg) error {
 			// The tests in this package are particular about the tenant IDs
 			// they get in CREATE TENANT.
 			EnableTenantIDReuse: true,
+		},
+		KVClient: &kvcoord.ClientTestingKnobs{
+			EnableRandomTransactionRetryErrors: cfg.randomTxnRetries,
 		},
 	}
 
@@ -513,6 +517,9 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 				defaultTestTenant = base.TODOTestTenantDisabled
 			}
 
+			// TODO(ssd): Once TestServer starts up reliably enough:
+			// randomTxnRetries := !d.HasArg("disable-txn-retries")
+			randomTxnRetries := false
 			lastCreatedCluster = name
 			cfg := clusterCfg{
 				name:              name,
@@ -524,6 +531,7 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 				beforeVersion:     beforeVersion,
 				testingKnobCfg:    testingKnobCfg,
 				defaultTestTenant: defaultTestTenant,
+				randomTxnRetries:  randomTxnRetries,
 			}
 			err := ds.addCluster(t, cfg)
 			if err != nil {

--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
@@ -517,9 +518,11 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 				defaultTestTenant = base.TODOTestTenantDisabled
 			}
 
-			// TODO(ssd): Once TestServer starts up reliably enough:
-			// randomTxnRetries := !d.HasArg("disable-txn-retries")
-			randomTxnRetries := false
+			randomTxnRetries := !d.HasArg("disable-txn-retries")
+			if util.RaceEnabled {
+				randomTxnRetries = false
+			}
+
 			lastCreatedCluster = name
 			cfg := clusterCfg{
 				name:              name,

--- a/pkg/ccl/backupccl/testdata/backup-restore/metadata
+++ b/pkg/ccl/backupccl/testdata/backup-restore/metadata
@@ -2,7 +2,7 @@
 #
 # This also serves as a regression test for #86806 -- a bug in which 2
 # or more forecsts would break metadata SST writing.
-new-cluster name=s
+new-cluster name=s disable-txn-retries
 ----
 
 exec-sql

--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",
+        "//pkg/util/randutil",
         "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -994,7 +994,13 @@ func (db *DB) TxnRootKV(ctx context.Context, retryable func(context.Context, *Tx
 // runTxn runs the given retryable transaction function using the given *Txn.
 func runTxn(ctx context.Context, txn *Txn, retryable func(context.Context, *Txn) error) error {
 	err := txn.exec(ctx, func(ctx context.Context, txn *Txn) error {
-		return retryable(ctx, txn)
+		if err := retryable(ctx, txn); err != nil {
+			return err
+		}
+		if txn.TestingShouldReturnRandomRetry() {
+			return txn.GenerateForcedRetryableError(ctx, "randomized retriable error")
+		}
+		return nil
 	})
 	if err != nil {
 		if rollbackErr := txn.Rollback(ctx); rollbackErr != nil {

--- a/pkg/kv/kvclient/kvcoord/testing_knobs.go
+++ b/pkg/kv/kvclient/kvcoord/testing_knobs.go
@@ -57,6 +57,10 @@ type ClientTestingKnobs struct {
 	// error which, if non-nil, becomes the result of the batch. Otherwise, execution
 	// continues.
 	OnRangeSpanningNonTxnalBatch func(ba *kvpb.BatchRequest) *kvpb.Error
+
+	// EnableRandomTransactionRetryErrors allows transaction retry
+	// loops to randomly inject retriable errors.
+	EnableRandomTransactionRetryErrors bool
 }
 
 var _ base.ModuleTestingKnobs = &ClientTestingKnobs{}

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -33,6 +35,16 @@ const (
 	// OpTxnCoordSender represents a txn coordinator send operation.
 	OpTxnCoordSender = "txn coordinator send"
 )
+
+// DisableCommitSanityCheck allows opting out of a fatal assertion error that was observed in the wild
+// and for which a root cause is not yet available.
+//
+// See: https://github.com/cockroachdb/cockroach/pull/73512.
+var DisableCommitSanityCheck = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_COMMIT_SANITY_CHECK", false)
+
+// forceTxnRetries enables random transaction retries for test builds
+// even if they aren't enabled via testing knobs.
+var forceTxnRetries = envutil.EnvOrDefaultBool("COCKROACH_FORCE_RANDOM_TXN_RETRIES", false)
 
 // txnState represents states relating to whether an EndTxn request needs
 // to be sent.
@@ -1509,6 +1521,16 @@ func (tc *TxnCoordSender) HasPerformedWrites() bool {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.hasPerformedWritesLocked()
+}
+
+func (tc *TxnCoordSender) TestingRandomRetryableErrorsEnabled() bool {
+	if tc.testingKnobs.EnableRandomTransactionRetryErrors {
+		return true
+	}
+	if forceTxnRetries && buildutil.CrdbTestBuild {
+		return true
+	}
+	return false
 }
 
 func (tc *TxnCoordSender) hasPerformedReadsLocked() bool {

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -248,6 +248,11 @@ func (m *MockTransactionalSender) HasPerformedWrites() bool {
 	panic("unimplemented")
 }
 
+// TestingRandomRetryableErrorsEnabled is part of TxnSenderFactory.
+func (m *MockTransactionalSender) TestingRandomRetryableErrorsEnabled() bool {
+	return false
+}
+
 // MockTxnSenderFactory is a TxnSenderFactory producing MockTxnSenders.
 type MockTxnSenderFactory struct {
 	senderFunc func(context.Context, *roachpb.Transaction, *kvpb.BatchRequest) (

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -334,6 +334,13 @@ type TxnSender interface {
 
 	// HasPerformedWrites returns true if a write has been performed.
 	HasPerformedWrites() bool
+
+	// TestingRandomRetriableErrorsEnabled returns true if
+	// transaction retry errors should be randomly returned to
+	// callers. Note, it is the responsibility of (*kv.DB).Txn()
+	// to return the retries. This lives here since the TxnSender
+	// is what has access to the server's testing knobs.
+	TestingRandomRetryableErrorsEnabled() bool
 }
 
 // SteppingMode is the argument type to ConfigureStepping.

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -1411,6 +1412,27 @@ func (txn *Txn) GenerateForcedRetryableError(
 	defer txn.mu.Unlock()
 	now := txn.db.clock.NowAsClockTimestamp()
 	return txn.mu.sender.ManualRestart(ctx, txn.mu.userPriority, now.ToTimestamp(), msg)
+}
+
+var (
+	randRetryRngSource, _     = randutil.NewPseudoRand()
+	randomTxnRetryProbability = 0.1
+)
+
+// TestingShouldReturnRandomRetry returns true if we should generate a
+// random, retriable error for this transaction.
+func (txn *Txn) TestingShouldReturnRandomRetry() bool {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+
+	if !txn.mu.sender.TestingRandomRetryableErrorsEnabled() {
+		return false
+	}
+
+	if txn.mu.sender.ClientFinalized() {
+		return false
+	}
+	return randRetryRngSource.Float64() < randomTxnRetryProbability
 }
 
 // IsSerializablePushAndRefreshNotPossible returns true if the transaction is

--- a/pkg/server/tenantsettingswatcher/overrides_store.go
+++ b/pkg/server/tenantsettingswatcher/overrides_store.go
@@ -11,6 +11,7 @@
 package tenantsettingswatcher
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -90,8 +91,8 @@ func (s *overridesStore) SetAll(allOverrides map[roachpb.TenantID][]kvpb.TenantS
 		})
 		// Sanity check.
 		for i := 1; i < len(overrides); i++ {
-			if overrides[i].Name == overrides[i-1].Name {
-				panic("duplicate setting")
+			if overrides[i].Name == overrides[i-1].Name && overrides[i].Value != overrides[i-1].Value {
+				panic(fmt.Sprintf("duplicate setting override for setting %q on tenant %d with differing values", overrides[i].Name, tenantID.InternalValue))
 			}
 		}
 		s.mu.tenants[tenantID] = newTenantOverrides(overrides)

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1764,6 +1764,16 @@ func (ief *InternalDB) txn(
 			if err != nil {
 				return err
 			}
+			// We check this testing condition here since
+			// a random retry cannot be generated after a
+			// successful commit. Since we commit below,
+			// this is our last chance to generate a
+			// random retry for users of
+			// (*InternalDB).Txn.
+			if kvTxn.TestingShouldReturnRandomRetry() {
+				return kvTxn.GenerateForcedRetryableError(ctx, "randomized retriable error")
+			}
+
 			return commitTxnFn(ctx)
 		}); descs.IsTwoVersionInvariantViolationError(err) {
 			continue


### PR DESCRIPTION
Occasionally, we see bugs caused by mismangement of state inside a
function that will be retried.

This is a cheap way to help us hunt down such bugs.

However, in its current form, it is too noisy to turn on even
metamorphically.

Further, it is not clear to me that this is the right shape of this
feature. An alternative would be a testing knob that allows you to
enable this on a per-test server basis; however that will be just as
noisy for the time being.

Informs https://github.com/cockroachdb/cockroach/issues/106417

Epic: none

Release note: None