### PR TITLE
ui-e2e-tests: steps to enable cypress tests

### DIFF
--- a/pkg/ui/workspaces/e2e-tests/Dockerfile.cypress
+++ b/pkg/ui/workspaces/e2e-tests/Dockerfile.cypress
@@ -1,0 +1,3 @@
+FROM cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+RUN curl -fsSL https://get.pnpm.io/install.sh | env SHELL=bash PNPM_HOME=/usr/local/bin PNPM_VERSION=8.5.1 sh -
+RUN pnpm --version

--- a/pkg/ui/workspaces/e2e-tests/build/compose-entrypoint.sh
+++ b/pkg/ui/workspaces/e2e-tests/build/compose-entrypoint.sh
@@ -3,16 +3,16 @@ set -uemo pipefail
 
 set -x
 
-# Copy the /e2e tree into /scratch and remove any existing node_modules, to
+# Copy the /ui tree into /scratch and remove any existing node_modules, to
 # prevent files with unexpected owners from escaping
 mkdir /scratch
-cp --recursive --no-target-directory --no-preserve=owner /e2e /scratch
+cp --recursive --no-target-directory --no-preserve=owner /ui /scratch
 cd /scratch
 
 # Remove and reinstall any node_modules that may have been copied, since they're
 # potentially specific to the host platform.
 rm -rf node_modules/
-pnpm install --filter . --force --frozen-lockfile
+pnpm install --filter workspaces/e2e-tests --force --frozen-lockfile
 
 # Run tests, passing extra CLI arguments through to Cypress
-pnpm run cy:run "$@"
+pnpm run -C ./workspaces/e2e-tests cy:run "$@"

--- a/pkg/ui/workspaces/e2e-tests/compose.yaml
+++ b/pkg/ui/workspaces/e2e-tests/compose.yaml
@@ -18,9 +18,12 @@ services:
       COCKROACH_DATABASE: movr
 
   cypress:
-    image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
-    working_dir: /e2e
-    entrypoint: ./build/compose-entrypoint.sh
+    build:
+      context: .
+      dockerfile: Dockerfile.cypress
+    image: crdb_ci-cypress_20230719
+    working_dir: /ui
+    entrypoint: ./workspaces/e2e-tests/build/compose-entrypoint.sh
     environment:
       IS_DOCKER: "1"
     depends_on:
@@ -29,7 +32,7 @@ services:
     networks:
       - db
     volumes:
-      - ./:/e2e
+      - ../../:/ui
       - ./artifacts:/artifacts
 
 networks:


### PR DESCRIPTION
This doesn't get the job fully working yet, but it's an improvement.

Epic: none
Part of https://github.com/cockroachdb/cockroach/issues/106584
Release note: None