### PR TITLE
sql: fix rare flake in a stmt bundle test

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -408,6 +408,9 @@ func (ih *instrumentationHelper) Finish(
 		)
 		phaseTimes := statsCollector.PhaseTimes()
 		execLatency := phaseTimes.GetServiceLatencyNoOverhead()
+		// Note that we want to remove the request from the local registry
+		// _before_ inserting the bundle to prevent rare test flakes (#106284).
+		ih.stmtDiagnosticsRecorder.MaybeRemoveRequest(ih.diagRequestID, ih.diagRequest, execLatency)
 		if ih.stmtDiagnosticsRecorder.IsConditionSatisfied(ih.diagRequest, execLatency) {
 			placeholders := p.extendedEvalCtx.Placeholders
 			ob := ih.emitExplainAnalyzePlanToOutputBuilder(ih.explainFlags, phaseTimes, queryLevelStats)
@@ -430,7 +433,6 @@ func (ih *instrumentationHelper) Finish(
 			)
 			telemetry.Inc(sqltelemetry.StatementDiagnosticsCollectedCounter)
 		}
-		ih.stmtDiagnosticsRecorder.MaybeRemoveRequest(ih.diagRequestID, ih.diagRequest, execLatency)
 	}
 
 	// If there was a communication error already, no point in setting any


### PR DESCRIPTION
This commit fixes an extremely rare flake that can occur in `TestDiagnosticsRequest/ongoing_request_canceled`. The way we finish the bundle collection is as follows:
- in `instrumentationHelper.Finish`, if the condition is satisfied (or the request wasn't conditional), we insert a bundle into the system table
  - this also marks the request as completed in the system table (1)
- then we check whether the request needs to be removed from the local registry and do so if necessary (which is when continuous capture is not enabled). (2)

If it just so happens that the test checks whether the completed request was removed from the registry between (1) and (2), the test will fail. This commit fixes things by removing the request from the local registry first.

Fixes: #106284.

Release note: None