### PR TITLE
multitenant: Use proper tenant flag in upgradeinterlockccl

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
@@ -124,7 +124,7 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 		ServerArgs: base.TestServerArgs{
 			// Test validates tenant behavior. No need for the default test
 			// tenant.
-			DefaultTestTenant: base.TODOTestTenantDisabled,
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 			Settings:          settings,
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),


### PR DESCRIPTION
Switch TODOTestTenantDisabled to TestControlsTenantsExplicitly since test directly manipulates tenants.

Epic: CRDB-18499
Informs: #76378
Release note: None