### PR TITLE
statusccl: unskip testTenantRanges pagination

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -1390,7 +1390,6 @@ func testTenantRangesRPC(_ context.Context, t *testing.T, helper serverccl.Tenan
 	})
 
 	t.Run("test tenant ranges pagination", func(t *testing.T) {
-		skip.UnderStressWithIssue(t, 92382)
 		ctx := context.Background()
 		resp1, err := tenantA.TenantRanges(ctx, &serverpb.TenantRangesRequest{
 			Limit: 1,


### PR DESCRIPTION
This test was mistakenly skipped in #105197, but
the flake was addressed in #99054.

The flake on the 22.2 release branch (tracked in #92382) was not novel, but untreated. I misinterpreted this, and thought the skip on master would be for good measure, not realizing the flake was already treated.

Epic: none
Release note: None