### PR TITLE
jobsprofiler: stringify protobin files when requested

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -82,7 +82,7 @@ func (r *Registry) maybeDumpTrace(resumerCtx context.Context, resumer Resumer, j
 		return
 	}
 
-	resumerTraceFilename := fmt.Sprintf("resumer-trace-n%s.%s.txt",
+	resumerTraceFilename := fmt.Sprintf("resumer-trace-n%s.%s.binpb",
 		r.ID().String(), timeutil.Now().Format("20060102_150405.00"))
 	td := jobspb.TraceData{CollectedSpans: sp.GetConfiguredRecording()}
 	b, err := protoutil.Marshal(&td)

--- a/pkg/jobs/jobsprofiler/profilerconstants/constants.go
+++ b/pkg/jobs/jobsprofiler/profilerconstants/constants.go
@@ -37,14 +37,6 @@ func MakeNodeProcessorProgressInfoKey(flowID string, instanceID string, processo
 	return fmt.Sprintf("%s%s,%s,%d", NodeProcessorProgressInfoKeyPrefix, flowID, instanceID, processorID)
 }
 
-const ResumerTraceInfoKeyPrefix = "~resumer-trace-"
-
-// MakeResumerTraceInfoKey returns the info_key used for rows that store the
-// traces on completion of a resumer's execution.
-func MakeResumerTraceInfoKey(traceID uint64, nodeID string) string {
-	return fmt.Sprintf("%s%d-%s", ResumerTraceInfoKeyPrefix, traceID, nodeID)
-}
-
 // ExecutionDetailsChunkKeyPrefix is the prefix of the info key used for rows that
 // store chunks of a job's execution details.
 const ExecutionDetailsChunkKeyPrefix = "~profiler/"

--- a/pkg/sql/jobs_profiler_execution_details_test.go
+++ b/pkg/sql/jobs_profiler_execution_details_test.go
@@ -349,11 +349,12 @@ func TestListProfilerExecutionDetails(t *testing.T) {
 
 		runner.Exec(t, `SELECT crdb_internal.request_job_execution_details($1)`, importJobID)
 		files := listExecutionDetails(t, s, jobspb.JobID(importJobID))
-		require.Len(t, files, 4)
+		require.Len(t, files, 5)
 		require.Regexp(t, "distsql\\..*\\.html", files[0])
 		require.Regexp(t, "goroutines\\..*\\.txt", files[1])
-		require.Regexp(t, "resumer-trace-n[0-9]\\..*\\.txt", files[2])
-		require.Regexp(t, "trace\\..*\\.zip", files[3])
+		require.Regexp(t, "resumer-trace-n[0-9].*\\.binpb", files[2])
+		require.Regexp(t, "resumer-trace-n[0-9].*\\.binpb\\.txt", files[3])
+		require.Regexp(t, "trace\\..*\\.zip", files[4])
 
 		// Resume the job, so it can write another DistSQL diagram and goroutine
 		// snapshot.
@@ -363,15 +364,17 @@ func TestListProfilerExecutionDetails(t *testing.T) {
 		jobutils.WaitForJobToSucceed(t, runner, jobspb.JobID(importJobID))
 		runner.Exec(t, `SELECT crdb_internal.request_job_execution_details($1)`, importJobID)
 		files = listExecutionDetails(t, s, jobspb.JobID(importJobID))
-		require.Len(t, files, 8)
+		require.Len(t, files, 10)
 		require.Regexp(t, "distsql\\..*\\.html", files[0])
 		require.Regexp(t, "distsql\\..*\\.html", files[1])
 		require.Regexp(t, "goroutines\\..*\\.txt", files[2])
 		require.Regexp(t, "goroutines\\..*\\.txt", files[3])
-		require.Regexp(t, "resumer-trace-n[0-9]\\..*\\.txt", files[4])
-		require.Regexp(t, "resumer-trace-n[0-9]\\..*\\.txt", files[5])
-		require.Regexp(t, "trace\\..*\\.zip", files[6])
-		require.Regexp(t, "trace\\..*\\.zip", files[7])
+		require.Regexp(t, "resumer-trace-n[0-9].*\\.binpb", files[4])
+		require.Regexp(t, "resumer-trace-n[0-9].*\\.binpb\\.txt", files[5])
+		require.Regexp(t, "resumer-trace-n[0-9].*\\.binpb", files[6])
+		require.Regexp(t, "resumer-trace-n[0-9].*\\.binpb\\.txt", files[7])
+		require.Regexp(t, "trace\\..*\\.zip", files[8])
+		require.Regexp(t, "trace\\..*\\.zip", files[9])
 	})
 }
 


### PR DESCRIPTION
This change is in preparation for a larger change that
will allow downloading debug files from the `Advanded Debugging`
tab on the job details page.

With this change a `binpb` file will have a `binpb.txt` version of the
file listed too. If the user requests to download
a `binpb.txt` file we unmarshal and stringify the contents
of the file before serving them to the user. Currently, there
is only one protobin file type written by a job resumer on
completion.

Informs: #105076
Release note: None