### PR TITLE
build: use absolute path to pnpm-lock.yaml

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -39,7 +39,7 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
         always-auth: true
         cache: 'pnpm'
-        cache-dependency-path: 'pkg/ui/pnpm-lock.yaml'
+        cache-dependency-path: "${{ github.workspace }}/pkg/ui/pnpm-lock.yaml"
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -38,7 +38,7 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
         always-auth: true
         cache: 'pnpm'
-        cache-dependency-path: 'pkg/ui/pnpm-lock.yaml'
+        cache-dependency-path: "${{ github.workspace }}/pkg/ui/pnpm-lock.yaml"
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Previously, actions/setup-node@v3 was used with a relative path for `cache-dependency-path`. This had an unexpected interaction with the `.defaults.run.working-directory: "pkg/ui/workspaces/cluster-ui"` declaration, which caused setup-node's cleanup action to look for pkg/ui/workspaces/cluster-ui/pkg/ui/pnpm-lock.yaml. Naturally, this file didn't exist. Use an absolute path (thanks, `github.workspace`!) to pnpm-lock.yaml instead.

Release note: None
Epic: none