### PR TITLE
sql/schemachanger: fix incorrect errors dropping primary key columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3414,3 +3414,19 @@ t_99764  CREATE TABLE public.t_99764 (
              i INT8 NOT NULL,
              CONSTRAINT t_99764_pkey PRIMARY KEY (i ASC)
          )
+
+# Validate that DROP COLUMN CASCADE generates the proper error if we attempt
+# to drop a key column
+subtest alter_table_drop_cascade_with_key
+
+statement ok
+create table t_drop_cascade_with_key(n int primary key, k int);
+
+statement ok
+alter table t_drop_cascade_with_key add column j int as (n) stored null;
+
+statement ok
+set sql_safe_updates=false
+
+statement error pgcode 42P10 column "n" is referenced by.*
+alter table t_drop_cascade_with_key drop column n cascade;


### PR DESCRIPTION
Previously, the declarative schema changer in DROP COLUMN CASCADE scenarios would either hang (23.1) or generate incorrect errors (master) when dropping a primary key column. This was because the primary index would be replaced during a DROP CASCADE scenario when cleaning up the cascade column. The check to see if the target column was a key could look for the original index, which will no longer be public. To address this bug, this patch checks if the target dropped column is a key column first.

Fixes: #105953

Release note (bug fix) : DROP COLUMN cascade involving a primary key column could end up hanging