### PR TITLE
streamingccl: unskip TestStreamDeleteRange

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -111,6 +111,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "//pkg/util/span",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -44,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/jackc/pgx/v4"
@@ -297,6 +297,16 @@ func TestReplicationStreamInitialization(t *testing.T) {
 	})
 }
 
+func spansForTables(db *kv.DB, codec keys.SQLCodec, tables ...string) []roachpb.Span {
+	spans := make([]roachpb.Span, 0, len(tables))
+	for _, table := range tables {
+		desc := desctestutils.TestingGetPublicTableDescriptor(
+			db, codec, "d", table)
+		spans = append(spans, desc.PrimaryIndexSpan(codec))
+	}
+	return spans
+}
+
 func encodeSpec(
 	t *testing.T,
 	h *replicationtestutils.ReplicationHelper,
@@ -305,13 +315,16 @@ func encodeSpec(
 	previousReplicatedTime hlc.Timestamp,
 	tables ...string,
 ) []byte {
-	var spans []roachpb.Span
-	for _, table := range tables {
-		desc := desctestutils.TestingGetPublicTableDescriptor(
-			h.SysServer.DB(), srcTenant.Codec, "d", table)
-		spans = append(spans, desc.PrimaryIndexSpan(srcTenant.Codec))
-	}
+	spans := spansForTables(h.SysServer.DB(), srcTenant.Codec, tables...)
+	return encodeSpecForSpans(t, initialScanTime, previousReplicatedTime, spans)
+}
 
+func encodeSpecForSpans(
+	t *testing.T,
+	initialScanTime hlc.Timestamp,
+	previousReplicatedTime hlc.Timestamp,
+	spans []roachpb.Span,
+) []byte {
 	spec := &streampb.StreamPartitionSpec{
 		InitialScanTimestamp:        initialScanTime,
 		PreviousReplicatedTimestamp: previousReplicatedTime,
@@ -632,23 +645,10 @@ func TestCompleteStreamReplication(t *testing.T) {
 	}
 }
 
-func sortDelRanges(receivedDelRanges []kvpb.RangeFeedDeleteRange) {
-	sort.Slice(receivedDelRanges, func(i, j int) bool {
-		if !receivedDelRanges[i].Timestamp.Equal(receivedDelRanges[j].Timestamp) {
-			return receivedDelRanges[i].Timestamp.Compare(receivedDelRanges[j].Timestamp) < 0
-		}
-		if !receivedDelRanges[i].Span.Key.Equal(receivedDelRanges[j].Span.Key) {
-			return receivedDelRanges[i].Span.Key.Compare(receivedDelRanges[j].Span.Key) < 0
-		}
-		return receivedDelRanges[i].Span.EndKey.Compare(receivedDelRanges[j].Span.EndKey) < 0
-	})
-}
-
 func TestStreamDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 93568)
 	skip.UnderStressRace(t, "disabled under stress and race")
 
 	h, cleanup := replicationtestutils.NewReplicationHelper(t, base.TestServerArgs{
@@ -676,15 +676,46 @@ USE d;
 	replicationProducerSpec := h.StartReplicationStream(t, testTenantName)
 	streamID := replicationProducerSpec.StreamID
 	initialScanTimestamp := replicationProducerSpec.ReplicationStartTime
+	streamResumeTimestamp := h.SysServer.Clock().Now()
 
 	const streamPartitionQuery = `SELECT * FROM crdb_internal.stream_partition($1, $2)`
 	// Only subscribe to table t1 and t2, not t3.
-	source, feed := startReplication(ctx, t, h, makePartitionStreamDecoder,
-		streamPartitionQuery, streamID, encodeSpec(t, h, srcTenant, initialScanTimestamp,
-			hlc.Timestamp{}, "t1", "t2"))
-	defer feed.Close(ctx)
+	// We start the stream at a resume timestamp to avoid any initial scan.
+	spans := spansForTables(h.SysServer.DB(), srcTenant.Codec, "t1", "t2")
+	spec := encodeSpecForSpans(t, initialScanTimestamp, streamResumeTimestamp, spans)
 
-	// TODO(casper): Replace with DROP TABLE once drop table uses the MVCC-compatible DelRange
+	source, feed := startReplication(ctx, t, h, makePartitionStreamDecoder,
+		streamPartitionQuery, streamID, spec)
+	defer feed.Close(ctx)
+	codec := source.mu.codec.(*partitionStreamDecoder)
+
+	// We wait for the frontier to advance because we want to
+	// ensure that we encounter the range deletes during the
+	// rangefeed's steady state rather than the catchup scan.
+	//
+	// The representation of the range deletes we send is slightly
+	// different if we encounter them during the catchup scan.
+	//
+	// NB: It is _still_ possible that we encounter the range
+	// deletes during a catchup scan if we hit a rangefeed restart
+	// during the test.
+	f, err := span.MakeFrontier(spans...)
+	require.NoError(t, err)
+	for f.Frontier().IsEmpty() {
+		t.Logf("waiting for frontier to advance to a non-zero timestamp")
+		source.mu.Lock()
+		source.mu.rows.Next()
+		source.mu.codec.decode()
+		if codec.e.Checkpoint != nil {
+			for _, rs := range codec.e.Checkpoint.ResolvedSpans {
+				_, err := f.Forward(rs.Span, rs.Timestamp)
+				require.NoError(t, err)
+			}
+		}
+		source.mu.Unlock()
+	}
+	t.Logf("frontier advanced to a %s", f.Frontier())
+
 	t1Span, t2Span, t3Span := h.TableSpan(srcTenant.Codec, "t1"),
 		h.TableSpan(srcTenant.Codec, "t2"), h.TableSpan(srcTenant.Codec, "t3")
 	// Range deleted is outside the subscribed spans
@@ -694,30 +725,31 @@ USE d;
 	// Range is t1e - t2sn, emitting t2s - t2sn.
 	require.NoError(t, h.SysServer.DB().DelRangeUsingTombstone(ctx, t1Span.EndKey, t2Span.Key.Next()))
 
-	// Expected DelRange spans after sorting.
-	expectedDelRangeSpan1 := roachpb.Span{Key: t1Span.Key, EndKey: t1Span.EndKey}
-	expectedDelRangeSpan2 := roachpb.Span{Key: t2Span.Key, EndKey: t2Span.EndKey}
-	expectedDelRangeSpan3 := roachpb.Span{Key: t2Span.Key, EndKey: t2Span.Key.Next()}
+	// Expected DelRange events. We store these and the received
+	// del ranges in maps to account for possible duplicate
+	// delivery.
+	expectedDelRanges := make(map[string]struct{})
+	expectedDelRanges[roachpb.Span{Key: t1Span.Key, EndKey: t1Span.EndKey}.String()] = struct{}{}
+	expectedDelRanges[roachpb.Span{Key: t2Span.Key, EndKey: t2Span.EndKey}.String()] = struct{}{}
+	expectedDelRanges[roachpb.Span{Key: t2Span.Key, EndKey: t2Span.Key.Next()}.String()] = struct{}{}
 
-	codec := source.mu.codec.(*partitionStreamDecoder)
-	receivedDelRanges := make([]kvpb.RangeFeedDeleteRange, 0, 3)
+	receivedDelRanges := make(map[string]struct{})
 	for {
 		source.mu.Lock()
 		require.True(t, source.mu.rows.Next())
 		source.mu.codec.decode()
 		if codec.e.Batch != nil {
-			receivedDelRanges = append(receivedDelRanges, codec.e.Batch.DelRanges...)
+			for _, dr := range codec.e.Batch.DelRanges {
+				receivedDelRanges[dr.Span.String()] = struct{}{}
+			}
 		}
 		source.mu.Unlock()
-		if len(receivedDelRanges) == 3 {
+		if len(receivedDelRanges) >= 3 {
 			break
 		}
 	}
 
-	sortDelRanges(receivedDelRanges)
-	require.Equal(t, expectedDelRangeSpan1, receivedDelRanges[0].Span)
-	require.Equal(t, expectedDelRangeSpan2, receivedDelRanges[1].Span)
-	require.Equal(t, expectedDelRangeSpan3, receivedDelRanges[2].Span)
+	require.Equal(t, expectedDelRanges, receivedDelRanges)
 
 	// Adding a SSTable that contains DeleteRange
 	batchHLCTime := h.SysServer.Clock().Now()
@@ -734,17 +766,19 @@ USE d;
 		// Delete range for t3s - t3e, emitting nothing.
 		storageutils.RangeKV(string(t3Span.Key), string(t3Span.EndKey), ts, ""),
 	})
-	expectedDelRange1 := kvpb.RangeFeedDeleteRange{Span: t1Span, Timestamp: batchHLCTime}
-	expectedDelRange2 := kvpb.RangeFeedDeleteRange{Span: t2Span, Timestamp: batchHLCTime}
 	require.Equal(t, t1Span.Key, start)
 	require.Equal(t, t3Span.EndKey, end)
 
+	expectedDelRanges = make(map[string]struct{})
+	expectedDelRanges[t1Span.String()] = struct{}{}
+	expectedDelRanges[t2Span.String()] = struct{}{}
+
 	// Using same batch ts so that this SST can be emitted through rangefeed.
-	_, _, _, err := h.SysServer.DB().AddSSTableAtBatchTimestamp(ctx, start, end, data, false,
+	_, _, _, err = h.SysServer.DB().AddSSTableAtBatchTimestamp(ctx, start, end, data, false,
 		false, hlc.Timestamp{}, nil, false, batchHLCTime)
 	require.NoError(t, err)
 
-	receivedDelRanges = receivedDelRanges[:0]
+	receivedDelRanges = make(map[string]struct{})
 	receivedKVs := make([]roachpb.KeyValue, 0)
 	for {
 		source.mu.Lock()
@@ -753,18 +787,18 @@ USE d;
 		if codec.e.Batch != nil {
 			require.Empty(t, codec.e.Batch.Ssts)
 			receivedKVs = append(receivedKVs, codec.e.Batch.KeyValues...)
-			receivedDelRanges = append(receivedDelRanges, codec.e.Batch.DelRanges...)
+			for _, dr := range codec.e.Batch.DelRanges {
+				receivedDelRanges[dr.Span.String()] = struct{}{}
+			}
 		}
 		source.mu.Unlock()
 
-		if len(receivedDelRanges) == 2 && len(receivedKVs) == 1 {
+		if len(receivedDelRanges) >= 2 && len(receivedKVs) >= 1 {
 			break
 		}
 	}
 
-	sortDelRanges(receivedDelRanges)
 	require.Equal(t, t2Span.Key, receivedKVs[0].Key)
 	require.Equal(t, batchHLCTime, receivedKVs[0].Value.Timestamp)
-	require.Equal(t, expectedDelRange1, receivedDelRanges[0])
-	require.Equal(t, expectedDelRange2, receivedDelRanges[1])
+	require.Equal(t, expectedDelRanges, receivedDelRanges)
 }


### PR DESCRIPTION
This test had previously timed out. The timeout we saw was the result of a couple of issues.

When waiting for all delete ranges, our loop exit condition was very strict. We would only stop looking for rows if the number of delete ranges was exactly 3. If, however, we got 4 delete ranges, with 2 coming in a single batch, we would never hit this condition.

How would that happen though? One possibility are rangefeed duplicates. Another, and what appears to have been happening in this test, is that the representation of the range deletes observed by the rangefeed consumer is slightly different depending on whether the range delete is delivered as part of a catch-up scan or as part of the rangefeeds steady state. I believe this is because the range deletes overlap but are issued at different time points.  When we get them as part of the steady state, we get a trimmed version of the original event. When we get them as part of the catch-up scan, we get them broke up at the point of overlap.

Fixes #93568

Epic: none

Release note: None