### PR TITLE
release-22.2: prevent data loss for at risk indexes and add tooling to detect them

### DIFF
--- a/pkg/sql/catalog/internal/validate/validate.go
+++ b/pkg/sql/catalog/internal/validate/validate.go
@@ -33,6 +33,10 @@ const (
 
 	// Write is the default validation level when writing a descriptor.
 	Write = catalog.ValidationLevelAllPreTxnCommit
+
+	// ForUpgrade is the validation used by doctor which includes
+	// extra things for upgrades
+	ForUpgrade = catalog.ValidationLevelExtraForUpgrade
 )
 
 // Self is a convenience function for Validate called at the
@@ -205,6 +209,11 @@ func (vea *validationErrorAccumulator) validateDescriptorsAtLevel(
 // IsActive implements the ValidationErrorAccumulator interface.
 func (vea *validationErrorAccumulator) IsActive(version clusterversion.Key) bool {
 	return vea.activeVersion.IsActive(version)
+}
+
+// HasExtraChecksForUpgrade implements catalog.ValidationErrorAccumulator.
+func (vea *validationErrorAccumulator) HasExtraChecksForUpgrade() bool {
+	return vea.targetLevel == catalog.ValidationLevelExtraForUpgrade
 }
 
 func (vea *validationErrorAccumulator) reportDescGetterError(

--- a/pkg/sql/catalog/nstree/catalog.go
+++ b/pkg/sql/catalog/nstree/catalog.go
@@ -226,7 +226,7 @@ func (c Catalog) ValidateWithRecover(
 			ve = append(ve, err)
 		}
 	}()
-	return c.Validate(ctx, version, catalog.NoValidationTelemetry, validate.Write, desc)
+	return c.Validate(ctx, version, catalog.NoValidationTelemetry, validate.ForUpgrade, desc)
 }
 
 // ByteSize returns memory usage of the underlying map in bytes.

--- a/pkg/sql/catalog/tabledesc/helpers_test.go
+++ b/pkg/sql/catalog/tabledesc/helpers_test.go
@@ -40,6 +40,11 @@ func (cea *constraintValidationErrorAccumulator) IsActive(version clusterversion
 	return true
 }
 
