### PR TITLE
sql,server: add endpoint to list a job's execution details

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -5241,6 +5241,50 @@ Support status: [reserved](#support-status)
 
 
 
+## ListJobProfilerExecutionDetails
+
+`GET /_status/list_job_profiler_execution_details/{job_id}`
+
+
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| job_id | [int64](#cockroach.server.serverpb.ListJobProfilerExecutionDetailsRequest-int64) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| files | [string](#cockroach.server.serverpb.ListJobProfilerExecutionDetailsResponse-string) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+
 ## RequestCA
 
 `GET /_join/v1/ca`

--- a/pkg/jobs/jobsprofiler/profilerconstants/constants.go
+++ b/pkg/jobs/jobsprofiler/profilerconstants/constants.go
@@ -42,15 +42,15 @@ func MakeNodeProcessorProgressInfoKey(flowID string, instanceID string, processo
 const ExecutionDetailsChunkKeyPrefix = "~profiler/"
 
 // MakeProfilerExecutionDetailsChunkKeyPrefix is the prefix of the info key used to store all
-// chunks of a job's execution details for a given filename.
+// chunks of a job's execution details.
 func MakeProfilerExecutionDetailsChunkKeyPrefix(filename string) string {
 	return fmt.Sprintf("%s%s", ExecutionDetailsChunkKeyPrefix, filename)
 }
 
-// MakeProfilerBundleChunkKey is the info key used to store a chunk of a job's
-// execution details for a given filename.
-func MakeProfilerBundleChunkKey(filename string, chunkCounter int) string {
-	return fmt.Sprintf("%s%s#%04d", ExecutionDetailsChunkKeyPrefix, filename, chunkCounter)
+// MakeProfilerExecutionDetailsChunkKey is the info key used to store a chunk of
+// a job's execution details.
+func MakeProfilerExecutionDetailsChunkKey(chunkName string) string {
+	return fmt.Sprintf("%s%s", ExecutionDetailsChunkKeyPrefix, chunkName)
 }
 
 // GetNodeProcessorProgressInfoKeyParts deconstructs the passed in info key and

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -2064,6 +2064,14 @@ message NetworkConnectivityResponse {
    bytes data = 1;
  }
 
+ message ListJobProfilerExecutionDetailsRequest {
+  int64 job_id = 1;
+ }
+
+ message ListJobProfilerExecutionDetailsResponse {
+   repeated string files = 1;
+ }
+
 
 service Status {
   // Certificates retrieves a copy of the TLS certificates.
@@ -2538,6 +2546,13 @@ service Status {
   rpc GetJobProfilerExecutionDetails(GetJobProfilerExecutionDetailRequest) returns (GetJobProfilerExecutionDetailResponse) {
     option (google.api.http) = {
       get: "/_status/job_profiler_execution_details/{job_id}/{filename}"
+    };
+  }
+
+  rpc ListJobProfilerExecutionDetails(ListJobProfilerExecutionDetailsRequest) returns
+    (ListJobProfilerExecutionDetailsResponse) {
+    option (google.api.http) = {
+      get: "/_status/list_job_profiler_execution_details/{job_id}"
     };
   }
 }

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -4146,3 +4146,25 @@ func (s *statusServer) GetJobProfilerExecutionDetails(
 	}
 	return &serverpb.GetJobProfilerExecutionDetailResponse{Data: data}, nil
 }
+
+// ListJobProfilerExecutionDetails lists all the stored execution details for a
+// given job ID.
+func (s *statusServer) ListJobProfilerExecutionDetails(
+	ctx context.Context, req *serverpb.ListJobProfilerExecutionDetailsRequest,
+) (*serverpb.ListJobProfilerExecutionDetailsResponse, error) {
+	ctx = s.AnnotateCtx(ctx)
+	// TODO(adityamaru): Figure out the correct privileges required to get execution details.
+	_, err := s.privilegeChecker.requireAdminUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	jobID := jobspb.JobID(req.JobId)
+	execCfg := s.sqlServer.execCfg
+	eb := sql.MakeJobProfilerExecutionDetailsBuilder(execCfg.SQLStatusServer, execCfg.InternalDB, jobID)
+	files, err := eb.ListExecutionDetailFiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &serverpb.ListJobProfilerExecutionDetailsResponse{Files: files}, nil
+}

--- a/pkg/sql/jobs_profiler_bundle_test.go
+++ b/pkg/sql/jobs_profiler_bundle_test.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"net/http"
 	"runtime/pprof"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -72,7 +73,7 @@ func TestReadWriteProfilerExecutionDetails(t *testing.T) {
 					infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), base.SQLInstanceID(1))
 					p.PhysicalInfrastructure = infra
 					jobsprofiler.StorePlanDiagram(ctx, s.Stopper(), &p, s.InternalDB().(isql.DB), j.ID())
-					checkForPlanDiagram(ctx, t, s.InternalDB().(isql.DB), j.ID())
+					checkForPlanDiagrams(ctx, t, s.InternalDB().(isql.DB), j.ID(), 1)
 					return nil
 				},
 			}
@@ -113,6 +114,100 @@ func TestReadWriteProfilerExecutionDetails(t *testing.T) {
 		require.True(t, strings.Contains(string(goroutines), fmt.Sprintf("labels: {\"foo\":\"bar\", \"job\":\"IMPORT id=%d\", \"n\":\"1\"}", importJobID)))
 		require.True(t, strings.Contains(string(goroutines), "github.com/cockroachdb/cockroach/pkg/sql_test.fakeExecResumer.Resume"))
 	})
