### PR TITLE
cli: hide the 'connect' and 'join' commands from 'cockroach help'

### DIFF
--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -37,8 +37,12 @@ var connectCmd = &cobra.Command{
 	Use:   "connect [command]",
 	Short: "Create certificates for securely connecting with clusters\n",
 	Long: `
-Bootstrap security certificates for connecting to new or existing clusters.`,
-	RunE: UsageAndErr,
+Bootstrap security certificates for connecting to new or existing clusters.
+
+THIS COMMAND IS EXPERIMENTAL.
+`,
+	RunE:   UsageAndErr,
+	Hidden: true,
 }
 
 func init() {
@@ -53,9 +57,12 @@ var connectInitCmd = &cobra.Command{
 	Long: `
 Connects to other nodes and negotiates an initialization bundle for use with
 secure inter-node connections.
+
+THIS COMMAND IS EXPERIMENTAL.
 `,
-	Args: cobra.NoArgs,
-	RunE: clierrorplus.MaybeDecorateError(runConnectInit),
+	Args:   cobra.NoArgs,
+	RunE:   clierrorplus.MaybeDecorateError(runConnectInit),
+	Hidden: true,
 }
 
 // runConnectInit connects to other nodes and negotiates an initialization bundle

--- a/pkg/cli/connect_join.go
+++ b/pkg/cli/connect_join.go
@@ -35,10 +35,12 @@ import (
 const nodeJoinTimeout = 1 * time.Minute
 
 var connectJoinCmd = &cobra.Command{
-	Use:   "join <join-token>",
-	Short: "request the TLS certs for a new node from an existing node",
-	Args:  cobra.MinimumNArgs(1),
-	RunE:  clierrorplus.MaybeDecorateError(runConnectJoin),
+	Use:    "join <join-token>",
+	Short:  "request the TLS certs for a new node from an existing node",
+	Long:   `THIS COMMAND IS EXPERIMENTAL.`,
+	Args:   cobra.MinimumNArgs(1),
+	RunE:   clierrorplus.MaybeDecorateError(runConnectJoin),
+	Hidden: true,
 }
 
 func requestPeerCA(

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1254,7 +1254,6 @@ func TestFlagUsage(t *testing.T) {
 Available Commands:
   start             start a node in a multi-node cluster
   start-single-node start a single-node cluster
-  connect           Create certificates for securely connecting with clusters
 
   init              initialize a cluster
   cert              create ca, node, and client certs

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -111,7 +111,7 @@ To initialize the cluster, use 'cockroach init'.
 // startSingleNodeCmd starts a node by initializing the stores.
 var startSingleNodeCmd = &cobra.Command{
 	Use:   "start-single-node",
-	Short: "start a single-node cluster",
+	Short: "start a single-node cluster\n",
 	Long: `
 Start a CockroachDB node, which will export data from one or more
 storage devices, specified via --store flags.


### PR DESCRIPTION
Informs CRDB-29671.

The functionality is not yet complete (see epic CRDB-6663). Until it is, let's not list it in command help texts.

Release note: None