### PR TITLE
c-deps: support 16K pages for ARM64

### DIFF
--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -24,7 +24,10 @@ configure_make(
             "--with-lg-page=14",
         ],
         "@io_bazel_rules_go//go/platform:linux_amd64": ["--host=x86_64-unknown-linux-gnu"],
-        "@io_bazel_rules_go//go/platform:linux_arm64": ["--host=aarch64-unknown-linux-gnu"],
+        "@io_bazel_rules_go//go/platform:linux_arm64": [
+            "--host=aarch64-unknown-linux-gnu",
+            "--with-lg-page=16",
+        ],
         "@io_bazel_rules_go//go/platform:linux_s390x": ["--host=s390x-unknown-linux-gnu"],
         # NB: Normally host detection is handled by configure, but the version
         # of jemalloc we have vendored is pretty ancient and can't handle some


### PR DESCRIPTION
We have had two reports of users not being able to run cockroach 23.1 on linux/arm64 with 16k pages (jemalloc does not support the page size). This change attempts to fix this by compiling jemalloc with 16K page support, only in the linux/arm64 configuration.

Epic: None
Informs: #106745
Release note: None