### PR TITLE
sql: fix CREATE OR REPLACE VIEW cross-db type reference errors

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -612,6 +612,12 @@ func (p *planner) replaceViewDesc(
 		toReplace.ViewQuery = updatedQuery
 	}
 
+	typeReplacedQuery, err := serializeUserDefinedTypes(ctx, p.SemaCtx(), toReplace.ViewQuery, false /* multiStmt */)
+	if err != nil {
+		return nil, err
+	}
+	toReplace.ViewQuery = typeReplacedQuery
+
 	// Check that the new view has at least as many columns as the old view before
 	// adding result columns.
 	if len(n.columns) < len(toReplace.ClusterVersion().Columns) {

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1924,3 +1924,33 @@ statement error pgcode 22P02 invalid input value for enum e105259: "foo"
 SELECT * FROM v105259
 
 subtest end
+
+# Regression test for #106602. Check for cross-database type references when
+# executing CREATE OR REPLACE VIEW.
+subtest regression_106602
+
+statement ok
+SET CLUSTER SETTING sql.cross_db_views.enabled = FALSE
+
+statement ok
+CREATE DATABASE db106602a
+
+statement ok
+CREATE DATABASE db106602b
+
+statement ok
+USE db106602a;
+
+statement ok
+CREATE TYPE e AS ENUM ('foo');
+
+statement ok
+USE db106602b;
+
+statement ok
+CREATE VIEW v AS (SELECT 1)
+
+statement error cross database type references are not supported: db106602a.public.e
+CREATE OR REPLACE VIEW v AS (SELECT 1 FROM (VALUES (1)) val(i) WHERE 'foo'::db106602a.e = 'foo'::db106602a.e)
+
+subtest end


### PR DESCRIPTION
Fixes #106602

Release note (bug fix): A bug has been fixed that allowed views created
with `CREATE OR REPLACE VIEW` to reference user-defined types in other
databases, even with `sql.cross_db_views.enabled` set to `false`. This
bug was present since user-defined types were introduced in version
20.1.
