### PR TITLE
kvcoord: raise ambiguous errors on batches with commit

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2340,7 +2340,7 @@ func (ds *DistSender) sendToReplicas(
 			// evaluating twice, overwriting another unrelated write that fell
 			// in-between.
 			//
-			if withCommit && !grpcutil.RequestDidNotStart(err) {
+			if withCommit {
 				ambiguousError = err
 			}
 			log.VErrEventf(ctx, 2, "RPC error: %s", err)


### PR DESCRIPTION
WIP: This intends to raise an error on a KV batch that has an ambiguous error on one of its writes, and also has an `EndTxn` request in the batch.

Part of: #103817

Release note (bug fix): TBD