### PR TITLE
roachtest: deflake c2c/shutdown/src tests

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -399,6 +399,9 @@ func (rd *replicationDriver) setupC2C(ctx context.Context, t test.Test, c cluste
 	destNode := dstCluster.SeededRandNode(rd.rng)
 
 	addr, err := c.ExternalPGUrl(ctx, t.L(), srcNode, "")
+	t.L().Printf("Randomly chosen src node %d for gateway with address %s", srcNode, addr)
+	t.L().Printf("Randomly chosen dst node %d for gateway", destNode)
+
 	require.NoError(t, err)
 
 	srcDB := c.Conn(ctx, t.L(), srcNode[0])
@@ -925,7 +928,8 @@ func registerClusterToCluster(r registry.Registry) {
 type c2cPhase int
 
 const (
-	phaseInitialScan c2cPhase = iota
+	phaseNotReady c2cPhase = iota
+	phaseInitialScan
 	phaseSteadyState
 	phaseCutover
 )
@@ -990,8 +994,9 @@ func makeReplShutdownDriver(
 	rd := makeReplicationDriver(t, c, rsp.replicationSpec)
 	return replShutdownDriver{
 		replicationDriver: rd,
-		phase:             c2cPhase(rd.rng.Intn(int(phaseCutover) + 1)),
-		rsp:               rsp,
+		// choose either initialScan (1), SteadyState (2), or cutover (3)
+		phase: c2cPhase(rd.rng.Intn(int(phaseCutover)) + 1),
+		rsp:   rsp,
 	}
 }
 
@@ -1036,6 +1041,7 @@ func (rrd *replShutdownDriver) getTargetAndWatcherNodes(ctx context.Context) {
 		// shut down roachprod node 5.
 		coordinatorNode += rrd.rsp.srcNodes
 	}
+	rrd.t.L().Printf("node %d is coordinator for target job %d", coordinatorNode, int(jobID))
 
 	var targetNode int
 
@@ -1063,7 +1069,13 @@ func getPhase(rd *replicationDriver, dstJobID jobspb.JobID) c2cPhase {
 	require.Equal(rd.t, jobs.StatusRunning, jobs.Status(jobStatus))
 
 	streamIngestProgress := getJobProgress(rd.t, rd.setup.dst.sysSQL, dstJobID).GetStreamIngest()
+
 	if streamIngestProgress.ReplicatedTime.IsEmpty() {
+		if len(streamIngestProgress.StreamAddresses) == 0 {
+			return phaseNotReady
+		}
+		// Only return phaseInitialScan once all available stream addresses from the
+		// source cluster have been persisted.
 		return phaseInitialScan
 	}
 	if streamIngestProgress.CutoverTime.IsEmpty() {


### PR DESCRIPTION
This patch ensures the c2c/shutdown/src tests wait to shutdown nodes until all src node addresses have been persisted to the ingestion job record. This ensures the stream ingestion job can communicat with multiple src cluster nodes if any of them shut down.

Fixes #106491, #106374

Release note: None