### PR TITLE
backupccl: record backing file size during backup

### DIFF
--- a/pkg/ccl/backupccl/backuppb/backup.proto
+++ b/pkg/ccl/backupccl/backuppb/backup.proto
@@ -48,6 +48,7 @@ message BackupManifest {
     util.hlc.Timestamp start_time = 7 [(gogoproto.nullable) = false];
     util.hlc.Timestamp end_time = 8 [(gogoproto.nullable) = false];
     string locality_kv = 9 [(gogoproto.customname) = "LocalityKV"];
+    uint64 backing_file_size = 10;
   }
 
   message DescriptorRevision {

--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -125,8 +125,13 @@ func (s *fileSSTSink) flushFile(ctx context.Context) error {
 		log.Warningf(ctx, "failed to close write in fileSSTSink: % #v", pretty.Formatter(err))
 		return errors.Wrap(err, "writing SST")
 	}
+	wroteSize := s.sst.Meta.Size
 	s.outName = ""
 	s.out = nil
+
+	for i := range s.flushedFiles {
+		s.flushedFiles[i].BackingFileSize = wroteSize
+	}
 
 	progDetails := backuppb.BackupManifest_Progress{
 		RevStartTime:   s.flushedRevStart,

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -31,6 +31,7 @@ type SSTWriter struct {
 	DataSize int64
 	scratch  []byte
 
+	Meta              *sstable.WriterMetadata
 	supportsRangeKeys bool // TODO(erikgrinaker): remove after 22.2
 }
 
@@ -135,8 +136,10 @@ func (fw *SSTWriter) Finish() error {
 	if err := fw.fw.Close(); err != nil {
 		return err
 	}
+	var err error
+	fw.Meta, err = fw.fw.Metadata()
 	fw.fw = nil
-	return nil
+	return err
 }
 
 // ClearRawRange implements the Engine interface.


### PR DESCRIPTION
Release note: none.
Epic: none.