### PR TITLE
sql: deflake guardrails logictest by disabling distributed configs

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -934,13 +934,6 @@ func TestTenantLogic_group_join(
 	runLogicTest(t, "group_join")
 }
 
-func TestTenantLogic_guardrails(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "guardrails")
-}
-
 func TestTenantLogic_hash_join(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/guardrails
+++ b/pkg/sql/logictest/testdata/logic_test/guardrails
@@ -1,6 +1,6 @@
-# LogicTest: !metamorphic-batch-sizes
-# We disable metamorphic batch sizes so that we read a predictable number of
-# rows in each limited scan.
+# LogicTest: !metamorphic-batch-sizes local local-legacy-schema-changer local-mixed-22.2-23.1 local-vec-off
+# We disable metamorphic batch sizes and only use local configs so that we read
+# a predictable number of rows in each limited scan.
 
 statement ok
 CREATE TABLE guardrails (i INT PRIMARY KEY);

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -905,13 +905,6 @@ func TestLogic_group_join(
 	runLogicTest(t, "group_join")
 }
 
-func TestLogic_guardrails(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "guardrails")
-}
-
 func TestLogic_hash_join(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -905,13 +905,6 @@ func TestLogic_group_join(
 	runLogicTest(t, "group_join")
 }
 
-func TestLogic_guardrails(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "guardrails")
-}
-
 func TestLogic_hash_join(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -912,13 +912,6 @@ func TestLogic_group_join(
 	runLogicTest(t, "group_join")
 }
 
-func TestLogic_guardrails(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "guardrails")
-}
-
 func TestLogic_hash_join(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Fixes #106526
Fixes #106787

Release note: None