### PR TITLE
release-22.2: sql: add tests for CTAS, CMVAS with every SHOW statement

### DIFF
--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -96,6 +96,207 @@ func TestCreateAsVTable(t *testing.T) {
 	waitForJobsSuccess(t, sqlRunner)
 }
 
+func TestCreateAsShow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		sql   string
+		setup string
+		skip  bool
+	}{
+		{
+			sql: "SHOW CLUSTER SETTINGS",
+		},
+		{
+			sql: "SHOW DATABASES",
+		},
+		{
+			sql:   "SHOW ENUMS",
+			setup: "CREATE TYPE e AS ENUM ('a', 'b')",
+		},
+		{
+			sql: "SHOW CREATE DATABASE defaultdb",
+		},
+		{
+			sql: "SHOW CREATE ALL SCHEMAS",
+		},
+		{
+			sql: "SHOW CREATE ALL TABLES",
+		},
+		{
+			sql:   "SHOW CREATE TABLE show_create_tbl",
+			setup: "CREATE TABLE show_create_tbl (id int PRIMARY KEY)",
+			// TODO(sql-foundations): Fix `relation "show_create_tbl" does not exist` error in job.
+			//  See https://github.com/cockroachdb/cockroach/issues/106260.
+			skip: true,
+		},
+		{
+			sql:   "SHOW CREATE FUNCTION show_create_fn",
+			setup: "CREATE FUNCTION show_create_fn(i int) RETURNS INT AS 'SELECT i' LANGUAGE SQL",
+			// TODO(sql-foundations): Fix `unknown function: show_create_fn(): function undefined` error in job.
+			//  See https://github.com/cockroachdb/cockroach/issues/106268.
+			skip: true,
+		},
+		{
+			sql: "SHOW CREATE ALL TYPES",
+		},
+		{
+			sql: "SHOW INDEXES FROM DATABASE defaultdb",
+		},
+		{
+			sql:   "SHOW INDEXES FROM show_indexes_tbl",
+			setup: "CREATE TABLE show_indexes_tbl (id int PRIMARY KEY)",
+			// TODO(sql-foundations): Fix `relation "show_indexes_tbl" does not exist` error in job.
+			//  See https://github.com/cockroachdb/cockroach/issues/106260.
+			skip: true,
+		},
+		{
+			sql:   "SHOW COLUMNS FROM show_columns_tbl",
+			setup: "CREATE TABLE show_columns_tbl (id int PRIMARY KEY)",
+			// TODO(sql-foundations): Fix `relation "show_columns_tbl" does not exist` error in job.
+			//  See https://github.com/cockroachdb/cockroach/issues/106260.
+			skip: true,
+		},
+		{
+			sql:   "SHOW CONSTRAINTS FROM show_constraints_tbl",
+			setup: "CREATE TABLE show_constraints_tbl (id int PRIMARY KEY)",
+			// TODO(sql-foundations): Fix `relation "show_constraints_tbl" does not exist` error in job.
+			//  See https://github.com/cockroachdb/cockroach/issues/106260.
+			skip: true,
+		},
+		{
+			sql: "SHOW PARTITIONS FROM DATABASE defaultdb",
+		},
+		{
+			sql:   "SHOW PARTITIONS FROM TABLE show_partitions_tbl",
+			setup: "CREATE TABLE show_partitions_tbl (id int PRIMARY KEY)",
+			// TODO(sql-foundations): Fix `relation "show_partitions_tbl" does not exist` error in job.
+			//  See https://github.com/cockroachdb/cockroach/issues/106260.
+			skip: true,
+		},
+		{
+			sql:   "SHOW PARTITIONS FROM INDEX show_partitions_idx_tbl@show_partitions_idx_tbl_pkey",
+			setup: "CREATE TABLE show_partitions_idx_tbl (id int PRIMARY KEY)",
+			// TODO(sql-foundations): Fix `relation "show_partitions_idx_tbl" does not exist` error in job.
+			//  See https://github.com/cockroachdb/cockroach/issues/106260.
+			skip: true,
+		},
+		{
+			sql: "SHOW GRANTS",
+		},
+		{
+			sql: "SHOW JOBS",
+		},
+		{
+			sql: "SHOW CHANGEFEED JOBS",
+		},
+		{
+			sql: "SHOW ALL CLUSTER STATEMENTS",
+		},
+		{
+			sql: "SHOW ALL LOCAL STATEMENTS",
+		},
+		{
+			sql: "SHOW ALL LOCAL STATEMENTS",
+		},
+		{
+			sql:   "SHOW RANGE FROM TABLE show_ranges_tbl FOR ROW (0)",
+			setup: "CREATE TABLE show_ranges_tbl (id int PRIMARY KEY)",
+			// TODO(sql-foundations): Fix `invalid memory address or nil pointer dereference` error in job.
+			//  See https://github.com/cockroachdb/cockroach/issues/106397.
+			skip: true,
+		},
+		{
+			sql: "SHOW SURVIVAL GOAL FROM DATABASE",
+		},
+		{
+			sql: "SHOW REGIONS FROM DATABASE",
+		},
+		{
+			sql: "SHOW GRANTS ON ROLE",
+		},
+		{
+			sql: "SHOW ROLES",
+		},
+		{
+			sql: "SHOW SCHEMAS",
+		},
+		{
+			sql:   "SHOW SEQUENCES",
+			setup: "CREATE SEQUENCE seq",
+		},
+		{
+			sql: "SHOW ALL SESSIONS",
+		},
+		{
+			sql: "SHOW CLUSTER SESSIONS",
+		},
+		{
+			sql: "SHOW SYNTAX 'SELECT 1'",
+		},
+		{
+			sql:   "SHOW FUNCTIONS",
+			setup: "CREATE FUNCTION show_functions_fn(i int) RETURNS INT AS 'SELECT i' LANGUAGE SQL",
+		},
+		{
+			sql: "SHOW TABLES",
+		},
+		{
+			sql: "SHOW ALL TRANSACTIONS",
+		},
+		{
+			sql: "SHOW CLUSTER TRANSACTIONS",
+		},
+		{
+			sql: "SHOW USERS",
+		},
+		{
+			sql: "SHOW ALL",
+		},
+		{
+			sql: "SHOW ZONE CONFIGURATIONS",
+		},
+		{
+			sql: "SHOW SCHEDULES",
+		},
+		{
+			sql: "SHOW JOBS FOR SCHEDULES SELECT id FROM [SHOW SCHEDULES]",
+		},
+		{
+			sql: "SHOW FULL TABLE SCANS",
+		},
+		{
+			sql: "SHOW DEFAULT PRIVILEGES",
+		},
+	}
+
+	ctx := context.Background()
+	testCluster := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{})
+	defer testCluster.Stopper().Stop(ctx)
+	sqlRunner := sqlutils.MakeSQLRunner(testCluster.ServerConn(0))
+
+	for i, testCase := range testCases {
+		t.Run(testCase.sql, func(t *testing.T) {
+			if testCase.skip {
+				return
+			}
+			if testCase.setup != "" {
+				sqlRunner.Exec(t, testCase.setup)
+			}
+			createTableStmt := fmt.Sprintf(
+				"CREATE TABLE test_table_%d AS SELECT * FROM [%s]",
+				i, testCase.sql,
+			)
+			sqlRunner.Exec(t, createTableStmt)
+			// Skip `CREATE MATERIALIZED VIEW` in 22.2 to avoid
+			// "views do not currently support * expressions" error.
+			i++
+		})
+	}
+
+	waitForJobsSuccess(t, sqlRunner)
+}
+
 func waitForJobsSuccess(t *testing.T, sqlRunner *sqlutils.SQLRunner) {
 	query := `SELECT job_id, status, error, description 
 FROM [SHOW JOBS] 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -317,7 +317,7 @@ func (node *ShowChangefeedJobs) Format(ctx *FmtCtx) {
 	}
 }
 
-// ShowSurvivalGoal represents a SHOW REGIONS statement
+// ShowSurvivalGoal represents a SHOW SURVIVAL GOAL statement
 type ShowSurvivalGoal struct {
 	DatabaseName Name
 }


### PR DESCRIPTION
Backport 2/2 commits from #106407.

/cc @cockroachdb/release

---

Fixes #105895

Adds tests for CREATE TABLE AS, CREATE MATERIALIZED VIEW AS sourcing from
all SHOW statements.

Release note: None

Release justification: Add test coverage.
