### PR TITLE
release-23.1: sql: fix `CREATE TABLE AS` sourcing `SHOW <show_subcmd> <table>` job failures

### DIFF
--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -137,9 +137,6 @@ func TestCreateAsShow(t *testing.T) {
 		{
 			sql:   "SHOW CREATE TABLE show_create_tbl",
 			setup: "CREATE TABLE show_create_tbl (id int PRIMARY KEY)",
-			// TODO(sql-foundations): Fix `relation "show_create_tbl" does not exist` error in job.
-			//  See https://github.com/cockroachdb/cockroach/issues/106260.
-			skip: true,
 		},
 		{
 			sql:   "SHOW CREATE FUNCTION show_create_fn",
@@ -157,23 +154,14 @@ func TestCreateAsShow(t *testing.T) {
 		{
 			sql:   "SHOW INDEXES FROM show_indexes_tbl",
 			setup: "CREATE TABLE show_indexes_tbl (id int PRIMARY KEY)",
-			// TODO(sql-foundations): Fix `relation "show_indexes_tbl" does not exist` error in job.
-			//  See https://github.com/cockroachdb/cockroach/issues/106260.
-			skip: true,
 		},
 		{
 			sql:   "SHOW COLUMNS FROM show_columns_tbl",
 			setup: "CREATE TABLE show_columns_tbl (id int PRIMARY KEY)",
-			// TODO(sql-foundations): Fix `relation "show_columns_tbl" does not exist` error in job.
-			//  See https://github.com/cockroachdb/cockroach/issues/106260.
-			skip: true,
 		},
 		{
 			sql:   "SHOW CONSTRAINTS FROM show_constraints_tbl",
 			setup: "CREATE TABLE show_constraints_tbl (id int PRIMARY KEY)",
-			// TODO(sql-foundations): Fix `relation "show_constraints_tbl" does not exist` error in job.
-			//  See https://github.com/cockroachdb/cockroach/issues/106260.
-			skip: true,
 		},
 		{
 			sql: "SHOW PARTITIONS FROM DATABASE defaultdb",
@@ -181,16 +169,10 @@ func TestCreateAsShow(t *testing.T) {
 		{
 			sql:   "SHOW PARTITIONS FROM TABLE show_partitions_tbl",
 			setup: "CREATE TABLE show_partitions_tbl (id int PRIMARY KEY)",
-			// TODO(sql-foundations): Fix `relation "show_partitions_tbl" does not exist` error in job.
-			//  See https://github.com/cockroachdb/cockroach/issues/106260.
-			skip: true,
 		},
 		{
 			sql:   "SHOW PARTITIONS FROM INDEX show_partitions_idx_tbl@show_partitions_idx_tbl_pkey",
 			setup: "CREATE TABLE show_partitions_idx_tbl (id int PRIMARY KEY)",
-			// TODO(sql-foundations): Fix `relation "show_partitions_idx_tbl" does not exist` error in job.
-			//  See https://github.com/cockroachdb/cockroach/issues/106260.
-			skip: true,
 		},
 		{
 			sql: "SHOW GRANTS",

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/errors"
@@ -296,18 +295,11 @@ func (d *delegator) delegateShowCreateAllTables() (tree.Statement, error) {
 func (d *delegator) showTableDetails(
 	name *tree.UnresolvedObjectName, query string,
 ) (tree.Statement, error) {
-	// We avoid the cache so that we can observe the details without
-	// taking a lease, like other SHOW commands.
-	flags := cat.Flags{AvoidDescriptorCaches: true, NoTableStats: true}
-	tn := name.ToTableName()
-	dataSource, resName, err := d.catalog.ResolveDataSource(d.ctx, flags, &tn)
+
+	dataSource, resName, err := d.resolveAndModifyUnresolvedObjectName(name)
 	if err != nil {
 		return nil, err
 	}
-	if err := d.catalog.CheckAnyPrivilege(d.ctx, dataSource); err != nil {
-		return nil, err
-	}
-
 	fullQuery := fmt.Sprintf(query,
 		lexbase.EscapeSQLString(resName.Catalog()),
 		lexbase.EscapeSQLString(resName.Table()),

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -418,7 +418,13 @@ func (b *Builder) buildStmt(
 	default:
 		// See if this statement can be rewritten to another statement using the
 		// delegate functionality.
-		newStmt, err := delegate.TryDelegate(b.ctx, b.catalog, b.evalCtx, stmt)
+		newStmt, err := delegate.TryDelegate(
+			b.ctx,
+			b.catalog,
+			b.evalCtx,
+			stmt,
+			b.qualifyDataSourceNamesInAST,
+		)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #107099.

/cc @cockroachdb/release

---

Fixes #106260

Previously `CREATE TABLE AS`/`CREATE MATERIALIZED VIEW AS` sourcing from `SHOW <show_subcmd> <table>` generated a failing schema change job with a `relation "tbl" does not exist error` because the SHOW source table was not fully qualified.

This PR fixes this by respecting the `Builder.qualifyDataSourceNamesInAST` flag in `delegate.TryDelegate()` which implements the failing SHOW commands.

Release note (bug fix): Fix failing schema change job when CREATE TABLE AS or CREATE MATERAILIZED VIEW AS sources from a SHOW command:
1. CREATE TABLE t AS SELECT * FROM [SHOW CREATE TABLE tbl];
2. CREATE TABLE t AS SELECT * FROM [SHOW INDEXES FROM tbl];
3. CREATE TABLE t AS SELECT * FROM [SHOW COLUMNS FROM tbl];
4. CREATE TABLE t AS SELECT * FROM [SHOW CONSTRAINTS FROM tbl];
5. CREATE TABLE t AS SELECT * FROM [SHOW PARTITIONS FROM TABLE tbl];
6. CREATE TABLE t AS SELECT * FROM [SHOW PARTITIONS FROM INDEX tbl@tbl_pkey];

Release justification: Fix broken CTAS/CMVAS statements.