### PR TITLE
sql/importer: deflake TestRandomParquetExports

### DIFF
--- a/pkg/util/parquet/testutils.go
+++ b/pkg/util/parquet/testutils.go
@@ -499,6 +499,13 @@ func serializeIntArray[I int | int32 | uint32](ints []I) string {
 // 32]" to an array of ints.
 func deserializeIntArray(s string) ([]int, error) {
 	vals := strings.Split(strings.Trim(s, "[]"), " ")
+
+	// If there are no values, strings.Split returns an array of length 1
+	// containing the empty string.
+	if len(vals) == 0 || (len(vals) == 1 && vals[0] == "") {
+		return []int{}, nil
+	}
+
 	result := make([]int, 0, len(vals))
 	for _, val := range vals {
 		intVal, err := strconv.Atoi(val)


### PR DESCRIPTION
This test would flake in the case that a table is exported with no rows. This change modifies testing code to account for this case.

Release note: None
Fixes: https://github.com/cockroachdb/cockroach/issues/106909
Epic: None