### PR TITLE
sql/tests: adjust several tests to work with test tenant 

### DIFF
--- a/pkg/sql/tests/autocommit_extended_protocol_test.go
+++ b/pkg/sql/tests/autocommit_extended_protocol_test.go
@@ -12,20 +12,19 @@ package tests
 
 import (
 	"context"
-	gosql "database/sql"
 	"errors"
 	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/jackc/pgx/v4"
@@ -36,16 +35,13 @@ import (
 // optimization is applied when doing a simple INSERT with a prepared statement.
 func TestInsertFastPathExtendedProtocol(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := context.Background()
-
-	var db *gosql.DB
-
 	params, _ := CreateTestServerParams()
 	params.Settings = cluster.MakeTestingClusterSettings()
-
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: params})
-	defer tc.Stopper().Stop(ctx)
-	db = tc.ServerConn(0)
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
 	_, err := db.Exec(`CREATE TABLE fast_path_test(val int);`)
 	require.NoError(t, err)
 
@@ -87,21 +83,18 @@ func TestInsertFastPathExtendedProtocol(t *testing.T) {
 // executed in the same transaction as a DDL.
 func TestInsertFastPathDisableDDLExtendedProtocol(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := context.Background()
-
-	var db *gosql.DB
-
 	params, _ := CreateTestServerParams()
 	params.Settings = cluster.MakeTestingClusterSettings()
-
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: params})
-	defer tc.Stopper().Stop(ctx)
-	db = tc.ServerConn(0)
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
 	_, err := db.Exec(`CREATE TABLE fast_path_test(val int, j int);`)
 	require.NoError(t, err)
 
 	// Use pgx so that we can introspect error codes returned from cockroach.
-	pgURL, cleanup := sqlutils.PGUrl(t, tc.Server(0).ServingSQLAddr(), "", url.User("root"))
+	pgURL, cleanup := sqlutils.PGUrl(t, s.ServingSQLAddr(), "", url.User("root"))
 	defer cleanup()
 	conf, err := pgx.ParseConfig(pgURL.String())
 	require.NoError(t, err)
@@ -153,9 +146,9 @@ func TestInsertFastPathDisableDDLExtendedProtocol(t *testing.T) {
 // in an implicit transaction.
 func TestErrorDuringExtendedProtocolCommit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ctx := context.Background()
+	defer log.Scope(t).Close(t)
 
-	var db *gosql.DB
+	ctx := context.Background()
 
 	var shouldErrorOnAutoCommit syncutil.AtomicBool
 	var traceID atomic.Uint64
@@ -184,20 +177,19 @@ func TestErrorDuringExtendedProtocolCommit(t *testing.T) {
 	}
 	params.Settings = cluster.MakeTestingClusterSettings()
 
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: params})
-	defer tc.Stopper().Stop(ctx)
-	db = tc.ServerConn(0)
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
 
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
 	var i int
-	var s string
+	var str string
 	// Use placeholders to force usage of extended protocol.
-	err = conn.QueryRowContext(ctx, "SELECT 'cat', $1::int8", 1).Scan(&s, &i)
+	err = conn.QueryRowContext(ctx, "SELECT 'cat', $1::int8", 1).Scan(&str, &i)
 	require.EqualError(t, err, "pq: injected error")
 	// Check that the error was handled correctly, and another statement
 	// doesn't confuse the server.
-	err = conn.QueryRowContext(ctx, "SELECT 'dog', $1::int8", 2).Scan(&s, &i)
+	err = conn.QueryRowContext(ctx, "SELECT 'dog', $1::int8", 2).Scan(&str, &i)
 	require.NoError(t, err)
 	require.Equal(t, 2, i)
 }

--- a/pkg/sql/tests/empty_query_test.go
+++ b/pkg/sql/tests/empty_query_test.go
@@ -30,6 +30,7 @@ import (
 func TestEmptyQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false, UseDatabase: "defaultdb"})
 	defer s.Stopper().Stop(context.Background())
 

--- a/pkg/sql/tests/hash_sharded_test.go
+++ b/pkg/sql/tests/hash_sharded_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
@@ -76,9 +75,11 @@ func verifyTableDescriptorState(
 func TestBasicHashShardedIndexes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	ctx := context.Background()
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	codec := s.TenantOrServer().Codec()
 	if _, err := db.Exec(`CREATE DATABASE d`); err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +100,7 @@ func TestBasicHashShardedIndexes(t *testing.T) {
 		if _, err := db.Exec(`CREATE INDEX foo ON kv_primary (v)`); err != nil {
 			t.Fatal(err)
 		}
-		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, `d`, `kv_primary`)
+		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, `d`, `kv_primary`)
 		verifyTableDescriptorState(t, tableDesc, "kv_primary_pkey" /* shardedIndexName */)
 		shardColID := getShardColumnID(t, tableDesc, "kv_primary_pkey" /* shardedIndexName */)
 
