### PR TITLE
sctest: Fix bug that backup/restore suite would secretely early return

### DIFF
--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -1091,7 +1091,7 @@ func Backup(t *testing.T, path string, newCluster NewClusterFunc) {
 		}
 		successExpected := atomic.Bool{}
 		stageChan := make(chan stage)
-		var closedStageChan bool // mark when stageChan is closed in the callback
+		var closeStageChan sync.Once
 		ctx, cancel := context.WithCancel(context.Background())
 		_, db, cleanup := newCluster(t, &scexec.TestingKnobs{
 			BeforeStage: func(p scplan.Plan, stageIdx int) error {
@@ -1100,23 +1100,20 @@ func Backup(t *testing.T, path string, newCluster NewClusterFunc) {
 				if p.Stages[stageIdx].Type() == scop.BackfillType && hasDMLInSetup {
 					successExpected.Store(false)
 				}
-				// If the plan has no post-commit stages, we'll close the
-				// stageChan eagerly.
-				if p.Stages[len(p.Stages)-1].Phase < scop.PostCommitPhase {
-
-					// The other test goroutine will set stageChan to nil later on.
-					// We only want to close it once, and then we don't want to look
-					// at it again. Avoid the racy access to stageChan by consulting
-					// the bool.
-					if !closedStageChan {
-						closedStageChan = true
-						close(stageChan)
+				if p.Stages[stageIdx].Phase == scop.StatementPhase {
+					return nil
+				}
+				if p.Stages[stageIdx].Phase == scop.PreCommitPhase {
+					if p.Stages[len(p.Stages)-1].Phase < scop.PostCommitPhase {
+						// We've seen all stmts in the test case (bc we're in PreCommitPhase)
+						// and there is no PostCommitPhase in the plan.
+						closeStageChan.Do(func() {
+							close(stageChan)
+						})
 					}
 					return nil
 				}
-				if p.Stages[stageIdx].Phase < scop.PostCommitPhase {
-					return nil
-				}
+
 				if stageChan != nil {
 					s := stage{p: p, stageIdx: stageIdx, resume: make(chan error)}
 					select {


### PR DESCRIPTION
   Previously, the backup/restore testing suite would quietly early return
    on certain test cases without running any actual content (i.e. no
    backups were taken nor restores were done). This commit fixes that.

  Fix #104205

   Release note: None