### PR TITLE
release-22.2: kvprober: special case node-is-decommissioned errors

### DIFF
--- a/pkg/kv/kvprober/kvprober_test.go
+++ b/pkg/kv/kvprober/kvprober_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -78,6 +79,31 @@ func TestReadProbe(t *testing.T) {
 		require.Zero(t, p.Metrics().ReadProbeFailures.Count())
 	})
 
+	// Once a node is fully decommissioned, neither kvclient nor kvprober work from
+	// the node. This does not indicate a service health issue; it is expected behavior.
+	//
+	// This is not tested with an integration test, since the kvclient of a decommissioned
+	// node will occasionally return other errors. We choose not to filter those out for
+	// reasons given at errorIsExpectedDuringNormalOperation. As a result, an integration test
+	// would be flaky. We believe a unit test is sufficient, largely because the main risk
+	// in only having a unit test is false positive pages on SRE, due to changes in what errors
+	// are returned from the kvclient of a decommissioned node. Though false positive pages add
+	// ops load, they do not directly affect the customer experience.
+	t.Run("planning fails due to decommissioning but not counted as error", func(t *testing.T) {
+		m := &mock{
+			t:       t,
+			read:    true,
+			planErr: errors.New("n2 was permanently removed from the cluster at 2009-11-10 23:00:00 +0000 UTC m=+0.000000001; it is not allowed to rejoin the cluster"),
+		}
+		p := initTestProber(ctx, m)
+		p.readProbeImpl(ctx, m, m, m)
+
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Zero(t, p.Metrics().ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().ReadProbeFailures.Count())
+	})
+
 	t.Run("txn fails", func(t *testing.T) {
 		m := &mock{
 			t:      t,
@@ -106,6 +132,22 @@ func TestReadProbe(t *testing.T) {
 		require.Equal(t, int64(1), p.Metrics().ReadProbeAttempts.Count())
 		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
 		require.Equal(t, int64(1), p.Metrics().ReadProbeFailures.Count())
+	})
+
+	// See comment above matching case in TestReadProbe regarding planning.
+	t.Run("read fails due to decommissioning but not counted as error", func(t *testing.T) {
+		m := &mock{
+			t:       t,
+			read:    true,
+			readErr: errors.New("n2 was permanently removed from the cluster at 2009-11-10 23:00:00 +0000 UTC m=+0.000000001; it is not allowed to rejoin the cluster"),
+		}
+		p := initTestProber(ctx, m)
+		p.readProbeImpl(ctx, m, m, m)
+
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().ReadProbeFailures.Count())
 	})
 }
 
@@ -163,6 +205,22 @@ func TestWriteProbe(t *testing.T) {
 		require.Zero(t, p.Metrics().WriteProbeFailures.Count())
 	})
 
+	// See comment above matching case in TestReadProbe regarding planning.
+	t.Run("planning fails due to decommissioning but not counted as error", func(t *testing.T) {
+		m := &mock{
+			t:       t,
+			write:   true,
+			planErr: errors.New("n2 was permanently removed from the cluster at 2009-11-10 23:00:00 +0000 UTC m=+0.000000001; it is not allowed to rejoin the cluster"),
+		}
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
+
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Zero(t, p.Metrics().WriteProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().WriteProbeFailures.Count())
+	})
+
 	t.Run("open txn fails", func(t *testing.T) {
 		m := &mock{
 			t:      t,
@@ -191,6 +249,22 @@ func TestWriteProbe(t *testing.T) {
 		require.Equal(t, int64(1), p.Metrics().WriteProbeAttempts.Count())
 		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
 		require.Equal(t, int64(1), p.Metrics().WriteProbeFailures.Count())
+	})
+
+	// See comment above matching case in TestReadProbe regarding planning.
+	t.Run("write fails due to decommissioning but not counted as error", func(t *testing.T) {
+		m := &mock{
+			t:        t,
+			write:    true,
+			writeErr: errors.New("n2 was permanently removed from the cluster at 2009-11-10 23:00:00 +0000 UTC m=+0.000000001; it is not allowed to rejoin the cluster"),
+		}
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
+
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().WriteProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().WriteProbeFailures.Count())
 	})
 }
 


### PR DESCRIPTION
Release justification: `kvprober` is off by default and undocumented. It should only be used in CC prod as a result. Without this change, SRE is paged during decommission operations run in CC.

Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/104365.

/cc https://github.com/orgs/cockroachdb/teams/release

kvprober: special case node-is-decommissioned errors

kvprober runs on decommissioned node. In CC, this is generally fine, since
automation fully takes down nodes once they reach the decommissioned state. But
there is a brief period where a node is running and in the decommissioned
state, and we see kvprober errors in metrics during this period, as in below.
This sometimes leads to false positive kvprober pages in CC production.

‹rpc error: code = PermissionDenied desc = n1 was permanently removed from...

To be clear, the errors are not wrong per say. They just are expected to
happen, once a node is decommissioned.

This commit adds special handling for errors of the kind above, by doing a
substring match on the error string. To be exact, kvprober now logs such errors
at warning level and does not increment any error counters. This way, an
operation like decommissioning a node does not cause false positive kvprober
pages in CC production.

Fixes https://github.com/cockroachdb/cockroach/issues/104367

Release note: None, since kvprober is not used by customers. (It is not
documented.)

Co-authored-by: Josh Carp [carp@cockroachlabs.com](mailto:carp@cockroachlabs.com)