### PR TITLE
server: fix recently introduced bug

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -868,7 +868,7 @@ func (t *TestTenant) Tracer() *tracing.Tracer {
 
 // TracerI is part of the serverutils.TestTenantInterface.
 func (t *TestTenant) TracerI() interface{} {
-	return t.Tracer
+	return t.Tracer()
 }
 
 // SettingsWatcher is part of the serverutils.TestTenantInterface.


### PR DESCRIPTION
Over in 609230c7122fe5935a6faa3a900abe8975062ed2 on `TestTenant.TracerI` we returned the function rather than the underlying tracer.

Epic: None

Release note: None