### PR TITLE
sql: fix labelled tuple type checking

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1248,3 +1248,10 @@ INSERT INTO t94092 VALUES (1);
 
 query error expected tuple \(\) to have a length of 2
 SELECT (c, 1) != (()) FROM t94092;
+
+# Regression test for #106303.
+statement error pgcode 42601 mismatch in tuple definition: 0 expressions, 1 labels
+SELECT (ROW() AS a) IS NOT UNKNOWN
+
+statement error pgcode 42601 mismatch in tuple definition: 0 expressions, 1 labels
+SELECT CASE WHEN False THEN ROW() ELSE (ROW() AS a) END

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2802,6 +2802,16 @@ func typeCheckSameTypedTupleExprs(
 		return nil, nil, err
 	}
 
+	// All labeled tuples must have the same number of expressions as labels.
+	for i := range exprs {
+		if e, ok := exprs[i].(*Tuple); ok && len(e.Labels) > 0 && len(e.Labels) != len(e.Exprs) {
+			return nil, nil, pgerror.Newf(pgcode.Syntax,
+				"mismatch in tuple definition: %d expressions, %d labels",
+				len(e.Exprs), len(e.Labels),
+			)
+		}
+	}
+
 	// All expressions within tuples at the same indexes must be the same type.
 	resTypes := types.MakeLabeledTuple(make([]*types.T, firstLen), first.Labels)
 	sameTypeExprs := make([]Expr, 0, len(exprs))


### PR DESCRIPTION
Fixes #106303

Release note (bug fix): A bug has been fixed that caused internal errors
instead of user errors when queries contained labelled tuples with a
different number of elements and labels, e.g., `(ROW(1, 2) AS a)`. This
bug was present since v23.1.0.