@@ -133,7 +134,7 @@ func TestBasicHashShardedIndexes(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, `d`, `kv_secondary`)
+		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, `d`, `kv_secondary`)
 		verifyTableDescriptorState(t, tableDesc, "sharded_secondary" /* shardedIndexName */)
 	})
 
@@ -150,7 +151,7 @@ func TestBasicHashShardedIndexes(t *testing.T) {
 		if _, err := db.Exec(`CREATE INDEX sharded_secondary2 ON kv_secondary2 (k) USING HASH WITH (bucket_count=12)`); err != nil {
 			t.Fatal(err)
 		}
-		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, `d`, `kv_secondary2`)
+		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, `d`, `kv_secondary2`)
 		verifyTableDescriptorState(t, tableDesc, "sharded_secondary2" /* shardedIndexName */)
 	})
 }

--- a/pkg/sql/tests/inverted_index_test.go
+++ b/pkg/sql/tests/inverted_index_test.go
@@ -16,8 +16,8 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -34,10 +34,10 @@ func TestInvertedIndex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-	defer tc.Stopper().Stop(context.Background())
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
 
-	db := sqlutils.MakeSQLRunner(tc.Conns[0])
+	db := sqlutils.MakeSQLRunner(conn)
 
 	db.Exec(t, "CREATE DATABASE IF NOT EXISTS test")
 	db.Exec(t, "CREATE TABLE test.jsons (i INT PRIMARY KEY, j JSONB)")

--- a/pkg/sql/tests/main_test.go
+++ b/pkg/sql/tests/main_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -29,5 +30,6 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	defer ccl.TestingEnableEnterprise()()
 	os.Exit(m.Run())
 }

--- a/pkg/sql/tests/random_schema_test.go
+++ b/pkg/sql/tests/random_schema_test.go
@@ -17,7 +17,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -39,8 +38,6 @@ func TestCreateRandomSchema(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	defer ccl.TestingEnableEnterprise()()
-
 	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)

--- a/pkg/sql/tests/rename_column_test.go
+++ b/pkg/sql/tests/rename_column_test.go
@@ -12,6 +12,7 @@ package tests
 
 import (
 	"context"
+	gosql "database/sql"
 	"path"
 	"testing"
 
@@ -20,9 +21,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,6 +33,7 @@ import (
 // yet public.
 func TestRenameColumnDuringConcurrentMutation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	// The structure of the test is to intentionally block a complex
 	// column addition schema change at various events and then issue
@@ -61,37 +64,36 @@ func TestRenameColumnDuringConcurrentMutation(t *testing.T) {
 		<-ev.unblock
 	}
 	ctx := context.Background()
-	var tc *testcluster.TestCluster
-	tc = testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			Knobs: base.TestingKnobs{
-				SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-					RunBeforePublishWriteAndDelete: func() {
-						maybeBlockOnEvent(publishWriteOnly)
-					},
-					RunBeforeBackfill: func() error {
-						maybeBlockOnEvent(backfill)
+	var s serverutils.TestServerInterface
+	var db *gosql.DB
+	s, db, _ = serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+				RunBeforePublishWriteAndDelete: func() {
+					maybeBlockOnEvent(publishWriteOnly)
+				},
+				RunBeforeBackfill: func() error {
+					maybeBlockOnEvent(backfill)
+					return nil
+				},
+				RunBeforeResume: func(jobID jobspb.JobID) error {
+					// Load the job to figure out if it's the rename or the
+					// backfill.
+					scJob, err := s.TenantOrServer().JobRegistry().(*jobs.Registry).LoadJob(ctx, jobID)
+					if err != nil {
+						return err
+					}
+					pl := scJob.Payload()
+					if pl.GetSchemaChange().TableMutationID == descpb.InvalidMutationID {
 						return nil
-					},
-					RunBeforeResume: func(jobID jobspb.JobID) error {
-						// Load the job to figure out if it's the rename or the
-						// backfill.
-						scJob, err := tc.Server(0).JobRegistry().(*jobs.Registry).LoadJob(ctx, jobID)
-						if err != nil {
-							return err
-						}
-						pl := scJob.Payload()
-						if pl.GetSchemaChange().TableMutationID == descpb.InvalidMutationID {
-							return nil
-						}
-						maybeBlockOnEvent(resume)
-						return nil
-					},
+					}
+					maybeBlockOnEvent(resume)
+					return nil
 				},
 			},
 		},
 	})
