### PR TITLE
diagnosticsccl: remove uses of `TODOTestTenantDisabled`

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/server/serverpb",
         "//pkg/sql",
         "//pkg/sql/contention",
-        "//pkg/sql/pgwire",
         "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/tests",
         "//pkg/testutils/serverutils",

--- a/pkg/ccl/serverccl/diagnosticsccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/diagnosticsccl/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/clusterversion",
         "//pkg/config/zonepb",

--- a/pkg/ccl/serverccl/diagnosticsccl/main_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/main_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -23,5 +24,6 @@ func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	kvtenantccl.InitConnectorFactory()
+	defer ccl.TestingEnableEnterprise()()
 	os.Exit(m.Run())
 }

--- a/pkg/ccl/serverccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/tenant_test_utils.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/contention"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -100,7 +99,7 @@ func newTestTenant(
 	tenant, tenantConn := serverutils.StartTenant(t, server, args)
 	sqlDB := sqlutils.MakeSQLRunner(tenantConn)
 	status := tenant.StatusServer().(serverpb.SQLStatusServer)
-	sqlStats := tenant.PGServer().(*pgwire.Server).SQLServer.
+	sqlStats := tenant.SQLServer().(*sql.Server).
 		GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
 	contentionRegistry := tenant.ExecutorConfig().(sql.ExecutorConfig).ContentionRegistry
 

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -154,9 +154,9 @@ func TestInternalFullTableScan(t *testing.T) {
 		err.Error())
 
 	mon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
-	mon.StartNoReserved(ctx, s.(*server.TestServer).Server.PGServer().SQLServer.GetBytesMonitor())
+	mon.StartNoReserved(ctx, s.SQLServer().(*sql.Server).GetBytesMonitor())
 	ie := sql.MakeInternalExecutor(
-		s.(*server.TestServer).Server.PGServer().SQLServer, sql.MemoryMetrics{}, mon,
+		s.SQLServer().(*sql.Server), sql.MemoryMetrics{}, mon,
 	)
 	ie.SetSessionData(
 		&sessiondata.SessionData{
@@ -193,9 +193,9 @@ func TestInternalStmtFingerprintLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	mon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
-	mon.StartNoReserved(ctx, s.(*server.TestServer).Server.PGServer().SQLServer.GetBytesMonitor())
+	mon.StartNoReserved(ctx, s.SQLServer().(*sql.Server).GetBytesMonitor())
 	ie := sql.MakeInternalExecutor(
-		s.(*server.TestServer).Server.PGServer().SQLServer, sql.MemoryMetrics{}, mon,
+		s.SQLServer().(*sql.Server), sql.MemoryMetrics{}, mon,
 	)
 	_, err = ie.Exec(ctx, "stmt-exceeds-fingerprint-limit", nil, "SELECT 1")
 	require.NoError(t, err)
@@ -324,9 +324,9 @@ func TestSessionBoundInternalExecutor(t *testing.T) {
 
 	expDB := "foo"
 	mon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
-	mon.StartNoReserved(ctx, s.(*server.TestServer).Server.PGServer().SQLServer.GetBytesMonitor())
+	mon.StartNoReserved(ctx, s.SQLServer().(*sql.Server).GetBytesMonitor())
 	ie := sql.MakeInternalExecutor(
-		s.(*server.TestServer).Server.PGServer().SQLServer, sql.MemoryMetrics{}, mon,
+		s.SQLServer().(*sql.Server), sql.MemoryMetrics{}, mon,
 	)
 	ie.SetSessionData(
 		&sessiondata.SessionData{
@@ -391,9 +391,9 @@ func TestInternalExecAppNameInitialization(t *testing.T) {
 		defer s.Stopper().Stop(context.Background())
 
 		mon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
-		mon.StartNoReserved(context.Background(), s.(*server.TestServer).Server.PGServer().SQLServer.GetBytesMonitor())
+		mon.StartNoReserved(context.Background(), s.SQLServer().(*sql.Server).GetBytesMonitor())
 		ie := sql.MakeInternalExecutor(
-			s.(*server.TestServer).Server.PGServer().SQLServer, sql.MemoryMetrics{}, mon,
+			s.SQLServer().(*sql.Server), sql.MemoryMetrics{}, mon,
 		)
 		ie.SetSessionData(
 			&sessiondata.SessionData{

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -160,9 +160,6 @@ type TestServerInterface interface {
 	// MigrationServer returns the internal *migrationServer as in interface{}
 	MigrationServer() interface{}
 
-	// SQLServer returns the *sql.Server as an interface{}.
-	SQLServer() interface{}
-
 	// SQLLivenessProvider returns the sqlliveness.Provider as an interface{}.
 	SQLLivenessProvider() interface{}
 

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -110,6 +110,9 @@ type TestTenantInterface interface {
 	// interface{}.
 	TenantStatusServer() interface{}
 
+	// SQLServer returns the *sql.Server as an interface{}.
+	SQLServer() interface{}
+
 	// DistSQLServer returns the *distsql.ServerImpl as an interface{}.
 	DistSQLServer() interface{}
 


### PR DESCRIPTION
Informs #76378 
Epic: CRDB-18499
First commit from #106900.

Followup issue: #106901
