### PR TITLE
release-23.1: rpc: correctly handle transitions from Ready to Shutdown

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2593,7 +2593,7 @@ func (rpcCtx *Context) runHeartbeat(
 						return
 					}
 					st = conn.grpcConn.GetState()
-					if st == connectivity.TransientFailure {
+					if st != connectivity.Ready {
 						connFailedCh <- st
 						return
 					}


### PR DESCRIPTION
Previously if the connection changed state from Ready to Shutdown either without going through TransientFailure or passing too rapidly through that state where the WaitForStateChange was not notified, a goroutine could leak waiting for a transition that would never happen. With this change it will always mark the connection as failed any time it moves out of the Ready state.

Epic: none
Fixes: #106773

Release note: None

Release justification: In certain network disconnect scenarios we see unbounded growth of goroutines. This can cause memory issues if the problem runs for an extended period of time. 