### PR TITLE
sqlstats: update sql activity updater job tests

### DIFF
--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -34,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,236 +41,175 @@ import (
 func TestSqlActivityUpdateJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t, "test is too slow to run under race")
 
-	// Start the cluster. (One node is sufficient; the outliers system is currently in-memory only.)
+	ctx := context.Background()
+
+	stubTime := timeutil.Now().Truncate(time.Hour)
+	sqlStatsKnobs := &sqlstats.TestingKnobs{
+		StubTimeNow: func() time.Time { return stubTime },
+		AOSTClause:  "AS OF SYSTEM TIME '-1us'",
+	}
+
+	// Start the cluster.
 	// Disable the job since it is called manually from a new instance to avoid
 	// any race conditions.
-	ctx := context.Background()
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true,
-		Knobs: base.TestingKnobs{UpgradeManager: &upgradebase.TestingKnobs{
-			DontUseJobs:                       true,
-			SkipUpdateSQLActivityJobBootstrap: true,
-		}}})
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Insecure: true,
+		Knobs: base.TestingKnobs{
+			SQLStatsKnobs: sqlStatsKnobs,
+			UpgradeManager: &upgradebase.TestingKnobs{
+				DontUseJobs:                       true,
+				SkipUpdateSQLActivityJobBootstrap: true,
+			}}})
 	defer srv.Stopper().Stop(context.Background())
-	defer db.Close()
+	defer sqlDB.Close()
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
 
 	var count int
-	row := db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.transaction_activity")
-	err := row.Scan(&count)
-	require.NoError(t, err)
+	row := db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity")
+	row.Scan(&count)
 	require.Equal(t, 0, count, "system.transaction_activity: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.statement_activity")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity")
+	row.Scan(&count)
 	require.Equal(t, 0, count, "system.statement_activity: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.jobs WHERE job_type = 'AUTO UPDATE SQL ACTIVITY' and id = 103 ")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t,
+		"SELECT count_rows() FROM system.public.jobs WHERE job_type = 'AUTO UPDATE SQL ACTIVITY' and id = 103")
+	row.Scan(&count)
 	require.Equal(t, 0, count, "jobs: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.transaction_statistics")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_statistics")
+	row.Scan(&count)
 	require.Equal(t, 0, count, "system.transaction_statistics: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.statement_statistics")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_statistics")
+	row.Scan(&count)
 	require.Equal(t, 0, count, "system.statement_statistics: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() FROM crdb_internal.transaction_activity")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.transaction_activity")
+	row.Scan(&count)
 	require.Equal(t, 0, count, "crdb_internal.transaction_activity: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() FROM crdb_internal.statement_activity")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.statement_activity")
+	row.Scan(&count)
 	require.Equal(t, 0, count, "crdb_internal.statement_activity: expect:0, actual:%d", count)
 
 	execCfg := srv.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
-	updater := newSqlActivityUpdater(st, execCfg.InternalDB, nil)
+	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
 
-	// Transient failures from AOST queries: https://github.com/cockroachdb/cockroach/issues/97840
-	testutils.SucceedsWithin(t, func() error {
-		// Verify no error with empty stats
-		return updater.TransferStatsToActivity(ctx)
-	}, 30*time.Second)
+	require.NoError(t, updater.TransferStatsToActivity(ctx))
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.transaction_activity")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity")
+	row.Scan(&count)
 	require.Equal(t, 0, count, "system.transaction_activity: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.statement_activity")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity")
+	row.Scan(&count)
 	require.Equal(t, 0, count, "system.statement_activity: expect:0, actual:%d", count)
 
 	appName := "TestSqlActivityUpdateJob"
-	_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", appName)
-	require.NoError(t, err)
+	db.Exec(t, "SET SESSION application_name=$1", appName)
+	db.Exec(t, "SELECT 1;")
 
-	_, err = db.ExecContext(ctx, "SELECT 1;")
-	require.NoError(t, err)
-	srv.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
 	srv.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
 
-	_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", "randomIgnore")
-	require.NoError(t, err)
+	db.Exec(t, "SET SESSION application_name=$1", "randomIgnore")
 
