### PR TITLE
sql: do not audit internal executors

### DIFF
--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -131,7 +131,7 @@ func (p *planner) maybeLogStatement(
 	queryStats *topLevelQueryStats,
 	statsCollector sqlstats.StatsCollector,
 ) {
-	p.maybeAuditRoleBasedAuditEvent(ctx)
+	p.maybeAuditRoleBasedAuditEvent(ctx, execType)
 	p.maybeLogStatementInternal(ctx, execType, isCopy, numRetries, txnCounter,
 		rows, bulkJobId, err, queryReceived, hasAdminRoleCache,
 		telemetryLoggingMetrics, stmtFingerprintID, queryStats, statsCollector,


### PR DESCRIPTION
Previously, we were using `planner.isInternalPlanner` to check whether audit logging should be applied, but that field is not set for internal executors, and I believe IE should be excluded from audit too.

Epic: None

Release note: None