### PR TITLE
opt: add EliminateConstValueSubquery normalization rule

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -348,7 +348,7 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 				}
 				return nil
 			}, false /* expectErrors */, base, plans,
-			"distsql-1-subquery.html distsql-2-main-query.html vec-1-subquery-v.txt vec-1-subquery.txt vec-2-main-query-v.txt vec-2-main-query.txt")
+			"distsql.html vec-v.txt vec.txt")
 	})
 
 	t.Run("permission error", func(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -467,7 +467,7 @@ VALUES
           FROM
             (VALUES (tab_54747.col_95055)) AS tab_54752 (col_95061)
           WHERE
-            (SELECT 0) < tab_54752.col_95061
+            (SELECT random()::INT) < tab_54752.col_95061
         )
       FROM
         (VALUES (0:::OID), (3790322641:::OID)) AS tab_54747 (col_95055)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -4,7 +4,7 @@
 # Uncorrelated subqueries.
 # ------------------------------------------------------------------------------
 statement ok
-CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT);
+CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, FAMILY (a, b, c));
 CREATE TABLE abc2 (a INT PRIMARY KEY, b INT, c INT)
 
 query T
@@ -13,22 +13,12 @@ EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 distribution: local
 vectorized: true
 ·
-• root
+• split
+│ index: abc@abc_pkey
+│ expiry: CAST(NULL AS STRING)
 │
-├── • split
-│   │ index: abc@abc_pkey
-│   │ expiry: CAST(NULL AS STRING)
-│   │
-│   └── • values
-│         size: 1 column, 1 row
-│
-└── • subquery
-    │ id: @S1
-    │ original sql: (SELECT 42)
-    │ exec mode: one row
-    │
-    └── • values
-          size: 1 column, 1 row
+└── • values
+      size: 1 column, 1 row
 
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
@@ -39,23 +29,13 @@ EXPLAIN ALTER RANGE RELOCATE FROM 11 TO 22 FOR VALUES ((SELECT 1))
 distribution: local
 vectorized: true
 ·
-• root
+• relocate range
+│ replicas: VOTERS
+│ to: 22
+│ from: 11
 │
-├── • relocate range
-│   │ replicas: VOTERS
-│   │ to: 22
-│   │ from: 11
-│   │
-│   └── • values
-│         size: 1 column, 1 row
-│
-└── • subquery
-    │ id: @S1
-    │ original sql: (SELECT 1)
-    │ exec mode: one row
-    │
-    └── • values
-          size: 1 column, 1 row
+└── • values
+      size: 1 column, 1 row
 
 query T
 EXPLAIN ALTER RANGE 22 RELOCATE FROM ((SELECT 1)) TO ((SELECT 2))
@@ -63,31 +43,13 @@ EXPLAIN ALTER RANGE 22 RELOCATE FROM ((SELECT 1)) TO ((SELECT 2))
 distribution: local
 vectorized: true
 ·
-• root
+• relocate range
+│ replicas: VOTERS
+│ to: 2
+│ from: 1
 │
-├── • relocate range
-│   │ replicas: VOTERS
-│   │ to: @S1
-│   │ from: @S2
-│   │
-│   └── • values
-│         size: 1 column, 1 row
-│
-├── • subquery
-│   │ id: @S1
-│   │ original sql: ((SELECT 2))
-│   │ exec mode: one row
-│   │
-│   └── • values
-│         size: 1 column, 1 row
-│
-└── • subquery
-    │ id: @S2
-    │ original sql: ((SELECT 1))
-    │ exec mode: one row
-    │
-    └── • values
-          size: 1 column, 1 row
+└── • values
+      size: 1 column, 1 row
 
 query T
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
@@ -228,7 +190,7 @@ vectorized: true
 
 # the subquery's plan must be visible in EXPLAIN
 query T
-EXPLAIN VALUES (1), ((SELECT 2))
+EXPLAIN VALUES (1), ((SELECT random()::INT))
 ----
 distribution: local
 vectorized: true
@@ -240,7 +202,7 @@ vectorized: true
 │
 └── • subquery
     │ id: @S1
-    │ original sql: (SELECT 2)
+    │ original sql: (SELECT random()::INT8)
     │ exec mode: one row
     │
     └── • values
@@ -290,6 +252,33 @@ vectorized: true
                   estimated row count: 1,000 (missing stats)
                   table: tab4@tab4_pkey
                   spans: FULL SCAN
