### PR TITLE
ttl: show table name for jobs in SHOW SCHEDULES

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2239,8 +2239,7 @@ func (r *restoreResumer) publishDescriptors(
 				jobsKnobs,
 				jobs.ScheduledJobTxn(txn),
 				user,
-				mutTable.GetID(),
-				mutTable.GetRowLevelTTL(),
+				mutTable,
 			)
 			if err != nil {
 				return err

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-ttl
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-ttl
@@ -34,7 +34,7 @@ job cancel=a
 ----
 
 query-sql
-SELECT count(1) FROM [SHOW SCHEDULES] WHERE label LIKE 'row-level-ttl-%';
+SELECT count(1) FROM [SHOW SCHEDULES] WHERE label LIKE 'row-level-ttl%';
 ----
 0
 
@@ -75,7 +75,7 @@ job cancel=b
 ----
 
 query-sql
-SELECT count(1) FROM [SHOW SCHEDULES] WHERE label LIKE 'row-level-ttl-%';
+SELECT count(1) FROM [SHOW SCHEDULES] WHERE label LIKE 'row-level-ttl%';
 ----
 0
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/row_level_ttl
+++ b/pkg/ccl/backupccl/testdata/backup-restore/row_level_ttl
@@ -20,7 +20,7 @@ new-cluster name=s2 share-io-dir=s1 allow-implicit-access
 
 query-sql
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label LIKE 'row-level-ttl-%'
+WHERE label LIKE 'row-level-ttl%'
 ----
 0
 
@@ -43,7 +43,7 @@ CREATE TABLE public.t (
 
 query-sql
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label LIKE 'row-level-ttl-%'
+WHERE label LIKE 'row-level-ttl%'
 ----
 1
 
@@ -53,7 +53,7 @@ DROP DATABASE d
 
 query-sql
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label LIKE 'row-level-ttl-%'
+WHERE label LIKE 'row-level-ttl%'
 ----
 0
 
@@ -76,7 +76,7 @@ CREATE TABLE public.t (
 
 query-sql
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label LIKE 'row-level-ttl-%'
+WHERE label LIKE 'row-level-ttl%'
 ----
 1
 
@@ -86,7 +86,7 @@ DROP DATABASE d
 
 query-sql
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label LIKE 'row-level-ttl-%'
+WHERE label LIKE 'row-level-ttl%'
 ----
 0
 
@@ -113,7 +113,7 @@ CREATE TABLE public.t (
 
 query-sql
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label LIKE 'row-level-ttl-%'
+WHERE label LIKE 'row-level-ttl%'
 ----
 1
 
@@ -123,6 +123,6 @@ DROP TABLE d.public.t
 
 query-sql
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label LIKE 'row-level-ttl-%'
+WHERE label LIKE 'row-level-ttl%'
 ----
 0

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -508,6 +508,7 @@ go_library(
         "//pkg/sql/storageparam/tablestorageparam",
         "//pkg/sql/syntheticprivilege",
         "//pkg/sql/syntheticprivilegecache",
+        "//pkg/sql/ttl/ttlbase",
         "//pkg/sql/types",
         "//pkg/sql/vtable",
         "//pkg/storage",

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -799,8 +799,7 @@ func (p *planner) RepairTTLScheduledJobForTable(ctx context.Context, tableID int
 		p.ExecCfg().JobsKnobs(),
 		jobs.ScheduledJobTxn(p.InternalSQLTxn()),
 		p.User(),
-		tableDesc.GetID(),
-		tableDesc.GetRowLevelTTL(),
+		tableDesc,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/descmetadata/BUILD.bazel
+++ b/pkg/sql/descmetadata/BUILD.bazel
@@ -10,10 +10,12 @@ go_library(
         "//pkg/settings",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/isql",
         "//pkg/sql/schemachanger/scexec",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessioninit",
+        "//pkg/sql/ttl/ttlbase",
     ],
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -233,17 +233,17 @@ CREATE TABLE tbl_schedules (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl_schedules'
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_schedules'
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 1
 
 let $schedule_id
-SELECT id FROM [SHOW SCHEDULES] WHERE label = 'row-level-ttl-$table_id'
+SELECT id FROM [SHOW SCHEDULES] WHERE label = 'row-level-ttl: $label_suffix'
 
 statement error cannot drop a row level TTL schedule\nHINT: use ALTER TABLE test\.public\.tbl_schedules RESET \(ttl\) instead
 DROP SCHEDULE $schedule_id
@@ -321,12 +321,12 @@ CREATE TABLE tbl_reset_ttl (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl_reset_ttl'
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_reset_ttl'
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 1
 
@@ -351,10 +351,90 @@ SELECT crdb_internal.validate_ttl_scheduled_jobs()
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 0
 
+subtest end
+
+# Ensure that SHOW SCHEDULES's label column is updated to reflect the new table
+# name.
+subtest rename_table
+
+statement ok
+CREATE TABLE tbl_rename (
+  id INT PRIMARY KEY
+) WITH (ttl_expire_after = '10 minutes')
+
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_rename'
+
+query I
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl: $label_suffix'
+----
+1
+
+statement ok
+ALTER TABLE tbl_rename RENAME TO tbl_renamed
+
+query I
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl: $label_suffix'
+----
+0
+
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_renamed'
+
+query I
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl: $label_suffix'
+----
+1
+
+subtest end
+
+subtest rename_table_legacy_label
+
+statement ok
+CREATE TABLE tbl_rename_legacy_label (
+  id INT PRIMARY KEY
+) WITH (ttl_expire_after = '10 minutes')
+
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_rename_legacy_label'
+
+query I
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl: $label_suffix'
+----
+1
+
+# Simulate a "legacy" label to ensure that it will be appropriately updated
+# when the table is renamed.
+statement ok
+UPDATE system.scheduled_jobs SET schedule_name = 'row-level-ttl-1234' WHERE schedule_name = 'row-level-ttl: $label_suffix';
+
+statement ok
+ALTER TABLE tbl_rename_legacy_label RENAME TO tbl_renamed2
+
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_renamed2'
+
+# Legacy label no longer exists.
+query I
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl-1234'
+----
+0
+
+# Renamed and new formatted label is showing up as expected.
+query I
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl: $label_suffix'
+----
+1
 subtest end
 
 subtest drop_table
@@ -365,12 +445,13 @@ CREATE TABLE tbl_drop_table (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl_drop_table'
+
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_drop_table'
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 1
 
@@ -379,7 +460,7 @@ DROP TABLE tbl_drop_table
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 0
 
@@ -395,15 +476,15 @@ statement ok
 CREATE TABLE drop_me.tbl () WITH (ttl_expire_after = '10 minutes');
 CREATE TABLE drop_me.tbl2 () WITH (ttl_expire_after = '10 minutes')
 
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl'
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl'
 
-let $table_id2
-SELECT oid FROM pg_class WHERE relname = 'tbl2'
+let $label_suffix2
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl2'
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label IN ('row-level-ttl-$table_id', 'row-level-ttl-$table_id2')
+WHERE label IN ('row-level-ttl: $label_suffix', 'row-level-ttl: $label_suffix2')
 ----
 2
 
@@ -412,7 +493,7 @@ DROP SCHEMA drop_me CASCADE
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 0
 
@@ -431,15 +512,15 @@ statement ok
 CREATE TABLE tbl () WITH (ttl_expire_after = '10 minutes');
 CREATE TABLE tbl2 () WITH (ttl_expire_after = '10 minutes')
 
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl'
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl'
 
-let $table_id2
-SELECT oid FROM pg_class WHERE relname = 'tbl2'
+let $label_suffix2
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl2'
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label IN ('row-level-ttl-$table_id', 'row-level-ttl-$table_id2')
+WHERE label IN ('row-level-ttl: $label_suffix', 'row-level-ttl: $label_suffix2')
 ----
 2
 
@@ -449,7 +530,7 @@ DROP DATABASE drop_me CASCADE
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 0
 
@@ -494,18 +575,18 @@ CREATE TABLE public.tbl_ttl_on_noop (
   CONSTRAINT tbl_ttl_on_noop_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl_ttl_on_noop'
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_ttl_on_noop'
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 ACTIVE  @hourly  root
 
 let $schedule_id
 SELECT id FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 
 query T
 SELECT create_statement FROM [SHOW CREATE SCHEDULE $schedule_id]
@@ -533,12 +614,12 @@ CREATE TABLE public.tbl_ttl_job_cron (
   CONSTRAINT tbl_ttl_job_cron_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@daily')
 
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl_ttl_job_cron'
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_ttl_job_cron'
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 ACTIVE  @daily  root
 
@@ -557,7 +638,7 @@ CREATE TABLE public.tbl_ttl_job_cron (
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 ACTIVE  @weekly  root
 
@@ -575,7 +656,7 @@ CREATE TABLE public.tbl_ttl_job_cron (
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 ACTIVE  @hourly  root
 
@@ -1037,12 +1118,12 @@ CREATE TABLE public.create_table_no_ttl_set_ttl_expire_after (
   CONSTRAINT create_table_no_ttl_set_ttl_expire_after_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'create_table_no_ttl_set_ttl_expire_after'
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'create_table_no_ttl_set_ttl_expire_after'
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 ACTIVE  @hourly  root
 
@@ -1051,7 +1132,7 @@ ALTER TABLE create_table_no_ttl_set_ttl_expire_after RESET (ttl)
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 
 subtest end
@@ -1078,12 +1159,12 @@ CREATE TABLE public.create_table_no_ttl_set_ttl_expiration_expression (
   FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
 
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'create_table_no_ttl_set_ttl_expiration_expression'
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'create_table_no_ttl_set_ttl_expiration_expression'
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 ACTIVE  @hourly  root
 
@@ -1092,7 +1173,7 @@ ALTER TABLE create_table_no_ttl_set_ttl_expiration_expression RESET (ttl)
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
 
 subtest end
@@ -1102,12 +1183,12 @@ subtest special_table_name
 statement ok
 CREATE TABLE "Table-Name" (id INT PRIMARY KEY) WITH (ttl_expire_after = '10 hours')
 
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'Table-Name'
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'Table-Name'
 
 let $schedule_id
 SELECT id FROM [SHOW SCHEDULES]
-WHERE label = 'row-level-ttl-$table_id'
+WHERE label = 'row-level-ttl: $label_suffix'
 
 query T
 SELECT create_statement FROM [SHOW CREATE SCHEDULE $schedule_id]

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1568,8 +1568,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 							sc.execCfg.JobsKnobs(),
 							scheduledJobs,
 							scTable.GetPrivileges().Owner(),
-							scTable.GetID(),
-							modify.RowLevelTTL(),
+							scTable,
 						)
 						if err != nil {
 							return err

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
@@ -1181,6 +1182,12 @@ func (s *TestState) DeleteDatabaseRoleSettings(_ context.Context, dbID descpb.ID
 // DeleteSchedule implements scexec.DescriptorMetadataUpdater
 func (s *TestState) DeleteSchedule(ctx context.Context, id int64) error {
 	s.LogSideEffectf("delete job schedule #%d", id)
+	return nil
+}
+
+// UpdateTTLScheduleLabel implements scexec.DescriptorMetadataUpdater
+func (s *TestState) UpdateTTLScheduleLabel(ctx context.Context, tbl *tabledesc.Mutable) error {
+	s.LogSideEffectf("update ttl schedule label #%d", tbl.ID)
 	return nil
 }
 

--- a/pkg/sql/schemachanger/scexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/nstree",
+        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/schemachanger/scerrors",

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/scmutationexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -348,6 +349,10 @@ type DescriptorMetadataUpdater interface {
 
 	// DeleteSchedule deletes the given schedule.
 	DeleteSchedule(ctx context.Context, id int64) error
+
+	// UpdateTTLScheduleLabel updates the schedule_name for the TTL Scheduled Job
+	// of the given table.
+	UpdateTTLScheduleLabel(ctx context.Context, tbl *tabledesc.Mutable) error
 }
 
 // StatsRefreshQueue queues table for stats refreshes.

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -518,7 +518,14 @@ func (noopMetadataUpdater) DeleteDatabaseRoleSettings(ctx context.Context, dbID 
 	return nil
 }
 
-// DeleteScheduleID implements scexec.DescriptorMetadataUpdater
+// DeleteScheduleID implements scexec.DescriptorMetadataUpdater.
 func (noopMetadataUpdater) DeleteSchedule(ctx context.Context, scheduleID int64) error {
+	return nil
+}
+
+// UpdateTTLScheduleLabel implements scexec.DescriptorMetadataUpdater.
+func (noopMetadataUpdater) UpdateTTLScheduleLabel(
+	ctx context.Context, tbl *tabledesc.Mutable,
+) error {
 	return nil
 }

--- a/pkg/sql/ttl/ttlbase/BUILD.bazel
+++ b/pkg/sql/ttl/ttlbase/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/catpb",
+        "//pkg/sql/catalog/tabledesc",
     ],
 )
 

--- a/pkg/sql/ttl/ttlbase/ttl_helpers.go
+++ b/pkg/sql/ttl/ttlbase/ttl_helpers.go
@@ -12,11 +12,13 @@ package ttlbase
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 )
 
 // DefaultAOSTDuration is the default duration to use in the AS OF SYSTEM TIME
@@ -30,6 +32,12 @@ var startKeyCompareOps = map[catenumpb.IndexColumn_Direction]string{
 var endKeyCompareOps = map[catenumpb.IndexColumn_Direction]string{
 	catenumpb.IndexColumn_ASC:  "<",
 	catenumpb.IndexColumn_DESC: ">",
+}
+
+// BuildScheduleLabel returns a string value intended for use as the
+// schedule_name/label column for the scheduled job created by row level TTL.
+func BuildScheduleLabel(tbl *tabledesc.Mutable) string {
+	return fmt.Sprintf("row-level-ttl: %s [%d]", tbl.GetName(), tbl.ID)
 }
 
 func BuildSelectQuery(

--- a/pkg/sql/ttl/ttlschedule/ttlschedule.go
+++ b/pkg/sql/ttl/ttlschedule/ttlschedule.go
@@ -136,6 +136,9 @@ func (s rowLevelTTLExecutor) ExecuteJob(
 		return err
 	}
 
+	// TODO(chrisseto): Should opName be updated to match schedule_name? We'll
+	// have to query to resolve the table name or delegate to sj.ScheduleLabel,
+	// which may make debugging quite confusing if the label gets out of whack.
 	p, cleanup := cfg.PlanHookMaker(
 		ctx,
 		fmt.Sprintf("invoke-row-level-ttl-%d", args.TableID),


### PR DESCRIPTION
Previously, `SHOW SCHEDULES` would only show a table's ID for row level TTL jobs. For the convenience of debugging, this commit upgrades the `label` column to contain the table's name instead of its ID.

Rather than performing table name resolution at query time, the job name is set at creation time and updated by the schema change during table renames. This minimizes the likelihood of `SHOW SCHEDULES` being rendered unusable when a cluster is in an unstable state.

Epic: CRDB-18322
Fixes: #93774