### PR TITLE
changefeedccl: Add a test verifying descriptor fetch behavior

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -180,6 +180,7 @@ go_test(
     srcs = [
         "alter_changefeed_test.go",
         "avro_test.go",
+        "changefeed_dist_test.go",
         "changefeed_test.go",
         "csv_test.go",
         "encoder_test.go",

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -109,23 +109,21 @@ func emitResolvedTimestamp(
 }
 
 // createProtectedTimestampRecord will create a record to protect the spans for
-// this changefeed at the resolved timestamp. The progress struct will be
-// updated to refer to this new protected timestamp record.
+// this changefeed at the resolved timestamp.
 func createProtectedTimestampRecord(
 	ctx context.Context,
 	codec keys.SQLCodec,
 	jobID jobspb.JobID,
 	targets changefeedbase.Targets,
 	resolved hlc.Timestamp,
-	progress *jobspb.ChangefeedProgress,
 ) *ptpb.Record {
-	progress.ProtectedTimestampRecord = uuid.MakeV4()
+	ptsID := uuid.MakeV4()
 	deprecatedSpansToProtect := makeSpansToProtect(codec, targets)
 	targetToProtect := makeTargetToProtect(targets)
 
-	log.VEventf(ctx, 2, "creating protected timestamp %v at %v", progress.ProtectedTimestampRecord, resolved)
+	log.VEventf(ctx, 2, "creating protected timestamp %v at %v", ptsID, resolved)
 	return jobsprotectedts.MakeRecord(
-		progress.ProtectedTimestampRecord, int64(jobID), resolved, deprecatedSpansToProtect,
+		ptsID, int64(jobID), resolved, deprecatedSpansToProtect,
 		jobsprotectedts.Jobs, targetToProtect)
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_dist_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPTSRecordProtectsTargetsAndDescriptorTable tests that descriptors are not
+// GC'd when they are protected by a PTS record.
+func TestPTSRecordProtectsTargetsAndDescriptorTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, stopServer := startTestFullServer(t, feedTestOptions{})
+	defer stopServer()
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	sqlDB.Exec(t, "CREATE TABLE foo (a INT, b STRING)")
+	ts := s.Clock().Now()
+	ctx := context.Background()
+
+	fooDescr := cdctest.GetHydratedTableDescriptor(t, s.ExecutorConfig(), "d", "foo")
+	var targets changefeedbase.Targets
+	targets.Add(changefeedbase.Target{
+		TableID: fooDescr.GetID(),
+	})
+
+	// Lay protected timestamp record.
+	ptr := createProtectedTimestampRecord(ctx, s.Codec(), 42, targets, ts)
+	require.NoError(t, execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return execCfg.ProtectedTimestampProvider.WithTxn(txn).Protect(ctx, ptr)
+	}))
+
+	// Alter foo few times, then force GC at ts-1.
+	sqlDB.Exec(t, "ALTER TABLE foo ADD COLUMN c STRING")
+	sqlDB.Exec(t, "ALTER TABLE foo ADD COLUMN d STRING")
+	require.NoError(t, s.ForceTableGC(ctx, "system", "descriptor", ts.Add(-1, 0)))
+
+	// We can still fetch table descriptors because of protected timestamp record.
+	asOf := ts
+	_, err := fetchTableDescriptors(ctx, &execCfg, targets, asOf)
+	require.NoError(t, err)
+}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1488,8 +1488,9 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 	recordID := progress.ProtectedTimestampRecord
 	if recordID == uuid.Nil {
 		ptr := createProtectedTimestampRecord(
-			ctx, cf.flowCtx.Codec(), cf.spec.JobID, AllTargets(cf.spec.Feed), highWater, progress,
+			ctx, cf.flowCtx.Codec(), cf.spec.JobID, AllTargets(cf.spec.Feed), highWater,
 		)
+		progress.ProtectedTimestampRecord = ptr.ID.GetUUID()
 		if err := pts.Protect(ctx, ptr); err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -253,8 +253,8 @@ func changefeedPlanHook(
 				jobID,
 				AllTargets(details),
 				details.StatementTime,
-				progress.GetChangefeed(),
 			)
+			progress.GetChangefeed().ProtectedTimestampRecord = ptr.ID.GetUUID()
 
 			jr.Progress = *progress.GetChangefeed()
 


### PR DESCRIPTION
Add a test verifying descriptor table is protected when we protect changefeed target.

Informs: #106608

Release note: None