### PR TITLE
release-23.1: build: don't use `goimports` for `goyacc`

### DIFF
--- a/pkg/sql/lexbase/sql-gen.sh
+++ b/pkg/sql/lexbase/sql-gen.sh
@@ -31,4 +31,3 @@ GENYACC=$LANG-gen.y
         echo "$ret"; exit 1; \
       fi;
     rm $GENYACC
-    $6 -w $4

--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -100,12 +100,10 @@ export HOME=$(GENDIR)
 export GOPATH=/nonexist-gopath
 export GOROOT=
 $(location :sql-gen) $(location sql.y) sql $(location replace_help_rules.awk) \
-    $(location sql.go) $(location @org_golang_x_tools//cmd/goyacc) \
-    $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports) \
+    $(location sql.go) $(location @org_golang_x_tools//cmd/goyacc)
 """,
     exec_tools = [
         ":sql-gen",
-        "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",
         "@go_sdk//:bin/go",
         "@org_golang_x_tools//cmd/goyacc",
     ],

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -25,18 +25,16 @@ package parser
 
 import (
     "fmt"
+    "math"
     "strings"
 
     "go/constant"
 
     "github.com/cockroachdb/cockroach/pkg/geo/geopb"
-    "github.com/cockroachdb/cockroach/pkg/roachpb"
     "github.com/cockroachdb/cockroach/pkg/security/username"
-    "github.com/cockroachdb/cockroach/pkg/sql/lexbase"
     "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
     "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
     "github.com/cockroachdb/cockroach/pkg/sql/privilege"
-    "github.com/cockroachdb/cockroach/pkg/sql/roleoption"
     "github.com/cockroachdb/cockroach/pkg/sql/scanner"
     "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
     "github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"

--- a/pkg/sql/plpgsql/parser/BUILD.bazel
+++ b/pkg/sql/plpgsql/parser/BUILD.bazel
@@ -15,13 +15,11 @@ genrule(
     cmd = """
     export GOPATH=/nonexist-gopath
       $(location :plpgsql-gen) $(location plpgsql.y) plpgsql ""\
-          $(location plpgsql.go) $(location @org_golang_x_tools//cmd/goyacc) \
-          $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports) \
+          $(location plpgsql.go) $(location @org_golang_x_tools//cmd/goyacc)
 
     """,
     exec_tools = [
         ":plpgsql-gen",
-        "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",
         "@org_golang_x_tools//cmd/goyacc",
     ],
     visibility = ["//visibility:public"],

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -4,7 +4,6 @@ package parser
 import (
   "fmt"
 
-  "github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser/lexbase"
   "github.com/cockroachdb/cockroach/pkg/sql/scanner"
   "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
   "github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1452,7 +1452,7 @@ func TestLint(t *testing.T) {
 		if pkgSpecified {
 			skip.IgnoreLint(t, "PKG specified")
 		}
-		ignore := `zcgo*|\.(pb(\.gw)?)|(\.[eo]g)\.go|/testdata/|^sql/parser/sql\.go$|(_)?generated(_test)?\.go$`
+		ignore := `zcgo*|\.(pb(\.gw)?)|(\.[eo]g)\.go|/testdata/|^sql/parser/sql\.go$|(_)?generated(_test)?\.go$|^sql/pgrepl/pgreplparser/pgrepl\.go$|^sql/plpgsql/parser/plpgsql\.go$`
 		cmd, stderr, filter, err := dirCmd(pkgDir, "crlfmt", "-fast", "-ignore", ignore, "-tab", "2", ".")
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Backport 1/1 commits from #106544.

/cc @cockroachdb/release

---

We use `goimports` to clean up (add/remove imports) code. This is unnecessary as we know what code we need.

Part of #106541.
Epic: CRDB-8308
Release note: None
