### PR TITLE
roachtest: fix decommission test issues during teardown

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -97,9 +97,10 @@ func registerDecommission(r registry.Registry) {
 	{
 		numNodes := 4
 		r.Add(registry.TestSpec{
-			Name:    "decommission/mixed-versions",
-			Owner:   registry.OwnerKV,
-			Cluster: r.MakeClusterSpec(numNodes),
+			Name:                "decommission/mixed-versions",
+			Owner:               registry.OwnerKV,
+			Cluster:             r.MakeClusterSpec(numNodes),
+			SkipPostValidations: registry.PostValidationInvalidDescriptors | registry.PostValidationNoDeadNodes,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionMixedVersions(ctx, t, c, t.BuildVersion())
 			},


### PR DESCRIPTION
During teardown, roachtest attempts to perform post-test validation of invalid descriptors and dead nodes, which should not apply during a test such as `decommission/mixed-version`, as the validation cannot connect to the decommissioned nodes. This change disables this validation.

Fixes: #101620

Release note: None