-	// The check to calculate the rows uses the follower_read_timestamp which will
-	// skip the upsert because it will see there are no rows.
-	testutils.SucceedsWithin(t, func() error {
-		var txnAggTs time.Time
-		row = db.QueryRowContext(ctx, `SELECT count_rows(), aggregated_ts 
-			FROM system.public.transaction_statistics AS OF SYSTEM TIME follower_read_timestamp() 
-			WHERE app_name = $1 
-			GROUP BY aggregated_ts`, appName)
-		err = row.Scan(&count, &txnAggTs)
-		if err != nil {
-			return err
-		}
-		if count <= 0 {
-			return errors.New("Need to wait for row to populate with follower_read_timestamp.")
-		}
-
-		var stmtAggTs time.Time
-		row = db.QueryRowContext(ctx, `SELECT count_rows(), aggregated_ts 
-			FROM system.public.statement_statistics AS OF SYSTEM TIME follower_read_timestamp() 
-			WHERE app_name = $1 
-			GROUP BY aggregated_ts`, appName)
-		err = row.Scan(&count, &stmtAggTs)
-		if err != nil {
-			return err
-		}
-		if count <= 0 {
-			return errors.New("Need to wait for row to populate with follower_read_timestamp.")
-		}
-		require.Equal(t, stmtAggTs, txnAggTs)
-		return nil
-	}, 30*time.Second)
-
-	// Run the updater to add rows to the activity tables
+	// Run the updater to add rows to the activity tables.
 	// This will use the transfer all scenarios with there only
-	// being a few rows
-	err = updater.TransferStatsToActivity(ctx)
-	require.NoError(t, err)
+	// being a few rows.
+	require.NoError(t, updater.TransferStatsToActivity(ctx))
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.transaction_activity WHERE app_name = $1", appName)
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity WHERE app_name = $1", appName)
+	row.Scan(&count)
 	require.Equal(t, count, 1, "system.transaction_activity after transfer: expect:1, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.statement_activity WHERE app_name = $1", appName)
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity WHERE app_name = $1", appName)
+	row.Scan(&count)
 	require.Equal(t, count, 1, "system.statement_activity after transfer: expect:1, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM crdb_internal.transaction_activity WHERE app_name = $1", appName)
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.transaction_activity WHERE app_name = $1", appName)
+	row.Scan(&count)
 	require.Equal(t, count, 1, "crdb_internal.transaction_activity after transfer: expect:1, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM crdb_internal.statement_activity WHERE app_name = $1", appName)
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.statement_activity WHERE app_name = $1", appName)
+	row.Scan(&count)
 	require.Equal(t, count, 1, "crdb_internal.statement_activity after transfer: expect:1, actual:%d", count)
 
-	// Reset the stats and verify it's empty
-	_, err = db.ExecContext(ctx, "SELECT crdb_internal.reset_sql_stats()")
-	require.NoError(t, err)
+	// Reset the stats and verify all sql stats tables are empty.
+	db.Exec(t, "SELECT crdb_internal.reset_sql_stats()")
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.transaction_activity")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity")
+	row.Scan(&count)
 	require.Zero(t, count, "system.transaction_activity after transfer: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM system.public.statement_activity")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity")
+	row.Scan(&count)
 	require.Zero(t, count, "system.statement_activity after transfer: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM crdb_internal.transaction_activity")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.transaction_activity")
+	row.Scan(&count)
 	require.Zero(t, count, "crdb_internal.transaction_activity after transfer: expect:0, actual:%d", count)
 
-	row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-		"FROM crdb_internal.statement_activity")
-	err = row.Scan(&count)
-	require.NoError(t, err)
+	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.statement_activity")
+	row.Scan(&count)
 	require.Zero(t, count, "crdb_internal.statement_activity after transfer: expect:0, actual:%d", count)
 }
 
-// TestSqlActivityUpdateJob verifies that the
+// TestSqlActivityUpdateTopLimitJob verifies that the
 // job is created.
 func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t, "test is too slow to run under race")
 
