### PR TITLE
cluster-ui: speed up insights page request 

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
@@ -61,7 +61,7 @@ export async function getContentionDetailsApi(
   const result = await executeInternalSql<ContentionResponseColumns>(request);
 
   if (sqlResultsAreEmpty(result)) {
-    if (result.error) {
+    if (result?.error) {
       // We don't return an error if it failed to retrieve the contention information.
       getLogger().error(
         "Insights encounter an error while retrieving contention information.",
@@ -76,7 +76,7 @@ export async function getContentionDetailsApi(
   }
 
   const contentionDetails: ContentionDetails[] = [];
-  result.execution.txn_results.forEach(x => {
+  result.execution?.txn_results.forEach(x => {
     x.rows.forEach(row => {
       contentionDetails.push({
         blockingExecutionID: row.blocking_txn_id,

--- a/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
@@ -196,7 +196,7 @@ FROM
           statistics -> 'statistics' ->> 'lastExecAt' DESC
       ) AS rank 
     FROM 
-      crdb_internal.statement_statistics 
+      crdb_internal.statement_statistics_persisted 
     WHERE 
       aggregated_ts >= now() - INTERVAL '1 week'
   ) 

--- a/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
@@ -175,26 +175,34 @@ const dropUnusedIndexQuery: SchemaInsightQuery<ClusterIndexUsageStatistic> = {
 const createIndexRecommendationsQuery: SchemaInsightQuery<CreateIndexRecommendationsResponse> =
   {
     name: "CreateIndex",
-    query: `SELECT
-       encode(fingerprint_id, 'hex') AS fingerprint_id,  
-       metadata ->> 'db' AS db, 
-       metadata ->> 'query' AS query, 
-       metadata ->> 'querySummary' as querySummary, 
-       metadata ->> 'implicitTxn' AS implicitTxn, 
-       index_recommendations 
-    FROM (
-      SELECT 
-        fingerprint_id, 
-        statistics -> 'statistics' ->> 'lastExecAt' as lastExecAt, 
-        metadata, 
-        index_recommendations, 
-        row_number() over(
-          PARTITION BY 
-            fingerprint_id 
-          ORDER BY statistics -> 'statistics' ->> 'lastExecAt' DESC
-        ) AS rank 
-      FROM crdb_internal.statement_statistics WHERE aggregated_ts >= now() - INTERVAL '1 week')
-      WHERE rank=1 AND array_length(index_recommendations,1) > 0;`,
+    query: `
+SELECT
+  encode(fingerprint_id, 'hex') AS fingerprint_id, 
+  metadata ->> 'db' AS db, 
+  metadata ->> 'query' AS query, 
+  metadata ->> 'querySummary' as querySummary, 
+  metadata ->> 'implicitTxn' AS implicitTxn, 
+  index_recommendations 
+FROM 
+  (
+    SELECT 
+      fingerprint_id, 
+      statistics -> 'statistics' ->> 'lastExecAt' as lastExecAt, 
+      metadata, 
+      index_recommendations, 
+      row_number() over(
+        PARTITION BY fingerprint_id 
+        ORDER BY 
+          statistics -> 'statistics' ->> 'lastExecAt' DESC
+      ) AS rank 
+    FROM 
+      crdb_internal.statement_statistics 
+    WHERE 
+      aggregated_ts >= now() - INTERVAL '1 week'
+  ) 
+WHERE 
+  rank = 1 AND array_length(index_recommendations, 1) > 0;
+`,
     toSchemaInsight: createIndexRecommendationsToSchemaInsight,
   };
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -126,8 +126,8 @@ export function sqlResultsAreEmpty(
   result: SqlExecutionResponse<unknown>,
 ): boolean {
   return (
-    !result.execution?.txn_results?.length ||
-    result.execution.txn_results.every(txn => txnResultIsEmpty(txn))
+    !result?.execution?.txn_results?.length ||
+    result?.execution.txn_results.every(txn => txnResultIsEmpty(txn))
   );
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.spec.ts
@@ -1,0 +1,234 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  getTxnInsightsContentionDetailsApi,
+  TxnStmtFingerprintsResponseColumns,
+  FingerprintStmtsResponseColumns,
+} from "./txnInsightsApi";
+import * as sqlApi from "./sqlApi";
+import { SqlExecutionResponse } from "./sqlApi";
+import {
+  InsightExecEnum,
+  InsightNameEnum,
+  TxnContentionInsightDetails,
+} from "../insights";
+import { ContentionResponseColumns } from "./contentionApi";
+import moment from "moment-timezone";
+
+function mockSqlResponse<T>(rows: T[]): SqlExecutionResponse<T> {
+  return {
+    execution: {
+      retries: 0,
+      txn_results: [
+        {
+          tag: "",
+          start: "",
+          end: "",
+          rows_affected: 0,
+          statement: 1,
+          rows: [...rows],
+        },
+      ],
+    },
+  };
+}
+
+type TxnContentionDetailsTests = {
+  name: string;
+  contentionResp: SqlExecutionResponse<ContentionResponseColumns>;
+  txnFingerprintsResp: SqlExecutionResponse<TxnStmtFingerprintsResponseColumns>;
+  stmtsFingerprintsResp: SqlExecutionResponse<FingerprintStmtsResponseColumns>;
+  expected: TxnContentionInsightDetails;
+};
+
+describe("test txn insights api functions", () => {
+  const waitingTxnID = "1a2a4828-5fc6-42d1-ab93-fadd4a514b69";
+  const contentionDetailsMock: ContentionResponseColumns = {
+    contention_duration: "00:00:00.00866",
+    waiting_stmt_id: "17761e953a52c0300000000000000001",
+    waiting_stmt_fingerprint_id: "b75264458f6e2ef3",
+    schema_name: "public",
+    database_name: "system",
+    table_name: "namespace",
+    index_name: "primary",
+    key: `/NamespaceTable/30/1/0/0/"movr"/4/1`,
+    collection_ts: "2023-07-28 19:25:36.434081+00",
+    blocking_txn_id: "a13773b3-9bca-4019-9cfb-a376d6a4f412",
+    blocking_txn_fingerprint_id: "4329ab5f4493f82d",
+    waiting_txn_id: waitingTxnID,
+    waiting_txn_fingerprint_id: "1831d909096f992c",
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test.each([
+    {
+      name: "all api responses empty",
+      contentionResp: mockSqlResponse([]),
+      txnFingerprintsResp: mockSqlResponse([]),
+      stmtsFingerprintsResp: mockSqlResponse([]),
+      expected: null,
+    },
+    {
+      name: "no fingerprints available",
+      contentionResp: mockSqlResponse([contentionDetailsMock]),
+      txnFingerprintsResp: mockSqlResponse([]),
+      stmtsFingerprintsResp: mockSqlResponse([]),
+      expected: {
+        transactionExecutionID: contentionDetailsMock.waiting_txn_id,
+        application: undefined,
+        transactionFingerprintID:
+          contentionDetailsMock.waiting_txn_fingerprint_id,
+        blockingContentionDetails: [
+          {
+            blockingExecutionID: contentionDetailsMock.blocking_txn_id,
+            blockingTxnFingerprintID:
+              contentionDetailsMock.blocking_txn_fingerprint_id,
+            blockingTxnQuery: null,
+            collectionTimeStamp: moment("2023-07-28 19:25:36.434081+00").utc(),
+            contendedKey: '/NamespaceTable/30/1/0/0/"movr"/4/1',
+            contentionTimeMs: 9,
+            databaseName: contentionDetailsMock.database_name,
+            indexName: contentionDetailsMock.index_name,
+            schemaName: contentionDetailsMock.schema_name,
+            tableName: contentionDetailsMock.table_name,
+            waitingStmtFingerprintID:
+              contentionDetailsMock.waiting_stmt_fingerprint_id,
+            waitingStmtID: contentionDetailsMock.waiting_stmt_id,
+            waitingTxnFingerprintID:
+              contentionDetailsMock.waiting_txn_fingerprint_id,
+            waitingTxnID: contentionDetailsMock.waiting_txn_id,
+          },
+        ],
+        execType: InsightExecEnum.TRANSACTION,
+        insightName: InsightNameEnum.highContention,
+      },
+    },
+    {
+      name: "no stmt fingerprints available",
+      contentionResp: mockSqlResponse([contentionDetailsMock]),
+      txnFingerprintsResp: mockSqlResponse<TxnStmtFingerprintsResponseColumns>([
+        {
+          transaction_fingerprint_id:
+            contentionDetailsMock.blocking_txn_fingerprint_id,
+          query_ids: ["a", "b", "c"],
+          app_name: undefined,
+        },
+      ]),
+      stmtsFingerprintsResp: mockSqlResponse([]),
+      expected: {
+        transactionExecutionID: contentionDetailsMock.waiting_txn_id,
+        application: undefined,
+        transactionFingerprintID:
+          contentionDetailsMock.waiting_txn_fingerprint_id,
+        blockingContentionDetails: [
+          {
+            blockingExecutionID: contentionDetailsMock.blocking_txn_id,
+            blockingTxnFingerprintID:
+              contentionDetailsMock.blocking_txn_fingerprint_id,
+            blockingTxnQuery: [
+              "Query unavailable for statement fingerprint 000000000000000a",
+              "Query unavailable for statement fingerprint 000000000000000b",
+              "Query unavailable for statement fingerprint 000000000000000c",
+            ],
+            collectionTimeStamp: moment("2023-07-28 19:25:36.434081+00").utc(),
+            contendedKey: '/NamespaceTable/30/1/0/0/"movr"/4/1',
+            contentionTimeMs: 9,
+            databaseName: contentionDetailsMock.database_name,
+            indexName: contentionDetailsMock.index_name,
+            schemaName: contentionDetailsMock.schema_name,
+            tableName: contentionDetailsMock.table_name,
+            waitingStmtFingerprintID:
+              contentionDetailsMock.waiting_stmt_fingerprint_id,
+            waitingStmtID: contentionDetailsMock.waiting_stmt_id,
+            waitingTxnFingerprintID:
+              contentionDetailsMock.waiting_txn_fingerprint_id,
+            waitingTxnID: contentionDetailsMock.waiting_txn_id,
+          },
+        ],
+        execType: InsightExecEnum.TRANSACTION,
+        insightName: InsightNameEnum.highContention,
+      },
+    },
+    {
+      name: "all info available",
+      contentionResp: mockSqlResponse([contentionDetailsMock]),
+      txnFingerprintsResp: mockSqlResponse<TxnStmtFingerprintsResponseColumns>([
+        {
+          transaction_fingerprint_id:
+            contentionDetailsMock.blocking_txn_fingerprint_id,
+          query_ids: ["a", "b", "c"],
+          app_name: undefined,
+        },
+      ]),
+      stmtsFingerprintsResp: mockSqlResponse<FingerprintStmtsResponseColumns>([
+        {
+          statement_fingerprint_id: "a",
+          query: "select 1",
+        },
+        {
+          statement_fingerprint_id: "b",
+          query: "select 2",
+        },
+        {
+          statement_fingerprint_id: "c",
+          query: "select 3",
+        },
+      ]),
+      expected: {
+        transactionExecutionID: contentionDetailsMock.waiting_txn_id,
+        application: undefined,
+        transactionFingerprintID:
+          contentionDetailsMock.waiting_txn_fingerprint_id,
+        blockingContentionDetails: [
+          {
+            blockingExecutionID: contentionDetailsMock.blocking_txn_id,
+            blockingTxnFingerprintID:
+              contentionDetailsMock.blocking_txn_fingerprint_id,
+            blockingTxnQuery: ["select 1", "select 2", "select 3"],
+            collectionTimeStamp: moment("2023-07-28 19:25:36.434081+00").utc(),
+            contendedKey: '/NamespaceTable/30/1/0/0/"movr"/4/1',
+            contentionTimeMs: 9,
+            databaseName: contentionDetailsMock.database_name,
+            indexName: contentionDetailsMock.index_name,
+            schemaName: contentionDetailsMock.schema_name,
+            tableName: contentionDetailsMock.table_name,
+            waitingStmtFingerprintID:
+              contentionDetailsMock.waiting_stmt_fingerprint_id,
+            waitingStmtID: contentionDetailsMock.waiting_stmt_id,
+            waitingTxnFingerprintID:
+              contentionDetailsMock.waiting_txn_fingerprint_id,
+            waitingTxnID: contentionDetailsMock.waiting_txn_id,
+          },
+        ],
+        execType: InsightExecEnum.TRANSACTION,
+        insightName: InsightNameEnum.highContention,
+      },
+    },
+  ] as TxnContentionDetailsTests[])(
+    "$name",
+    async (tc: TxnContentionDetailsTests) => {
+      await jest
+        .spyOn(sqlApi, "executeInternalSql")
+        .mockReturnValueOnce(Promise.resolve(tc.contentionResp))
+        .mockReturnValueOnce(Promise.resolve(tc.txnFingerprintsResp))
+        .mockReturnValueOnce(Promise.resolve(tc.stmtsFingerprintsResp));
+
+      const res = await getTxnInsightsContentionDetailsApi({
+        txnExecutionID: waitingTxnID,
+      });
+      expect(res).toEqual(tc.expected);
+    },
+  );
+});

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
@@ -9,17 +9,17 @@
 // licenses/APL.txt.
 
 import {
-  SqlApiResponse,
   executeInternalSql,
   formatApiResult,
   INTERNAL_SQL_API_APP,
+  isMaxSizeError,
   LARGE_RESULT_SIZE,
   LONG_TIMEOUT,
   sqlApiErrorMessage,
+  SqlApiResponse,
   SqlExecutionRequest,
   SqlExecutionResponse,
   sqlResultsAreEmpty,
-  isMaxSizeError,
 } from "./sqlApi";
 import {
   ContentionDetails,
@@ -56,12 +56,13 @@ const makeInsightsSqlRequest = (
 });
 
 export type TxnWithStmtFingerprints = {
-  application: string;
+  application: string; // TODO #108051: (xinhaoz) this field seems deprecated.
   transactionFingerprintID: string;
   queryIDs: string[]; // Statement fingerprint IDs.
 };
 
-type TxnStmtFingerprintsResponseColumns = {
+// Exported for testing.
+export type TxnStmtFingerprintsResponseColumns = {
   transaction_fingerprint_id: string;
   query_ids: string[]; // Statement Fingerprint IDs.
   app_name: string;
@@ -74,7 +75,7 @@ SELECT
   DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS transaction_fingerprint_id,
   app_name,
   ARRAY( SELECT jsonb_array_elements_text(metadata -> 'stmtFingerprintIDs' )) AS query_ids
-FROM crdb_internal.transaction_statistics
+FROM crdb_internal.transaction_statistics_persisted
 WHERE app_name != '${INTERNAL_SQL_API_APP}'
   AND encode(fingerprint_id, 'hex') = 
       ANY ARRAY[ ${txnFingerprintIDs.map(id => `'${id}'`).join(",")} ]`;
@@ -90,7 +91,7 @@ function formatTxnFingerprintsResults(
     transactionFingerprintID: FixFingerprintHexValue(
       row.transaction_fingerprint_id,
     ),
-    queryIDs: row.query_ids,
+    queryIDs: row.query_ids.map(id => FixFingerprintHexValue(id)),
     application: row.app_name,
   }));
 }
@@ -100,7 +101,7 @@ type StmtFingerprintToQueryRecord = Map<
   string // Value = query string
 >;
 
-type FingerprintStmtsResponseColumns = {
+export type FingerprintStmtsResponseColumns = {
   statement_fingerprint_id: string;
   query: string;
 };
@@ -111,7 +112,7 @@ const fingerprintStmtsQuery = (stmtFingerprintIDs: string[]): string => `
 SELECT
   DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS statement_fingerprint_id,
   (metadata ->> 'query') AS query
-FROM crdb_internal.statement_statistics
+FROM crdb_internal.statement_statistics_persisted
 WHERE encode(fingerprint_id, 'hex') =
       ANY ARRAY[ ${stmtFingerprintIDs.map(id => `'${id}'`).join(",")} ]`;
 
@@ -119,7 +120,7 @@ function createStmtFingerprintToQueryMap(
   response: SqlExecutionResponse<FingerprintStmtsResponseColumns>,
 ): StmtFingerprintToQueryRecord {
   const idToQuery: Map<string, string> = new Map();
-  if (sqlResultsAreEmpty(response)) {
+  if (!response || sqlResultsAreEmpty(response)) {
     // No statement fingerprint results.
     return idToQuery;
   }
@@ -159,7 +160,7 @@ function formatTxnContentionDetailsResponse(
 }
 
 export async function getTxnInsightsContentionDetailsApi(
-  req: TxnInsightDetailsRequest,
+  req: Pick<TxnInsightDetailsRequest, "txnExecutionID">,
 ): Promise<TxnContentionInsightDetails> {
   // Note that any errors encountered fetching these results are caught
   // earlier in the call stack.
@@ -173,15 +174,13 @@ export async function getTxnInsightsContentionDetailsApi(
 
   const contentionResponse = await getContentionDetailsApi({
     waitingTxnID: req.txnExecutionID,
-    waitingStmtID: null,
-    start: null,
-    end: null,
   });
   const contentionResults = contentionResponse.results;
 
   if (contentionResults.length === 0) {
-    return;
+    return null;
   }
+
   const contentionDetails =
     formatTxnContentionDetailsResponse(contentionResults);
 
@@ -203,6 +202,7 @@ export async function getTxnInsightsContentionDetailsApi(
       )}`,
     );
   }
+
   const txnsWithStmtFingerprints = formatTxnFingerprintsResults(
     getStmtFingerprintsResponse,
   );
@@ -213,18 +213,23 @@ export async function getTxnInsightsContentionDetailsApi(
   );
 
   // Request query string from stmt fingerprint ids.
-  const stmtQueriesResponse =
-    await executeInternalSql<FingerprintStmtsResponseColumns>(
-      makeInsightsSqlRequest([
-        fingerprintStmtsQuery(Array.from(stmtFingerprintIDs)),
-      ]),
-    );
-  if (stmtQueriesResponse.error) {
-    throw new Error(
-      `Error while retrieving statements information: ${sqlApiErrorMessage(
-        stmtQueriesResponse.error.message,
-      )}`,
-    );
+  let stmtQueriesResponse: SqlExecutionResponse<FingerprintStmtsResponseColumns> | null =
+    null;
+
+  if (stmtFingerprintIDs.size) {
+    stmtQueriesResponse =
+      await executeInternalSql<FingerprintStmtsResponseColumns>(
+        makeInsightsSqlRequest([
+          fingerprintStmtsQuery(Array.from(stmtFingerprintIDs)),
+        ]),
+      );
+    if (stmtQueriesResponse.error) {
+      throw new Error(
+        `Error while retrieving statements information: ${sqlApiErrorMessage(
+          stmtQueriesResponse.error.message,
+        )}`,
+      );
+    }
   }
 
   return buildTxnContentionInsightDetails(
@@ -239,11 +244,7 @@ function buildTxnContentionInsightDetails(
   txnsWithStmtFingerprints: TxnWithStmtFingerprints[],
   stmtFingerprintToQuery: StmtFingerprintToQueryRecord,
 ): TxnContentionInsightDetails {
-  if (
-    !partialTxnContentionDetails &&
-    !txnsWithStmtFingerprints.length &&
-    !stmtFingerprintToQuery.size
-  ) {
+  if (!partialTxnContentionDetails && !txnsWithStmtFingerprints.length) {
     return null;
   }
 
@@ -258,7 +259,9 @@ function buildTxnContentionInsightDetails(
     }
 
     blockedRow.blockingTxnQuery = currBlockedFingerprintStmts.queryIDs.map(
-      id => stmtFingerprintToQuery.get(id) ?? "",
+      id =>
+        stmtFingerprintToQuery.get(id) ??
+        `Query unavailable for statement fingerprint ${id}`,
     );
   });
 
@@ -470,7 +473,7 @@ export async function getTxnInsightDetailsApi(
   // (e.g. when there is no high contention to report).
   //
   // Note the way we construct the object below is important. We spread the
-  // the existing object fields into a new object in order to ensure a new
+  // existing object fields into a new object in order to ensure a new
   // reference is returned so that components will be notified that there
   // was a change. However, we want the internal objects (e.g. txnDetails)
   // should only change when they are re-fetched so that components don't update
@@ -506,8 +509,9 @@ export async function getTxnInsightDetailsApi(
 
       const txnDetailsRes = result.execution.txn_results[0];
       if (txnDetailsRes.rows?.length) {
-        const txnDetails = formatTxnInsightsRow(txnDetailsRes.rows[0]);
-        txnInsightDetails.txnDetails = txnDetails;
+        txnInsightDetails.txnDetails = formatTxnInsightsRow(
+          txnDetailsRes.rows[0],
+        );
       }
     } catch (e) {
       errors.txnDetailsErr = e;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
@@ -29,7 +29,9 @@ export function QueriesCell(
     (transactionQueries.length === 1 &&
       transactionQueries[0]?.length < textLimit)
   ) {
-    const query = transactionQueries?.length ? transactionQueries[0] : "";
+    const query = transactionQueries?.length
+      ? transactionQueries[0]
+      : "Query not available.";
     return <div>{query}</div>;
   }
 


### PR DESCRIPTION
Previously, we were querying from `crdb_internal.statement_statistics` and
`crdb_internal.transaction_statistics` on the schema insights and txn insights
pages. Querying from this table is slow because it triggers a cluster-wide
fanout to collect unflushsed sql stats. We can use the persisted table instead,
which will lag behind a little in live data, but will be much faster to query from.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/107291

Release note (bug fix): Schema insights page should hit request timeouts less
frequently, if at all.

DB Console Loom, showing pages issuing requests work as expected:
https://www.loom.com/share/ef1baad105d0444596a32c8430234b88