### PR TITLE
sql: remove isInternalPlanner boolean

### DIFF
--- a/pkg/sql/audit_logging.go
+++ b/pkg/sql/audit_logging.go
@@ -120,10 +120,8 @@ func (p *planner) shouldNotRoleBasedAudit(execType executorType) bool {
 	// Do not do audit work if role-based auditing is not enabled.
 	// Do not emit audit events for reserved users/roles. This does not omit the
 	// root user.
-	// Do not emit audit events for internal planners.
 	// Do not emit audit events for internal executors.
 	return !auditlogging.UserAuditEnabled(p.execCfg.Settings, p.EvalContext().ClusterID) ||
 		p.User().IsReserved() ||
-		p.isInternalPlanner ||
 		execType == executorTypeInternal
 }

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2001,10 +2001,9 @@ func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) erro
 	}
 
 	// Set index recommendations, so it can be saved on statement statistics.
-	// TODO(yuzefovich): figure out whether we want to set isInternalPlanner
-	// to true for the internal executors.
-	isInternal := ex.executorType == executorTypeInternal || planner.isInternalPlanner
-	planner.instrumentation.SetIndexRecommendations(ctx, ex.server.idxRecommendationsCache, planner, isInternal)
+	planner.instrumentation.SetIndexRecommendations(
+		ctx, ex.server.idxRecommendationsCache, planner, ex.executorType == executorTypeInternal,
+	)
 
 	return nil
 }

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -297,6 +297,7 @@ func startConnExecutor(
 	)
 	// This pool should never be Stop()ed because, if the test is failing, memory
 	// is not properly released.
+	collectionFactory := descs.NewBareBonesCollectionFactory(st, keys.SystemSQLCodec)
 	cfg := &ExecutorConfig{
 		AmbientCtx: ambientCtx,
 		Settings:   st,
@@ -325,6 +326,7 @@ func startConnExecutor(
 					NodeID:            nodeID,
 					TempFS:            tempFS,
 					ParentDiskMonitor: execinfra.NewTestDiskMonitor(ctx, st),
+					CollectionFactory: collectionFactory,
 				},
 				flowinfra.NewRemoteFlowRunner(ambientCtx, stopper, nil /* acc */),
 			),
