### PR TITLE
release-22.2: sql: do not type-check subqueries outside of optbuilder

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -525,6 +525,20 @@ func serializeUserDefinedTypes(
 		default:
 			return true, expr, nil
 		}
+		// We cannot type-check subqueries without using optbuilder, and there
+		// is no need to because we only need to rewrite string values that are
+		// directly cast to enums. For example, we must rewrite the 'foo' in:
+		//
+		//   SELECT 'foo'::myenum
+		//
+		// We don't need to rewrite the 'foo' in the query below, which can be
+		// corrupted by renaming the 'foo' value in the myenum type.
+		//
+		//   SELECT (SELECT 'foo')::myenum
+		//
+		if _, ok := innerExpr.(*tree.Subquery); ok {
+			return true, expr, nil
+		}
 		// semaCtx may be nil if this is a virtual view being created at
 		// init time.
 		var typeResolver tree.TypeReferenceResolver

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1532,3 +1532,30 @@ DROP VIEW cd_v1;
 
 statement ok
 DROP VIEW cd_v1 CASCADE;
+
+subtest end
+
+# Regression test for #105259. Do not type-check subqueries in views outside
+# optbuilder. Doing so can cause internal errors.
+subtest regression_105259
+
+statement ok
+CREATE TYPE e105259 AS ENUM ('foo');
+
+statement ok
+CREATE VIEW v105259 AS
+SELECT (SELECT 'foo')::e105259
+
+query T
+SELECT * FROM v105259
+----
+foo
+
+statement ok
+ALTER TYPE e105259 RENAME VALUE 'foo' TO 'bar'
+
+# Renaming the enum value corrupts the view. This is expected behavior.
+statement error pgcode 22P02 invalid input value for enum e105259: "foo"
+SELECT * FROM v105259
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #106868.

/cc @cockroachdb/release

---

This commit fixes a bug that was caused when attempting to re-type-check
a view's query that contains a subquery. This type-checking occurred
outside of optbuilder. However, the logic for type-checking subqueries
is only implemented within optbuilder, so it failed.

Fixes #105259

Release note (bug fix): A bug has been fixed that caused internal errors
when using user-defined types in views and user-defined functions that
have subqueries. This bug was present when using views since version
v21.2. It was present when using user-defined functions since v23.1.

Release justification: Minor bug fix for views with subqueries.

