### PR TITLE
changefeedccl: Treat drop descriptors as terminal

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -109,6 +109,11 @@ func refreshUDT(
 		tableDesc, err = collection.ByIDWithLeased(txn).WithoutNonPublic().Get().Table(ctx, tableID)
 		return err
 	}); err != nil {
+		if errors.Is(err, catalog.ErrDescriptorDropped) {
+			// Dropped descriptors are a bad news.
+			return nil, changefeedbase.WithTerminalError(err)
+		}
+
 		// Manager can return all kinds of errors during chaos, but based on
 		// its usage, none of them should ever be terminal.
 		return nil, changefeedbase.MarkRetryableError(err)

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -154,6 +154,9 @@ func fetchTableDescriptors(
 		})
 	}
 	if err := sql.DescsTxn(ctx, execCfg, fetchSpans); err != nil {
+		if errors.Is(err, catalog.ErrDescriptorDropped) {
+			return nil, changefeedbase.WithTerminalError(err)
+		}
 		return nil, err
 	}
 	return targetDescs, nil


### PR DESCRIPTION
Prior to this change, changefeed would sometimes treat droped descriptors (ErrDroppedDescriptor) as a terminal error, and sometimes it would be treated as a retryable error (though, upon retry, the error would be upgraded to terminal).

This PR cleans up this logic and ensures that any
"dropped descriptor" error is treated as terminal.

Informs https://github.com/cockroachlabs/support/issues/2408 
Release note: None