### PR TITLE
grpcinterceptor: Use ctxutil to detect context cancellation

### DIFF
--- a/pkg/util/ctxutil/BUILD.bazel
+++ b/pkg/util/ctxutil/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/ctxutil",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_cockroachdb_errors//:errors"],
+    deps = [
+        "//pkg/util/buildutil",
+        "//pkg/util/log",
+    ],
 )
 
 go_test(

--- a/pkg/util/ctxutil/context.go
+++ b/pkg/util/ctxutil/context.go
@@ -12,8 +12,10 @@ package ctxutil
 
 import (
 	"context"
+	_ "unsafe" // Must import unsafe to enable linkname.
 
-	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // WhenDoneFunc is the callback invoked by context when it becomes done.
@@ -24,19 +26,50 @@ type WhenDoneFunc func(err error)
 // as the cause for cancellation (cause is nil prior to go1.20).
 type WhenDoneCauseFunc func(err, cause error)
 
-// ErrNeverCompletes is an error indicating that the context never completes.
-var ErrNeverCompletes = errors.New("context never completes")
-
 // WhenDone arranges for the specified function to be invoked when
-// parent context becomes done.
-// If the context never becomes done, returns ErrNeverCompletes error.
-func WhenDone(parent context.Context, done WhenDoneFunc) error {
+// parent context becomes done and returns true.
+// If the context is non-cancellable (i.e. `Done() == nil`), returns false and
+// never calls the function.
+// If the parent context is derived from context.WithCancel or
+// context.WithTimeout/Deadline, then no additional goroutines are created.
+// Otherwise, a goroutine is spun up by context.Context to detect
+// parent cancellation.
+func WhenDone(parent context.Context, done WhenDoneFunc) bool {
 	if parent.Done() == nil {
-		return ErrNeverCompletes
+		return false
 	}
+
+	// All contexts that complete (ctx.Done() != nil) used in cockroach should
+	// support direct cancellation detection, since they should be derived from
+	// one of the standard context.Context.
+	// But, be safe and loudly fail tests in case somebody introduces strange
+	// context implementation.
+	if buildutil.CrdbTestBuild && !CanDirectlyDetectCancellation(parent) {
+		log.Fatalf(parent, "expected context that supports direct cancellation detection, found %T", parent)
+	}
+
 	c := &whenDone{Context: parent, notify: func(err, cause error) { done(err) }}
 	context_propagateCancel(parent, c)
-	return nil
+	return true
+}
+
+// CanDirectlyDetectCancellation checks to make sure that the parent
+// context can be used to detect parent cancellation without the need
+// to spin up goroutine.
+// That would mean that the parent context is derived from
+// context.WithCancel or context.WithTimeout/Deadline.
+// Even if parent is not derived from one of the above contexts (i.e. it
+// is a custom implementation), WhenDone function can still be used; it just
+// means that there will be an additional goroutine spun up.  As such,
+// this function is meant to be used in test environment only.
+func CanDirectlyDetectCancellation(parent context.Context) bool {
+	// context.parentCancelCtx would have been preferred mechanism to check
+	// if the cancellation can be propagated; alas, this function returns
+	// an unexported *cancelCtx, which we do not have access to.
+	// So, instead try to do what that method essentially does by
+	// getting access to internal cancelCtxKey.
+	cancellable, ok := parent.Value(&context_cancelCtxKey).(context.Context)
+	return ok && cancellable.Done() == parent.Done()
 }
 
 type whenDone struct {
@@ -50,3 +83,6 @@ func (c *whenDone) cancelWithCause(removeFromParent bool, err, cause error) {
 		context_removeChild(c.Context, c)
 	}
 }
+
+//go:linkname context_cancelCtxKey context.cancelCtxKey
+var context_cancelCtxKey int

--- a/pkg/util/ctxutil/context_abi.go
+++ b/pkg/util/ctxutil/context_abi.go
@@ -18,13 +18,13 @@ import (
 )
 
 // WhenDoneCause is the same as WhenDone, but accepts WhenDoneCauseFunc as a callback.
-func WhenDoneCause(parent context.Context, done WhenDoneCauseFunc) error {
+func WhenDoneCause(parent context.Context, done WhenDoneCauseFunc) bool {
 	if parent.Done() == nil {
-		return ErrNeverCompletes
+		return false
 	}
 	c := &whenDone{Context: parent, notify: done}
 	context_propagateCancel(parent, c)
-	return nil
+	return true
 }
 
 // Gross hack to access internal context function.  Sometimes, go makes things

--- a/pkg/util/ctxutil/context_test.go
+++ b/pkg/util/ctxutil/context_test.go
@@ -21,11 +21,72 @@ import (
 func TestWhenDone(t *testing.T) {
 	parent, cancelParent := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	require.NoError(t, WhenDone(parent, func(err error) { close(done) }))
+
+	require.True(t, WhenDone(parent, func(err error) { close(done) }))
 	cancelParent()
 	select {
 	case <-done:
 	case <-time.After(30 * time.Second):
 		t.Fatal("timeout")
 	}
+}
+
+func TestCanPropagateCancellation(t *testing.T) {
+	t.Run("withCancel", func(t *testing.T) {
+		parent, cancelParent := context.WithCancel(context.Background())
+		defer cancelParent()
+		require.True(t, CanDirectlyDetectCancellation(parent))
+	})
+
+	t.Run("withCancelEmbed", func(t *testing.T) {
+		parent, cancelParent := context.WithCancel(context.Background())
+		defer cancelParent()
+		ctx := &myCtx{parent}
+		require.True(t, CanDirectlyDetectCancellation(ctx))
+	})
+
+	t.Run("nested", func(t *testing.T) {
+		parent, cancelParent := context.WithCancel(context.Background())
+		defer cancelParent()
+		timeoutCtx, cancelTimeout := context.WithTimeout(parent, time.Hour)
+		defer cancelTimeout()
+		ctx := &myCtx{timeoutCtx}
+		require.True(t, CanDirectlyDetectCancellation(ctx))
+	})
+
+	t.Run("nonCancellable", func(t *testing.T) {
+		require.False(t, CanDirectlyDetectCancellation(context.Background()))
+	})
+
+	t.Run("nonCancellableCustom", func(t *testing.T) {
+		require.False(t, CanDirectlyDetectCancellation(&noOpCtx{}))
+	})
+
+	t.Run("nonCancellableCustomEmbed", func(t *testing.T) {
+		require.False(t, CanDirectlyDetectCancellation(&myCtx{&noOpCtx{}}))
+	})
+}
+
+type myCtx struct {
+	context.Context
+}
+
+type noOpCtx struct{}
+
+var _ context.Context = (*noOpCtx)(nil)
+
+func (n *noOpCtx) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (n *noOpCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (n *noOpCtx) Err() error {
+	return nil
+}
+
+func (n *noOpCtx) Value(key any) any {
+	return nil
 }

--- a/pkg/util/tracing/grpcinterceptor/BUILD.bazel
+++ b/pkg/util/tracing/grpcinterceptor/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/tracing/grpcinterceptor",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/ctxutil",
         "//pkg/util/grpcutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/util/tracing/grpcinterceptor/grpc_interceptor.go
+++ b/pkg/util/tracing/grpcinterceptor/grpc_interceptor.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"sync/atomic"
 
+	"github.com/cockroachdb/cockroach/pkg/util/ctxutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -327,8 +328,6 @@ func StreamClientInterceptor(
 func newTracingClientStream(
 	ctx context.Context, cs grpc.ClientStream, desc *grpc.StreamDesc, clientSpan *tracing.Span,
 ) grpc.ClientStream {
-	finishChan := make(chan struct{})
-
 	isFinished := new(int32)
 	*isFinished = 0
 	finishFunc := func(err error) {
@@ -338,28 +337,28 @@ func newTracingClientStream(
 		if !atomic.CompareAndSwapInt32(isFinished, 0, 1) {
 			return
 		}
-		close(finishChan)
 		defer clientSpan.Finish()
 		if err != nil {
 			clientSpan.Recordf("error: %s", err)
 			setGRPCErrorTag(clientSpan, err)
 		}
 	}
-	go func() {
-		select {
-		case <-finishChan:
-			// The client span is being finished by another code path; hence, no
-			// action is necessary.
-		case <-ctx.Done():
-			// A streaming RPC can be finished by the caller cancelling the ctx. If
-			// the ctx is cancelled, the caller doesn't necessarily need to interact
-			// with the stream anymore (see [1]), so finishChan might never be
-			// signaled). Thus, we listen for ctx cancellation and finish the span.
-			//
-			// [1] https://pkg.go.dev/google.golang.org/grpc#ClientConn.NewStream
-			finishFunc(nil /* err */)
-		}
-	}()
+
+	// If the context is non-cancellable (ctx.Done() == nil), WhenDone returns
+	// false and never invokes the function. Even though it is strange to see
+	// non-cancellable context here, it's not exactly broken if we never invoke
+	// this function because of context cancellation.  The finishFunc
+	// can still be invoked directly.
+	_ = ctxutil.WhenDone(ctx, func(err error) {
+		// A streaming RPC can be finished by the caller cancelling the ctx. If
+		// the ctx is cancelled, the caller doesn't necessarily need to interact
+		// with the stream anymore (see [1]), so finishChan might never be
+		// signaled). Thus, we listen for ctx cancellation and finish the span.
+		//
+		// [1] https://pkg.go.dev/google.golang.org/grpc#ClientConn.NewStream
+		finishFunc(nil /* err */)
+	})
+
 	return &tracingClientStream{
 		ClientStream: cs,
 		desc:         desc,


### PR DESCRIPTION
Previous commit #76306 arranged for interceptors to run for all rpcs (local or otherwise).  In doing so, it added an additional go routine for each RPC whose purpose was to detect context completion, and to arrange for the cleanup function to run when that happened.

`ctxutil.WhenDone` (added by #103866/commits/dfe4ef82810aaf81ae21afecce83cbc1fb6783dd) allows for the same functionality without the additional goroutine cost.

Informs #107053

Release note: None