### PR TITLE
rpc: Skip TestGRPCKeepaliveFailureFailsInflightRPCs under stress

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -1234,6 +1234,7 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 func TestGRPCKeepaliveFailureFailsInflightRPCs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.UnderShort(t, "Takes too long given https://github.com/grpc/grpc-go/pull/2642")
+	skip.UnderStress(t, "Under high parallelism (>100) on the host node, this test reuses ports and fails")
 
 	sc := log.Scope(t)
 	defer sc.Close(t)


### PR DESCRIPTION
The test TestGRPCKeepaliveFailureFailsInflightRPCs launches 13 variations of connections and runs a client/server for each connection. At parallelism over 100 this test fails consistently within a minute, while at lower levels it passes consistently for over an hour.

It appears that it starts attempting to reuse network ports that are in partially closed states between iterations of a run and this causes the problem.  In CI we frequently run multiple parallel runs and so it is certainly conceviable that it is ocassionally pushing the number of concurrent runs of this test past 100 and causing failures.

Since this test is mostly a functional test and not intended to be run for stress, skipping under stress will get almost all the benefit and remove the flakiness.

Epic: none
Fixes: #106637

Release note: None