### PR TITLE
cli/interactive_tests: re-enable sql_mem_monitor test

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -389,6 +389,13 @@ func TestDockerCLI_test_sql_demo_node_cmds(t *testing.T) {
 	runTestDockerCLI(t, "test_sql_demo_node_cmds", "../cli/interactive_tests/test_sql_demo_node_cmds.tcl")
 }
 
+func TestDockerCLI_test_sql_mem_monitor(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_sql_mem_monitor", "../cli/interactive_tests/test_sql_mem_monitor.tcl")
+}
+
 func TestDockerCLI_test_sql_safe_updates(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -2,19 +2,18 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-# This test ensures that the memory monitor does its main job, namely
-# prevent the server from dying because of lack of memory when a
-# client runs a "large" query.
+# This test ensures that the memory monitor does its main job, namely prevents
+# the server from dying because of lack of memory when a client runs a "large"
+# query.
 # To test this 4 steps are needed:
 # 1. a baseline memory usage is measured;
-# 2. memory is limited using 'ulimit', and the server restarted with
-#    that limit;
-# 3. a first test ensure that the server does indeed crash when memory
+# 2. memory is limited using 'ulimit', and the server restarted with that limit;
+# 3. the 1st test ensures that the server does indeed crash when memory
 #    consumption is not limited by a monitor;
-# 4. the monitor is configured with a limit and a 2nd test ensures
-#    that the server does not crash any more.
-# Note that step 3 is needed so as to ensure that the mechanism used
-# in step 4 does indeed push memory consumption past the limit.
+# 4. the monitor is configured with a limit and the 2nd test ensures that the
+#    server does not crash any more - an error is returned instead.
+# Note that step 3 is needed so as to ensure that the mechanism used in step 4
+# does indeed push memory consumption past the limit.
 
 # Set up the initial cluster.
 start_server $argv
@@ -25,7 +24,7 @@ start_server $argv
 
 # Make some initial request to check the data is there and define the
 # baseline memory consumption.
-system "echo 'select * from system.information_schema.columns;' | $argv sql >/dev/null"
+system "echo 'select count(*) from generate_series(1,10000000);' | $argv sql >/dev/null"
 
 # What memory is currently consumed by the server?
 set vmem [ exec ps -o vsz= -p [ exec cat server_pid ] ]
@@ -43,8 +42,10 @@ eexpect ":/# "
 send "ulimit -v [ expr {3*$vmem/2} ]\r"
 eexpect ":/# "
 
-# Start a server with this limit set.
-send "$argv start-single-node --insecure --max-sql-memory=25% -s=path=logs/db --background --pid-file=server_pid\r"
+# Start a server with this limit set. Note that we're setting max-sql-memory so
+# high so that ulimit kills the process before root SQL monitor's limit has been
+# consumed.
+send "$argv start-single-node --insecure --max-sql-memory=75% -s=path=logs/db --background --pid-file=server_pid\r"
 eexpect ":/# "
 send "$argv sql --insecure -e 'select 1'\r"
 eexpect "1 row"
@@ -63,26 +64,34 @@ eexpect "1 row"
 eexpect root@
 
 start_test "Ensure that memory over-allocation without monitoring crashes the server"
-# Now try to run a large-ish query on the client.
-# The query is a 4-way cross-join on information_schema.columns,
-# resulting in ~8 million rows loaded into memory when run on an
-# empty database.
-send "set database=system;\r"
-eexpect root@
-# Disable query distribution to force in-memory computation.
-send "set distsql=off;\r"
+# Now try to run a large-ish query on the client. The query is a 4-way cross
+# join on top of a CTE with 10M rows.
+#
+# Disable spilling to disk by giving huge workmem budget to the query
+# (importantly, this budget must be larger than vmem).
+send "set distsql_workmem='32GiB';\r"
 eexpect SET
 send "with a as (select * from generate_series(1,10000000)) select * from a as a, a as b, a as c, a as d limit 10;\r"
 eexpect "connection lost"
 
 # Check that the query crashed the server
 set spawn_id $shell_spawn_id
-# Error is either "out of memory" (Go) or "cannot allocate memory" (C++)
+# Error is either an explicit "out of memory" emitted by Go or one of the errors
+# thrown by CGo.
+#
+# "fatal error: unexpected signal during runtime execution" might seem like it
+# doesn't belong here, but it's an artifact of how we're limiting the memory
+# usage of the CRDB process. In particular, ulimit is a "user limit" which is
+# enforced not at the OS kernel level (i.e. not via oomkiller) but at the
+# process execution level. As a result, memory allocation error doesn't kill the
+# process, so it keeps on running and can hit this "fatal error" later on.
 expect {
     "out of memory" {}
     "cannot allocate memory" {}
     "std::bad_alloc" {}
     "Resource temporarily unavailable" {}
+    "_Cfunc_calloc" {}
+    "fatal error: unexpected signal during runtime execution" {}
     timeout { handle_timeout "memory allocation error" }
 }
 # Stop the tail command.
@@ -95,7 +104,14 @@ eexpect root@
 end_test
 
 start_test "Ensure that memory monitoring prevents crashes"
-# Re-launch a server with relatively lower limit for SQL memory
+# Re-launch the server with relatively low limit for SQL memory. A couple of
+# notable callouts:
+# - we couldn't have created a new cluster from scratch with such a low SQL
+#   memory limit because migrations wouldn't be able to run. However, we're
+#   reusing existing data directory, so we're able to start up the node.
+# - the default value of distsql_workmem (64MiB) is used and is larger than the
+#   SQL memory limit. As a result, we don't attempt to spill to disk and hit the
+#   root memory limit.
 set spawn_id $shell_spawn_id
 send "$argv start-single-node --insecure --max-sql-memory=1000K -s=path=logs/db \r"
 eexpect "restarted pre-existing node"
@@ -105,10 +121,8 @@ sleep 2
 set spawn_id $client_spawn_id
 send "select 1;\r"
 eexpect root@
-send "set database=system;\r"
-eexpect root@
 send "with a as (select * from generate_series(1,100000)) select * from a as a, a as b, a as c, a as d limit 10;\r"
-eexpect "memory budget exceeded"
+eexpect "root: memory budget exceeded"
 eexpect root@
 
 # Check we can send another query without error -- the server has survived.


### PR DESCRIPTION
This commit re-enables `sql_mem_monitor` CLI interactive test that has been skipped for some time. The test verifies that SQL memory accounting system prevents the server crashing when a memory intensive query is executed. In particular, it runs the query twice:
- the first run has memory monitoring disabled, so the crash is expected
- the second run sets low root SQL monitor limit and monitoring enabled, so the query errors out without crashing the server.

I ran this test quite a few times and got a couple of failures, and each of them was due to the server not crashing on the first run. I believe this was because the test has rotted over time: the query is performing a cross join that can now spill to disk (it couldn't when the test was written), so it seems feasible that the server wouldn't crash as the test expects. This commit goes around this by effectively disabling the memory accounting system (it sets very high root SQL memory limit) as well as disk spilling (by setting very high `distsql_workmem` limit).

This commit also adds a couple of other errors I saw into the allow-list of how the server can crash:
- `_Cfunc_calloc` - seems reasonable enough
- `fatal error: unexpected signal during runtime execution` might seem like it doesn't belong here, but it's an artifact of how we're limiting the memory usage of the CRDB process. In particular, ulimit is a "user limit" which is enforced not at the OS kernel level (i.e. not via oomkiller) but at the process execution level. As a result, memory allocation error doesn't kill the process, so it keeps on running and can hit this "fatal error" later on.

Fixes: #106462.

Release note: None