+}
+
+func TestListProfilerExecutionDetails(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Timeout the test in a few minutes if it hasn't succeeded.
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*2)
+	defer cancel()
+
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
+	defer jobs.ResetConstructors()()
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+
+	expectedDiagrams := 1
+	jobs.RegisterConstructor(jobspb.TypeImport, func(j *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+		return fakeExecResumer{
+			OnResume: func(ctx context.Context) error {
+				p := sql.PhysicalPlan{}
+				infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), base.SQLInstanceID(1))
+				p.PhysicalInfrastructure = infra
+				jobsprofiler.StorePlanDiagram(ctx, s.Stopper(), &p, s.InternalDB().(isql.DB), j.ID())
+				checkForPlanDiagrams(ctx, t, s.InternalDB().(isql.DB), j.ID(), expectedDiagrams)
+				if err := execCfg.JobRegistry.CheckPausepoint("fakeresumer.pause"); err != nil {
+					return err
+				}
+				return nil
+			},
+		}
+	}, jobs.UsesTenantCostControl)
+
+	runner.Exec(t, `CREATE TABLE t (id INT)`)
+	runner.Exec(t, `INSERT INTO t SELECT generate_series(1, 100)`)
+
+	t.Run("list execution detail files", func(t *testing.T) {
+		runner.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = 'fakeresumer.pause'`)
+		var importJobID int
+		runner.QueryRow(t, `IMPORT INTO t CSV DATA ('nodelocal://1/foo') WITH DETACHED`).Scan(&importJobID)
+		jobutils.WaitForJobToPause(t, runner, jobspb.JobID(importJobID))
+
+		runner.Exec(t, `SELECT crdb_internal.request_job_execution_details($1)`, importJobID)
+		files := listExecutionDetails(t, s, jobspb.JobID(importJobID))
+		require.Len(t, files, 2)
+		require.Regexp(t, "distsql\\..*\\.html", files[0])
+		require.Regexp(t, "goroutines\\..*\\.txt", files[1])
+
+		// Resume the job, so it can write another DistSQL diagram and goroutine
+		// snapshot.
+		runner.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = ''`)
+		expectedDiagrams = 2
+		runner.Exec(t, `RESUME JOB $1`, importJobID)
+		jobutils.WaitForJobToSucceed(t, runner, jobspb.JobID(importJobID))
+		runner.Exec(t, `SELECT crdb_internal.request_job_execution_details($1)`, importJobID)
+		files = listExecutionDetails(t, s, jobspb.JobID(importJobID))
+		require.Len(t, files, 4)
+		require.Regexp(t, "distsql\\..*\\.html", files[0])
+		require.Regexp(t, "distsql\\..*\\.html", files[1])
+		require.Regexp(t, "goroutines\\..*\\.txt", files[2])
+		require.Regexp(t, "goroutines\\..*\\.txt", files[3])
+	})
+}
+
+func listExecutionDetails(
+	t *testing.T, s serverutils.TestServerInterface, jobID jobspb.JobID,
+) []string {
+	t.Helper()
+
+	client, err := s.GetAdminHTTPClient()
+	require.NoError(t, err)
+
+	url := s.AdminURL().String() + fmt.Sprintf("/_status/list_job_profiler_execution_details/%d", jobID)
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+
+	req.Header.Set("Content-Type", httputil.ProtoContentType)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	edResp := serverpb.ListJobProfilerExecutionDetailsResponse{}
+	require.NoError(t, protoutil.Unmarshal(body, &edResp))
+	sort.Slice(edResp.Files, func(i, j int) bool {
+		return edResp.Files[i] < edResp.Files[j]
+	})
+	return edResp.Files
 }
 
 func checkExecutionDetails(


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/105384 we added infrastructure to request and store execution details for a job. This currently only includes the DistSQL diagram generated during a job execution. Going forward this will include several files such as traces, goroutines, profiles etc.

This change introduces an endpoint that allows listing all such files that are available for consumption. This list will be displayed on the job details page allowing the user to download any subset of the files collected during job execution.

Informs: #105076
Release note: None