### PR TITLE
cloud: fix incorrect rebase of ResumingReader open at size patch

### DIFF
--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -631,7 +631,7 @@ func TestReadFileAtReturnsSize(t *testing.T) {
 	_, err = w.Write(data)
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
-	reader, _, err := s.ReadFile(ctx, file, cloud.ReadOptions{NoFileSize: true})
+	reader, _, err := s.ReadFile(ctx, file, cloud.ReadOptions{})
 	require.NoError(t, err)
 
 	rr, ok := reader.(*cloud.ResumingReader)

--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -294,7 +294,7 @@ func (g *gcsStorage) ReadFile(
 					return nil, 0, io.EOF
 				}
 			}
-			r, err := g.bucket.Object(object).NewRangeReader(ctx, pos, -1)
+			r, err := g.bucket.Object(object).NewRangeReader(ctx, pos, length)
 			if err != nil {
 				return nil, 0, err
 			}

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -480,7 +480,7 @@ func TestReadFileAtReturnsSize(t *testing.T) {
 	_, err = w.Write(data)
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
-	reader, _, err := s.ReadFile(ctx, file, cloud.ReadOptions{NoFileSize: true})
+	reader, _, err := s.ReadFile(ctx, file, cloud.ReadOptions{})
 	require.NoError(t, err)
 
 	rr, ok := reader.(*cloud.ResumingReader)

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -486,7 +486,7 @@ func TestReadFileAtReturnsSize(t *testing.T) {
 	_, err = w.Write(data)
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
-	reader, _, err := s.ReadFile(ctx, file, cloud.ReadOptions{NoFileSize: true})
+	reader, _, err := s.ReadFile(ctx, file, cloud.ReadOptions{})
 	require.NoError(t, err)
 
 	rr, ok := reader.(*cloud.ResumingReader)


### PR DESCRIPTION
Recently #103462 was merged after incorrectly rebasing and did not correctly incorporate the addition of the NoFileSize read option for external storages. This patch fixes the rebase in GCS storage and in cloud unit tests.

Fixes: #107136
Fixes: #107138

Cloud Unit Test Manual Run: https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_CloudUnitTests/10977689

Release note: None