### PR TITLE
kv,ccl: remove uses of `TODOTestTenantDisabled`

### DIFF
--- a/pkg/configprofiles/datadriven_test.go
+++ b/pkg/configprofiles/datadriven_test.go
@@ -67,13 +67,13 @@ func TestDataDriven(t *testing.T) {
 				numExpectedTasks := len(configprofiles.TestingGetProfiles()[setter.String()])
 
 				s, _, _ = serverutils.StartServer(t, base.TestServerArgs{
+					DefaultTestTenant: base.TestControlsTenantsExplicitly,
+
 					AutoConfigProvider: provider,
 					// This test does not exercise security parameters, so we
 					// keep the configuration simpler to keep the test code also
 					// simple.
 					Insecure: true,
-					// The test controls secondary tenants manually.
-					DefaultTestTenant: base.TODOTestTenantDisabled,
 				})
 				// We need to force the connection to the system tenant,
 				// because at least one of the config profiles changes the

--- a/pkg/configprofiles/profiles_test.go
+++ b/pkg/configprofiles/profiles_test.go
@@ -37,7 +37,9 @@ func TestProfilesValidSQL(t *testing.T) {
 			defer log.Scope(t).Close(t)
 
 			s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-				DefaultTestTenant: base.TODOTestTenantDisabled,
+				// The predefined config profiles are meant to be executed in
+				// the system tenant only.
+				DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 			})
 			defer s.Stopper().Stop(context.Background())
 			db := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/kv/kvclient/kvtenant/tenant_kv_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_kv_test.go
@@ -36,9 +36,7 @@ func TestTenantRangeQPSStat(t *testing.T) {
 	ts, hostDB, _ := serverutils.StartServer(t,
 		base.TestServerArgs{
 			InsecureWebAccess: true,
-			// Must disable test tenant because test below assumes that
-			// it is connecting to the host tenant.
-			DefaultTestTenant: base.TODOTestTenantDisabled,
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
 					// We disable the split queue as an untimely split can cause the QPS

--- a/pkg/kv/kvclient/kvtenant/tenant_range_lookup_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_range_lookup_test.go
@@ -33,7 +33,7 @@ func TestRangeLookupPrefetchFiltering(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TODOTestTenantDisabled, // we're going to manually add tenants
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
 					DisableMergeQueue: true,

--- a/pkg/kv/kvclient/kvtenant/tenant_scan_range_descriptors_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_scan_range_descriptors_test.go
@@ -30,7 +30,7 @@ func setup(
 ) (*testcluster.TestCluster, serverutils.TestTenantInterface, rangedesc.IteratorFactory) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TODOTestTenantDisabled, // we're going to manually add tenants
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
 					DisableMergeQueue: true,

--- a/pkg/kv/kvclient/kvtenant/tenant_trace_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_trace_test.go
@@ -55,9 +55,7 @@ func testTenantTracesAreRedactedImpl(t *testing.T, redactable bool) {
 	recCh := make(chan tracingpb.Recording, 1)
 
 	args := base.TestServerArgs{
-		// Test hangs within a tenant. More investigation is required.
-		// Tracked with #76378.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				EvalKnobs: kvserverbase.BatchEvalTestingKnobs{

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher_test.go
@@ -32,7 +32,9 @@ func TestWatchAuthErr(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	host, _, _ := serverutils.StartServer(t, base.TestServerArgs{DefaultTestTenant: base.TODOTestTenantDisabled})
+	host, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+	})
 	defer host.Stopper().Stop(ctx)
 
 	tenant, _ := serverutils.StartTenant(t, host, base.TestTenantArgs{

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/decoder_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/decoder_test.go
@@ -36,7 +36,9 @@ func TestDecodeCapabilities(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TODOTestTenantDisabled, // system.tenants only exists for the system tenant
+			// Capabilities are only available in the system tenant's
+			// system.tenants table.
+			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 		},
 	})
 	defer tc.Stopper().Stop(ctx)

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor_test.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor_test.go
@@ -151,7 +151,7 @@ func BenchmarkKVAccessorUpdate(b *testing.B) {
 				ServerArgs: base.TestServerArgs{
 					// Requires span_configuration table which is not visible
 					// from secondary tenants.
-					DefaultTestTenant: base.TODOTestTenantDisabled,
+					DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 				},
 			})
 			defer tc.Stopper().Stop(ctx)
@@ -193,7 +193,7 @@ func TestKVAccessorPagination(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			// Requires span_configuration table which is not visible
 			// from secondary tenants.
-			DefaultTestTenant: base.TODOTestTenantDisabled,
+			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 		},
 	})
 	defer tc.Stopper().Stop(ctx)


### PR DESCRIPTION
Informs #76378.
Epic: CRDB-18499.

See individual commits for details.