### PR TITLE
copy: fix vectorized copy bug with CSV header

### DIFF
--- a/pkg/sql/copy/BUILD.bazel
+++ b/pkg/sql/copy/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/desctestutils",
+        "//pkg/sql/parser",
         "//pkg/sql/randgen",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqltestutils",

--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -126,8 +127,17 @@ func TestDataDriven(t *testing.T) {
 						case "copy-from", "copy-from-error", "copy-from-kvtrace":
 							kvtrace := d.Cmd == "copy-from-kvtrace"
 							lines := strings.Split(d.Input, "\n")
+							expectedRows := len(lines) - 1
 							stmt := lines[0]
 							data := strings.Join(lines[1:], "\n")
+							st, err := parser.ParseOne(stmt)
+							require.NoError(t, err)
+							if copy, ok := st.AST.(*tree.CopyFrom); ok {
+								if copy.Options.HasHeader {
+									expectedRows--
+								}
+							}
+
 							if kvtrace {
 								err := conn.Exec(ctx, "SET TRACING=on,kv")
 								require.NoError(t, err)
@@ -140,7 +150,7 @@ func TestDataDriven(t *testing.T) {
 							switch d.Cmd {
 							case "copy-from":
 								require.NoError(t, err, "%s\n%s\n", d.Cmd, d.Input)
-								require.Equal(t, int(rows), len(lines)-1, "Not all rows were inserted")
+								require.Equal(t, int(rows), expectedRows, "Not all rows were inserted")
 								return fmt.Sprintf("%d", rows)
 							case "copy-from-error":
 								require.Error(t, err, "copy-from-error didn't return and error!")

--- a/pkg/sql/copy/testdata/copy_from
+++ b/pkg/sql/copy/testdata/copy_from
@@ -712,3 +712,15 @@ SELECT * FROM tfam2
 1|2|1|4
 2|1|2|3
 3|5|2|1
+
+# regression test for #106913
+exec-ddl
+CREATE TABLE theader (n1 numeric(19, 2))
+----
+
+copy-from
+COPY theader FROM STDIN WITH CSV HEADER
+n1
+12.123
+----
+1

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -788,7 +788,7 @@ func (c *copyMachine) readCSVData(ctx context.Context, final bool) (brk bool, er
 	// the header row in all circumstances. Do the same.
 	if c.csvExpectHeader {
 		c.csvExpectHeader = false
-		return false, nil
+		return c.readCSVData(ctx, final)
 	}
 
 	c.csvInput.Write(fullLine)


### PR DESCRIPTION
When a CSV includes a header we would return early from readCSVData and
go around again but the memory accounting logic doesn't allow empty
batches when variable sized types (i.e. Decimal) are involved. Fix this
by reading another row.

Fixes: #106913
Release note (sql change): Fix COPY CSV with HEADER regression, first
introduced 23.1. A workaround is to disable vectorized COPY by setting
vectorize session variable to false or to remove the header row from 
the COPY data.
