### PR TITLE
changefeedccl: fix flake in TestParquetRows

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -324,6 +324,7 @@ go_test(
         "@org_golang_google_api//option",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_x_exp//slices",
         "@org_golang_x_text//collate",
     ],
 )

--- a/pkg/ccl/changefeedccl/parquet.go
+++ b/pkg/ccl/changefeedccl/parquet.go
@@ -116,7 +116,8 @@ func newParquetWriterFromRow(
 			return nil, err
 		}
 	}
-	writer, err := newParquetWriter(schemaDef, sink, opts...)
+	writer, err := parquet.NewWriter(schemaDef, sink, opts...)
+
 	if err != nil {
 		return nil, err
 	}
@@ -323,18 +324,4 @@ func deserializeMap(s string) (orderedKeys []string, m map[string]int, err error
 		m[key] = value
 	}
 	return orderedKeys, m, nil
-}
-
-// newParquetWriter allocates a new parquet writer using the provided
-// schema definition.
-func newParquetWriter(
-	sch *parquet.SchemaDefinition, sink io.Writer, opts ...parquet.Option,
-) (*parquet.Writer, error) {
-	if includeParquestTestMetadata {
-		// To use parquet test utils for reading datums, the writer needs to be
-		// configured with additional metadata.
-		return parquet.NewWriterWithReaderMeta(sch, sink, opts...)
-	}
-
-	return parquet.NewWriter(sch, sink, opts...)
 }

