### PR TITLE
backupccl: add RESTORE job to wait for background downloads

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -479,8 +479,12 @@ message RestoreDetails {
   roachpb.Locality execution_locality = 30 [(gogoproto.nullable) = false];
   
   bool experimental_online = 31;
+  
+  // DownloadSpans indicates this job is the download-step of a multi-step
+  // online restore.
+  repeated roachpb.Span download_spans = 32 [(gogoproto.nullable) = false]; 
 
-  // NEXT ID: 31.
+  // NEXT ID: 33.
 }
 
 
@@ -496,6 +500,11 @@ message RestoreProgress {
   }
 
   repeated FrontierEntry checkpoint = 2 [(gogoproto.nullable) = false];
+
+  // TotalDownloadRequired is set in the download job for an online restore, and
+  // reflects the total amount that was initially found to be needing to be 
+  // downloaded. 
+  uint64 total_download_required = 3;
 }
 
 message ImportDetails {


### PR DESCRIPTION
After an online restore completes its initial data mounting phase, we
actually go download the data in the background, both so that it will be
faster to access once it is stored locally but also to make it
permanently owned by the cluster, rather than remaining linked to the
backup, which could be moved, expire, etc.

Users need to be able to see, observe and control this process, in
particular they need to know when it completes or will complete, so that
they know when to expect normal performance or when they can lift
modification/expiration blocks on their backups.

This change introduces new RESTORE job, created by the initial restore
job after it has linked in the external sstables, which polls the stores
to determine how much data remains to be downloaded, and completes when
this number reaches zero.

A future change will likely extend this job to also explicitly invoke a
compaction specifically configured to download these files, to make this
happen more immediately and to make it controllable by the job, but for
now this initial implementation only waits and polls to track the state
of the compaction, rather than actively compacting itself.

Release note: none.
Epic: none.