### PR TITLE
cmd/roachtest: Unskip clearrange/zfs test

### DIFF
--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -41,26 +41,24 @@ func registerClearRange(r registry.Registry) {
 					runClearRange(ctx, t, c, checks, rangeTombstones)
 				},
 			})
-
-			// Using a separate clearrange test on zfs instead of randomly
-			// using the same test, cause the Timeout might be different,
-			// and may need to be tweaked.
-			r.Add(registry.TestSpec{
-				Name:  fmt.Sprintf(`clearrange/zfs/checks=%t/rangeTs=%t`, checks, rangeTombstones),
-				Skip:  "Consistently failing. See #68716 context.",
-				Owner: registry.OwnerStorage,
-				// 5h for import, 120 for the test. The import should take closer
-				// to <3:30h but it varies.
-				Timeout:           5*time.Hour + 120*time.Minute,
-				Cluster:           r.MakeClusterSpec(10, spec.CPU(16), spec.SetFileSystem(spec.Zfs)),
-				EncryptionSupport: registry.EncryptionMetamorphic,
-				Leases:            registry.MetamorphicLeases,
-				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runClearRange(ctx, t, c, checks, rangeTombstones)
-				},
-			})
 		}
 	}
+	// Using a separate clearrange test on zfs instead of randomly
+	// using the same test, cause the Timeout might be different,
+	// and may need to be tweaked.
+	r.Add(registry.TestSpec{
+		Name:  `clearrange/zfs/checks=true/rangeTs=true`,
+		Owner: registry.OwnerStorage,
+		// 5h for import, 120 for the test. The import should take closer
+		// to <3:30h but it varies.
+		Timeout:           5*time.Hour + 120*time.Minute,
+		Cluster:           r.MakeClusterSpec(10, spec.CPU(16), spec.SetFileSystem(spec.Zfs)),
+		EncryptionSupport: registry.EncryptionMetamorphic,
+		Leases:            registry.MetamorphicLeases,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runClearRange(ctx, t, c, true /* checks */, true /* rangeTombstones */)
+		},
+	})
 }
 
 func runClearRange(


### PR DESCRIPTION
In my test runs, the clearrange/zfs tests reliably pass now, thanks to improvements over the 1.5+ years since this test was first skipped. This change unskips the checks=true/rangeTs=true variant of the test to get the highest possible test coverage while not significantly blowing up the list of tests (as rangeTs=false is less supported going forward anyway).

Epic: none
Fixes #68716.
Fixes #74708.

Release note: None