--- a/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
@@ -148,7 +148,7 @@ func (parquetSink *parquetCloudStorageSink) EmitResolvedTimestamp(
 
 	// TODO: Ideally, we do not create a new schema and writer every time
 	// we emit a resolved timestamp. Currently, util/parquet does not support it.
-	writer, err := newParquetWriter(sch, &buf)
+	writer, err := parquet.NewWriter(sch, &buf)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/parquet_test.go
+++ b/pkg/ccl/changefeedccl/parquet_test.go
@@ -37,6 +37,9 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+// TestParquetRows tests that the parquetWriter correctly writes datums. It does
+// this by setting up a rangefeed on a table wih data and verifying the writer
+// writes the correct datums the parquet file.
 func TestParquetRows(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -64,11 +67,13 @@ func TestParquetRows(t *testing.T) {
 	}{
 		{
 			testName: "mixed",
-			createTable: `CREATE TABLE foo (
-    	int32Col INT4 PRIMARY KEY,
-      stringCol STRING ,
-      uuidCol UUID
-  )`,
+			createTable: `
+				CREATE TABLE foo (
+				int32Col INT4 PRIMARY KEY,
+				stringCol STRING,
+				uuidCol UUID
+				)
+		    `,
 			stmts: []string{
 				`INSERT INTO foo VALUES (0, 'a1', '2fec7a4b-0a78-40ce-92e0-d1c0fac70436')`,
 				`INSERT INTO foo VALUES (1,   'b1', '0ce43188-e4a9-4b73-803b-a253abc57e6b')`,
@@ -194,6 +199,8 @@ func makeRangefeedReaderAndDecoder(
 	return popRow, cleanup, decoder
 }
 
+// TestParquetResolvedTimestamps runs tests a changefeed with format=parquet and
+// resolved timestamps enabled.
 func TestParquetResolvedTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/importer/export_base.go
+++ b/pkg/sql/importer/export_base.go
@@ -35,11 +35,6 @@ var eventMemoryMultipier = settings.RegisterFloatSetting(
 
 // ExportTestingKnobs contains testing knobs for Export.
 type ExportTestingKnobs struct {
-	// EnableParquetTestMetadata makes `EXPORT INTO ` with the
-	// parquet format write CRDB-specific metadata that is required
-	// for tests to read raw data in parquet files into CRDB datums.
-	EnableParquetTestMetadata bool
-
 	// MemoryMonitor is a test memory monitor to report allocations to.
 	MemoryMonitor *mon.BytesMonitor
 }

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -670,7 +670,7 @@ func (sp *parquetWriterProcessor) Run(ctx context.Context, output execinfra.RowR
 		for {
 			var rows int64
 			buf.Reset()
-			writer, err := newWriter(sch, &buf, compression, knobs)
+			writer, err := crlparquet.NewWriter(sch, &buf, crlparquet.WithCompressionCodec(compression))
 			if err != nil {
 				return err
 			}
@@ -794,21 +794,6 @@ func (sp *parquetWriterProcessor) testingKnobsOrNil() *ExportTestingKnobs {
 		return nil
 	}
 	return sp.flowCtx.TestingKnobs().Export.(*ExportTestingKnobs)
-}
-
-func newWriter(
-	sch *crlparquet.SchemaDefinition,
-	buf *bytes.Buffer,
-	compression crlparquet.CompressionCodec,
-	knobs *ExportTestingKnobs, /* may be nil */
-) (*crlparquet.Writer, error) {
-	if knobs != nil && knobs.EnableParquetTestMetadata {
-		// In tests, configure the writer to add metadata to allow CRDB datums
-		// to be reconstructed after being written to parquet files.
-		return crlparquet.NewWriterWithReaderMeta(sch, buf, crlparquet.WithCompressionCodec(compression))
-	} else {
-		return crlparquet.NewWriter(sch, buf, crlparquet.WithCompressionCodec(compression))
-	}
 }
 
 func init() {

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -179,11 +179,6 @@ func TestRandomParquetExports(t *testing.T) {
 		DefaultTestTenant: base.TODOTestTenantDisabled,
 		UseDatabase:       dbName,
 		ExternalIODir:     dir,
-		Knobs: base.TestingKnobs{
-			DistSQL: &execinfra.TestingKnobs{
-				Export: &importer.ExportTestingKnobs{EnableParquetTestMetadata: true},
-			},
-		},
 	})
 	ctx := context.Background()
 	defer srv.Stopper().Stop(ctx)
@@ -283,11 +278,6 @@ func TestBasicParquetTypes(t *testing.T) {
 		DefaultTestTenant: base.TODOTestTenantDisabled,
 		UseDatabase:       dbName,
 		ExternalIODir:     dir,
-		Knobs: base.TestingKnobs{
-			DistSQL: &execinfra.TestingKnobs{
-				Export: &importer.ExportTestingKnobs{EnableParquetTestMetadata: true},
-			},
-		},
 	})
 	ctx := context.Background()
 	defer srv.Stopper().Stop(ctx)
@@ -425,8 +415,7 @@ func TestMemoryMonitor(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			DistSQL: &execinfra.TestingKnobs{
 				Export: &importer.ExportTestingKnobs{
-					EnableParquetTestMetadata: true,
-					MemoryMonitor:             mm,
+					MemoryMonitor: mm,
 				},
 			},
 		},

--- a/pkg/util/parquet/BUILD.bazel
+++ b/pkg/util/parquet/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/bitarray",
+        "//pkg/util/buildutil",
         "//pkg/util/duration",
         "//pkg/util/encoding",
         "//pkg/util/timeofday",

--- a/pkg/util/parquet/testutils.go
+++ b/pkg/util/parquet/testutils.go
@@ -13,7 +13,6 @@ package parquet
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"math"
 	"os"
 	"strconv"
@@ -30,15 +29,6 @@ import (
 	"github.com/lib/pq/oid"
 	"github.com/stretchr/testify/require"
 )
-
-// NewWriterWithReaderMeta constructs a Writer that writes additional metadata
-// required to use the reader utility functions below.
-func NewWriterWithReaderMeta(
-	sch *SchemaDefinition, sink io.Writer, opts ...Option,
-) (*Writer, error) {
-	opts = append(opts, WithMetadata(MakeReaderMetadata(sch)))
-	return NewWriter(sch, sink, opts...)
-}
 
 // ReadFileAndVerifyDatums asserts that a parquet file's metadata matches the
 // metadata from the writer and its data matches writtenDatums.
@@ -69,7 +59,7 @@ func ReadFileAndVerifyDatums(
 // ReadFile reads a parquet file and returns the contained metadata and datums.
 //
 // To use this function, the Writer must be configured to write CRDB-specific
-// metadata for the reader. See NewWriterWithReaderMeta.
+// metadata for the reader. See NewWriter() and buildutil.CrdbTestBuild.
 //
 // NB: The returned datums may not be hydrated or identical to the ones
 // which were written. See comment on ValidateDatum for more info.
@@ -95,7 +85,7 @@ func ReadFile(parquetFile string) (meta ReadDatumsMetadata, datums [][]tree.Datu
 	if typFamiliesMeta == nil {
 		return ReadDatumsMetadata{}, nil,
 			errors.AssertionFailedf("missing type family metadata. ensure the writer is configured" +
-				" to write reader metadata. see NewWriterWithReaderMeta()")
+				" to write reader metadata. see NewWriter() and buildutil.CrdbTestBuild")
 	}
 	typFamilies, err := deserializeIntArray(*typFamiliesMeta)
 	if err != nil {
@@ -112,7 +102,7 @@ func ReadFile(parquetFile string) (meta ReadDatumsMetadata, datums [][]tree.Datu
 	if typOidsMeta == nil {
 		return ReadDatumsMetadata{}, nil,
 			errors.AssertionFailedf("missing type oid metadata. ensure the writer is configured" +
-				" to write reader metadata. see NewWriterWithReaderMeta()")
+				" to write reader metadata. see NewWriter() and buildutil.CrdbTestBuild)")
 	}
 	typOids, err := deserializeIntArray(*typOidsMeta)
 	if err != nil {

--- a/pkg/util/parquet/writer.go
+++ b/pkg/util/parquet/writer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/apache/arrow/go/v11/parquet/file"
 	"github.com/apache/arrow/go/v11/parquet/metadata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -162,6 +163,13 @@ func NewWriter(sch *SchemaDefinition, sink io.Writer, opts ...Option) (*Writer, 
 	for _, opt := range opts {
 		err := opt.apply(&cfg)
 		if err != nil {
+			return nil, err
+		}
+	}
+	// Add additional metadata required to use the reader utility functions in
+	// testutils.go.
+	if buildutil.CrdbTestBuild {
+		if err := WithMetadata(MakeReaderMetadata(sch)).apply(&cfg); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/util/parquet/writer_test.go
+++ b/pkg/util/parquet/writer_test.go
@@ -128,7 +128,7 @@ func TestRandomDatums(t *testing.T) {
 	schemaDef, err := NewSchema(sch.columnNames, sch.columnTypes)
 	require.NoError(t, err)
 
-	writer, err := NewWriterWithReaderMeta(schemaDef, f, WithMaxRowGroupLength(maxRowGroupSize))
+	writer, err := NewWriter(schemaDef, f, WithMaxRowGroupLength(maxRowGroupSize))
 	require.NoError(t, err)
 
 	for _, row := range datums {
@@ -501,7 +501,7 @@ func TestBasicDatums(t *testing.T) {
 			schemaDef, err := NewSchema(tc.sch.columnNames, tc.sch.columnTypes)
 			require.NoError(t, err)
 
-			writer, err := NewWriterWithReaderMeta(schemaDef, f, WithMaxRowGroupLength(maxRowGroupSize))
+			writer, err := NewWriter(schemaDef, f, WithMaxRowGroupLength(maxRowGroupSize))
 			require.NoError(t, err)
 
 			for _, row := range datums {


### PR DESCRIPTION
changefeedccl: fix flake in TestParquetRows
Previously, this test would flake when rows were not emitted
in the exact order they were inserted/modified. This change
makes the test resilient to different ordering.

Epic: None
Fixes: https://github.com/cockroachdb/cockroach/issues/106911
Release note: None

---

util/parquet: make metadata transparent in tests
Previously, users of the library would need to explicitly
call `NewWriterWithReaderMetadata()` to configure the parquet
writer to add metadata required to use reader utils in
`pkg/util/parquet/testutils.go`. This led to a lot of code
uncessary code duplication. This moves the logic to decide if
metadata should be written to `NewWriter()` so callers do not
need to do the extra work.

Epic: None
Release note: None