### PR TITLE
upgrademanager: simplify TestMigrationFailure

### DIFF
--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     args = ["-test.timeout=295s"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/clusterversion",
         "//pkg/jobs",

--- a/pkg/upgrade/upgrademanager/main_test.go
+++ b/pkg/upgrade/upgrademanager/main_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -25,6 +26,7 @@ func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	defer ccl.TestingEnableEnterprise()()
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Informs #76378 
Epic: CRDB-18499

This also removes `TODOTestTenantDisabled`.

(I have verified the test works, albeit still flaky due to #106648, by temporarily removing the skip.)

Followup issues: #107393,  #107395, #107396, #107397

Release note: None