### PR TITLE
telemetryccl: skip TestTelemetry under deadlock

### DIFF
--- a/pkg/ccl/telemetryccl/telemetry_test.go
+++ b/pkg/ccl/telemetryccl/telemetry_test.go
@@ -23,6 +23,7 @@ func TestTelemetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes >1min under race")
+	skip.UnderDeadlock(t, "takes >1min under deadlock")
 
 	sqltestutils.TelemetryTest(
 		t,

--- a/pkg/sql/telemetry_test.go
+++ b/pkg/sql/telemetry_test.go
@@ -31,6 +31,7 @@ func TestTelemetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes >1min under race")
+	skip.UnderDeadlock(t, "takes >1min under deadlock")
 
 	sqltestutils.TelemetryTest(
 		t,


### PR DESCRIPTION
Fixes #83495.

This test is extremely large. It takes an unreasonable amount of time with the race or deadlock detector enabled.

Release note: None