### PR TITLE
cli,server: log the initiation of shutdown more clearly

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -859,6 +859,8 @@ func createAndStartServerAsync(
 			go func() {
 				select {
 				case req := <-s.ShutdownRequested():
+					shutdownCtx := s.AnnotateCtx(context.Background())
+					log.Infof(shutdownCtx, "server requesting spontaneous shutdown: %v", req.ShutdownCause())
 					shutdownReqC <- req
 				case <-stopper.ShouldQuiesce():
 				}

--- a/pkg/server/stop_trigger.go
+++ b/pkg/server/stop_trigger.go
@@ -64,7 +64,7 @@ type ShutdownRequest struct {
 // MakeShutdownRequest constructs a ShutdownRequest.
 func MakeShutdownRequest(reason ShutdownReason, err error) ShutdownRequest {
 	if reason == ShutdownReasonDrainRPC && err != nil {
-		panic("unexpected err for ShutdownReasonDrainRPC")
+		panic(errors.NewAssertionErrorWithWrappedErrf(err, "programming error: unexpected err for ShutdownReasonDrainRPC"))
 	}
 	return ShutdownRequest{
 		Reason: reason,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -645,8 +645,10 @@ func (ts *TestServer) Start(ctx context.Context) error {
 		// If the server requests a shutdown, do that simply by stopping the
 		// stopper.
 		select {
-		case <-ts.Server.ShutdownRequested():
-			ts.Stopper().Stop(ts.Server.AnnotateCtx(context.Background()))
+		case req := <-ts.Server.ShutdownRequested():
+			shutdownCtx := ts.Server.AnnotateCtx(context.Background())
+			log.Infof(shutdownCtx, "server requesting spontaneous shutdown: %v", req.ShutdownCause())
+			ts.Stopper().Stop(shutdownCtx)
 		case <-ts.Stopper().ShouldQuiesce():
 		}
 	}()
@@ -1179,8 +1181,10 @@ func (ts *TestServer) StartTenant(
 		// If the server requests a shutdown, do that simply by stopping the
 		// tenant's stopper.
 		select {
-		case <-sw.ShutdownRequested():
-			stopper.Stop(sw.AnnotateCtx(context.Background()))
+		case req := <-sw.ShutdownRequested():
+			shutdownCtx := sw.AnnotateCtx(context.Background())
+			log.Infof(shutdownCtx, "server requesting spontaneous shutdown: %v", req.ShutdownCause())
+			stopper.Stop(shutdownCtx)
 		case <-stopper.ShouldQuiesce():
 		}
 	}()


### PR DESCRIPTION
Epic: CRDB-26691
Helped debug issues with #96144.

Prior to this patch, the error object that triggers spontaneous shutdown and flows through the `stopTrigger` was only kept in RAM and printed at the very tail end of server shutdown (when the CLI code was exiting).

This patch ensures it is logged as soon as the shutdown is triggered. It makes debugging slightly easier.

Release note: None