### PR TITLE
release-22.2: idxconstraint: cancel checking for index constraint initialization

### DIFF
--- a/pkg/sql/constraint.go
+++ b/pkg/sql/constraint.go
@@ -125,7 +125,7 @@ func (p *planner) ConstrainPrimaryIndexSpanByExpr(
 
 	ic.Init(
 		fe, nil, indexCols, notNullIndexCols, nil, opt.ColSet{},
-		consolidate, evalCtx, &nf, partition.PrefixSorter{},
+		consolidate, evalCtx, &nf, partition.PrefixSorter{}, func() {}, /* checkCancellation */
 	)
 
 	remaining := ic.RemainingFilters()

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -136,6 +136,7 @@ func TestIndexConstraints(t *testing.T) {
 					filters, optionalFilters, indexCols, sv.NotNullCols(), computedCols,
 					colsInComputedColsExpressions,
 					true /* consolidate */, &evalCtx, &f, partition.PrefixSorter{},
+					func() {}, /* checkCancellation */
 				)
 				result := ic.Constraint()
 				var buf bytes.Buffer
@@ -254,6 +255,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 					nil /* computedCols */, opt.ColSet{}, /* colsInComputedColsExpressions */
 					true, /* consolidate */
 					&evalCtx, &f, partition.PrefixSorter{},
+					func() {}, /* checkCancellation */
 				)
 				_ = ic.Constraint()
 				_ = ic.RemainingFilters()

--- a/pkg/sql/opt/invertedidx/geo_test.go
+++ b/pkg/sql/opt/invertedidx/geo_test.go
@@ -501,7 +501,8 @@ func TestTryFilterGeoIndex(t *testing.T) {
 			nil, /* optionalFilters */
 			tab,
 			md.Table(tab).Index(tc.indexOrd),
-			nil, /* computedColumns */
+			nil,       /* computedColumns */
+			func() {}, /* checkCancellation */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -73,6 +73,7 @@ func TryFilterInvertedIndex(
 	tabID opt.TableID,
 	index cat.Index,
 	computedColumns map[opt.ColumnID]opt.ScalarExpr,
+	checkCancellation func(),
 ) (
 	spanExpr *inverted.SpanExpression,
 	constraint *constraint.Constraint,
@@ -83,7 +84,7 @@ func TryFilterInvertedIndex(
 	// Attempt to constrain the prefix columns, if there are any. If they cannot
 	// be constrained to single values, the index cannot be used.
 	constraint, filters, ok = constrainPrefixColumns(
-		evalCtx, factory, filters, optionalFilters, tabID, index,
+		evalCtx, factory, filters, optionalFilters, tabID, index, checkCancellation,
 	)
 	if !ok {
 		return nil, nil, nil, nil, false
@@ -376,6 +377,7 @@ func constrainPrefixColumns(
 	optionalFilters memo.FiltersExpr,
 	tabID opt.TableID,
 	index cat.Index,
+	checkCancellation func(),
 ) (constraint *constraint.Constraint, remainingFilters memo.FiltersExpr, ok bool) {
 	tabMeta := factory.Metadata().TableMeta(tabID)
 	prefixColumnCount := index.NonInvertedPrefixColumnCount()
@@ -421,7 +423,7 @@ func constrainPrefixColumns(
 		prefixColumns, notNullCols, tabMeta.ComputedCols,
 		tabMeta.ColsInComputedColsExpressions,
 		false, /* consolidate */
-		evalCtx, factory, ps,
+		evalCtx, factory, ps, checkCancellation,
 	)
 	constraint = ic.UnconsolidatedConstraint()
 	if constraint.Prefix(evalCtx) < prefixColumnCount {

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -865,7 +865,8 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			nil, /* optionalFilters */
 			tab,
 			md.Table(tab).Index(tc.indexOrd),
-			nil, /* computedColumns */
+			nil,       /* computedColumns */
+			func() {}, /* checkCancellation */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/invertedidx/trigram_test.go
+++ b/pkg/sql/opt/invertedidx/trigram_test.go
@@ -112,7 +112,8 @@ func TestTryFilterTrigram(t *testing.T) {
 			nil, /* optionalFilters */
 			tab,
 			md.Table(tab).Index(trigramOrd),
-			nil, /* computedColumns */
+			nil,       /* computedColumns */
+			func() {}, /* checkCancellation */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -231,6 +231,7 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 		columns, notNullCols, tabMeta.ComputedCols,
 		tabMeta.ColsInComputedColsExpressions,
 		true /* consolidate */, c.e.evalCtx, c.e.f, ps,
+		c.checkCancellation,
 	)
 	return ic
 }


### PR DESCRIPTION
Backport 1/1 commits from #106887.

/cc @cockroachdb/release

---

It may be possible, if there's a bug in the index constraint
initialization code, for it to get stuck in an infinite loop and
allocate memory continually until the node OOMs, as seen recently
in a support issue.

This adds cancel checking to `makeSpansForAnd` to allow the query to
timeout, if a timeout is set, instead of consume memory indefinitely.

Informs https://github.com/cockroachlabs/support/issues/2456

Release note (bug fix): This adds cancel checking to index constraint
initialization code, to allow queries to timeout during query
optimization if analyzing predicates to constrain an index starts
using too many resources. Example of setting a timeout:
`SET statement_timeout='5.0s';`

Release justification: Prevent a query from OOMing a node.
