### PR TITLE
serverccl: remove remaining uses of TODOTestTenantDisabled

### DIFF
--- a/pkg/ccl/serverccl/admin_test.go
+++ b/pkg/ccl/serverccl/admin_test.go
@@ -173,7 +173,7 @@ func TestListTenants(t *testing.T) {
 
 	ctx := context.Background()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)
 
@@ -206,14 +206,13 @@ func TestListTenants(t *testing.T) {
 
 func TestTableAndDatabaseDetailsAndStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{DefaultTestTenant: base.TODOTestTenantDisabled})
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	st, db := serverutils.StartTenant(t, s, base.TestTenantArgs{
-		TenantID: serverutils.TestTenantID(),
-	})
+	st := s.TenantOrServer()
 	_, err := db.Exec("CREATE TABLE test (id int)")
 	require.NoError(t, err)
 	_, err = db.Exec("INSERT INTO test VALUES (1)")

--- a/pkg/ccl/serverccl/api_v2_tenant_test.go
+++ b/pkg/ccl/serverccl/api_v2_tenant_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,8 @@ import (
 
 func TestExecSQL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	server.SQLAPIClock = timeutil.NewManualTime(timeutil.FromUnixMicros(0))
 	defer func() {
 		server.SQLAPIClock = timeutil.DefaultTimeSource{}

--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -63,18 +63,20 @@ func TestSharedProcessTenantNodeLocalAccess(t *testing.T) {
 	}()
 
 	tc := serverutils.StartNewTestCluster(t, nodeCount, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{DefaultTestTenant: base.TODOTestTenantDisabled},
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		},
 		ServerArgsPerNode: map[int]base.TestServerArgs{
 			0: {
-				DefaultTestTenant: base.TODOTestTenantDisabled,
+				DefaultTestTenant: base.TestControlsTenantsExplicitly,
 				ExternalIODir:     dirs[0],
 			},
 			1: {
-				DefaultTestTenant: base.TODOTestTenantDisabled,
+				DefaultTestTenant: base.TestControlsTenantsExplicitly,
 				ExternalIODir:     dirs[1],
 			},
 			2: {
-				DefaultTestTenant: base.TODOTestTenantDisabled,
+				DefaultTestTenant: base.TestControlsTenantsExplicitly,
 				ExternalIODir:     dirs[2],
 			},
 		},
@@ -135,7 +137,7 @@ func TestSharedProcessServerInheritsTempStorageLimit(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Settings:          st,
 		TempStorageConfig: base.DefaultTestTempStorageConfigWithSize(st, specialSize),
-		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)
 
@@ -158,7 +160,7 @@ func TestServerControllerHTTP(t *testing.T) {
 	ctx := context.Background()
 
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)
 
@@ -334,7 +336,9 @@ func TestServerControllerDefaultHTTPTenant(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{DefaultTestTenant: base.TODOTestTenantDisabled})
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+	})
 	defer s.Stopper().Stop(ctx)
 
 	_, sql, err := s.StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
@@ -420,7 +424,7 @@ func TestServerControllerMultiNodeTenantStartup(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			},
-			DefaultTestTenant: base.TODOTestTenantDisabled,
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		}})
 	defer func() {
 		t.Logf("stopping test cluster")
@@ -472,7 +476,7 @@ func TestServerStartStop(t *testing.T) {
 	ctx := context.Background()
 
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)
 
@@ -635,7 +639,7 @@ func TestServiceShutdownUsesGracefulDrain(t *testing.T) {
 	ctx := context.Background()
 
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -39,33 +39,19 @@ import (
 )
 
 // TestSQLServer starts up a semi-dedicated SQL server and runs some smoke test
-// queries. The SQL server shares some components, notably Gossip, with a test
-// server serving as a KV backend.
-//
-// TODO(tbg): start narrowing down and enumerating the unwanted dependencies. In
-// the end, the SQL server in this test should not depend on a Gossip instance
-// and must not rely on having a NodeID/NodeDescriptor/NodeLiveness/...
-//
-// In short, it should not rely on the test server through anything other than a
-// `*kv.DB` and a small number of allowlisted RPCs.
+// queries.
 func TestSQLServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
-		// We need to disable the default test tenant because we're going to create
-		// our own.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	}})
-	defer tc.Stopper().Stop(ctx)
+	ts, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		// This test is specific to secondary tenants; no need to run it
+		// using the system tenant.
+		DefaultTestTenant: base.TestTenantAlwaysEnabled,
+	})
+	defer ts.Stopper().Stop(ctx)
 
