### PR TITLE
tracing/collector: fix a flake in recently added test

### DIFF
--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -270,9 +270,6 @@ func TestClusterInflightTraces(t *testing.T) {
 				for i, s := range tc.Servers {
 					tenant, db, err := s.StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{TenantName: "app"})
 					require.NoError(t, err)
-					defer func() {
-						require.NoError(t, db.Close())
-					}()
 					tenants[i] = tenant
 					dbs[i] = db
 				}


### PR DESCRIPTION
Not quite sure how it happened, but we just saw a test flake where we were trying to stop the shared process server before it was started. This error was exposed when closing the DB connection. This commit removes that closing altogether since it doesn't seem necessary.

Fixes: #106902.

Release note: None