### PR TITLE
streamingest: unskip TestTenantStreamingUnavailableStreamAddress

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -420,8 +420,11 @@ func requireReplicatedTime(targetTime hlc.Timestamp, progress *jobspb.Progress) 
 }
 
 func CreateScatteredTable(t *testing.T, c *TenantStreamingClusters, numNodes int) {
-	// Create a source table with multiple ranges spread across multiple nodes
-	numRanges := 10
+	// Create a source table with multiple ranges spread across multiple nodes. We
+	// need around 50 or more ranges because there are already over 50 system
+	// ranges, so if we write just a few ranges those might all be on a single
+	// server, which will cause the test to flake.
+	numRanges := 50
 	rowsPerRange := 20
 	c.SrcTenantSQL.Exec(t, "CREATE TABLE d.scattered (key INT PRIMARY KEY)")
 	c.SrcTenantSQL.Exec(t, "INSERT INTO d.scattered (key) SELECT * FROM generate_series(1, $1)",


### PR DESCRIPTION
Changing a few things to get this test to pass under stress:
- use 50 ranges instead of 10, because there are already 50-ish system ranges,
  so if we write only 10 more ranges those might not get distributed on all
  servers.
- avoid reading from the source cluster after stopping a node, it's flaky,
  see https://github.com/cockroachdb/cockroach/issues/107499 for more info.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/107023
Fixes: https://github.com/cockroachdb/cockroach/issues/106865

Release note: None