### PR TITLE
release-22.2: userfile: fix transaction retry upload bug

### DIFF
--- a/pkg/cloud/userfile/filetable/file_table_read_writer.go
+++ b/pkg/cloud/userfile/filetable/file_table_read_writer.go
@@ -471,16 +471,19 @@ type payloadWriter struct {
 	payloadTableName        string
 }
 
-// WriteChunk inserts a single row into the Payload table as an operation in the
-// transaction txn.
-// TODO(janexing): can the insert happen with a nil txn?
-func (p *payloadWriter) WriteChunk(
-	buf []byte, txn *kv.Txn, ie sqlutil.InternalExecutor,
-) (int, error) {
-	insertChunkQuery := fmt.Sprintf(`INSERT INTO %s VALUES ($1, $2, $3)`, p.payloadTableName)
-	_, err := ie.ExecEx(p.ctx, "insert-file-chunk", txn, p.execSessionDataOverride,
-		insertChunkQuery, p.fileID, p.byteOffset, buf)
-	if err != nil {
+// WriteChunkInTxn inserts a single row into the Payload table as an
+// operation in the transaction txn.
+//
+// TODO(janexing): Is it necessary to run the insert in a txn?
+func (p *payloadWriter) WriteChunkInTxn(buf []byte) (int, error) {
+	if err := p.ief.TxnWithExecutor(p.ctx, p.db, nil /* sessionData */, func(
+		ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor,
+	) error {
+		insertChunkQuery := fmt.Sprintf(`INSERT INTO %s VALUES ($1, $2, $3)`, p.payloadTableName)
+		_, err := ie.ExecEx(p.ctx, "insert-file-chunk", txn, p.execSessionDataOverride,
+			insertChunkQuery, p.fileID, p.byteOffset, buf)
+		return err
+	}); err != nil {
 		return 0, err
 	}
 
@@ -581,18 +584,10 @@ func (w *chunkWriter) Write(buf []byte) (int, error) {
 		// If the buffer has been filled to capacity, write the chunk inside a txn
 		// retry loop.
 		if w.buf.Len() == w.buf.Cap() {
-			// TODO(janexing): Is it necessary to run the following within a txn?
-			if err := w.pw.ief.TxnWithExecutor(w.pw.ctx, w.pw.db, nil /* sessionData */, func(
-				ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor,
-			) error {
-				if n, err := w.pw.WriteChunk(w.buf.Bytes(), txn, ie); err != nil {
-					return err
-				} else if n != w.buf.Len() {
-					return errors.Wrap(io.ErrShortWrite, "error when writing in chunkWriter")
-				}
-				return nil
-			}); err != nil {
+			if n, err := w.pw.WriteChunkInTxn(w.buf.Bytes()); err != nil {
 				return 0, err
+			} else if n != w.buf.Len() {
+				return n, errors.Wrap(io.ErrShortWrite, "error when writing in chunkWriter")
 			}
 			w.buf.Reset()
 		}
@@ -613,18 +608,10 @@ func (w *chunkWriter) Close() error {
 	// payloadWriter Write() method, then the txn is aborted and the error is
 	// propagated here.
 	if w.buf.Len() > 0 {
-		// TODO(janexing): Is it necessary to run the following within a txn?
-		if err := w.pw.ief.TxnWithExecutor(w.pw.ctx, w.pw.db, nil /* sessionData */, func(
-			ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor,
-		) error {
-			if n, err := w.pw.WriteChunk(w.buf.Bytes(), txn, ie); err != nil {
-				return err
-			} else if n != w.buf.Len() {
-				return errors.Wrap(io.ErrShortWrite, "error when closing chunkWriter")
-			}
-			return nil
-		}); err != nil {
+		if n, err := w.pw.WriteChunkInTxn(w.buf.Bytes()); err != nil {
 			return err
+		} else if n != w.buf.Len() {
+			return errors.Wrap(io.ErrShortWrite, "error when closing chunkWriter")
 		}
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #106503.

/cc @cockroachdb/release

---

The payloadWriter's WriteChunk method maintains internal state that is mutated on each call.  As a result, calls to this method inside a retryable Txn func could result in data being written into the payload table with a wrongly recorded byte_offset.

We believe it may also be the cause of infrequent test failures in which userfile-based backup files appear to be empty.

Note that along the userfile read path, we read a given chunk of data with a call like:

    SELECT substr(payload, $2+1-byte_offset, $3)
    FROM %s WHERE file_id=$1 AND byte_offset <= $2
    ORDER BY byte_offset DESC
    LIMIT 1

where $2 is the current position of the reader. In the face of the upload bug, it is possible that first chunk of data is actually written at a byte offset > 0. So, on the very first call to this select, no rows will match and we will assume that the file is empty.

This was found via an in-progress testing feature that randomly injects retryable errors into transactions. I haven't included this test here as it requires other, unrelated fixes to work reliably.

Informs #104561
Informs #106417

Epic: none

Release note (bug fix): Fix a rare bug in which some userfile uploads would silently upload incorrect data.

Release justification: Bug fix for serious issue.
