### PR TITLE
tenantcostclient: tighten query RU estimate test

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
@@ -130,6 +130,10 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 			sql:   "SELECT 'deadbeef' FROM generate_series(1, 50000)",
 			count: 10,
 		},
+		{ // Delete (this also ensures that two runs work with the same dataset)
+			sql:   "DELETE FROM abcd WHERE true",
+			count: 1,
+		},
 	}
 
 	var err error
@@ -191,12 +195,7 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 	// Check the estimated RU aggregate for all the queries against the actual
 	// measured RU consumption for the tenant.
 	tenantMeasuredRUs = getTenantRUs() - tenantStartRUs
-	// Usually, the difference is within 0.25 delta, but in rare cases it can be
-	// outside of that delta (when ran on the gceworker, it was outside the 0.5
-	// delta within 6 minutes of stressing), so we allow for generous 0.75
-	// delta. This still provides a good enough sanity check for the RU
-	// estimation.
-	const deltaFraction = 0.75
+	const deltaFraction = 0.05
 	allowedDelta := tenantMeasuredRUs * deltaFraction
 	require.InDeltaf(t, tenantMeasuredRUs, tenantEstimatedRUs, allowedDelta,
 		"estimated RUs (%d) were not within %f RUs of the expected value (%f)",


### PR DESCRIPTION
The query RU estimate test involves two runs of test queries:
- via EXPLAIN ANALYZE to get the RU estimate
- "vanilla" way and getting the precise RU usage.

One of the test queries is a large INSERT, and previously we didn't delete the data after the first run. As a result, the second run would operate on 2x size of the data set. This commit fixes that oversight by including a DELETE query into the test query set which allows us to tighten the delta margin from 0.75 to 0.05 (got no failures in over 1k runs with 0.05 now).

Epic: None

Release note: None