### PR TITLE
compose: start `docker-compose` with a non-empty `PATH`

### DIFF
--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -115,6 +115,7 @@ func TestComposeCompare(t *testing.T) {
 		fmt.Sprintf("COMPARE_DIR_PATH=%s", compareDir),
 		fmt.Sprintf("ARTIFACTS=%s", *flagArtifacts),
 		fmt.Sprintf("COCKROACH_DEV_LICENSE=%s", envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "")),
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -513,6 +513,7 @@ func TestLint(t *testing.T) {
 					":!util/log/test_log_scope.go",           // For TEST_UNDECLARED_OUTPUT_DIR, REMOTE_EXEC
 					":!testutils/datapathutils/data_path.go", // For TEST_UNDECLARED_OUTPUT_DIR, REMOTE_EXEC
 					":!testutils/backup.go",                  // For BACKUP_TESTING_BUCKET
+					":!compose/compose_test.go",              // For PATH.
 				},
 			},
 		} {


### PR DESCRIPTION
`docker-compose` invokes `docker`, but obviously this will fail if there is nothing in the `PATH`.

Epic: none
Release note: None