### PR TITLE
changefdeedccl: Unskip alter changefeed tests

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -868,19 +867,13 @@ func TestAlterChangefeedDatabaseQualifiedNames(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 83946)
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sqlDB.Exec(t, `CREATE DATABASE movr`)
-		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING)`)
-		sqlDB.Exec(t, `CREATE TABLE movr.users (id INT PRIMARY KEY, name STRING)`)
-		sqlDB.Exec(t,
-			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
-		)
-		sqlDB.Exec(t,
-			`INSERT INTO movr.users VALUES (1, 'Bob')`,
-		)
-		testFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers WITH resolved = '100ms', diff`)
+		sqlDB.Exec(t, `CREATE TABLE d.drivers (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE d.users (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t, `INSERT INTO d.drivers VALUES (1, 'Alice')`)
+		sqlDB.Exec(t, `INSERT INTO d.users VALUES (1, 'Bob')`)
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR d.drivers WITH resolved = '100ms', diff`)
 		defer closeFeed(t, testFeed)
 
 		assertPayloads(t, testFeed, []string{
@@ -894,7 +887,7 @@ func TestAlterChangefeedDatabaseQualifiedNames(t *testing.T) {
 
 		require.NoError(t, feed.Pause())
 
-		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD movr.users WITH initial_scan UNSET diff`, feed.JobID()))
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD d.users WITH initial_scan UNSET diff`, feed.JobID()))
 
 		require.NoError(t, feed.Resume())
 
@@ -902,9 +895,7 @@ func TestAlterChangefeedDatabaseQualifiedNames(t *testing.T) {
 			`users: [1]->{"after": {"id": 1, "name": "Bob"}}`,
 		})
 
