### PR TITLE
parser: Fix AS OF failures in TestRandomSyntaxSelect

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -843,3 +843,22 @@ RESET large_full_scan_rows;
 # Regression test for #58104.
 statement ok
 SELECT * FROM pg_catalog.pg_attrdef WHERE (adnum = 1 AND adrelid = 1) OR (adbin = 'foo' AND adrelid = 2)
+
+# Tests with SELECT AS clause.
+statement ok
+CREATE TABLE t(a INT, b INT);
+
+statement ok
+INSERT INTO t values(10, 20);
+
+query I colnames
+SELECT -488 AS OF FROM t;
+----
+of
+-488
+
+query I colnames
+SELECT -488 OF FROM t;
+----
+of
+-488

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -489,6 +489,7 @@ func TestContextualHelp(t *testing.T) {
 
 		{`SELECT 1 ??`, `SELECT`},
 		{`SELECT * FROM ??`, `<SOURCE>`},
+		{`SELECT 1 AS OF ??`, `SELECT`},
 		{`SELECT 1 FROM foo ??`, `SELECT`},
 		{`SELECT 1 FROM foo WHERE ??`, `SELECT`},
 		{`SELECT 1 FROM (SELECT ??`, `SELECT`},
@@ -552,7 +553,7 @@ func TestContextualHelp(t *testing.T) {
 
 		{`BACKUP foo TO 'bar' ??`, `BACKUP`},
 		{`BACKUP DATABASE ??`, `BACKUP`},
-		{`BACKUP foo TO 'bar' AS OF ??`, `BACKUP`},
+		{`BACKUP foo TO 'bar' AS OF SYSTEM ??`, `BACKUP`},
 
 		{`RESTORE foo FROM 'bar' ??`, `RESTORE`},
 		{`RESTORE DATABASE ??`, `RESTORE`},

--- a/pkg/sql/parser/lexer.go
+++ b/pkg/sql/parser/lexer.go
@@ -224,7 +224,10 @@ func (l *lexer) Lex(lval *sqlSymType) int {
 		case AS:
 			switch nextToken.id {
 			case OF:
-				lval.id = AS_LA
+				switch secondToken.id {
+				case SYSTEM:
+					lval.id = AS_LA
+				}
 			}
 		case NOT:
 			switch nextToken.id {

--- a/pkg/sql/parser/lexer_test.go
+++ b/pkg/sql/parser/lexer_test.go
@@ -27,6 +27,7 @@ func TestLexer(t *testing.T) {
 		{`NOT IN`, []int{NOT_LA, IN}},
 		{`NOT SIMILAR`, []int{NOT_LA, SIMILAR}},
 		{`AS OF SYSTEM TIME`, []int{AS_LA, OF, SYSTEM, TIME}},
+		{`AS OF`, []int{AS, OF}},
 	}
 	for i, d := range testData {
 		s := makeSQLScanner(d.sql)

--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -3069,3 +3069,11 @@ SELECT * FROM ROWS FROM (json_to_record('')) AS t (a "Nice Enum 📙", b STRING,
 SELECT (*) FROM ROWS FROM ((json_to_record(('')))) AS t (a "Nice Enum 📙", b STRING, c foo) -- fully parenthesized
 SELECT * FROM ROWS FROM (json_to_record('_')) AS t (a "Nice Enum 📙", b STRING, c foo) -- literals removed
 SELECT * FROM ROWS FROM (json_to_record('')) AS _ (_ _, _ STRING, _ _) -- identifiers removed
+
+parse
+SELECT 123 AS OF FROM t
+----
+SELECT 123 AS of FROM t -- normalized!
+SELECT (123) AS of FROM t -- fully parenthesized
+SELECT _ AS of FROM t -- literals removed
+SELECT 123 AS _ FROM _ -- identifiers removed


### PR DESCRIPTION
One of the test cases failing within the TestRandomSyntaxSelect is the usage of 'AS OF' contained within the select clause, for example - SELECT 10 AS OF FROM <table_name>. The grammar uses a single token lookahead to determine that AS OF should pick the AS OF SYSTEM TIME rule. However, this isn't accurate. This PR fixes this bug by using two token lookahead instead of one to pick the right target rule when the keywords AS OF occur adjacently within the SELECT clause.

Informs https://github.com/cockroachdb/cockroach/issues/87361,
Informs https://github.com/cockroachdb/cockroach/issues/99184

Epic: None
Release note: none