### PR TITLE
acceptance: Fix DockerCSharp Test

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -39,7 +39,6 @@ func TestDockerC(t *testing.T) {
 }
 
 func TestDockerCSharp(t *testing.T) {
-	skip.WithIssue(t, 86852, "test not to up to date anymore")
 	s := log.Scope(t)
 	defer s.Close(t)
 

--- a/pkg/acceptance/testdata/csharp/Program.cs
+++ b/pkg/acceptance/testdata/csharp/Program.cs
@@ -60,7 +60,7 @@ namespace CockroachDrivers
                 using (var cmd = new NpgsqlCommand("SELECT id, balance FROM bank.accounts", conn))
                 using (var reader = cmd.ExecuteReader())
                     while (reader.Read())
-                        Console.Write("\taccount {0}: {1}\n", reader.GetString(0), reader.GetString(1));
+                        Console.Write("\taccount {0}: {1}\n", reader.GetInt32(0), reader.GetInt32(1));
             }
         }
 
@@ -138,7 +138,7 @@ namespace CockroachDrivers
                 using (var cmd = new NpgsqlCommand("SELECT id, balance FROM bank.accounts", conn))
                 using (var reader = cmd.ExecuteReader())
                     while (reader.Read())
-                        Console.Write("\taccount {0}: {1}\n", reader.GetString(0), reader.GetString(1));
+                        Console.Write("\taccount {0}: {1}\n", reader.GetInt32(0), reader.GetInt32(1));
             }
         }
 
@@ -200,8 +200,8 @@ namespace CockroachDrivers
                         {
                             throw new DataException(String.Format("SELECT can't find inserted value: read {0}, expecting 42", a));
                         }
-                        var ts = reader.GetTimeStamp(1);
-                        var expectedTs = new NpgsqlTypes.NpgsqlDateTime(2015, 5, 7, 18, 20, 0, DateTimeKind.Unspecified);
+                        var ts = reader.GetDateTime(1);
+                        var expectedTs = new DateTime(2015, 5, 7, 18, 20, 0, DateTimeKind.Unspecified);
                         if (ts != expectedTs)
                         {
                             throw new DataException(String.Format("SELECT unexpected value for ts: read {0}, expecting {1}", ts, expectedTs));
@@ -212,7 +212,7 @@ namespace CockroachDrivers
                 using (var cmd = new NpgsqlCommand("INSERT INTO test.f VALUES (@x, @ts)", conn))
                 {
                     cmd.Parameters.Add("x", NpgsqlTypes.NpgsqlDbType.Integer).Value = 1;
-                    cmd.Parameters.Add("ts", NpgsqlTypes.NpgsqlDbType.Timestamp).Value = new NpgsqlTypes.NpgsqlDateTime(DateTime.Now);
+                    cmd.Parameters.Add("ts", NpgsqlTypes.NpgsqlDbType.Timestamp).Value = DateTime.Now;
                     cmd.Prepare();
                     var rows = cmd.ExecuteNonQuery();
                     if (rows != 1)
@@ -311,7 +311,7 @@ namespace CockroachDrivers
                 {
                     cmd.Parameters.Add("id", NpgsqlTypes.NpgsqlDbType.Integer).Value = 1;
                     cmd.Parameters.Add("balance", NpgsqlTypes.NpgsqlDbType.Integer).Value = 1000;
-                    cmd.Parameters.Add("cdate", NpgsqlTypes.NpgsqlDbType.Date).Value = new NpgsqlTypes.NpgsqlDate(DateTime.Now);
+                    cmd.Parameters.Add("cdate", NpgsqlTypes.NpgsqlDbType.Date).Value = DateTime.Now;
                     cmd.Prepare();
                     var rows = cmd.ExecuteNonQuery();
                     if (rows != 1)

--- a/pkg/acceptance/testdata/csharp/acceptance.csproj
+++ b/pkg/acceptance/testdata/csharp/acceptance.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="npgsql" Version="6.0.4" />


### PR DESCRIPTION
This PR updates the .net framework within the csproj setup to .net 6. 
Additionally, it also fixes the CS program that we run as
a part of this test with the new npgsql DateTime
changes made as a part of npgsql 6 version update. The old datetime 
types have been deprecated and needed to be removed. 
With these fixes, the test is running successfully and can be unskipped.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/86852
Release note: none