### PR TITLE
logic: skip_on_retry works when errors are expected

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/schema_change_in_txn
+++ b/pkg/ccl/logictestccl/testdata/logic_test/schema_change_in_txn
@@ -1,3 +1,7 @@
+# Skip the rest of the test if a retry occurs. They can happen and are fine
+# but there's no way to encapsulate that in logictests.
+skip_on_retry
+
 # Backing up and restoring a descriptor will increment the version of the
 # descriptor before restoring it so we cannot achieve the expected behaviour in
 # this test.

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3130,8 +3130,8 @@ func (t *logicTest) maybeSkipOnRetry(err error) {
 func (t *logicTest) verifyError(
 	sql, pos, expectNotice, expectErr, expectErrCode string, err error,
 ) (bool, error) {
+	t.maybeSkipOnRetry(err)
 	if expectErr == "" && expectErrCode == "" && err != nil {
-		t.maybeSkipOnRetry(err)
 		return t.unexpectedError(sql, pos, err)
 	}
 	if expectNotice != "" {


### PR DESCRIPTION
Previously, we have `skip_on_retry` directive for logic test which, when set, it skips the rest of test if a statement fails with TransactionRetryError. However, it won't skip if the statement is expected to fail with certain error message. This PR ensures that whenever we have a TransactionRetryError and `skip_on_retry` is set, we always skip the rest of the test, even if the stmt is expected to fail.

fixes #104464

Release note: None