### PR TITLE
sql/sem/builtins: deflake TestSerialNormalizationWithUniqueUnorderedID

### DIFF
--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -124,7 +124,7 @@ CREATE TABLE t (
   j INT
 )`)
 
-		numberOfRows := 10000
+		numberOfRows := 100000
 
 		// Insert rows.
 		tdb.Exec(t, fmt.Sprintf(`


### PR DESCRIPTION
This patch increases the sample count for a probabilistic test that
tests for uniform distribution so that it is less likely to flake.

Fixes #106580

Release note: None