### PR TITLE
upgrade/upgrades: skip TestJSONForwardingIndexes

### DIFF
--- a/pkg/upgrade/upgrades/json_forward_indexes_test.go
+++ b/pkg/upgrade/upgrades/json_forward_indexes_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestJSONForwardingIndexes(t *testing.T) {
+	skip.WithIssue(t, 107169, "flaky test")
 	var err error
 	skip.UnderStressRace(t)
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
Refs: #107169

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes
Release note: None
Epic: None