### PR TITLE
kvserver: log receiver snapshot trace on transport errors

### DIFF
--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -250,7 +250,7 @@ func TestAddReplicaWithReceiverThrottling(t *testing.T) {
 	ltk.storeKnobs.BeforeSendSnapshotThrottle = func() {
 		atomic.AddInt64(&count, 1)
 	}
-	ltk.storeKnobs.AfterSendSnapshotThrottle = func() {
+	ltk.storeKnobs.AfterSnapshotThrottle = func() {
 		atomic.AddInt64(&count, -1)
 	}
 	ctx := context.Background()

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -428,9 +428,12 @@ type StoreTestingKnobs struct {
 	// BeforeSendSnapshotThrottle intercepts replicas before entering send
 	// snapshot throttling.
 	BeforeSendSnapshotThrottle func()
-	// AfterSendSnapshotThrottle intercepts replicas after receiving a spot in the
-	// send snapshot semaphore.
-	AfterSendSnapshotThrottle func()
+	// AfterSnapshotThrottle intercepts replicas after receiving a spot in the
+	// send/recv snapshot semaphore.
+	AfterSnapshotThrottle func()
+	// BeforeRecvAcceptedSnapshot intercepts replicas before receiving the batches
+	// of a reserved and accepted snapshot.
+	BeforeRecvAcceptedSnapshot func()
 	// SelectDelegateSnapshotSender returns an ordered list of replica which will
 	// be used as delegates for sending a snapshot.
 	SelectDelegateSnapshotSender func(*roachpb.RangeDescriptor) []roachpb.ReplicaDescriptor


### PR DESCRIPTION
In #106363, the receiver side of snapshots was modified to log the trace
of the current context when context errors (such as timeouts or
client-side context cancellation) occur. This modifies that change to
log these traces whenever there is any transport error receiving
requests or sending responses from the server side of a snapshot - i.e.
any time that the traces cannot be collected and returned to the client.
Additionally, testing for these scenarios has been incorporated as well.

Part of: #105820

Release Note: None