### PR TITLE
sql: fix panic in request_job_execution_details

### DIFF
--- a/pkg/jobs/utils.go
+++ b/pkg/jobs/utils.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
@@ -139,4 +140,16 @@ ORDER BY created`
 		}
 	}
 	return false /* exists */, err
+}
+
+// JobExists returns true if there is a row corresponding to jobID in the
+// system.jobs table.
+func JobExists(
+	ctx context.Context, jobID jobspb.JobID, txn *kv.Txn, ex isql.Executor,
+) (bool, error) {
+	row, err := ex.QueryRow(ctx, "check-for-job", txn, `SELECT id FROM system.jobs WHERE id = $1`, jobID)
+	if err != nil {
+		return false, err
+	}
+	return row != nil, nil
 }

--- a/pkg/sql/jobs_profiler_execution_details_test.go
+++ b/pkg/sql/jobs_profiler_execution_details_test.go
@@ -220,6 +220,10 @@ func TestReadWriteProfilerExecutionDetails(t *testing.T) {
 		require.True(t, strings.Contains(string(goroutines), fmt.Sprintf("labels: {\"foo\":\"bar\", \"job\":\"IMPORT id=%d\", \"n\":\"1\"}", importJobID)))
 		require.True(t, strings.Contains(string(goroutines), "github.com/cockroachdb/cockroach/pkg/sql_test.fakeExecResumer.Resume"))
 	})
+
+	t.Run("execution details for invalid job ID", func(t *testing.T) {
+		runner.ExpectErr(t, `job -123 not found; cannot request execution details`, `SELECT crdb_internal.request_job_execution_details(-123)`)
+	})
 }
 
 func TestListProfilerExecutionDetails(t *testing.T) {


### PR DESCRIPTION
This was fixed in  https://github.com/cockroachdb/cockroach/pull/106904 but it looks like some file movement in #105624 got rid of the nil check. This patch re-adds the nil check along with a test, and also some additional safeguards to not collect any execution details for non-existent jobs.

Fixes: #106970
Release note: None