### PR TITLE
kvserver: make lease preference enforcement more responsive

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -84,6 +84,7 @@ go_library(
         "kv.go",
         "kvbench.go",
         "latency_verifier.go",
+        "lease_preferences.go",
         "ledger.go",
         "libpq.go",
         "libpq_blocklist.go",

--- a/pkg/cmd/roachtest/tests/lease_preferences.go
+++ b/pkg/cmd/roachtest/tests/lease_preferences.go
@@ -1,0 +1,229 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+// ideas for faster lease preference enforcement
+// - add a chained action for maybe shedding the lease
+// - try to shed the lease directly upon acquisition
+// - increase the priority of lease preference satisfaction
+//   - for enqueue only
+//   - with an action
+//
+// scenarios
+// - universal
+//   - 3 racks rack=0..2
+//   - N nodes
+//   - R ranges
+//
+// - outages
+//   - 1 node in rack=0
+//   - rack=0
+//
+// - preferences
+//   - [[+rack=0]]
+//   - [[+rack=0],[+rack=1]]
+//   - [[+rack=0]] -> [[+rack=1]]
+//   - [[-rack=2]]
+//
+// - other activity
+//   - zone config change (upreplication/downreplication)
+//   - load
+//
+// assume starting with lease_preferences: [[+dc=1],[+dc=2]] num_replicas=5
+//
+// 1. stopping rand node in dc=1 causes all leases to move to other nodes in dc=1
+// 2. stopping all nodes in dc=1 causes all leases to move to dc=2
+// 3. changing lease preference from [[dc=1],[dc=2]] -> [[dc=2],[dc=1]] causes
+//
+// events
+// - kv workload
+// - num_replicas++
+
+// 1=n1,n2
+// 2=n3,n4
+// 3=n5
+var localityMap = map[int]string{
+	1: "1",
+	2: "1",
+	3: "2",
+	4: "2",
+	5: "3",
+	6: "3",
+}
+
+type leasePreferencesSpec struct {
+	nodeLocalities map[int]string
+	preferences    string
+	ranges         int
+}
+
+func registerLeasePreferences(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:    "lease-preferences/partial-first-preference-down",
+		Owner:   registry.OwnerKV,
+		Timeout: 30 * time.Minute,
+		Cluster: r.MakeClusterSpec(7, spec.CPU(4)),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runLeasePreferences(ctx, t, c, leasePreferencesSpec{
+				nodeLocalities: localityMap,
+				preferences:    `[+dc=0], [+dc=1]`,
+				ranges:         1000,
+			})
+		},
+	})
+}
+
+func runLeasePreferences(
+	ctx context.Context, t test.Test, c cluster.Cluster, spec leasePreferencesSpec,
+) {
+	// Setup Cluster
+	//
+	// Every node's locality should be specified. The last node is not part of
+	// the cockroach cluster but can be used for the workload.
+	require.Equal(t, len(spec.nodeLocalities), c.Spec().NodeCount-1)
+	c.Put(ctx, t.Cockroach(), "./cockroach")
+	t.Status("starting cluster")
+	for i := 1; i <= len(localityMap); i++ {
+		// Don't start a backup schedule because....
+		opts := option.DefaultStartOpts()
+		opts.RoachprodOpts.ScheduleBackups = false
+		opts.RoachprodOpts.ExtraArgs = append(opts.RoachprodOpts.ExtraArgs,
+			fmt.Sprintf("locality=dc=%s", localityMap[i]))
+		c.Start(ctx, t.L(), opts, install.MakeClusterSettings(), c.Node(i))
+	}
+
+	workloadNode := c.Spec().NodeCount
+	numNodes := c.Spec().NodeCount - 1
+
+	conn := c.Conn(ctx, t.L(), numNodes)
+
+	// Setup DB
+	t.L().Printf("creating workload database")
+	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
+	require.NoError(t, err)
+
+	// Setup Zone Configs
+	t.L().Printf("setting zone configs")
+	// Every node will have a replica for every range. Set the lease preference
+	// to be on the last node, which won't be stopped/decommissioned etc.
+	configureAllZones(t, ctx, conn, zoneConfig{
+		replicas:  numNodes,
+		leaseNode: numNodes,
+	})
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		`ALTER kv CONFIGURE ZONE USING num_replicas = %d, lease_preferences = '[%s]'`,
+		numNodes, spec.preferences,
+	))
+	require.NoError(t, err)
+	require.NoError(t, WaitForReplication(ctx, t, conn, numNodes))
+
+	// Setup ranges/replicas
+	c.Run(ctx, c.Node(workloadNode), fmt.Sprintf(
+		`./cockroach workload init kv --splits %d {pgurl:%d}`, spec.ranges, numNodes))
+	require.NoError(t, WaitForReplication(ctx, t, conn, numNodes))
+
+	stopOpts := option.DefaultStopOpts()
+	stopOpts.RoachprodOpts.Sig = 9
+	c.Stop(ctx, t.L(), stopOpts, c.Node(1))
+
+	sleepFor(ctx, t, 5*time.Second)
+	start := timeutil.Now()
+	defer t.L().Printf("lease preference satisfaction took %v", timeutil.Now().Sub(start))
+
+	if err := waitForExpectedLeaseCounts(ctx, t, conn, map[string]int{
+		"1": 0,
+		"2": 1000,
+		"3": 0,
+	}); err != nil {
+		t.L().Printf("err=%v", err)
+	}
+}
+
+func waitForExpectedLeaseCounts(
+	ctx context.Context, t test.Test, conn *gosql.DB, expectedLeaseCounts map[string]int,
+) error {
+	const checkInterval = 5 * time.Second
+
+	var checkTimer timeutil.Timer
+	defer checkTimer.Stop()
+	checkTimer.Reset(checkInterval)
+
+	t.L().Printf(
+		"checking for locality lease counts match %+v",
+		expectedLeaseCounts)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-checkTimer.C:
+			checkTimer.Read = true
+			leaseCounts, err := dcLeaseCounts(ctx, t, conn)
+			if err != nil {
+				return err
+			}
+			t.L().Printf("locality lease counts %+v", leaseCounts)
+			matches := true
+			for dc := range expectedLeaseCounts {
+				if count, ok := leaseCounts[dc]; expectedLeaseCounts[dc] == 0 && (!ok || count == 0) {
+					continue
+				}
+				if expectedLeaseCounts[dc] != leaseCounts[dc] {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				return nil
+			}
+			checkTimer.Reset(checkInterval)
+		}
+	}
+}
+
+func dcLeaseCounts(ctx context.Context, t test.Test, conn *gosql.DB) (map[string]int, error) {
+	rows, err := conn.QueryContext(ctx, `
+    SELECT 
+      SPLIT_PART(lease_holder_locality, 'dc=', 2) AS locality_value,
+      COUNT(*)
+    FROM
+      (SELECT lease_holder_locality FROM [SHOW RANGES FROM DATABASE kv WITH DETAILS])
+    GROUP BY
+     locality_value;
+  `)
+	if err != nil {
+		return nil, err
+	}
+	dcLeaseCounts := map[string]int{}
+	var dc string
+	var leaseCount int
+	for rows.Next() {
+		require.NoError(t, rows.Scan(&dc, &leaseCount))
+		dcLeaseCounts[dc] = leaseCount
+	}
+	return dcLeaseCounts, nil
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -83,6 +83,7 @@ func RegisterTests(r registry.Registry) {
 	registerKnex(r)
 	registerLOQRecovery(r)
 	registerLargeRange(r)
+  registerLeasePreferences(r)
 	registerLedger(r)
 	registerLibPQ(r)
 	registerLiquibase(r)

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2827,7 +2827,7 @@ func (a Allocator) PreferredLeaseholders(
 			if !ok {
 				continue
 			}
-			if constraint.ConjunctionsCheck(storeDesc, preference.Constraints) {
+			if constraint.CheckStoreConjunction(storeDesc, preference.Constraints) {
 				preferred = append(preferred, repl)
 			}
 		}

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2635,7 +2635,7 @@ func (a Allocator) shouldTransferLeaseForAccessLocality(
 		}
 	}
 
-	log.KvDistribution.VEventf(ctx, 1,
+	log.KvDistribution.VEventf(ctx, 5,
 		"shouldTransferLease qpsStats: %+v, replicaLocalities: %+v, replicaWeights: %+v",
 		qpsStats, replicaLocalities, replicaWeights)
 	sourceWeight := math.Max(minReplicaWeight, replicaWeights[source.Node.NodeID])
@@ -2752,7 +2752,7 @@ func loadBasedLeaseRebalanceScore(
 
 	log.KvDistribution.VEventf(
 		ctx,
-		2,
+		5,
 		"node: %d, sourceWeight: %.2f, remoteWeight: %.2f, remoteLatency: %v, "+
 			"rebalanceThreshold: %.2f, meanLeases: %.2f, sourceLeaseCount: %d, overfullThreshold: %d, "+
 			"remoteLeaseCount: %d, underfullThreshold: %d, totalScore: %d",

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -2010,7 +2010,7 @@ func allocateConstraintsCheck(
 	}
 
 	for i, constraints := range analyzed.Constraints {
-		if constraintsOK := constraint.ConjunctionsCheck(
+		if constraintsOK := constraint.CheckStoreConjunction(
 			store, constraints.Constraints,
 		); constraintsOK {
 			valid = true
@@ -2050,9 +2050,7 @@ func replaceConstraintsCheck(
 	for i, constraints := range analyzed.Constraints {
 		matchingStores := analyzed.SatisfiedBy[i]
 		satisfiedByExistingStore := containsStore(matchingStores, existingStore.StoreID)
-		satisfiedByCandidateStore := constraint.ConjunctionsCheck(
-			store, constraints.Constraints,
-		)
+		satisfiedByCandidateStore := constraint.CheckStoreConjunction(store, constraints.Constraints)
 		if satisfiedByCandidateStore {
 			valid = true
 		}
@@ -2147,7 +2145,7 @@ func rebalanceFromConstraintsCheck(
 	// satisfied by existing replicas or that is only fully satisfied because of
 	// fromStoreID, then it's necessary.
 	for i, constraints := range analyzed.Constraints {
-		if constraintsOK := constraint.ConjunctionsCheck(
+		if constraintsOK := constraint.CheckStoreConjunction(
 			store, constraints.Constraints,
 		); constraintsOK {
 			valid = true

--- a/pkg/kv/kvserver/allocator/base.go
+++ b/pkg/kv/kvserver/allocator/base.go
@@ -76,7 +76,7 @@ func IsStoreValid(
 		return true
 	}
 	for _, subConstraints := range constraints {
-		if constraintsOK := constraint.ConjunctionsCheck(
+		if constraintsOK := constraint.CheckStoreConjunction(
 			store, subConstraints.Constraints,
 		); constraintsOK {
 			return true

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -868,7 +868,8 @@ func (rp ReplicaPlanner) considerRebalance(
 		if !canTransferLeaseFrom(ctx, repl) {
 			return nil, stats, nil
 		}
-		return rp.shedLeaseTarget(
+		var err error
+		op, err = rp.shedLeaseTarget(
 			ctx,
 			repl,
 			desc,
@@ -878,8 +879,11 @@ func (rp ReplicaPlanner) considerRebalance(
 				ExcludeLeaseRepl:       false,
 				CheckCandidateFullness: true,
 			},
-		), stats, nil
-
+		)
+		if err != nil {
+			return nil, stats, err
+		}
+		return op, stats, nil
 	}
 
 	// If we have a valid rebalance action (ok == true) and we haven't
@@ -925,22 +929,35 @@ func (rp ReplicaPlanner) shedLeaseTarget(
 	desc *roachpb.RangeDescriptor,
 	conf roachpb.SpanConfig,
 	opts allocator.TransferLeaseOptions,
-) (op AllocationOp) {
+) (op AllocationOp, _ error) {
 	usage := repl.RangeUsageInfo()
+	existingVoters := desc.Replicas().VoterDescriptors()
 	// Learner replicas aren't allowed to become the leaseholder or raft leader,
 	// so only consider the `VoterDescriptors` replicas.
 	target := rp.allocator.TransferLeaseTarget(
 		ctx,
 		rp.storePool,
 		conf,
-		desc.Replicas().VoterDescriptors(),
+		existingVoters,
 		repl,
 		usage,
 		false, /* forceDecisionWithoutStats */
 		opts,
 	)
 	if target == (roachpb.ReplicaDescriptor{}) {
-		return nil
+		// If we don't find a suitable target, but we own a lease violating the
+		// lease preferences, return an error to place the replica in purgatory and
+		// retry sooner. This typically happens when we've just acquired a
+		// violating lease and we eagerly enqueue the replica before we've received
+		// Raft leadership, which prevents us from finding appropriate lease
+		// targets since we can't determine if any are behind. We disable the
+		// snapshot check when checking the whether the existing voters are able to
+		// take the lease, because we assume any voter failing the snapshot check
+		// will only fail it for a short time.
+		if repl.LeaseViolatesPreferences(ctx) {
+			return nil, CantTransferLeaseViolatingPreferencesError{RangeID: desc.RangeID}
+		}
+		return nil, nil
 	}
 
 	op = AllocationTransferLeaseOp{
@@ -949,7 +966,7 @@ func (rp ReplicaPlanner) shedLeaseTarget(
 		Usage:              usage,
 		bypassSafetyChecks: false,
 	}
-	return op
+	return op, nil
 }
 
 // maybeTransferLeaseAwayTarget is called whenever a replica on a given store
@@ -1015,3 +1032,26 @@ func (rp ReplicaPlanner) maybeTransferLeaseAwayTarget(
 
 	return op, nil
 }
+
+// CantTransferLeaseViolatingPreferencesError is an error returned when a lease
+// violates the lease preferences, but we couldn't find a valid target to
+// transfer the lease to. It indicates that the replica should be sent to
+// purgatory, to retry the transfer faster.
+type CantTransferLeaseViolatingPreferencesError struct {
+	RangeID roachpb.RangeID
+}
+
+var _ errors.SafeFormatter = CantTransferLeaseViolatingPreferencesError{}
+
+func (e CantTransferLeaseViolatingPreferencesError) Error() string { return fmt.Sprint(e) }
+
+func (e CantTransferLeaseViolatingPreferencesError) Format(s fmt.State, verb rune) {
+	errors.FormatError(e, s, verb)
+}
+
+func (e CantTransferLeaseViolatingPreferencesError) SafeFormatError(p errors.Printer) (next error) {
+	p.Printf("can't transfer r%d lease violating preferences, no suitable target", e.RangeID)
+	return nil
+}
+
+func (CantTransferLeaseViolatingPreferencesError) PurgatoryErrorMarker() {}

--- a/pkg/kv/kvserver/asim/queue/allocator_replica.go
+++ b/pkg/kv/kvserver/asim/queue/allocator_replica.go
@@ -96,7 +96,7 @@ func (sr *SimulatorReplica) LeaseViolatesPreferences(context.Context) bool {
 		return false
 	}
 	for _, preference := range conf.LeasePreferences {
-		if constraint.ConjunctionsCheck(storeDesc, preference.Constraints) {
+		if constraint.CheckStoreConjunction(storeDesc, preference.Constraints) {
 			return false
 		}
 	}

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -170,6 +170,19 @@ var (
 		Measurement: "Replicas",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaLeaseViolatingPreferencesCount = metric.Metadata{
+		Name:        "leases.preferences.violating",
+		Help:        "Number of replica leaseholders which violate lease preferences",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLeaseLessPreferredCount = metric.Metadata{
+		Name: "leases.preferences.less-preferred",
+		Help: "Number of replica leaseholders which satisfy a lease " +
+			"preference which is not the most preferred",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// Storage metrics.
 	metaLiveBytes = metric.Metadata{
@@ -2174,14 +2187,16 @@ type StoreMetrics struct {
 	// Lease request metrics for successful and failed lease requests. These
 	// count proposals (i.e. it does not matter how many replicas apply the
 	// lease).
-	LeaseRequestSuccessCount  *metric.Counter
-	LeaseRequestErrorCount    *metric.Counter
-	LeaseRequestLatency       metric.IHistogram
-	LeaseTransferSuccessCount *metric.Counter
-	LeaseTransferErrorCount   *metric.Counter
-	LeaseExpirationCount      *metric.Gauge
-	LeaseEpochCount           *metric.Gauge
-	LeaseLivenessCount        *metric.Gauge
+	LeaseRequestSuccessCount       *metric.Counter
+	LeaseRequestErrorCount         *metric.Counter
+	LeaseRequestLatency            metric.IHistogram
+	LeaseTransferSuccessCount      *metric.Counter
+	LeaseTransferErrorCount        *metric.Counter
+	LeaseExpirationCount           *metric.Gauge
+	LeaseEpochCount                *metric.Gauge
+	LeaseLivenessCount             *metric.Gauge
+	LeaseViolatingPreferencesCount *metric.Gauge
+	LeaseLessPreferredCount        *metric.Gauge
 
 	// Storage metrics.
 	ResolveCommitCount *metric.Counter
@@ -2828,11 +2843,13 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 			Duration: histogramWindow,
 			Buckets:  metric.IOLatencyBuckets,
 		}),
-		LeaseTransferSuccessCount: metric.NewCounter(metaLeaseTransferSuccessCount),
-		LeaseTransferErrorCount:   metric.NewCounter(metaLeaseTransferErrorCount),
-		LeaseExpirationCount:      metric.NewGauge(metaLeaseExpirationCount),
-		LeaseEpochCount:           metric.NewGauge(metaLeaseEpochCount),
-		LeaseLivenessCount:        metric.NewGauge(metaLeaseLivenessCount),
+		LeaseTransferSuccessCount:      metric.NewCounter(metaLeaseTransferSuccessCount),
+		LeaseTransferErrorCount:        metric.NewCounter(metaLeaseTransferErrorCount),
+		LeaseExpirationCount:           metric.NewGauge(metaLeaseExpirationCount),
+		LeaseEpochCount:                metric.NewGauge(metaLeaseEpochCount),
+		LeaseLivenessCount:             metric.NewGauge(metaLeaseLivenessCount),
+		LeaseViolatingPreferencesCount: metric.NewGauge(metaLeaseViolatingPreferencesCount),
+		LeaseLessPreferredCount:        metric.NewGauge(metaLeaseLessPreferredCount),
 
 		// Intent resolution metrics.
 		ResolveCommitCount: metric.NewCounter(metaResolveCommit),

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -523,9 +523,14 @@ func (r *Replica) leasePostApplyLocked(
 	// If we acquired a new lease, and it violates the lease preferences, enqueue
 	// it in the replicate queue.
 	if leaseChangingHands && iAmTheLeaseHolder {
-		violatesPreferences := leaseViolatesPreferences(st, r.store.StoreID(), r.store.Attrs(),
+		preferenceStatus := makeLeasePreferenceStatus(st, r.store.StoreID(), r.store.Attrs(),
 			r.store.nodeDesc.Attrs, r.store.nodeDesc.Locality, r.mu.conf.LeasePreferences)
-		if violatesPreferences {
+		switch preferenceStatus {
+		case leasePreferencesOK, leasePreferencesLessPreferred:
+			// We could also enqueue the lease when we are a less preferred
+			// leaseholder, however the replicate queue will eventually get to it and
+			// we already satisfy _some_ preference.
+		case leasePreferencesViolating:
 			log.VEventf(ctx, 2,
 				"acquired lease violates lease preferences, enqueueing for transfer [lease=%v preferences=%v]",
 				newLease, r.mu.conf.LeasePreferences)

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1551,7 +1551,7 @@ func (r *Replica) LeaseViolatesPreferences(ctx context.Context) bool {
 		return false
 	}
 	for _, preference := range conf.LeasePreferences {
-		if constraint.ConjunctionsCheck(*storeDesc, preference.Constraints) {
+		if constraint.CheckStoreConjunction(*storeDesc, preference.Constraints) {
 			return false
 		}
 	}

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1536,25 +1536,42 @@ func (r *Replica) hasCorrectLeaseTypeRLocked(lease roachpb.Lease) bool {
 	return hasExpirationLease == r.shouldUseExpirationLeaseRLocked()
 }
 
-// LeaseViolatesPreferences checks if current replica owns the lease and if it
-// violates the lease preferences defined in the span config. If there is an
-// error or no preferences defined then it will return false and consider that
-// to be in-conformance.
+// LeaseViolatesPreferences checks if this replica owns the lease and if it
+// violates the lease preferences defined in the span config. If no preferences
+// are defined then it will return false and consider it to be in conformance.
 func (r *Replica) LeaseViolatesPreferences(ctx context.Context) bool {
-	storeDesc, err := r.store.Descriptor(ctx, true /* useCached */)
-	if err != nil {
-		log.Infof(ctx, "Unable to load the descriptor %v: cannot check if lease violates preference", err)
+	storeID := r.store.StoreID()
+	storeAttrs := r.store.Attrs()
+	nodeAttrs := r.store.nodeDesc.Attrs
+	nodeLocality := r.store.nodeDesc.Locality
+	now := r.Clock().NowAsClockTimestamp()
+	r.mu.RLock()
+	leaseStatus := r.leaseStatusAtRLocked(ctx, now)
+	preferences := r.mu.conf.LeasePreferences
+	r.mu.RUnlock()
+	return leaseViolatesPreferences(
+		leaseStatus, storeID, storeAttrs, nodeAttrs, nodeLocality, preferences)
+}
+
+// leaseViolatesPreferences returns true if the given lease is valid, owned by
+// the given store, and does not satisfy the lease preferences.
+func leaseViolatesPreferences(
+	leaseStatus kvserverpb.LeaseStatus,
+	storeID roachpb.StoreID,
+	storeAttrs, nodeAttrs roachpb.Attributes,
+	nodeLocality roachpb.Locality,
+	preferences []roachpb.LeasePreference,
+) bool {
+	if !leaseStatus.IsValid() || !leaseStatus.Lease.OwnedBy(storeID) {
 		return false
 	}
-	conf := r.SpanConfig()
-	if len(conf.LeasePreferences) == 0 {
+	if len(preferences) == 0 {
 		return false
 	}
-	for _, preference := range conf.LeasePreferences {
-		if constraint.CheckStoreConjunction(*storeDesc, preference.Constraints) {
+	for _, preference := range preferences {
+		if constraint.CheckConjunction(storeAttrs, nodeAttrs, nodeLocality, preference.Constraints) {
 			return false
 		}
 	}
-	// We have at lease one preference set up, but we don't satisfy any.
 	return true
 }

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1536,42 +1536,65 @@ func (r *Replica) hasCorrectLeaseTypeRLocked(lease roachpb.Lease) bool {
 	return hasExpirationLease == r.shouldUseExpirationLeaseRLocked()
 }
 
+// leasePreferencesStatus represents the state of satisfying lease preferences.
+type leasePreferencesStatus int
+
+const (
+	// leasePreferencesViolating indicates the leaseholder does not
+	// satisfy any lease preference applied.
+	leasePreferencesViolating leasePreferencesStatus = iota
+	// leasePreferencesLessPreferred indicates the leaseholder satisfies _some_
+	// preference, however not the most preferred.
+	leasePreferencesLessPreferred
+	// leasePreferencesOK indicates the lease satisfies the first
+	// preference, or no lease preferences are applied.
+	leasePreferencesOK
+)
+
 // LeaseViolatesPreferences checks if this replica owns the lease and if it
 // violates the lease preferences defined in the span config. If no preferences
 // are defined then it will return false and consider it to be in conformance.
 func (r *Replica) LeaseViolatesPreferences(ctx context.Context) bool {
 	storeID := r.store.StoreID()
-	storeAttrs := r.store.Attrs()
-	nodeAttrs := r.store.nodeDesc.Attrs
-	nodeLocality := r.store.nodeDesc.Locality
 	now := r.Clock().NowAsClockTimestamp()
 	r.mu.RLock()
 	leaseStatus := r.leaseStatusAtRLocked(ctx, now)
 	preferences := r.mu.conf.LeasePreferences
 	r.mu.RUnlock()
-	return leaseViolatesPreferences(
+
+	if !leaseStatus.IsValid() || !leaseStatus.Lease.OwnedBy(storeID) {
+		return false
+	}
+
+	storeAttrs := r.store.Attrs()
+	nodeAttrs := r.store.nodeDesc.Attrs
+	nodeLocality := r.store.nodeDesc.Locality
+	preferenceStatus := makeLeasePreferenceStatus(
 		leaseStatus, storeID, storeAttrs, nodeAttrs, nodeLocality, preferences)
+
+	return preferenceStatus == leasePreferencesViolating
 }
 
-// leaseViolatesPreferences returns true if the given lease is valid, owned by
-// the given store, and does not satisfy the lease preferences.
-func leaseViolatesPreferences(
+func makeLeasePreferenceStatus(
 	leaseStatus kvserverpb.LeaseStatus,
 	storeID roachpb.StoreID,
 	storeAttrs, nodeAttrs roachpb.Attributes,
 	nodeLocality roachpb.Locality,
 	preferences []roachpb.LeasePreference,
-) bool {
+) leasePreferencesStatus {
 	if !leaseStatus.IsValid() || !leaseStatus.Lease.OwnedBy(storeID) {
-		return false
+		return leasePreferencesOK
 	}
 	if len(preferences) == 0 {
-		return false
+		return leasePreferencesOK
 	}
-	for _, preference := range preferences {
+	for i, preference := range preferences {
 		if constraint.CheckConjunction(storeAttrs, nodeAttrs, nodeLocality, preference.Constraints) {
-			return false
+			if i > 0 {
+				return leasePreferencesLessPreferred
+			}
+			return leasePreferencesOK
 		}
 	}
-	return true
+	return leasePreferencesViolating
 }

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -662,7 +662,7 @@ func (rq *replicateQueue) process(
 		}
 
 		if requeue {
-			log.KvDistribution.VEventf(ctx, 1, "re-processing")
+			log.KvDistribution.VEventf(ctx, 1, "re-queuing")
 			rq.maybeAdd(ctx, repl, rq.store.Clock().NowAsClockTimestamp())
 		}
 		return true, nil

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -80,6 +80,13 @@ const (
 	// replicateQueueTimerDuration is the duration between replication of queued
 	// replicas.
 	replicateQueueTimerDuration = 0 // zero duration to process replication greedily
+
+	// replicateQueueLeasePreferencePriority is the priority replicas are
+	// enqueued into the replicate queue with when violating lease preferences.
+	// This priority is lower than any voter up-replication, yet higher than
+	// removal, non-voter addition and rebalancing.
+	// See allocatorimpl.AllocatorAction.Priority.
+	replicateQueueLeasePreferencePriority = 1001
 )
 
 // MinLeaseTransferInterval controls how frequently leases can be transferred

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2926,22 +2926,24 @@ func (s *Store) RangeFeed(
 // whenever availability changes.
 func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	var (
-		raftLeaderCount               int64
-		leaseHolderCount              int64
-		leaseExpirationCount          int64
-		leaseEpochCount               int64
-		leaseLivenessCount            int64
-		raftLeaderNotLeaseHolderCount int64
-		raftLeaderInvalidLeaseCount   int64
-		quiescentCount                int64
-		uninitializedCount            int64
-		averageQueriesPerSecond       float64
-		averageRequestsPerSecond      float64
-		averageReadsPerSecond         float64
-		averageWritesPerSecond        float64
-		averageReadBytesPerSecond     float64
-		averageWriteBytesPerSecond    float64
-		averageCPUNanosPerSecond      float64
+		raftLeaderCount                int64
+		leaseHolderCount               int64
+		leaseExpirationCount           int64
+		leaseEpochCount                int64
+		leaseLivenessCount             int64
+		leaseViolatingPreferencesCount int64
+		leaseLessPreferredCount        int64
+		raftLeaderNotLeaseHolderCount  int64
+		raftLeaderInvalidLeaseCount    int64
+		quiescentCount                 int64
+		uninitializedCount             int64
+		averageQueriesPerSecond        float64
+		averageRequestsPerSecond       float64
+		averageReadsPerSecond          float64
+		averageWritesPerSecond         float64
+		averageReadBytesPerSecond      float64
+		averageWriteBytesPerSecond     float64
+		averageCPUNanosPerSecond       float64
 
 		rangeCount                int64
 		unavailableRangeCount     int64
@@ -3004,6 +3006,13 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			if metrics.LivenessLease {
 				leaseLivenessCount++
 			}
+			// NB: Can't be satisfying a less preferred preference, and also
+			// satisfying no preferences.
+			if metrics.ViolatingLeasePreferences {
+				leaseViolatingPreferencesCount++
+			} else if metrics.LessPreferredLease {
+				leaseLessPreferredCount++
+			}
 		}
 		if metrics.Quiescent {
 			quiescentCount++
@@ -3062,6 +3071,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.LeaseHolderCount.Update(leaseHolderCount)
 	s.metrics.LeaseExpirationCount.Update(leaseExpirationCount)
 	s.metrics.LeaseEpochCount.Update(leaseEpochCount)
+	s.metrics.LeaseViolatingPreferencesCount.Update(leaseViolatingPreferencesCount)
+	s.metrics.LeaseLessPreferredCount.Update(leaseLessPreferredCount)
 	s.metrics.LeaseLivenessCount.Update(leaseLivenessCount)
 	s.metrics.QuiescentCount.Update(quiescentCount)
 	s.metrics.UninitializedCount.Update(uninitializedCount)

--- a/pkg/roachpb/span_config.go
+++ b/pkg/roachpb/span_config.go
@@ -18,12 +18,12 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// StoreMatchesConstraint returns whether a store's attributes or node's
-// locality match the constraint's spec. It notably ignores whether the
-// constraint is required, prohibited, positive, or otherwise.
-func StoreMatchesConstraint(store StoreDescriptor, c Constraint) bool {
+// MatchesConstraint return whether the given attributes and locality tags match
+// the constraint's spec. It ignores whether the constraint is required,
+// prohibited, positive, or otherwise.
+func MatchesConstraint(storeAttrs, nodeAttrs Attributes, nodeLocality Locality, c Constraint) bool {
 	if c.Key == "" {
-		for _, attrs := range []Attributes{store.Attrs, store.Node.Attrs} {
+		for _, attrs := range []Attributes{storeAttrs, nodeAttrs} {
 			for _, attr := range attrs.Attrs {
 				if attr == c.Value {
 					return true
@@ -32,7 +32,7 @@ func StoreMatchesConstraint(store StoreDescriptor, c Constraint) bool {
 		}
 		return false
 	}
-	for _, tier := range store.Node.Locality.Tiers {
+	for _, tier := range nodeLocality.Tiers {
 		if c.Key == tier.Key && c.Value == tier.Value {
 			return true
 		}


### PR DESCRIPTION
When a leaseholder is lost, any surviving replica may acquire the lease, even if it violates lease preferences. There are two main reasons for this: we need to elect a new Raft leader who will acquire the lease, which is agnostic to lease preferences, and there may not even be any surviving replicas that satisfy the lease preferences at all, so we don't want to keep the range unavailable while we try to figure this out (considering e.g. network timeouts can delay this for many seconds).

However, after acquiring a lease, we rely on the replicate queue to transfer the lease back to a replica that conforms with the preferences, which can take several minutes. In multi-region clusters, this can cause severe latency degradation if the lease is acquired in a remote region.

This patch will detect lease preference violations when a replica acquires a new lease, and eagerly enqueue it in the replicate queue for transfer (if possible).

Resolves https://github.com/cockroachdb/cockroach/issues/106100.
Epic: none

Release note (bug fix): When losing a leaseholder and using lease preferences, the lease can be acquired by any other replica (regardless of lease preferences) in order to restore availability as soon as possible. The new leaseholder will now immediately check if it violates the lease preferences, and attempt to transfer the lease to a replica that satisfies the preferences if possible.