### PR TITLE
ui: increase polling of stmnt diagnostics if not completed

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.ts
@@ -70,10 +70,16 @@ export function* requestStatementsDiagnosticsSaga(): any {
   }
 }
 
-export function* receivedStatementsDiagnosticsSaga(delayMs: number) {
-  yield delay(delayMs);
-  yield put(actions.invalidated());
-}
+export const receivedStatementsDiagnosticsSaga = (delayMs: number) => {
+  const frequentPollingDelay = Math.min(delayMs, 30000);
+  return function* (action: ReturnType<typeof actions.received>) {
+    // If we have active requests for statement diagnostics then poll for new data more often (every 30s or as defined
+    // with CACHE_INVALIDATION_PERIOD (if it less than 30s).
+    const hasActiveRequests = action.payload.some(s => !s.completed);
+    yield delay(hasActiveRequests ? frequentPollingDelay : delayMs);
+    yield put(actions.invalidated());
+  };
+};
 
 export function* statementsDiagnosticsSagas(
   delayMs: number = CACHE_INVALIDATION_PERIOD,
@@ -88,6 +94,6 @@ export function* statementsDiagnosticsSagas(
     takeLatest(actions.request, requestStatementsDiagnosticsSaga),
     takeEvery(actions.createReport, createDiagnosticsReportSaga),
     takeEvery(actions.cancelReport, cancelDiagnosticsReportSaga),
-    takeLatest(actions.received, receivedStatementsDiagnosticsSaga, delayMs),
+    takeLatest(actions.received, receivedStatementsDiagnosticsSaga(delayMs)),
   ]);
 }

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -367,16 +367,19 @@ const userSQLRolesReducerObj = new CachedDataReducer(
 export const invalidateUserSQLRoles = userSQLRolesReducerObj.invalidateData;
 export const refreshUserSQLRoles = userSQLRolesReducerObj.refresh;
 
+export const statementDiagnosticInvalidationPeriod = moment.duration(5, "m");
 const statementDiagnosticsReportsReducerObj = new CachedDataReducer(
   clusterUiApi.getStatementDiagnosticsReports,
   "statementDiagnosticsReports",
-  moment.duration(5, "m"),
+  statementDiagnosticInvalidationPeriod,
   moment.duration(1, "m"),
 );
 export const refreshStatementDiagnosticsRequests =
   statementDiagnosticsReportsReducerObj.refresh;
 export const invalidateStatementDiagnosticsRequests =
   statementDiagnosticsReportsReducerObj.invalidateData;
+export const RECEIVE_STATEMENT_DIAGNOSTICS_REPORT =
+  statementDiagnosticsReportsReducerObj.RECEIVE;
 
 const dataDistributionReducerObj = new CachedDataReducer(
   api.getDataDistribution,


### PR DESCRIPTION
This change conditionally increases refresh rate of statement diagnostics if there is not completed diagnostics request. It polls every 5 min by default and in case of not completed request - it polls every 30 seconds.

Release note (ui change): periodically poll for statement diagnostics results if there's 
not completed requests.
 
Resolves: #106154