### PR TITLE
sql: TestRandomSyntaxFunctions fix flakes

### DIFF
--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -3314,7 +3314,7 @@ func makeSpanStatsGenerator(
 	spans := make([]roachpb.Span, 0, argSpans.Len())
 	for _, span := range argSpans.Array {
 		s := tree.MustBeDTuple(span)
-		if s.D[0] == tree.DNull || s.D[1] == tree.DNull {
+		if len(s.D) != 2 || s.D[0] == tree.DNull || s.D[1] == tree.DNull {
 			continue
 		}
 		startKey := roachpb.Key(tree.MustBeDBytes(s.D[0]))

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -352,7 +352,8 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 					continue
 				case "crdb_internal.reset_sql_stats",
 					"crdb_internal.check_consistency",
-					"crdb_internal.request_statement_bundle":
+					"crdb_internal.request_statement_bundle",
+					"crdb_internal.reset_activity_tables":
 					// Skipped due to long execution time.
 					continue
 				}
@@ -414,7 +415,11 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 			limit = " LIMIT 100"
 		}
 		s := fmt.Sprintf("SELECT %s(%s) %s", nb.name, strings.Join(args, ", "), limit)
-		return db.exec(t, ctx, s)
+		// Use a re-settable timeout since in concurrent scenario some operations may
+		// involve schema changes like truncates. In general this should make
+		// this test more resilient as the timeouts are reset as long progress
+		// is made on *some* connection.
+		return db.execWithResettableTimeout(t, ctx, s, *flagRSGExecTimeout, *flagRSGGoRoutines)
 	})
 }
 


### PR DESCRIPTION
Previously, this test could flake due to the following:

1. The timeout is used for specific functions, so moving to a resettable timeout is beneficial, which allows these to be extended as long as connections make progress
2. Panics inside crdb_internal.tenant_span_stats due to nil pointer dereferences.

Fixes: #99182
Fixes: https://github.com/cockroachdb/cockroach/issues/107237