### PR TITLE
release-23.1: github-pull-request-make: stress if test was unskipped...

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -126,7 +126,7 @@ func pkgsFromDiff(r io.Reader) (map[string]pkg, error) {
 			if !bytes.HasPrefix(line, []byte{'-'}) {
 				curTestName = string(currentGoTestRE.ReplaceAll(line, []byte(replacement)))
 			}
-		case bytes.HasPrefix(line, []byte{'-'}) && bytes.Contains(line, []byte(".Skip")):
+		case bytes.HasPrefix(line, []byte{'-'}) && bytes.Contains(line, []byte(".Skip")) || bytes.Contains(line, []byte("skip.")):
 			if curPkgName != "" && len(curTestName) > 0 {
 				curPkg := pkgs[curPkgName]
 				curPkg.tests = append(curPkg.tests, curTestName)


### PR DESCRIPTION
...via `skip` pkg

Backport 1/1 commit from #106921.

Epic: none
Release note: None
Release justification: Test-only code change