### PR TITLE
sqlproxyccl: remove uses of TODOTestTenantDisabled

### DIFF
--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -87,12 +87,8 @@ func TestBackendDialTLS(t *testing.T) {
 	ctx := context.Background()
 
 	storageServer, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Insecure: false,
-		// StartServer will sometimes start a tenant. This test requires
-		// storage server to be the system tenant, otherwise the
-		// tenant10ToStorage test will fail, since the storage server will
-		// server tenant 10.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
+		Insecure:          false,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer storageServer.Stopper().Stop(ctx)
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -144,8 +144,10 @@ func TestProxyProtocol(t *testing.T) {
 		// it. More investigation required (tracked with #76378).
 		DefaultTestTenant: base.TODOTestTenantDisabled,
 	})
-	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
-	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
+
+	ts := sql.(*server.TestServer).TenantOrServer()
+	ts.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
+	pgs := ts.PGServer().(*pgwire.Server)
 	pgs.TestingEnableAuthLogging()
 	defer sql.Stopper().Stop(ctx)
 
@@ -257,7 +259,7 @@ func TestPrivateEndpointsACL(t *testing.T) {
 		// it. More investigation required (tracked with #76378).
 		DefaultTestTenant: base.TODOTestTenantDisabled,
 	})
-	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 	defer sql.Stopper().Stop(ctx)
 
 	// Create a default user.
@@ -434,7 +436,7 @@ func TestAllowedCIDRRangesACL(t *testing.T) {
 		// it. More investigation required (tracked with #76378).
 		DefaultTestTenant: base.TODOTestTenantDisabled,
 	})
-	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 	defer sql.Stopper().Stop(ctx)
 
 	// Create a default user.
@@ -708,7 +710,7 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 		DefaultTestTenant: base.TODOTestTenantDisabled,
 	},
 	)
-	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
 	pgs.TestingEnableAuthLogging()
 	defer sql.Stopper().Stop(ctx)
@@ -911,7 +913,7 @@ func TestProxyTLSClose(t *testing.T) {
 			DefaultTestTenant: base.TODOTestTenantDisabled,
 		},
 	)
-	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
 	pgs.TestingEnableAuthLogging()
 	defer sql.Stopper().Stop(ctx)
@@ -968,7 +970,7 @@ func TestProxyModifyRequestParams(t *testing.T) {
 			DefaultTestTenant: base.TODOTestTenantDisabled,
 		},
 	)
-	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
 	pgs.TestingEnableAuthLogging()
 	defer sql.Stopper().Stop(ctx)
@@ -1033,7 +1035,7 @@ func TestInsecureProxy(t *testing.T) {
 			Insecure:          false,
 		},
 	)
-	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
 	pgs.TestingEnableAuthLogging()
 	defer sql.Stopper().Stop(ctx)
@@ -1214,7 +1216,7 @@ func TestDenylistUpdate(t *testing.T) {
 			DefaultTestTenant: base.TODOTestTenantDisabled,
 		},
 	)
-	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 	defer sql.Stopper().Stop(ctx)
 
 	// Create some user with password authn.
