### PR TITLE
schemachanger: Fix CREATE SEQUENCE OWNED BY failure

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2403,3 +2403,10 @@ CREATE SEQUENCE TIMESTAMPTZ . PRIMARY . IS;
 
 statement error pgcode 3F000 cannot create \"timestamptz.is\" because the target database or schema does not exist
 CREATE SEQUENCE TIMESTAMPTZ . IS;
+
+# The following subtest ensures OWNED BY option returns a reasonable user error
+# when the table name is missing.
+subtest regression_106838
+
+statement error pgcode 42601 pq: invalid OWNED BY option
+CREATE SEQUENCE s_106838 OWNED BY col;


### PR DESCRIPTION
Previously, stmts like `CREATE SEQUENCE s OWNED BY col` where table name is missing will fail with an internal error. This commit fix this.

Fix #106838
Release note: None