### PR TITLE
util/log: allow custom crash report tags

### DIFF
--- a/pkg/util/log/logcrash/BUILD.bazel
+++ b/pkg/util/log/logcrash/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/util",
+        "//pkg/util/envutil",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
@@ -49,6 +50,7 @@ go_test(
         "@com_github_kr_pretty//:pretty",
         "@com_github_pmezard_go_difflib//difflib",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
             "@org_golang_x_sys//unix",

--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -13,6 +13,7 @@ package logcrash
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -263,7 +264,23 @@ func SetupCrashReporter(ctx context.Context, cmd string) {
 			"buildchannel": info.Channel,
 			"envchannel":   info.EnvChannel,
 		})
+
 	})
+}
+
+func getTagsFromEnvironment() map[string]string {
+	tags := map[string]string{}
+	rawTags := envutil.EnvOrDefaultString("COCKROACH_CRASH_REPORT_TAGS", "")
+	if len(rawTags) > 0 {
+		envTags := strings.Split(rawTags, ";")
+		for _, tag := range envTags {
+			parts := strings.Split(tag, "=")
+			if len(parts) == 2 {
+				tags[parts[0]] = parts[1]
+			}
+		}
+	}
+	return tags
 }
 
 func uptimeTag(now time.Time) string {


### PR DESCRIPTION
Today it can be difficult to trace back a sentry event to the CC cluster where
it originated, especially for serverless clusters. This change enables a new
environment variable (COCKROACH_CRASH_REPORT_TAGS), which allows
the database operator to provide additional information that will be included
in the sentry event.

Release Note: None