### PR TITLE
c2c: run TestTenantStreamingMultipleNodes on a single multitenant cluster

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -61,6 +61,8 @@ type TenantStreamingClustersArgs struct {
 	RetentionTTLSeconds            int
 	TestingKnobs                   *sql.StreamingTestingKnobs
 	TenantCapabilitiesTestingKnobs *tenantcapabilities.TestingKnobs
+
+	MultitenantSingleClusterNumNodes int
 }
 
 var DefaultTenantStreamingClustersArgs = TenantStreamingClustersArgs{
@@ -101,6 +103,38 @@ type TenantStreamingClusters struct {
 	DestSysSQL     *sqlutils.SQLRunner
 	DestTenantConn *gosql.DB
 	DestTenantSQL  *sqlutils.SQLRunner
+}
+
+func (c *TenantStreamingClusters) setupSrcTenant() {
+	tenantArgs := base.TestSharedProcessTenantArgs{
+		TenantName: c.Args.SrcTenantName,
+		TenantID:   c.Args.SrcTenantID,
+	}
+	srcTenantServer, srcTenantConn := serverutils.StartSharedProcessTenant(c.T, c.SrcCluster.Server(0),
+		tenantArgs)
+
+	testutils.SucceedsSoon(c.T, func() error {
+		return srcTenantConn.Ping()
+	})
+
+	c.SrcTenantServer = srcTenantServer
+	c.SrcTenantConn = srcTenantConn
+	c.SrcTenantSQL = sqlutils.MakeSQLRunner(srcTenantConn)
+}
+
+func (c *TenantStreamingClusters) init() {
+	c.SrcSysSQL.ExecMultiple(c.T, ConfigureClusterSettings(c.Args.SrcClusterSettings)...)
+	c.SrcSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING sql.split_at.allow_for_secondary_tenant.enabled=true`, c.Args.SrcTenantName)
+	c.SrcSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING sql.scatter.allow_for_secondary_tenant.enabled=true`, c.Args.SrcTenantName)
+	if c.Args.SrcInitFunc != nil {
+		c.Args.SrcInitFunc(c.T, c.SrcSysSQL, c.SrcTenantSQL)
+	}
+	c.DestSysSQL.ExecMultiple(c.T, ConfigureClusterSettings(c.Args.DestClusterSettings)...)
+	if c.Args.DestInitFunc != nil {
+		c.Args.DestInitFunc(c.T, c.DestSysSQL)
+	}
+	// Enable stream replication on dest by default.
+	c.DestSysSQL.Exec(c.T, `SET CLUSTER SETTING cross_cluster_replication.enabled = true;`)
 }
 
 // StartDestTenant starts the destination tenant and returns a cleanup
@@ -244,27 +278,54 @@ func CreateServerArgs(args TenantStreamingClustersArgs) base.TestServerArgs {
 	}
 }
 
