### PR TITLE
sql: fix SHOW GRANTS when schema is offline

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -624,3 +624,48 @@ SELECT owner FROM [SHOW TABLES] WHERE table_name = 'testtable_greeting_owner';
 testuser
 
 subtest end
+
+subtest show-grants-during-restore
+
+# Ensure that SHOW GRANTS works during a restore.
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_flow';
+----
+
+restore expect-pausepoint tag=restore_bar
+RESTORE DATABASE testdb FROM LATEST IN 'nodelocal://1/test/' WITH new_db_name=bar;
+----
+job paused at pausepoint
+
+# Ensure that SHOW GRANTS works during a restore.
+# https://github.com/cockroachdb/cockroach/issues/106370 was a bug where
+# this would fail with `schema "public" is offline: restoring`.
+query-sql
+SELECT * FROM [SHOW GRANTS] WHERE relation_name = 'testtable_simple';
+----
+testdb public testtable_simple admin ALL true
+testdb public testtable_simple root ALL true
+testdb public testtable_simple testuser ALL true
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = ''
+----
+
+job resume=restore_bar
+----
+
+job tag=restore_bar wait-for-state=succeeded
+----
+
+exec-sql
+USE bar;
+----
+
+query-sql
+SELECT * FROM [SHOW GRANTS] WHERE relation_name = 'testtable_simple';
+----
+bar public testtable_simple admin ALL true
+bar public testtable_simple root ALL true
+
+subtest end

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1683,7 +1683,7 @@ var informationSchemaRoleRoutineGrantsTable = virtualSchemaTable{
 			}
 
 			err := db.ForEachSchema(func(id descpb.ID, name string) error {
-				sc, err := p.Descriptors().ByIDWithLeased(p.txn).WithoutNonPublic().Get().Schema(ctx, id)
+				sc, err := p.Descriptors().ByIDWithLeased(p.txn).Get().Schema(ctx, id)
 				if err != nil {
 					return err
 				}
@@ -1691,6 +1691,13 @@ var informationSchemaRoleRoutineGrantsTable = virtualSchemaTable{
 					fn, err := p.Descriptors().MutableByID(p.txn).Function(ctx, sig.ID)
 					if err != nil {
 						return err
+					}
+					canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, fn, db, false /* allowAdding */)
+					if err != nil {
+						return err
+					}
+					if !canSeeDescriptor {
+						return nil
 					}
 					privs := fn.GetPrivileges()
 					scNameStr := tree.NewDString(sc.GetName())


### PR DESCRIPTION
This issue also affected any usage of the information_schema.role_routine_grants table,
but that is probably too low-level to include in the release note.

fixes https://github.com/cockroachdb/cockroach/issues/106370
Release note (bug fix): Fixed a bug where SHOW GRANTS could fail if any objects were offline, which can happen during a RESTORE.