### PR TITLE
CODEOWNERS: remove noreview from pkg/internal/workloadreplay

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -477,7 +477,7 @@
 /pkg/internal/rsg/           @cockroachdb/sql-queries
 /pkg/internal/sqlsmith/      @cockroachdb/sql-queries
 /pkg/internal/team/          @cockroachdb/test-eng
-/pkg/internal/workloadreplay/          @cockroachdb/test-eng-noreview
+/pkg/internal/workloadreplay/          @cockroachdb/test-eng
 /pkg/jobs/                   @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
 /pkg/keys/                   @cockroachdb/kv-prs
 /pkg/keysbase/               @cockroachdb/kv-prs


### PR DESCRIPTION
Test engineering will review workloadreplay code base changes.

Epic: None
Release Note: None