### PR TITLE
colenc: remove usage of TODOTestTenantDisabled

### DIFF
--- a/pkg/sql/colenc/encode_test.go
+++ b/pkg/sql/colenc/encode_test.go
@@ -51,13 +51,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These tests fail when run within a tenant because it relies on
-// TestingGetTableDescriptor which isn't supported in multi-tenancy.
-// Tracked with #76378.
-var testArgs = base.TestServerArgs{
-	DefaultTestTenant: base.TODOTestTenantDisabled,
-}
-
 // TestEncoderEquality tests that the vector encoder and the row based encoder
 // produce the exact same KV batches. Check constraints and partial indexes
 // are left to copy datadriven tests so we don't have to muck with generating
@@ -67,8 +60,9 @@ func TestEncoderEqualityDatums(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	codec, sv := s.TenantOrServer().Codec(), &s.TenantOrServer().ClusterSettings().SV
 
 	compDec, err := tree.ParseDDecimal("-0")
 	require.NoError(t, err)
@@ -77,7 +71,6 @@ func TestEncoderEqualityDatums(t *testing.T) {
 	require.NoError(t, err)
 
 	rng, _ := randutil.NewTestRand()
-	sv := &s.ClusterSettings().SV
 	testCases := []struct {
 		cols     string
 		datums   tree.Datums
@@ -239,8 +232,8 @@ func TestEncoderEqualityDatums(t *testing.T) {
 			r.Exec(t, s)
 		}
 		desc := desctestutils.TestingGetTableDescriptor(
-			kvdb, keys.SystemSQLCodec, "defaultdb", "public", tableName)
-		runComparison(t, desc, []tree.Datums{tc.datums}, tableDef, sv)
+			kvdb, codec, "defaultdb", "public", tableName)
+		runComparison(t, desc, []tree.Datums{tc.datums}, tableDef, sv, codec)
 	}
 	// Now test these schemas with bunch of rows of rand datums
 	for i, tc := range testCases {
@@ -253,13 +246,13 @@ func TestEncoderEqualityDatums(t *testing.T) {
 			r.Exec(t, s)
 		}
 		desc := desctestutils.TestingGetTableDescriptor(
-			kvdb, keys.SystemSQLCodec, "defaultdb", "public", tableName)
+			kvdb, codec, "defaultdb", "public", tableName)
 		cols := desc.PublicColumns()
 		datums := make([]tree.Datums, 100)
 		for i := 0; i < len(datums); i++ {
 			datums[i] = makeRow(rng, cols)
 		}
-		runComparison(t, desc, datums, tableDef, sv)
+		runComparison(t, desc, datums, tableDef, sv, codec)
 	}
 }
 
@@ -267,10 +260,10 @@ func TestEncoderEqualityRand(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	codec, sv := s.TenantOrServer().Codec(), &s.TenantOrServer().ClusterSettings().SV
 	rng, _ := randutil.NewTestRand()
-	sv := &s.ClusterSettings().SV
 	for i := 0; i < 100; i++ {
 		tableName := fmt.Sprintf("t%d", i)
 		ct := randgen.RandCreateTableWithName(rng, tableName, i, false /* isMultiRegion */)
@@ -278,13 +271,13 @@ func TestEncoderEqualityRand(t *testing.T) {
 		r := sqlutils.MakeSQLRunner(db)
 		r.Exec(t, tableDef)
 		desc := desctestutils.TestingGetTableDescriptor(
-			kvdb, keys.SystemSQLCodec, "defaultdb", "public", tableName)
+			kvdb, codec, "defaultdb", "public", tableName)
 		cols := desc.WritableColumns()
 		datums := make([]tree.Datums, 10)
 		for i := 0; i < len(datums); i++ {
 			datums[i] = makeRow(rng, cols)
 		}
-		runComparison(t, desc, datums, tableDef, sv)
+		runComparison(t, desc, datums, tableDef, sv, codec)
 	}
 }
 
@@ -293,9 +286,9 @@ func TestEncoderEqualityString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
-	sv := &s.ClusterSettings().SV
+	codec, sv := s.TenantOrServer().Codec(), &s.TenantOrServer().ClusterSettings().SV
 
 	for i, tc := range []struct {
 		tableDef string
@@ -324,7 +317,7 @@ func TestEncoderEqualityString(t *testing.T) {
 		tableDef := fmt.Sprintf(tc.tableDef, tableName)
 		r.Exec(t, tableDef)
 		desc := desctestutils.TestingGetTableDescriptor(
-			kvdb, keys.SystemSQLCodec, "defaultdb", "public", tableName)
+			kvdb, codec, "defaultdb", "public", tableName)
 		var typs []*types.T
 		cols := desc.PublicColumns()
 		for _, c := range cols {
@@ -346,7 +339,7 @@ func TestEncoderEqualityString(t *testing.T) {
 			}
 			datums = append(datums, ds)
 		}
-		runComparison(t, desc, datums, tableDef, sv)
+		runComparison(t, desc, datums, tableDef, sv, codec)
 	}
 }
 