-	_, db := serverutils.StartTenant(
-		t,
-		tc.Server(0),
-		base.TestTenantArgs{TenantID: serverutils.TestTenantID()},
-	)
-	defer db.Close()
 	r := sqlutils.MakeSQLRunner(db)
 	r.QueryStr(t, `SELECT 1`)
 	r.Exec(t, `CREATE DATABASE foo`)
@@ -83,7 +69,7 @@ func TestTenantCannotSetClusterSetting(t *testing.T) {
 	ctx := context.Background()
 
 	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
-		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	}})
 	defer tc.Stopper().Stop(ctx)
 
@@ -101,6 +87,8 @@ func TestTenantCannotSetClusterSetting(t *testing.T) {
 	}
 }
 
+// TestTenantCanUseEnterpriseFeatures verifies that tenants can get a license
+// from the env variable.
 func TestTenantCanUseEnterpriseFeatures(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -112,12 +100,16 @@ func TestTenantCanUseEnterpriseFeatures(t *testing.T) {
 	defer ccl.TestingDisableEnterprise()()
 	defer envutil.TestSetEnv(t, "COCKROACH_TENANT_LICENSE", license)()
 
-	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	}})
-	defer tc.Stopper().Stop(context.Background())
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		// Note: we can't use `TestTenantAlwaysEnabled` here because
+		// (currently) that requires the enterprise license to be set at
+		// the storage layer, which we just disabled above (because we
+		// want to check the effects of the env var instead).
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+	})
+	defer s.Stopper().Stop(context.Background())
 
-	_, db := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: serverutils.TestTenantID()})
+	_, db := serverutils.StartTenant(t, s, base.TestTenantArgs{TenantID: serverutils.TestTenantID()})
 	defer db.Close()
 
 	_, err := db.Exec(`BACKUP INTO 'userfile:///backup'`)
@@ -131,12 +123,12 @@ func TestTenantUnauthenticatedAccess(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
-		DefaultTestTenant: base.TestTenantProbabilistic,
-	}})
-	defer tc.Stopper().Stop(ctx)
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+	})
+	defer s.Stopper().Stop(ctx)
 
-	_, err := tc.Server(0).StartTenant(ctx,
+	_, err := s.StartTenant(ctx,
 		base.TestTenantArgs{
 			TenantID: roachpb.MustMakeTenantID(security.EmbeddedTenantIDs()[0]),
 			TestingKnobs: base.TestingKnobs{
@@ -156,22 +148,20 @@ func TestTenantHTTP(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	}})
-	defer tc.Stopper().Stop(ctx)
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		// This test is specific to secondary tenants; no need to run it
+		// using the system tenant.
+		DefaultTestTenant: base.TestTenantAlwaysEnabled,
+	})
+	defer s.Stopper().Stop(ctx)
 
-	tenant, err := tc.Server(0).StartTenant(ctx,
-		base.TestTenantArgs{
-			TenantID: serverutils.TestTenantID(),
-		})
-	require.NoError(t, err)
+	ts := s.TenantOrServer()
 
 	t.Run("prometheus", func(t *testing.T) {
-		httpClient, err := tenant.GetUnauthenticatedHTTPClient()
+		httpClient, err := ts.GetUnauthenticatedHTTPClient()
 		require.NoError(t, err)
 		defer httpClient.CloseIdleConnections()
-		resp, err := httpClient.Get(tenant.AdminURL().WithPath("/_status/vars").String())
+		resp, err := httpClient.Get(ts.AdminURL().WithPath("/_status/vars").String())
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
@@ -179,10 +169,10 @@ func TestTenantHTTP(t *testing.T) {
 		require.Contains(t, string(body), "sql_ddl_started_count_internal")
 	})
 	t.Run("pprof", func(t *testing.T) {
-		httpClient, err := tenant.GetAdminHTTPClient()
+		httpClient, err := ts.GetAdminHTTPClient()
 		require.NoError(t, err)
 		defer httpClient.CloseIdleConnections()
-		u := tenant.AdminURL().WithPath("/debug/pprof/goroutine")
+		u := ts.AdminURL().WithPath("/debug/pprof/goroutine")
 		q := u.Query()
 		q.Set("debug", "2")
 		u.RawQuery = q.Encode()
@@ -193,7 +183,6 @@ func TestTenantHTTP(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, string(body), "goroutine")
 	})
-
 }
 
 // TestTenantProcessDebugging verifies that in-process SQL tenant servers gate
