### PR TITLE
release-22.2: disable schema changer corpus test

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -34,6 +34,7 @@ func registerDeclSchemaChangeCompatMixedVersions(r registry.Registry) {
 			if c.Spec().Cloud != spec.GCE {
 				t.Skip("uses gs://cockroach-corpus; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
+			t.Skip("backwards compatibility testing can be disabled, now that 22.1 is out of support.")
 			runDeclSchemaChangeCompatMixedVersions(ctx, t, c, *t.BuildVersion())
 		},
 	})


### PR DESCRIPTION
The schema changer corpus tests were an automated way test on mixed version states from the previous releases branch. Now, that 21.2 is no longer supported this testing is no longer necessary, and the files for this test are no longer generated.

Fixes: #106482

Release justification: test only change
Release note: None