### PR TITLE
release-23.1: bazel,ci: don't consult GitHub API for maybe_stress; add retries

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -228,7 +228,15 @@ get_upstream_branch() {
 }
 
 changed_go_pkgs() {
-  git fetch --quiet origin
+  n=0
+  until git fetch --quiet origin; do
+    n=$((n+1))
+    if [ "$n" -ge 3 ]; then
+      echo "Could not fetch from GitHub"
+      exit 1
+    fi
+    sleep 5
+  done
   upstream_branch=$(get_upstream_branch)
   # Find changed packages, minus those that have been removed entirely. Note
   # that the three-dot notation means we are diffing against the merge-base of

--- a/build/teamcity/cockroach/ci/tests/maybe_stress.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stress.sh
@@ -8,7 +8,15 @@ source "$dir/teamcity-support.sh"  # For $root, would_stress
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 if would_stress; then
-    git fetch origin master
+    n=0
+    until git fetch origin master; do
+          n=$((n+1))
+          if [ "$n" -ge 3 ]; then
+              echo "Could not fetch from GitHub"
+              exit 1
+          fi
+          sleep 5
+    done
     tc_start_block "Run stress tests"
     run_bazel env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh stress
     tc_end_block "Run stress tests"

--- a/build/teamcity/cockroach/ci/tests/maybe_stress.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stress.sh
@@ -8,6 +8,7 @@ source "$dir/teamcity-support.sh"  # For $root, would_stress
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 if would_stress; then
+    git fetch origin master
     tc_start_block "Run stress tests"
     run_bazel env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh stress
     tc_end_block "Run stress tests"

--- a/build/teamcity/cockroach/ci/tests/maybe_stressrace.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stressrace.sh
@@ -8,6 +8,7 @@ source "$dir/teamcity-support.sh"  # For $root, would_stress
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 if would_stress; then
+    git fetch origin master
     tc_start_block "Run stress tests"
     run_bazel env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh stressrace
     tc_end_block "Run stress tests"

--- a/build/teamcity/cockroach/ci/tests/maybe_stressrace.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stressrace.sh
@@ -8,7 +8,15 @@ source "$dir/teamcity-support.sh"  # For $root, would_stress
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 if would_stress; then
-    git fetch origin master
+    n=0
+    until git fetch origin master; do
+          n=$((n+1))
+          if [ "$n" -ge 3 ]; then
+              echo "Could not fetch from GitHub"
+              exit 1
+          fi
+          sleep 5
+    done
     tc_start_block "Run stress tests"
     run_bazel env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh stressrace
     tc_end_block "Run stress tests"

--- a/pkg/cmd/github-pull-request-make/BUILD.bazel
+++ b/pkg/cmd/github-pull-request-make/BUILD.bazel
@@ -8,8 +8,6 @@ go_library(
     deps = [
         "//pkg/build/bazel",
         "//pkg/testutils/buildutil",
-        "@com_github_google_go_github//github",
-        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 
@@ -28,7 +26,5 @@ go_test(
     embed = [":github-pull-request-make_lib"],
     deps = [
         "//pkg/testutils/datapathutils",
-        "//pkg/testutils/skip",
-        "@com_github_kr_pretty//:pretty",
     ],
 )

--- a/pkg/cmd/github-pull-request-make/main_test.go
+++ b/pkg/cmd/github-pull-request-make/main_test.go
@@ -11,17 +11,11 @@
 package main
 
 import (
-	"context"
 	"os"
-	"path/filepath"
 	"reflect"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
-	"github.com/kr/pretty"
 )
 
 func TestPkgsFromDiff(t *testing.T) {
@@ -57,34 +51,4 @@ func TestPkgsFromDiff(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestPkgsFromDiffHelper(t *testing.T) {
-	// This helper can easily generate new test cases.
-	skip.IgnoreLint(t, "only for manual use")
-
-	ctx := context.Background()
-	client := ghClient(ctx)
-
-	const prNum = 10305
-
-	diff, err := getDiff(ctx, client, "cockroachdb", "cockroach", prNum)
-	if err != nil {
-		t.Fatal(err)
-	}
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	name := filepath.Join(wd, "testdata", strconv.Itoa(prNum)+".diff")
-	if err := os.WriteFile(name, []byte(diff), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	pkgs, err := pkgsFromDiff(strings.NewReader(diff))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Errorf("read the following information:\n%v\n\ndiff at %s", pretty.Sprint(pkgs), name)
 }


### PR DESCRIPTION
Just do a local `git diff` in this case.

Epic: none
Release note: None
Release justification: Test-only code changes

Backport:
  * 1/1 commits from "bazel,ci: don't consult GitHub API for `maybe_stress`." (#99496)
  * 1/1 commits from "ci: add some retries for `git fetch`es" (#107211)

Please see individual PRs for details.

/cc @cockroachdb/release
