### PR TITLE
testserver: avoid nodelocal capability in some cases

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1130,7 +1130,21 @@ func (ts *TestServer) StartTenant(
 	baseCfg.DisableTLSForHTTP = params.DisableTLSForHTTP
 	baseCfg.EnableDemoLoginEndpoint = params.EnableDemoLoginEndpoint
 
-	if ts.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_1TenantCapabilities) {
+	// Waiting for capabilities can take 3+ seconds since the
+	// rangefeedcache needs to wait for the closed timestamp
+	// before flushing updates. To avoid paying this cost in all
+	// cases, we only set the nodelocal storage capability if the
+	// caller has configured an ExternalIODir since nodelocal
+	// storage only works with that configured.
+	//
+	// TODO(ssd): We should do more here. We could have the caller
+	// pass in explicitly that they want these capabilities. Or,
+	// we could modify the system in some way to avoid waiting on
+	// capabilities for so long. Also, note that this doesn't
+	// apply to StartSharedProcessTenant.
+	shouldGrantNodelocalCap := ts.params.ExternalIODir != ""
+	canGrantNodelocalCap := ts.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_1TenantCapabilities)
+	if canGrantNodelocalCap && shouldGrantNodelocalCap {
 		_, err := ie.Exec(ctx, "testserver-alter-tenant-cap", nil,
 			"ALTER TENANT [$1] GRANT CAPABILITY can_use_nodelocal_storage", params.TenantID.ToUint64())
 		if err != nil {


### PR DESCRIPTION
Waiting for the nodelocal capability takes time because we won't see the update until the closed timestamp for the relevant ranges advance.

We could, and perhaps should, lower the closed timestamp target in tests. Or perhaps make other changes that avoid this long wait.

But, while we decide on what to do, we can avoid doing this at all for tests that can't possibly be using nodelocal storage because they haven't set an external storage dir.

Epic: CRDB-18499

Release note: None