### PR TITLE
ts: correctly set Columnar flag on memory context

### DIFF
--- a/pkg/ts/maintenance.go
+++ b/pkg/ts/maintenance.go
@@ -61,6 +61,7 @@ func (tsdb *DB) MaintainTimeSeries(
 	if tsdb.WriteRollups() {
 		qmc := MakeQueryMemoryContext(mem, mem, QueryMemoryOptions{
 			BudgetBytes: budgetBytes,
+			Columnar:    tsdb.WriteColumnar(),
 		})
 		if err := tsdb.rollupTimeSeries(ctx, series, now, qmc); err != nil {
 			return err

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -315,6 +315,7 @@ func (s *Server) Query(
 							BudgetBytes:             s.queryMemoryMax / int64(s.queryWorkerMax),
 							EstimatedSources:        estimatedSourceCount,
 							InterpolationLimitNanos: interpolationLimit,
+							Columnar:                s.db.WriteColumnar(),
 						},
 					)
 


### PR DESCRIPTION
This flag is used to determine the size of the slab, and it wasn't set properly since 2018. The impact is that for non-rollup we'll be able to retrieve more samples in a single operation because the columnar slab size is smaller (in a test I observed 4.5kb vs 14.5kv for the row format slab).

Epic: None

Release note: None