### PR TITLE
storage: Add range key buffering to MultiSSTWriter

### DIFF
--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -12,6 +12,7 @@ package kvserver
 
 import (
 	"context"
+	"fmt"
 	io "io"
 	"path/filepath"
 	"strconv"
@@ -251,6 +252,128 @@ func TestSSTSnapshotStorageContextCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestMultiSSTWriterBuffer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	testRangeID := roachpb.RangeID(1)
+	testSnapUUID := uuid.Must(uuid.FromBytes([]byte("foobar1234567890")))
+	testLimiter := rate.NewLimiter(rate.Inf, 0)
+
+	cleanup, eng := newOnDiskEngine(ctx, t)
+	defer cleanup()
+	defer eng.Close()
+
+	sstSnapshotStorage := NewSSTSnapshotStorage(eng, testLimiter)
+	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
+
+	snapStrategy := kvBatchSnapshotStrategy{
+		scratch: scratch,
+		st:      cluster.MakeTestingClusterSettings(),
+	}
+
+	clearSpan := func(ctx context.Context, span roachpb.Span, w *storage.MultiSSTWriter) error {
+		// Clear all existing replica state, including both point keys and range keys.
+		if err := w.PutRangeDel(ctx, span.Key, span.EndKey); err != nil {
+			return err
+		}
+		if err := w.PutRangeKeyDel(ctx, span.Key, span.EndKey); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	keySpans := []roachpb.Span{
+		{Key: []byte("a"), EndKey: []byte("c")},
+		{Key: []byte("d"), EndKey: []byte("e")},
+		//{Key: []byte("f"), EndKey: []byte("h")},
+	}
+	msstw, err := storage.NewMultiSSTWriter(ctx, snapStrategy.CreateNewSSTWriter, clearSpan, keySpans, 128<<20)
+	require.NoError(t, err)
+	_, err = msstw.Finish(ctx)
+	require.NoError(t, err)
+
+	for i, m := range msstw.TableMetadata() {
+		fmt.Printf("Table %d\n", i+1)
+		fmt.Printf("Smallest Point Key: %d\n", m.SmallestPoint)
+		fmt.Printf("Largest Point Key: %d\n", m.LargestPoint)
+		fmt.Printf("Point keys: %d\n", m.Properties.NumEntries-1)
+		fmt.Printf("Smallest Range Key: %d\n", m.SmallestRangeKey)
+		fmt.Printf("Largest Range Key: %d\n", m.LargestRangeKey)
+		fmt.Printf("Range key sets: %d\n", m.Properties.NumRangeKeySets)
+		fmt.Printf("Range deletes: %d\n", m.Properties.NumRangeDeletions)
+	}
+
+	//var err error
+
+	//datadriven.RunTest(t, "testdata/multi_sst_writer", func(t *testing.T, td *datadriven.TestData) string {
+	//	switch td.Cmd {
+	//	case "init":
+	//		keySpans = []roachpb.Span{}
+	//		for _, line := range strings.Split(td.Input, "\n") {
+	//			parts := strings.Fields(line)
+	//			keySpans = append(keySpans, roachpb.Span{Key: []byte(parts[0]), EndKey: []byte(parts[1])})
+	//		}
+	//		msstw, err = storage.NewMultiSSTWriter(ctx, snapStrategy.CreateNewSSTWriter, clearSpan, keySpans, 128<<20)
+	//		require.NoError(t, err)
+	//		return fmt.Sprintf("Initialized writer with %d keyspans.", len(keySpans))
+	//	case "finish":
+	//		showRange := len(td.CmdArgs) > 0 && td.CmdArgs[0].Key == "show-range-sets"
+	//		_, err := msstw.Finish(ctx)
+	//		require.NoError(t, err)
+	//		var b strings.Builder
+	//		for i, m := range msstw.TableMetadata() {
+	//			fmt.Fprintf(&b, "Table %d\n", i+1)
+	//			fmt.Fprintf(&b, "Smallest Point Key: %d\n", m.SmallestPoint)
+	//			fmt.Fprintf(&b, "Largest Point Key: %d\n", m.LargestPoint)
+	//			fmt.Fprintf(&b, "Point keys: %d\n", m.Properties.NumEntries-1)
+	//			if showRange {
+	//				fmt.Fprintf(&b, "Smallest Range Key: %d\n", m.SmallestRangeKey)
+	//				fmt.Fprintf(&b, "Largest Range Key: %d\n", m.LargestRangeKey)
+	//				fmt.Fprintf(&b, "Range key sets: %d\n", m.Properties.NumRangeKeySets)
+	//				fmt.Fprintf(&b, "Range key deletes: %d\n", m.Properties.NumRangeKeyDels)
+	//				fmt.Fprintf(&b, "Range deletes: %d\n", m.Properties.NumRangeDeletions)
+	//			}
+	//		}
+	//		return b.String()
+	//	case "write":
+	//		for _, line := range strings.Split(td.Input, "\n") {
+	//			parts := strings.Fields(line)
+	//			if len(parts) == 0 {
+	//				continue
+	//			}
+	//			if len(parts) == 1 {
+	//				// point key
+	//				key := storage.EngineKey{Key: []byte(parts[0])}
+	//				err := msstw.Put(ctx, key, []byte{})
+	//				require.NoError(t, err)
+	//			} else {
+	//				// range key
+	//				start := []byte(parts[0])
+	//				end := []byte(parts[1])
+	//				suffix := storage.EncodeMVCCTimestampSuffix(hlc.Timestamp{WallTime: time})
+	//				value, err := storage.EncodeMVCCValue(storage.MVCCValue{
+	//					MVCCValueHeader: enginepb.MVCCValueHeader{
+	//						LocalTimestamp: hlc.ClockTimestamp{WallTime: time},
+	//					},
+	//				})
+	//				time++
+	//				require.NoError(t, err)
+	//				err = msstw.PutRangeKey(ctx, start, end, suffix, value)
+	//				require.NoError(t, err)
+	//			}
+	//		}
+	//		return ""
+	//	case "close":
+	//		msstw.Close()
+	//	default:
+	//		return "unknown command"
+	//	}
+	//	return ""
+	//})
+}
+
 // TestMultiSSTWriterInitSST tests that multiSSTWriter initializes each of the
 // SST files associated with the replicated key ranges by writing a range
 // deletion tombstone that spans the entire range of each respectively.
@@ -280,7 +403,18 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 		st:      cluster.MakeTestingClusterSettings(),
 	}
 
