### PR TITLE
sql,server: support collecting labelled goroutines in the job profiler

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -4139,7 +4139,7 @@ func (s *statusServer) GetJobProfilerExecutionDetails(
 
 	jobID := jobspb.JobID(req.JobId)
 	execCfg := s.sqlServer.execCfg
-	eb := sql.MakeJobProfilerExecutionDetailsBuilder(execCfg.InternalDB, jobID)
+	eb := sql.MakeJobProfilerExecutionDetailsBuilder(execCfg.SQLStatusServer, execCfg.InternalDB, jobID)
 	data, err := eb.ReadExecutionDetail(ctx, req.Filename)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change collect cluster-wide goroutines that have a pprof label tying it to the particular job's execution, whose job execution details have been requested. This relies on the support added to the pprofui server to collect cluster-wide, labelled goroutines in https://github.com/cockroachdb/cockroach/pull/105916.

Informs: #105076
Release note: None