### PR TITLE
row: Avoid allocations when using ConsumeKVProvider

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
@@ -737,7 +737,7 @@ func randEncDatumPrimaryFamily(
 
 // readSortedRangeFeedValues reads n values, and sorts them based on key order.
 func readSortedRangeFeedValues(
-	t *testing.T, n int, row func(t *testing.T) *kvpb.RangeFeedValue,
+	t *testing.T, n int, row func(t testing.TB) *kvpb.RangeFeedValue,
 ) (res []kvpb.RangeFeedValue) {
 	t.Helper()
 	for i := 0; i < n; i++ {

--- a/pkg/ccl/changefeedccl/cdctest/row.go
+++ b/pkg/ccl/changefeedccl/cdctest/row.go
@@ -33,8 +33,8 @@ import (
 // Instead of trying to generate KVs ourselves (subject to encoding restrictions, etc), it is
 // simpler to just "INSERT ..." into the table, and then use this function to read next value.
 func MakeRangeFeedValueReader(
-	t *testing.T, execCfgI interface{}, desc catalog.TableDescriptor,
-) (func(t *testing.T) *kvpb.RangeFeedValue, func()) {
+	t testing.TB, execCfgI interface{}, desc catalog.TableDescriptor,
+) (func(t testing.TB) *kvpb.RangeFeedValue, func()) {
 	t.Helper()
 	execCfg := execCfgI.(sql.ExecutorConfig)
 	rows := make(chan *kvpb.RangeFeedValue)
@@ -60,7 +60,7 @@ func MakeRangeFeedValueReader(
 
 	// Helper to read next rangefeed value.
 	dups := make(map[string]struct{})
-	return func(t *testing.T) *kvpb.RangeFeedValue {
+	return func(t testing.TB) *kvpb.RangeFeedValue {
 		t.Helper()
 		for {
 			select {
@@ -84,7 +84,7 @@ func MakeRangeFeedValueReader(
 // GetHydratedTableDescriptor returns a table descriptor for the specified
 // table.  The descriptor is "hydrated" if it has user defined data types.
 func GetHydratedTableDescriptor(
-	t *testing.T, execCfgI interface{}, parts ...tree.Name,
+	t testing.TB, execCfgI interface{}, parts ...tree.Name,
 ) (td catalog.TableDescriptor) {
 	t.Helper()
 	dbName, scName, tableName := func() (tree.Name, tree.Name, tree.Name) {

--- a/pkg/ccl/changefeedccl/parquet_test.go
+++ b/pkg/ccl/changefeedccl/parquet_test.go
@@ -159,7 +159,7 @@ func TestParquetRows(t *testing.T) {
 
 func makeRangefeedReaderAndDecoder(
 	t *testing.T, s serverutils.TestServerInterface,
-) (func(t *testing.T) *kvpb.RangeFeedValue, func(), cdcevent.Decoder) {
+) (func(t testing.TB) *kvpb.RangeFeedValue, func(), cdcevent.Decoder) {
 	tableDesc := cdctest.GetHydratedTableDescriptor(t, s.ExecutorConfig(), "foo")
 	popRow, cleanup := cdctest.MakeRangeFeedValueReader(t, s.ExecutorConfig(), tableDesc)
 	targets := changefeedbase.Targets{}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -671,10 +671,13 @@ func (rf *Fetcher) ConsumeKVProvider(ctx context.Context, f *KVProvider) error {
 	if !rf.args.WillUseKVProvider {
 		return errors.AssertionFailedf("ConsumeKVProvider is called instead of StartScan")
 	}
-	if rf.kvFetcher != nil {
+	if rf.kvFetcher == nil {
+		rf.kvFetcher = newKVFetcher(f)
+	} else {
 		rf.kvFetcher.Close(ctx)
+		rf.kvFetcher.reset(f)
 	}
-	rf.kvFetcher = newKVFetcher(f)
+
 	return rf.startScan(ctx)
 }
 

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -338,6 +338,10 @@ func (f *KVFetcher) SetupNextFetch(
 	)
 }
 
+func (f *KVFetcher) reset(b KVBatchFetcher) {
+	*f = KVFetcher{KVBatchFetcher: b}
+}
+
 // KVProvider is a KVBatchFetcher that returns a set slice of kvs.
 type KVProvider struct {
 	KVs []roachpb.KeyValue


### PR DESCRIPTION
There is no need to allocate new KVFetcher when calling
ConsumeKVProvider repeatedly.

Issues: None
Epic: None
Release note: None