### PR TITLE
bazel: make `fastbuild` the default `-c` again; never strip for `dev` builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,7 +36,7 @@ build --define gotags=bazel,gss
 build --experimental_proto_descriptor_sets_include_source_info
 build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
 build --symlink_prefix=_bazel/
-build -c dbg
+build:dev --strip=never
 common --experimental_allow_tags_propagation
 test --config=test --experimental_ui_max_stdouterr_bytes=10485760
 build --ui_event_filters=-DEBUG

--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -38,7 +38,7 @@ fi
 
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
-"$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci" -- build \
+"$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci" -- build -c opt \
 		       --config "$CONFIG" --config ci $EXTRA_ARGS \
 		       //pkg/cmd/cockroach-short //pkg/cmd/cockroach \
 		       //pkg/cmd/cockroach-sql \

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
@@ -27,8 +27,8 @@ mkdir -p "$PWD/bin"
 chmod o+rwx "$PWD/bin"
 
 # Build the roachtest binary.
-bazel build //pkg/cmd/roachtest --config ci
-BAZEL_BIN=$(bazel info bazel-bin --config ci)
+bazel build //pkg/cmd/roachtest --config ci -c opt
+BAZEL_BIN=$(bazel info bazel-bin --config ci -c opt)
 cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
@@ -39,8 +39,8 @@ chmod a+w bin/roachtest
 bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
-bazel build @com_github_cockroachdb_pebble//cmd/pebble --config ci
-BAZEL_BIN=$(bazel info bazel-bin --config ci)
+bazel build @com_github_cockroachdb_pebble//cmd/pebble --config ci -c opt
+BAZEL_BIN=$(bazel info bazel-bin --config ci -c opt)
 cp $BAZEL_BIN/external/com_github_cockroachdb_pebble/cmd/pebble/pebble_/pebble ./pebble.linux
 chmod a+w ./pebble.linux
 
@@ -67,8 +67,8 @@ function prepare_datadir() {
 # Build the mkbench tool from within the Pebble repo. This is used to parse
 # the benchmark data.
 function build_mkbench() {
-  bazel build @com_github_cockroachdb_pebble//internal/mkbench --config ci
-  BAZEL_BIN=$(bazel info bazel-bin --config ci)
+  bazel build @com_github_cockroachdb_pebble//internal/mkbench --config ci -c opt
+  BAZEL_BIN=$(bazel info bazel-bin --config ci -c opt)
   cp $BAZEL_BIN/external/com_github_cockroachdb_pebble/internal/mkbench/mkbench_/mkbench .
   chmod a+w mkbench
 }

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
@@ -27,8 +27,8 @@ mkdir -p "$PWD/bin"
 chmod o+rwx "$PWD/bin"
 
 # Build the roachtest binary.
-bazel build //pkg/cmd/roachtest --config ci
-BAZEL_BIN=$(bazel info bazel-bin --config ci)
+bazel build //pkg/cmd/roachtest --config ci -c opt
+BAZEL_BIN=$(bazel info bazel-bin --config ci -c opt)
 cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
@@ -39,8 +39,8 @@ chmod a+w bin/roachtest
 bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
-bazel build @com_github_cockroachdb_pebble//cmd/pebble --config race --config ci
-BAZEL_BIN=$(bazel info bazel-bin --config race --config ci)
+bazel build @com_github_cockroachdb_pebble//cmd/pebble --config race --config ci -c opt
+BAZEL_BIN=$(bazel info bazel-bin --config race --config ci -c opt)
 cp $BAZEL_BIN/external/com_github_cockroachdb_pebble/cmd/pebble/pebble_/pebble ./pebble.linux
 chmod a+w ./pebble.linux
 

--- a/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
@@ -35,21 +35,21 @@ for platform in "${cross_builds[@]}"; do
 
   echo "Building $platform, os=$os, arch=$arch..."
   # Build cockroach, workload and geos libs.
-  bazel build --config $platform --config ci --config force_build_cdeps \
+  bazel build --config $platform --config ci -c opt --config force_build_cdeps \
         //pkg/cmd/cockroach //pkg/cmd/workload \
         //c-deps:libgeos
-  BAZEL_BIN=$(bazel info bazel-bin --config $platform --config ci)
+  BAZEL_BIN=$(bazel info bazel-bin --config $platform --config ci -c opt)
 
   # N.B. roachtest is built once, for the host architecture.
   if [[ $os == "linux" && $arch == $host_arch ]]; then
-    bazel build --config $platform --config ci //pkg/cmd/roachtest
+    bazel build --config $platform --config ci  -c opt //pkg/cmd/roachtest
 
     cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin/roachtest
     # Make it writable to simplify cleanup and copying (e.g., scp retry).
     chmod a+w bin/roachtest
   fi
   # Build cockroach-short with assertions enabled.
-  bazel build --config $platform --config ci //pkg/cmd/cockroach-short --crdb_test
+  bazel build --config $platform --config ci -c opt //pkg/cmd/cockroach-short --crdb_test
   # Copy the binaries.
   cp $BAZEL_BIN/pkg/cmd/cockroach/cockroach_/cockroach bin/cockroach.$os-$arch
   cp $BAZEL_BIN/pkg/cmd/workload/workload_/workload    bin/workload.$os-$arch


### PR DESCRIPTION
This is a partial revert of `60e8bcec61269c6648dc40c8094fbf303b8a02aa`.

In that commit I made a change to make un-stripped binaries the default by making `dbg` the default `--compilation_mode`. This had unexpected consequences as this actually disables inlining and optimization, thereby breaking some tests, and overall it is surprising that a Go binary built by Bazel would be un-optimized by default since this is the opposite of `go build`'s default behavior.

Instead, we make `fastbuild` the default (again), and to solve the problem of binaries being unstripped we set `--strip never` for `dev` builds. (`dev doctor` makes you clarify that your build is a `dev` build on setup so no one can miss this.)

Now we have the following behavior for each `compilation_mode`:

* `dbg`: disable optimizations and inlining.
* `fastbuild` and `opt`: will produce the same binary, except `fastbuild` defaults to stripping in non-`dev` configurations.

If you want an un-optimized binary for some reason, it still works to build with `-c dbg`.

Epic: CRDB-17171
Release note: None