### PR TITLE
release-23.1: roachtest: deflake `kv/quiescence/nodes=3`

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -391,15 +391,18 @@ func registerKVContention(r registry.Registry) {
 func registerKVQuiescenceDead(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:                "kv/quiescence/nodes=3",
-		Owner:               registry.OwnerKV,
+		Owner:               registry.OwnerReplication,
 		Cluster:             r.MakeClusterSpec(4),
+		Leases:              registry.EpochLeases,
 		SkipPostValidations: registry.PostValidationNoDeadNodes,
-		Leases:              registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
-			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
+			settings := install.MakeClusterSettings(install.ClusterSettingsOption{
+				"sql.stats.automatic_collection.enabled": "false",
+			})
+			c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, c.Range(1, nodes))
 			m := c.NewMonitor(ctx, c.Range(1, nodes))
 
 			db := c.Conn(ctx, t.L(), 1)


### PR DESCRIPTION
Backport 1/1 commits from #106379.

/cc @cockroachdb/release

---

This roachtest measures kv0 QPS to ensure quiescence does not affect throughput too much. However, the test also runs a backup, which can interfere with QPS.

This patch disables backups for this test. It also disables expiration lease metamorphism, and reassigns the test to replication.

Resolves #105980.
Epic: none
Release note: None
