### PR TITLE
bazel,dev: in `dev`, handle different `--compilation_mode`s correctly...

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,6 +36,7 @@ build --define gotags=bazel,gss
 build --experimental_proto_descriptor_sets_include_source_info
 build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
 build --symlink_prefix=_bazel/
+build -c dbg
 common --experimental_allow_tags_propagation
 test --config=test --experimental_ui_max_stdouterr_bytes=10485760
 build --ui_event_filters=-DEBUG

--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -38,7 +38,7 @@ fi
 
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
-"$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci" -- build -c opt \
+"$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci" -- build \
 		       --config "$CONFIG" --config ci $EXTRA_ARGS \
 		       //pkg/cmd/cockroach-short //pkg/cmd/cockroach \
 		       //pkg/cmd/cockroach-sql \

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
@@ -27,8 +27,8 @@ mkdir -p "$PWD/bin"
 chmod o+rwx "$PWD/bin"
 
 # Build the roachtest binary.
-bazel build //pkg/cmd/roachtest --config ci -c opt
-BAZEL_BIN=$(bazel info bazel-bin --config ci -c opt)
+bazel build //pkg/cmd/roachtest --config ci
+BAZEL_BIN=$(bazel info bazel-bin --config ci)
 cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
@@ -39,8 +39,8 @@ chmod a+w bin/roachtest
 bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
-bazel build @com_github_cockroachdb_pebble//cmd/pebble --config ci -c opt
-BAZEL_BIN=$(bazel info bazel-bin --config ci -c opt)
+bazel build @com_github_cockroachdb_pebble//cmd/pebble --config ci
+BAZEL_BIN=$(bazel info bazel-bin --config ci)
 cp $BAZEL_BIN/external/com_github_cockroachdb_pebble/cmd/pebble/pebble_/pebble ./pebble.linux
 chmod a+w ./pebble.linux
 
@@ -67,8 +67,8 @@ function prepare_datadir() {
 # Build the mkbench tool from within the Pebble repo. This is used to parse
 # the benchmark data.
 function build_mkbench() {
-  bazel build @com_github_cockroachdb_pebble//internal/mkbench --config ci -c opt
-  BAZEL_BIN=$(bazel info bazel-bin --config ci -c opt)
+  bazel build @com_github_cockroachdb_pebble//internal/mkbench --config ci
+  BAZEL_BIN=$(bazel info bazel-bin --config ci)
   cp $BAZEL_BIN/external/com_github_cockroachdb_pebble/internal/mkbench/mkbench_/mkbench .
   chmod a+w mkbench
 }

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
@@ -27,8 +27,8 @@ mkdir -p "$PWD/bin"
 chmod o+rwx "$PWD/bin"
 
 # Build the roachtest binary.
-bazel build //pkg/cmd/roachtest --config ci -c opt
-BAZEL_BIN=$(bazel info bazel-bin --config ci -c opt)
+bazel build //pkg/cmd/roachtest --config ci
+BAZEL_BIN=$(bazel info bazel-bin --config ci)
 cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
@@ -39,8 +39,8 @@ chmod a+w bin/roachtest
 bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
-bazel build @com_github_cockroachdb_pebble//cmd/pebble --config race --config ci -c opt
-BAZEL_BIN=$(bazel info bazel-bin --config race --config ci -c opt)
+bazel build @com_github_cockroachdb_pebble//cmd/pebble --config race --config ci
+BAZEL_BIN=$(bazel info bazel-bin --config race --config ci)
 cp $BAZEL_BIN/external/com_github_cockroachdb_pebble/cmd/pebble/pebble_/pebble ./pebble.linux
 chmod a+w ./pebble.linux
 

--- a/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
@@ -35,21 +35,21 @@ for platform in "${cross_builds[@]}"; do
 
   echo "Building $platform, os=$os, arch=$arch..."
   # Build cockroach, workload and geos libs.
-  bazel build --config $platform --config ci -c opt --config force_build_cdeps \
+  bazel build --config $platform --config ci --config force_build_cdeps \
         //pkg/cmd/cockroach //pkg/cmd/workload \
         //c-deps:libgeos
-  BAZEL_BIN=$(bazel info bazel-bin --config $platform --config ci -c opt)
+  BAZEL_BIN=$(bazel info bazel-bin --config $platform --config ci)
 
   # N.B. roachtest is built once, for the host architecture.
   if [[ $os == "linux" && $arch == $host_arch ]]; then
-    bazel build --config $platform --config ci  -c opt //pkg/cmd/roachtest
+    bazel build --config $platform --config ci //pkg/cmd/roachtest
 
     cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin/roachtest
     # Make it writable to simplify cleanup and copying (e.g., scp retry).
     chmod a+w bin/roachtest
   fi
   # Build cockroach-short with assertions enabled.
-  bazel build --config $platform --config ci -c opt //pkg/cmd/cockroach-short --crdb_test
+  bazel build --config $platform --config ci //pkg/cmd/cockroach-short --crdb_test
   # Copy the binaries.
   cp $BAZEL_BIN/pkg/cmd/cockroach/cockroach_/cockroach bin/cockroach.$os-$arch
   cp $BAZEL_BIN/pkg/cmd/workload/workload_/workload    bin/workload.$os-$arch

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -404,13 +404,6 @@ config_setting(
     },
 )
 