-	defer tc.Stopper().Stop(ctx)
+	defer s.Stopper().Stop(ctx)
 	for _, testCase := range []struct {
 		name   string
 		evType eventType
@@ -103,14 +105,14 @@ func TestRenameColumnDuringConcurrentMutation(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			eventToBlockOn = testCase.evType
 			dbName := path.Base(t.Name())
-			tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+			tdb := sqlutils.MakeSQLRunner(db)
 			tdb.Exec(t, "SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';")
 			tdb.Exec(t, "SET use_declarative_schema_changer = 'off';")
 			tdb.Exec(t, "CREATE DATABASE "+dbName)
 			tdb.Exec(t, "CREATE TABLE "+dbName+".foo (i INT PRIMARY KEY)")
 			scDone := make(chan error)
 			go func() {
-				_, err := tc.ServerConn(0).Exec(
+				_, err := db.Exec(
 					"ALTER TABLE " + dbName + ".foo ADD COLUMN j INT NOT NULL DEFAULT 7 CHECK (j > 0) REFERENCES " + dbName + ".foo(i)")
 				scDone <- err
 			}()

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 	"time"
 
-	// Enable CCL statements.
-	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/rsg"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -612,7 +610,6 @@ var ignoredRegex = regexp.MustCompile(strings.Join(ignoredErrorPatterns, "|"))
 func TestRandomSyntaxSQLSmith(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer ccl.TestingEnableEnterprise()()
 
 	var smither *sqlsmith.Smither
 
@@ -766,7 +763,6 @@ func testRandomSyntax(
 		skip.IgnoreLint(t, "enable with '-rsg <duration>'")
 	}
 	ctx := context.Background()
-	defer ccl.TestingEnableEnterprise()()
 
 	params, _ := tests.CreateTestServerParams()
 	params.UseDatabase = databaseName

--- a/pkg/sql/tests/schema_changes_in_parallel_test.go
+++ b/pkg/sql/tests/schema_changes_in_parallel_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -30,6 +31,7 @@ import (
 // effectively reproduced a race in the rules engine's object pooling.
 func TestSchemaChangesInParallel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{

--- a/pkg/sql/tests/search_path_test.go
+++ b/pkg/sql/tests/search_path_test.go
@@ -28,6 +28,7 @@ import (
 func TestSearchPathEndToEnd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)

--- a/pkg/sql/tests/show_commit_timestamp_test.go
+++ b/pkg/sql/tests/show_commit_timestamp_test.go
@@ -38,7 +38,6 @@ import (
 // pgx.
 func TestShowCommitTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -45,6 +45,7 @@ import (
 func TestInitialKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	const keysPerDesc = 2
 
 	testutils.RunTrueAndFalse(t, "system tenant", func(t *testing.T, systemTenant bool) {
@@ -114,6 +115,7 @@ func TestInitialKeys(t *testing.T) {
 func TestInitialKeysAndSplits(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "initial_keys"), func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "initial-keys":
@@ -167,6 +169,7 @@ func TestInitialKeysAndSplits(t *testing.T) {
 func TestSystemTableLiterals(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	type testcase struct {
 		schema string
 		pkg    catalog.TableDescriptor

--- a/pkg/sql/tests/tracing_sql_test.go
+++ b/pkg/sql/tests/tracing_sql_test.go
@@ -16,22 +16,22 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSetTraceSpansVerbosityBuiltin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	si, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer si.Stopper().Stop(context.Background())
-	s := si.(*server.TestServer)
 	r := sqlutils.MakeSQLRunner(db)
-
-	tr := s.Tracer()
+	tr := si.TenantOrServer().Tracer()
 
 	// Try to toggle the verbosity of a trace that doesn't exist, returns false.
 	// NB: Technically this could return true in the unlikely scenario that there


### PR DESCRIPTION
This commit adjusts multiple tests to work with the test tenant. It also sprinkles log scopes in the tests that were missing it and moves the ccl license enablement into `main_test`.

Note that in `TestTruncatePreservesSplitPoints` it reaches into the cluster setting for allowing tenants to split ranges to override the setting explicitly rather than via SQL (which I'm not sure if possible and non-flaky now).

Addresses: #76378.
Epic: CRDB-18499.

Release note: None