### PR TITLE
dev: use `bazel test` to run acceptance tests, not `bazel run`

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=77
+DEV_VERSION=78
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/acceptance.go
+++ b/pkg/cmd/dev/acceptance.go
@@ -76,7 +76,7 @@ func (d *dev) acceptance(cmd *cobra.Command, commandLine []string) error {
 	cockroachBin := filepath.Join(workspace, "artifacts", "cockroach-short")
 
 	var args []string
-	args = append(args, "run", "//pkg/acceptance:acceptance_test", "--config=test")
+	args = append(args, "test", "//pkg/acceptance:acceptance_test")
 	if numCPUs != 0 {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
 	}


### PR DESCRIPTION
This is probably some oversight or historical artifact, but `bazel test` is conceptually correct and what we should be using in CI.

Epic: CRDB-17171
Release note: None