### PR TITLE
backupccl: fix txn retry bug during planning

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -559,7 +559,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		initialDetails := details
 		if err := insqlDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			backupDetails, m, err := getBackupDetailAndManifest(
-				ctx, p.ExecCfg(), txn, details, p.User(), backupDest,
+				ctx, p.ExecCfg(), txn, initialDetails, p.User(), backupDest,
 			)
 			if err != nil {
 				return err


### PR DESCRIPTION
If the Txn modified here was retried, in some cases we would fail with a nil pointer dereference.

The details struct passed into getBackupManifestAndDetails is passed by value and then modified inside the function. As part of that modification, we update the EncryptionOptions. But, I believe when we are in encryption mode none we actually end up setting the encryption options to nil.

https://github.com/cockroachdb/cockroach/blob/3a523711f46921916b6bd1af5153868e1489565e/pkg/ccl/backupccl/backup_planning.go#L1621
https://github.com/cockroachdb/cockroach/blob/3a523711f46921916b6bd1af5153868e1489565e/pkg/ccl/backupccl/backupencryption/encryption.go#L213-L258

Informs #106417

The change here maybe isn't the best way to solve this. We can update the encryption option handling code to better handle the case of encryption mode None, But really, ownership over these structs needs to be made much cleaner.

Epic: none

Release note: None