@@ -203,14 +192,10 @@ func TestTenantProcessDebugging(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	}})
-	defer tc.Stopper().Stop(ctx)
-	db := tc.ServerConn(0)
-	defer db.Close()
-
-	s := tc.Server(0)
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+	})
+	defer s.Stopper().Stop(ctx)
 
 	tenant, _, err := s.StartSharedProcessTenant(ctx,
 		base.TestSharedProcessTenantArgs{
@@ -263,9 +248,9 @@ func TestTenantProcessDebugging(t *testing.T) {
 		_, err = db.Exec(`ALTER TENANT processdebug GRANT CAPABILITY can_debug_process=true`)
 		require.NoError(t, err)
 
-		tc.WaitForTenantCapabilities(t, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
+		serverutils.WaitForTenantCapabilities(t, s, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
 			tenantcapabilities.CanDebugProcess: "true",
-		})
+		}, "")
 
 		resp, err = httpClient.Get(url.String())
 		require.NoError(t, err)
@@ -278,9 +263,9 @@ func TestTenantProcessDebugging(t *testing.T) {
 		_, err = db.Exec(`ALTER TENANT processdebug REVOKE CAPABILITY can_debug_process`)
 		require.NoError(t, err)
 
-		tc.WaitForTenantCapabilities(t, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
+		serverutils.WaitForTenantCapabilities(t, s, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
 			tenantcapabilities.CanDebugProcess: "false",
-		})
+		}, "")
 	})
 
 	t.Run("vmodule", func(t *testing.T) {
@@ -306,9 +291,9 @@ func TestTenantProcessDebugging(t *testing.T) {
 		_, err = db.Exec(`ALTER TENANT processdebug GRANT CAPABILITY can_debug_process=true`)
 		require.NoError(t, err)
 
-		tc.WaitForTenantCapabilities(t, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
+		serverutils.WaitForTenantCapabilities(t, s, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
 			tenantcapabilities.CanDebugProcess: "true",
-		})
+		}, "")
 
 		resp, err = httpClient.Get(url.String())
 		require.NoError(t, err)
@@ -321,9 +306,9 @@ func TestTenantProcessDebugging(t *testing.T) {
 		_, err = db.Exec(`ALTER TENANT processdebug REVOKE CAPABILITY can_debug_process`)
 		require.NoError(t, err)
 
-		tc.WaitForTenantCapabilities(t, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
+		serverutils.WaitForTenantCapabilities(t, s, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
 			tenantcapabilities.CanDebugProcess: "false",
-		})
+		}, "")
 	})
 }
 
@@ -332,14 +317,12 @@ func TestNonExistentTenant(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TODOTestTenantDisabled,
-		},
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
-	defer tc.Stopper().Stop(ctx)
+	defer s.Stopper().Stop(ctx)
 
-	_, err := tc.Server(0).StartTenant(ctx,
+	_, err := s.StartTenant(ctx,
 		base.TestTenantArgs{
 			TenantID:            serverutils.TestTenantID(),
 			DisableCreateTenant: true,
@@ -355,17 +338,11 @@ func TestTenantRowIDs(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	}})
-	defer tc.Stopper().Stop(ctx)
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestTenantAlwaysEnabled,
+	})
+	defer s.Stopper().Stop(ctx)
 	const numRows = 10
-	tenant, db := serverutils.StartTenant(
-		t,
-		tc.Server(0),
-		base.TestTenantArgs{TenantID: serverutils.TestTenantID()},
-	)
-	defer db.Close()
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `CREATE TABLE foo(key INT PRIMARY KEY DEFAULT unique_rowid(), val INT)`)
 	sqlDB.Exec(t, fmt.Sprintf("INSERT INTO foo (val) SELECT * FROM generate_series(1, %d)", numRows))
