### PR TITLE
compose: Deflake TestComposeCompare

### DIFF
--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -109,10 +109,8 @@ func TestCompare(t *testing.T) {
 				{
 					name: "cockroach2",
 					mutators: []randgen.Mutator{
-						randgen.StatisticsMutator,
 						randgen.ForeignKeyMutator,
 						randgen.ColumnFamilyMutator,
-						randgen.StatisticsMutator,
 						randgen.IndexStoringMutator,
 						randgen.PartialIndexMutator,
 					},

--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -34,7 +34,7 @@ var (
 	// arrayContentsTypes contains all of the types that are valid to store within
 	// an array.
 	arrayContentsTypes []*types.T
-	collationLocales   = [...]string{"da", "de", "en"}
+	collationLocales   = [...]string{"da_DK", "de_DE", "en_US"}
 )
 
 func init() {


### PR DESCRIPTION
We identified and fixed two issues in TestComposeCompare failure as reported by TeamCity:
 1. Certain collations used in the test are supported in CRDB but not in Postgres. We changed them to be such that both systems support.
 2. CRDB does not support ALTER TABLE INJECT STATISTICS within an explicit transaction and we disabled them in the test.

Informs #82867

Release note: None