### PR TITLE
acceptance: skip flakey test

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -298,13 +298,6 @@ func TestDockerCLI_test_log_flags(t *testing.T) {
 	runTestDockerCLI(t, "test_log_flags", "../cli/interactive_tests/test_log_flags.tcl")
 }
 
-func TestDockerCLI_test_missing_log_output(t *testing.T) {
-	s := log.Scope(t)
-	defer s.Close(t)
-
-	runTestDockerCLI(t, "test_missing_log_output", "../cli/interactive_tests/test_missing_log_output.tcl")
-}
-
 func TestDockerCLI_test_multiline_statements(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl.disabled
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl.disabled
@@ -1,5 +1,7 @@
 #! /usr/bin/env expect -f
 
+# disabled until #107122 is resolved.
+
 source [file join [file dirname $argv0] common.tcl]
 
 spawn /bin/bash


### PR DESCRIPTION
Skips `TestDockerCLI_test_missing_log_output`.

Informs #107122

Release note: None