### PR TITLE
release-22.2: engineccl: add 22.2 to benchmark fixture name

### DIFF
--- a/pkg/ccl/storageccl/engineccl/.gitignore
+++ b/pkg/ccl/storageccl/engineccl/.gitignore
@@ -1,3 +1,4 @@
 # Do not add environment-specific entries here (see the top-level .gitignore
 # for reasoning and alternatives).
 mvcc_data
+mvcc_data_v22.2

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -130,7 +130,7 @@ func runIterate(
 
 	// Store the database in this directory so we don't have to regenerate it on
 	// each benchmark run.
-	eng, err := loadTestData("mvcc_data", numKeys, numBatches, batchTimeSpan, valueBytes)
+	eng, err := loadTestData("mvcc_data_v22.2", numKeys, numBatches, batchTimeSpan, valueBytes)
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
Reusing existing fixtures on CI agents is fragile; a fixture might exist from a different version.

In later releases this is already fixed using some general infrastructure for such fixtures.

On 22.2 branch we make a minimal fix: append the version to the directory so it doesn't conflict with other versions.

Fixes: #94913
Release note: None
Release justification: flaky benchmark fix