### PR TITLE
roachtest: pass url to workload

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -250,7 +250,7 @@ func runDecommission(
 
 		c.Start(ctx, t.L(), withDecommissionVMod(startOpts), install.MakeClusterSettings(), c.Node(i))
 	}
-	c.Run(ctx, c.Node(pinnedNode), `./workload init kv --drop`)
+	c.Run(ctx, c.Node(pinnedNode), fmt.Sprintf(`./workload init kv --drop {pgurl:%d}`, pinnedNode))
 
 	h := newDecommTestHelper(t, c)
 


### PR DESCRIPTION
If no URL is passed to `workload` it uses the default port to connect. However, local clusters have different port assignments. This test can be failed, before this change, by creating a small named local cluster, and then executing the test. The ports are at an offset because of the small local cluster and the test fails. This behaviour is generally not seen due to the fact that there is usually only one local test cluster present.

But these changes are required to enable future work that will make ports configurable for local and remote clusters, and then we require commands not to rely on default ports, but rather be passed connection information for the cluster used in the test.

Release note: None
Epic: None