### PR TITLE
jobs: enable downloading execution detail files

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/jobProfilerApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/jobProfilerApi.ts
@@ -16,12 +16,29 @@ export type ListJobProfilerExecutionDetailsRequest =
 export type ListJobProfilerExecutionDetailsResponse =
   cockroach.server.serverpb.ListJobProfilerExecutionDetailsResponse;
 
-export const getExecutionDetails = (
+export type GetJobProfilerExecutionDetailRequest =
+  cockroach.server.serverpb.GetJobProfilerExecutionDetailRequest;
+export type GetJobProfilerExecutionDetailResponse =
+  cockroach.server.serverpb.GetJobProfilerExecutionDetailResponse;
+
+export const listExecutionDetailFiles = (
   req: ListJobProfilerExecutionDetailsRequest,
 ): Promise<cockroach.server.serverpb.ListJobProfilerExecutionDetailsResponse> => {
   return fetchData(
     cockroach.server.serverpb.ListJobProfilerExecutionDetailsResponse,
     `/_status/list_job_profiler_execution_details/${req.job_id}`,
+    null,
+    null,
+    "30M",
+  );
+};
+
+export const getExecutionDetailFile = (
+  req: GetJobProfilerExecutionDetailRequest,
+): Promise<cockroach.server.serverpb.GetJobProfilerExecutionDetailResponse> => {
+  return fetchData(
+    cockroach.server.serverpb.GetJobProfilerExecutionDetailResponse,
+    `/_status/job_profiler_execution_details/${req.job_id}/${req.filename}`,
     null,
     null,
     "30M",

--- a/pkg/ui/workspaces/cluster-ui/src/downloadFile/downloadFile.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/downloadFile/downloadFile.tsx
@@ -15,16 +15,13 @@ import React, {
   useImperativeHandle,
 } from "react";
 
-type FileTypes = "text/plain" | "application/json";
-
 export interface DownloadAsFileProps {
   fileName?: string;
-  fileType?: FileTypes;
-  content?: string;
+  content?: Blob;
 }
 
 export interface DownloadFileRef {
-  download: (name: string, type: FileTypes, body: string) => void;
+  download: (name: string, body: Blob) => void;
 }
 
 /*
@@ -58,13 +55,12 @@ export interface DownloadFileRef {
 // tslint:disable-next-line:variable-name
 export const DownloadFile = forwardRef<DownloadFileRef, DownloadAsFileProps>(
   (props, ref) => {
-    const { children, fileName, fileType, content } = props;
+    const { children, fileName, content } = props;
     const anchorRef = useRef<HTMLAnchorElement>();
 
-    const bootstrapFile = (name: string, type: FileTypes, body: string) => {
+    const bootstrapFile = (name: string, body: Blob) => {
       const anchorElement = anchorRef.current;
-      const file = new Blob([body], { type });
-      anchorElement.href = URL.createObjectURL(file);
+      anchorElement.href = URL.createObjectURL(body);
       anchorElement.download = name;
     };
 
@@ -72,12 +68,12 @@ export const DownloadFile = forwardRef<DownloadFileRef, DownloadAsFileProps>(
       if (content === undefined) {
         return;
       }
-      bootstrapFile(fileName, fileType, content);
-    }, [fileName, fileType, content]);
+      bootstrapFile(fileName, content);
+    }, [fileName, content]);
 
     useImperativeHandle(ref, () => ({
-      download: (name: string, type: FileTypes, body: string) => {
-        bootstrapFile(name, type, body);
+      download: (name: string, body: Blob) => {
+        bootstrapFile(name, body);
         anchorRef.current.click();
       },
     }));

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -40,6 +40,8 @@ import jobStyles from "src/jobs/jobs.module.scss";
 import classNames from "classnames/bind";
 import { Timestamp } from "../../timestamp";
 import {
+  GetJobProfilerExecutionDetailRequest,
+  GetJobProfilerExecutionDetailResponse,
   ListJobProfilerExecutionDetailsRequest,
   ListJobProfilerExecutionDetailsResponse,
   RequestState,
@@ -60,14 +62,17 @@ enum TabKeysEnum {
 
 export interface JobDetailsStateProps {
   jobRequest: RequestState<JobResponse>;
-  jobProfilerResponse: RequestState<ListJobProfilerExecutionDetailsResponse>;
+  jobProfilerExecutionDetailFilesResponse: RequestState<ListJobProfilerExecutionDetailsResponse>;
   jobProfilerLastUpdated: moment.Moment;
   jobProfilerDataIsValid: boolean;
+  onDownloadExecutionFileClicked: (
+    req: GetJobProfilerExecutionDetailRequest,
+  ) => Promise<GetJobProfilerExecutionDetailResponse>;
 }
 
 export interface JobDetailsDispatchProps {
   refreshJob: (req: JobRequest) => void;
-  refreshExecutionDetails: (
+  refreshExecutionDetailFiles: (
     req: ListJobProfilerExecutionDetailsRequest,
   ) => void;
 }
@@ -130,10 +135,15 @@ export class JobDetails extends React.Component<
     return (
       <JobProfilerView
         jobID={id}
-        executionDetailsResponse={this.props.jobProfilerResponse}
-        refreshExecutionDetails={this.props.refreshExecutionDetails}
+        executionDetailFilesResponse={
+          this.props.jobProfilerExecutionDetailFilesResponse
+        }
+        refreshExecutionDetailFiles={this.props.refreshExecutionDetailFiles}
         lastUpdated={this.props.jobProfilerLastUpdated}
         isDataValid={this.props.jobProfilerDataIsValid}
+        onDownloadExecutionFileClicked={
+          this.props.onDownloadExecutionFileClicked
+        }
       />
     );
   };

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
@@ -23,6 +23,7 @@ import { selectID } from "../../selectors";
 import {
   ListJobProfilerExecutionDetailsRequest,
   createInitialState,
+  getExecutionDetailFile,
 } from "src/api";
 import {
   initialState,
@@ -39,15 +40,17 @@ const mapStateToProps = (
   const jobID = selectID(state, props);
   return {
     jobRequest: state.adminUI?.job?.cachedData[jobID] ?? emptyState,
-    jobProfilerResponse: state.adminUI?.executionDetails ?? initialState,
-    jobProfilerLastUpdated: state.adminUI?.executionDetails?.lastUpdated,
-    jobProfilerDataIsValid: state.adminUI?.executionDetails?.valid,
+    jobProfilerExecutionDetailFilesResponse:
+      state.adminUI?.executionDetailFiles ?? initialState,
+    jobProfilerLastUpdated: state.adminUI?.executionDetailFiles?.lastUpdated,
+    jobProfilerDataIsValid: state.adminUI?.executionDetailFiles?.valid,
+    onDownloadExecutionFileClicked: getExecutionDetailFile,
   };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch): JobDetailsDispatchProps => ({
   refreshJob: (req: JobRequest) => jobActions.refresh(req),
-  refreshExecutionDetails: (req: ListJobProfilerExecutionDetailsRequest) =>
+  refreshExecutionDetailFiles: (req: ListJobProfilerExecutionDetailsRequest) =>
     dispatch(jobProfilerActions.refresh(req)),
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
@@ -1,5 +1,26 @@
 @import "src/core/index.module";
 
+.crl-job-profiler-view {
+    &__actions-column {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        justify-content: flex-end;
+    }
+}
+
+.column-size-medium {
+    width: 230px;
+}
+
+.download-execution-detail-button {
+    white-space: nowrap;
+
+    >svg {
+        margin-right: $spacing-x-small;
+    }
+}
+
 .sorted-table {
     width: 100%;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.reducer.ts
@@ -17,7 +17,7 @@ import {
   ListJobProfilerExecutionDetailsResponse,
 } from "src/api";
 
-export type JobProfilerState =
+export type JobProfilerExecutionDetailFilesState =
   RequestState<ListJobProfilerExecutionDetailsResponse>;
 
 export const initialState =

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.sagas.ts
@@ -13,7 +13,7 @@ import { actions } from "./jobProfiler.reducer";
 import { call, put, all, takeEvery } from "redux-saga/effects";
 import {
   ListJobProfilerExecutionDetailsRequest,
-  getExecutionDetails,
+  listExecutionDetailFiles,
 } from "src/api";
 
 export function* refreshJobProfilerSaga(
@@ -26,7 +26,7 @@ export function* requestJobProfilerSaga(
   action: PayloadAction<ListJobProfilerExecutionDetailsRequest>,
 ): any {
   try {
-    const result = yield call(getExecutionDetails, action.payload);
+    const result = yield call(listExecutionDetailFiles, action.payload);
     yield put(actions.received(result));
   } catch (e) {
     yield put(actions.failed(e));

--- a/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
@@ -77,8 +77,8 @@ import {
   reducer as tableDetails,
 } from "./databaseTableDetails/tableDetails.reducer";
 import {
-  JobProfilerState,
-  reducer as executionDetails,
+  JobProfilerExecutionDetailFilesState,
+  reducer as executionDetailFiles,
 } from "./jobs/jobProfiler.reducer";
 
 export type AdminUiState = {
@@ -95,7 +95,7 @@ export type AdminUiState = {
   indexStats: IndexStatsReducerState;
   jobs: JobsState;
   job: JobDetailsReducerState;
-  executionDetails: JobProfilerState;
+  executionDetailFiles: JobProfilerExecutionDetailFilesState;
   clusterLocks: ClusterLocksReqState;
   databasesList: DatabasesListState;
   databaseDetails: KeyedDatabaseDetailsState;
@@ -129,7 +129,7 @@ export const reducers = combineReducers<AdminUiState>({
   indexStats,
   jobs,
   job,
-  executionDetails,
+  executionDetailFiles,
   clusterLocks,
   databasesList,
   databaseDetails,

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -220,13 +220,13 @@ export const jobProfilerRequestKey = (
 ): string => `${req.job_id}`;
 
 const jobProfilerReducerObj = new KeyedCachedDataReducer(
-  api.getExecutionDetails,
+  api.listExecutionDetailFiles,
   "jobProfiler",
   jobProfilerRequestKey,
   null,
   moment.duration(10, "m"),
 );
-export const refreshExecutionDetails = jobProfilerReducerObj.refresh;
+export const refreshListExecutionDetailFiles = jobProfilerReducerObj.refresh;
 
 export const queryToID = (req: api.QueryPlanRequestMessage): string =>
   req.query;

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -476,7 +476,7 @@ export function getJob(
   );
 }
 
-export function getExecutionDetails(
+export function listExecutionDetailFiles(
   req: ListJobProfilerExecutionDetailsRequestMessage,
   timeout?: moment.Duration,
 ): Promise<ListJobProfilerExecutionDetailsResponseMessage> {

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
@@ -16,19 +16,19 @@ import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import {
   createSelectorForKeyedCachedDataField,
-  refreshExecutionDetails,
+  refreshListExecutionDetailFiles,
   refreshJob,
 } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { ListJobProfilerExecutionDetailsResponseMessage } from "src/util/api";
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 
 const selectJob = createSelectorForKeyedCachedDataField("job", selectID);
-const selectExecutionDetails =
+const selectExecutionDetailFiles =
   createSelectorForKeyedCachedDataField<ListJobProfilerExecutionDetailsResponseMessage>(
     "jobProfiler",
     selectID,
   );
-
 const mapStateToProps = (
   state: AdminUIState,
   props: RouteComponentProps,
@@ -36,15 +36,19 @@ const mapStateToProps = (
   const jobID = selectID(state, props);
   return {
     jobRequest: selectJob(state, props),
-    jobProfilerResponse: selectExecutionDetails(state, props),
+    jobProfilerExecutionDetailFilesResponse: selectExecutionDetailFiles(
+      state,
+      props,
+    ),
     jobProfilerLastUpdated: state.cachedData.jobProfiler[jobID]?.setAt,
     jobProfilerDataIsValid: state.cachedData.jobProfiler[jobID]?.valid,
+    onDownloadExecutionFileClicked: clusterUiApi.getExecutionDetailFile,
   };
 };
 
 const mapDispatchToProps = {
   refreshJob,
-  refreshExecutionDetails,
+  refreshExecutionDetailFiles: refreshListExecutionDetailFiles,
 };
 
 export default withRouter(


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/106879 we added a table to the `Advanced Debugging`
tab of the job details page. This table lists out all
the execution detail files that are available for the
given job.

This change is a follow up to add download functionality
to each row in the table. The format of the downloaded
file is determined by the prefix of the filename.

A final change to allow users to generate execution details
will be added in the next follow up.

Informs: https://github.com/cockroachdb/cockroach/issues/105076
Release note: None