### PR TITLE
bench, collector: remove usages of base.TODOTestTenantDisabled

### DIFF
--- a/pkg/bench/foreachdb.go
+++ b/pkg/bench/foreachdb.go
@@ -47,7 +47,7 @@ func benchmarkCockroach(b *testing.B, f BenchmarkFn) {
 	s, db, _ := serverutils.StartServer(
 		b, base.TestServerArgs{
 			UseDatabase:       "bench",
-			DefaultTestTenant: base.TODOTestTenantDisabled,
+			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(83461),
 		})
 	defer s.Stopper().Stop(context.TODO())
 
@@ -65,7 +65,7 @@ func benchmarkSharedProcessTenantCockroach(b *testing.B, f BenchmarkFn) {
 	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(
 		b, base.TestServerArgs{
-			DefaultTestTenant: base.TODOTestTenantDisabled,
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		})
 	defer s.Stopper().Stop(ctx)
 
@@ -114,7 +114,7 @@ func benchmarkSepProcessTenantCockroach(b *testing.B, f BenchmarkFn) {
 	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(
 		b, base.TestServerArgs{
-			DefaultTestTenant: base.TODOTestTenantDisabled,
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		})
 	defer s.Stopper().Stop(ctx)
 
@@ -143,7 +143,7 @@ func benchmarkMultinodeCockroach(b *testing.B, f BenchmarkFn) {
 			ReplicationMode: base.ReplicationAuto,
 			ServerArgs: base.TestServerArgs{
 				UseDatabase:       "bench",
-				DefaultTestTenant: base.TODOTestTenantDisabled,
+				DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(83461),
 			},
 		})
 	if _, err := tc.Conns[0].Exec(`CREATE DATABASE bench`); err != nil {

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -217,8 +217,7 @@ func TestClusterInflightTraces(t *testing.T) {
 	defer cancel()
 	args := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			// The test itself creates tenants however necessary.
-			DefaultTestTenant: base.TODOTestTenantDisabled,
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		},
 	}
 


### PR DESCRIPTION
We have four variants of running cockroach in benchmarks, two of them create tenants on their own, so now they are marked as explicitly controlling tenants. Eventually, we'll want to transition `benchmarkCockroach` and `benchmarkMultinodeCockroach` to use tenants too, and that work is tracked by #83461.

This commit also removes a single usage of the TODO value in `util/tracing/collector` where the test itself creates tenants.

Addresses: #76378.
Epic: CRDB-18499

Release note: None