-		sqlDB.Exec(t,
-			`INSERT INTO movr.drivers VALUES (3, 'Carol')`,
-		)
+		sqlDB.Exec(t, `INSERT INTO d.drivers VALUES (3, 'Carol')`)
 
 		assertPayloads(t, testFeed, []string{
 			`drivers: [3]->{"after": {"id": 3, "name": "Carol"}}`,
@@ -1397,89 +1388,9 @@ func TestAlterChangefeedAddTargetsDuringBackfill(t *testing.T) {
 	cdcTestWithSystem(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection, feedTestNoForcedSyntheticTimestamps)
 }
 
-func TestAlterChangefeedUpdateFilter(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	// Skip this test for now.  It used to test alter changefeed with
-	// now deprecated and removed 'primary_key_filter' option.
-	// Since predicates and projections are no longer a "string" option,
-	// alter statement implementation (and grammar) needs to be updated, and
-	// this test modified and re-enabled.
-	skip.WithIssue(t, 82491)
-
-	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
-		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
-
-		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo`)
-		defer closeFeed(t, testFeed)
-
-		sqlDB.Exec(t, `INSERT INTO foo  SELECT *, 'initial' FROM generate_series(1, 5)`)
-		assertPayloads(t, testFeed, []string{
-			`foo: [1]->{"after": {"a": 1, "b": "initial"}}`,
-			`foo: [2]->{"after": {"a": 2, "b": "initial"}}`,
-			`foo: [3]->{"after": {"a": 3, "b": "initial"}}`,
-			`foo: [4]->{"after": {"a": 4, "b": "initial"}}`,
-			`foo: [5]->{"after": {"a": 5, "b": "initial"}}`,
-		})
-
-		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
-		require.True(t, ok)
-
-		require.NoError(t, feed.TickHighWaterMark(s.Server.Clock().Now()))
-		require.NoError(t, feed.Pause())
-
-		// Try to set an invalid filter (column b is not part of primary key).
-		sqlDB.ExpectErr(t, "cannot be fully constrained",
-			fmt.Sprintf(`ALTER CHANGEFEED %d SET schema_change_policy='stop', primary_key_filter='b IS NULL'`, feed.JobID()))
-
-		// Set filter to emit a > 4.  We expect to see update row 5, and onward.
-		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d SET schema_change_policy='stop', primary_key_filter='a > 4'`, feed.JobID()))
-		require.NoError(t, feed.Resume())
-
-		// Upsert 10 new values -- we expect to see only 5-10
-		sqlDB.Exec(t, `UPSERT INTO foo  SELECT *, 'updated' FROM generate_series(1, 10)`)
-		assertPayloads(t, testFeed, []string{
-			`foo: [5]->{"after": {"a": 5, "b": "updated"}}`,
-			`foo: [6]->{"after": {"a": 6, "b": "updated"}}`,
-			`foo: [7]->{"after": {"a": 7, "b": "updated"}}`,
-			`foo: [8]->{"after": {"a": 8, "b": "updated"}}`,
-			`foo: [9]->{"after": {"a": 9, "b": "updated"}}`,
-			`foo: [10]->{"after": {"a": 10, "b": "updated"}}`,
-		})
-
-		// Pause again, clear out filter and verify we get expected values.
-		require.NoError(t, feed.TickHighWaterMark(s.Server.Clock().Now()))
-		require.NoError(t, feed.Pause())
-
-		// Set filter to emit a > 4.  We expect to see update row 5, and onward.
-		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d UNSET primary_key_filter`, feed.JobID()))
-		require.NoError(t, feed.Resume())
-
-		sqlDB.Exec(t, `UPSERT INTO foo  SELECT *, 'new value' FROM generate_series(1, 10)`)
-		assertPayloads(t, testFeed, []string{
-			`foo: [1]->{"after": {"a": 1, "b": "new value"}}`,
-			`foo: [2]->{"after": {"a": 2, "b": "new value"}}`,
-			`foo: [3]->{"after": {"a": 3, "b": "new value"}}`,
-			`foo: [4]->{"after": {"a": 4, "b": "new value"}}`,
-			`foo: [5]->{"after": {"a": 5, "b": "new value"}}`,
-			`foo: [6]->{"after": {"a": 6, "b": "new value"}}`,
-			`foo: [7]->{"after": {"a": 7, "b": "new value"}}`,
-			`foo: [8]->{"after": {"a": 8, "b": "new value"}}`,
-			`foo: [9]->{"after": {"a": 9, "b": "new value"}}`,
-			`foo: [10]->{"after": {"a": 10, "b": "new value"}}`,
-		})
-	}
-
-	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection)
-}
-
 func TestAlterChangefeedInitialScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.WithIssue(t, 83946)
 
 	testFn := func(initialScanOption string) cdcTestFn {
 		return func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -94,8 +94,7 @@ func readNextMessages(
 			return nil, ctx.Err()
 		}
 		if log.V(1) {
-			log.Infof(context.Background(), "About to read a message (%d out of %d) from %v (%T)",
-				len(actual), numMessages, f, f)
+			log.Infof(context.Background(), "About to read a message (%d out of %d)", len(actual), numMessages)
 		}
 		m, err := f.Next()
 		if log.V(1) {

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -251,6 +251,10 @@ func (b *blockingBuffer) AcquireMemory(ctx context.Context, n int64) (alloc Allo
 
 // Add implements Writer interface.
 func (b *blockingBuffer) Add(ctx context.Context, e Event) error {
+	if log.V(2) {
+		log.Infof(ctx, "Add event: %s", e.String())
+	}
+
 	// Immediately enqueue event if it already has allocation,
 	// or if it's a Flush request -- which has no allocations.
 	// Such events happen when we switch from backfill to rangefeed mode.

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -12,6 +12,7 @@ package kvevent
 
 import (
 	"context"
+	"fmt"
 	"time"
 	"unsafe"
 
@@ -221,6 +222,20 @@ func (e *Event) DetachAlloc() Alloc {
 	a := e.alloc
 	e.alloc.clear()
 	return a
+}
+
+// String implements Stringer.
+func (e *Event) String() string {
+	switch {
+	case e.et == TypeFlush:
+		return "flush"
+	case e.et == TypeKV:
+		kv := e.KV()
+		return fmt.Sprintf("%s@%s", roachpb.PrettyPrintKey(nil, kv.Key), kv.Value.Timestamp)
+	default:
+		r := e.Resolved()
+		return fmt.Sprintf("resolved %s@%s (bt=%s)", r.Span, r.Timestamp, r.BoundaryType)
+	}
 }
 
 func getTypeForBoundary(bt jobspb.ResolvedSpan_BoundaryType) Type {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -158,6 +158,9 @@ func (t seenTrackerMap) markSeen(m *cdctest.TestFeedMessage) (isNew bool) {
 	// Fixme.
 	seenKey := m.Topic + m.Partition + string(m.Key) + string(m.Value)
 	if _, ok := t[seenKey]; ok {
+		if log.V(1) {
+			log.Infof(context.Background(), "skip dup %s", seenKey)
+		}
 		return false
 	}
 	t[seenKey] = struct{}{}
@@ -1080,7 +1083,6 @@ func (f *cloudFeedFactory) Feed(
 			parquetPossible = false
 		}
 		if parquetPossible {
-			log.Infof(context.Background(), "using parquet format")
 			createStmt.Options = append(
 				createStmt.Options,
 				tree.KVOption{
@@ -1137,8 +1139,9 @@ type cloudFeed struct {
 	dir    string
 	isBare bool
 
-	resolved string
-	rows     []*cdctest.TestFeedMessage
+	resolved  string
+	seenFiles map[string]struct{}
+	rows      []*cdctest.TestFeedMessage
 }
 
 var _ cdctest.TestFeed = (*cloudFeed)(nil)
@@ -1448,21 +1451,15 @@ func (c *cloudFeed) walkDir(path string, info os.FileInfo, err error) error {
 		return nil
 	}
 
-	tsFromPath := func(p string) string {
-		return strings.Split(filepath.Base(p), "-")[0]
+	// Skip files we processed before.
+	if c.seenFiles == nil {
+		c.seenFiles = make(map[string]struct{})
 	}
-
-	// Skip files with timestamp greater than the previously observed timestamp.
-	// Note: theoretically, we should be able to skip any file with timestamp
-	// greater *or equal* to the previously observed timestamp.  However, alter
-	// changefeed pose a problem, since a table maybe added with initial scan
-	// option, causing new events (possibly including resolved event) to be
-	// emitted as of previously emitted timestamp.
-	// See https://github.com/cockroachdb/cockroach/issues/84102
-	if strings.Compare(tsFromPath(c.resolved), tsFromPath(path)) >= 0 {
-		// Already output this in a previous walkDir.
+	if _, seen := c.seenFiles[path]; seen {
+		log.Infof(context.Background(), "Skip file %s", path)
 		return nil
 	}
+	c.seenFiles[path] = struct{}{}
 
 	details, err := c.Details()
 	if err != nil {


### PR DESCRIPTION
Fixes #83946

Unskip previously skipped tests.
TestAlterChangefeedInitialScan is no longer flaky. Fix TestAlterChangefeedDatabaseQualifiedNames -- the flakiness was due to the incorrect logic in test feed machinery that would erroneously skip data file.
Remove TestAlterChangefeedUpdateFilter test -- as the comment says it's a test for now removed/deprecated primary_key_filter option (replaced with cdc queries).  Ability to alter changefeeds with cdc query is currently on a backlog and the test will need to be re-written enterely to support that.

Release note: None