### PR TITLE
release-23.1: prevent data loss for at risk indexes and add tooling to detect them

### DIFF
--- a/pkg/sql/catalog/internal/validate/validate.go
+++ b/pkg/sql/catalog/internal/validate/validate.go
@@ -33,6 +33,10 @@ const (
 
 	// Write is the default validation level when writing a descriptor.
 	Write = catalog.ValidationLevelAllPreTxnCommit
+
+	// ForUpgrade is the validation used by doctor which includes
+	// extra things for upgrades
+	ForUpgrade = catalog.ValidationLevelExtraForUpgrade
 )
 
 // Self is a convenience function for Validate called at the
@@ -214,6 +218,11 @@ func (vea *validationErrorAccumulator) validateDescriptorsAtLevel(
 // IsActive implements the ValidationErrorAccumulator interface.
 func (vea *validationErrorAccumulator) IsActive(version clusterversion.Key) bool {
 	return vea.activeVersion.IsActive(version)
+}
+
+// HasExtraChecksForUpgrade implements catalog.ValidationErrorAccumulator.
+func (vea *validationErrorAccumulator) HasExtraChecksForUpgrade() bool {
+	return vea.targetLevel == catalog.ValidationLevelExtraForUpgrade
 }
 
 func (vea *validationErrorAccumulator) reportDescGetterError(

--- a/pkg/sql/catalog/nstree/catalog.go
+++ b/pkg/sql/catalog/nstree/catalog.go
@@ -300,7 +300,7 @@ func (c Catalog) ValidateWithRecover(
 			ve = append(ve, err)
 		}
 	}()
-	return c.Validate(ctx, version, catalog.NoValidationTelemetry, validate.Write, desc)
+	return c.Validate(ctx, version, catalog.NoValidationTelemetry, validate.ForUpgrade, desc)
 }
 
 // ByteSize returns memory usage of the underlying map in bytes.

--- a/pkg/sql/catalog/randgen/tables.go
+++ b/pkg/sql/catalog/randgen/tables.go
@@ -188,6 +188,16 @@ func (g *testSchemaGenerator) genOneTable(
 			colName := ng.GenerateOne(0)
 			tmpl.desc.Columns[i+1].Name = colName
 			tmpl.desc.Families[0].ColumnNames[i+1] = colName
+			for j := range tmpl.desc.PrimaryIndex.KeyColumnNames {
+				if tmpl.desc.PrimaryIndex.KeyColumnIDs[j] == tmpl.desc.Columns[i+1].ID {
+					tmpl.desc.PrimaryIndex.KeyColumnNames[j] = colName
+				}
+			}
+			for j := range tmpl.desc.PrimaryIndex.StoreColumnNames {
+				if tmpl.desc.PrimaryIndex.StoreColumnIDs[j] == tmpl.desc.Columns[i+1].ID {
+					tmpl.desc.PrimaryIndex.StoreColumnNames[j] = colName
+				}
+			}
 		}
 		ng := randident.NewNameGenerator(&nameGenCfg, g.rand, "primary")
 		idxName := ng.GenerateOne(0)

--- a/pkg/sql/catalog/randgen/templates.go
+++ b/pkg/sql/catalog/randgen/templates.go
@@ -163,6 +163,22 @@ outer:
 				t.desc.Families[0].ColumnIDs, colID)
 			t.desc.Families[0].ColumnNames = append(
 				t.desc.Families[0].ColumnNames, newColDef.Name)
+			// Add to the primary index as either a key or store column.
+			for i, name := range origDesc.PrimaryIndex.KeyColumnNames {
+				if name == origColDef.Name {
+					t.desc.PrimaryIndex.KeyColumnIDs = append(t.desc.PrimaryIndex.KeyColumnIDs, colID)
+					t.desc.PrimaryIndex.KeyColumnNames = append(t.desc.PrimaryIndex.KeyColumnNames, name)
+					t.desc.PrimaryIndex.KeyColumnDirections = append(t.desc.PrimaryIndex.KeyColumnDirections, origDesc.PrimaryIndex.KeyColumnDirections[i])
+					break
+				}
+			}
+			for _, name := range origDesc.PrimaryIndex.StoreColumnNames {
+				if name == origColDef.Name {
+					t.desc.PrimaryIndex.StoreColumnIDs = append(t.desc.PrimaryIndex.StoreColumnIDs, colID)
+					t.desc.PrimaryIndex.StoreColumnNames = append(t.desc.PrimaryIndex.StoreColumnNames, name)
+					break
+				}
+			}
 		}
 		g.models.tb = append(g.models.tb, t)
 	}
