### PR TITLE
release-23.1: sql: only skip import worker failure under race,stress,deadlock

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5386,6 +5386,10 @@ func TestImportWorkerFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderStressWithIssue(t, 102839, "flaky test")
+	skip.UnderDeadlockWithIssue(t, 102839, "flaky test")
+	skip.UnderRaceWithIssue(t, 102839, "flaky test")
+
 	allowResponse := make(chan struct{})
 	params := base.TestClusterArgs{}
 	params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()


### PR DESCRIPTION
Backport 1/1 commits from #105712.

/cc @cockroachdb/release

---

Better to have the test running some of the time to catch regressions.

Informs: #102839
Epic: None
Release note: None

