### PR TITLE
Revert "github-pull-request-make: temporary workaround"

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -209,11 +209,6 @@ func main() {
 
 	if len(pkgs) > 0 {
 		for name, pkg := range pkgs {
-			// [knz] Temporary hack to get #106928 over the finish line.
-			if strings.HasPrefix(name, "pkg/server") {
-				continue
-			}
-
 			// 20 minutes total seems OK, but at least 2 minutes per test.
 			// This should be reduced. See #46941.
 			duration := (20 * time.Minute) / time.Duration(len(pkgs))


### PR DESCRIPTION
Epic: CRDB-18499

This reverts commit da33ea2b127c92f15bf6afbd7e444e6dcc1e8c67.
Not needed any more since is merged now.