+func startC2CTestCluster(
+	ctx context.Context, t *testing.T, serverArgs base.TestServerArgs, numNodes int,
+) (*testcluster.TestCluster, url.URL, func()) {
+	params := base.TestClusterArgs{ServerArgs: serverArgs}
+	c := testcluster.StartTestCluster(t, numNodes, params)
+	c.Server(0).Clock().Now()
+	// TODO(casper): support adding splits when we have multiple nodes.
+	pgURL, cleanupSinkCert := sqlutils.PGUrl(t, c.Server(0).ServingSQLAddr(), t.Name(), url.User(username.RootUser))
+	return c, pgURL, func() {
+		c.Stopper().Stop(ctx)
+		cleanupSinkCert()
+	}
+}
+
+func CreateMultiTenantStreamingCluster(
+	ctx context.Context, t *testing.T, args TenantStreamingClustersArgs,
+) (*TenantStreamingClusters, func()) {
+	require.Greater(t, args.MultitenantSingleClusterNumNodes, 1,
+		"CreateMultiTenantStreamingCLuster requires a multi node cluster, "+
+			"as the src and destination app tenants connect to different nodes")
+	serverArgs := CreateServerArgs(args)
+	cluster, url, cleanup := startC2CTestCluster(ctx, t, serverArgs,
+		args.MultitenantSingleClusterNumNodes)
+
+	tsc := &TenantStreamingClusters{
+		T:             t,
+		Args:          args,
+		SrcCluster:    cluster,
+		SrcSysSQL:     sqlutils.MakeSQLRunner(cluster.ServerConn(0)),
+		SrcSysServer:  cluster.Server(0),
+		SrcURL:        url,
+		SrcCleanup:    cleanup,
+		DestCluster:   cluster,
+		DestSysSQL:    sqlutils.MakeSQLRunner(cluster.ServerConn(1)),
+		DestSysServer: cluster.Server(1),
+	}
+	tsc.setupSrcTenant()
+	tsc.init()
+	return tsc, func() {
+		require.NoError(t, tsc.SrcTenantConn.Close())
+		cleanup()
+	}
+}
+
 func CreateTenantStreamingClusters(
 	ctx context.Context, t *testing.T, args TenantStreamingClustersArgs,
 ) (*TenantStreamingClusters, func()) {
 	serverArgs := CreateServerArgs(args)
-
-	startTestCluster := func(
-		ctx context.Context,
-		t *testing.T,
-		serverArgs base.TestServerArgs,
-		numNodes int,
-	) (*testcluster.TestCluster, url.URL, func()) {
-		params := base.TestClusterArgs{ServerArgs: serverArgs}
-		c := testcluster.StartTestCluster(t, numNodes, params)
-		c.Server(0).Clock().Now()
-		// TODO(casper): support adding splits when we have multiple nodes.
-		pgURL, cleanupSinkCert := sqlutils.PGUrl(t, c.Server(0).ServingSQLAddr(), t.Name(), url.User(username.RootUser))
-		return c, pgURL, func() {
-			c.Stopper().Stop(ctx)
-			cleanupSinkCert()
-		}
-	}
 
 	g := ctxgroup.WithContext(ctx)
 
@@ -273,7 +334,7 @@ func CreateTenantStreamingClusters(
 	var srcCleanup func()
 	g.GoCtx(func(ctx context.Context) error {
 		// Start the source cluster.
-		srcCluster, srcURL, srcCleanup = startTestCluster(ctx, t, serverArgs, args.SrcNumNodes)
+		srcCluster, srcURL, srcCleanup = startC2CTestCluster(ctx, t, serverArgs, args.SrcNumNodes)
 		return nil
 	})
 
@@ -281,60 +342,29 @@ func CreateTenantStreamingClusters(
 	var destCleanup func()
 	g.GoCtx(func(ctx context.Context) error {
 		// Start the destination cluster.
-		destCluster, _, destCleanup = startTestCluster(ctx, t, serverArgs, args.DestNumNodes)
+		destCluster, _, destCleanup = startC2CTestCluster(ctx, t, serverArgs, args.DestNumNodes)
 		return nil
 	})
 
 	require.NoError(t, g.Wait())
 
-	tenantArgs := base.TestSharedProcessTenantArgs{
-		TenantName: args.SrcTenantName,
-		TenantID:   args.SrcTenantID,
-	}
-	srcTenantServer, srcTenantConn := serverutils.StartSharedProcessTenant(t, srcCluster.Server(0),
-		tenantArgs)
-
-	testutils.SucceedsSoon(t, func() error {
-		return srcTenantConn.Ping()
-	})
-
 	tsc := &TenantStreamingClusters{
-		T:               t,
-		Args:            args,
-		SrcCluster:      srcCluster,
-		SrcTenantConn:   srcTenantConn,
-		SrcTenantServer: srcTenantServer,
-		SrcSysSQL:       sqlutils.MakeSQLRunner(srcCluster.ServerConn(0)),
-		SrcTenantSQL:    sqlutils.MakeSQLRunner(srcTenantConn),
-		SrcSysServer:    srcCluster.Server(0),
-		SrcURL:          srcURL,
-		SrcCleanup: func() {
-			require.NoError(t, srcTenantConn.Close())
-			srcCleanup()
-		},
+		T:             t,
+		Args:          args,
+		SrcCluster:    srcCluster,
+		SrcSysSQL:     sqlutils.MakeSQLRunner(srcCluster.ServerConn(0)),
+		SrcSysServer:  srcCluster.Server(0),
+		SrcURL:        srcURL,
+		SrcCleanup:    srcCleanup,
 		DestCluster:   destCluster,
 		DestSysSQL:    sqlutils.MakeSQLRunner(destCluster.ServerConn(0)),
 		DestSysServer: destCluster.Server(0),
 	}
+	tsc.setupSrcTenant()
+	tsc.init()
 
-	tsc.SrcSysSQL.ExecMultiple(t, ConfigureClusterSettings(args.SrcClusterSettings)...)
-	tsc.SrcSysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING sql.split_at.
-allow_for_secondary_tenant.
-enabled=true`, args.SrcTenantName)
-	tsc.SrcSysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING sql.scatter.allow_for_secondary_tenant.
-enabled=true`, args.SrcTenantName)
-	if args.SrcInitFunc != nil {
-		args.SrcInitFunc(t, tsc.SrcSysSQL, tsc.SrcTenantSQL)
-	}
-
-	tsc.DestSysSQL.ExecMultiple(t, ConfigureClusterSettings(args.DestClusterSettings)...)
-	if args.DestInitFunc != nil {
-		args.DestInitFunc(t, tsc.DestSysSQL)
-	}
-	// Enable stream replication on dest by default.
-	tsc.DestSysSQL.Exec(t, `SET CLUSTER SETTING cross_cluster_replication.enabled = true;`)
 	return tsc, func() {
-		require.NoError(t, srcTenantConn.Close())
+		require.NoError(t, tsc.SrcTenantConn.Close())
 		srcCleanup()
 		destCleanup()
 	}
@@ -390,7 +420,7 @@ func requireReplicatedTime(targetTime hlc.Timestamp, progress *jobspb.Progress) 
 
 func CreateScatteredTable(t *testing.T, c *TenantStreamingClusters, numNodes int) {
 	// Create a source table with multiple ranges spread across multiple nodes
-	numRanges := 50
+	numRanges := 10
 	rowsPerRange := 20
 	c.SrcTenantSQL.Exec(t, "CREATE TABLE d.scattered (key INT PRIMARY KEY)")
 	c.SrcTenantSQL.Exec(t, "INSERT INTO d.scattered (key) SELECT * FROM generate_series(1, $1)",
@@ -398,6 +428,17 @@ func CreateScatteredTable(t *testing.T, c *TenantStreamingClusters, numNodes int
 	c.SrcTenantSQL.Exec(t, "ALTER TABLE d.scattered SPLIT AT (SELECT * FROM generate_series($1::INT, $2::INT, $3::INT))",
 		rowsPerRange, (numRanges-1)*rowsPerRange, rowsPerRange)
 	c.SrcTenantSQL.Exec(t, "ALTER TABLE d.scattered SCATTER")
+	testutils.SucceedsSoon(t, func() error {
+		var leaseHolderCount int
+		c.SrcTenantSQL.QueryRow(t,
+			`SELECT count(DISTINCT lease_holder) FROM [SHOW RANGES FROM DATABASE d WITH DETAILS]`).
+			Scan(&leaseHolderCount)
+		require.Greater(t, leaseHolderCount, 0)
+		if leaseHolderCount == 1 {
+			return errors.New("leaseholders not scattered yet")
+		}
+		return nil
+	})
 }
 
 var defaultSrcClusterSetting = map[string]string{

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -652,12 +652,9 @@ func TestTenantStreamingMultipleNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRace(t, "takes too long with multiple nodes")
-
 	ctx := context.Background()
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs
-	args.SrcNumNodes = 4
-	args.DestNumNodes = 3
+	args.MultitenantSingleClusterNumNodes = 3
 
 	// Track the number of unique addresses that were connected to
 	clientAddresses := make(map[string]struct{})
@@ -670,7 +667,7 @@ func TestTenantStreamingMultipleNodes(t *testing.T) {
 		},
 	}
 
-	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
+	c, cleanup := replicationtestutils.CreateMultiTenantStreamingCluster(ctx, t, args)
 	defer cleanup()
 
 	// Make sure we have data on all nodes, so that we will have multiple


### PR DESCRIPTION
TestTenantStreamingMultipleNodes flakes because the unit test infra cannot
handle the resources required to run 2 multinode test clusters. This patch
unskips TestTenantStreamingMultipleNodes by refactoring it to run on a single
multi tenant cluster (i.e. the src and dest tenants run on the same cluster and
have the same system tenant), halving the number clusters/servers used by the
test.

This patch also modifies the CreateStatteredTable helper to wait until
leaseholders have been scattered for the newly scattered table, ensuring the
dsp.PartitionSpans() call during ingestion job planning returns multiple source
nodes to stream from.

Fixes https://github.com/cockroachdb/cockroach/issues/106194

Release note: None