### PR TITLE
release-23.1: kvserver: avoid leaked replica mutex during delegated snapshot

### DIFF
--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -576,6 +576,7 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	existingClosed := r.mu.state.RaftClosedTimestamp
 	newClosed := b.state.RaftClosedTimestamp
 	if !newClosed.IsEmpty() && newClosed.Less(existingClosed) && raftClosedTimestampAssertionsEnabled {
+		r.mu.Unlock()
 		return errors.AssertionFailedf(
 			"raft closed timestamp regression; replica has: %s, new batch has: %s.",
 			existingClosed.String(), newClosed.String())

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2956,15 +2956,15 @@ func (r *Replica) validateSnapshotDelegationRequest(
 	// that is also needs a snapshot, then any snapshot it sends will be useless.
 	r.mu.RLock()
 	replIdx := r.mu.state.RaftAppliedIndex + 1
-
 	status := r.raftStatusRLocked()
+	r.mu.RUnlock()
+
 	if status == nil {
 		// This code path is sometimes hit during scatter for replicas that
 		// haven't woken up yet.
 		return errors.Errorf("raft status not initialized")
 	}
 	replTerm := status.Term
-	r.mu.RUnlock()
 
 	// Delegate has a different term than the coordinator. This typically means
 	// the lease has been transferred, and we should not process this request.

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -617,8 +617,10 @@ func (r *Replica) applySnapshot(
 	if isInitialSnap {
 		// NB: this will also call setDescLockedRaftMuLocked.
 		if err := r.initFromSnapshotLockedRaftMuLocked(ctx, desc); err != nil {
+			r.mu.Unlock()
 			log.Fatalf(ctx, "unable to initialize replica while applying snapshot: %+v", err)
 		} else if err := r.store.markReplicaInitializedLockedReplLocked(ctx, r); err != nil {
+			r.mu.Unlock()
 			log.Fatalf(ctx, "unable to mark replica initialized while applying snapshot: %+v", err)
 		}
 	} else {


### PR DESCRIPTION
Backport 3/4 commits from #106574.

/cc @cockroachdb/release

Release justification: fixes a possible replica deadlock.

---

Prompted by https://github.com/cockroachdb/cockroach/issues/106568, I went
through all callers to `repl.mu.Lock` and `repl.mu.RLock` trying to find places
where we're leaking the mutex on certain return paths.

I found some, including one that at least seems to possibly explain what we saw in https://github.com/cockroachdb/cockroach/issues/106568.

I also looked into the possibility of panics under a held lock being recovered from
at higher levels in the stack, in particular this code:

https://github.com/cockroachdb/cockroach/blob/81569be4aeb61620d2fd51c41b416f7d0986698e/pkg/sql/colexecerror/error.go#L27-L30

However, it seems sufficiently restricted to recovering only from errors it knows to
be safe to recover from, and in particular it doesn't look like it will ever recover from
any panic in kvserver. I will say that this looks a little brittle, though I don't see a much
better way of doing what this code is trying to achieve.

Release note: None
Epic: None