@@ -1970,7 +1972,7 @@ func TestConnectionMigration(t *testing.T) {
 
 	// Start first SQL pod.
 	tenant1, tenantDB1 := serverutils.StartTenant(t, s, tests.CreateTestTenantParams(tenantID))
-	tenant1.(*server.TestTenant).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	tenant1.(*server.TestTenant).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 	defer tenant1.Stopper().Stop(ctx)
 	defer tenantDB1.Close()
 
@@ -1978,7 +1980,7 @@ func TestConnectionMigration(t *testing.T) {
 	params2 := tests.CreateTestTenantParams(tenantID)
 	params2.DisableCreateTenant = true
 	tenant2, tenantDB2 := serverutils.StartTenant(t, s, params2)
-	tenant2.(*server.TestTenant).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	tenant2.(*server.TestTenant).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 	defer tenant2.Stopper().Stop(ctx)
 	defer tenantDB2.Close()
 
@@ -3024,7 +3026,7 @@ func startTestTenantPodsWithStopper(
 		params.TestingKnobs = knobs
 		params.Stopper = stopper
 		tenant, tenantDB := serverutils.StartTenant(t, ts, params)
-		tenant.(*server.TestTenant).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
+		tenant.(*server.TestTenant).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 
 		// Create a test user. We only need to do it once.
 		if i == 0 {

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -137,13 +137,7 @@ func TestProxyProtocol(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Insecure: false,
-		// Need to disable the test tenant here because it appears as though
-		// we're not able to establish the necessary connections from within
-		// it. More investigation required (tracked with #76378).
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 
 	ts := sql.(*server.TestServer).TenantOrServer()
 	ts.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
@@ -252,15 +246,11 @@ func TestPrivateEndpointsACL(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Insecure: false,
-		// Need to disable the test tenant here because it appears as though
-		// we're not able to establish the necessary connections from within
-		// it. More investigation required (tracked with #76378).
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
-	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer sql.Stopper().Stop(ctx)
+
+	ts := sql.(*server.TestServer).TenantOrServer()
+	ts.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 
 	// Create a default user.
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -429,15 +419,11 @@ func TestAllowedCIDRRangesACL(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Insecure: false,
-		// Need to disable the test tenant here because it appears as though
-		// we're not able to establish the necessary connections from within
-		// it. More investigation required (tracked with #76378).
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
-	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer sql.Stopper().Stop(ctx)
+
+	ts := sql.(*server.TestServer).TenantOrServer()
+	ts.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
 
 	// Create a default user.
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -702,18 +688,13 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Insecure: false,
-		// Need to disable the test tenant here because it appears as though
-		// we're not able to establish the necessary connections from within
-		// it. More investigation required (tracked with #76378).
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	},
-	)
-	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
-	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
-	pgs.TestingEnableAuthLogging()
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer sql.Stopper().Stop(ctx)
+
+	ts := sql.(*server.TestServer).TenantOrServer()
+	ts.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
+	pgs := ts.PGServer().(*pgwire.Server)
+	pgs.TestingEnableAuthLogging()
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
@@ -904,19 +885,13 @@ func TestProxyTLSClose(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t,
-		base.TestServerArgs{
-			Insecure: false,
-			// Need to disable the test tenant here because it appears as though
-			// we're not able to establish the necessary connections from within
-			// it. More investigation required (tracked with #76378).
-			DefaultTestTenant: base.TODOTestTenantDisabled,
-		},
-	)
-	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
-	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
-	pgs.TestingEnableAuthLogging()
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer sql.Stopper().Stop(ctx)
+
+	ts := sql.(*server.TestServer).TenantOrServer()
+	ts.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
+	pgs := ts.PGServer().(*pgwire.Server)
+	pgs.TestingEnableAuthLogging()
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
@@ -961,19 +936,13 @@ func TestProxyModifyRequestParams(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, sqlDB, _ := serverutils.StartServer(t,
-		base.TestServerArgs{
-			Insecure: false,
-			// Need to disable the test tenant here because it appears as though
-			// we're not able to establish the necessary connections from within
-			// it. More investigation required (tracked with #76378).
-			DefaultTestTenant: base.TODOTestTenantDisabled,
-		},
-	)
-	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
-	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
-	pgs.TestingEnableAuthLogging()
+	sql, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer sql.Stopper().Stop(ctx)
+
+	ts := sql.(*server.TestServer).TenantOrServer()
+	ts.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
+	pgs := ts.PGServer().(*pgwire.Server)
+	pgs.TestingEnableAuthLogging()
 
 	// Create some user with password authn.
 	_, err := sqlDB.Exec("CREATE USER testuser WITH PASSWORD 'foo123'")
@@ -1025,20 +994,13 @@ func TestInsecureProxy(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t,
-		base.TestServerArgs{
-			// Need to disable the test tenant here as the test below
-			// complains about not being able to find the user. This may be
-			// because of the connection through the proxy server. More
-			// investigation is required (tracked with #76378).
-			DefaultTestTenant: base.TODOTestTenantDisabled,
-			Insecure:          false,
-		},
-	)
-	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
-	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
-	pgs.TestingEnableAuthLogging()
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer sql.Stopper().Stop(ctx)
+
+	ts := sql.(*server.TestServer).TenantOrServer()
+	ts.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
+	pgs := ts.PGServer().(*pgwire.Server)
+	pgs.TestingEnableAuthLogging()
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
@@ -1207,17 +1169,12 @@ func TestDenylistUpdate(t *testing.T) {
 	_, err = denyList.Write(bytes)
 	require.NoError(t, err)
 
-	sql, sqlDB, _ := serverutils.StartServer(t,
-		base.TestServerArgs{
-			Insecure: false,
-			// Need to disable the test tenant here because it appears as though
-			// we're not able to establish the necessary connections from within
-			// it. More investigation required (tracked with #76378).
-			DefaultTestTenant: base.TODOTestTenantDisabled,
-		},
-	)
-	sql.(*server.TestServer).PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
+	sql, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer sql.Stopper().Stop(ctx)
+
+	sql.(*server.TestServer).TenantOrServer().
+		PGPreServer().(*pgwire.PreServeConnHandler).
+		TestingSetTrustClientProvidedRemoteAddr(true)
 
 	// Create some user with password authn.
 	_, err = sqlDB.Exec("CREATE USER testuser WITH PASSWORD 'foo123'")
@@ -1961,8 +1918,8 @@ func TestConnectionMigration(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	params, _ := tests.CreateTestServerParams()
-	// Test must be run from the system tenant as it's altering tenants.
-	params.DefaultTestTenant = base.TODOTestTenantDisabled
+	params.DefaultTestTenant = base.TestControlsTenantsExplicitly
+
 	s, mainDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 	tenantID := serverutils.TestTenantID()

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -643,10 +643,8 @@ func newTestDirectoryCache(
 		ServerArgs: base.TestServerArgs{
 			// We need to start the cluster insecure in order to not
 			// care about TLS settings for the RPC client connection.
-			Insecure: true,
-			// Test fails when run within a tenant. More investigation
-			// is required here. Tracked with #76387.
-			DefaultTestTenant: base.TODOTestTenantDisabled,
+			Insecure:          true,
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		},
 	})
 	clusterStopper := tc.Stopper()

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -432,15 +432,9 @@ func TestClientAddrOverride(t *testing.T) {
 	// Enable conn/auth logging.
 	// We can't use the cluster settings to do this, because
 	// cluster settings for booleans propagate asynchronously.
-	var pgServer *pgwire.Server
-	var pgPreServer *pgwire.PreServeConnHandler
-	if len(s.TestTenants()) > 0 {
-		pgServer = s.TestTenants()[0].PGServer().(*pgwire.Server)
-		pgPreServer = s.TestTenants()[0].(*server.TestTenant).PGPreServer()
-	} else {
-		pgServer = s.PGServer().(*pgwire.Server)
-		pgPreServer = s.(*server.TestServer).PGPreServer()
-	}
+	ts := s.(*server.TestServer).TenantOrServer()
+	pgServer := ts.PGServer().(*pgwire.Server)
+	pgPreServer := ts.PGPreServer().(*pgwire.PreServeConnHandler)
 	pgServer.TestingEnableAuthLogging()
 
 	testCases := []struct {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -496,7 +496,7 @@ func (ts *TestServer) PGServer() interface{} {
 
 // PGPreServer exposes the pgwire.PreServeConnHandler instance used by
 // the TestServer.
-func (ts *TestServer) PGPreServer() *pgwire.PreServeConnHandler {
+func (ts *TestServer) PGPreServer() interface{} {
 	if ts != nil {
 		return ts.pgPreServer
 	}
@@ -703,7 +703,7 @@ func (t *TestTenant) PGServer() interface{} {
 
 // PGPreServer exposes the pgwire.PreServeConnHandler instance used by
 // the TestServer.
-func (ts *TestTenant) PGPreServer() *pgwire.PreServeConnHandler {
+func (ts *TestTenant) PGPreServer() interface{} {
 	if ts != nil {
 		return ts.pgPreServer
 	}

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -228,7 +228,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 		pgServer := testServer.PGServer().(*pgwire.Server)
 		pgServer.TestingEnableConnLogging()
 		pgServer.TestingEnableAuthLogging()
-		testServer.PGPreServer().TestingAcceptSystemIdentityOption(true)
+		testServer.PGPreServer().(*pgwire.PreServeConnHandler).TestingAcceptSystemIdentityOption(true)
 
 		httpClient, err := s.GetAdminHTTPClient()
 		if err != nil {
@@ -643,7 +643,7 @@ func TestClientAddrOverride(t *testing.T) {
 	testServer := s.(*server.TestServer)
 	pgServer := testServer.PGServer().(*pgwire.Server)
 	pgServer.TestingEnableAuthLogging()
-	pgPreServer := testServer.PGPreServer()
+	pgPreServer := testServer.PGPreServer().(*pgwire.PreServeConnHandler)
 
 	testCases := []struct {
 		specialAddr string

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -94,6 +94,9 @@ type TestTenantInterface interface {
 	// PGServer returns the tenant's *pgwire.Server as an interface{}.
 	PGServer() interface{}
 
+	// PGPreServer returns the tenant's *pgwire.PreServeConnHandler as an interface{}.
+	PGPreServer() interface{}
+
 	// DiagnosticsReporter returns the tenant's *diagnostics.Reporter as an
 	// interface{}. The DiagnosticsReporter periodically phones home to report
 	// diagnostics and usage.


### PR DESCRIPTION
Informs #76378
Epic: CRDB-18499

Most tests using that flag are in fact able to work well with
randomization enabled. This patch lets them do that.

The remainder control their tenants directly, so we change the
configuration flag to explain that too.

