### PR TITLE
tree: fix statement tag for tree.ShowSequences

### DIFF
--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1954,7 +1954,7 @@ func (*ShowSequences) StatementReturnType() StatementReturnType { return Rows }
 func (*ShowSequences) StatementType() StatementType { return TypeDML }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*ShowSequences) StatementTag() string { return "SHOW SCHEMAS" }
+func (*ShowSequences) StatementTag() string { return "SHOW SEQUENCES" }
 
 // StatementReturnType implements the Statement interface.
 func (*ShowDefaultPrivileges) StatementReturnType() StatementReturnType { return Rows }


### PR DESCRIPTION
Epic: None

Release note (bug fix): The statement tag for `SHOW SEQUENCES` is now
corrected to be `SHOW SEQUENCES` instead of `SHOW SCHEMAS`.