### PR TITLE
roachprod: keep reference to parent logger

### DIFF
--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -82,20 +82,33 @@ func newRemoteSession(l *logger.Logger, command *remoteCommand) *remoteSession {
 			debugName = GenFilenameFromArgs(20, command.cmd)
 		}
 
-		cl, err := l.ChildLogger(filepath.Join("ssh", fmt.Sprintf(
-			"ssh_%s_n%v_%s",
-			timeutil.Now().Format(`150405.000000000`),
-			command.node,
-			debugName,
-		)))
-
-		// Check the logger file since running roachprod from the cli will result in a fileless logger.
-		if err == nil && l.File != nil {
-			logfile = cl.File.Name()
-			loggingArgs = []string{
-				"-vvv", "-E", logfile,
+		// Check the logger file since running roachprod from the cli will
+		// result in a fileless logger.
+		if l.File != nil {
+			// We use the logger instance as a proxy to the artifacts dir in
+			// a roachtest run. The RootLogger's directory will be the root
+			// of the artifacts directory, which ensures that every ssh_*
+			// file ends up in the same location.
+			artifactsLogger := l
+			if rl := l.RootLogger(); rl.File != nil {
+				artifactsLogger = rl
 			}
-			cl.Close()
+			cl, err := artifactsLogger.ChildLogger(filepath.Join("ssh", fmt.Sprintf(
+				"ssh_%s_n%v_%s",
+				timeutil.Now().Format(`150405.000000000`),
+				command.node,
+				debugName,
+			)))
+
+			if err == nil {
+				logfile = cl.File.Name()
+				loggingArgs = []string{
+					"-vvv", "-E", logfile,
+				}
+				cl.Close()
+			} else {
+				l.Printf("could not create child logger: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This changes roachprod's Logger to keep a reference to the parent instance when a call to `ChildLogger` is made. This allows any logger instance to then reference the root logger in the chain via a new `RootLogger` function added in this commit.

This function is used in `newRemoteSession`: when determining the path to the SSH log file, we now generate a path relative to the root logger, instead of relative to the logger instance passed as parameter. This makes it so that, on roachtest failures, the `ssh/` directory is created at the top of the artifacts directory regardless of whether the test itself is using a `ChildLogger` or not.

Ideally, the `remoteSession` would have access to the artifacts directory, since that's what it actually cares about. Making that plumbing, however, would involve a significant amount of infrastructure and test changes, so this commit takes the pragmatic approach of assuming that the root logger points to the root of the artifacts directory, an assumption that will likely hold for a long time.

Epic: none

Release note: None