### PR TITLE
db-console: skip undefined regions on database pages

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/databases/utils.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/utils.ts
@@ -22,6 +22,10 @@ export function createNodesByRegionMap(
 ): Record<string, number[]> {
   const nodesByRegionMap: Record<string, number[]> = {};
   nodes.forEach((node: number) => {
+    // If the node's region doesn't exist skip it.
+    if (nodeRegions[node.toString()] == null) {
+      return;
+    }
     const region: string = nodeRegions[node.toString()];
     if (nodesByRegionMap[region] == null) {
       nodesByRegionMap[region] = [];


### PR DESCRIPTION
Resolves: #106697

This patch skips `undefined` regions on the databases pages. The `undefined` behaviour occurs when we try to match a database's node IDs (i.e. the nodes with ranges that contain data belong to one of the database's tables) from the database details endpoint, to nodes' region information from the nodes endpoint.

The nodes endpoint is authoritative and is refreshed at a regular interval. However, the database details endpoint is only fetched once on page load, and it's node information comes from a cache leading to the potential of stale data (this information is authoritative in 23.1, but not in 22.2, meaning refreshing here wouldn't do any good).

Consequently when trying to match cached node IDs with recent node regions information, we can come across behaviour where we try to get region information for a node ID that is no longer valid (i.e. in the case of a decommissioned node), resulting in `undefined` and surfacing outdated node information.

This change ensures that when we encounter such occurrences, we avoid displaying them in the console.

Release note (bug fix): Avoid displaying `undefined` regions and outdated node information on the databases pages.