### PR TITLE
opt: fix top-k ordering enforcement

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -603,3 +603,22 @@ NULL   2
 
 statement ok
 RESET null_ordered_last
+
+# Regression test for #106678.
+statement ok
+CREATE TABLE t106678 (a INT, b INT);
+INSERT INTO t106678 VALUES (2, 0), (1, 100), (2, 0), (3, 20), (1, -1);
+
+# The results should be ordered by (a, b), not just by (a).
+query II
+SELECT a, b FROM (SELECT a, b FROM t106678 ORDER BY a LIMIT 3) ORDER BY a, b;
+----
+1  -1
+1  100
+2  0
+
+# Should return the (1, -1) row, not the (1, 100) row.
+query II
+SELECT a, b FROM (SELECT a, b FROM t106678 ORDER BY a LIMIT 3) ORDER BY a, b LIMIT 1
+----
+1  -1

--- a/pkg/sql/opt/ordering/topk.go
+++ b/pkg/sql/opt/ordering/topk.go
@@ -19,7 +19,7 @@ import (
 func topKCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
 	// TopK orders its own input, so the ordering it can provide is its own.
 	topK := expr.(*memo.TopKExpr)
-	return required.Intersects(&topK.Ordering)
+	return topK.Ordering.Implies(required)
 }
 
 func topKBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) opt.Ordering {

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -3140,3 +3140,46 @@ project
       └── aggregations
            └── const-agg [as=c2:2, outer=(2)]
                 └── c2:2
+
+# Regression test for #106678 - sort the output of a top-k operator when the
+# top-k ordering is a prefix of the required ordering.
+exec-ddl
+CREATE TABLE t106678 (a INT, b INT);
+----
+
+# There should be a segmented sort on top of the top-k operator.
+opt
+SELECT a, b FROM (SELECT a, b FROM t106678 ORDER BY a LIMIT 3) ORDER BY a, b;
+----
+sort (segmented)
+ ├── columns: a:1 b:2
+ ├── cardinality: [0 - 3]
+ ├── ordering: +1,+2
+ └── top-k
+      ├── columns: a:1 b:2
+      ├── internal-ordering: +1
+      ├── k: 3
+      ├── cardinality: [0 - 3]
+      ├── ordering: +1
+      └── scan t106678
+           └── columns: a:1 b:2
+
+# The top limit should become a top-k as well, since the inner top-k does not
+# provide an ordering on (a, b).
+opt
+SELECT a, b FROM (SELECT a, b FROM t106678 ORDER BY a LIMIT 3) ORDER BY a, b LIMIT 1
+----
+top-k
+ ├── columns: a:1 b:2
+ ├── internal-ordering: +1,+2
+ ├── k: 1
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ └── top-k
+      ├── columns: a:1 b:2
+      ├── internal-ordering: +1
+      ├── k: 3
+      ├── cardinality: [0 - 3]
+      └── scan t106678
+           └── columns: a:1 b:2


### PR DESCRIPTION
#### opt: fix top-k ordering enforcement

Previously, the top-k ordering logic would report that a top-k operator
can provide a required ordering as long as the top-k's internal ordering
*intersects* the required ordering. "Intersects" in this context means
that an actual ordering can be selected that satisfies both the required
and internal ordering.

This was incorrect because top-k operators only return results according
to their internal ordering. This could result in incorrectly-sorted output
rows. The incorrect sorting can then lead to incorrect results if parent
operators depend on the ordering.

This patch fixes the problem by changing the "can provide" logic to only
return true when the internal ordering *implies* the required ordering.

Fixes #106678

Release note (bug fix): Fixed a bug existing since before v22.2 that
could cause a query with `LIMIT` and `ORDER BY` to return results in
the wrong order. This bug could cause incorrect results as well if the
`LIMIT` was nested within an outer query, e.g. under another `LIMIT`.