@@ -343,7 +345,7 @@ func startConnExecutor(
 		TestingKnobs:            ExecutorTestingKnobs{},
 		StmtDiagnosticsRecorder: stmtdiagnostics.NewRegistry(nil, st),
 		HistogramWindowInterval: base.DefaultHistogramWindowInterval(),
-		CollectionFactory:       descs.NewBareBonesCollectionFactory(st, keys.SystemSQLCodec),
+		CollectionFactory:       collectionFactory,
 	}
 
 	s := NewServer(cfg, pool)

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -499,9 +499,9 @@ func (ds *ServerImpl) newFlowContext(
 	}
 
 	if localState.IsLocal && localState.Collection != nil {
-		// If we were passed a descs.Collection to use, then take it. In this case,
-		// the caller will handle releasing the used descriptors, so we don't need
-		// to cleanup the descriptors when cleaning up the flow.
+		// If we were passed a descs.Collection to use, then take it. In this
+		// case, the caller will handle releasing the used descriptors, so we
+		// don't need to clean up the descriptors when cleaning up the flow.
 		flowCtx.Descriptors = localState.Collection
 	} else {
 		// If we weren't passed a descs.Collection, then make a new one. We are

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -805,10 +805,6 @@ type PlanningCtx struct {
 	isLocal bool
 	planner *planner
 
-	// usePlannerDescriptorsForLocalFlow may be set to true to force
-	// planner.Descriptors() use for local flows.
-	usePlannerDescriptorsForLocalFlow bool
-
 	stmtType tree.StatementReturnType
 	// planDepth is set to the current depth of the planNode tree. It's used to
 	// keep track of whether it's valid to run a root node in a special fast path

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -198,15 +198,12 @@ func RunCDCEvaluation(
 		return err
 	}
 
-	// Execute the flow.  Force the use of planner descriptor cache when setting
-	// up this local flow.  This is necessary so that as soon as the local flow
-	// setup completes, and all descriptors have been resolved (including leases
-	// for user defined types), we can release those descriptors. If we don't,
-	// then the descriptor leases acquired will be held for the
-	// DefaultDescriptorLeaseDuration (5 minutes), blocking potential schema
-	// changes.
-	cdcPlan.PlanCtx.usePlannerDescriptorsForLocalFlow = true
 	p := cdcPlan.PlanCtx.planner
+	// Make sure that as soon as the local flow setup completes, and all
+	// descriptors have been resolved (including leases for user defined types),
+	// we can release those descriptors. If we don't, then the descriptor leases
+	// acquired will be held for the DefaultDescriptorLeaseDuration (5 minutes),
+	// blocking potential schema changes.
 	finishedSetupFn := func(flowinfra.Flow) {
 		p.Descriptors().ReleaseAll(ctx)
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -688,14 +688,8 @@ func (dsp *DistSQLPlanner) Run(
 	localState.Txn = txn
 	localState.LocalProcs = plan.LocalProcessors
 	localState.LocalVectorSources = plan.LocalVectorSources
-	// If we have access to a planner and are currently being used to plan
-	// statements in a user transaction, then take the descs.Collection to resolve
-	// types with during flow execution. This is necessary to do in the case of
-	// a transaction that has already created or updated some types. If we do not
-	// use the local descs.Collection, we would attempt to acquire a lease on
-	// modified types when accessing them, which would error out.
-	if planCtx.planner != nil &&
-		(!planCtx.planner.isInternalPlanner || planCtx.usePlannerDescriptorsForLocalFlow) {
+	if planCtx.planner != nil {
+		// Note that the planner's collection will only be used for local plans.
 		localState.Collection = planCtx.planner.Descriptors()
 	}
 

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -170,7 +170,7 @@ func (ef *execFactory) ConstructScan(
 	scan.lockingStrength = descpb.ToScanLockingStrength(params.Locking.Strength)
 	scan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
 	scan.localityOptimized = params.LocalityOptimized
-	if !ef.isExplain && !(ef.planner.isInternalPlanner || ef.planner.SessionData().Internal) {
+	if !ef.isExplain && !ef.planner.SessionData().Internal {
 		idxUsageKey := roachpb.IndexUsageKey{
 			TableID: roachpb.TableID(tabDesc.GetID()),
 			IndexID: roachpb.IndexID(idx.GetID()),
@@ -666,7 +666,7 @@ func (ef *execFactory) ConstructIndexJoin(
 	tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
 	tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 
-	if !ef.isExplain && !(ef.planner.isInternalPlanner || ef.planner.SessionData().Internal) {
+	if !ef.isExplain && !ef.planner.SessionData().Internal {
 		idxUsageKey := roachpb.IndexUsageKey{
 			TableID: roachpb.TableID(tabDesc.GetID()),
 			IndexID: roachpb.IndexID(idx.GetID()),
@@ -726,7 +726,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
 	tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 
-	if !ef.isExplain && !(ef.planner.isInternalPlanner || ef.planner.SessionData().Internal) {
+	if !ef.isExplain && !ef.planner.SessionData().Internal {
 		idxUsageKey := roachpb.IndexUsageKey{
 			TableID: roachpb.TableID(tabDesc.GetID()),
 			IndexID: roachpb.IndexID(idx.GetID()),
@@ -866,7 +866,7 @@ func (ef *execFactory) ConstructInvertedJoin(
 	tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
 	tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 
-	if !ef.isExplain && !(ef.planner.isInternalPlanner || ef.planner.SessionData().Internal) {
+	if !ef.isExplain && !ef.planner.SessionData().Internal {
 		idxUsageKey := roachpb.IndexUsageKey{
 			TableID: roachpb.TableID(tabDesc.GetID()),
 			IndexID: roachpb.IndexID(idx.GetID()),
@@ -934,7 +934,7 @@ func (ef *execFactory) constructScanForZigzag(
 		return nil, nil, err
 	}
 
-	if !ef.isExplain && !(ef.planner.isInternalPlanner || ef.planner.SessionData().Internal) {
+	if !ef.isExplain && !ef.planner.SessionData().Internal {
 		idxUsageKey := roachpb.IndexUsageKey{
 			TableID: roachpb.TableID(tableDesc.GetID()),
 			IndexID: roachpb.IndexID(idxDesc.GetID()),

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -179,10 +179,6 @@ type planner struct {
 	// never be accessed directly. Nothing explicitly resets this field.
 	internalSQLTxn internalTxn
 
-	// isInternalPlanner is set to true when this planner is not bound to
-	// a SQL session.
-	isInternalPlanner bool
-
 	atomic struct {
 		// innerPlansMustUseLeafTxn is set to 1 if the "outer" plan is using
 		// the LeafTxn forcing the "inner" plans to use the LeafTxns too. An
@@ -399,7 +395,6 @@ func newInternalPlanner(
 	p.txn = txn
 	p.stmt = Statement{}
 	p.cancelChecker.Reset(ctx)
-	p.isInternalPlanner = true
 
 	p.semaCtx = tree.MakeSemaContext()
 	p.semaCtx.SearchPath = &sd.SearchPath
@@ -454,7 +449,6 @@ func newInternalPlanner(
 	p.extendedEvalCtx.ExecCfg = execCfg
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 	p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
-	p.extendedEvalCtx.Descs = params.collection
 
 	p.queryCacheSession.Init()
 	p.optPlanningCtx.init(p)


### PR DESCRIPTION
This boolean is very confusing and can mislead people, so let's remove it.

It was introduced in bf9ffe9c3258712bfe81024c7dc33f73fe8aeb9b with one specific use case in mind: lease management for user defined types when the execution flow occurs in the context of a user transaction. In that scenario, the execution engine uses the planner's `descs.Collection` when running the local plan. However, I don't see the reason why we cannot do the same thing for queries outside of the user transaction (where we have the "internal planner" object), so this commit removes that extra conditional. That said, I don't quite understand how these things work, but we can always go back to not using the planner's collection for "internal planners" (we'd name the boolean differently though) if we see any fallout.

Epic: None
Release note: None