### PR TITLE
kvflowcontrol: send verbose logging to vevent

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
@@ -154,7 +154,7 @@ func (c *Controller) Admit(
 			c.mode() == kvflowcontrol.ApplyToElastic && class == admissionpb.RegularWorkClass {
 
 			if log.ExpensiveLogEnabled(ctx, 2) {
-				log.Infof(ctx, "admitted request (pri=%s stream=%s tokens=%s wait-duration=%s mode=%s)",
+				log.VEventf(ctx, 2, "admitted request (pri=%s stream=%s tokens=%s wait-duration=%s mode=%s)",
 					pri, connection.Stream(), tokens, c.clock.PhysicalTime().Sub(tstart), c.mode())
 			}
 
@@ -182,7 +182,7 @@ func (c *Controller) Admit(
 		}
 
 		if !logged && log.ExpensiveLogEnabled(ctx, 2) {
-			log.Infof(ctx, "waiting for flow tokens (pri=%s stream=%s tokens=%s)",
+			log.VEventf(ctx, 2, "waiting for flow tokens (pri=%s stream=%s tokens=%s)",
 				pri, connection.Stream(), tokens)
 			logged = true
 		}
@@ -292,7 +292,7 @@ func (c *Controller) adjustTokens(
 	}
 
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.Infof(ctx, "adjusted flow tokens (pri=%s stream=%s delta=%s): regular=%s elastic=%s",
+		log.VEventf(ctx, 2, "adjusted flow tokens (pri=%s stream=%s delta=%s): regular=%s elastic=%s",
 			pri, stream, delta, b.tokens[regular], b.tokens[elastic])
 	}
 }

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowtokentracker/tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowtokentracker/tracker.go
@@ -115,7 +115,7 @@ func (dt *Tracker) Track(
 		position: pos,
 	})
 	if log.ExpensiveLogEnabled(ctx, 1) {
-		log.Infof(ctx, "tracking %s flow control tokens for pri=%s stream=%s pos=%s",
+		log.VEventf(ctx, 1, "tracking %s flow control tokens for pri=%s stream=%s pos=%s",
 			tokens, pri, dt.stream, pos)
 	}
 	return true
@@ -160,7 +160,7 @@ func (dt *Tracker) Untrack(
 		if len(dt.trackedM[pri]) > 0 {
 			remaining = fmt.Sprintf(" (%s, ...)", dt.trackedM[pri][0].tokens)
 		}
-		log.Infof(ctx, "released %s flow control tokens for %d out of %d tracked deductions for pri=%s stream=%s, up to %s; %d tracked deduction(s) remain%s",
+		log.VEventf(ctx, 1, "released %s flow control tokens for %d out of %d tracked deductions for pri=%s stream=%s, up to %s; %d tracked deduction(s) remain%s",
 			tokens, untracked, trackedBefore, pri, dt.stream, upto, len(dt.trackedM[pri]), remaining)
 	}
 	if len(dt.trackedM[pri]) == 0 {


### PR DESCRIPTION
KVFlowcontrol logging was written into Info category if tracing was enabled. That was producing tremendous amount of logging. This commit changes logging to send to active trace and event log only.

Epic: none

Release note: None