### PR TITLE
release-22.2: sql: fix panic in SHOW GRANTS ON SCHEMA

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -195,3 +195,12 @@ test           sc102962     root     ALL             true
 
 statement error pgcode 2BP01 pq: cannot drop role/user r102962: grants still exist on test.sc102962
 DROP ROLE r102962
+
+subtest end
+
+subtest regression_97547
+
+statement error database \"db_97547\" does not exist
+SHOW GRANTS ON SCHEMA db_97547.* FOR testuser
+
+subtest end

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -118,7 +118,7 @@ func (p *planner) GetSchemasForDB(
 	ctx context.Context, dbName string,
 ) (map[descpb.ID]string, error) {
 	dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(ctx, p.txn, dbName,
-		tree.DatabaseLookupFlags{AvoidLeased: true})
+		tree.DatabaseLookupFlags{AvoidLeased: true, Required: true})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/97547

Release justification: bug fix
Release note (bug fix): Fixed a crash that could occur if SHOW GRANTS ON SCHEMA referenced a non-existent database name.