### PR TITLE
ttljob: fix minor book-keeping bug during txn retry

### DIFF
--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//pkg/jobs/jobstest",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvserver",
         "//pkg/roachpb",
         "//pkg/scheduledjobs",
         "//pkg/security/securityassets",


### PR DESCRIPTION
Previously, we would double-count the number of deleted rows in the face of a transaction retry.

Here, we move the counting outside of the Txn func and use a small helper function to force transaction retries during the test.

It wasn't clear to me whether we wanted the metric to be the total number of deletion attempts or the total committed deletions.  I've made it the latter.

It seems likely that a transaction retry here is not very likely at all, but this was found when trying to apply random transaction retries to the entire test suite.

Informs #106417

Epic: none

Release note: none