### PR TITLE
jobs: add table to display execution details

### DIFF
--- a/pkg/jobs/execution_detail_utils.go
+++ b/pkg/jobs/execution_detail_utils.go
@@ -143,7 +143,7 @@ func ListExecutionDetailFiles(
 			func(infoKey string, value []byte) error {
 				// Look for the final chunk of each file to find the unique file name.
 				if strings.HasSuffix(infoKey, finalChunkSuffix) {
-					files = append(files, strings.TrimSuffix(infoKey, finalChunkSuffix))
+					files = append(files, strings.TrimPrefix(strings.TrimSuffix(infoKey, finalChunkSuffix), profilerconstants.ExecutionDetailsChunkKeyPrefix))
 				}
 				return nil
 			}); err != nil {

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -26,3 +26,4 @@ export * from "./eventsApi";
 export * from "./databaseDetailsApi";
 export * from "./tableDetailsApi";
 export * from "./types";
+export * from "./jobProfilerApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/jobProfilerApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/jobProfilerApi.ts
@@ -1,0 +1,29 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { fetchData } from "./fetchData";
+
+export type ListJobProfilerExecutionDetailsRequest =
+  cockroach.server.serverpb.ListJobProfilerExecutionDetailsRequest;
+export type ListJobProfilerExecutionDetailsResponse =
+  cockroach.server.serverpb.ListJobProfilerExecutionDetailsResponse;
+
+export const getExecutionDetails = (
+  req: ListJobProfilerExecutionDetailsRequest,
+): Promise<cockroach.server.serverpb.ListJobProfilerExecutionDetailsResponse> => {
+  return fetchData(
+    cockroach.server.serverpb.ListJobProfilerExecutionDetailsResponse,
+    `/_status/list_job_profiler_execution_details/${req.job_id}`,
+    null,
+    null,
+    "30M",
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -39,10 +39,14 @@ import jobStyles from "src/jobs/jobs.module.scss";
 
 import classNames from "classnames/bind";
 import { Timestamp } from "../../timestamp";
-import { RequestState } from "../../api";
+import {
+  ListJobProfilerExecutionDetailsRequest,
+  ListJobProfilerExecutionDetailsResponse,
+  RequestState,
+} from "../../api";
 import moment from "moment-timezone";
 import { CockroachCloudContext } from "src/contexts";
-import { InlineAlert } from "@cockroachlabs/ui-components";
+import { JobProfilerView } from "./jobProfilerView";
 
 const { TabPane } = Tabs;
 
@@ -51,15 +55,21 @@ const jobCx = classNames.bind(jobStyles);
 
 enum TabKeysEnum {
   OVERVIEW = "Overview",
-  PROFILER = "Profiler",
+  PROFILER = "Advanced Debugging",
 }
 
 export interface JobDetailsStateProps {
   jobRequest: RequestState<JobResponse>;
+  jobProfilerResponse: RequestState<ListJobProfilerExecutionDetailsResponse>;
+  jobProfilerLastUpdated: moment.Moment;
+  jobProfilerDataIsValid: boolean;
 }
 
 export interface JobDetailsDispatchProps {
   refreshJob: (req: JobRequest) => void;
+  refreshExecutionDetails: (
+    req: ListJobProfilerExecutionDetailsRequest,
+  ) => void;
 }
 
 export interface JobDetailsState {
@@ -117,25 +127,14 @@ export class JobDetails extends React.Component<
     job: cockroach.server.serverpb.JobResponse,
   ): React.ReactElement => {
     const id = job?.id;
-    // This URL results in a cluster-wide CPU profile to be collected for 5
-    // seconds. We set `tagfocus` (tf) to only view the samples corresponding to
-    // this job's execution.
-    const url = `debug/pprof/ui/cpu?node=all&seconds=5&labels=true&tf=job.*${id}`;
     return (
-      <Row gutter={24}>
-        <Col className="gutter-row" span={24}>
-          <SummaryCard className={cardCx("summary-card")}>
-            <SummaryCardItem
-              label="Cluster-wide CPU Profile"
-              value={<a href={url}>Profile</a>}
-            />
-            <InlineAlert
-              intent="warning"
-              title="This operation buffers profiles in memory for all the nodes in the cluster and can result in increased memory usage."
-            />
-          </SummaryCard>
-        </Col>
-      </Row>
+      <JobProfilerView
+        jobID={id}
+        executionDetailsResponse={this.props.jobProfilerResponse}
+        refreshExecutionDetails={this.props.refreshExecutionDetails}
+        lastUpdated={this.props.jobProfilerLastUpdated}
+        isDataValid={this.props.jobProfilerDataIsValid}
+      />
     );
   };
 
@@ -300,7 +299,7 @@ export class JobDetails extends React.Component<
                     {this.renderOverviewTabContent(hasNextRun, nextRun, job)}
                   </TabPane>
                   {!useContext(CockroachCloudContext) && (
-                    <TabPane tab={TabKeysEnum.PROFILER} key="profiler">
+                    <TabPane tab={TabKeysEnum.PROFILER} key="advancedDebugging">
                       {this.renderProfilerTabContent(job)}
                     </TabPane>
                   )}

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
@@ -20,7 +20,15 @@ import {
 import { JobRequest, JobResponse } from "src/api/jobsApi";
 import { actions as jobActions } from "src/store/jobDetails";
 import { selectID } from "../../selectors";
-import { createInitialState } from "src/api";
+import {
+  ListJobProfilerExecutionDetailsRequest,
+  createInitialState,
+} from "src/api";
+import {
+  initialState,
+  actions as jobProfilerActions,
+} from "src/store/jobs/jobProfiler.reducer";
+import { Dispatch } from "redux";
 
 const emptyState = createInitialState<JobResponse>();
 
@@ -31,12 +39,17 @@ const mapStateToProps = (
   const jobID = selectID(state, props);
   return {
     jobRequest: state.adminUI?.job?.cachedData[jobID] ?? emptyState,
+    jobProfilerResponse: state.adminUI?.executionDetails ?? initialState,
+    jobProfilerLastUpdated: state.adminUI?.executionDetails?.lastUpdated,
+    jobProfilerDataIsValid: state.adminUI?.executionDetails?.valid,
   };
 };
 
-const mapDispatchToProps = {
+const mapDispatchToProps = (dispatch: Dispatch): JobDetailsDispatchProps => ({
   refreshJob: (req: JobRequest) => jobActions.refresh(req),
-};
+  refreshExecutionDetails: (req: ListJobProfilerExecutionDetailsRequest) =>
+    dispatch(jobProfilerActions.refresh(req)),
+});
 
 export const JobDetailsPageConnected = withRouter(
   connect<JobDetailsStateProps, JobDetailsDispatchProps, RouteComponentProps>(

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
@@ -1,0 +1,5 @@
+@import "src/core/index.module";
+
+.sorted-table {
+    width: 100%;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
@@ -1,0 +1,136 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import moment from "moment-timezone";
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  RequestState,
+  ListJobProfilerExecutionDetailsResponse,
+  ListJobProfilerExecutionDetailsRequest,
+} from "src/api";
+import { InlineAlert } from "@cockroachlabs/ui-components";
+import { Row, Col } from "antd";
+import "antd/lib/col/style";
+import "antd/lib/row/style";
+import { SummaryCard, SummaryCardItem } from "src/summaryCard";
+import classNames from "classnames";
+import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
+import long from "long";
+import { ColumnDescriptor, SortSetting, SortedTable } from "src/sortedtable";
+import classnames from "classnames/bind";
+import styles from "./jobProfilerView.module.scss";
+import { EmptyTable } from "src/empty";
+import { useScheduleFunction } from "src/util/hooks";
+
+const cardCx = classNames.bind(summaryCardStyles);
+const cx = classnames.bind(styles);
+
+export type JobProfilerStateProps = {
+  jobID: long;
+  executionDetailsResponse: RequestState<ListJobProfilerExecutionDetailsResponse>;
+  lastUpdated: moment.Moment;
+  isDataValid: boolean;
+};
+
+export type JobProfilerDispatchProps = {
+  refreshExecutionDetails: (
+    req: ListJobProfilerExecutionDetailsRequest,
+  ) => void;
+};
+
+export type JobProfilerViewProps = JobProfilerStateProps &
+  JobProfilerDispatchProps;
+
+export function makeJobProfilerViewColumns(): ColumnDescriptor<string>[] {
+  return [
+    {
+      name: "executionDetailFiles",
+      title: "Execution Detail Files",
+      hideTitleUnderline: true,
+      cell: (executionDetails: string) => executionDetails,
+    },
+  ];
+}
+
+export const JobProfilerView: React.FC<JobProfilerViewProps> = ({
+  jobID,
+  executionDetailsResponse,
+  lastUpdated,
+  isDataValid,
+  refreshExecutionDetails,
+}: JobProfilerViewProps) => {
+  const columns = makeJobProfilerViewColumns();
+  const [sortSetting, setSortSetting] = useState<SortSetting>({
+    ascending: true,
+    columnTitle: "executionDetailFiles",
+  });
+  const req =
+    new cockroach.server.serverpb.ListJobProfilerExecutionDetailsRequest({
+      job_id: jobID,
+    });
+  const refresh = useCallback(() => {
+    refreshExecutionDetails(req);
+  }, [refreshExecutionDetails, req]);
+  const [refetch] = useScheduleFunction(
+    refresh,
+    true,
+    10 * 1000, // 10s polling interval
+    lastUpdated,
+  );
+  useEffect(() => {
+    if (!isDataValid) refetch();
+  }, [isDataValid, refetch]);
+
+  const onChangeSortSetting = (ss: SortSetting): void => {
+    setSortSetting(ss);
+  };
+
+  // This URL results in a cluster-wide CPU profile to be collected for 5
+  // seconds. We set `tagfocus` (tf) to only view the samples corresponding to
+  // this job's execution.
+  const url = `debug/pprof/ui/cpu?node=all&seconds=5&labels=true&tf=job.*${jobID}`;
+  const summaryCardStylesCx = classNames.bind(summaryCardStyles);
+  return (
+    <div>
+      <Row gutter={24}>
+        <Col className="gutter-row" span={24}>
+          <SummaryCard className={cardCx("summary-card")}>
+            <SummaryCardItem
+              label="Cluster-wide CPU Profile"
+              value={<a href={url}>Profile</a>}
+            />
+            <InlineAlert
+              intent="warning"
+              title="This operation buffers profiles in memory for all the nodes in the cluster and can result in increased memory usage."
+            />
+          </SummaryCard>
+        </Col>
+      </Row>
+      <>
+        <p className={summaryCardStylesCx("summary--card__divider--large")} />
+        <Row gutter={24}>
+          <Col className="gutter-row" span={24}>
+            <SortedTable
+              data={executionDetailsResponse.data?.files}
+              columns={columns}
+              tableWrapperClassName={cx("sorted-table")}
+              sortSetting={sortSetting}
+              onChangeSortSetting={onChangeSortSetting}
+              renderNoResult={
+                <EmptyTable title="No execution detail files found." />
+              }
+            />
+          </Col>
+        </Row>
+      </>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.reducer.ts
@@ -1,0 +1,64 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { DOMAIN_NAME } from "../utils";
+import moment from "moment-timezone";
+import { createInitialState, RequestState } from "src/api/types";
+import {
+  ListJobProfilerExecutionDetailsRequest,
+  ListJobProfilerExecutionDetailsResponse,
+} from "src/api";
+
+export type JobProfilerState =
+  RequestState<ListJobProfilerExecutionDetailsResponse>;
+
+export const initialState =
+  createInitialState<ListJobProfilerExecutionDetailsResponse>();
+
+const JobProfilerExecutionDetailsSlice = createSlice({
+  name: `${DOMAIN_NAME}/jobProfilerExecutionDetails`,
+  initialState,
+  reducers: {
+    received: (
+      state,
+      action: PayloadAction<ListJobProfilerExecutionDetailsResponse>,
+    ) => {
+      state.data = action.payload;
+      state.valid = true;
+      state.error = null;
+      state.inFlight = false;
+      state.lastUpdated = moment.utc();
+    },
+    failed: (state, action: PayloadAction<Error>) => {
+      state.inFlight = false;
+      state.valid = false;
+      state.error = action.payload;
+      state.lastUpdated = moment.utc();
+    },
+    invalidated: state => {
+      state.valid = false;
+    },
+    refresh: (
+      state,
+      _action: PayloadAction<ListJobProfilerExecutionDetailsRequest>,
+    ) => {
+      state.inFlight = true;
+    },
+    request: (
+      state,
+      _action: PayloadAction<ListJobProfilerExecutionDetailsRequest>,
+    ) => {
+      state.inFlight = true;
+    },
+  },
+});
+
+export const { reducer, actions } = JobProfilerExecutionDetailsSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.sagas.ts
@@ -1,0 +1,41 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { PayloadAction } from "@reduxjs/toolkit";
+import { actions } from "./jobProfiler.reducer";
+import { call, put, all, takeEvery } from "redux-saga/effects";
+import {
+  ListJobProfilerExecutionDetailsRequest,
+  getExecutionDetails,
+} from "src/api";
+
+export function* refreshJobProfilerSaga(
+  action: PayloadAction<ListJobProfilerExecutionDetailsRequest>,
+) {
+  yield put(actions.request(action.payload));
+}
+
+export function* requestJobProfilerSaga(
+  action: PayloadAction<ListJobProfilerExecutionDetailsRequest>,
+): any {
+  try {
+    const result = yield call(getExecutionDetails, action.payload);
+    yield put(actions.received(result));
+  } catch (e) {
+    yield put(actions.failed(e));
+  }
+}
+
+export function* jobProfilerSaga() {
+  yield all([
+    takeEvery(actions.refresh, refreshJobProfilerSaga),
+    takeEvery(actions.request, requestJobProfilerSaga),
+  ]);
+}

--- a/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
@@ -76,6 +76,10 @@ import {
   KeyedTableDetailsState,
   reducer as tableDetails,
 } from "./databaseTableDetails/tableDetails.reducer";
+import {
+  JobProfilerState,
+  reducer as executionDetails,
+} from "./jobs/jobProfiler.reducer";
 
 export type AdminUiState = {
   statementDiagnostics: StatementDiagnosticsState;
@@ -91,6 +95,7 @@ export type AdminUiState = {
   indexStats: IndexStatsReducerState;
   jobs: JobsState;
   job: JobDetailsReducerState;
+  executionDetails: JobProfilerState;
   clusterLocks: ClusterLocksReqState;
   databasesList: DatabasesListState;
   databaseDetails: KeyedDatabaseDetailsState;
@@ -124,6 +129,7 @@ export const reducers = combineReducers<AdminUiState>({
   indexStats,
   jobs,
   job,
+  executionDetails,
   clusterLocks,
   databasesList,
   databaseDetails,

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -212,6 +212,19 @@ const jobReducerObj = new KeyedCachedDataReducer(
 );
 export const refreshJob = jobReducerObj.refresh;
 
+export const jobProfilerRequestKey = (
+  req: api.ListJobProfilerExecutionDetailsRequestMessage,
+): string => `${req.job_id}`;
+
+const jobProfilerReducerObj = new KeyedCachedDataReducer(
+  api.getExecutionDetails,
+  "jobProfiler",
+  jobProfilerRequestKey,
+  null,
+  moment.duration(10, "m"),
+);
+export const refreshExecutionDetails = jobProfilerReducerObj.refresh;
+
 export const queryToID = (req: api.QueryPlanRequestMessage): string =>
   req.query;
 
@@ -561,6 +574,7 @@ export interface APIReducersState {
   nonTableStats: CachedDataReducerState<api.NonTableStatsResponseMessage>;
   logs: CachedDataReducerState<api.LogEntriesResponseMessage>;
   liveness: CachedDataReducerState<api.LivenessResponseMessage>;
+  jobProfiler: KeyedCachedDataReducerState<api.ListJobProfilerExecutionDetailsResponseMessage>;
   jobs: KeyedCachedDataReducerState<api.JobsResponseMessage>;
   job: KeyedCachedDataReducerState<api.JobResponseMessage>;
   queryPlan: CachedDataReducerState<api.QueryPlanResponseMessage>;
@@ -623,6 +637,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [nonTableStatsReducerObj.actionNamespace]: nonTableStatsReducerObj.reducer,
   [logsReducerObj.actionNamespace]: logsReducerObj.reducer,
   [livenessReducerObj.actionNamespace]: livenessReducerObj.reducer,
+  [jobProfilerReducerObj.actionNamespace]: jobProfilerReducerObj.reducer,
   [jobsReducerObj.actionNamespace]: jobsReducerObj.reducer,
   [jobReducerObj.actionNamespace]: jobReducerObj.reducer,
   [queryPlanReducerObj.actionNamespace]: queryPlanReducerObj.reducer,

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -90,6 +90,11 @@ export type JobsResponseMessage = protos.cockroach.server.serverpb.JobsResponse;
 export type JobRequestMessage = protos.cockroach.server.serverpb.JobRequest;
 export type JobResponseMessage = protos.cockroach.server.serverpb.JobResponse;
 
+export type ListJobProfilerExecutionDetailsRequestMessage =
+  protos.cockroach.server.serverpb.ListJobProfilerExecutionDetailsRequest;
+export type ListJobProfilerExecutionDetailsResponseMessage =
+  protos.cockroach.server.serverpb.ListJobProfilerExecutionDetailsResponse;
+
 export type QueryPlanRequestMessage =
   protos.cockroach.server.serverpb.QueryPlanRequest;
 export type QueryPlanResponseMessage =
@@ -466,6 +471,18 @@ export function getJob(
   return timeoutFetch(
     serverpb.JobResponse,
     `${API_PREFIX}/jobs/${req.job_id}`,
+    null,
+    timeout,
+  );
+}
+
+export function getExecutionDetails(
+  req: ListJobProfilerExecutionDetailsRequestMessage,
+  timeout?: moment.Duration,
+): Promise<ListJobProfilerExecutionDetailsResponseMessage> {
+  return timeoutFetch(
+    serverpb.ListJobProfilerExecutionDetailsResponse,
+    `${STATUS_PREFIX}/list_job_profiler_execution_details/${req.job_id}`,
     null,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
@@ -16,23 +16,35 @@ import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import {
   createSelectorForKeyedCachedDataField,
+  refreshExecutionDetails,
   refreshJob,
 } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
+import { ListJobProfilerExecutionDetailsResponseMessage } from "src/util/api";
 
 const selectJob = createSelectorForKeyedCachedDataField("job", selectID);
+const selectExecutionDetails =
+  createSelectorForKeyedCachedDataField<ListJobProfilerExecutionDetailsResponseMessage>(
+    "jobProfiler",
+    selectID,
+  );
 
 const mapStateToProps = (
   state: AdminUIState,
   props: RouteComponentProps,
 ): JobDetailsStateProps => {
+  const jobID = selectID(state, props);
   return {
     jobRequest: selectJob(state, props),
+    jobProfilerResponse: selectExecutionDetails(state, props),
+    jobProfilerLastUpdated: state.cachedData.jobProfiler[jobID]?.setAt,
+    jobProfilerDataIsValid: state.cachedData.jobProfiler[jobID]?.valid,
   };
 };
 
 const mapDispatchToProps = {
   refreshJob,
+  refreshExecutionDetails,
 };
 
 export default withRouter(


### PR DESCRIPTION
In #105384 and #106629 we added support to collect and list files that had been collected as part of
a job's execution details. These files are meant
to provide improved obersvability into the state
of a job.

This change is the first of a few that exposes these endpoints on the DBConsole job details page. This change only adds support for listing files that have been requested as part of a job's execution details.
A future change will add support to request these files, sort them and download them from the job details page.

This page is not available on the Cloud Console as it is meant for advanced debugging.

Informs: #105076

Release note (ui change): add table in the Profiler job details page that lists all the available files describing a job's execution details
<img width="1505" alt="Screenshot 2023-07-18 at 2 26 50 PM" src="https://github.com/cockroachdb/cockroach/assets/13837382/aebe18a6-9c25-4c9a-ad7c-a94e2e4c97ff">
<img width="1510" alt="Screenshot 2023-07-18 at 2 27 03 PM" src="https://github.com/cockroachdb/cockroach/assets/13837382/da9b3a21-8dc6-47ca-ac02-24d8bb7d09e7">