-	msstw, err := storage.NewMultiSSTWriter(ctx, snapStrategy.CreateNewSSTWriter, keySpans)
+	clearSpan := func(ctx context.Context, span roachpb.Span, w *storage.MultiSSTWriter) error {
+		// Clear all existing replica state, including both point keys and range keys.
+		if err := w.PutRangeDel(ctx, span.Key, span.EndKey); err != nil {
+			return err
+		}
+		if err := w.PutRangeKeyDel(ctx, span.Key, span.EndKey); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	msstw, err := storage.NewMultiSSTWriter(ctx, snapStrategy.CreateNewSSTWriter, clearSpan, keySpans, 128<<20)
 	require.NoError(t, err)
 	_, err = msstw.Finish(ctx)
 	require.NoError(t, err)

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -169,136 +169,6 @@ type kvBatchSnapshotStrategy struct {
 	st      *cluster.Settings
 }
 
-// multiSSTWriter is a wrapper around an SSTWriter and SSTSnapshotStorageScratch
-// that handles chunking SSTs and persisting them to disk.
-type multiSSTWriter struct {
-	st       *cluster.Settings
-	scratch  *SSTSnapshotStorageScratch
-	currSST  storage.SSTWriter
-	keySpans []roachpb.Span
-	currSpan int
-	// The approximate size of the SST chunk to buffer in memory on the receiver
-	// before flushing to disk.
-	sstChunkSize int64
-	// The total size of SST data. Updated on SST finalization.
-	dataSize int64
-}
-
-func newMultiSSTWriter(
-	ctx context.Context,
-	st *cluster.Settings,
-	scratch *SSTSnapshotStorageScratch,
-	keySpans []roachpb.Span,
-	sstChunkSize int64,
-) (multiSSTWriter, error) {
-	msstw := multiSSTWriter{
-		st:           st,
-		scratch:      scratch,
-		keySpans:     keySpans,
-		sstChunkSize: sstChunkSize,
-	}
-	if err := msstw.initSST(ctx); err != nil {
-		return msstw, err
-	}
-	return msstw, nil
-}
-
-func (msstw *multiSSTWriter) initSST(ctx context.Context) error {
-	newSSTFile, err := msstw.scratch.NewFile(ctx, msstw.sstChunkSize)
-	if err != nil {
-		return errors.Wrap(err, "failed to create new sst file")
-	}
-	newSST := storage.MakeIngestionSSTWriter(ctx, msstw.st, newSSTFile)
-	msstw.currSST = newSST
-	if err := msstw.currSST.ClearRawRange(
-		msstw.keySpans[msstw.currSpan].Key, msstw.keySpans[msstw.currSpan].EndKey,
-		true /* pointKeys */, true, /* rangeKeys */
-	); err != nil {
-		msstw.currSST.Close()
-		return errors.Wrap(err, "failed to clear range on sst file writer")
-	}
-	return nil
-}
-
-func (msstw *multiSSTWriter) finalizeSST(ctx context.Context) error {
-	err := msstw.currSST.Finish()
-	if err != nil {
-		return errors.Wrap(err, "failed to finish sst")
-	}
-	msstw.dataSize += msstw.currSST.DataSize
-	msstw.currSpan++
-	msstw.currSST.Close()
-	return nil
-}
-
-func (msstw *multiSSTWriter) Put(ctx context.Context, key storage.EngineKey, value []byte) error {
-	for msstw.keySpans[msstw.currSpan].EndKey.Compare(key.Key) <= 0 {
-		// Finish the current SST, write to the file, and move to the next key
-		// range.
-		if err := msstw.finalizeSST(ctx); err != nil {
-			return err
-		}
-		if err := msstw.initSST(ctx); err != nil {
-			return err
-		}
-	}
-	if msstw.keySpans[msstw.currSpan].Key.Compare(key.Key) > 0 {
-		return errors.AssertionFailedf("client error: expected %s to fall in one of %s", key.Key, msstw.keySpans)
-	}
-	if err := msstw.currSST.PutEngineKey(key, value); err != nil {
-		return errors.Wrap(err, "failed to put in sst")
-	}
-	return nil
-}
-
-func (msstw *multiSSTWriter) PutRangeKey(
-	ctx context.Context, start, end roachpb.Key, suffix []byte, value []byte,
-) error {
-	if start.Compare(end) >= 0 {
-		return errors.AssertionFailedf("start key %s must be before end key %s", end, start)
-	}
-	for msstw.keySpans[msstw.currSpan].EndKey.Compare(start) <= 0 {
-		// Finish the current SST, write to the file, and move to the next key
-		// range.
-		if err := msstw.finalizeSST(ctx); err != nil {
-			return err
-		}
-		if err := msstw.initSST(ctx); err != nil {
-			return err
-		}
-	}
-	if msstw.keySpans[msstw.currSpan].Key.Compare(start) > 0 ||
-		msstw.keySpans[msstw.currSpan].EndKey.Compare(end) < 0 {
-		return errors.AssertionFailedf("client error: expected %s to fall in one of %s",
-			roachpb.Span{Key: start, EndKey: end}, msstw.keySpans)
-	}
-	if err := msstw.currSST.PutEngineRangeKey(start, end, suffix, value); err != nil {
-		return errors.Wrap(err, "failed to put range key in sst")
-	}
-	return nil
-}
-
-func (msstw *multiSSTWriter) Finish(ctx context.Context) (int64, error) {
-	if msstw.currSpan < len(msstw.keySpans) {
-		for {
-			if err := msstw.finalizeSST(ctx); err != nil {
-				return 0, err
-			}
-			if msstw.currSpan >= len(msstw.keySpans) {
-				break
-			}
-			if err := msstw.initSST(ctx); err != nil {
-				return 0, err
-			}
-		}
-	}
-	return msstw.dataSize, nil
-}
-
-func (msstw *multiSSTWriter) Close() {
-	msstw.currSST.Close()
-}
-
 // snapshotTimingTag represents a lazy tracing span tag containing information
 // on how long individual parts of a snapshot take. Individual stopwatches can
 // be added to a snapshotTimingTag.
@@ -358,6 +228,18 @@ func (tag *snapshotTimingTag) Render() []attribute.KeyValue {
 	return tags
 }
 
+// CreateNewSSTWriter creates a new SSTWriter to be used by storage.MultiSSTWriter.
+func (kvSS *kvBatchSnapshotStrategy) CreateNewSSTWriter(
+	ctx context.Context,
+) (storage.SSTWriter, error) {
+	newSSTFile, err := kvSS.scratch.NewFile(ctx, kvSS.sstChunkSize)
+	if err != nil {
+		return storage.SSTWriter{}, err
+	}
+	writer := storage.MakeIngestionSSTWriter(ctx, kvSS.st, newSSTFile)
+	return writer, nil
+}
+
 // Receive implements the snapshotStrategy interface.
 //
 // NOTE: This function assumes that the point and range (e.g. MVCC range
@@ -410,7 +292,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 	// At the moment we'll write at most five SSTs.
 	// TODO(jeffreyxiao): Re-evaluate as the default range size grows.
 	keyRanges := rditer.MakeReplicatedKeySpans(header.State.Desc)
-	msstw, err := newMultiSSTWriter(ctx, kvSS.st, kvSS.scratch, keyRanges, kvSS.sstChunkSize)
+	msstw, err := storage.NewMultiSSTWriter(ctx, kvSS.CreateNewSSTWriter, keyRanges)
 	if err != nil {
 		return noSnap, err
 	}

--- a/pkg/kv/kvserver/testdata/multi_sst_writer
+++ b/pkg/kv/kvserver/testdata/multi_sst_writer
@@ -1,0 +1,16 @@
+
+init
+a c
+d e
+f h
+----
+Initialized writer with 3 keyspans.
+
+finish
+----
+Table 1
+Point keys: 0
+Table 2
+Point keys: 0
+Table 3
+Point keys: 0

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "intent_interleaving_iter.go",
         "intent_reader_writer.go",
         "min_version.go",
+        "multi_sst_writer.go",
         "mvcc.go",
         "mvcc_incremental_iterator.go",
         "mvcc_key.go",

--- a/pkg/storage/multi_sst_writer.go
+++ b/pkg/storage/multi_sst_writer.go
@@ -1,6 +1,4 @@
-package storage
-
-// Copyright 2018 The Cockroach Authors.
+// Copyright 2023 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -10,131 +8,295 @@ package storage
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+package storage
+
 import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/rangekey"
+	"github.com/cockroachdb/pebble/sstable"
 )
 