@@ -375,7 +352,7 @@ func TestTenantRowIDs(t *testing.T) {
 	rows := sqlDB.Query(t, "SELECT key FROM foo")
 	defer rows.Close()
 	rowCount := 0
-	instanceID := int(tenant.SQLInstanceID())
+	instanceID := int(s.TenantOrServer().SQLInstanceID())
 	for rows.Next() {
 		var key int
 		if err := rows.Scan(&key); err != nil {
@@ -394,24 +371,18 @@ func TestTenantInstanceIDReclaimLoop(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	settings := cluster.MakeTestingClusterSettings()
-	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			Settings: settings,
-			// Don't use a default test tenant. We will explicitly create one.
-			DefaultTestTenant: base.TODOTestTenantDisabled,
-		},
+	clusterSettings := cluster.MakeTestingClusterSettings()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Settings:          clusterSettings,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
-	defer tc.Stopper().Stop(ctx)
+	defer s.Stopper().Stop(ctx)
 
-	clusterSettings := tc.Server(0).ClusterSettings()
 	instancestorage.ReclaimLoopInterval.Override(ctx, &clusterSettings.SV, 250*time.Millisecond)
 	instancestorage.PreallocatedCount.Override(ctx, &clusterSettings.SV, 5)
 
 	_, db := serverutils.StartTenant(
-		t,
-		tc.Server(0),
-		base.TestTenantArgs{TenantID: serverutils.TestTenantID(), Settings: settings},
+		t, s, base.TestTenantArgs{TenantID: serverutils.TestTenantID(), Settings: clusterSettings},
 	)
 	defer db.Close()
 	sqlDB := sqlutils.MakeSQLRunner(db)

--- a/pkg/ccl/serverccl/server_startup_guardrails_test.go
+++ b/pkg/ccl/serverccl/server_startup_guardrails_test.go
@@ -84,9 +84,7 @@ func TestServerStartupGuardrails(t *testing.T) {
 			)
 
 			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-				// Disable the default test tenant, since we create one explicitly
-				// below.
-				DefaultTestTenant: base.TODOTestTenantDisabled,
+				DefaultTestTenant: base.TestControlsTenantsExplicitly,
 				Settings:          storageSettings,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{

--- a/pkg/ccl/serverccl/shared_process_tenant_test.go
+++ b/pkg/ccl/serverccl/shared_process_tenant_test.go
@@ -29,7 +29,7 @@ func TestSharedProcessTenantNoSpanLimit(t *testing.T) {
 
 	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TODOTestTenantDisabled,
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		}})
 	defer tc.Stopper().Stop(ctx)
 

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -382,9 +382,7 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	serverParams.Knobs.SpanConfig = &spanconfig.TestingKnobs{
 		ManagerDisableJobCreation: true, // TODO(irfansharif): #74919.
 	}
-	// Need to disable the test tenant here as the non-tenant case below
-	// assumes that it's operating within the system tenant.
-	serverParams.DefaultTestTenant = base.TODOTestTenantDisabled
+	serverParams.DefaultTestTenant = base.TestControlsTenantsExplicitly
 	testCluster := serverutils.StartNewTestCluster(t, 3 /* numNodes */, base.TestClusterArgs{
 		ServerArgs: serverParams,
 	})

--- a/pkg/ccl/serverccl/tenant_decommissioned_host_test.go
+++ b/pkg/ccl/serverccl/tenant_decommissioned_host_test.go
@@ -41,8 +41,7 @@ func TestTenantWithDecommissionedID(t *testing.T) {
 
 	ctx := context.Background()
 	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
-		// Disable the default test tenant since we are creating our own.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	}})
 	defer tc.Stopper().Stop(ctx)
 

--- a/pkg/ccl/serverccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/tenant_test_utils.go
@@ -144,12 +144,9 @@ func NewTestTenantHelper(
 ) TenantTestHelper {
 	t.Helper()
 
-	t.Helper()
-
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs = knobs
-	// We're running tenant tests, no need for a default tenant.
-	params.DefaultTestTenant = base.TODOTestTenantDisabled
+	params.DefaultTestTenant = base.TestControlsTenantsExplicitly
 	testCluster := serverutils.StartNewTestCluster(t, 1 /* numNodes */, base.TestClusterArgs{
 		ServerArgs: params,
 	})


### PR DESCRIPTION
Epic: CRDB-18499
Informs #76378.

This also simplifies some tests so they don't need to start an entire
cluster.

The remaining mentions of `TODOTestTenantDisabled` are handled in
issues  #106897, #106903 and #106901.

