### PR TITLE
sqlproxyccl: deflake TestDeleteTenant

### DIFF
--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -496,13 +496,28 @@ func TestDeleteTenant(t *testing.T) {
 		process.Stopper.Stop(ctx)
 	}
 
-	// Report failure connecting to the pod to force refresh of addrs.
-	require.NoError(t, dir.ReportFailure(ctx, tenantID, addr))
+	// There is a rare race condition where the watch event can overwrite
+	// ListPods inside ReportFailure. If that happens, retrying the ReportFailure
+	// should work as expected.
+	// See https://github.com/cockroachdb/cockroach/issues/86077
+	testutils.SucceedsSoon(t, func() error {
+		// Report failure connecting to the pod to force refresh of addrs.
+		if err := dir.ReportFailure(ctx, tenantID, addr); err != nil {
+			return err
+		}
 
-	// Ensure that tenant has no valid IP addresses.
-	pods, err = dir.TryLookupTenantPods(ctx, tenantID)
-	require.NoError(t, err)
-	require.Empty(t, pods)
+		// Ensure that tenant has no valid IP addresses.
+		pods, err = dir.TryLookupTenantPods(ctx, tenantID)
+		if err != nil {
+			return err
+		}
+
+		if len(pods) != 0 {
+			return errors.Newf("expected 0 pods found %v", pods)
+		}
+
+		return nil
+	})
 
 	// Report failure again to ensure that works when there is no ip address.
 	require.NoError(t, dir.ReportFailure(ctx, tenantID, addr))


### PR DESCRIPTION
There is a small race condition in the tenant directory cache.

1. If ReportFailure is called, the tenant dir rebuilds the cache by listing the available pods.
2. There is a watch attempting to push events to the cache. If an event was generated before the most recent list, the watch event can roll back cache state.

This race is okay in production because when the sql proxy tries to dial the stale pod, the dial will fail and the proxy will refresh the list again.

This change adjusts the test to work like production. If the list is stale, ReportFailure is retried to refresh the list of pods.

Fixes: #86077