### PR TITLE
Revert "roachprod: provide workaround for long-running AWS clusters"

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1261,18 +1261,6 @@ var storageSnapshotCmd = &cobra.Command{
 	}),
 }
 
-var fixLongRunningAWSHostnamesCmd = &cobra.Command{
-	Use:   "fix-long-running-aws-hostnames <cluster>",
-	Short: "changes the hostnames of VMs in long-running AWS clusters",
-	Long: `This is a temporary workaround, and will be removed once we no longer ` +
-		`have AWS clusters that were created with the default hostname.`,
-
-	Args: cobra.ExactArgs(1),
-	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-		return roachprod.FixLongRunningAWSHostnames(context.Background(), config.Logger, args[0])
-	}),
-}
-
 // Before executing any command, validate and canonicalize args.
 func validateAndConfigure(cmd *cobra.Command, args []string) {
 	// Skip validation for commands that are self-sufficient.
@@ -1389,7 +1377,6 @@ func main() {
 		grafanaURLCmd,
 		rootStorageCmd,
 		snapshotCmd,
-		fixLongRunningAWSHostnamesCmd,
 		updateCmd,
 	)
 	setBashCompletionFunction()

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -332,19 +332,6 @@ func (c *SyncedCluster) roachprodEnvRegex(node Node) string {
 // By wrapping every command with a hostname check as is done here, we
 // ensure that the cached cluster information is still correct.
 func (c *SyncedCluster) validateHostnameCmd(cmd string, node Node) string {
-	// TODO(renato): remove this logic once we no longer have AWS clusters
-	// created with the default hostnames.
-	var awsNote string
-	nodeVM := c.VMs[node-1]
-	if nodeVM.Provider == aws.ProviderName {
-		awsNote = fmt.Sprintf(
-			"\nNOTE: host validation failed in AWS cluster. If you are sure this cluster still "+
-				"exists (i.e., you can see it when you run 'roachprod list'), then please run:\n\t"+
-				"roachprod fix-long-running-aws-hostnames %s",
-			c.Name,
-		)
-	}
-
 	isValidHost := fmt.Sprintf("[[ `hostname` == '%s' ]]", vm.Name(c.Name, int(node)))
 	errMsg := fmt.Sprintf("expected host to be part of %s, but is `hostname`", c.Name)
 	elseBranch := "fi"
@@ -358,10 +345,10 @@ fi
 
 	return fmt.Sprintf(`
 if ! %s; then
-    echo "%s%s"
+    echo "%s"
     exit 1
 %s
-`, isValidHost, errMsg, awsNote, elseBranch)
+`, isValidHost, errMsg, elseBranch)
 }
 
 // validateHost will run `validateHostnameCmd` on the node passed to
@@ -388,14 +375,11 @@ func (c *SyncedCluster) newSession(
 		node: node,
 		user: c.user(node),
 		host: c.Host(node),
-		cmd:  cmd,
+		cmd:  c.validateHostnameCmd(cmd, node),
 	}
 
 	for _, opt := range options {
 		opt(command)
-	}
-	if !command.hostValidationDisabled {
-		command.cmd = c.validateHostnameCmd(cmd, node)
 	}
 	return newRemoteSession(l, command)
 }
@@ -2659,32 +2643,6 @@ func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, node Node) e
 
 	if err := c.setClusterSettings(ctx, l, node); err != nil {
 		return errors.WithDetail(err, "install.Init() failed: unable to set cluster settings.")
-	}
-
-	return nil
-}
-
-// FixLongRunningAWSHostnames updates the hostname on an AWS cluster
-// that was created with the default hostname.
-//
-// TODO(renato): remove this function (and corresponding roachprod
-// command) once we no longer have clusters created with the default
-// hostnames.
-func (c *SyncedCluster) FixLongRunningAWSHostnames(ctx context.Context, l *logger.Logger) error {
-	for i, nodeVM := range c.VMs {
-		node := Node(i + 1)
-		newHostname := vm.Name(c.Name, int(node))
-		if nodeVM.Provider == aws.ProviderName {
-			l.Printf("changing hostname of VM %d", node)
-			cmd := fmt.Sprintf("sudo hostnamectl set-hostname %s", newHostname)
-			s := c.newSession(l, node, cmd, withHostValidationDisabled())
-			defer s.Close()
-			out, err := s.CombinedOutput(ctx)
-			if err != nil {
-				return fmt.Errorf("could not fix hostname for node %d: %w\n%s", node, err, string(out))
-			}
-			l.Printf("hostname successfully changed to %s", newHostname)
-		}
 	}
 
 	return nil

--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -54,10 +54,6 @@ type remoteCommand struct {
 	cmd           string
 	debugDisabled bool
 	debugName     string
-
-	// TODO(renato): remove this option once we no longer have AWS
-	// clusters with default hostnames.
-	hostValidationDisabled bool
 }
 
 type remoteSessionOption = func(c *remoteCommand)
@@ -71,12 +67,6 @@ func withDebugDisabled() remoteSessionOption {
 func withDebugName(name string) remoteSessionOption {
 	return func(c *remoteCommand) {
 		c.debugName = name
-	}
-}
-
-func withHostValidationDisabled() remoteSessionOption {
-	return func(c *remoteCommand) {
-		c.hostValidationDisabled = true
 	}
 }
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -2031,19 +2031,3 @@ func createAttachMountVolumes(
 	}
 	return nil
 }
-
-func FixLongRunningAWSHostnames(ctx context.Context, l *logger.Logger, clusterName string) error {
-	if err := LoadClusters(); err != nil {
-		return err
-	}
-	c, err := newCluster(l, clusterName)
-	if err != nil {
-		return err
-	}
-
-	if err := c.FixLongRunningAWSHostnames(ctx, l); err != nil {
-		return err
-	}
-	l.Printf("Done! You are now able to use your AWS cluster normally.")
-	return nil
-}


### PR DESCRIPTION
This reverts commit e6cf25d31f2d078ada0881f98b6e17e77c2a621f.

The oldest `aws` cluster at the time of this commit is ~17d old, long after the hostname validation was introduced.

Since we now have an easy way to update roachprod (`roachprod update`), it should be straightforward for anyone to be running updated versions of roachprod that include hostname validation.

Epic: none

Release note: None