### PR TITLE
upgrades: fix transaction retry bug in auto config job migration

### DIFF
--- a/pkg/upgrade/upgrades/create_auto_config_runner_job.go
+++ b/pkg/upgrade/upgrades/create_auto_config_runner_job.go
@@ -31,10 +31,10 @@ func createAutoConfigRunnerJob(
 	}
 
 	if err := d.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		row, err := d.DB.Executor().QueryRowEx(
+		row, err := txn.QueryRowEx(
 			ctx,
 			"check for existing auto config runner job",
-			nil,
+			txn.KV(),
 			sessiondata.RootUserSessionDataOverride,
 			"SELECT 1 FROM system.jobs WHERE id = $1",
 			jobs.AutoConfigRunnerJobID,


### PR DESCRIPTION
The SELECT query here, despite being inside the func passed to Txn wasn't actually using the transaction. If the Txn retries, then the following select appears to hang forever.

This has not been observed in any real-world test but was observed when experimenting with randomly injecting retryable errors (#106506).

Informs #106417

Epic: none

Release note: None