### PR TITLE
build: use pnpm for cluster-ui auto-publishing

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -28,14 +28,18 @@ jobs:
         path: ~/.cache/bazel
         key: ${{ runner.os }}-bazel-cache
 
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 8
+
     - name: Setup NodeJS
       uses: actions/setup-node@v3
       with:
         node-version: 16
         registry-url: 'https://registry.npmjs.org'
         always-auth: true
-        cache: 'yarn'
-        cache-dependency-path: pkg/ui/workspaces/cluster-ui/yarn.lock
+        cache: 'pnpm'
+        cache-dependency-path: 'pkg/ui/pnpm-lock.yaml'
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -59,10 +63,10 @@ jobs:
     - name: Build Cluster UI
       if: steps.version-check.outputs.published == 'no'
       run: |
-        yarn install --frozen-lockfile
+        pnpm install --frozen-lockfile
         bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
         cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
-        yarn build
+        pnpm build
 
     - name: Create version tag and push
       if: steps.version-check.outputs.published == 'no'

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -6,7 +6,6 @@ on:
       - 'release-*'
     paths:
       - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
-      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
       - 'pkg/ui/workspaces/cluster-ui/package.json'
 
 jobs:
@@ -28,14 +27,18 @@ jobs:
         path: ~/.cache/bazel
         key: ${{ runner.os }}-bazel-cache
 
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 8
+
     - name: Setup NodeJS
       uses: actions/setup-node@v3
       with:
         node-version: 16
         registry-url: 'https://registry.npmjs.org'
         always-auth: true
-        cache: 'yarn'
-        cache-dependency-path: pkg/ui/workspaces/cluster-ui/yarn.lock
+        cache: 'pnpm'
+        cache-dependency-path: 'pkg/ui/pnpm-lock.yaml'
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -64,10 +67,10 @@ jobs:
     - name: Build Cluster UI
       if: steps.version-check.outputs.published == 'no'
       run: |
-        yarn install --frozen-lockfile
+        pnpm install --frozen-lockfile
         bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
         cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
-        yarn build
+        pnpm build
 
     - name: Create version tag and push
       if: steps.version-check.outputs.published == 'no'


### PR DESCRIPTION
The pkg/ui/ tree recently switched to pnpm (from yarn) for package management [1], but the GitHub workflow to automatically publish new versions of pkg/ui/workspaces/cluster-ui wasn't updated to align with that. Use pnpm for dependency management when auto-publishing canary and full-release versions of cluster-ui.

Release note: None
Epic: None