### PR TITLE
ui: add timescale label to statement diagnostics

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.module.scss
@@ -8,7 +8,6 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    margin-bottom: $spacing-mid-large;
   }
 
   &__footer {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
@@ -29,6 +29,7 @@ const ts: TimeScale = {
   key: "Custom",
 };
 const mockSetTimeScale = jest.fn();
+const requestTime = moment();
 
 function generateDiagnosticsRequest(
   extendObject: Partial<StatementDiagnosticsReport> = {},
@@ -57,9 +58,9 @@ describe("DiagnosticsView", () => {
           <DiagnosticsView
             activateDiagnosticsRef={activateDiagnosticsRef}
             statementFingerprint={statementFingerprint}
-            hasData={false}
             diagnosticsReports={[]}
             dismissAlertMessage={() => {}}
+            requestTime={undefined}
             currentScale={ts}
             onChangeTimeScale={mockSetTimeScale}
           />
@@ -88,7 +89,7 @@ describe("DiagnosticsView", () => {
           <DiagnosticsView
             activateDiagnosticsRef={activateDiagnosticsRef}
             statementFingerprint={statementFingerprint}
-            hasData={true}
+            requestTime={undefined}
             diagnosticsReports={diagnosticsRequests}
             dismissAlertMessage={() => {}}
             currentScale={ts}
@@ -122,10 +123,10 @@ describe("DiagnosticsView", () => {
           <DiagnosticsView
             activateDiagnosticsRef={activateDiagnosticsRef}
             statementFingerprint={statementFingerprint}
-            hasData={true}
             diagnosticsReports={diagnosticsRequests}
             dismissAlertMessage={() => {}}
             currentScale={ts}
+            requestTime={requestTime}
             onChangeTimeScale={mockSetTimeScale}
           />
         </TestStoreProvider>,
@@ -146,10 +147,10 @@ describe("DiagnosticsView", () => {
           <DiagnosticsView
             activateDiagnosticsRef={activateDiagnosticsRef}
             statementFingerprint={statementFingerprint}
-            hasData={true}
             diagnosticsReports={diagnosticsRequests}
             dismissAlertMessage={() => {}}
             currentScale={ts}
+            requestTime={requestTime}
             onChangeTimeScale={mockSetTimeScale}
           />
         </TestStoreProvider>,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -943,8 +943,8 @@ export class StatementDetails extends React.Component<
         activateDiagnosticsRef={this.activateDiagnosticsRef}
         diagnosticsReports={this.props.diagnosticsReports}
         dismissAlertMessage={this.props.dismissStatementDiagnosticsAlertMessage}
-        hasData={this.hasDiagnosticReports()}
         statementFingerprint={fingerprint}
+        requestTime={moment(this.props.requestTime)}
         onDownloadDiagnosticBundleClick={this.props.onDiagnosticBundleDownload}
         onDiagnosticCancelRequestClick={report =>
           this.props.onDiagnosticCancelRequest(report)


### PR DESCRIPTION
Epic: None

This change adds a timescale label to the diagnostics tab of the statement details page. Additionally, it lists the number of active statement diagnostic requests that are not displayed due to the current time window.

Loom demo of changes:
https://www.loom.com/share/eb99a5eb408942a7bb19fccc970778e5

Release note (ui change): Added timescale label to the diagnostics tab of the statement details page. Users are now able to see the time window for which the statement diagnostics are displayed.