### PR TITLE
kvserver: skip promote non voter under race

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2211,10 +2211,11 @@ func TestPromoteNonVoterInAddVoter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// This test is slow under stress and can time out when upreplicating /
+	// This test is slow under stress/race and can time out when upreplicating /
 	// rebalancing to ensure all stores have the same range count initially, due
 	// to slow heartbeats.
 	skip.UnderStress(t)
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
TestPromoteNonVoterInAddVoter requires that the initial range count of each store is balanced. Under stress/race builds this takes much longer and may time out before achieved.

TestPromoteNonVoterInAddVoter was already skipped under stress, also skip the test under race.

Resolves: #105883

Release note: None