### PR TITLE
kvprober: enable kvprober metamorphically, deflake kvprober_integration_test.go

### DIFF
--- a/pkg/kv/kvprober/BUILD.bazel
+++ b/pkg/kv/kvprober/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/util",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
         "//pkg/util/metric",

--- a/pkg/kv/kvprober/helpers_test.go
+++ b/pkg/kv/kvprober/helpers_test.go
@@ -25,6 +25,8 @@ var (
 	ReadInterval         = readInterval
 	WriteEnabled         = writeEnabled
 	WriteInterval        = writeInterval
+	QuarantineEnabled    = quarantineWriteEnabled
+	QuarantineInterval   = quarantineWriteInterval
 	NumStepsToPlanAtOnce = numStepsToPlanAtOnce
 )
 

--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -44,11 +44,18 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("disabled by default", func(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
 		s, _, p, cleanup := initTestServer(t, base.TestingKnobs{})
 		defer cleanup()
 
+		kvprober.ReadEnabled.Override(ctx, &s.ClusterSettings().SV, false)
 		kvprober.ReadInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
+
+		kvprober.WriteEnabled.Override(ctx, &s.ClusterSettings().SV, false)
+		kvprober.WriteInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
+
+		kvprober.QuarantineEnabled.Override(ctx, &s.ClusterSettings().SV, false)
+		kvprober.QuarantineInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
 
 		require.NoError(t, p.Start(ctx, s.Stopper()))
 
@@ -68,6 +75,9 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 
 		kvprober.WriteEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 		kvprober.WriteInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
+
+		kvprober.QuarantineEnabled.Override(ctx, &s.ClusterSettings().SV, true)
+		kvprober.QuarantineInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
 
 		require.NoError(t, p.Start(ctx, s.Stopper()))
 
@@ -106,6 +116,9 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 
 		kvprober.WriteEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 		kvprober.WriteInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
+
+		kvprober.QuarantineEnabled.Override(ctx, &s.ClusterSettings().SV, true)
+		kvprober.QuarantineInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
 
 		require.NoError(t, p.Start(ctx, s.Stopper()))
 
@@ -154,6 +167,9 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 		kvprober.WriteEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 		kvprober.WriteInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
 
+		kvprober.QuarantineEnabled.Override(ctx, &s.ClusterSettings().SV, true)
+		kvprober.QuarantineInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
+
 		// Probe exactly ten times so we can make assertions below.
 		for i := 0; i < 10; i++ {
 			p.ReadProbe(ctx, s.DB())
@@ -198,6 +214,9 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 
 		kvprober.WriteEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 		kvprober.WriteInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
+
+		kvprober.QuarantineEnabled.Override(ctx, &s.ClusterSettings().SV, true)
+		kvprober.QuarantineInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
 
 		// Probe exactly ten times so we can make assertions below.
 		for i := 0; i < 10; i++ {

--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -57,8 +58,6 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 		kvprober.QuarantineEnabled.Override(ctx, &s.ClusterSettings().SV, false)
 		kvprober.QuarantineInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
 
-		require.NoError(t, p.Start(ctx, s.Stopper()))
-
 		time.Sleep(100 * time.Millisecond)
 
 		require.Zero(t, p.Metrics().ProbePlanAttempts.Count())
@@ -78,8 +77,6 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 
 		kvprober.QuarantineEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 		kvprober.QuarantineInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
-
-		require.NoError(t, p.Start(ctx, s.Stopper()))
 
 		testutils.SucceedsSoon(t, func() error {
 			if p.Metrics().ReadProbeAttempts.Count() < int64(50) {
@@ -119,8 +116,6 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 
 		kvprober.QuarantineEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 		kvprober.QuarantineInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
-
-		require.NoError(t, p.Start(ctx, s.Stopper()))
 
 		// Expect >=2 failures eventually due to unavailable time-series range.
 		// TODO(josh): Once structured logging is in, can check that failures
@@ -177,10 +172,11 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 		}
 
 		// Expect all read probes to fail but write probes & planning to succeed.
-		require.Equal(t, int64(10), p.Metrics().ReadProbeAttempts.Count())
-		require.Equal(t, int64(10), p.Metrics().ReadProbeFailures.Count())
+		require.Equal(t, p.Metrics().ReadProbeAttempts.Count(), p.Metrics().ReadProbeFailures.Count())
+		// kvprober is running in background, so more than ten probes may be run.
+		require.GreaterOrEqual(t, p.Metrics().ReadProbeFailures.Count(), int64(10))
 
-		require.Equal(t, int64(10), p.Metrics().WriteProbeAttempts.Count())
+		require.GreaterOrEqual(t, p.Metrics().WriteProbeAttempts.Count(), int64(10))
 		require.Zero(t, p.Metrics().WriteProbeFailures.Count())
 
 		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
@@ -225,10 +221,11 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 		}
 
 		// Expect all write probes to fail but read probes & planning to succeed.
-		require.Equal(t, int64(10), p.Metrics().WriteProbeAttempts.Count())
-		require.Equal(t, int64(10), p.Metrics().WriteProbeFailures.Count())
+		require.Equal(t, p.Metrics().WriteProbeAttempts.Count(), p.Metrics().WriteProbeFailures.Count())
+		// kvprober is running in background, so more than ten probes may be run.
+		require.GreaterOrEqual(t, p.Metrics().WriteProbeFailures.Count(), int64(10))
 
-		require.Equal(t, int64(10), p.Metrics().ReadProbeAttempts.Count())
+		require.GreaterOrEqual(t, p.Metrics().ReadProbeAttempts.Count(), int64(10))
 		require.Zero(t, p.Metrics().ReadProbeFailures.Count())
 
 		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
@@ -251,7 +248,8 @@ func TestWriteProbeDoesNotLeaveLiveData(t *testing.T) {
 	lastStep := p.WriteProbeReturnLastStep(ctx, s.DB())
 
 	// Expect write probe to succeed.
-	require.Equal(t, int64(1), p.Metrics().WriteProbeAttempts.Count())
+	// kvprober is running in background, so more than one probe may be run.
+	require.Greater(t, p.Metrics().WriteProbeAttempts.Count(), int64(0))
 	require.Zero(t, p.Metrics().WriteProbeFailures.Count())
 	require.Zero(t, p.Metrics().ProbePlanFailures.Count())
 
@@ -277,10 +275,21 @@ func TestPlannerMakesPlansCoveringAllRanges(t *testing.T) {
 
 	ctx := context.Background()
 	// Disable split and merge queue just in case.
-	_, sqlDB, p, cleanup := initTestServer(t, base.TestingKnobs{
+	s, sqlDB, _, cleanup := initTestServer(t, base.TestingKnobs{
 		Store: &kvserver.StoreTestingKnobs{DisableSplitQueue: true, DisableMergeQueue: true},
 	})
 	defer cleanup()
+
+	// Create a kvprober and don't call Start, so that we can manually
+	// call the planner from this test, without any planning happening in the
+	// background.
+	p := kvprober.NewProber(kvprober.Opts{
+		Tracer:                  s.TracerI().(*tracing.Tracer),
+		DB:                      s.DB(),
+		HistogramWindowInterval: time.Minute, // actual value not important to test
+		Settings:                s.ClusterSettings(),
+	})
+	p.SetPlanningRateLimits(0)
 
 	rangeIDToTimesWouldBeProbed := make(map[int64]int)
 

--- a/pkg/kv/kvprober/settings.go
+++ b/pkg/kv/kvprober/settings.go
@@ -14,8 +14,11 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
+
+var enabled = util.ConstantWithMetamorphicTestBool("kv.prober.*.enabled", false)
 
 // kv.prober.bypass_admission_control controls whether kvprober's requests
 // should bypass kv layer's admission control. Setting this value to true
@@ -27,14 +30,13 @@ var bypassAdmissionControl = settings.RegisterBoolSetting(
 	"set to bypass admission control queue for kvprober requests; "+
 		"note that dedicated clusters should have this set as users own capacity planning "+
 		"but serverless clusters should not have this set as SREs own capacity planning",
-	true,
-)
+	util.ConstantWithMetamorphicTestBool("kv.prober.bypass_admission_control.enabled", true))
 
 var readEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.prober.read.enabled",
 	"whether the KV read prober is enabled",
-	false)
+	enabled)
 
 // TODO(josh): Another option is for the cluster setting to be a QPS target
 // for the cluster as a whole.
@@ -44,7 +46,7 @@ var readInterval = settings.RegisterDurationSetting(
 	"how often each node sends a read probe to the KV layer on average (jitter is added); "+
 		"note that a very slow read can block kvprober from sending additional probes; "+
 		"kv.prober.read.timeout controls the max time kvprober can be blocked",
-	1*time.Minute, func(duration time.Duration) error {
+	1*time.Second, func(duration time.Duration) error {
 		if duration <= 0 {
 			return errors.New("param must be >0")
 		}
@@ -70,7 +72,7 @@ var writeEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.prober.write.enabled",
 	"whether the KV write prober is enabled",
-	false)
+  enabled)
 
 var writeInterval = settings.RegisterDurationSetting(
 	settings.TenantWritable,
@@ -78,7 +80,7 @@ var writeInterval = settings.RegisterDurationSetting(
 	"how often each node sends a write probe to the KV layer on average (jitter is added); "+
 		"note that a very slow read can block kvprober from sending additional probes; "+
 		"kv.prober.write.timeout controls the max time kvprober can be blocked",
-	10*time.Second, func(duration time.Duration) error {
+	5*time.Second, func(duration time.Duration) error {
 		if duration <= 0 {
 			return errors.New("param must be >0")
 		}
@@ -148,7 +150,7 @@ var quarantineWriteEnabled = settings.RegisterBoolSetting(
 		"quarantine pool holds a separate group of ranges that have previously failed "+
 		"a probe which are continually probed. This helps determine outages for ranges "+
 		" with a high level of confidence",
-	false)
+	enabled)
 
 var quarantineWriteInterval = settings.RegisterDurationSetting(
 	settings.TenantWritable,

--- a/pkg/kv/kvprober/settings.go
+++ b/pkg/kv/kvprober/settings.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-var enabled = util.ConstantWithMetamorphicTestBool("kv.prober.*.enabled", false)
+var defaultEnabled = util.ConstantWithMetamorphicTestBool("kv.prober.*.enabled", false)
 
 // kv.prober.bypass_admission_control controls whether kvprober's requests
 // should bypass kv layer's admission control. Setting this value to true
@@ -36,7 +36,7 @@ var readEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.prober.read.enabled",
 	"whether the KV read prober is enabled",
-	enabled)
+	defaultEnabled)
 
 // TODO(josh): Another option is for the cluster setting to be a QPS target
 // for the cluster as a whole.
@@ -72,7 +72,7 @@ var writeEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.prober.write.enabled",
 	"whether the KV write prober is enabled",
-  enabled)
+	defaultEnabled)
 
 var writeInterval = settings.RegisterDurationSetting(
 	settings.TenantWritable,
@@ -150,7 +150,7 @@ var quarantineWriteEnabled = settings.RegisterBoolSetting(
 		"quarantine pool holds a separate group of ranges that have previously failed "+
 		"a probe which are continually probed. This helps determine outages for ranges "+
 		" with a high level of confidence",
-	enabled)
+	defaultEnabled)
 
 var quarantineWriteInterval = settings.RegisterDurationSetting(
 	settings.TenantWritable,


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/106835. I ran the tests 100 times, and all runs were successful.

Side note: If https://github.com/cockroachdb/cockroach/issues/105807 is closed, kvprober will be enabled metamorphically in roachtests too. I could put up a more ad-hoc PR enabling kvprober from roachtests, if KV thinks that is desirable. Let me know.

**kvprober: metamorphically enable / configure kvprober**

This commit metamorphically enables & configures kvprober. Though kvprober
is off by default & not documented publicly, we run with kvprober enabled in
CC. So we should test CRDB with kvprober enabled. This commit is
inspired by the crdb_internal.probe_ranges corruption bug, tho it targets
kvprober proper, not crdb_internal.probe_ranges.

This commit also adjusts the kvprober default intervals to what they are set at
in CC. This is mostly done to improve the quality of tests with kvprober
enabled.

Release note: None.

**kvprober: slightly improve integration test by enabling quarantine probing**

Release note: None.

**kvprober: deflake kvprober_integration_test.go**

This commit deflakes TestProberDesReadsAndWrites. Multiple test cases asserted
that N probes would run, but in reality more than N may run, since kvprober
is both called in the test and run in the background as part of the test
server.

This commit also deflakes TestPlannerMakesPlansCoveringAllRanges. To ensure
the condition checked in the test is hit, it is necessary to create a
kvprober without ever calling Start.

Release note: None.