### PR TITLE
acceptance: add log dir as a writable path

### DIFF
--- a/pkg/cmd/dev/acceptance.go
+++ b/pkg/cmd/dev/acceptance.go
@@ -93,6 +93,7 @@ func (d *dev) acceptance(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, "--test_arg", "-test.v")
 	}
 	args = append(args, fmt.Sprintf("--test_arg=-l=%s", logDir))
+	args = append(args, fmt.Sprintf("--sandbox_writable_path=%s", logDir))
 	args = append(args, "--test_env=TZ=America/New_York")
 	args = append(args, fmt.Sprintf("--test_arg=-b=%s", cockroachBin))
 	args = append(args, additionalBazelArgs...)


### PR DESCRIPTION
Otherwise you get a sandbox error.

Epic: CRDB-17171
Release note: None