### PR TITLE
diagnosticsccl: unskip TestTenantReport

### DIFF
--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -43,7 +43,6 @@ const elemName = "somestring"
 
 func TestTenantReport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 101622, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	rt := startReporterTest(t, base.TestTenantDisabled)


### PR DESCRIPTION
The flakiness of the test was resolved by #106053.

Addresses: #101622.
Epic: None

Release note: None