### PR TITLE
dev: reject builds when CRL JS dependencies are 'pnpm link'ed

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -29,10 +29,12 @@ import (
 )
 
 const (
-	crossFlag       = "cross"
-	nogoDisableFlag = "--//build/toolchains:nogo_disable_flag"
-	geosTarget      = "//c-deps:libgeos"
-	devTarget       = "//pkg/cmd/dev:dev"
+	crossFlag          = "cross"
+	cockroachTargetOss = "//pkg/cmd/cockroach-oss:cockroach-oss"
+	cockroachTarget    = "//pkg/cmd/cockroach:cockroach"
+	nogoDisableFlag    = "--//build/toolchains:nogo_disable_flag"
+	geosTarget         = "//c-deps:libgeos"
+	devTarget          = "//pkg/cmd/dev:dev"
 )
 
 type buildTarget struct {
@@ -77,9 +79,9 @@ var buildTargetMapping = map[string]string{
 	"bazel-remote":         bazelRemoteTarget,
 	"buildifier":           "@com_github_bazelbuild_buildtools//buildifier:buildifier",
 	"buildozer":            "@com_github_bazelbuild_buildtools//buildozer:buildozer",
-	"cockroach":            "//pkg/cmd/cockroach:cockroach",
+	"cockroach":            cockroachTarget,
 	"cockroach-sql":        "//pkg/cmd/cockroach-sql:cockroach-sql",
-	"cockroach-oss":        "//pkg/cmd/cockroach-oss:cockroach-oss",
+	"cockroach-oss":        cockroachTargetOss,
 	"cockroach-short":      "//pkg/cmd/cockroach-short:cockroach-short",
 	"crlfmt":               "@com_github_cockroachdb_crlfmt//:crlfmt",
 	"dev":                  devTarget,
@@ -95,7 +97,7 @@ var buildTargetMapping = map[string]string{
 	"obsservice":           "//pkg/obsservice/cmd/obsservice:obsservice",
 	"optgen":               "//pkg/sql/opt/optgen/cmd/optgen:optgen",
 	"optfmt":               "//pkg/sql/opt/optgen/cmd/optfmt:optfmt",
-	"oss":                  "//pkg/cmd/cockroach-oss:cockroach-oss",
+	"oss":                  cockroachTargetOss,
 	"reduce":               "//pkg/cmd/reduce:reduce",
 	"roachprod":            "//pkg/cmd/roachprod:roachprod",
 	"roachprod-stress":     "//pkg/cmd/roachprod-stress:roachprod-stress",
@@ -172,6 +174,10 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 	args = append(args, additionalBazelArgs...)
 	configArgs := getConfigArgs(args)
 	configArgs = append(configArgs, getConfigArgs(additionalBazelArgs)...)
+
+	if err := d.assertNoLinkedNpmDeps(buildTargets); err != nil {
+		return err
+	}
 
 	if cross == "" {
 		// Do not log --build_event_binary_file=... because it is not relevant to the actual call

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -49,6 +49,14 @@ cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkou
 exec
 dev build -- --verbose_failures --sandbox_debug
 ----
+bazel info workspace --color=no
+ls crdb-checkout/pkg/ui/node_modules/@cockroachlabs
+ls crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/node_modules/@cockroachlabs
+ls crdb-checkout/pkg/ui/workspaces/db-console/src/js/node_modules/@cockroachlabs
+ls crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/node_modules/@cockroachlabs
+ls crdb-checkout/pkg/ui/workspaces/cluster-ui/node_modules/@cockroachlabs
+ls crdb-checkout/pkg/ui/workspaces/db-console/node_modules/@cockroachlabs
+ls crdb-checkout/pkg/ui/workspaces/e2e-tests/node_modules/@cockroachlabs
 bazel build //pkg/cmd/cockroach:cockroach --verbose_failures --sandbox_debug --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin


### PR DESCRIPTION
When working with first-party JS dependencies that aren't in this monorepo, the idiomatic development workflow uses pnpm link [1] to link multiple JS packages together. Specifically, running `pnpm link /path/to/github.com/cockroachdb/ui/packages/foo` from within pkg/ui/workspaces/* creates a symbolic link at
node_modules/@cockroachlabs/foo that points to
../../(…)/ui/packages/foo. This works quite smoothly for local development, as changes in the 'foo' package are automatically seen by a `pnpm webpack --watch` running in CRDB. The two packages act like they're maintained in the same repo, while allowing independent version history, CI processes, etc.

Unfortunately, rules_js currently offers no way to link outside of the Bazel workspace. Such a symlink is either ignored by rules_js (since it doesn't appear in pnpm-lock.yaml) or is rejected if it's manually added to the lockfile [2]. Allowing Bazel-based builds of CockroachDB when 'pnpm link'ed packages are present introduces dependency skew between Bazel and non-Bazel builds. To allow `pnpm link` to be used safely, pre-emptively reject builds of 'cockroach' and 'cockroach-oss' that are run through the 'dev' helper when linked @cockroachlabs/ packages are detected.

[1] https://pnpm.io/cli/link
[2] https://github.com/aspect-build/rules_js/issues/1165

Release note: None
Epic: none

-----

Example output: 
<img width="998" alt="image" src="https://github.com/cockroachdb/cockroach/assets/665775/3fd43abe-f5c2-4ddd-bc60-16a73db12836">

Total duration is 16ms on my machine since we're checking so few files. We can drop these into a goroutine per first-party JS if we want, but this is certainly fast enough to be conversational.