### PR TITLE
storage: restore synthetic timestamp handling in MVCCValue.GetLocalTimestamp

### DIFF
--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -106,6 +106,17 @@ func (v MVCCValue) LocalTimestampNeeded(keyTS hlc.Timestamp) bool {
 // provided key version timestamp and returned.
 func (v MVCCValue) GetLocalTimestamp(keyTS hlc.Timestamp) hlc.ClockTimestamp {
 	if v.LocalTimestamp.IsEmpty() {
+		if keyTS.Synthetic {
+			// A synthetic version timestamp means that the version timestamp is
+			// disconnected from real time and did not come from an HLC clock on the
+			// leaseholder that wrote the value or from somewhere else in the system.
+			// As a result, the version timestamp cannot be cast to a clock timestamp,
+			// so we return min_clock_timestamp instead. The effect of this is that
+			// observed timestamps can not be used to avoid uncertainty retries for
+			// values without a local timestamp and with a synthetic version
+			// timestamp.
+			return hlc.MinClockTimestamp
+		}
 		return hlc.ClockTimestamp(keyTS)
 	}
 	return v.LocalTimestamp


### PR DESCRIPTION
Fixes #106569.

In 37739949, we stopped decoding the synthetic timestamp bit from MVCC keys. When doing so, we removed logic from `MVCCValue.GetLocalTimestamp` that handles synthetic timestamps. In doing so, we missed the fact that the timestamp provided to `MVCCValue.GetLocalTimestamp` can also come from `MVCCMetadata.Timestamp`, which has not yet been stripped of synthetic timestamps. Eventually, we will get to that as part of #101938, but for now, we restore this handling.

Release note: None