### PR TITLE
release-23.1: ui: fix timescale for rolling window

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
@@ -19,9 +19,10 @@ import { TestStoreProvider } from "src/test-utils";
 import { StatementDiagnosticsReport } from "../../api";
 import moment from "moment-timezone";
 import { SortedTable } from "src/sortedtable";
+import { TimeScale } from "src/timeScaleDropdown";
 
 const activateDiagnosticsRef = { current: { showModalFor: jest.fn() } };
-const ts = {
+const ts: TimeScale = {
   windowSize: moment.duration(20, "day"),
   sampleSize: moment.duration(5, "minutes"),
   fixedWindowEnd: moment.utc("2023.01.5"),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -851,6 +851,7 @@ export const getStatementDetailsPropsFixture = (
     "3": "gcp-us-west1",
     "4": "gcp-europe-west1",
   },
+  requestTime: moment.utc("2021.12.12"),
   refreshStatementDetails: noop,
   refreshStatementDiagnosticsRequests: noop,
   refreshNodes: noop,
@@ -860,6 +861,7 @@ export const getStatementDetailsPropsFixture = (
   diagnosticsReports: [],
   dismissStatementDiagnosticsAlertMessage: noop,
   onTimeScaleChange: noop,
+  onRequestTimeChange: noop,
   createStatementDiagnosticsReport: noop,
   uiConfig: {
     showStatementDiagnosticsLink: true,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -144,6 +144,7 @@ export interface StatementDetailsDispatchProps {
     ascending: boolean,
   ) => void;
   onBackToStatementsClick?: () => void;
+  onRequestTimeChange: (t: moment.Moment) => void;
 }
 
 export interface StatementDetailsStateProps {
@@ -160,6 +161,7 @@ export interface StatementDetailsStateProps {
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
   hasAdminRole?: UIConfigState["hasAdminRole"];
   statementFingerprintInsights?: StmtInsightEvent[];
+  requestTime: moment.Moment;
 }
 
 export type StatementDetailsOwnProps = StatementDetailsDispatchProps &
@@ -247,12 +249,10 @@ export class StatementDetails extends React.Component<
     this.props.diagnosticsReports.length > 0;
 
   changeTimeScale = (ts: TimeScale): void => {
-    if (ts.key !== "Custom") {
-      ts.fixedWindowEnd = moment();
-    }
     if (this.props.onTimeScaleChange) {
       this.props.onTimeScaleChange(ts);
     }
+    this.props.onRequestTimeChange(moment());
   };
 
   refreshStatementDetails = (): void => {
@@ -701,14 +701,17 @@ export class StatementDetails extends React.Component<
             <TimeScaleDropdown
               options={timeScale1hMinOptions}
               currentScale={this.props.timeScale}
-              setTimeScale={this.props.onTimeScaleChange}
+              setTimeScale={this.changeTimeScale}
             />
           </PageConfigItem>
         </PageConfig>
         <p className={timeScaleStylesCx("time-label", "label-margin")}>
           Showing aggregated stats from{" "}
           <span className={timeScaleStylesCx("bold")}>
-            <FormattedTimescale ts={this.props.timeScale} />
+            <FormattedTimescale
+              ts={this.props.timeScale}
+              requestTime={moment(this.props.requestTime)}
+            />
           </span>
         </p>
         <section className={cx("section")}>
@@ -899,7 +902,10 @@ export class StatementDetails extends React.Component<
         <p className={timeScaleStylesCx("time-label", "label-margin")}>
           Showing explain plans from{" "}
           <span className={timeScaleStylesCx("bold")}>
-            <FormattedTimescale ts={this.props.timeScale} />
+            <FormattedTimescale
+              ts={this.props.timeScale}
+              requestTime={moment(this.props.requestTime)}
+            />
           </span>
         </p>
         <section className={cx("section")}>

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -50,6 +50,7 @@ import {
 } from "src/api";
 import { TimeScale } from "../timeScaleDropdown";
 import { getMatchParamByName, statementAttr } from "src/util";
+import { selectRequestTime } from "src/statementsPage/statementsPage.selectors";
 
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
@@ -76,6 +77,7 @@ const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
     isTenant: selectIsTenant(state),
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
     hasAdminRole: selectHasAdminRole(state),
+    requestTime: selectRequestTime(state),
     statementFingerprintInsights: selectStatementFingerprintInsights(
       state,
       props,
@@ -169,6 +171,14 @@ const mapDispatchToProps = (
         tableName,
       }),
     ),
+  onRequestTimeChange: (t: moment.Moment) => {
+    dispatch(
+      localStorageActions.update({
+        key: "requestTime/StatementsPage",
+        value: t,
+      }),
+    );
+  },
   onBackToStatementsClick: () =>
     dispatch(
       analyticsActions.track({

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -572,6 +572,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     ascending: false,
     columnTitle: "executionCount",
   },
+  requestTime: moment.utc("2021.12.12"),
   search: "",
   filters: {
     app: "",
@@ -621,6 +622,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   onChangeLimit: noop,
   onChangeReqSort: noop,
   onApplySearchCriteria: noop,
+  onRequestTimeChange: noop,
 };
 
 export const statementsPagePropsWithRequestError: StatementsPageProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -86,6 +86,11 @@ export const selectSortSetting = createSelector(
   localStorage => localStorage["sortSetting/StatementsPage"],
 );
 
+export const selectRequestTime = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["requestTime/StatementsPage"],
+);
+
 export const selectFilters = createSelector(
   localStorageSelector,
   localStorage => localStorage["filters/StatementsPage"],

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -128,6 +128,7 @@ export interface StatementsPageDispatchProps {
   onChangeLimit: (limit: number) => void;
   onChangeReqSort: (sort: SqlStatsSortType) => void;
   onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) => void;
+  onRequestTimeChange: (t: moment.Moment) => void;
 }
 export interface StatementsPageStateProps {
   statements: AggregateStatistics[];
@@ -150,6 +151,7 @@ export interface StatementsPageStateProps {
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
   hasAdminRole?: UIConfigState["hasAdminRole"];
   stmtsTotalRuntimeSecs: number;
+  requestTime: moment.Moment;
 }
 
 export interface StatementsPageState {
@@ -285,9 +287,6 @@ export class StatementsPage extends React.Component<
   };
 
   changeTimeScale = (ts: TimeScale): void => {
-    if (ts.key !== "Custom") {
-      ts.fixedWindowEnd = moment();
-    }
     this.setState(prevState => ({
       ...prevState,
       timeScale: ts,
@@ -303,8 +302,6 @@ export class StatementsPage extends React.Component<
       this.props.onChangeReqSort(this.state.reqSortSetting);
     }
 
-    // Force an update on TimeScale to update the fixedWindowEnd
-    this.changeTimeScale(this.state.timeScale);
     if (this.props.timeScale !== this.state.timeScale) {
       this.props.onTimeScaleChange(this.state.timeScale);
     }
@@ -315,6 +312,7 @@ export class StatementsPage extends React.Component<
         getSortLabel(this.state.reqSortSetting, "Statement"),
       );
     }
+    this.props.onRequestTimeChange(moment());
     this.refreshStatements();
     const ss: SortSetting = {
       ascending: false,
@@ -610,7 +608,12 @@ export class StatementsPage extends React.Component<
       isSelectedColumn(userSelectedColumnsToShow, c),
     );
 
-    const period = <FormattedTimescale ts={this.props.timeScale} />;
+    const period = (
+      <FormattedTimescale
+        ts={this.props.timeScale}
+        requestTime={moment(this.props.requestTime)}
+      />
+    );
     const sortSettingLabel = getSortLabel(
       this.props.reqSortSetting,
       "Statement",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -39,6 +39,7 @@ import {
   selectFilters,
   selectSearch,
   selectStatementsLastUpdated,
+  selectRequestTime,
 } from "./statementsPage.selectors";
 import {
   selectTimeScale,
@@ -110,6 +111,7 @@ export const ConnectedStatementsPage = withRouter(
         lastUpdated: selectStatementsLastUpdated(state),
         statementsError: selectStatementsLastError(state),
         limit: selectStmtsPageLimit(state),
+        requestTime: selectRequestTime(state),
         reqSortSetting: selectStmtsPageReqSort(state),
         stmtsTotalRuntimeSecs:
           state.adminUI?.statements?.data?.stmts_total_runtime_secs ?? 0,
@@ -230,6 +232,14 @@ export const ConnectedStatementsPage = withRouter(
             localStorageActions.update({
               key: "sortSetting/StatementsPage",
               value: { columnTitle: columnName, ascending: ascending },
+            }),
+          );
+        },
+        onRequestTimeChange: (t: moment.Moment) => {
+          dispatch(
+            localStorageActions.update({
+              key: "requestTime/StatementsPage",
+              value: t,
             }),
           );
         },

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -82,6 +82,8 @@ export type LocalStorageState = {
   "statusSetting/JobsPage": string;
   "showSetting/JobsPage": string;
   [LocalStorageKeys.DB_DETAILS_VIEW_MODE]: ViewMode;
+  "requestTime/StatementsPage": moment.Moment;
+  "requestTime/TransactionsPage": moment.Moment;
 };
 
 type Payload = {
@@ -273,6 +275,8 @@ const initialState: LocalStorageState = {
   [LocalStorageKeys.DB_DETAILS_VIEW_MODE]:
     JSON.parse(localStorage.getItem(LocalStorageKeys.DB_DETAILS_VIEW_MODE)) ||
     defaultDatabaseDetailsViewMode,
+  "requestTime/StatementsPage": null,
+  "requestTime/TransactionsPage": null,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/formattedTimeScale.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/formattedTimeScale.tsx
@@ -16,7 +16,10 @@ import { toRoundedDateRange } from "./utils";
 import { TimeScale } from "./timeScaleTypes";
 import { Timezone } from "src/timestamp";
 
-export const FormattedTimescale = (props: { ts: TimeScale }) => {
+export const FormattedTimescale = (props: {
+  ts: TimeScale;
+  requestTime?: moment.Moment;
+}) => {
   const timezone = useContext(TimezoneContext);
 
   const [start, end] = toRoundedDateRange(props.ts);
@@ -30,8 +33,8 @@ export const FormattedTimescale = (props: { ts: TimeScale }) => {
     omitDayFormat || startEndOnSameDay ? "" : endTz.format(dateFormat);
   const timeStart = startTz.format(timeFormat);
   const timeEnd =
-    props.ts.key !== "Custom" && props.ts.fixedWindowEnd
-      ? props.ts.fixedWindowEnd.tz(timezone).format(timeFormat)
+    props.ts.key !== "Custom" && props.requestTime?.isValid()
+      ? props.requestTime.tz(timezone).format(timeFormat)
       : endTz.format(timeFormat);
 
   return (

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -117,6 +117,7 @@ export interface TransactionDetailsStateProps {
   transactionInsights: TxnInsightEvent[];
   hasAdminRole?: UIConfigState["hasAdminRole"];
   isDataValid: boolean;
+  requestTime: moment.Moment;
 }
 
 export interface TransactionDetailsDispatchProps {
@@ -125,6 +126,7 @@ export interface TransactionDetailsDispatchProps {
   refreshUserSQLRoles: () => void;
   refreshTransactionInsights: (req: TxnInsightsRequest) => void;
   onTimeScaleChange: (ts: TimeScale) => void;
+  onRequestTimeChange: (t: moment.Moment) => void;
 }
 
 export type TransactionDetailsProps = TransactionDetailsStateProps &
@@ -209,12 +211,10 @@ export class TransactionDetails extends React.Component<
   };
 
   changeTimeScale = (ts: TimeScale): void => {
-    if (ts.key !== "Custom") {
-      ts.fixedWindowEnd = moment();
-    }
     if (this.props.onTimeScaleChange) {
       this.props.onTimeScaleChange(ts);
     }
+    this.props.onRequestTimeChange(moment());
   };
 
   refreshData = (): void => {
@@ -291,7 +291,12 @@ export class TransactionDetails extends React.Component<
     const { latestTransactionText } = this.state;
     const statementsForTransaction = this.getStatementsForTransaction();
     const transactionStats = transaction?.stats_data?.stats;
-    const period = <FormattedTimescale ts={this.props.timeScale} />;
+    const period = (
+      <FormattedTimescale
+        ts={this.props.timeScale}
+        requestTime={moment(this.props.requestTime)}
+      />
+    );
 
     return (
       <div>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
@@ -12,7 +12,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { Dispatch } from "redux";
-
+import { actions as localStorageActions } from "src/store/localStorage";
 import { AppState, uiConfigActions } from "src/store";
 import { actions as nodesActions } from "../store/nodes";
 import { actions as sqlStatsActions } from "src/store/sqlStats";
@@ -53,6 +53,7 @@ import {
 } from "../util";
 import { TimeScale } from "../timeScaleDropdown";
 import { actions as analyticsActions } from "../store/analytics";
+import { selectRequestTime } from "src/transactionsPage/transactionsPage.selectors";
 
 export const selectTransaction = createSelector(
   (state: AppState) => state.adminUI?.transactions,
@@ -119,6 +120,7 @@ const mapStateToProps = (
     isDataValid: isValid,
     limit: selectTxnsPageLimit(state),
     reqSortSetting: selectTxnsPageReqSort(state),
+    requestTime: selectRequestTime(state),
   };
 };
 
@@ -145,6 +147,14 @@ const mapDispatchToProps = (
   },
   refreshTransactionInsights: (req: TxnInsightsRequest) => {
     dispatch(transactionInsights.refresh(req));
+  },
+  onRequestTimeChange: (t: moment.Moment) => {
+    dispatch(
+      localStorageActions.update({
+        key: "requestTime/StatementsPage",
+        value: t,
+      }),
+    );
   },
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
@@ -52,6 +52,11 @@ export const selectSortSetting = createSelector(
   localStorage => localStorage["sortSetting/TransactionsPage"],
 );
 
+export const selectRequestTime = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["requestTime/TransactionsPage"],
+);
+
 export const selectFilters = createSelector(
   localStorageSelector,
   localStorage => localStorage["filters/TransactionsPage"],

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -113,6 +113,7 @@ export interface TransactionsPageStateProps {
   search: string;
   sortSetting: SortSetting;
   hasAdminRole?: UIConfigState["hasAdminRole"];
+  requestTime: moment.Moment;
 }
 
 export interface TransactionsPageDispatchProps {
@@ -132,6 +133,7 @@ export interface TransactionsPageDispatchProps {
     ascending: boolean,
   ) => void;
   onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) => void;
+  onRequestTimeChange: (t: moment.Moment) => void;
 }
 
 export type TransactionsPageProps = TransactionsPageStateProps &
@@ -387,9 +389,6 @@ export class TransactionsPage extends React.Component<
   };
 
   changeTimeScale = (ts: TimeScale): void => {
-    if (ts.key !== "Custom") {
-      ts.fixedWindowEnd = moment();
-    }
     this.setState(prevState => ({ ...prevState, timeScale: ts }));
   };
 
@@ -410,8 +409,6 @@ export class TransactionsPage extends React.Component<
       this.props.onChangeReqSort(this.state.reqSortSetting);
     }
 
-    // Force an update on TimeScale to update the fixedWindowEnd
-    this.changeTimeScale(this.state.timeScale);
     if (this.props.timeScale !== this.state.timeScale) {
       this.props.onTimeScaleChange(this.state.timeScale);
     }
@@ -423,6 +420,7 @@ export class TransactionsPage extends React.Component<
         getSortLabel(this.state.reqSortSetting, "Transaction"),
       );
     }
+    this.props.onRequestTimeChange(moment());
     this.refreshData();
     const ss: SortSetting = {
       ascending: false,
@@ -539,7 +537,12 @@ export class TransactionsPage extends React.Component<
       isSelectedColumn(userSelectedColumnsToShow, c),
     );
 
-    const period = <FormattedTimescale ts={this.props.timeScale} />;
+    const period = (
+      <FormattedTimescale
+        ts={this.props.timeScale}
+        requestTime={moment(this.props.requestTime)}
+      />
+    );
     const sortSettingLabel = getSortLabel(
       this.props.reqSortSetting,
       "Transaction",

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -30,6 +30,7 @@ import {
   selectTransactionsDataValid,
   selectTransactionsLastUpdated,
   selectTransactionsDataInFlight,
+  selectRequestTime,
 } from "./transactionsPage.selectors";
 import { selectHasAdminRole, selectIsTenant } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
@@ -95,6 +96,7 @@ export const TransactionsPageConnected = withRouter(
         hasAdminRole: selectHasAdminRole(state),
         limit: selectTxnsPageLimit(state),
         reqSortSetting: selectTxnsPageReqSort(state),
+        requestTime: selectRequestTime(state),
       },
       activePageProps: mapStateToRecentTransactionsPageProps(state),
     }),
@@ -181,6 +183,14 @@ export const TransactionsPageConnected = withRouter(
               sortValue: sort,
             }),
           ),
+        onRequestTimeChange: (t: moment.Moment) => {
+          dispatch(
+            localStorageActions.update({
+              key: "requestTime/StatementsPage",
+              value: t,
+            }),
+          );
+        },
       },
       activePageProps: mapDispatchToRecentTransactionsPageProps(dispatch),
     }),

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -53,6 +53,7 @@ import { appNamesAttr, statementAttr } from "src/util/constants";
 import { selectTimeScale } from "src/redux/timeScale";
 import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 import moment from "moment-timezone";
+import { requestTimeLocalSetting } from "./statementsPage";
 
 const { generateStmtDetailsToID } = util;
 
@@ -133,6 +134,7 @@ const mapStateToProps = (
     ),
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
     hasAdminRole: selectHasAdminRole(state),
+    requestTime: requestTimeLocalSetting.selector(state),
     statementFingerprintInsights: selectStatementFingerprintInsights(
       state,
       props,
@@ -158,6 +160,7 @@ const mapDispatchToProps: StatementDetailsDispatchProps = {
   },
   onTabChanged: trackStatementDetailsSubnavSelectionAction,
   onTimeScaleChange: setGlobalTimeScaleAction,
+  onRequestTimeChange: (t: moment.Moment) => requestTimeLocalSetting.set(t),
   onDiagnosticBundleDownload: trackDownloadDiagnosticsBundleAction,
   onDiagnosticCancelRequest: (
     report: clusterUiApi.StatementDiagnosticsReport,

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -121,6 +121,12 @@ export const sortSettingLocalSetting = new LocalSetting(
   { ascending: false, columnTitle: "executionCount" },
 );
 
+export const requestTimeLocalSetting = new LocalSetting(
+  "requestTime/StatementsPage",
+  (state: AdminUIState) => state.localSettings,
+  null,
+);
+
 export const filtersLocalSetting = new LocalSetting<AdminUIState, Filters>(
   "filters/StatementsPage",
   (state: AdminUIState) => state.localSettings,
@@ -183,6 +189,7 @@ const fingerprintsPageActions = {
       ascending: ascending,
       columnTitle: columnName,
     }),
+  onRequestTimeChange: (t: moment.Moment) => requestTimeLocalSetting.set(t),
   onFilterChange: (filters: Filters) => filtersLocalSetting.set(filters),
   onSelectDiagnosticsReportDropdownOption: (
     report: clusterUiApi.StatementDiagnosticsReport,
@@ -247,6 +254,7 @@ export default withRouter(
         isReqInFlight: selectStatementsDataInFlight(state),
         lastUpdated: selectStatementsLastUpdated(state),
         statementsError: state.cachedData.statements.lastError,
+        requestTime: requestTimeLocalSetting.selector(state),
         hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
         hasAdminRole: selectHasAdminRole(state),
         limit: limitSetting.selector(state),

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
@@ -26,6 +26,7 @@ import {
   selectData,
   selectLastError,
   limitSetting,
+  requestTimeLocalSetting,
 } from "src/views/transactions/transactionsPage";
 import {
   TransactionDetailsStateProps,
@@ -103,6 +104,7 @@ export default withRouter(
         isDataValid: isValid,
         limit: limitSetting.selector(state),
         reqSortSetting: reqSortSetting.selector(state),
+        requestTime: requestTimeLocalSetting.selector(state),
       };
     },
     {
@@ -111,6 +113,7 @@ export default withRouter(
       refreshUserSQLRoles,
       onTimeScaleChange: setGlobalTimeScaleAction,
       refreshTransactionInsights: refreshTxnInsights,
+      onRequestTimeChange: (t: moment.Moment) => requestTimeLocalSetting.set(t),
     },
   )(TransactionDetails),
 );

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -86,6 +86,12 @@ export const sortSettingLocalSetting = new LocalSetting(
   { ascending: false, columnTitle: "executionCount" },
 );
 
+export const requestTimeLocalSetting = new LocalSetting(
+  "requestTime/TransactionsPage",
+  (state: AdminUIState) => state.localSettings,
+  null,
+);
+
 export const filtersLocalSetting = new LocalSetting<AdminUIState, Filters>(
   "filters/TransactionsPage",
   (state: AdminUIState) => state.localSettings,
@@ -144,6 +150,7 @@ const fingerprintsPageActions = {
   onChangeLimit: (newLimit: number) => limitSetting.set(newLimit),
   onChangeReqSort: (sort: api.SqlStatsSortType) => reqSortSetting.set(sort),
   onApplySearchCriteria: trackApplySearchCriteriaAction,
+  onRequestTimeChange: (t: moment.Moment) => requestTimeLocalSetting.set(t),
 };
 
 type StateProps = {
@@ -182,6 +189,7 @@ const TransactionsPageConnected = withRouter(
         hasAdminRole: selectHasAdminRole(state),
         limit: limitSetting.selector(state),
         reqSortSetting: reqSortSetting.selector(state),
+        requestTime: requestTimeLocalSetting.selector(state),
       },
       activePageProps: mapStateToRecentTransactionsPageProps(state),
     }),


### PR DESCRIPTION
Backport 1/1 commits from #106623.

/cc @cockroachdb/release

---

The change introduced on #105157 had an undesired
change on the Metrics page. We want to show the end period
of the select, but when the fixed window end for that this
caused the Metrics page to stop loading new data.
We want the metrics page to keep updating when any of the
rolling windows is selected, and we also want to know
the time a time period was requested, so it can be used
to provide more information on SQL Activity pages.

This commit remove the setting of the fixedWindowEnd, since
that was not the best approach and instead creates a value
on local storage for the requestTime, that can be used to create
the label for the timescale, without interferring on
Metrics page (or any other that have an automatic update).

Epic: none

Release note (bug fix): Fix the Metrics page that was not
updating automatically on rolling window options.

Release note (bug fix): Statement Diagnostics not always 
showing is now fixed and they show for the correct time period selected.

---

Release justification: bug fix
