### PR TITLE
kvserver: deflake TestMergeQueueSeesNonVoters

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4722,10 +4722,6 @@ func TestMergeQueueSeesNonVoters(t *testing.T) {
 		t.Run(subtest.name, func(t *testing.T) {
 			tc, _ := setupTestClusterWithDummyRange(t, clusterArgs, dbName, "kv", numNodes)
 			defer tc.Stopper().Stop(ctx)
-			// We're controlling merge queue operation via
-			// `store.SetMergeQueueActive`, so enable the cluster setting here.
-			_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING kv.range_merge.queue_enabled=true`)
-			require.NoError(t, err)
 
 			store, err := tc.Server(0).GetStores().(*kvserver.Stores).GetStore(1)
 			require.Nil(t, err)


### PR DESCRIPTION
TestMergeQueueSeesNonVoters was flaky because of a race between turning the merge queue on and off. The merge queue was first turned on via a cluster config, and then turned off using the store directly. However, it's possible for the cluster config to take effect after the queue was turned off via the store and leave the merge queue on for the rest of the test, causing unexpected range merges. The cluster config is actually unnecessary, so this change just removes it.

Fixes: #105726
Epic: CRDB-29164

Release note: None