@@ -192,6 +208,14 @@ func defaultTemplate() tbTemplate {
 			t.desc.Families[0].ColumnIDs, colID)
 		t.desc.Families[0].ColumnNames = append(
 			t.desc.Families[0].ColumnNames, colName)
+		if colID == 0 {
+			t.desc.PrimaryIndex.KeyColumnIDs = []descpb.ColumnID{colID}
+			t.desc.PrimaryIndex.KeyColumnNames = []string{colName}
+			t.desc.PrimaryIndex.KeyColumnDirections = []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC}
+		} else {
+			t.desc.PrimaryIndex.StoreColumnIDs = append(t.desc.PrimaryIndex.StoreColumnIDs, colID)
+			t.desc.PrimaryIndex.StoreColumnNames = append(t.desc.PrimaryIndex.StoreColumnNames, colName)
+		}
 	}
 	return t
 }

--- a/pkg/sql/catalog/tabledesc/helpers_test.go
+++ b/pkg/sql/catalog/tabledesc/helpers_test.go
@@ -40,6 +40,11 @@ func (cea *constraintValidationErrorAccumulator) IsActive(version clusterversion
 	return true
 }
 
+// HasExtraChecksForUpgrade implements catalog.ValidationErrorAccumulator.
+func (cea *constraintValidationErrorAccumulator) HasExtraChecksForUpgrade() bool {
+	return true
+}
+
 func ValidateConstraints(immI catalog.TableDescriptor) error {
 	imm, ok := immI.(*immutable)
 	if !ok {

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -763,7 +763,7 @@ func (desc *wrapper) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 			desc.validateColumnFamilies(columnsByID),
 			desc.validateCheckConstraints(columnsByID),
 			desc.validateUniqueWithoutIndexConstraints(columnsByID),
-			desc.validateTableIndexes(columnsByID),
+			desc.validateTableIndexes(columnsByID, vea.HasExtraChecksForUpgrade()),
 			desc.validatePartitioning(),
 		}
 		hasErrs := false
@@ -1284,7 +1284,9 @@ func (desc *wrapper) validateUniqueWithoutIndexConstraints(
 // IDs are unique, and the family of the primary key is 0. This does not check
 // if indexes are unique (i.e. same set of columns, direction, and uniqueness)
 // as there are practical uses for them.
-func (desc *wrapper) validateTableIndexes(columnsByID map[descpb.ColumnID]catalog.Column) error {
+func (desc *wrapper) validateTableIndexes(
+	columnsByID map[descpb.ColumnID]catalog.Column, upgradeChecks bool,
+) error {
 	if len(desc.PrimaryIndex.KeyColumnIDs) == 0 {
 		return ErrMissingPrimaryKey
 	}
@@ -1555,6 +1557,40 @@ func (desc *wrapper) validateTableIndexes(columnsByID map[descpb.ColumnID]catalo
 			if len(foundIn) > 1 {
 				return errors.AssertionFailedf("index %q has column ID %d present in: %v",
 					idx.GetName(), colID, foundIn)
+			}
+		}
+		// Checks after this point are for future release. Also exclude system
+		// tables from these checks.
+		if !upgradeChecks {
+			continue
+		}
+		// Check that each non-virtual column is in the key or store columns of
+		// the primary index.
+		if idx.Primary() {
+			keyCols := idx.CollectKeyColumnIDs()
+			storeCols := idx.CollectPrimaryStoredColumnIDs()
+			for _, col := range desc.PublicColumns() {
+				if col.IsVirtual() {
+					if storeCols.Contains(col.GetID()) {
+						return errors.Newf(
+							"primary index %q store columns cannot contain virtual column ID %d",
+							idx.GetName(), col.GetID(),
+						)
+					}
+					// No need to check anything else for virtual columns.
+					continue
+				}
+				if !keyCols.Contains(col.GetID()) && !storeCols.Contains(col.GetID()) {
+					return errors.Newf(
+						"primary index %q must contain column ID %d in either key or store columns",
+						idx.GetName(), col.GetID(),
+					)
+				}
+			}
+		} else if len(desc.Mutations) == 0 && desc.DeclarativeSchemaChangerState == nil {
+			if idx.IndexDesc().EncodingType != catenumpb.SecondaryIndexEncoding {
+				return errors.AssertionFailedf("secondary index %q has invalid encoding type %d in proto, expected %d",
+					idx.GetName(), idx.IndexDesc().EncodingType, catenumpb.SecondaryIndexEncoding)
 			}
 		}
 	}

--- a/pkg/sql/catalog/validate.go
+++ b/pkg/sql/catalog/validate.go
@@ -42,6 +42,9 @@ const (
 	// Errors accumulated when validating up to this level come with additional
 	// telemetry.
 	ValidationLevelAllPreTxnCommit
+	// ValidationLevelExtraForUpgrade means do all of the above, but
+	// apply optional checks which aim at checking upgrade compatibility.
+	ValidationLevelExtraForUpgrade
 )
 
 // ValidationTelemetry defines the kind of telemetry keys to add to the errors.
@@ -71,6 +74,10 @@ type ValidationErrorAccumulator interface {
 	// be enabled, by comparing against the active version. If the active version
 	// is unknown the validation in question will always be enabled.
 	IsActive(version clusterversion.Key) bool
+
+	// HasExtraChecksForUpgrade returns if extra checks required for upgrades
+	// should be performed.
+	HasExtraChecksForUpgrade() bool
 }
 
 // ValidationErrors is the error container returned by Validate which contains

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -142,6 +142,21 @@ func (n *dropIndexNode) startExec(params runParams) error {
 			return false
 		}
 
+		// Determine if any of the columns stored by this index are *not* kept
+		// in the primary index. Dropping these columns will lead to data loss.
+		if idx != nil {
+			primaryStoredColumns := tableDesc.GetPrimaryIndex().CollectPrimaryStoredColumnIDs()
+			secondaryStoredColumns := idx.CollectSecondaryStoredColumnIDs()
+			for _, col := range tableDesc.AllColumns() {
+				if col.IsVirtual() {
+					secondaryStoredColumns.Remove(col.GetID())
+				}
+			}
+			if missingColumns := secondaryStoredColumns.Difference(primaryStoredColumns); !missingColumns.Empty() {
+				return sqlerrors.NewSecondaryIndexDataLossError(idx.GetName())
+			}
+		}
+
 		// Drop expression index columns if they are not key columns in any
 		// other index. They cannot be referenced in constraints, computed
 		// columns, or other indexes, so they are safe to drop.

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -466,3 +466,93 @@ t1_96731    t1_96731_pkey    PRIMARY KEY      PRIMARY KEY (i ASC)  true
 
 statement ok
 DROP TABLE t1_96731, t2_96731;
+
+
+# We had a bug where after adding a column it could have wound up only in a
+# secondary index as storing if the index was created as a side effect of
+# ALTER PRIMARY KEY on 20.2 and 21.1. Simulate this corruption and ensure
+# if such an index exists to prevent data loss drops are blocked with a link
+# to the technical advisory.
+subtest drop_index_data_loss_block
+
+statement ok
+CREATE TABLE t_with_idx_data_loss (n INT8 PRIMARY KEY, j INT8);
+CREATE INDEX ON t_with_idx_data_loss(n) STORING (j);
+
+# Corrupt the primary index to stop storing j, so the only source is storing
+# is a secondary index.
+statement ok
+WITH
+	to_json
+		AS (
+			SELECT
+				id,
+				crdb_internal.pb_to_json(
+					'cockroach.sql.sqlbase.Descriptor',
+					descriptor,
+					false
+				)
+					AS d
+			FROM
+				system.descriptor
+			WHERE
+				id IN ('t_with_idx_data_loss'::regclass::oid::int,)
+		),
+	modified
+		AS (
+			SELECT
+				id,
+				json_set(
+					json_set(
+						json_remove_path(
+							json_remove_path(
+								d,
+								ARRAY[
+									'table',
+									'primaryIndex',
+									'storeColumnIds'
+								]
+							),
+							ARRAY[
+								'table',
+								'primaryIndex',
+								'storeColumnNames'
+							]
+						),
+						ARRAY['table', 'version'],
+						(
+							(d->'table'->>'version')::INT8
+							+ 1
+						)::STRING::JSONB
+					),
+					ARRAY['table', 'modificationTime'],
+					json_build_object(
+						'wallTime',
+						(
+							(
+								extract('epoch', now())
+								* 1000000
+							)::INT8
+							* 1000
+						)::STRING
+					)
+				)
+					AS d
+			FROM
+				to_json
+		)
+SELECT
+	crdb_internal.unsafe_upsert_descriptor(
+		id,
+		crdb_internal.json_to_pb(
+			'cockroach.sql.sqlbase.Descriptor',
+			d
+		),
+		false
+	)
+FROM
+	modified;
+
+# Drop INDEX will be blocked
+statement error pq: index t_with_idx_data_loss_n_idx cannot be safely dropped, since doing so will lose data in certain columns
+DROP INDEX t_with_idx_data_loss@t_with_idx_data_loss_n_idx;

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -556,3 +556,12 @@ FROM
 # Drop INDEX will be blocked
 statement error pq: index t_with_idx_data_loss_n_idx cannot be safely dropped, since doing so will lose data in certain columns
 DROP INDEX t_with_idx_data_loss@t_with_idx_data_loss_n_idx;
+
+# Validate this object is seen as invalid.
+query TT
+SELECT obj_name, error FROM crdb_internal.invalid_objects
+----
+t_with_idx_data_loss  relation "t_with_idx_data_loss" (125): primary index "t_with_idx_data_loss_pkey" must contain column ID 2 in either key or store columns
+
+statement ok
+DROP TABLE t_with_idx_data_loss;

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
@@ -116,6 +116,43 @@ func maybeDropIndex(
 	return sie
 }
 
+// panicIfColumnsAreNotStoredElseWhere detects if dropping an index will lose a stored
+// column. Previously, we had an issue where new columns were accidentally
+// added into secondary indexes. This could lead to wrong results and data
+// loss, so for safety we are going to block dropping these secondary indexes.
+func panicIfColumnsAreNotStoredElseWhere(b BuildCtx, sie *scpb.SecondaryIndex) {
+	tblElts := b.QueryByID(sie.TableID)
+	secondaryIdxElts := tblElts.Filter(hasIndexIDAttrFilter(sie.IndexID))
+	_, _, indexName := scpb.FindIndexName(secondaryIdxElts)
+	_, _, pie := scpb.FindPrimaryIndex(b.QueryByID(sie.TableID))
+	primaryIdxElts := tblElts.Filter(hasIndexIDAttrFilter(pie.IndexID))
+
+	foundColumns := make(map[catid.ColumnID]struct{})
+	primaryIdxElts.ForEachElementStatus(func(current scpb.Status, target scpb.TargetStatus, e scpb.Element) {
+		idxColumn, ok := (e).(*scpb.IndexColumn)
+		if !ok {
+			return
+		}
+		foundColumns[idxColumn.ColumnID] = struct{}{}
+	})
+	secondaryIdxElts.ForEachElementStatus(func(current scpb.Status, target scpb.TargetStatus, e scpb.Element) {
+		idxColumn, ok := (e).(*scpb.IndexColumn)
+		if !ok {
+			return
+		}
+		columnElts := tblElts.Filter(hasColumnIDAttrFilter(idxColumn.ColumnID))
+		// Skip columns that are virtual.
+		_, _, columnType := scpb.FindColumnType(columnElts)
+		if columnType.IsVirtual {
+			return
+		}
+		// Check if the column is stored in primary index.
+		if _, found := foundColumns[idxColumn.ColumnID]; !found {
+			panic(sqlerrors.NewSecondaryIndexDataLossError(indexName.Name))
+		}
+	})
+}
+
 // dropSecondaryIndex is a helper to drop a secondary index which may be used
 // both in DROP INDEX and as a cascade from another operation.
 func dropSecondaryIndex(
@@ -125,6 +162,9 @@ func dropSecondaryIndex(
 	sie *scpb.SecondaryIndex,
 ) {
 	{
+		// Sanity: We had a pretty severe bug with a data loss risk, prevent
+		// dropping of any indexes that are the sole source for given data.
+		panicIfColumnsAreNotStoredElseWhere(b, sie)
 		next := b.WithNewSourceElementID()
 		// Maybe drop dependent views.
 		// If CASCADE and there are "dependent" views (i.e. views that use this

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -412,3 +412,16 @@ func errHasCode(err error, code ...pgcode.Code) bool {
 	}
 	return false
 }
+
+// NewSecondaryIndexDataLossError creates an error if dropping a secondary
+// index could lead to losing a column.
+func NewSecondaryIndexDataLossError(indexName string) error {
+	return errors.WithIssueLink(errors.Newf("index %s cannot be safely dropped, "+
+		"since doing so will lose data in certain columns", indexName),
+		errors.IssueLink{
+			IssueURL: "https://www.cockroachlabs.com/docs/advisories/a99561",
+			Detail: "Dropping this secondary index may lead to data loss, please " +
+				"contact support.",
+		},
+	)
+}


### PR DESCRIPTION
This patch aims at doing the following:

1. Extend the debug doctor / crdb_internal.invalid_objects to detect indexes which could potentially lose data by being dropped specifically when a column is only stored inside them
2. Add a check inside DROP INDEX to prevent dropping indexes with this problem to avoid data loss.

Fixes: #106794
Informs: #106739 

Release justification: low risk and prevents a potentially dangerous action by users