### PR TITLE
ui: fix creation index syntax on console

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.spec.ts
@@ -20,19 +20,20 @@ describe("Create index name", () => {
     {
       name: "one parameter no space",
       query: "CREATE INDEX ON t(i) STORING (k)",
-      expected: "CREATE INDEX IF NOT EXISTS t_i_rec_idx ON t(i) STORING (k)",
+      expected:
+        "CREATE INDEX IF NOT EXISTS t_i_storing_rec_idx ON t(i) STORING (k)",
     },
     {
       name: "two parameters",
       query: "CREATE INDEX ON t (i, j) STORING (k)",
       expected:
-        "CREATE INDEX IF NOT EXISTS t_i_j_rec_idx ON t (i, j) STORING (k)",
+        "CREATE INDEX IF NOT EXISTS t_i_j_storing_rec_idx ON t (i, j) STORING (k)",
     },
     {
       name: "one parameter, one expression",
       query: "CREATE INDEX ON t (i, (j + k)) STORING (k)",
       expected:
-        "CREATE INDEX IF NOT EXISTS t_i_expr_rec_idx ON t (i, (j + k)) STORING (k)",
+        "CREATE INDEX IF NOT EXISTS t_i_expr_storing_rec_idx ON t (i, (j + k)) STORING (k)",
     },
     {
       name: "one parameter, one expression no parenthesis",
@@ -43,7 +44,7 @@ describe("Create index name", () => {
       name: "two expressions",
       query: "CREATE INDEX ON t ((i+l), (j + k)) STORING (k)",
       expected:
-        "CREATE INDEX IF NOT EXISTS t_expr_expr1_rec_idx ON t ((i+l), (j + k)) STORING (k)",
+        "CREATE INDEX IF NOT EXISTS t_expr_expr1_storing_rec_idx ON t ((i+l), (j + k)) STORING (k)",
     },
     {
       name: "one expression, one parameter",
@@ -54,19 +55,19 @@ describe("Create index name", () => {
       name: "two expressions, one parameter",
       query: "CREATE INDEX ON t ((i + l), (j + k), a) STORING (k)",
       expected:
-        "CREATE INDEX IF NOT EXISTS t_expr_expr1_a_rec_idx ON t ((i + l), (j + k), a) STORING (k)",
+        "CREATE INDEX IF NOT EXISTS t_expr_expr1_a_storing_rec_idx ON t ((i + l), (j + k), a) STORING (k)",
     },
     {
       name: "invalid expression, missing )",
       query: "CREATE INDEX ON t ((i + l, (j + k), a) STORING (k)",
       expected:
-        "CREATE INDEX IF NOT EXISTS t_expr_expr1_expr2_rec_idx ON t ((i + l, (j + k), a) STORING (k)",
+        "CREATE INDEX IF NOT EXISTS t_expr_expr1_expr2_storing_rec_idx ON t ((i + l, (j + k), a) STORING (k)",
     },
     {
       name: "invalid expression, extra )",
       query: "CREATE INDEX ON t ((i + l)), (j + k), a) STORING (k)",
       expected:
-        "CREATE INDEX IF NOT EXISTS t_expr_rec_idx ON t ((i + l)), (j + k), a) STORING (k)",
+        "CREATE INDEX IF NOT EXISTS t_expr_storing_rec_idx ON t ((i + l)), (j + k), a) STORING (k)",
     },
   ];
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
@@ -256,8 +256,12 @@ export function createIdxName(statement: string): string {
       idxName += "_" + value;
     }
   }
-
-  idxName += "_rec_idx";
+  const suffix =
+    statement.indexOf("STORING") >= 0 ? "_storing_rec_idx" : "_rec_idx";
+  // The table name is fully qualified at this point, but we don't need the full name,
+  // so just use the last value (also an index name can't have ".")
+  const idxNameArr = idxName.split(".");
+  idxName = idxNameArr[idxNameArr.length - 1].replace(/\s/g, "_") + suffix;
 
   return statement.replace(
     "CREATE INDEX ON ",


### PR DESCRIPTION
With an update to make the table name fully qualified, the index name was also using the fully qualified name, which contains ".", and that causes an invalid syntax since index name can't have periods.
Having the qualified name is not important for the index name itself, so this commit fixes by ignoring that part and using just the table name, how it was doing previously. It also fixes an invalid syntax when there were spaces on the name generate.

It also add a little more observability into indexes being created with STORING clause, adding that to the suffix of the index creation.

Fixes #107168

Before
<img width="583" alt="Screenshot 2023-07-19 at 10 23 21 AM" src="https://github.com/cockroachdb/cockroach/assets/1017486/e5792419-31af-4e5f-994e-13ddb716009c">


After
https://www.loom.com/share/33da8b46fc9e4f72944c1d0ab943dea0

Release note (bug fix): Index recommendation on the UI no longer uses the full qualified name of a table to create an index name, allowing the creating of indexes directly from the Console to work.