### PR TITLE
release-23.1: sql: do not type-check subqueries outside of optbuilder

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -514,6 +514,20 @@ func serializeUserDefinedTypes(
 		default:
 			return true, expr, nil
 		}
+		// We cannot type-check subqueries without using optbuilder, and there
+		// is no need to because we only need to rewrite string values that are
+		// directly cast to enums. For example, we must rewrite the 'foo' in:
+		//
+		//   SELECT 'foo'::myenum
+		//
+		// We don't need to rewrite the 'foo' in the query below, which can be
+		// corrupted by renaming the 'foo' value in the myenum type.
+		//
+		//   SELECT (SELECT 'foo')::myenum
+		//
+		if _, ok := innerExpr.(*tree.Subquery); ok {
+			return true, expr, nil
+		}
 		// semaCtx may be nil if this is a virtual view being created at
 		// init time.
 		var typeResolver tree.TypeReferenceResolver

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3574,3 +3574,30 @@ statement error function undefined\nHINT: lower-case alternative public.lowercas
 SELECT public."LOWERCASE_HINT_ERROR_EXPLICIT_SCHEMA_FN"();
 
 subtest end
+
+# Regression test for #105259. Do not type-check subqueries in UDFs outside
+# optbuilder. Doing so can cause internal errors.
+subtest regression_105259
+
+statement ok
+CREATE TYPE e105259 AS ENUM ('foo');
+
+statement ok
+CREATE FUNCTION f() RETURNS VOID LANGUAGE SQL AS $$
+  SELECT (SELECT 'foo')::e105259;
+  SELECT NULL;
+$$
+
+query T
+SELECT f()
+----
+NULL
+
+statement ok
+ALTER TYPE e105259 RENAME VALUE 'foo' TO 'bar'
+
+# Renaming the enum value corrupts the UDF. This is expected behavior.
+statement error pgcode 22P02 invalid input value for enum e105259: "foo"
+SELECT f()
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1847,3 +1847,30 @@ DROP VIEW cd_v1;
 
 statement ok
 DROP VIEW cd_v1 CASCADE;
+
+subtest end
+
+# Regression test for #105259. Do not type-check subqueries in views outside
+# optbuilder. Doing so can cause internal errors.
+subtest regression_105259
+
+statement ok
+CREATE TYPE e105259 AS ENUM ('foo');
+
+statement ok
+CREATE VIEW v105259 AS
+SELECT (SELECT 'foo')::e105259
+
+query T
+SELECT * FROM v105259
+----
+foo
+
+statement ok
+ALTER TYPE e105259 RENAME VALUE 'foo' TO 'bar'
+
+# Renaming the enum value corrupts the view. This is expected behavior.
+statement error pgcode 22P02 invalid input value for enum e105259: "foo"
+SELECT * FROM v105259
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1485,6 +1485,20 @@ func (b *builderState) serializeUserDefinedTypes(queryStr string) string {
 		default:
 			return true, expr, nil
 		}
+		// We cannot type-check subqueries without using optbuilder, and there
+		// is no need to because we only need to rewrite string values that are
+		// directly cast to enums. For example, we must rewrite the 'foo' in:
+		//
+		//   SELECT 'foo'::myenum
+		//
+		// We don't need to rewrite the 'foo' in the query below, which can be
+		// corrupted by renaming the 'foo' value in the myenum type.
+		//
+		//   SELECT (SELECT 'foo')::myenum
+		//
+		if _, ok := innerExpr.(*tree.Subquery); ok {
+			return true, expr, nil
+		}
 		var typ *types.T
 		typ, err = tree.ResolveType(b.ctx, typRef, b.semaCtx.TypeResolver)
 		if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #106868.

/cc @cockroachdb/release

---

This commit fixes a bug that was caused when attempting to re-type-check
a view's query that contains a subquery. This type-checking occurred
outside of optbuilder. However, the logic for type-checking subqueries
is only implemented within optbuilder, so it failed.

Fixes #105259

Release note (bug fix): A bug has been fixed that caused internal errors
when using user-defined types in views and user-defined functions that
have subqueries. This bug was present when using views since version
v21.2. It was present when using user-defined functions since v23.1.

Release justification: Minor bug fix for views and UDFs with subqueries.

