### PR TITLE
backupccl: teach online restore to target relevant key spans

### DIFF
--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -223,7 +223,7 @@ func makeSimpleImportSpans(
 								if cover[i].Span.Overlaps(sp) {
 									// If this is the last partition, we might have added it above.
 									if i == len(cover)-1 {
-										if last := len(cover[i].Files) - 1; last < 0 || cover[i].Files[last] != fileSpec {
+										if last := len(cover[i].Files) - 1; last < 0 || cover[i].Files[last].Path != fileSpec.Path {
 											cover[i].Files = append(cover[i].Files, fileSpec)
 											lastCovSpanSize += sz
 										}
@@ -472,9 +472,13 @@ func generateAndSendImportSpans(
 		}
 		for layer := range covFilesByLayer {
 			for _, f := range covFilesByLayer[layer] {
-				fileSpec := execinfrapb.RestoreFileSpec{Path: f.Path, Dir: backups[layer].Dir}
+				fileSpec := execinfrapb.RestoreFileSpec{
+					Path:                  f.Path,
+					Dir:                   backups[layer].Dir,
+					BackupFileEntrySpan:   f.Span,
+					BackupFileEntryCounts: f.EntryCounts}
 				if dir, ok := backupLocalityMap[layer][f.LocalityKV]; ok {
-					fileSpec = execinfrapb.RestoreFileSpec{Path: f.Path, Dir: dir}
+					fileSpec.Dir = dir
 				}
 				entry.Files = append(entry.Files, fileSpec)
 			}

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -292,6 +292,8 @@ message RestoreFileSpec {
   optional string path = 2 [(gogoproto.nullable) = false];
   reserved 3;
   reserved 4;
+  optional roachpb.Span backup_file_entry_span = 5 [(gogoproto.nullable) = false];
+  optional roachpb.RowCount backup_file_entry_counts = 6 [(gogoproto.nullable) = false];
 }
 
 message TableRekey {


### PR DESCRIPTION
This patch refactors the online restore prototype to call generateAndSendImportSpans() and ingest SSTs from the streamed restoreSpanEntries.  This change also adds the backup file entry span and data size to the RestoreFileSpec in order to plumb the required data for each AddRemoteSSTable request. Each AddRemoteSSTable call ingests a unique file with a non-overlapping keyspan relative to all other remotely ingested files. This calling convention helps pebble ingest these remote files into L6.

Epic: None

Release note: None