### PR TITLE
roachtest: backport improvements to `mixedversion` framework (secure clusters, fixtures opt-out)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -194,6 +194,7 @@ require (
 	github.com/pierrre/geohash v1.0.0
 	github.com/pires/go-proxyproto v0.7.0
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/pressly/goose/v3 v3.5.3
 	github.com/prometheus/client_golang v1.12.1
@@ -353,7 +354,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/openzipkin/zipkin-go v0.2.5 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.6.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e // indirect

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1202,7 +1202,7 @@ func attachToExistingCluster(
 		}
 		if !opt.skipWipe {
 			if clusterWipe {
-				if err := c.WipeE(ctx, l, c.All()); err != nil {
+				if err := c.WipeE(ctx, l, false /* preserveCerts */, c.All()); err != nil {
 					return nil, err
 				}
 			} else {
@@ -2214,7 +2214,9 @@ func (c *clusterImpl) Signal(
 
 // WipeE wipes a subset of the nodes in a cluster. See cluster.Start() for a
 // description of the nodes parameter.
-func (c *clusterImpl) WipeE(ctx context.Context, l *logger.Logger, nodes ...option.Option) error {
+func (c *clusterImpl) WipeE(
+	ctx context.Context, l *logger.Logger, preserveCerts bool, nodes ...option.Option,
+) error {
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "cluster.WipeE")
 	}
@@ -2224,16 +2226,16 @@ func (c *clusterImpl) WipeE(ctx context.Context, l *logger.Logger, nodes ...opti
 	}
 	c.setStatusForClusterOpt("wiping", false, nodes...)
 	defer c.clearStatusForClusterOpt(false)
-	return roachprod.Wipe(ctx, l, c.MakeNodes(nodes...), false /* preserveCerts */)
+	return roachprod.Wipe(ctx, l, c.MakeNodes(nodes...), preserveCerts)
 }
 
 // Wipe is like WipeE, except instead of returning an error, it does
 // c.t.Fatal(). c.t needs to be set.
-func (c *clusterImpl) Wipe(ctx context.Context, nodes ...option.Option) {
+func (c *clusterImpl) Wipe(ctx context.Context, preserveCerts bool, nodes ...option.Option) {
 	if ctx.Err() != nil {
 		return
 	}
-	if err := c.WipeE(ctx, c.l, nodes...); err != nil {
+	if err := c.WipeE(ctx, c.l, preserveCerts, nodes...); err != nil {
 		c.t.Fatal(err)
 	}
 }

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2064,10 +2064,6 @@ func (c *clusterImpl) StartE(
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "cluster.StartE")
 	}
-	// If the test failed (indicated by a canceled ctx), short-circuit.
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 	c.setStatusForClusterOpt("starting", startOpts.RoachtestOpts.Worker, opts...)
 	defer c.clearStatusForClusterOpt(startOpts.RoachtestOpts.Worker)
 
@@ -2102,7 +2098,9 @@ func (c *clusterImpl) StartE(
 		return err
 	}
 
-	if settings.Secure {
+	// Do not refetch certs if that step already happened once (i.e., we
+	// are restarting a node).
+	if settings.Secure && c.localCertsDir == "" {
 		if err := c.RefetchCertsFromNode(ctx, 1); err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1500,10 +1500,12 @@ func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger, dest 
 			// Ignore the files in the the log directory; we pull the logs separately anyway
 			// so this would only cause duplication.
 			excludeFiles := "*.log,*.txt,*.pprof"
-			cmd := fmt.Sprintf(
-				"%s debug zip --exclude-files='%s' --url {pgurl:%d} %s",
-				defaultCockroachPath, excludeFiles, i, zipName,
-			)
+			cmd := roachtestutil.NewCommand("%s debug zip", defaultCockroachPath).
+				Flag("exclude-files", fmt.Sprintf("'%s'", excludeFiles)).
+				Flag("url", fmt.Sprintf("{pgurl:%d}", i)).
+				MaybeFlag(c.IsSecure(), "certs-dir", "certs").
+				Arg(zipName).
+				String()
 			if err := c.RunE(ctx, c.Node(i), cmd); err != nil {
 				l.Printf("%s debug zip failed on node %d: %v", defaultCockroachPath, i, err)
 				if i < c.spec.NodeCount {

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -115,8 +115,8 @@ type Cluster interface {
 
 	// Deleting CockroachDB data and logs on nodes.
 
-	WipeE(ctx context.Context, l *logger.Logger, opts ...option.Option) error
-	Wipe(ctx context.Context, opts ...option.Option)
+	WipeE(ctx context.Context, l *logger.Logger, preserveCerts bool, opts ...option.Option) error
+	Wipe(ctx context.Context, preserveCerts bool, opts ...option.Option)
 
 	// Internal niche tools.
 

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -117,7 +117,10 @@ func UploadVersion(
 func InstallFixtures(
 	ctx context.Context, l *logger.Logger, c cluster.Cluster, nodes option.NodeListOption, v string,
 ) error {
-	c.Run(ctx, nodes, "mkdir -p {store-dir}")
+	if err := c.RunE(ctx, nodes, "mkdir -p {store-dir}"); err != nil {
+		return fmt.Errorf("creating store-dir: %w", err)
+	}
+
 	vv := version.MustParse("v" + v)
 	// The fixtures use cluster version (major.minor) but the input might be
 	// a patch release.
@@ -133,7 +136,10 @@ func InstallFixtures(
 		}
 	}
 	// Extract fixture. Fail if there's already an LSM in the store dir.
-	c.Run(ctx, nodes, "ls {store-dir}/marker.* 1> /dev/null 2>&1 && exit 1 || (cd {store-dir} && tar -xf fixture.tgz)")
+	if err := c.RunE(ctx, nodes, "ls {store-dir}/marker.* 1> /dev/null 2>&1 && exit 1 || (cd {store-dir} && tar -xf fixture.tgz)"); err != nil {
+		return fmt.Errorf("extracting fixtures: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/cmd/roachtest/roachtestutil/clusterupgrade",
         "//pkg/cmd/roachtest/test",
         "//pkg/roachpb",
+        "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/util/ctxgroup",
         "//pkg/util/randutil",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -23,12 +23,14 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/version",
+        "@com_github_pkg_errors//:errors",
     ],
 )
 
 go_test(
     name = "mixedversion_test",
     srcs = [
+        "mixedversion_test.go",
         "planner_test.go",
         "runner_test.go",
     ],

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -35,22 +35,26 @@
 //
 // Typical usage:
 //
-//	mvt, err := mixedversion.NewTest(...)
-//	mvt.InMixedVersion("test my feature", func(l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-//	    l.Printf("testing feature X")
-//	    node, db := h.RandomDB(rng, c.All())
-//	    l.Printf("running query on node %d", node)
-//	    _, err := db.ExecContext(ctx, "SELECT * FROM test")
-//	    return err
-//	})
-//	mvt.InMixedVersion("test another feature", func(l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-//	    l.Printf("testing feature Y")
-//	    node, db := h.RandomDB(rng, c.All())
-//	    l.Printf("running query on node %d", node)
-//	    _, err := db.ExecContext(ctx, "SELECT * FROM test2")
-//	    return err
-//	})
-//	mvt.Run()
+//			mvt, err := mixedversion.NewTest(...)
+//			mvt.InMixedVersion("test my feature", func(
+//		  ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper,
+//		 ) error {
+//			    l.Printf("testing feature X")
+//			    node, db := h.RandomDB(rng, c.All())
+//			    l.Printf("running query on node %d", node)
+//			    _, err := db.ExecContext(ctx, "SELECT * FROM test")
+//			    return err
+//			})
+//			mvt.InMixedVersion("test another feature", func(
+//	     ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper,
+//	   ) error {
+//			    l.Printf("testing feature Y")
+//			    node, db := h.RandomDB(rng, c.All())
+//			    l.Printf("running query on node %d", node)
+//			    _, err := db.ExecContext(ctx, "SELECT * FROM test2")
+//			    return err
+//			})
+//			mvt.Run()
 //
 // Functions passed to `InMixedVersion` will be called at arbitrary
 // points during an upgrade/downgrade process. They may also be called
@@ -84,6 +88,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -100,6 +105,11 @@ const (
 	// of migration steps before the new cluster version can be
 	// finalized.
 	runWhileMigratingProbability = 0.5
+
+	// numNodesInFixtures is the number of nodes expected to exist in a
+	// cluster that can use the test fixtures in
+	// `pkg/cmd/roachtest/fixtures`.
+	numNodesInFixtures = 4
 
 	// CurrentCockroachPath is the path to the binary where the current
 	// version of cockroach being tested is located. This file is
@@ -121,6 +131,12 @@ var (
 	// nodes in a cluster.
 	defaultClusterSettings = []install.ClusterSettingOption{
 		install.SecureOption(true),
+	}
+
+	defaultTestOptions = testOptions{
+		// We use fixtures more often than not as they are more likely to
+		// detect bugs, especially in migrations.
+		useFixturesProbability: 0.7,
 	}
 )
 
@@ -214,6 +230,14 @@ type (
 		crdbNodes option.NodeListOption
 	}
 
+	// testOptions contains some options that can be changed by the user
+	// that expose some control over the generated test plan.
+	testOptions struct {
+		useFixturesProbability float64
+	}
+
+	customOption func(*testOptions)
+
 	// Test is the main struct callers of this package interact with.
 	Test struct {
 		ctx       context.Context
@@ -221,6 +245,8 @@ type (
 		cluster   cluster.Cluster
 		logger    *logger.Logger
 		crdbNodes option.NodeListOption
+
+		options testOptions
 
 		rt    test.Test
 		prng  *rand.Rand
@@ -252,6 +278,22 @@ type (
 	StopFunc func()
 )
 
+// NeverUseFixtures is an option that can be passed to `NewTest` to
+// disable the use of fixtures in the test. Necessary if the test
+// wants to use a number of cockroach nodes other than 4.
+func NeverUseFixtures(opts *testOptions) {
+	opts.useFixturesProbability = 0
+}
+
+// AlwaysUseFixtures is an option that can be passed to `NewTest` to
+// force the test to always start the cluster from the fixtures in
+// `pkg/cmd/roachtest/fixtures`. Necessary if the test makes
+// assertions that rely on the existence of data present in the
+// fixtures.
+func AlwaysUseFixtures(opts *testOptions) {
+	opts.useFixturesProbability = 1
+}
+
 // NewTest creates a Test struct that users can use to create and run
 // a mixed-version roachtest.
 func NewTest(
@@ -260,27 +302,37 @@ func NewTest(
 	l *logger.Logger,
 	c cluster.Cluster,
 	crdbNodes option.NodeListOption,
+	options ...customOption,
 ) *Test {
 	testLogger, err := prefixedLogger(l, logPrefix)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	opts := defaultTestOptions
+	for _, fn := range options {
+		fn(&opts)
+	}
+
 	prng, seed := randutil.NewLockedPseudoRand()
 	testLogger.Printf("mixed-version random seed: %d", seed)
 
 	testCtx, cancel := context.WithCancel(ctx)
-	return &Test{
+	test := &Test{
 		ctx:       testCtx,
 		cancel:    cancel,
 		cluster:   c,
 		logger:    testLogger,
 		crdbNodes: crdbNodes,
+		options:   opts,
 		rt:        t,
 		prng:      prng,
 		seed:      seed,
 		hooks:     &testHooks{prng: prng, crdbNodes: crdbNodes},
 	}
+
+	assertValidTest(test, t.Fatal)
+	return test
 }
 
 // RNG returns the underlying random number generator used by the
@@ -433,6 +485,7 @@ func (t *Test) plan() (*TestPlan, error) {
 
 	planner := testPlanner{
 		initialVersion: previousRelease,
+		options:        t.options,
 		rt:             t.rt,
 		crdbNodes:      t.crdbNodes,
 		hooks:          t.hooks,
@@ -458,32 +511,47 @@ func (t *Test) runCommandFunc(nodes option.NodeListOption, cmd string) userFunc 
 	}
 }
 
-// startFromCheckpointStep is the step that starts the cluster from a
-// specific `version`, using checked-in fixtures.
-type startFromCheckpointStep struct {
+// installFixturesStep is the step that copies the fixtures from
+// `pkg/cmd/roachtest/fixtures` for a specific version into the nodes'
+// store dir.
+type installFixturesStep struct {
+	id        int
+	version   string
+	crdbNodes option.NodeListOption
+}
+
+func (s installFixturesStep) ID() int                { return s.id }
+func (s installFixturesStep) Background() shouldStop { return nil }
+
+func (s installFixturesStep) Description() string {
+	return fmt.Sprintf("installing fixtures for version %q", s.version)
+}
+
+func (s installFixturesStep) Run(
+	ctx context.Context, l *logger.Logger, c cluster.Cluster, h *Helper,
+) error {
+	return clusterupgrade.InstallFixtures(ctx, l, c, s.crdbNodes, s.version)
+}
+
+// startStep is the step that starts the cluster from a specific
+// `version`.
+type startStep struct {
 	id        int
 	rt        test.Test
 	version   string
 	crdbNodes option.NodeListOption
 }
 
-func (s startFromCheckpointStep) ID() int                { return s.id }
-func (s startFromCheckpointStep) Background() shouldStop { return nil }
+func (s startStep) ID() int                { return s.id }
+func (s startStep) Background() shouldStop { return nil }
 
-func (s startFromCheckpointStep) Description() string {
-	return fmt.Sprintf("starting cluster from fixtures for version %q", s.version)
+func (s startStep) Description() string {
+	return fmt.Sprintf("starting cluster at version %q", s.version)
 }
 
-// Run will copy the fixtures to all database nodes in the cluster,
-// upload the binary associated with that given version, and finally
-// start the cockroach binary on these nodes.
-func (s startFromCheckpointStep) Run(
-	ctx context.Context, l *logger.Logger, c cluster.Cluster, helper *Helper,
-) error {
-	if err := clusterupgrade.InstallFixtures(ctx, l, c, s.crdbNodes, s.version); err != nil {
-		return err
-	}
-
+// Run uploads the binary associated with the given version and starts
+// the cockroach binary on the nodes.
+func (s startStep) Run(ctx context.Context, l *logger.Logger, c cluster.Cluster, h *Helper) error {
 	binaryPath, err := clusterupgrade.UploadVersion(ctx, s.rt, l, c, s.crdbNodes, s.version)
 	if err != nil {
 		return err
@@ -517,7 +585,7 @@ func (s uploadCurrentVersionStep) Description() string {
 }
 
 func (s uploadCurrentVersionStep) Run(
-	ctx context.Context, l *logger.Logger, c cluster.Cluster, helper *Helper,
+	ctx context.Context, l *logger.Logger, c cluster.Cluster, h *Helper,
 ) error {
 	_, err := clusterupgrade.UploadVersion(ctx, s.rt, l, c, s.crdbNodes, clusterupgrade.MainVersion)
 	if err != nil {
@@ -547,9 +615,9 @@ func (s waitForStableClusterVersionStep) Description() string {
 }
 
 func (s waitForStableClusterVersionStep) Run(
-	ctx context.Context, l *logger.Logger, c cluster.Cluster, helper *Helper,
+	ctx context.Context, l *logger.Logger, c cluster.Cluster, h *Helper,
 ) error {
-	return clusterupgrade.WaitForClusterUpgrade(ctx, l, s.nodes, helper.Connect)
+	return clusterupgrade.WaitForClusterUpgrade(ctx, l, s.nodes, h.Connect)
 }
 
 // preserveDowngradeOptionStep sets the `preserve_downgrade_option`
@@ -568,16 +636,16 @@ func (s preserveDowngradeOptionStep) Description() string {
 }
 
 func (s preserveDowngradeOptionStep) Run(
-	ctx context.Context, l *logger.Logger, c cluster.Cluster, helper *Helper,
+	ctx context.Context, l *logger.Logger, c cluster.Cluster, h *Helper,
 ) error {
-	node, db := helper.RandomDB(s.prng, s.crdbNodes)
+	node, db := h.RandomDB(s.prng, s.crdbNodes)
 	l.Printf("checking binary version (via node %d)", node)
 	bv, err := clusterupgrade.BinaryVersion(db)
 	if err != nil {
 		return err
 	}
 
-	node, db = helper.RandomDB(s.prng, s.crdbNodes)
+	node, db = h.RandomDB(s.prng, s.crdbNodes)
 	downgradeOption := bv.String()
 	l.Printf("setting `preserve_downgrade_option` to %s (via node %d)", downgradeOption, node)
 	_, err = db.ExecContext(ctx, "SET CLUSTER SETTING cluster.preserve_downgrade_option = $1", downgradeOption)
@@ -603,7 +671,7 @@ func (s restartWithNewBinaryStep) Description() string {
 }
 
 func (s restartWithNewBinaryStep) Run(
-	ctx context.Context, l *logger.Logger, c cluster.Cluster, helper *Helper,
+	ctx context.Context, l *logger.Logger, c cluster.Cluster, h *Helper,
 ) error {
 	return clusterupgrade.RestartNodesWithNewBinary(
 		ctx,
@@ -639,9 +707,9 @@ func (s finalizeUpgradeStep) Description() string {
 }
 
 func (s finalizeUpgradeStep) Run(
-	ctx context.Context, l *logger.Logger, c cluster.Cluster, helper *Helper,
+	ctx context.Context, l *logger.Logger, c cluster.Cluster, h *Helper,
 ) error {
-	node, db := helper.RandomDB(s.prng, s.crdbNodes)
+	node, db := h.RandomDB(s.prng, s.crdbNodes)
 	l.Printf("resetting preserve_downgrade_option (via node %d)", node)
 	_, err := db.ExecContext(ctx, "RESET CLUSTER SETTING cluster.preserve_downgrade_option")
 	return err
@@ -665,10 +733,10 @@ func (s runHookStep) Description() string {
 }
 
 func (s runHookStep) Run(
-	ctx context.Context, l *logger.Logger, c cluster.Cluster, helper *Helper,
+	ctx context.Context, l *logger.Logger, c cluster.Cluster, h *Helper,
 ) error {
-	helper.SetContext(&s.testContext)
-	return s.hook.fn(ctx, l, s.prng, helper)
+	h.SetContext(&s.testContext)
+	return s.hook.fn(ctx, l, s.prng, h)
 }
 
 // sequentialRunStep is a "meta-step" that indicates that a sequence
@@ -820,4 +888,14 @@ func rngFromRNG(rng *rand.Rand) *rand.Rand {
 
 func versionMsg(version string) string {
 	return clusterupgrade.VersionMsg(version)
+}
+
+func assertValidTest(test *Test, fatalFunc func(...interface{})) {
+	if test.options.useFixturesProbability > 0 && len(test.crdbNodes) != numNodesInFixtures {
+		err := fmt.Errorf(
+			"invalid cluster: use of fixtures requires %d cockroach nodes, got %d (%v)",
+			numNodesInFixtures, len(test.crdbNodes), test.crdbNodes,
+		)
+		fatalFunc(errors.Wrap(err, "mixedversion.NewTest"))
+	}
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
@@ -1,0 +1,50 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mixedversion
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_assertValidTest(t *testing.T) {
+	var fatalErr error
+	fatalFunc := func() func(...interface{}) {
+		fatalErr = nil
+		return func(args ...interface{}) {
+			require.Len(t, args, 1)
+			err, isErr := args[0].(error)
+			require.True(t, isErr)
+
+			fatalErr = err
+		}
+	}
+
+	notEnoughNodes := option.NodeListOption{1, 2, 3}
+	tooManyNodes := option.NodeListOption{1, 2, 3, 5, 6}
+
+	for _, crdbNodes := range []option.NodeListOption{notEnoughNodes, tooManyNodes} {
+		mvt := newTest()
+		mvt.crdbNodes = crdbNodes
+
+		assertValidTest(mvt, fatalFunc())
+		require.Error(t, fatalErr)
+		require.Contains(t, fatalErr.Error(), "mixedversion.NewTest: invalid cluster: use of fixtures requires 4 cockroach nodes")
+
+		mvt = newTest(NeverUseFixtures)
+		mvt.crdbNodes = crdbNodes
+
+		assertValidTest(mvt, fatalFunc())
+		require.NoError(t, fatalErr)
+	}
+}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -28,6 +28,7 @@ type (
 	TestPlan struct {
 		initialVersion string
 		finalVersion   string
+		startClusterID int
 		steps          []testStep
 	}
 
@@ -35,9 +36,11 @@ type (
 	// a test plan from the given rng and user-provided hooks.
 	testPlanner struct {
 		stepCount      int
+		startClusterID int
 		initialVersion string
 		crdbNodes      option.NodeListOption
 		rt             test.Test
+		options        testOptions
 		hooks          *testHooks
 		prng           *rand.Rand
 		bgChans        []shouldStop
@@ -56,7 +59,7 @@ const (
 // following high level outline:
 //
 //   - start all nodes in the cluster from the predecessor version,
-//     using fixtures.
+//     maybe using fixtures.
 //   - set `preserve_downgrade_option`.
 //   - run startup hooks.
 //   - upgrade all nodes to the current cockroach version (running
@@ -94,6 +97,7 @@ func (p *testPlanner) Plan() *TestPlan {
 	return &TestPlan{
 		initialVersion: p.initialVersion,
 		finalVersion:   versionMsg(clusterupgrade.MainVersion),
+		startClusterID: p.startClusterID,
 		steps:          steps,
 	}
 }
@@ -120,12 +124,21 @@ func (p *testPlanner) finalContext(finalizing bool) Context {
 // upgrading/downgrading. It will also run any startup hooks the user
 // may have provided.
 func (p *testPlanner) initSteps() []testStep {
-	return append([]testStep{
-		startFromCheckpointStep{id: p.nextID(), version: p.initialVersion, rt: p.rt, crdbNodes: p.crdbNodes},
-		uploadCurrentVersionStep{id: p.nextID(), rt: p.rt, crdbNodes: p.crdbNodes, dest: CurrentCockroachPath},
-		waitForStableClusterVersionStep{id: p.nextID(), nodes: p.crdbNodes},
-		preserveDowngradeOptionStep{id: p.nextID(), prng: p.newRNG(), crdbNodes: p.crdbNodes},
-	}, p.hooks.StartupSteps(p.nextID, p.initialContext())...)
+	var steps []testStep
+	if p.prng.Float64() < p.options.useFixturesProbability {
+		steps = []testStep{installFixturesStep{id: p.nextID(), version: p.initialVersion, crdbNodes: p.crdbNodes}}
+	}
+	p.startClusterID = p.nextID()
+	steps = append(steps, startStep{id: p.startClusterID, version: p.initialVersion, rt: p.rt, crdbNodes: p.crdbNodes})
+
+	return append(
+		append(steps,
+			uploadCurrentVersionStep{id: p.nextID(), rt: p.rt, crdbNodes: p.crdbNodes, dest: CurrentCockroachPath},
+			waitForStableClusterVersionStep{id: p.nextID(), nodes: p.crdbNodes},
+			preserveDowngradeOptionStep{id: p.nextID(), prng: p.newRNG(), crdbNodes: p.crdbNodes},
+		),
+		p.hooks.StartupSteps(p.nextID, p.initialContext())...,
+	)
 }
 
 // finalSteps are the steps to be run once the nodes have been

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -587,7 +587,7 @@ func (r *testRunner) runWorker(
 		if c != nil && testToRun.canReuseCluster {
 			err = func() error {
 				l.PrintfCtx(ctx, "Using existing cluster: %s (arch=%q). Wiping", c.name, c.arch)
-				if err := c.WipeE(ctx, l); err != nil {
+				if err := c.WipeE(ctx, l, false /* preserveCerts */); err != nil {
 					return err
 				}
 				if err := c.RunE(ctx, c.All(), "rm -rf "+perfArtifactsDir); err != nil {

--- a/pkg/cmd/roachtest/tests/allocation_bench.go
+++ b/pkg/cmd/roachtest/tests/allocation_bench.go
@@ -323,7 +323,7 @@ func setupStatCollector(
 		if err := c.StopGrafana(ctx, t.L(), t.ArtifactsDir()); err != nil {
 			t.L().ErrorfCtx(ctx, "Error(s) shutting down prom/grafana %s", err)
 		}
-		c.Wipe(ctx)
+		c.Wipe(ctx, false /* preserveCerts */)
 	}
 
 	promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), cfg)

--- a/pkg/cmd/roachtest/tests/autoupgrade.go
+++ b/pkg/cmd/roachtest/tests/autoupgrade.go
@@ -248,7 +248,7 @@ func registerAutoUpgrade(r registry.Registry) {
 
 		// Wipe n3 to exclude it from the dead node check the roachtest harness
 		// will perform after the test.
-		c.Wipe(ctx, c.Node(nodeDecommissioned))
+		c.Wipe(ctx, false /* preserveCerts */, c.Node(nodeDecommissioned))
 	}
 
 	r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/cancel.go
+++ b/pkg/cmd/roachtest/tests/cancel.go
@@ -53,7 +53,7 @@ func registerCancel(r registry.Registry) {
 
 			t.Status("restoring TPCH dataset for Scale Factor 1")
 			if err := loadTPCHDataset(
-				ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false, /* disableMergeQueue */
+				ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false /* disableMergeQueue */, false, /* secure */
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/roachtest/tests/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/tests/clock_jump_crash.go
@@ -39,7 +39,7 @@ func runClockJump(ctx context.Context, t test.Test, c cluster.Cluster, tc clockJ
 	if err := c.RunE(ctx, c.Node(1), "test -x ./cockroach"); err != nil {
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	}
-	c.Wipe(ctx)
+	c.Wipe(ctx, false /* preserveCerts */)
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
 
 	db := c.Conn(ctx, t.L(), c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/tests/clock_monotonic.go
+++ b/pkg/cmd/roachtest/tests/clock_monotonic.go
@@ -41,7 +41,7 @@ func runClockMonotonicity(
 	if err := c.RunE(ctx, c.Node(1), "test -x ./cockroach"); err != nil {
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	}
-	c.Wipe(ctx)
+	c.Wipe(ctx, false /* preserveCerts */)
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
 
 	db := c.Conn(ctx, t.L(), c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/tests/cluster_init.go
+++ b/pkg/cmd/roachtest/tests/cluster_init.go
@@ -52,7 +52,7 @@ func runClusterInit(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// default to just the first node) and we want to make sure that we're not
 	// relying on it.
 	for _, initNode := range []int{2, 1} {
-		c.Wipe(ctx)
+		c.Wipe(ctx, false /* preserveCerts */)
 		t.L().Printf("starting test with init node %d", initNode)
 		startOpts := option.DefaultStartOpts()
 

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -735,7 +735,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 			}
 			// Now stop+wipe them for good to keep the logs simple and the dead node detector happy.
 			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Nodes(targetNodeA, targetNodeB))
-			c.Wipe(ctx, c.Nodes(targetNodeA, targetNodeB))
+			c.Wipe(ctx, false /* preserveCerts */, c.Nodes(targetNodeA, targetNodeB))
 		}
 	}
 
@@ -860,7 +860,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 			t.L().Printf("wiping n%d and adding it back to the cluster as a new node\n", targetNode)
 
 			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(targetNode))
-			c.Wipe(ctx, c.Node(targetNode))
+			c.Wipe(ctx, false /*preserveCerts */, c.Node(targetNode))
 
 			joinNode := h.getRandNode()
 			internalAddrs, err := c.InternalAddr(ctx, t.L(), c.Node(joinNode))

--- a/pkg/cmd/roachtest/tests/decommission_self.go
+++ b/pkg/cmd/roachtest/tests/decommission_self.go
@@ -31,7 +31,7 @@ func runDecommissionSelf(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// Stop n2 and exclude it from post-test consistency checks,
 			// as this node can't contact cluster any more and operations
 			// on it will hang.
-			u.c.Wipe(ctx, c.Node(2))
+			u.c.Wipe(ctx, false /* preserveCerts */, c.Node(2))
 		},
 		checkOneMembership(1, "decommissioned"),
 	)

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -160,5 +160,5 @@ func runInconsistency(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// roachtest checks that no nodes are down when the test finishes, but in this
 	// case we have a down node that we can't restart. Remove the data dir, which
 	// tells roachtest to ignore this node.
-	c.Wipe(ctx, c.Node(1))
+	c.Wipe(ctx, false /* preserveCerts */, c.Node(1))
 }

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -745,7 +745,7 @@ func registerKVScalability(r registry.Registry) {
 		const maxPerNodeConcurrency = 64
 		for i := nodes; i <= nodes*maxPerNodeConcurrency; i += nodes {
 			i := i // capture loop variable
-			c.Wipe(ctx, c.Range(1, nodes))
+			c.Wipe(ctx, false /* preserveCerts */, c.Range(1, nodes))
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
 
 			t.Status("running workload")

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -229,7 +229,7 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 		// Wipe cluster before starting a new run because factors like load-based
 		// splitting can significantly change the underlying layout of the table and
 		// affect benchmark results.
-		c.Wipe(ctx, roachNodes)
+		c.Wipe(ctx, false /* preserveCerts */, roachNodes)
 		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), roachNodes)
 		time.Sleep(restartWait)
 

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1964,7 +1964,7 @@ func (mvb *mixedVersionBackup) resetCluster(
 	ctx context.Context, l *logger.Logger, version string,
 ) error {
 	l.Printf("resetting cluster using version %s", version)
-	if err := mvb.cluster.WipeE(ctx, l, mvb.roachNodes); err != nil {
+	if err := mvb.cluster.WipeE(ctx, l, true /* preserveCerts */, mvb.roachNodes); err != nil {
 		return fmt.Errorf("failed to wipe cluster: %w", err)
 	}
 

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -30,9 +30,10 @@ import (
 func runMultiTenantTPCH(
 	ctx context.Context, t test.Test, c cluster.Cluster, enableDirectScans bool,
 ) {
+	secure := true
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(1))
-	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(install.SecureOption(true)), c.All())
+	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(install.SecureOption(secure)), c.All())
 
 	setupNames := []string{"single-tenant", "multi-tenant"}
 	const numRunsPerQuery = 3
@@ -50,7 +51,7 @@ func runMultiTenantTPCH(
 		}
 		t.Status("restoring TPCH dataset for Scale Factor 1 in ", setupNames[setupIdx])
 		if err := loadTPCHDataset(
-			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false, /* disableMergeQueue */
+			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false /* disableMergeQueue */, secure,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -82,7 +82,7 @@ func runQueryComparison(
 			return
 		}
 		c.Stop(clusterCtx, t.L(), option.DefaultStopOpts())
-		c.Wipe(clusterCtx)
+		c.Wipe(clusterCtx, false /* preserveCerts */)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/rapid_restart.go
+++ b/pkg/cmd/roachtest/tests/rapid_restart.go
@@ -39,7 +39,7 @@ func runRapidRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 		return timeutil.Now().After(deadline)
 	}
 	for j := 1; !done(); j++ {
-		c.Wipe(ctx, node)
+		c.Wipe(ctx, false /* preserveCerts */, node)
 
 		// The first 2 iterations we start the cockroach node and kill it right
 		// away. The 3rd iteration we let cockroach run so that we can check after
@@ -97,5 +97,5 @@ func runRapidRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// that consistency checks can be run, but in this case there's not much
 	// there in the first place anyway.
 	c.Stop(ctx, t.L(), option.DefaultStopOpts(), node)
-	c.Wipe(ctx, node)
+	c.Wipe(ctx, false /* preserveCerts */, node)
 }

--- a/pkg/cmd/roachtest/tests/reset_quorum.go
+++ b/pkg/cmd/roachtest/tests/reset_quorum.go
@@ -105,7 +105,7 @@ OR
 	// permanently (the wiping prevents the test runner from failing the
 	// test after it has passed - we cannot restart those nodes).
 	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(6, 8))
-	c.Wipe(ctx, c.Range(6, 8))
+	c.Wipe(ctx, false /* preserveCerts */, c.Range(6, 8))
 
 	// Should not be able to read from it even (generously) after a lease timeout.
 	_, err = db.QueryContext(ctx, `SET statement_timeout = '15s'; SELECT * FROM lostrange;`)

--- a/pkg/cmd/roachtest/tests/sstable_corruption.go
+++ b/pkg/cmd/roachtest/tests/sstable_corruption.go
@@ -127,7 +127,7 @@ func runSSTableCorruption(ctx context.Context, t test.Test, c cluster.Cluster) {
 	if err := c.StartE(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), crdbNodes); err != nil {
 		// Node detected corruption on start and crashed. This is good. No need
 		// to run workload; the test is complete.
-		_ = c.WipeE(ctx, t.L(), corruptNodes)
+		_ = c.WipeE(ctx, t.L(), false /* preserveCerts */, corruptNodes)
 		return
 	}
 
@@ -174,7 +174,7 @@ func runSSTableCorruption(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 
 	// Exempt corrupted nodes from roachtest harness' post-test liveness checks.
-	_ = c.WipeE(ctx, t.L(), corruptNodes)
+	_ = c.WipeE(ctx, t.L(), false /* preserveCerts */, corruptNodes)
 }
 
 func registerSSTableCorruption(r registry.Registry) {

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -82,7 +82,7 @@ func runTLP(ctx context.Context, t test.Test, c cluster.Cluster) {
 			return
 		}
 		c.Stop(ctx, t.L(), option.DefaultStopOpts())
-		c.Wipe(ctx)
+		c.Wipe(ctx, false /* preserveCerts */)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -42,6 +42,7 @@ func loadTPCHDataset(
 	m cluster.Monitor,
 	roachNodes option.NodeListOption,
 	disableMergeQueue bool,
+	secure bool,
 ) (retErr error) {
 	if c.Spec().Cloud != spec.GCE {
 		t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
@@ -93,7 +94,7 @@ func loadTPCHDataset(
 		// If the scale factor was smaller than the required scale factor, wipe the
 		// cluster and restore.
 		m.ExpectDeaths(int32(c.Spec().NodeCount))
-		c.Wipe(ctx, false /* preserveCerts */, roachNodes)
+		c.Wipe(ctx, secure, roachNodes)
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
 		m.ResetDeaths()
 	} else if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) &&

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -93,7 +93,7 @@ func loadTPCHDataset(
 		// If the scale factor was smaller than the required scale factor, wipe the
 		// cluster and restore.
 		m.ExpectDeaths(int32(c.Spec().NodeCount))
-		c.Wipe(ctx, roachNodes)
+		c.Wipe(ctx, false /* preserveCerts */, roachNodes)
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
 		m.ResetDeaths()
 	} else if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) &&

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1155,7 +1155,7 @@ func loadTPCCBench(
 
 		// If the dataset exists but is not large enough, wipe the cluster
 		// before restoring.
-		c.Wipe(ctx, roachNodes)
+		c.Wipe(ctx, false /* preserveCerts */, roachNodes)
 		startOpts, settings := b.startOpts()
 		c.Start(ctx, t.L(), startOpts, settings, roachNodes)
 	} else if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) &&

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -46,7 +46,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 
 		if err := loadTPCHDataset(
 			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx, c.Range(1, numNodes-1)),
-			c.Range(1, numNodes-1), true, /* disableMergeQueue */
+			c.Range(1, numNodes-1), true /* disableMergeQueue */, false, /* secure */
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -76,7 +76,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 
 		t.Status("setting up dataset")
 		err := loadTPCHDataset(
-			ctx, t, c, conn, b.ScaleFactor, m, roachNodes, true, /* disableMergeQueue */
+			ctx, t, c, conn, b.ScaleFactor, m, roachNodes, true /* disableMergeQueue */, false, /* secure */
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -577,7 +577,7 @@ func runTPCHVec(
 	conn := c.Conn(ctx, t.L(), 1)
 	t.Status("restoring TPCH dataset for Scale Factor 1")
 	if err := loadTPCHDataset(
-		ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), true, /* disableMergeQueue */
+		ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), true /* disableMergeQueue */, false, /* secure */
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -75,7 +75,7 @@ func registerValidateSystemSchemaAfterVersionUpgrade(r registry.Registry) {
 			// Wipe nodes in this test's cluster.
 			wipeClusterStep := func(nodes option.NodeListOption) versionStep {
 				return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
-					u.c.Wipe(ctx, nodes)
+					u.c.Wipe(ctx, false /* preserveCerts */, nodes)
 				}
 			}
 

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -101,7 +101,7 @@ DROP TABLE splitmerge.t;
 
 func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.All())
-	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All())
+	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(), mixedversion.AlwaysUseFixtures)
 	mvt.OnStartup(
 		"setup schema changer workload",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -279,7 +279,9 @@ func uploadAndStartFromCheckpointFixture(nodes option.NodeListOption, v string) 
 		startOpts := option.DefaultStartOpts()
 		// NB: can't start sequentially since cluster already bootstrapped.
 		startOpts.RoachprodOpts.Sequential = false
-		if err := clusterupgrade.StartWithBinary(ctx, t.L(), u.c, nodes, binary, startOpts); err != nil {
+		if err := clusterupgrade.StartWithSettings(
+			ctx, t.L(), u.c, nodes, startOpts, install.BinaryOption(binary),
+		); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -291,7 +293,9 @@ func uploadAndStart(nodes option.NodeListOption, v string) versionStep {
 		startOpts := option.DefaultStartOpts()
 		// NB: can't start sequentially since cluster already bootstrapped.
 		startOpts.RoachprodOpts.Sequential = false
-		if err := clusterupgrade.StartWithBinary(ctx, t.L(), u.c, nodes, binary, startOpts); err != nil {
+		if err := clusterupgrade.StartWithSettings(
+			ctx, t.L(), u.c, nodes, startOpts, install.BinaryOption(binary),
+		); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -362,7 +366,7 @@ func makeVersionFixtureAndFatal(
 			ctx,
 			`select regexp_extract(value, '^v([0-9]+\.[0-9]+\.[0-9]+)') from crdb_internal.node_build_info where field = 'Version';`,
 		).Scan(&makeFixtureVersion))
-		c.Wipe(ctx, c.Node(1))
+		c.Wipe(ctx, false /* preserveCerts */, c.Node(1))
 		useLocalBinary = true
 	}
 

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -776,8 +776,11 @@ func (c *SyncedCluster) useStartSingleNode() bool {
 // distributeCerts distributes certs if it's a secure cluster and we're
 // starting n1.
 func (c *SyncedCluster) distributeCerts(ctx context.Context, l *logger.Logger) error {
+	if !c.Secure {
+		return nil
+	}
 	for _, node := range c.TargetNodes() {
-		if node == 1 && c.Secure {
+		if node == 1 {
 			return c.DistributeCerts(ctx, l)
 		}
 	}


### PR DESCRIPTION
Backports:

  * 3/3 commits from "roachtest: update `mixedversion` to always use secure clusters" (#105454)
  * 1/1 commits from "roachtest: preserve certs in multitenant_tpch" (#105891)
  * 1/1 commits from "roachtest: validate cluster when using fixtures and provide opt-out" (#105455)

Please see individual PRs for details.

/cc @cockroachdb/release

Epic: none

Release note: None

Release justification: test-only changes.