### PR TITLE
testutils: return predecessor history from least to most recent

### DIFF
--- a/pkg/testutils/release/releases.go
+++ b/pkg/testutils/release/releases.go
@@ -100,19 +100,20 @@ func RandomPredecessorHistory(rng *rand.Rand, v *version.Version, k int) ([]stri
 }
 
 // predecessorHistory computes the history of size `k` for a given
-// version. The `releasePicker` function can be used to select which
-// patch release is used at each step.
+// version (from least to most recent, using the order an actual
+// upgrade would have to follow). The `releasePicker` function can be
+// used to select which patch release is used at each step.
 func predecessorHistory(
 	v *version.Version, k int, releasePicker func(Series) string,
 ) ([]string, error) {
-	var history []string
+	history := make([]string, k)
 	currentV := v
-	for i := 0; i < k; i++ {
+	for i := k - 1; i >= 0; i-- {
 		predecessor, err := predecessorSeries(currentV)
 		if err != nil {
 			return nil, err
 		}
-		history = append(history, releasePicker(predecessor))
+		history[i] = releasePicker(predecessor)
 		currentV = mustParseVersion(predecessor.Latest)
 	}
 

--- a/pkg/testutils/release/releases_test.go
+++ b/pkg/testutils/release/releases_test.go
@@ -118,15 +118,15 @@ func TestLatestPredecessorHistory(t *testing.T) {
 			name:           "valid history",
 			v:              "v23.1.1",
 			k:              3,
-			expectedLatest: []string{"22.2.8", "22.1.12", "19.2.0"},
-			expectedRandom: []string{"22.2.1", "22.1.12", "19.2.0"},
+			expectedLatest: []string{"19.2.0", "22.1.12", "22.2.8"},
+			expectedRandom: []string{"19.2.0", "22.1.12", "22.2.1"},
 		},
 		{
 			name:           "with pre-release",
 			v:              "v23.1.1-beta.1",
 			k:              2,
-			expectedLatest: []string{"22.2.8", "22.1.12"},
-			expectedRandom: []string{"22.2.5", "22.1.0"},
+			expectedLatest: []string{"22.1.12", "22.2.8"},
+			expectedRandom: []string{"22.1.0", "22.2.5"},
 		},
 	}
 


### PR DESCRIPTION
In #105231, the order returned by the predecessor history function was inadvertently changed: instead of returning a slice from oldest to newest release, the order was instead reversed (newest to oldest).

That breaks the (currently only) caller of `PredecessorHistory` with a parameter greater than 1: `tpcc/mixed-headroom/multiple-upgrades`. As a result, it would attempt an impossible upgrade path from a 23.1 release to a 22.2 release.

This commit fixes the API by returning the release histories from oldest to newest as expected, as this is the more sensible API.

Fixes: #106716

Release note: None