### PR TITLE
CODEOWNERS: move upgrade pkg to release-eng team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -364,7 +364,7 @@
 /pkg/ccl/jwtauthccl/         @cockroachdb/cloud-identity
 #!/pkg/ccl/kvccl/              @cockroachdb/kv-noreview
 /pkg/ccl/kvccl/kvtenantccl/  @cockroachdb/multi-tenant
-#!/pkg/ccl/upgradeccl/       @cockroachdb/unowned
+#!/pkg/ccl/upgradeccl/       @cockroachdb/release-eng
 #!/pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 #!/pkg/ccl/sqlitelogictestccl/ @cockroachdb/sql-queries-noreview
 /pkg/ccl/multiregionccl/     @cockroachdb/sql-foundations
@@ -482,7 +482,7 @@
 /pkg/keysbase/               @cockroachdb/kv-prs
 # Don't ping KV on updates to reserved descriptor IDs and such.
 #!/pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
-/pkg/upgrade/                @cockroachdb/sql-foundations
+/pkg/upgrade/                @cockroachdb/release-eng
 /pkg/keyvisualizer/          @cockroachdb/cluster-observability
 /pkg/multitenant/            @cockroachdb/multi-tenant
 /pkg/release/                @cockroachdb/dev-inf

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -110,3 +110,6 @@ cockroachdb/unowned:
 cockroachdb/migrations:
   label: T-migrations
   triage_column_id: 18330909
+cockroachdb/release-eng:
+  label: T-release
+  triage_column_id: 9149730


### PR DESCRIPTION
The release-eng team is best equipped to triage and prioritize issues relating to version upgrades.

Epic: None
Refs: https://github.com/cockroachdb/cockroach/issues/105767
Release note: None