### PR TITLE
ui: fix webpack builds outside of Bazel

### DIFF
--- a/pkg/ui/workspaces/db-console/webpack.config.js
+++ b/pkg/ui/workspaces/db-console/webpack.config.js
@@ -67,14 +67,8 @@ module.exports = (env, argv) => {
   // node_modules.
   let modules = [
     ...localRoots,
-    path.resolve(__dirname, "node_modules"),
-    path.resolve(__dirname, "../..", "node_modules"),
+    "node_modules",
   ];
-
-  if (isBazelBuild) {
-    // required for bazel build to resolve properly dependencies
-    modules.push("node_modules");
-  }
 
   const config = {
     context: __dirname,


### PR DESCRIPTION
Previously, the "node_modules" string (with no absolute or relative) path separators was added to the array of directories to search when resolving modules for Bazel builds only. That was technically correct, but it was rules_js' use of the pnpm directory layout that required that change. Now that CRDB uses pnpm for non-Bazel builds, there's no need for conditionally modifying that array.

Release note: None
Epic: None