### PR TITLE
kvserver: remove redundant "too little" log line

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -865,14 +865,6 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 				rctx.LocalDesc.StoreID,
 				rctx.LocalDesc.Capacity.Load(),
 			)
-			log.KvDistribution.Infof(
-				ctx,
-				"r%d's %s load is too little to matter relative to s%d's %s total load",
-				candidateReplica.GetRangeID(),
-				candidateReplica.RangeUsageInfo().Load(),
-				rctx.LocalDesc.StoreID,
-				rctx.LocalDesc.Capacity.Load(),
-			)
 			continue
 		}
 


### PR DESCRIPTION
Some small improvements and fixes for allocator/store rebalancer logging.

Epic: none
Release note: None