### PR TITLE
testutils,roachtest: only use private bucket in private tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -477,7 +477,7 @@
 /pkg/internal/rsg/           @cockroachdb/sql-queries
 /pkg/internal/sqlsmith/      @cockroachdb/sql-queries
 /pkg/internal/team/          @cockroachdb/test-eng
-/pkg/internal/workloadreplay/          @cockroachdb/test-eng-noreview
+/pkg/internal/workloadreplay/          @cockroachdb/test-eng
 /pkg/jobs/                   @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
 /pkg/keys/                   @cockroachdb/kv-prs
 /pkg/keysbase/               @cockroachdb/kv-prs

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -82,12 +82,7 @@ const (
 	rows3GiB   = rows30GiB / 10
 )
 
-var backupTestingBucket = func() string {
-	if env := os.Getenv("BACKUP_TESTING_BUCKET"); env != "" {
-		return env
-	}
-	return "cockroachdb-backup-testing"
-}()
+var backupTestingBucket = testutils.BackupTestingBucket()
 
 func destinationName(c cluster.Cluster) string {
 	dest := c.Name()

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/roachprod/vm/aws",
         "//pkg/roachprod/vm/gce",
         "//pkg/roachprod/vm/local",
+        "//pkg/testutils",
         "//pkg/util/intsets",
         "//pkg/util/log",
         "//pkg/util/retry",

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -819,7 +820,7 @@ func (c *SyncedCluster) shouldAdvertisePublicIP() bool {
 func (c *SyncedCluster) createFixedBackupSchedule(
 	ctx context.Context, l *logger.Logger, scheduledBackupArgs string,
 ) error {
-	externalStoragePath := `gs://cockroach-backup-testing-private`
+	externalStoragePath := fmt.Sprintf("gs://%s", testutils.BackupTestingBucket())
 	for _, cloud := range c.Clouds() {
 		if !strings.Contains(cloud, gce.ProviderName) {
 			l.Printf(`no scheduled backup created as there exists a vm not on google cloud`)

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2313,8 +2313,9 @@ func (t *logicTest) maybeBackupRestore(
 		}
 	}
 
-	backupLocation := fmt.Sprintf("gs://cockroach-backup-testing-private/logic-test-backup-restore-nightly/%s?AUTH=implicit",
-		strconv.FormatInt(timeutil.Now().UnixNano(), 10))
+	bucket := testutils.BackupTestingBucket()
+	backupLocation := fmt.Sprintf("gs://%s/logic-test-backup-restore-nightly/%s?AUTH=implicit",
+		bucket, strconv.FormatInt(timeutil.Now().UnixNano(), 10))
 
 	// Perform the backup and restore as root.
 	t.setUser(username.RootUser, 0 /* nodeIdx */)

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "testutils",
     srcs = [
+        "backup.go",
         "base.go",
         "dir.go",
         "error.go",

--- a/pkg/testutils/backup.go
+++ b/pkg/testutils/backup.go
@@ -1,0 +1,30 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package testutils
+
+import "os"
+
+const (
+	defaultBackupBucket       = "cockroachdb-backup-testing"
+	backupTestingBucketEnvVar = "BACKUP_TESTING_BUCKET"
+)
+
+// BackupTestingBucket returns the name of the GCS bucket that should
+// be used in a test run. Most times, this will be the regular public
+// bucket. In private test runs, the name of the bucket is passed
+// through an environment variable.
+func BackupTestingBucket() string {
+	if bucket := os.Getenv(backupTestingBucketEnvVar); bucket != "" {
+		return bucket
+	}
+
+	return defaultBackupBucket
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -512,6 +512,7 @@ func TestLint(t *testing.T) {
 					":!internal/team/team.go",                // For BAZEL_TEST.
 					":!util/log/test_log_scope.go",           // For TEST_UNDECLARED_OUTPUT_DIR, REMOTE_EXEC
 					":!testutils/datapathutils/data_path.go", // For TEST_UNDECLARED_OUTPUT_DIR, REMOTE_EXEC
+					":!testutils/backup.go",                  // For BACKUP_TESTING_BUCKET
 				},
 			},
 		} {


### PR DESCRIPTION
This fixes an issue with the default location for backups taken during tests that use a real GCS bucket. Previously, some of these backups were using the hardcoded private bucket name, causing many tests to fail with permission errors.

In this commit, we centralize the logic for figuring out which bucket to use in a `testutils` function, and reuse that across logic tests and roachtests.

Fixes: #107056

Release note: None