-config_setting(
-    name = "opt",
-    values = {
-        "compilation_mode": "opt",
-    },
-)
-
 bool_flag(
     name = "nogo_flag",
     build_setting_default = False,

--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=79
+DEV_VERSION=80
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -503,7 +503,7 @@ func (d *dev) doctor(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	bazelBin, err := d.getBazelBin(ctx)
+	bazelBin, err := d.getBazelBin(ctx, []string{})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -315,7 +315,7 @@ func (d *dev) generateJs(cmd *cobra.Command) error {
 		return fmt.Errorf("building JS development prerequisites: %w", err)
 	}
 
-	bazelBin, err := d.getBazelBin(ctx)
+	bazelBin, err := d.getBazelBin(ctx, []string{})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/roachprod_stress.go
+++ b/pkg/cmd/dev/roachprod_stress.go
@@ -120,7 +120,7 @@ func (d *dev) roachprodStress(cmd *cobra.Command, commandLine []string) error {
 	if _, err := d.exec.CommandContextSilent(ctx, "bazel", args...); err != nil {
 		return err
 	}
-	if err := d.stageArtifacts(ctx, roachprodStressTarget); err != nil {
+	if err := d.stageArtifacts(ctx, roachprodStressTarget, []string{}); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -463,7 +463,7 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 //
 // See https://github.com/bazelbuild/rules_nodejs/issues/2028
 func arrangeFilesForWatchers(d *dev, ossOnly bool) error {
-	bazelBin, err := d.getBazelBin(d.cli.Context())
+	bazelBin, err := d.getBazelBin(d.cli.Context(), []string{})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -102,7 +102,7 @@ func mustGetFlagDuration(cmd *cobra.Command, name string) time.Duration {
 	return val
 }
 
-func (d *dev) getBazelInfo(ctx context.Context, key string) (string, error) {
+func (d *dev) getBazelInfo(ctx context.Context, key string, extraArgs []string) (string, error) {
 	args := []string{"info", key, "--color=no"}
 	out, err := d.exec.CommandContextSilent(ctx, "bazel", args...)
 	if err != nil {
@@ -117,15 +117,17 @@ func (d *dev) getWorkspace(ctx context.Context) (string, error) {
 		return os.Getwd()
 	}
 
-	return d.getBazelInfo(ctx, "workspace")
+	return d.getBazelInfo(ctx, "workspace", []string{})
 }
 
-func (d *dev) getBazelBin(ctx context.Context) (string, error) {
-	return d.getBazelInfo(ctx, "bazel-bin")
+// The second argument should be the relevant "config args", namely Bazel arguments
+// that are --config or --compilation_mode arguments (see getConfigArgs()).
+func (d *dev) getBazelBin(ctx context.Context, configArgs []string) (string, error) {
+	return d.getBazelInfo(ctx, "bazel-bin", configArgs)
 }
 
 func (d *dev) getExecutionRoot(ctx context.Context) (string, error) {
-	return d.getBazelInfo(ctx, "execution_root")
+	return d.getBazelInfo(ctx, "execution_root", []string{})
 }
 
 // getDevBin returns the path to the running dev executable.


### PR DESCRIPTION
... and switch our default compilation mode to `dbg`.

Under `fastbuild`, built binaries are stripped. This is not the case with `dbg`. Have `dev doctor` recommend using `dbg`, and either way make `dev` resilient to whatever kind of `--compilation_mode` you're using.

In principle or theory `dbg` is slower than `fastbuild`, but for the Go compiler it generates debuggable binaries by default and you have to opt-in to stripping, so it shoould make no real difference.

Now, we think of the `--compilation_mode` simply as follows: `dbg` is the default that everyone is opted into by default unless they explicitly set `-c opt` (we use this for release). For now I don't see a reason anyone would need `fastbuild`.

Epic: CRDB-17171
Release note: None
Closes: #106820