### PR TITLE
server: avoid deadlock when initing additional stores

### DIFF
--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/storage",
+        "//pkg/util/buildutil",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1910,13 +1910,17 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// initialized.
 	s.grpc.setMode(modeOperational)
 
+	s.nodeLiveness.Start(workersCtx)
+
 	// We'll block here until all stores are fully initialized. We do this here
-	// for two reasons:
+	// for several reasons:
 	// - some of the components below depend on all stores being fully
 	//   initialized (like the debug server registration for e.g.)
 	// - we'll need to do it after having opened up the RPC floodgates (due to
 	//   the hazard described in Node.start, around initializing additional
 	//   stores)
+	// - we'll need to do it after starting node liveness, see:
+	//   https://github.com/cockroachdb/cockroach/issues/106706#issuecomment-1640254715
 	s.node.waitForAdditionalStoreInit()
 
 	additionalStoreIDs, err := state.additionalStoreIDs()
@@ -1963,11 +1967,6 @@ func (s *Server) PreStart(ctx context.Context) error {
 	log.Ops.Infof(ctx, "advertising CockroachDB node at %s", log.SafeManaged(s.cfg.AdvertiseAddr))
 
 	log.Event(ctx, "accepting connections")
-
-	// Begin the node liveness heartbeat. Add a callback which records the local
-	// store "last up" timestamp for every store whenever the liveness record is
-	// updated.
-	s.nodeLiveness.Start(workersCtx)
 
 	// Begin recording status summaries.
 	if err := s.node.startWriteNodeStatus(base.DefaultMetricsSampleInterval); err != nil {


### PR DESCRIPTION
We need to start node liveness before waiting for additional store init.

Otherwise, we can end up in a situation where each node is sitting on the
channel and nobody has started their liveness yet. The sender to the channel
will first have to get an Increment through KV, but if nobody acquires the
lease (since nobody's heartbeat loop is running), this will never happen.

In practice, *most of the time*, there is no deadlock because the lease
acquisition path performs a synchronous heartbeat to the own entry in most
cases (ignoring the fact that liveness hasn't been started yet). But there is
also another path where someone else's epoch needs to be incremented, and this
path also checks if the node itself is live - which it won't necessarily be
(liveness loop is not running yet).

Fixes #106706

Epic: None
Release note (bug fix): a rare (!) situation in which nodes would get stuck
during start-up was addressed. This is unlikely to have been encountered by
production users This is unlikely to have been encountered by users. If so, it
would manifest itself through a stack frame sitting on a select in
`waitForAdditionalStoreInit` for extended periods of time (i.e. minutes).
