### PR TITLE
release-23.1: roachtest: Update gopg ignorelist

### DIFF
--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -47,6 +47,7 @@ var gopgIgnoreList = blocklist{
 	"pg | ORM struct model | fetches Author relations":    "41690",
 	"pg | ORM struct model | fetches Book relations":      "41690",
 	"pg | ORM struct model | fetches Genre relations":     "41690",
+	"pg | ORM | ForEach works with scalars":               "Test Setup",
 	// Different error message for context cancellation timeout.
 	"pg | OnConnect | does not panic on timeout": "41690",
 	// These tests assume different transaction isolation level (READ COMMITTED).


### PR DESCRIPTION
This PR updates the go-pg ignorelist with a test
that seems to be flaky due to test setup issues.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/106578
Release note: none
Release justification: test only change