### PR TITLE
server: ensure SQL statement diagnostic requests work with secondary tenants

### DIFF
--- a/pkg/server/application_api/BUILD.bazel
+++ b/pkg/server/application_api/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     args = ["-test.timeout=295s"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl",
         "//pkg/config/zonepb",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -403,10 +403,7 @@ func newTenantServer(
 	}
 
 	// Tell the status/admin servers how to access SQL structures.
-	//
-	// TODO(knz): If/when we want to support statement diagnostic requests
-	// in secondary tenants, this is where we would call setStmtDiagnosticsRequester(),
-	// like in NewServer().
+	sStatus.setStmtDiagnosticsRequester(sqlServer.execCfg.StmtDiagnosticsRecorder)
 	serverIterator.sqlServer = sqlServer
 	sStatus.baseStatusServer.sqlServer = sqlServer
 	sAdmin.sqlServer = sqlServer


### PR DESCRIPTION
Fixes #107243.

Release note (bug fix): A bug with the "SQL statement diagnostic
request" HTTP API that would affect e.g. CC Serverless was fixed. This
bug had existed since v22.x.

Epic: CRDB-26687
Informs: CRDB-18499
Informs #76378.
