### PR TITLE
server,storage: breakdown byte counts in SpanStats by backing storage

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -936,7 +936,7 @@ func runDebugCompact(cmd *cobra.Command, args []string) error {
 	}
 
 	{
-		approxBytesBefore, err := db.ApproximateDiskBytes(roachpb.KeyMin, roachpb.KeyMax)
+		approxBytesBefore, _, _, err := db.ApproximateDiskBytes(roachpb.KeyMin, roachpb.KeyMax)
 		if err != nil {
 			return errors.Wrap(err, "while computing approximate size before compaction")
 		}
@@ -966,7 +966,7 @@ func runDebugCompact(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s\n", db.GetMetrics())
 
 	{
-		approxBytesAfter, err := db.ApproximateDiskBytes(roachpb.KeyMin, roachpb.KeyMax)
+		approxBytesAfter, _, _, err := db.ApproximateDiskBytes(roachpb.KeyMin, roachpb.KeyMax)
 		if err != nil {
 			return errors.Wrap(err, "while computing approximate size after compaction")
 		}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2336,7 +2336,8 @@ func (r *Replica) GetEngineCapacity() (roachpb.StoreCapacity, error) {
 // GetApproximateDiskBytes returns an approximate measure of bytes in the store
 // in the specified key range.
 func (r *Replica) GetApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
-	return r.store.TODOEngine().ApproximateDiskBytes(from, to)
+	bytes, _, _, err := r.store.TODOEngine().ApproximateDiskBytes(from, to)
+	return bytes, err
 }
 
 func init() {

--- a/pkg/roachpb/span_stats.go
+++ b/pkg/roachpb/span_stats.go
@@ -56,3 +56,10 @@ var RangeDescPageSize = settings.RegisterIntSetting(
 		return nil
 	},
 )
+
+func (m *SpanStats) Add(other *SpanStats) {
+	m.TotalStats.Add(other.TotalStats)
+	m.ApproximateDiskBytes += other.ApproximateDiskBytes
+	m.RemoteFileBytes += other.RemoteFileBytes
+	m.ExternalFileBytes += other.ExternalFileBytes
+}

--- a/pkg/roachpb/span_stats.proto
+++ b/pkg/roachpb/span_stats.proto
@@ -43,8 +43,21 @@ message SpanStats {
   // range end, will have a range_count value of 1.
   int32 range_count = 2;
 
-  // The explicit jsontag prevents 'omitempty` from being added by default.
+  // ApproximateDiskBytes is the approximate size "on-disk" in all files of the
+  // data in the span. NB; this *includes* files stored remotely, not just on
+  // _local_ disk; see the RemoteFileBytes field below.
+  // NB: The explicit jsontag prevents 'omitempty` from being added by default.
   uint64 approximate_disk_bytes = 3 [(gogoproto.jsontag) = "approximate_disk_bytes"];
+
+  // RemoteFileBytes is the subset of ApproximateDiskBytes which are stored in
+  // "remote" files (i.e. shared files and external files).
+  uint64 remote_file_bytes = 5;
+
+  // ExternalFileBytes is the subset of RemoteFileBytes that are in "external"
+  // files (not written/owned by this cluster, such as in restored backups).
+  uint64 external_file_bytes = 6;
+
+  // NEXT ID: 7.
 }
 
 message SpanStatsResponse {
@@ -53,4 +66,6 @@ message SpanStatsResponse {
   reserved 3;
 
   map<string, SpanStats> span_to_stats = 4;
+
+  // NEXT ID: 5.
 }

--- a/pkg/roachpb/span_stats.proto
+++ b/pkg/roachpb/span_stats.proto
@@ -48,9 +48,9 @@ message SpanStats {
 }
 
 message SpanStatsResponse {
-  cockroach.storage.enginepb.MVCCStats total_stats = 1 [(gogoproto.nullable) = false];
-  // See the range_count comment for the SpanStats proto.
-  int32 range_count = 2;
-  uint64 approximate_disk_bytes = 3;
+  reserved 1;
+  reserved 2;
+  reserved 3;
+
   map<string, SpanStats> span_to_stats = 4;
 }

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -85,8 +85,7 @@ func (s *systemStatusServer) spanStatsFanOut(
 			if !exists {
 				res.SpanToStats[spanStr] = spanStats
 			} else {
-				res.SpanToStats[spanStr].ApproximateDiskBytes += spanStats.ApproximateDiskBytes
-				res.SpanToStats[spanStr].TotalStats.Add(spanStats.TotalStats)
+				res.SpanToStats[spanStr].Add(spanStats)
 			}
 		}
 	}
@@ -218,11 +217,13 @@ func (s *systemStatusServer) statsForSpan(
 	}
 	// Finally, get the approximate disk bytes from each store.
 	err = s.stores.VisitStores(func(store *kvserver.Store) error {
-		approxDiskBytes, err := store.TODOEngine().ApproximateDiskBytes(rSpan.Key.AsRawKey(), rSpan.EndKey.AsRawKey())
+		approxDiskBytes, remoteBytes, externalBytes, err := store.TODOEngine().ApproximateDiskBytes(rSpan.Key.AsRawKey(), rSpan.EndKey.AsRawKey())
 		if err != nil {
 			return err
 		}
 		spanStats.ApproximateDiskBytes += approxDiskBytes
+		spanStats.RemoteFileBytes += remoteBytes
+		spanStats.ExternalFileBytes += externalBytes
 		return nil
 	})
 

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -988,8 +988,11 @@ type Engine interface {
 	// When called, it may choose to block if the engine determines that it is in
 	// or approaching a state where further ingestions may risk its health.
 	PreIngestDelay(ctx context.Context)
-	// ApproximateDiskBytes returns an approximation of the on-disk size for the given key span.
-	ApproximateDiskBytes(from, to roachpb.Key) (uint64, error)
+	// ApproximateDiskBytes returns an approximation of the on-disk size and file
+	// counts for the given key span, along with how many of those bytes are on
+	// remote, as well as specifically external remote, storage.
+	ApproximateDiskBytes(from, to roachpb.Key) (total, remote, external uint64, _ error)
+
 	// CompactRange ensures that the specified range of key value pairs is
 	// optimized for space efficiency.
 	CompactRange(start, end roachpb.Key) error

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2040,14 +2040,16 @@ func (p *Pebble) GetTableMetrics(start, end roachpb.Key) ([]enginepb.SSTableMetr
 }
 
 // ApproximateDiskBytes implements the Engine interface.
-func (p *Pebble) ApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
+func (p *Pebble) ApproximateDiskBytes(
+	from, to roachpb.Key,
+) (bytes, remoteBytes, externalBytes uint64, _ error) {
 	fromEncoded := EngineKey{Key: from}.Encode()
 	toEncoded := EngineKey{Key: to}.Encode()
-	count, err := p.db.EstimateDiskUsage(fromEncoded, toEncoded)
+	bytes, remoteBytes, externalBytes, err := p.db.EstimateDiskUsageByBackingType(fromEncoded, toEncoded)
 	if err != nil {
-		return 0, err
+		return 0, 0, 0, err
 	}
-	return count, nil
+	return bytes, remoteBytes, externalBytes, nil
 }
 
 // Compact implements the Engine interface.

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1374,7 +1374,7 @@ func TestApproximateDiskBytes(t *testing.T) {
 	require.NoError(t, p.Flush())
 
 	approxBytes := func(span roachpb.Span) uint64 {
-		v, err := p.ApproximateDiskBytes(span.Key, span.EndKey)
+		v, _, _, err := p.ApproximateDiskBytes(span.Key, span.EndKey)
 		require.NoError(t, err)
 		t.Logf("%s (%x-%x): %d bytes", span, span.Key, span.EndKey, v)
 		return v


### PR DESCRIPTION
Release note: none.
Epic: none.