### PR TITLE
pgerror: add "initial connection heartbeat failed" to SQL retryable

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -88,6 +88,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "//pkg/util/stop",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -34,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 )
@@ -431,4 +433,47 @@ func TestTenantInstanceIDReclaimLoop(t *testing.T) {
 func TestSystemConfigWatcherCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	systemconfigwatchertest.TestSystemConfigWatcher(t, false /* skipSecondary */)
+}
+
+func TestStartTenantWithStaleInstance(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
+		// We need to disable the default test tenant because we're going to
+		// create our own.
+		DefaultTestTenant: base.TestTenantDisabled,
+	}})
+	defer tc.Stopper().Stop(ctx)
+
+	rpcAddr := func() string {
+		tenantStopper := stop.NewStopper()
+		defer tenantStopper.Stop(ctx)
+		server, db := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
+			Stopper:  tenantStopper,
+			TenantID: serverutils.TestTenantID(),
+		},
+		)
+		defer db.Close()
+		return server.RPCAddr()
+	}()
+
+	listener, err := net.Listen("tcp", rpcAddr)
+	require.NoError(t, err)
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	_, db := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
+		TenantID: serverutils.TestTenantID(),
+	})
+	defer func() {
+		_ = db.Close()
+	}()
+
+	// Query a table to make sure the tenant is healthy, doesn't really matter
+	// which table.
+	_, err = db.Exec("SELECT count(*) FROM system.sqlliveness")
+	require.NoError(t, err)
 }

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -165,7 +165,7 @@ func IsSQLRetryableError(err error) bool {
 	// here.
 	errString := FullError(err)
 	matched, merr := regexp.MatchString(
-		"(no inbound stream connection|connection reset by peer|connection refused|failed to send RPC|rpc error: code = Unavailable|(^|\\s)EOF|result is ambiguous)",
+		"(no inbound stream connection|initial connection heartbeat failed|connection reset by peer|connection refused|failed to send RPC|rpc error: code = Unavailable|(^|\\s)EOF|result is ambiguous)",
 		errString)
 	if merr != nil {
 		return false


### PR DESCRIPTION
This commit adds `initial connection heartbeat failed` error to the list of SQL retryable errors. `IsSQLRetryableError` is used in three places:
- rerunning distributed query as local
- `IsPermanentSchemaChangeError`
- `validateUniqueConstraint`

and in all cases I think it makes sense to consider failing to establish a connection as a retryable error.

This commit includes the test from Jeff that exposed the gap in the retry-as-local mechanism.

Fixes: #106537.

Release note: None