### PR TITLE
kvserver: avoid running intensive decommission test under deadlock

### DIFF
--- a/pkg/kv/kvserver/client_decommission_test.go
+++ b/pkg/kv/kvserver/client_decommission_test.go
@@ -34,9 +34,10 @@ func TestDecommission(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Five nodes is too much to reliably run under testrace with our aggressive
-	// liveness timings.
-	skip.UnderRace(t, "#39807 and #37811")
+	// Five nodes is too much to reliably run under race/deadlock with our
+	// aggressive liveness timings.
+	skip.UnderRaceWithIssue(t, 39807, "#39807 and #37811")
+	skip.UnderDeadlockWithIssue(t, 39807, "#39807 and #37811")
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 5, base.TestClusterArgs{


### PR DESCRIPTION
The kvserver test `TestDecommission`, which runs a 5-node cluster and decommissions 4 of those 5 nodes, has trouble completing fast enough when under a race or deadlock configuration. While race configurations were already skipped, this modifies the test to be skipped under deadlock configurations as well.

Fixes: #106096

Release note: None