### PR TITLE
changefeedccl: Adjust feature flag directly

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4419,13 +4419,16 @@ func TestChangefeedErrors(t *testing.T) {
 
 	// Feature flag for changefeeds is off — test that CREATE CHANGEFEED and
 	// EXPERIMENTAL CHANGEFEED FOR surface error.
-	sqlDB.Exec(t, `SET CLUSTER SETTING feature.changefeed.enabled = false`)
-	sqlDB.ExpectErr(t, `feature CHANGEFEED was disabled by the database administrator`,
-		`CREATE CHANGEFEED FOR foo`)
-	sqlDB.ExpectErr(t, `feature CHANGEFEED was disabled by the database administrator`,
-		`EXPERIMENTAL CHANGEFEED FOR foo`)
-
-	sqlDB.Exec(t, `SET CLUSTER SETTING feature.changefeed.enabled = true`)
+	func() {
+		featureChangefeedEnabled.Override(context.Background(), &s.ClusterSettings().SV, false)
+		defer func() {
+			featureChangefeedEnabled.Override(context.Background(), &s.ClusterSettings().SV, true)
+		}()
+		sqlDB.ExpectErr(t, `feature CHANGEFEED was disabled by the database administrator`,
+			`CREATE CHANGEFEED FOR foo`)
+		sqlDB.ExpectErr(t, `feature CHANGEFEED was disabled by the database administrator`,
+			`EXPERIMENTAL CHANGEFEED FOR foo`)
+	}()
 
 	sqlDB.ExpectErr(
 		t, `unknown format: nope`,


### PR DESCRIPTION
Cluster setting changes via `SET CLUSTER SETTING` command wait for asynchronous propagate of the setting into local setting registry.  However, very infrequently they could time out. So, harden the test against that.

Fixes #96329

Release note: None