### PR TITLE
cli: unskip test_demo_partitioning interactive test

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -158,6 +158,13 @@ func TestDockerCLI_test_demo_node_cmds(t *testing.T) {
 	runTestDockerCLI(t, "test_demo_node_cmds", "../cli/interactive_tests/test_demo_node_cmds.tcl")
 }
 
+func TestDockerCLI_test_demo_partitioning(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_demo_partitioning", "../cli/interactive_tests/test_demo_partitioning.tcl")
+}
+
 func TestDockerCLI_test_demo_telemetry(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -1,9 +1,5 @@
 #! /usr/bin/env expect -f
 
-# This test is skipped (flaky test) -- its filename lets it hide from the selector in
-# TestDockerCLI. Un-skip it by renaming after fixing
-# https://github.com/cockroachdb/cockroach/issues/96797.
-
 source [file join [file dirname $argv0] common.tcl]
 
 # Set a larger timeout as partitioning can be slow.


### PR DESCRIPTION
Fixes #96797.

Release note: None