@@ -354,21 +347,21 @@ func TestErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	codec, sv := s.TenantOrServer().Codec(), &s.TenantOrServer().ClusterSettings().SV
 	r := sqlutils.MakeSQLRunner(db)
 	r.Exec(t, "CREATE TABLE t (i int PRIMARY KEY, s STRING)")
 	desc := desctestutils.TestingGetTableDescriptor(
-		kvdb, keys.SystemSQLCodec, "defaultdb", "public", "t")
-	sv := &s.ClusterSettings().SV
-	enc := colenc.MakeEncoder(keys.SystemSQLCodec, desc, sv, nil, nil,
+		kvdb, codec, "defaultdb", "public", "t")
+	enc := colenc.MakeEncoder(codec, desc, sv, nil, nil,
 		nil /*metrics*/, nil /*partialIndexMap*/, func() error { return nil })
 	err := enc.PrepareBatch(ctx, nil, 0, 0)
 	require.Error(t, err)
 	err = enc.PrepareBatch(ctx, nil, 1, 0)
 	require.Error(t, err)
 
-	_, err = buildVecKVs([]tree.Datums{{tree.DNull, tree.DNull}}, desc, desc.PublicColumns(), sv)
+	_, err = buildVecKVs([]tree.Datums{{tree.DNull, tree.DNull}}, desc, desc.PublicColumns(), sv, codec)
 	require.Error(t, err, `null value in column "i" violates not-null constraint`)
 
 }
@@ -377,20 +370,20 @@ func TestColFamDropPKNot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	codec, sv := s.TenantOrServer().Codec(), &s.TenantOrServer().ClusterSettings().SV
 	r := sqlutils.MakeSQLRunner(db)
 	r.Exec(t, "CREATE TABLE t (i int PRIMARY KEY, s STRING, FAMILY (s), FAMILY (i))")
 	r.Exec(t, `INSERT INTO t VALUES (123,'asdf')`)
 	r.Exec(t, `ALTER TABLE t DROP COLUMN s`)
-	sv := &s.ClusterSettings().SV
 	desc := desctestutils.TestingGetTableDescriptor(
-		kvdb, keys.SystemSQLCodec, "defaultdb", "public", "t")
+		kvdb, codec, "defaultdb", "public", "t")
 
 	datums := []tree.Datum{tree.NewDInt(321)}
-	kvs1, err1 := buildRowKVs([]tree.Datums{datums}, desc, desc.PublicColumns(), sv)
+	kvs1, err1 := buildRowKVs([]tree.Datums{datums}, desc, desc.PublicColumns(), sv, codec)
 	require.NoError(t, err1)
-	kvs2, err2 := buildVecKVs([]tree.Datums{datums}, desc, desc.PublicColumns(), sv)
+	kvs2, err2 := buildVecKVs([]tree.Datums{datums}, desc, desc.PublicColumns(), sv, codec)
 	require.NoError(t, err2)
 	checkEqual(t, kvs1, kvs2)
 }
@@ -399,19 +392,19 @@ func TestColFamilies(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	codec, sv := s.TenantOrServer().Codec(), &s.TenantOrServer().ClusterSettings().SV
 	r := sqlutils.MakeSQLRunner(db)
 	r.Exec(t, "CREATE TABLE t (id INT PRIMARY KEY, c1 INT NOT NULL, c2 INT NOT NULL, FAMILY cf1 (id, c1), FAMILY cf2(c2))")
-	sv := &s.ClusterSettings().SV
 	desc := desctestutils.TestingGetTableDescriptor(
-		kvdb, keys.SystemSQLCodec, "defaultdb", "public", "t")
+		kvdb, codec, "defaultdb", "public", "t")
 
 	row1 := []tree.Datum{tree.NewDInt(2), tree.NewDInt(1), tree.NewDInt(2)}
 	row2 := []tree.Datum{tree.NewDInt(1), tree.NewDInt(2), tree.NewDInt(1)}
-	kvs1, err1 := buildRowKVs([]tree.Datums{row1, row2}, desc, desc.PublicColumns(), sv)
+	kvs1, err1 := buildRowKVs([]tree.Datums{row1, row2}, desc, desc.PublicColumns(), sv, codec)
 	require.NoError(t, err1)
