### PR TITLE
release-23.1: kvserver: avoid running intensive decommission test under deadlock

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3284,9 +3284,10 @@ func TestDecommission(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Five nodes is too much to reliably run under testrace with our aggressive
-	// liveness timings.
-	skip.UnderRace(t, "#39807 and #37811")
+	// Five nodes is too much to reliably run under race/deadlock with our
+	// aggressive liveness timings.
+	skip.UnderRaceWithIssue(t, 39807, "#39807 and #37811")
+	skip.UnderDeadlockWithIssue(t, 39807, "#39807 and #37811")
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 5, base.TestClusterArgs{


### PR DESCRIPTION
Backport 1/1 commits from #107110.

/cc @cockroachdb/release

---

The kvserver test `TestDecommission`, which runs a 5-node cluster and decommissions 4 of those 5 nodes, has trouble completing fast enough when under a race or deadlock configuration. While race configurations were already skipped, this modifies the test to be skipped under deadlock configurations as well.

Fixes: #106096

Release note: None

---

Release Justification: Test-only fix
