### PR TITLE
asim: add random predefined cluster config selection

### DIFF
--- a/pkg/kv/kvserver/asim/tests/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/tests/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "assert.go",
         "default_settings.go",
         "rand_framework.go",
+        "rand_gen.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/tests",
     visibility = ["//visibility:public"],

--- a/pkg/kv/kvserver/asim/tests/rand_framework.go
+++ b/pkg/kv/kvserver/asim/tests/rand_framework.go
@@ -50,7 +50,7 @@ func (f randTestingFramework) getCluster() gen.ClusterGen {
 	if !f.s.randOptions.cluster {
 		return defaultBasicClusterGen()
 	}
-	return gen.BasicCluster{}
+	return f.randomClusterInfoGen(f.s.randSource)
 }
 
 func (f randTestingFramework) getRanges() gen.RangeGen {

--- a/pkg/kv/kvserver/asim/tests/rand_gen.go
+++ b/pkg/kv/kvserver/asim/tests/rand_gen.go
@@ -1,0 +1,25 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/gen"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
+)
+
+// randomClusterInfoGen returns a randomly picked predefined configuration.
+func (f randTestingFramework) randomClusterInfoGen(randSource *rand.Rand) gen.LoadedCluster {
+	chosenIndex := randSource.Intn(len(state.ClusterOptions))
+	chosenType := state.ClusterOptions[chosenIndex]
+	return loadClusterInfo(chosenType)
+}

--- a/pkg/kv/kvserver/asim/tests/rand_test.go
+++ b/pkg/kv/kvserver/asim/tests/rand_test.go
@@ -70,7 +70,7 @@ func defaultSettings(randOptions testRandOptions) testSettings {
 // default
 func TestRandomized(t *testing.T) {
 	randOptions := testRandOptions{
-		cluster:        false,
+		cluster:        true,
 		ranges:         false,
 		load:           false,
 		staticSettings: false,


### PR DESCRIPTION
This patch takes the first step towards a randomized framework by enabling asim
testing to randomly select a cluster information configuration from a set of
predefined choices. These choices are hardcoded and represent common cluster
configurations.

TestRandomized now takes in `true` for randOptions.cluster to enable random
cluster config selection. This provides two modes for cluster generation:
1. Default: currently set to 3 nodes and 1 store per node
2. Random: randomly select a predefined cluster info

Part of: https://github.com/cockroachdb/cockroach/issues/106311

Release note: None