-	kvs2, err2 := buildVecKVs([]tree.Datums{row1, row2}, desc, desc.PublicColumns(), sv)
+	kvs2, err2 := buildVecKVs([]tree.Datums{row1, row2}, desc, desc.PublicColumns(), sv, codec)
 	require.NoError(t, err2)
 	checkEqual(t, kvs1, kvs2)
 }
@@ -421,14 +414,14 @@ func TestColIDToRowIndexNull(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	codec, sv := s.TenantOrServer().Codec(), &s.TenantOrServer().ClusterSettings().SV
 	r := sqlutils.MakeSQLRunner(db)
 	r.Exec(t, "CREATE TABLE t (i int PRIMARY KEY, s STRING)")
 	r.Exec(t, `ALTER TABLE t DROP COLUMN s`)
 	desc := desctestutils.TestingGetTableDescriptor(
-		kvdb, keys.SystemSQLCodec, "defaultdb", "public", "t")
-	sv := &s.ClusterSettings().SV
+		kvdb, codec, "defaultdb", "public", "t")
 	datums := []tree.Datum{tree.NewDInt(321)}
 
 	var cols []catalog.Column
@@ -438,9 +431,9 @@ func TestColIDToRowIndexNull(t *testing.T) {
 		}
 	}
 
-	kvs1, err1 := buildRowKVs([]tree.Datums{datums}, desc, cols, sv)
+	kvs1, err1 := buildRowKVs([]tree.Datums{datums}, desc, cols, sv, codec)
 	require.NoError(t, err1)
-	kvs2, err2 := buildVecKVs([]tree.Datums{datums}, desc, cols, sv)
+	kvs2, err2 := buildVecKVs([]tree.Datums{datums}, desc, cols, sv, codec)
 	require.NoError(t, err2)
 	checkEqual(t, kvs1, kvs2)
 }
@@ -449,13 +442,13 @@ func TestMissingNotNullCol(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	codec, sv := s.TenantOrServer().Codec(), &s.TenantOrServer().ClusterSettings().SV
 	r := sqlutils.MakeSQLRunner(db)
 	r.Exec(t, "CREATE TABLE t (i int PRIMARY KEY, s STRING NOT NULL)")
 	desc := desctestutils.TestingGetTableDescriptor(
-		kvdb, keys.SystemSQLCodec, "defaultdb", "public", "t")
-	sv := &s.ClusterSettings().SV
+		kvdb, codec, "defaultdb", "public", "t")
 	datums := []tree.Datum{tree.NewDInt(321)}
 
 	var cols []catalog.Column
@@ -465,7 +458,7 @@ func TestMissingNotNullCol(t *testing.T) {
 		}
 	}
 
-	_, err1 := buildVecKVs([]tree.Datums{datums}, desc, cols, sv)
+	_, err1 := buildVecKVs([]tree.Datums{datums}, desc, cols, sv, codec)
 	require.Error(t, err1, `null value in column "s" violates not-null constraint`)
 }
 
@@ -473,13 +466,14 @@ func TestMemoryQuota(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	codec, sv := s.TenantOrServer().Codec(), &s.TenantOrServer().ClusterSettings().SV
 
 	r := sqlutils.MakeSQLRunner(db)
 	r.Exec(t, "CREATE TABLE t (i INT PRIMARY KEY,s string)")
 	desc := desctestutils.TestingGetTableDescriptor(
-		kvdb, keys.SystemSQLCodec, "defaultdb", "public", "t")
+		kvdb, codec, "defaultdb", "public", "t")
 	factory := coldataext.NewExtendedColumnFactory(nil /*evalCtx */)
 	numRows := 3
 	cols := desc.PublicColumns()
