### PR TITLE
release-22.2: logictest: deflake udf tracing test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2186,8 +2186,8 @@ SELECT trace_fn(a) FROM trace_tab
 statement ok
 SET tracing = off
 
-query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message ~ 'udf'
+query T rowsort
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message ~ '^=== SPAN START: udf-stmt-trace_fn'
 ----
 === SPAN START: udf-stmt-trace_fn-0 ===
 === SPAN START: udf-stmt-trace_fn-1 ===


### PR DESCRIPTION
Backport 1/1 commits from #106424.

/cc @cockroachdb/release

---

This commit tightens up a regex filter in a UDF tracing test to ensure
that the filter won't match random DistSQL diagram URLs that exist in
`SHOW TRACE FOR SESSION`.

Fixes #106361

Release note: None

----

Release justification: Test-only change.
