### PR TITLE
idxconstraint: cancel checking for index constraint initialization

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -136,6 +136,7 @@ func TestIndexConstraints(t *testing.T) {
 					filters, optionalFilters, indexCols, sv.NotNullCols(), computedCols,
 					colsInComputedColsExpressions,
 					true /* consolidate */, &evalCtx, &f, partition.PrefixSorter{},
+					func() {}, /* checkCancellation */
 				)
 				result := ic.Constraint()
 				var buf bytes.Buffer
@@ -254,6 +255,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 					nil /* computedCols */, opt.ColSet{}, /* colsInComputedColsExpressions */
 					true, /* consolidate */
 					&evalCtx, &f, partition.PrefixSorter{},
+					func() {}, /* checkCancellation */
 				)
 				_ = ic.Constraint()
 				_ = ic.RemainingFilters()

--- a/pkg/sql/opt/invertedidx/geo_test.go
+++ b/pkg/sql/opt/invertedidx/geo_test.go
@@ -503,7 +503,8 @@ func TestTryFilterGeoIndex(t *testing.T) {
 			nil, /* optionalFilters */
 			tab,
 			md.Table(tab).Index(tc.indexOrd),
-			nil, /* computedColumns */
+			nil,       /* computedColumns */
+			func() {}, /* checkCancellation */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -1147,7 +1147,8 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			nil, /* optionalFilters */
 			tab,
 			md.Table(tab).Index(tc.indexOrd),
-			nil, /* computedColumns */
+			nil,       /* computedColumns */
+			func() {}, /* checkCancellation */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/invertedidx/trigram_test.go
+++ b/pkg/sql/opt/invertedidx/trigram_test.go
@@ -114,7 +114,8 @@ func TestTryFilterTrigram(t *testing.T) {
 			nil, /* optionalFilters */
 			tab,
 			md.Table(tab).Index(trigramOrd),
-			nil, /* computedColumns */
+			nil,       /* computedColumns */
+			func() {}, /* checkCancellation */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/invertedidx/tsearch_test.go
+++ b/pkg/sql/opt/invertedidx/tsearch_test.go
@@ -106,7 +106,8 @@ func TestTryFilterTSVector(t *testing.T) {
 			nil, /* optionalFilters */
 			tab,
 			md.Table(tab).Index(tsvectorOrd),
-			nil, /* computedColumns */
+			nil,       /* computedColumns */
+			func() {}, /* checkCancellation */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -234,6 +234,7 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 		columns, notNullCols, tabMeta.ComputedCols,
 		tabMeta.ColsInComputedColsExpressions,
 		true /* consolidate */, c.e.evalCtx, c.e.f, ps,
+		c.checkCancellation,
 	)
 	return ic
 }


### PR DESCRIPTION
It may be possible, if there's a bug in the index constraint
initialization code, for it to get stuck in an infinite loop and
allocate memory continually until the node OOMs, as seen recently
in a support issue.

This adds cancel checking to `makeSpansForAnd` to allow the query to
timeout, if a timeout is set, instead of consume memory indefinitely.

Informs https://github.com/cockroachlabs/support/issues/2456

Release note (bug fix): This adds cancel checking to index constraint
initialization code, to allow queries to timeout during query
optimization if analyzing predicates to constrain an index starts
using too many resources. Example of setting a timeout:
`SET statement_timeout='5.0s';`