-// multiSSTWriter is a wrapper around an SSTWriter and SSTSnapshotStorageScratch
-// that handles chunking SSTs and persisting them to disk.
-type multiSSTWriter struct {
+// MultiSSTWriter may be used to construct a series of non-overlapping sstables
+// from a stream of keys. The user may specify a set of fixed boundaries such
+// that no sstable produced will span the boundaries.
+type MultiSSTWriter struct {
 	// It is up to the caller to provide an SSTWriter to be used for creating a new file.
 	getNewSSTFile func(ctx context.Context) (SSTWriter, error)
+	onEnterSpan   func(ctsx context.Context, span roachpb.Span, writer *MultiSSTWriter) error
 	currSST       SSTWriter
 	keySpans      []roachpb.Span
 	currSpan      int
 	// The total size of SST data. Updated on SST finalization.
-	dataSize int64
+	dataSize      int64
+	tableMetadata []*sstable.WriterMetadata
+	// Used for fragmenting range keys.
+	rangeKeyFrag rangekey.Fragmenter
+	// Used for fragmenting range deletes.
+	rangeDelFrag rangekey.Fragmenter
+	// The max size of a sstable file.
+	maxSize int64
+	err     error
 }
 
 func NewMultiSSTWriter(
 	ctx context.Context,
 	getNewSSTFile func(ctx context.Context) (SSTWriter, error),
+	onEnterSpan func(ctx context.Context, span roachpb.Span, w *MultiSSTWriter) error,
 	keySpans []roachpb.Span,
-) (multiSSTWriter, error) {
-	msstw := multiSSTWriter{
+	maxSize int64,
+) (MultiSSTWriter, error) {
+	if len(keySpans) == 0 {
+		return MultiSSTWriter{}, errors.New("Cannot call NewMultiSSTWriter without any key spans.")
+	}
+
+	msstw := MultiSSTWriter{
 		getNewSSTFile: getNewSSTFile,
 		keySpans:      keySpans,
+		maxSize:       maxSize,
+		onEnterSpan:   onEnterSpan,
 	}
+	msstw.rangeKeyFrag = rangekey.Fragmenter{
+		Cmp:    EngineComparer.Compare,
+		Format: EngineComparer.FormatKey,
+		Emit: func(span rangekey.Span) {
+			// Once a span is emitted we can write all of its keys as we are guaranteed that there will be no overlap.
+			for _, key := range span.Keys {
+				if err := msstw.currSST.PutEngineRangeKey(span.Start, span.End, key.Suffix, key.Value); err != nil {
+					msstw.err = err
+					break
+				}
+			}
+		},
+	}
+
+	msstw.rangeDelFrag = rangekey.Fragmenter{
+		Cmp:    EngineComparer.Compare,
+		Format: EngineComparer.FormatKey,
+		Emit: func(span rangekey.Span) {
+			// Once a span is emitted we can clear that range.
+			if err := msstw.currSST.ClearRawRange(span.Start, span.End, true, false); err != nil {
+				msstw.err = err
+			}
+		},
+	}
+
 	if err := msstw.initSST(ctx); err != nil {
 		return msstw, err
 	}
+
+	if err := msstw.onEnterSpan(ctx, msstw.keySpans[msstw.currSpan], &msstw); err != nil {
+		return msstw, err
+	}
+
 	return msstw, nil
 }
 
-func (msstw *multiSSTWriter) initSST(ctx context.Context) error {
+func (msstw *MultiSSTWriter) initSST(ctx context.Context) error {
+	if msstw.err != nil {
+		return msstw.err
+	}
 	newSSTFile, err := msstw.getNewSSTFile(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new sst file writer")
 	}
 	msstw.currSST = newSSTFile
-	if err := msstw.currSST.ClearRawRange(
-		msstw.keySpans[msstw.currSpan].Key, msstw.keySpans[msstw.currSpan].EndKey,
-		true /* pointKeys */, true, /* rangeKeys */
-	); err != nil {
-		msstw.currSST.Close()
-		return errors.Wrap(err, "failed to clear range on sst file writer")
-	}
 	return nil
 }
 
-func (msstw *multiSSTWriter) finalizeSST() error {
-	err := msstw.currSST.Finish()
-	if err != nil {
+func (msstw *MultiSSTWriter) TableMetadata() []*sstable.WriterMetadata {
+	return msstw.tableMetadata
+}
+
+func (msstw *MultiSSTWriter) finalizeSST(incrementSpan bool) error {
+	if msstw.err != nil {
+		return msstw.err
+	}
+
+	if err := msstw.currSST.Finish(); err != nil {
 		return errors.Wrap(err, "failed to finish sst")
 	}
+
+	msstw.tableMetadata = append(msstw.tableMetadata, msstw.currSST.Meta)
 	msstw.dataSize += msstw.currSST.DataSize
-	msstw.currSpan++
-	msstw.currSST.Close()
+	if incrementSpan {
+		msstw.currSpan++
+	}
 	return nil
 }
 
-func (msstw *multiSSTWriter) Put(ctx context.Context, key EngineKey, value []byte) error {
-	for msstw.keySpans[msstw.currSpan].EndKey.Compare(key.Key) <= 0 {
+func (msstw *MultiSSTWriter) truncateAndFlushBuffered(key []byte) {
+	msstw.rangeKeyFrag.TruncateAndFlushTo(key)
+	msstw.rangeDelFrag.TruncateAndFlushTo(key)
+}
+
+func (msstw *MultiSSTWriter) updateCurrSST(ctx context.Context, key []byte) error {
+	// Ensure that the current sstable's bounds reflects the current span.
+	for msstw.currSpan < len(msstw.keySpans) && msstw.keySpans[msstw.currSpan].EndKey.Compare(key) <= 0 {
+		msstw.truncateAndFlushBuffered(msstw.keySpans[msstw.currSpan].EndKey)
 		// Finish the current SST, write to the file, and move to the next key
 		// range.
-		if err := msstw.finalizeSST(); err != nil {
+		if err := msstw.finalizeSST(true); err != nil {
+			return err
+		}
+
+		if msstw.currSpan >= len(msstw.keySpans) {
+			break
+		}
+
+		if err := msstw.initSST(ctx); err != nil {
+			return err
+		}
+
+		// Since we've moved on to a new span, we must initialize the new span.
+		if msstw.currSpan < len(msstw.keySpans) {
+			if err := msstw.onEnterSpan(ctx, msstw.keySpans[msstw.currSpan], msstw); err != nil {
+				return err
+			}
+		}
+	}
+
+	// If we have reached our sst file limit, flush all buffered keys and create a new sst file.
+	// Note: the span is not incremented in this case.
+	// TODO (rahul): include buffered keys size in this check
+	if msstw.currSST.DataSize >= msstw.maxSize {
+		msstw.truncateAndFlushBuffered(key)
+
+		if err := msstw.finalizeSST(false); err != nil {
 			return err
 		}
 		if err := msstw.initSST(ctx); err != nil {
 			return err
 		}
 	}
+	return nil
+}
+
+func (msstw *MultiSSTWriter) Put(ctx context.Context, key EngineKey, value []byte) error {
+	if msstw.err != nil {
+		return msstw.err
+	}
+
 	if msstw.keySpans[msstw.currSpan].Key.Compare(key.Key) > 0 {
 		return errors.AssertionFailedf("client error: expected %s to fall in one of %s", key.Key, msstw.keySpans)
 	}
+
+	if err := msstw.updateCurrSST(ctx, key.Key); err != nil {
+		return errors.Wrap(err, "failed to update the current sst")
+	}
+
 	if err := msstw.currSST.PutEngineKey(key, value); err != nil {
 		return errors.Wrap(err, "failed to put in sst")
 	}
+
 	return nil
 }
 
-func (msstw *multiSSTWriter) PutRangeKey(
-	ctx context.Context, start, end roachpb.Key, suffix []byte, value []byte,
-) error {
+func (msstw *MultiSSTWriter) PutRangeKeyDel(ctx context.Context, start, end roachpb.Key) error {
+	if msstw.err != nil {
+		return msstw.err
+	}
 	if start.Compare(end) >= 0 {
 		return errors.AssertionFailedf("start key %s must be before end key %s", end, start)
 	}
-	for msstw.keySpans[msstw.currSpan].EndKey.Compare(start) <= 0 {
-		// Finish the current SST, write to the file, and move to the next key
-		// range.
-		if err := msstw.finalizeSST(); err != nil {
-			return err
-		}
-		if err := msstw.initSST(ctx); err != nil {
-			return err
-		}
+
+	if err := msstw.updateCurrSST(ctx, start); err != nil {
+		return errors.Wrap(err, "failed to update the current sst")
 	}
-	if msstw.keySpans[msstw.currSpan].Key.Compare(start) > 0 ||
-		msstw.keySpans[msstw.currSpan].EndKey.Compare(end) < 0 {
-		return errors.AssertionFailedf("client error: expected %s to fall in one of %s",
-			roachpb.Span{Key: start, EndKey: end}, msstw.keySpans)
-	}
-	if err := msstw.currSST.PutEngineRangeKey(start, end, suffix, value); err != nil {
-		return errors.Wrap(err, "failed to put range key in sst")
-	}
+
+	// RangeKeyDelete cannot be written directly, must be buffered.
+	msstw.rangeKeyFrag.Add(rangekey.Span{
+		Start: start,
+		End:   end,
+		Keys: []rangekey.Key{
+			{Trailer: uint64(pebble.InternalKeyKindRangeKeyDelete)},
+		},
+	})
+
 	return nil
 }
 
-func (msstw *multiSSTWriter) Finish(ctx context.Context) (int64, error) {
+func (msstw *MultiSSTWriter) PutRangeKey(
+	ctx context.Context, start, end roachpb.Key, suffix []byte, value []byte,
+) error {
+	if msstw.err != nil {
+		return msstw.err
+	}
+	if start.Compare(end) >= 0 {
+		return errors.AssertionFailedf("start key %s must be before end key %s", end, start)
+	}
+
+	if err := msstw.updateCurrSST(ctx, start); err != nil {
+		return errors.Wrap(err, "failed to update the current sst")
+	}
+
+	// RangeKey cannot be written directly, must be buffered.
+	msstw.rangeKeyFrag.Add(rangekey.Span{
+		Start: start,
+		End:   end,
+		Keys: []rangekey.Key{
+			{Suffix: suffix, Value: value},
+		},
+	})
+
+	return nil
+}
+
+func (msstw *MultiSSTWriter) PutRangeDel(ctx context.Context, start, end roachpb.Key) error {
+	if msstw.err != nil {
+		return msstw.err
+	}
+
+	if start.Compare(end) >= 0 {
+		return errors.AssertionFailedf("start key %s must be before end key %s", end, start)
+	}
+
+	if err := msstw.updateCurrSST(ctx, start); err != nil {
+		return errors.Wrap(err, "failed to update the current sst")
+	}
+
+	// RangeDel cannot be written directly, must be buffered.
+	msstw.rangeDelFrag.Add(rangekey.Span{
+		Start: start,
+		End:   end,
+		Keys: []rangekey.Key{
+			{Trailer: uint64(pebble.InternalKeyKindRangeDelete)},
+		},
+	})
+
+	return nil
+}
+
+func (msstw *MultiSSTWriter) Finish(ctx context.Context) (int64, error) {
+	if msstw.err != nil {
+		return 0, msstw.err
+	}
+
 	if msstw.currSpan < len(msstw.keySpans) {
 		for {
-			if err := msstw.finalizeSST(); err != nil {
+			msstw.truncateAndFlushBuffered(msstw.keySpans[msstw.currSpan].EndKey)
+			if err := msstw.finalizeSST(true); err != nil {
 				return 0, err
 			}
+
 			if msstw.currSpan >= len(msstw.keySpans) {
 				break
 			}
+
 			if err := msstw.initSST(ctx); err != nil {
+				return 0, err
+			}
+
+			// Since we've moved on to a new span, we must initialize the new span.
+			if err := msstw.onEnterSpan(ctx, msstw.keySpans[msstw.currSpan], msstw); err != nil {
 				return 0, err
 			}
 		}
 	}
+	msstw.rangeDelFrag.Finish()
+	msstw.rangeKeyFrag.Finish()
 	return msstw.dataSize, nil
-}
-
-func (msstw *multiSSTWriter) Close() {
-	msstw.currSST.Close()
 }

--- a/pkg/storage/multi_sst_writer.go
+++ b/pkg/storage/multi_sst_writer.go
@@ -1,0 +1,140 @@
+package storage
+
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+)
+
+// multiSSTWriter is a wrapper around an SSTWriter and SSTSnapshotStorageScratch
+// that handles chunking SSTs and persisting them to disk.
+type multiSSTWriter struct {
+	// It is up to the caller to provide an SSTWriter to be used for creating a new file.
+	getNewSSTFile func(ctx context.Context) (SSTWriter, error)
+	currSST       SSTWriter
+	keySpans      []roachpb.Span
+	currSpan      int
+	// The total size of SST data. Updated on SST finalization.
+	dataSize int64
+}
+
+func NewMultiSSTWriter(
+	ctx context.Context,
+	getNewSSTFile func(ctx context.Context) (SSTWriter, error),
+	keySpans []roachpb.Span,
+) (multiSSTWriter, error) {
+	msstw := multiSSTWriter{
+		getNewSSTFile: getNewSSTFile,
+		keySpans:      keySpans,
+	}
+	if err := msstw.initSST(ctx); err != nil {
+		return msstw, err
+	}
+	return msstw, nil
+}
+
+func (msstw *multiSSTWriter) initSST(ctx context.Context) error {
+	newSSTFile, err := msstw.getNewSSTFile(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to create new sst file writer")
+	}
+	msstw.currSST = newSSTFile
+	if err := msstw.currSST.ClearRawRange(
+		msstw.keySpans[msstw.currSpan].Key, msstw.keySpans[msstw.currSpan].EndKey,
+		true /* pointKeys */, true, /* rangeKeys */
+	); err != nil {
+		msstw.currSST.Close()
+		return errors.Wrap(err, "failed to clear range on sst file writer")
+	}
+	return nil
+}
+
+func (msstw *multiSSTWriter) finalizeSST() error {
+	err := msstw.currSST.Finish()
+	if err != nil {
+		return errors.Wrap(err, "failed to finish sst")
+	}
+	msstw.dataSize += msstw.currSST.DataSize
+	msstw.currSpan++
+	msstw.currSST.Close()
+	return nil
+}
+
+func (msstw *multiSSTWriter) Put(ctx context.Context, key EngineKey, value []byte) error {
+	for msstw.keySpans[msstw.currSpan].EndKey.Compare(key.Key) <= 0 {
+		// Finish the current SST, write to the file, and move to the next key
+		// range.
+		if err := msstw.finalizeSST(); err != nil {
+			return err
+		}
+		if err := msstw.initSST(ctx); err != nil {
+			return err
+		}
+	}
+	if msstw.keySpans[msstw.currSpan].Key.Compare(key.Key) > 0 {
+		return errors.AssertionFailedf("client error: expected %s to fall in one of %s", key.Key, msstw.keySpans)
+	}
+	if err := msstw.currSST.PutEngineKey(key, value); err != nil {
+		return errors.Wrap(err, "failed to put in sst")
+	}
+	return nil
+}
+
+func (msstw *multiSSTWriter) PutRangeKey(
+	ctx context.Context, start, end roachpb.Key, suffix []byte, value []byte,
+) error {
+	if start.Compare(end) >= 0 {
+		return errors.AssertionFailedf("start key %s must be before end key %s", end, start)
+	}
+	for msstw.keySpans[msstw.currSpan].EndKey.Compare(start) <= 0 {
+		// Finish the current SST, write to the file, and move to the next key
+		// range.
+		if err := msstw.finalizeSST(); err != nil {
+			return err
+		}
+		if err := msstw.initSST(ctx); err != nil {
+			return err
+		}
+	}
+	if msstw.keySpans[msstw.currSpan].Key.Compare(start) > 0 ||
+		msstw.keySpans[msstw.currSpan].EndKey.Compare(end) < 0 {
+		return errors.AssertionFailedf("client error: expected %s to fall in one of %s",
+			roachpb.Span{Key: start, EndKey: end}, msstw.keySpans)
+	}
+	if err := msstw.currSST.PutEngineRangeKey(start, end, suffix, value); err != nil {
+		return errors.Wrap(err, "failed to put range key in sst")
+	}
+	return nil
+}
+
+func (msstw *multiSSTWriter) Finish(ctx context.Context) (int64, error) {
+	if msstw.currSpan < len(msstw.keySpans) {
+		for {
+			if err := msstw.finalizeSST(); err != nil {
+				return 0, err
+			}
+			if msstw.currSpan >= len(msstw.keySpans) {
+				break
+			}
+			if err := msstw.initSST(ctx); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return msstw.dataSize, nil
+}
+
+func (msstw *multiSSTWriter) Close() {
+	msstw.currSST.Close()
+}


### PR DESCRIPTION
This pr consists of two main changes. The first is moving the `MultiSSTWriter` to package `storage`. The second change comes from the following motivation.

Currently, when receiving a snapshot, we ingest a fixed number of sstables, corresponding to the range's various contiguous keyspaces. When the default range size increased from 64 MB to 512 MB, we started ingesting user data sstables up to 512 MB. These large files cause more expensive compactions. As a result of limiting the size of SSTables, this pr adds range key buffering and truncation to the existing MultiSSTWriter logic.

NEED TO FIX: 
- Currently TestMultiSSTWriterBuffer test is failing (needs to be fixed --> code seems to be adding to the internal SSTWriter fragmenter that claims to be closed)

TODO:
- Run tests (can't do it currently because fragmenter is not exported)
- Replace backups case to use the MultiSSTWriter (can maybe do this in a separate pr) 

Release note: None
Informs: #67284