### PR TITLE
release-23.1: roachtest: support `versions-binary-override` in `mixedversion`

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -392,8 +392,8 @@ runner itself.
 		cmd.Flags().StringToStringVar(
 			&versionsBinaryOverride, "versions-binary-override", nil,
 			"List of <version>=<path to cockroach binary>. If a certain version <ver> "+
-				"is present in the list,"+"the respective binary will be used when a "+
-				"multi-version test asks for the respective binary, instead of "+
+				"is present in the list, the respective binary will be used when a "+
+				"mixed-version test asks for the respective binary, instead of "+
 				"`roachprod stage <ver>`. Example: 20.1.4=cockroach-20.1,20.2.0=cockroach-20.2.")
 	}
 

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1969,7 +1969,7 @@ func (mvb *mixedVersionBackup) resetCluster(
 		return fmt.Errorf("failed to wipe cluster: %w", err)
 	}
 
-	cockroachPath := clusterupgrade.BinaryPathFromVersion(version)
+	cockroachPath := clusterupgrade.BinaryPathForVersion(mvb.t, version)
 	return clusterupgrade.StartWithSettings(
 		ctx, l, mvb.cluster, mvb.roachNodes, option.DefaultStartOptsNoBackups(),
 		install.BinaryOption(cockroachPath), install.SecureOption(true),

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -426,7 +426,7 @@ func makeVersionFixtureAndFatal(
 			name := clusterupgrade.CheckpointName(u.binaryVersion(ctx, t, 1).String())
 			u.c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.All())
 
-			binaryPath := clusterupgrade.BinaryPathFromVersion(makeFixtureVersion)
+			binaryPath := clusterupgrade.BinaryPathForVersion(t, makeFixtureVersion)
 			c.Run(ctx, c.All(), binaryPath, "debug", "pebble", "db", "checkpoint",
 				"{store-dir}", "{store-dir}/"+name)
 			// The `cluster-bootstrapped` marker can already be found within


### PR DESCRIPTION
Backport 1/1 commits from #106275.

/cc @cockroachdb/release

---

The `BinaryPathFromVersion` (now renamed to `BinaryPathForVersion` based on an early pull request review comment) was not taking into account the `versions-binary-override` flag passed to roachtest when determining the path where the binary for a certain version should live in a node.

This commit updates that function to take that into account. This improves the debugging experience for mixedversion tests by letting the user swap the binary of a certain version for a custom one, possibly with more debug code.

Epic: CRDB-19321

Release note: None

Release justification: test-only changes.