### PR TITLE
backup: remove unused benches

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -224,7 +224,6 @@ go_test(
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/storageccl",
         "//pkg/ccl/utilccl",
-        "//pkg/ccl/utilccl/sampledataccl",
         "//pkg/cloud",
         "//pkg/cloud/amazon",
         "//pkg/cloud/azure",

--- a/pkg/ccl/backupccl/bench_test.go
+++ b/pkg/ccl/backupccl/bench_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupencryption"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/sampledataccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -33,141 +32,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/stretchr/testify/require"
 )
-
-func BenchmarkDatabaseBackup(b *testing.B) {
-	// NB: This benchmark takes liberties in how b.N is used compared to the go
-	// documentation's description. We're getting useful information out of it,
-	// but this is not a pattern to cargo-cult.
-
-	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(b, multiNode,
-		0 /* numAccounts */, InitManualReplication)
-	defer cleanupFn()
-	sqlDB.Exec(b, `DROP TABLE data.bank`)
-
-	bankData := bank.FromRows(b.N).Tables()[0]
-	loadURI := "nodelocal://1/load"
-	if _, err := sampledataccl.ToBackup(b, bankData, dir, "load"); err != nil {
-		b.Fatalf("%+v", err)
-	}
-	sqlDB.Exec(b, fmt.Sprintf(`RESTORE data.* FROM '%s'`, loadURI))
-
-	// TODO(dan): Ideally, this would split and rebalance the ranges in a more
-	// controlled way. A previous version of this code did it manually with
-	// `SPLIT AT` and TestCluster's TransferRangeLease, but it seemed to still
-	// be doing work after returning, which threw off the timing and the results
-	// of the benchmark. DistSQL is working on improving this infrastructure, so
-	// use what they build.
-
-	b.ResetTimer()
-	var unused string
-	var dataSize int64
-	sqlDB.QueryRow(b, fmt.Sprintf(`BACKUP DATABASE data TO '%s'`, localFoo)).Scan(
-		&unused, &unused, &unused, &unused, &unused, &dataSize,
-	)
-	b.StopTimer()
-	b.SetBytes(dataSize / int64(b.N))
-}
-
-func BenchmarkDatabaseRestore(b *testing.B) {
-	// NB: This benchmark takes liberties in how b.N is used compared to the go
-	// documentation's description. We're getting useful information out of it,
-	// but this is not a pattern to cargo-cult.
-
-	_, sqlDB, dir, cleanup := backupRestoreTestSetup(b, multiNode,
-		0 /* numAccounts*/, InitManualReplication)
-	defer cleanup()
-	sqlDB.Exec(b, `DROP TABLE data.bank`)
-
-	bankData := bank.FromRows(b.N).Tables()[0]
-	if _, err := sampledataccl.ToBackup(b, bankData, dir, "foo"); err != nil {
-		b.Fatalf("%+v", err)
-	}
-
-	b.ResetTimer()
-	sqlDB.Exec(b, `RESTORE data.* FROM 'nodelocal://1/foo'`)
-	b.StopTimer()
-}
-
-func BenchmarkEmptyIncrementalBackup(b *testing.B) {
-	const numStatements = 100000
-
-	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(b, multiNode,
-		0 /* numAccounts */, InitManualReplication)
-	defer cleanupFn()
-
-	restoreURI := localFoo + "/restore"
-	fullURI := localFoo + "/full"
-
-	bankData := bank.FromRows(numStatements).Tables()[0]
-	_, err := sampledataccl.ToBackup(b, bankData, dir, "foo/restore")
-	if err != nil {
-		b.Fatalf("%+v", err)
-	}
-	sqlDB.Exec(b, `DROP TABLE data.bank`)
-	sqlDB.Exec(b, `RESTORE data.* FROM $1`, restoreURI)
-
-	var unused string
-	var dataSize int64
-	sqlDB.QueryRow(b, `BACKUP DATABASE data TO $1`, fullURI).Scan(
-		&unused, &unused, &unused, &unused, &unused, &dataSize,
-	)
-
-	// We intentionally don't write anything to the database between the full and
-	// incremental backup.
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		incrementalDir := localFoo + fmt.Sprintf("/incremental%d", i)
-		sqlDB.Exec(b, `BACKUP DATABASE data TO $1 INCREMENTAL FROM $2`, incrementalDir, fullURI)
-	}
-	b.StopTimer()
-
-	// We report the number of bytes that incremental backup was able to
-	// *skip*--i.e., the number of bytes in the full backup.
-	b.SetBytes(int64(b.N) * dataSize)
-}
-
-func BenchmarkDatabaseFullBackup(b *testing.B) {
-	const numStatements = 100000
-
-	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(b, multiNode,
-		0 /* numAccounts */, InitManualReplication)
-	defer cleanupFn()
-
-	restoreURI := localFoo + "/restore"
-	fullURI := localFoo + "/full"
-
-	bankData := bank.FromRows(numStatements).Tables()[0]
-	_, err := sampledataccl.ToBackup(b, bankData, dir, "foo/restore")
-	if err != nil {
-		b.Fatalf("%+v", err)
-	}
-	sqlDB.Exec(b, `DROP TABLE data.bank`)
-	sqlDB.Exec(b, `RESTORE data.* FROM $1`, restoreURI)
-
-	var unused string
-	var dataSize int64
-	sqlDB.QueryRow(b, `BACKUP DATABASE data TO $1`, fullURI).Scan(
-		&unused, &unused, &unused, &unused, &unused, &dataSize,
-	)
-
-	// We intentionally don't write anything to the database between the full and
-	// incremental backup.
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		backupDir := localFoo + fmt.Sprintf("/backup%d", i)
-		sqlDB.Exec(b, `BACKUP DATABASE data TO $1`, backupDir)
-	}
-	b.StopTimer()
-
-	// We report the number of bytes that incremental backup was able to
-	// *skip*--i.e., the number of bytes in the full backup.
-	b.SetBytes(int64(b.N) * dataSize)
-}
 
 // BenchmarkIteratorMemory benchmarks the memory used for creating an SST
 // iterator using ExternalSSTReader. It is meant to be used benchmark iterators


### PR DESCRIPTION
These benchmarks aren't useful (we use roachtests for end-to-end tests).

Fixes: https://github.com/cockroachdb/cockroach/issues/62083
Release note: None.
Epic: None.