### PR TITLE
sql: add max_connections session variable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5331,6 +5331,7 @@ locality                                                   region=test,dc=dc1
 locality_optimized_partitioned_index_scan                  on
 lock_timeout                                               0
 log_timezone                                               UTC
+max_connections                                            -1
 max_identifier_length                                      128
 max_index_keys                                             32
 node_id                                                    1

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2772,6 +2772,7 @@ locality                                                   region=test,dc=dc1  N
 locality_optimized_partitioned_index_scan                  on                  NULL      NULL        NULL        string
 lock_timeout                                               0                   NULL      NULL        NULL        string
 log_timezone                                               UTC                 NULL      NULL        NULL        string
+max_connections                                            -1                  NULL      NULL        NULL        string
 max_identifier_length                                      128                 NULL      NULL        NULL        string
 max_index_keys                                             32                  NULL      NULL        NULL        string
 node_id                                                    1                   NULL      NULL        NULL        string
@@ -2930,6 +2931,7 @@ locality                                                   region=test,dc=dc1  N
 locality_optimized_partitioned_index_scan                  on                  NULL  user     NULL      on                  on
 lock_timeout                                               0                   NULL  user     NULL      0s                  0s
 log_timezone                                               UTC                 NULL  user     NULL      UTC                 UTC
+max_connections                                            -1                  NULL  user     NULL      -1                  -1
 max_identifier_length                                      128                 NULL  user     NULL      128                 128
 max_index_keys                                             32                  NULL  user     NULL      32                  32
 node_id                                                    1                   NULL  user     NULL      1                   1
@@ -3085,6 +3087,7 @@ locality                                                   NULL    NULL     NULL
 locality_optimized_partitioned_index_scan                  NULL    NULL     NULL     NULL        NULL
 lock_timeout                                               NULL    NULL     NULL     NULL        NULL
 log_timezone                                               NULL    NULL     NULL     NULL        NULL
+max_connections                                            NULL    NULL     NULL     NULL        NULL
 max_identifier_length                                      NULL    NULL     NULL     NULL        NULL
 max_index_keys                                             NULL    NULL     NULL     NULL        NULL
 multiple_active_portals_enabled                            NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -107,6 +107,7 @@ locality                                                   region=test,dc=dc1
 locality_optimized_partitioned_index_scan                  on
 lock_timeout                                               0
 log_timezone                                               UTC
+max_connections                                            -1
 max_identifier_length                                      128
 max_index_keys                                             32
 node_id                                                    1

--- a/pkg/sql/logictest/testdata/logic_test/show_var
+++ b/pkg/sql/logictest/testdata/logic_test/show_var
@@ -6,3 +6,27 @@ query T
 SHOW search_path;
 ----
 public, public, a, b, c
+
+# Make sure that max_connections session var reflects cluster setting change.
+subtest max_connections_session_var
+
+statement ok
+
+query T
+SHOW max_connections;
+----
+-1
+
+statement ok
+SET CLUSTER SETTING server.max_connections_per_gateway = 2;
+
+query T
+SHOW max_connections;
+----
+2
+
+# Make sure that max_connections cannot be modified.
+statement error parameter "max_connections" cannot be changed
+SET max_connections = 2;
+
+subtest end

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2792,6 +2792,14 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`max_connections`: {
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			maxConn := maxNumNonAdminConnections.Get(&evalCtx.ExecCfg.Settings.SV)
+			return strconv.FormatInt(maxConn, 10), nil
+		},
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Previously, a session variable for `max_connections` did not exist. This was one of the incompatibilities that cropped up while using Promscale (now deprecated). This change adds the `max_connections` session variable by delegating the work to cluster setting `server.max_connections_per_gateway`.

Fixes: #80003

Release note (sql change): A new view-only session variable, `max_connections` was added. This can be used with SHOW to view the maximum amount of non-superuser SQL connections allowed at a given time.