-	// Start the cluster. (One node is sufficient; the outliers system is currently in-memory only.)
+	stubTime := timeutil.Now().Truncate(time.Hour)
+	sqlStatsKnobs := &sqlstats.TestingKnobs{
+		StubTimeNow: func() time.Time { return stubTime },
+		AOSTClause:  "AS OF SYSTEM TIME '-1us'",
+	}
+
+	// Start the cluster.
 	ctx := context.Background()
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true,
-		Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}})
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Insecure: true,
+		Knobs: base.TestingKnobs{
+			SQLStatsKnobs:    sqlStatsKnobs,
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
 	defer srv.Stopper().Stop(context.Background())
-	defer db.Close()
+	defer sqlDB.Close()
 
-	_, err := db.ExecContext(ctx, "INSERT INTO system.users VALUES ('node', NULL, true, 3)")
-	require.NoError(t, err)
+	db := sqlutils.MakeSQLRunner(sqlDB)
 
-	_, err = db.ExecContext(ctx, "GRANT node TO root")
-	require.NoError(t, err)
+	// Give permission to write to sys tables.
+	db.Exec(t, "INSERT INTO system.users VALUES ('node', NULL, true, 3)")
+	db.Exec(t, "GRANT node TO root")
 
-	// Make sure all the tables are empty initially
-	_, err = db.ExecContext(ctx, "DELETE FROM system.public.transaction_activity")
-	require.NoError(t, err)
-
-	_, err = db.ExecContext(ctx, "DELETE FROM system.public.statement_activity")
-	require.NoError(t, err)
-
-	_, err = db.ExecContext(ctx, "DELETE FROM system.public.transaction_statistics")
-	require.NoError(t, err)
-
-	_, err = db.ExecContext(ctx, "DELETE FROM system.public.statement_statistics")
-	require.NoError(t, err)
+	// Make sure all the tables are empty initially.
+	db.Exec(t, "DELETE FROM system.public.transaction_activity")
+	db.Exec(t, "DELETE FROM system.public.statement_activity")
+	db.Exec(t, "DELETE FROM system.public.transaction_statistics")
+	db.Exec(t, "DELETE FROM system.public.statement_statistics")
 
 	execCfg := srv.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
 	su := st.MakeUpdater()
 	const topLimit = 3
-	err = su.Set(ctx, "sql.stats.activity.top.max", settings.EncodedValue{
+	err := su.Set(ctx, "sql.stats.activity.top.max", settings.EncodedValue{
 		Value: settings.EncodeInt(int64(topLimit)),
 		Type:  "i",
 	})
 	require.NoError(t, err)
 
-	updater := newSqlActivityUpdater(st, execCfg.InternalDB, nil)
+	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
 
-	_, err = db.ExecContext(ctx, "SET tracing = true;")
-	require.NoError(t, err)
+	db.Exec(t, "SET tracing = true;")
 
-	_, err = db.ExecContext(ctx, "set cluster setting sql.txn_stats.sample_rate  = 1;")
-	require.NoError(t, err)
+	db.Exec(t, "set cluster setting sql.txn_stats.sample_rate  = 1;")
 
 	const appNamePrefix = "TestSqlActivityUpdateJobLoop"
 	getAppName := func(count int) string {
@@ -282,57 +219,18 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	updateStatsCount := 0
 	for i := 1; i <= 5; i++ {
 
-		// Generate unique rows in the statistics tables
-		const numQueries = topLimit*6 /*num columns*/ + 10 /*need more rows than limit*/
+		// Generate unique rows in the statistics tables.
+		// numQueries = per-column-limit * numColumns with some padding since we need more rows than the limit.
+		const numQueries = topLimit*6 + 10
 		for j := 0; j < numQueries; j++ {
 			appIndexCount++
-			_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", getAppName(appIndexCount))
-			require.NoError(t, err)
-			_, err = db.ExecContext(ctx, "SELECT 1;")
-			require.NoError(t, err)
+			db.Exec(t, "SET SESSION application_name=$1", getAppName(appIndexCount))
+			db.Exec(t, "SELECT 1;")
 		}
 
-		_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", "randomIgnore")
-		require.NoError(t, err)
+		db.Exec(t, "SET SESSION application_name=$1", "randomIgnore")
 
-		// Need to call it twice to actually cause a flush
 		srv.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
-		srv.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
-
-		// The check to calculate the rows uses the follower_read_timestamp which will
-		// skip the upsert because it will see there are no rows.
-		testutils.SucceedsWithin(t, func() error {
-			var txnAggTs time.Time
-			var count int
-			row := db.QueryRowContext(ctx, `SELECT count_rows(), aggregated_ts 
-			FROM system.public.transaction_statistics AS OF SYSTEM TIME follower_read_timestamp() 
-			WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%' 
-			GROUP BY aggregated_ts`)
-			err = row.Scan(&count, &txnAggTs)
-			if err != nil {
-				return err
-			}
-
-			if count < appIndexCount {
-				return errors.New("Need to wait for row to populate with follower_read_timestamp.")
-			}
-
-			var stmtAggTs time.Time
-			row = db.QueryRowContext(ctx, `SELECT count_rows(), aggregated_ts 
-			 FROM system.public.statement_statistics AS OF SYSTEM TIME follower_read_timestamp() 
-			 WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%' 
-			 GROUP BY aggregated_ts`)
-			err = row.Scan(&count, &stmtAggTs)
-
-			if err != nil {
-				return err
-			}
-			if count < appIndexCount {
-				return errors.New("Need to wait for row to populate with follower_read_timestamp.")
-			}
-			require.Equal(t, stmtAggTs, txnAggTs)
-			return nil
-		}, 1*time.Minute)
 
 		// The max number of queries is number of top columns * max number of
 		// queries per a column (6*3=18 for this test, 6*500=3000 default). Most of
@@ -341,35 +239,33 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		// values for each of the columns to make sure that it is always the max.
 		// Then run the update multiple times with new top queries each time. This
 		// is needed to simulate ORM which generates a lot of unique queries.
-		// Execution count
+
+		// Execution count.
 		for j := 0; j < topLimit; j++ {
 			updateStatsCount++
-			_, err = db.ExecContext(ctx, `UPDATE system.public.statement_statistics
+			db.Exec(t, `UPDATE system.public.statement_statistics
 			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
 			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
 			    WHERE app_name = $3;`, 10000+updateStatsCount, 0.0000001, getAppName(updateStatsCount))
-			require.NoError(t, err)
 		}
 
-		// Service latency time
+		// Service latency time.
 		for j := 0; j < topLimit; j++ {
 			updateStatsCount++
-			_, err = db.ExecContext(ctx, `UPDATE system.public.statement_statistics
+			db.Exec(t, `UPDATE system.public.statement_statistics
 			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
 			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
 			    WHERE app_name = $3;`, 1, 1000+updateStatsCount, getAppName(updateStatsCount))
-			require.NoError(t, err)
 		}
 
 		// Total execution time. Needs to be less than individual execution count
 		// and service latency, but greater when multiplied together.
 		for j := 0; j < topLimit; j++ {
 			updateStatsCount++
-			_, err = db.ExecContext(ctx, `UPDATE system.public.statement_statistics
+			db.Exec(t, `UPDATE system.public.statement_statistics
 			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
 			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
 			    WHERE app_name = $3;`, 500+updateStatsCount, 500+updateStatsCount, getAppName(updateStatsCount))
-			require.NoError(t, err)
 		}
 
 		// Remaining columns don't interact so a loop can be used
@@ -377,56 +273,58 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		for _, updateField := range columnsToChangeValues {
 			for j := 0; j < topLimit; j++ {
 				updateStatsCount++
-				_, err = db.ExecContext(ctx, `UPDATE system.public.statement_statistics
+				db.Exec(t, `UPDATE system.public.statement_statistics
 			SET statistics =  jsonb_set(statistics, $1, to_jsonb($2::INT)) 
 			WHERE app_name = $3;`, updateField, 10000+updateStatsCount, getAppName(updateStatsCount))
-				require.NoError(t, err)
 			}
 		}
 
-		// Run the updater to add rows to the activity tables
+		// Run the updater to add rows to the activity tables.
 		// This will use the transfer all scenarios with there only
-		// being a few rows
+		// being a few rows.
 		err = updater.TransferStatsToActivity(ctx)
 		require.NoError(t, err)
 
-		maxRows := topLimit * 6 // Number of top columns to select from
-		row := db.QueryRowContext(ctx, `SELECT count_rows() 
-		FROM system.public.transaction_activity 
-		WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%'`)
+		maxRows := topLimit * 6 // Number of top columns to select from.
+		row := db.QueryRow(t,
+			`SELECT count_rows() FROM system.public.transaction_activity WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%'`)
 		var count int
-		err = row.Scan(&count)
-		require.NoError(t, err)
+		row.Scan(&count)
 		require.LessOrEqual(t, count, maxRows, "transaction_activity after transfer: actual:%d, max:%d", count, maxRows)
 
-		row = db.QueryRowContext(ctx, `SELECT count_rows() 
-		FROM system.public.statement_activity 
-		WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%'`)
-		err = row.Scan(&count)
-		require.NoError(t, err)
+		row = db.QueryRow(t,
+			`SELECT count_rows() FROM system.public.statement_activity WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%'`)
+		row.Scan(&count)
 		require.LessOrEqual(t, count, maxRows, "statement_activity after transfer: actual:%d, max:%d", count, maxRows)
 
-		row = db.QueryRowContext(ctx, `SELECT count_rows() 
-		FROM system.public.transaction_activity`)
-		err = row.Scan(&count)
-		require.NoError(t, err)
+		row = db.QueryRow(t, `SELECT count_rows() FROM system.public.transaction_activity`)
+		row.Scan(&count)
 		require.LessOrEqual(t, count, maxRows, "transaction_activity after transfer: actual:%d, max:%d", count, maxRows)
 	}
 }
 
-func TestScheduledSQLStatsCompaction(t *testing.T) {
+func TestSqlActivityJobRunsAfterStatsFlush(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t, "test is too slow to run under race")
 
-	// Start the cluster. (One node is sufficient; the outliers system is currently in-memory only.)
+	sqlStatsKnobs := &sqlstats.TestingKnobs{
+		AOSTClause: "AS OF SYSTEM TIME '-1us'",
+	}
+
+	// Start the cluster.
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true,
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Insecure: true,
 		Settings: st,
-		Knobs:    base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}})
+		Knobs: base.TestingKnobs{
+			SQLStatsKnobs:    sqlStatsKnobs,
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
 	defer srv.Stopper().Stop(context.Background())
 	defer db.Close()
+
 	_, err := db.ExecContext(ctx, "SET CLUSTER SETTING sql.stats.flush.interval = '100ms'")
 	require.NoError(t, err)
 	appName := "TestScheduledSQLStatsCompaction"
@@ -467,7 +365,6 @@ func TestScheduledSQLStatsCompaction(t *testing.T) {
 func TestTransactionActivityMetadata(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRace(t, "test is too slow to run under race")
 
 	ctx := context.Background()
 	stubTime := timeutil.Now().Truncate(time.Hour)
@@ -536,7 +433,6 @@ func TestTransactionActivityMetadata(t *testing.T) {
 func TestActivityStatusCombineAPI(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRace(t, "test is too slow to run under race")
 
 	ctx := context.Background()
 	stubTime := timeutil.Now().Truncate(time.Hour)


### PR DESCRIPTION
A few updates to the SQL Activity Updater job tests:
- All tests now set the AOST clause used by the sql activity job queries to '-1 us' to prevent flaky timeouts and decrease test runtime.
- Use the SQL test runner to execute must-succeed queries for improved readability.
- Renamed `TestScheduledSQLStatsCompaction` in `sql_activity_update_job_test` to `TestSqlActivityJobRunsAfterStatsFlush` as this is a more accurate name for this test.
- Unskip these tests under stressrace / race, now that they are faster!

Epic: none
Fixes: #106437
Fixes: #106375

Release note: None