### PR TITLE
roachtest: disable scheduled backups by default

### DIFF
--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -26,7 +26,9 @@ type StartOpts struct {
 // DefaultStartOpts returns a StartOpts populated with default values.
 func DefaultStartOpts() StartOpts {
 	startOpts := StartOpts{RoachprodOpts: roachprod.DefaultStartOpts()}
-	startOpts.RoachprodOpts.ScheduleBackups = true
+	// TODO(#107056): Change this back to true once the
+	// permissions issue is resolved.
+	startOpts.RoachprodOpts.ScheduleBackups = false
 	return startOpts
 }
 


### PR DESCRIPTION
If we don't solve #107056 in a timely manner, we likely want to merge this so that nightlies don't fail.

Epic: none

Informs #107056

Release note: None