+// HasExtraChecksForUpgrade implements catalog.ValidationErrorAccumulator.
+func (cea *constraintValidationErrorAccumulator) HasExtraChecksForUpgrade() bool {
+	return true
+}
+
 func ValidateConstraints(immI catalog.TableDescriptor) error {
 	imm, ok := immI.(*immutable)
 	if !ok {

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -1170,7 +1170,7 @@ func (desc *wrapper) validateTableIndexes(
 	if len(desc.PrimaryIndex.KeyColumnIDs) == 0 {
 		return ErrMissingPrimaryKey
 	}
-
+	upgradeChecks := vea.HasExtraChecksForUpgrade()
 	indexNames := map[string]struct{}{}
 	indexIDs := map[descpb.IndexID]string{}
 	for _, idx := range desc.NonDropIndexes() {
@@ -1437,6 +1437,40 @@ func (desc *wrapper) validateTableIndexes(
 			if len(foundIn) > 1 {
 				return errors.AssertionFailedf("index %q has column ID %d present in: %v",
 					idx.GetName(), colID, foundIn)
+			}
+		}
+		// Checks after this point are for future release. Also exclude system
+		// tables from these checks.
+		if !upgradeChecks {
+			continue
+		}
+		// Check that each non-virtual column is in the key or store columns of
+		// the primary index.
+		if idx.Primary() {
+			keyCols := idx.CollectKeyColumnIDs()
+			storeCols := idx.CollectPrimaryStoredColumnIDs()
+			for _, col := range desc.PublicColumns() {
+				if col.IsVirtual() {
+					if storeCols.Contains(col.GetID()) {
+						return errors.Newf(
+							"primary index %q store columns cannot contain virtual column ID %d",
+							idx.GetName(), col.GetID(),
+						)
+					}
+					// No need to check anything else for virtual columns.
+					continue
+				}
+				if !keyCols.Contains(col.GetID()) && !storeCols.Contains(col.GetID()) {
+					return errors.Newf(
+						"primary index %q must contain column ID %d in either key or store columns",
+						idx.GetName(), col.GetID(),
+					)
+				}
+			}
+		} else if len(desc.Mutations) == 0 && desc.DeclarativeSchemaChangerState == nil {
+			if idx.IndexDesc().EncodingType != descpb.SecondaryIndexEncoding {
+				return errors.AssertionFailedf("secondary index %q has invalid encoding type %d in proto, expected %d",
+					idx.GetName(), idx.IndexDesc().EncodingType, descpb.SecondaryIndexEncoding)
 			}
 		}
 	}

--- a/pkg/sql/catalog/validate.go
+++ b/pkg/sql/catalog/validate.go
@@ -42,6 +42,9 @@ const (
 	// Errors accumulated when validating up to this level come with additional
 	// telemetry.
 	ValidationLevelAllPreTxnCommit
+	// ValidationLevelExtraForUpgrade means do all of the above, but
+	// apply optional checks which aim at checking upgrade compatibility.
+	ValidationLevelExtraForUpgrade
 )
 
 // ValidationTelemetry defines the kind of telemetry keys to add to the errors.
@@ -71,6 +74,10 @@ type ValidationErrorAccumulator interface {
 	// be enabled, by comparing against the active version. If the active version
 	// is unknown the validation in question will always be enabled.
 	IsActive(version clusterversion.Key) bool
+
+	// HasExtraChecksForUpgrade returns if extra checks required for upgrades
+	// should be performed.
+	HasExtraChecksForUpgrade() bool
 }
 
 // ValidationErrors is the error container returned by Validate which contains

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -455,3 +455,12 @@ FROM
 # Drop INDEX will be blocked
 statement error pq: index t_with_idx_data_loss_n_idx cannot be safely dropped, since doing so will lose data in certain columns
 DROP INDEX t_with_idx_data_loss@t_with_idx_data_loss_n_idx;
+
+# Validate this object is seen as invalid.
+query TT
+SELECT obj_name, error FROM crdb_internal.invalid_objects
+----
+t_with_idx_data_loss  relation "t_with_idx_data_loss" (123): primary index "t_with_idx_data_loss_pkey" must contain column ID 2 in either key or store columns
+
+statement ok
+DROP TABLE t_with_idx_data_loss;

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -366,3 +366,92 @@ subtest drop_primary_key
 
 statement error pgcode 0A000 cannot drop the primary index of a table using DROP INDEX
 CREATE TABLE drop_primary(); DROP INDEX drop_primary@drop_primary_pkey CASCADE;
+
+# We had a bug where after adding a column it could have wound up only in a
+# secondary index as storing if the index was created as a side effect of
+# ALTER PRIMARY KEY on 20.2 and 21.1. Simulate this corruption and ensure
+# if such an index exists to prevent data loss drops are blocked with a link
+# to the technical advisory.
+subtest drop_index_data_loss_block
+
+statement ok
+CREATE TABLE t_with_idx_data_loss (n INT8 PRIMARY KEY, j INT8);
+CREATE INDEX ON t_with_idx_data_loss(n) STORING (j);
+
+# Corrupt the primary index to stop storing j, so the only source is storing
+# is a secondary index.
+statement ok
+WITH
+	to_json
+		AS (
+			SELECT
+				id,
+				crdb_internal.pb_to_json(
+					'cockroach.sql.sqlbase.Descriptor',
+					descriptor,
+					false
+				)
+					AS d
+			FROM
+				system.descriptor
+			WHERE
+				id IN ('t_with_idx_data_loss'::regclass::oid::int,)
+		),
+	modified
+		AS (
+			SELECT
+				id,
+				json_set(
+					json_set(
+						json_remove_path(
+							json_remove_path(
+								d,
+								ARRAY[
+									'table',
+									'primaryIndex',
+									'storeColumnIds'
+								]
+							),
+							ARRAY[
+								'table',
+								'primaryIndex',
+								'storeColumnNames'
+							]
+						),
+						ARRAY['table', 'version'],
+						(
+							(d->'table'->>'version')::INT8
+							+ 1
+						)::STRING::JSONB
+					),
+					ARRAY['table', 'modificationTime'],
+					json_build_object(
+						'wallTime',
+						(
+							(
+								extract('epoch', now())
+								* 1000000
+							)::INT8
+							* 1000
+						)::STRING
+					)
+				)
+					AS d
+			FROM
+				to_json
+		)
+SELECT
+	crdb_internal.unsafe_upsert_descriptor(
+		id,
+		crdb_internal.json_to_pb(
+			'cockroach.sql.sqlbase.Descriptor',
+			d
+		),
+		false
+	)
+FROM
+	modified;
+
+# Drop INDEX will be blocked
+statement error pq: index t_with_idx_data_loss_n_idx cannot be safely dropped, since doing so will lose data in certain columns
+DROP INDEX t_with_idx_data_loss@t_with_idx_data_loss_n_idx;

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":529,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":546,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -373,3 +373,16 @@ func errHasCode(err error, code ...pgcode.Code) bool {
 	}
 	return false
 }
+
+// NewSecondaryIndexDataLossError creates an error if dropping a secondary
+// index could lead to losing a column.
+func NewSecondaryIndexDataLossError(indexName string) error {
+	return errors.WithIssueLink(errors.Newf("index %s cannot be safely dropped, "+
+		"since doing so will lose data in certain columns", indexName),
+		errors.IssueLink{
+			IssueURL: "https://www.cockroachlabs.com/docs/advisories/a99561",
+			Detail: "Dropping this secondary index may lead to data loss, please " +
+				"contact support.",
+		},
+	)
+}


### PR DESCRIPTION
Backport 2/2 commits from #106863.

/cc @cockroachdb/release

---

This patch aims at doing the following:

1. Extend the debug doctor / crdb_internal.invalid_objects to detect indexes which could potentially lose data by being dropped specifically when a column is only stored inside them
2. Add a check inside DROP INDEX to prevent dropping indexes with this problem to avoid data loss.

Fixes: #106794
Informs: #106739 

Release justification: low risk and prevents a potentially dangerous action by users
