### PR TITLE
acceptance: enable test_missing_log_output.tcl

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -298,6 +298,13 @@ func TestDockerCLI_test_log_flags(t *testing.T) {
 	runTestDockerCLI(t, "test_log_flags", "../cli/interactive_tests/test_log_flags.tcl")
 }
 
+func TestDockerCLI_test_missing_log_output(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_missing_log_output", "../cli/interactive_tests/test_missing_log_output.tcl")
+}
+
 func TestDockerCLI_test_multiline_statements(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -1,7 +1,5 @@
 #! /usr/bin/env expect -f
 
-# disabled until #48413 is resolved.
-
 source [file join [file dirname $argv0] common.tcl]
 
 spawn /bin/bash
@@ -14,7 +12,7 @@ eexpect "CockroachDB node starting"
 system "$argv sql --insecure -e \"select crdb_internal.force_log_fatal('helloworld')\" || true"
 eexpect ":/# "
 send "echo \$?\r"
-eexpect "255"
+eexpect "7"
 eexpect ":/# "
 end_test
 
@@ -106,25 +104,25 @@ eexpect ":/# "
 
 end_test
 
-
-
 start_server $argv
 
-start_test "Test that quit does not show INFO by default with --logtostderr"
-# Test quit as non-start command, this time with --logtostderr. Test
+start_test "Test that init does not show INFO by default with --logtostderr"
+# Test init as non-start command, this time with --logtostderr. Test
 # that the default logging level is WARNING, so that no INFO messages
 # are printed between the marker and the (first line) error message
-# from quit. Quit will error out because the server is already stopped.
-send "echo marker; $argv quit --logtostderr 2>&1 | grep -vE '^\[WEF\]\[0-9\]+|^node is draining'\r"
-eexpect "marker\r\nCommand \"quit\" is deprecated"
+# from init. Init will error out because the server is already initialized.
+send "echo marker; $argv init --logtostderr 2>&1\r"
+eexpect "marker\r\nERROR: cluster has already been initialized\r\nFailed running \"init\""
 eexpect ":/# "
 end_test
 
 start_test "Check that `--logtostderr` can override the default"
-send "$argv quit --logtostderr=INFO --vmodule=stopper=1\r"
-eexpect "stop has been called"
+send "$argv init --logtostderr=INFO --vmodule=peer=1\r"
+eexpect "probe starting"
 eexpect ":/# "
 end_test
+
+stop_server $argv
 
 send "exit\r"
 eexpect eof


### PR DESCRIPTION
This test is now enabled. It checks for the Fatal exit code 7 instead of 255, and the portion that tests the `quit` command is removed now that the command has been deprecated and removed.

Resolves #106461
Epic: None
Release note: None