### PR TITLE
tenantcostclient: speed up query RU estimate test

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/distsql",
         "//pkg/sql/execinfra",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slinstance",
         "//pkg/sql/stats",


### PR DESCRIPTION
This commit speeds up the query RU estimate test in two ways:
- it forces the production values for some of the metamorphic constants (this brought down the runtime from 93s to 37s for a particular seed)
- it reduces the number of rows inserted from 50k to 20k which should be (further bringing down the runtime to 13s).

Fixes: #106350.

Release note: None