+
+# Subqueries with single, constant values can be inlined for index-acceleration.
+query T
+EXPLAIN (VERBOSE)
+SELECT * FROM abc WHERE a = (SELECT 1)
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b, c)
+  estimated row count: 1 (missing stats)
+  table: abc@abc_pkey
+  spans: /1/0
+
+query T
+EXPLAIN (VERBOSE)
+SELECT * FROM abc WHERE a >= (SELECT 1)
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b, c)
+  estimated row count: 333 (missing stats)
+  table: abc@abc_pkey
+  spans: /1-
 
 # ------------------------------------------------------------------------------
 # Correlated subqueries.

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -9,7 +9,7 @@ CREATE TABLE t (
 INSERT INTO t VALUES (1, 1), (2, 2), (3, 3), (4, 1), (5, 1);
 
 statement ok
-CREATE FUNCTION one() RETURNS INT LANGUAGE SQL AS 'SELECT 1';
+CREATE FUNCTION one() RETURNS INT IMMUTABLE LANGUAGE SQL AS 'SELECT 1';
 
 query T
 EXPLAIN SELECT one()
@@ -27,7 +27,7 @@ distribution: local
 vectorized: true
 ·
 • filter
-│ filter: a = one()
+│ filter: a = 1
 │
 └── • scan
       missing stats
@@ -258,6 +258,51 @@ vectorized: true
     │
     └── • emptyrow
           columns: ()
+
+# Immutable UDFs can be inlined for index-acceleration.
+query T
+EXPLAIN (VERBOSE)
+SELECT * FROM t WHERE k = one()
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (k, a)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+
+statement ok
+CREATE FUNCTION num(n INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT n
+$$
+
+query T
+EXPLAIN (VERBOSE)
+SELECT * FROM t WHERE k = num(2)
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (k, a)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /2/0
+
+query T
+EXPLAIN (VERBOSE)
+SELECT * FROM t WHERE k >= num(2)
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (k, a)
+  estimated row count: 333 (missing stats)
+  table: t@t_pkey
+  spans: /2-
 
 
 subtest regressions

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -299,6 +299,14 @@ $input
 =>
 (Exists $input $subqueryPrivate)
 
+# EliminateConstValuesSubquery replaces a subquery with a constant value if the
+# subquery's input is a single-row, single-column Values expression with a
+# constant value.
+[EliminateConstValueSubquery, Normalize]
+(Subquery (Values [ (Tuple [ $value:(Const) ]) ]))
+=>
+$value
+
 # SimplifyCaseWhenConstValue removes branches known to not match. Any
 # branch known to match is used as the ELSE and further WHEN conditions
 # are skipped. If all WHEN conditions have been removed, the ELSE

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1251,21 +1251,16 @@ norm expect=InlineUDF
 SELECT one_strict() FROM (VALUES (1), (2), (3)) v(i)
 ----
 project
- ├── columns: one_strict:3
+ ├── columns: one_strict:3!null
  ├── cardinality: [3 - 3]
+ ├── fd: ()-->(3)
  ├── values
  │    ├── cardinality: [3 - 3]
  │    ├── ()
  │    ├── ()
  │    └── ()
  └── projections
-      └── subquery [as=one_strict:3, subquery]
-           └── values
-                ├── columns: "?column?":2!null
-                ├── cardinality: [1 - 1]
-                ├── key: ()
-                ├── fd: ()-->(2)
-                └── (1,)
+      └── 1 [as=one_strict:3]
 
 # A UDF is not inlined when the arguments are not constants or either Variable
 # or Const expressions.

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -983,6 +983,113 @@ select
                 └── 1
 
 # --------------------------------------------------
+# EliminateConstValueSubquery
+# --------------------------------------------------
+
+norm expect=EliminateConstValueSubquery
+SELECT (SELECT 1)
+----
+values
+ ├── columns: "?column?":2!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(2)
+ └── (1,)
+
+norm expect=EliminateConstValueSubquery
+SELECT * FROM a WHERE k = (SELECT 1)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+
+norm expect=EliminateConstValueSubquery
+SELECT * FROM a WHERE k >= (SELECT 1)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k:1 >= 1 [outer=(1), constraints=(/1: [/1 - ]; tight)]
+
+# Cannot eliminate multi-row values subquery.
+norm expect-not=EliminateConstValueSubquery
+SELECT (VALUES (1), (2))
+----
+values
+ ├── columns: column1:2
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(2)
+ └── tuple
+      └── subquery
+           └── max1-row
+                ├── columns: column1:1!null
+                ├── error: "more than one row returned by a subquery used as an expression"
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(1)
+                └── values
+                     ├── columns: column1:1!null
+                     ├── cardinality: [2 - 2]
+                     ├── (1,)
+                     └── (2,)
+
+# Cannot eliminate multi-column values subquery.
+norm expect-not=EliminateConstValueSubquery
+SELECT (1, 2) = (SELECT 1, 2)
+----
+values
+ ├── columns: "?column?":4
+ ├── cardinality: [1 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(4)
+ └── tuple
+      └── eq
+           ├── (1, 2)
+           └── subquery
+                └── values
+                     ├── columns: column3:3
+                     ├── cardinality: [1 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(3)
+                     └── ((1, 2),)
+
+# Cannot eliminate non-constant values subquery.
+norm expect-not=EliminateConstValueSubquery
+SELECT (SELECT gen_random_uuid())
+----
+values
+ ├── columns: gen_random_uuid:2
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(2)
+ └── tuple
+      └── subquery
+           └── values
+                ├── columns: gen_random_uuid:1
+                ├── cardinality: [1 - 1]
+                ├── volatile
+                ├── key: ()
+                ├── fd: ()-->(1)
+                └── (gen_random_uuid(),)
+
+# --------------------------------------------------
 # SimplifyCaseWhenConstValue
 # --------------------------------------------------
 

--- a/pkg/sql/opt/norm/testdata/rules/udf
+++ b/pkg/sql/opt/norm/testdata/rules/udf
@@ -46,16 +46,9 @@ norm format=show-scalars
 SELECT strict_fn(1, 'foo', true)
 ----
 values
- ├── columns: strict_fn:5
+ ├── columns: strict_fn:5!null
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(5)
  └── tuple
-      └── subquery
-           └── values
-                ├── columns: i:4!null
-                ├── cardinality: [1 - 1]
-                ├── key: ()
-                ├── fd: ()-->(4)
-                └── tuple
-                     └── const: 1
+      └── const: 1

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -143,27 +143,11 @@ norm expect=InlineWith
 WITH foo AS (SELECT 1), bar AS (SELECT 2) SELECT (SELECT * FROM foo) + (SELECT * FROM bar)
 ----
 values
- ├── columns: "?column?":5
+ ├── columns: "?column?":5!null
  ├── cardinality: [1 - 1]
- ├── immutable
  ├── key: ()
  ├── fd: ()-->(5)
- └── tuple
-      └── plus
-           ├── subquery
-           │    └── values
-           │         ├── columns: "?column?":3!null
-           │         ├── cardinality: [1 - 1]
-           │         ├── key: ()
-           │         ├── fd: ()-->(3)
-           │         └── (1,)
-           └── subquery
-                └── values
-                     ├── columns: "?column?":4!null
-                     ├── cardinality: [1 - 1]
-                     ├── key: ()
-                     ├── fd: ()-->(4)
-                     └── (2,)
+ └── (3,)
 
 norm expect=InlineWith
 WITH foo AS (SELECT 1), bar AS (SELECT 2) SELECT (SELECT * FROM foo) + (SELECT * FROM bar) + (SELECT * FROM bar)
@@ -190,20 +174,14 @@ with &2 (bar)
            └── plus
                 ├── plus
                 │    ├── subquery
-                │    │    └── values
-                │    │         ├── columns: "?column?":3!null
+                │    │    └── with-scan &2 (bar)
+                │    │         ├── columns: "?column?":4!null
+                │    │         ├── mapping:
+                │    │         │    └──  "?column?":2 => "?column?":4
                 │    │         ├── cardinality: [1 - 1]
                 │    │         ├── key: ()
-                │    │         ├── fd: ()-->(3)
-                │    │         └── (1,)
-                │    └── subquery
-                │         └── with-scan &2 (bar)
-                │              ├── columns: "?column?":4!null
-                │              ├── mapping:
-                │              │    └──  "?column?":2 => "?column?":4
-                │              ├── cardinality: [1 - 1]
-                │              ├── key: ()
-                │              └── fd: ()-->(4)
+                │    │         └── fd: ()-->(4)
+                │    └── 1
                 └── subquery
                      └── with-scan &2 (bar)
                           ├── columns: "?column?":5!null
@@ -417,14 +395,7 @@ anti-join-apply
  │    ├── outer: (2)
  │    ├── cardinality: [2 - 2]
  │    ├── (k:2,)
- │    └── tuple
- │         └── subquery
- │              └── values
- │                   ├── columns: column1:9!null
- │                   ├── cardinality: [1 - 1]
- │                   ├── key: ()
- │                   ├── fd: ()-->(9)
- │                   └── (1,)
+ │    └── (1,)
  └── filters
       └── column1:10 = k:2 [outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
 


### PR DESCRIPTION
The EliminateConstValueSubquery normalization rule replaces a subquery
with a constant value when the subquery's input is a single-rows,
single-column Values expression with a constant value. This enables
further optimization of the query.

Fixes #104218

Release note (performance improvement): The optimizer now produces more
efficient query plans in some cases for queries with  subqueries and
user-defined functions.
