### PR TITLE
sql: disallow schema changes for READ COMMITTED transactions

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1417,6 +1417,13 @@ func TestTenantLogic_raise(
 	runLogicTest(t, "raise")
 }
 
+func TestTenantLogic_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "read_committed")
+}
+
 func TestTenantLogic_reassign_owned_by(
 	t *testing.T,
 ) {
@@ -1632,13 +1639,6 @@ func TestTenantLogic_select_for_update(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "select_for_update")
-}
-
-func TestTenantLogic_select_for_update_read_committed(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "select_for_update_read_committed")
 }
 
 func TestTenantLogic_select_index(

--- a/pkg/sql/logictest/testdata/logic_test/read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/read_committed
@@ -1,5 +1,7 @@
 # LogicTest: !local-mixed-22.2-23.1
 
+subtest select_for_update
+
 # SELECT FOR UPDATE is prohibited under weaker isolation levels until we improve
 # locking. See #57031, #75457, #100144.
 
@@ -89,20 +91,25 @@ statement ok
 ROLLBACK
 
 statement ok
-SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
-
-# Creating a UDF using SELECT FOR UPDATE should succeed under read committed.
-statement ok
 CREATE FUNCTION wrangle (name STRING) RETURNS INT LANGUAGE SQL AS $$
   SELECT aisle FROM supermarket WHERE person = name FOR UPDATE
 $$
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
 
 # But calling that function should fail.
 query error pgcode 0A000 cannot execute SELECT FOR UPDATE statements under ReadCommitted isolation
 INSERT INTO supermarket (person, aisle) VALUES ('grandma', wrangle('matilda'))
 
 statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE
+
+statement ok
 DROP FUNCTION wrangle
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
 
 # Preparing a SELECT FOR UPDATE should succeed under read committed.
 statement ok
@@ -137,6 +144,93 @@ SELECT aisle
   FROM supermarket@{FORCE_ZIGZAG}
   WHERE starts_with = 'm' AND ends_with = 'lda'
   FOR UPDATE
+
+subtest end
+
+subtest schema_changes
+
+# Schema changes are prohibited under weaker isolation levels.
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+ALTER TABLE supermarket ADD COLUMN age INT
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+CREATE TABLE foo(a INT)
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+DROP TABLE supermarket
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+CREATE USER foo
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+DROP USER testuser
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+GRANT admin TO testuser
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+GRANT SELECT ON supermarket TO testuser
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+GRANT USAGE ON SCHEMA public TO testuser
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+GRANT CONNECT ON DATABASE postgres TO testuser
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+CREATE INDEX foo ON supermarket(ends_with, starts_with)
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+CREATE FUNCTION f (x INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT x+1
+$$
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+CREATE FUNCTION f (x INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT x+1
+$$;
+COMMIT
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+ALTER FUNCTION f (x INT) RENAME TO g
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+GRANT EXECUTE ON FUNCTION f (x INT) TO testuser
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+CREATE TYPE typ AS ENUM('a', 'b')
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+CREATE TYPE typ AS ENUM('a', 'b');
+COMMIT
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+ALTER TYPE typ ADD VALUE 'c'
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+GRANT USAGE ON TYPE typ TO testuser
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+CREATE DATABASE foo
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+ALTER DATABASE postgres RENAME TO foo
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+CREATE SCHEMA s
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+CREATE SCHEMA s;
+COMMIT
+
+statement error transaction involving a schema change needs to be SERIALIZABLE
+ALTER SCHEMA s RENAME TO foo
+
+subtest end
 
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1395,6 +1395,13 @@ func TestLogic_raise(
 	runLogicTest(t, "raise")
 }
 
+func TestLogic_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "read_committed")
+}
+
 func TestLogic_reassign_owned_by(
 	t *testing.T,
 ) {
@@ -1610,13 +1617,6 @@ func TestLogic_select_for_update(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "select_for_update")
-}
-
-func TestLogic_select_for_update_read_committed(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "select_for_update_read_committed")
 }
 
 func TestLogic_select_index(

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1395,6 +1395,13 @@ func TestLogic_raise(
 	runLogicTest(t, "raise")
 }
 
+func TestLogic_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "read_committed")
+}
+
 func TestLogic_reassign_owned_by(
 	t *testing.T,
 ) {
@@ -1610,13 +1617,6 @@ func TestLogic_select_for_update(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "select_for_update")
-}
-
-func TestLogic_select_for_update_read_committed(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "select_for_update_read_committed")
 }
 
 func TestLogic_select_index(

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1409,6 +1409,13 @@ func TestLogic_raise(
 	runLogicTest(t, "raise")
 }
 
+func TestLogic_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "read_committed")
+}
+
 func TestLogic_reassign_owned_by(
 	t *testing.T,
 ) {
@@ -1624,13 +1631,6 @@ func TestLogic_select_for_update(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "select_for_update")
-}
-
-func TestLogic_select_for_update_read_committed(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "select_for_update_read_committed")
 }
 
 func TestLogic_select_index(

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1381,6 +1381,13 @@ func TestLogic_raise(
 	runLogicTest(t, "raise")
 }
 
+func TestLogic_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "read_committed")
+}
+
 func TestLogic_reassign_owned_by(
 	t *testing.T,
 ) {
@@ -1596,13 +1603,6 @@ func TestLogic_select_for_update(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "select_for_update")
-}
-
-func TestLogic_select_for_update_read_committed(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "select_for_update_read_committed")
 }
 
 func TestLogic_select_index(

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1409,6 +1409,13 @@ func TestLogic_raise(
 	runLogicTest(t, "raise")
 }
 
+func TestLogic_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "read_committed")
+}
+
 func TestLogic_reassign_owned_by(
 	t *testing.T,
 ) {
@@ -1624,13 +1631,6 @@ func TestLogic_select_for_update(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "select_for_update")
-}
-
-func TestLogic_select_for_update_read_committed(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "select_for_update_read_committed")
 }
 
 func TestLogic_select_index(

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1549,6 +1549,13 @@ func TestLogic_rand_ident(
 	runLogicTest(t, "rand_ident")
 }
 
+func TestLogic_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "read_committed")
+}
+
 func TestLogic_reassign_owned_by(
 	t *testing.T,
 ) {
@@ -1771,13 +1778,6 @@ func TestLogic_select_for_update(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "select_for_update")
-}
-
-func TestLogic_select_for_update_read_committed(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "select_for_update_read_committed")
 }
 
 func TestLogic_select_index(

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -168,6 +168,11 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	var err error
 
 	if opt.IsDDLOp(e) {
+		if b.evalCtx.Txn.IsoLevel().ToleratesWriteSkew() {
+			return execPlan{}, pgerror.Newf(
+				pgcode.FeatureNotSupported, "transaction involving a schema change needs to be SERIALIZABLE",
+			)
+		}
 		// Mark the statement as containing DDL for use
 		// in the SQL executor.
 		b.IsDDL = true

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6818,7 +6818,7 @@ set_exprs_internal:
      It cannot be used by clients. */
   SET ROW '(' expr_list ')'
   {
-    $$.val = &tree.SetVar{Values: $4.exprs()}
+    $$.val = &tree.SetVar{Values: $4.exprs(), SetRow: true}
   }
 
 // %Help: SET SESSION - change a session variable

--- a/pkg/sql/parser/testdata/set
+++ b/pkg/sql/parser/testdata/set
@@ -626,3 +626,11 @@ SET LOCAL tracing = 'off'
 SET LOCAL tracing = ('off') -- fully parenthesized
 SET LOCAL tracing = '_' -- literals removed
 SET LOCAL tracing = 'off' -- identifiers removed
+
+parse
+SET "" = 'a'
+----
+SET "" = 'a'
+SET "" = ('a') -- fully parenthesized
+SET "" = '_' -- literals removed
+SET "" = 'a' -- identifiers removed

--- a/pkg/sql/sem/tree/set.go
+++ b/pkg/sql/sem/tree/set.go
@@ -26,6 +26,7 @@ type SetVar struct {
 	Values   Exprs
 	Reset    bool
 	ResetAll bool
+	SetRow   bool
 }
 
 // Format implements the NodeFormatter interface.
@@ -47,7 +48,7 @@ func (node *SetVar) Format(ctx *FmtCtx) {
 	if node.Local {
 		ctx.WriteString("LOCAL ")
 	}
-	if node.Name == "" {
+	if node.SetRow {
 		ctx.WriteString("ROW (")
 		ctx.FormatNode(&node.Values)
 		ctx.WriteString(")")

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -554,7 +554,7 @@ func (*AlterSequence) StatementType() StatementType { return TypeDDL }
 func (*AlterSequence) StatementTag() string { return "ALTER SEQUENCE" }
 
 // StatementReturnType implements the Statement interface.
-func (*AlterRole) StatementReturnType() StatementReturnType { return Ack }
+func (*AlterRole) StatementReturnType() StatementReturnType { return DDL }
 
 // StatementType implements the Statement interface.
 func (*AlterRole) StatementType() StatementType { return TypeDCL }
@@ -565,7 +565,7 @@ func (*AlterRole) StatementTag() string { return "ALTER ROLE" }
 func (*AlterRole) hiddenFromShowQueries() {}
 
 // StatementReturnType implements the Statement interface.
-func (*AlterRoleSet) StatementReturnType() StatementReturnType { return Ack }
+func (*AlterRoleSet) StatementReturnType() StatementReturnType { return DDL }
 
 // StatementType implements the Statement interface.
 func (*AlterRoleSet) StatementType() StatementType { return TypeDCL }
@@ -932,7 +932,7 @@ func (*CreateType) StatementTag() string { return "CREATE TYPE" }
 func (*CreateType) modifiesSchema() bool { return true }
 
 // StatementReturnType implements the Statement interface.
-func (*CreateRole) StatementReturnType() StatementReturnType { return Ack }
+func (*CreateRole) StatementReturnType() StatementReturnType { return DDL }
 
 // StatementType implements the Statement interface.
 func (*CreateRole) StatementType() StatementType { return TypeDCL }
@@ -1063,7 +1063,7 @@ func (*DropSequence) StatementType() StatementType { return TypeDDL }
 func (*DropSequence) StatementTag() string { return "DROP SEQUENCE" }
 
 // StatementReturnType implements the Statement interface.
-func (*DropRole) StatementReturnType() StatementReturnType { return Ack }
+func (*DropRole) StatementReturnType() StatementReturnType { return DDL }
 
 // StatementType implements the Statement interface.
 func (*DropRole) StatementType() StatementType { return TypeDCL }

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -106,7 +106,6 @@ func (p *planner) createNonDropDatabaseChangeJob(
 func (p *planner) createOrUpdateSchemaChangeJob(
 	ctx context.Context, tableDesc *tabledesc.Mutable, jobDesc string, mutationID descpb.MutationID,
 ) error {
-
 	// If there is a concurrent schema change using the declarative schema
 	// changer, then we must fail and wait for that schema change to conclude.
 	// The error here will be dealt with in


### PR DESCRIPTION
Due to how descriptor leasing works, schema changes are not safe in weaker isolation transactions. Until they are safe, we disallow them.

fixes https://github.com/cockroachdb/cockroach/issues/100143
Release note: None