@@ -490,7 +484,7 @@ func TestMemoryQuota(t *testing.T) {
 	cb := coldata.NewMemBatchWithCapacity(typs, numRows, factory)
 	txn := kvdb.NewTxn(ctx, t.Name())
 	kvb := txn.NewBatch()
-	enc := colenc.MakeEncoder(keys.SystemSQLCodec, desc, &s.ClusterSettings().SV, cb, cols,
+	enc := colenc.MakeEncoder(codec, desc, sv, cb, cols,
 		nil /*metrics*/, nil /*partialIndexMap*/, func() error {
 			if kvb.ApproximateMutationBytes() > 50 {
 				return colenc.ErrOverMemLimit
@@ -522,22 +516,22 @@ func TestCheckRowSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, db, kvdb := serverutils.StartServer(t, testArgs)
+	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	codec, sv := s.TenantOrServer().Codec(), &s.TenantOrServer().ClusterSettings().SV
 	r := sqlutils.MakeSQLRunner(db)
 	r.Exec(t, `SET CLUSTER SETTING sql.guardrails.max_row_size_err = '2KiB'`)
 	r.Exec(t, "CREATE TABLE t (i int PRIMARY KEY, s STRING)")
 	desc := desctestutils.TestingGetTableDescriptor(
-		kvdb, keys.SystemSQLCodec, "defaultdb", "public", "t")
-	sv := &s.ClusterSettings().SV
+		kvdb, codec, "defaultdb", "public", "t")
 	rng, _ := randutil.NewTestRand()
 	datums := []tree.Datum{tree.NewDInt(1234), tree.NewDString(randutil.RandString(rng, 3<<10, "asdf"))}
-	_, err1 := buildRowKVs([]tree.Datums{datums}, desc, desc.PublicColumns(), sv)
+	_, err1 := buildRowKVs([]tree.Datums{datums}, desc, desc.PublicColumns(), sv, codec)
 	code1 := pgerror.GetPGCodeInternal(err1, pgerror.ComputeDefaultCode)
-	require.Equal(t, code1, pgcode.ProgramLimitExceeded)
-	_, err2 := buildVecKVs([]tree.Datums{datums}, desc, desc.PublicColumns(), sv)
+	require.Equal(t, pgcode.ProgramLimitExceeded, code1)
+	_, err2 := buildVecKVs([]tree.Datums{datums}, desc, desc.PublicColumns(), sv, codec)
 	code2 := pgerror.GetPGCodeInternal(err2, pgerror.ComputeDefaultCode)
-	require.Equal(t, code2, pgcode.ProgramLimitExceeded)
+	require.Equal(t, pgcode.ProgramLimitExceeded, code2)
 }
 
 // runComparison compares row and vector output and prints out a test case
@@ -548,10 +542,11 @@ func runComparison(
 	rows []tree.Datums,
 	tableDef string,
 	sv *settings.Values,
+	codec keys.SQLCodec,
 ) {
-	rowKVs, err := buildRowKVs(rows, desc, desc.PublicColumns(), sv)
+	rowKVs, err := buildRowKVs(rows, desc, desc.PublicColumns(), sv, codec)
 	require.NoError(t, err)
-	vecKVs, err := buildVecKVs(rows, desc, desc.PublicColumns(), sv)
+	vecKVs, err := buildVecKVs(rows, desc, desc.PublicColumns(), sv, codec)
 	require.NoError(t, err)
 	if eq := checkEqual(t, rowKVs, vecKVs); !eq {
 		var sb strings.Builder
@@ -603,9 +598,13 @@ func checkEqual(t *testing.T, rowKVs, vecKVs kvs) bool {
 }
 
 func buildRowKVs(
-	datums []tree.Datums, desc catalog.TableDescriptor, cols []catalog.Column, sv *settings.Values,
+	datums []tree.Datums,
+	desc catalog.TableDescriptor,
+	cols []catalog.Column,
+	sv *settings.Values,
+	codec keys.SQLCodec,
 ) (kvs, error) {
-	inserter, err := row.MakeInserter(context.Background(), nil /*txn*/, keys.SystemSQLCodec, desc, cols, nil, sv, false, nil)
+	inserter, err := row.MakeInserter(context.Background(), nil /*txn*/, codec, desc, cols, nil, sv, false, nil)
 	if err != nil {
 		return kvs{}, err
 	}
@@ -623,7 +622,11 @@ func buildRowKVs(
 }
 
 func buildVecKVs(
-	datums []tree.Datums, desc catalog.TableDescriptor, cols []catalog.Column, sv *settings.Values,
+	datums []tree.Datums,
+	desc catalog.TableDescriptor,
+	cols []catalog.Column,
+	sv *settings.Values,
+	codec keys.SQLCodec,
 ) (kvs, error) {
 	p := &capturePutter{}
 	typs := make([]*types.T, len(cols))
@@ -645,7 +648,7 @@ func buildVecKVs(
 	}
 	b.SetLength(len(datums))
 
-	be := colenc.MakeEncoder(keys.SystemSQLCodec, desc, sv, b, cols, nil /*metrics*/, nil, /*partialIndexMap*/
+	be := colenc.MakeEncoder(codec, desc, sv, b, cols, nil /*metrics*/, nil, /*partialIndexMap*/
 		func() error { return nil })
 	rng, _ := randutil.NewTestRand()
 	if b.Length() > 1 && rng.Intn(2) == 0 {


### PR DESCRIPTION
This simply required using the correct codec as well as the correct settings object (the latter was only needed in `TestCheckRowSize`, but I adjusted all tests for consistency).

Addresses: #76378.
Epic: CRDB-18499

Release note: None