### PR TITLE
release-22.2: sql: function lower-case alternative hint support for explicit schema

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2819,3 +2819,23 @@ query I
 SELECT f_103869('sq_103869')
 ----
 2
+
+subtest lowercase_hint_error_implicit_schema
+
+statement ok
+CREATE FUNCTION lowercase_hint_error_implicit_schema_fn() RETURNS INT AS 'SELECT 1' LANGUAGE SQL
+
+statement error unknown function: LOWERCASE_HINT_ERROR_IMPLICIT_SCHEMA_FN\(\), but lowercase_hint_error_implicit_schema_fn\(\) exists: function undefined
+SELECT "LOWERCASE_HINT_ERROR_IMPLICIT_SCHEMA_FN"();
+
+subtest end
+
+subtest lowercase_hint_error_explicit_schema
+
+statement ok
+CREATE FUNCTION public.lowercase_hint_error_explicit_schema_fn() RETURNS INT AS 'SELECT 1' LANGUAGE SQL
+
+statement error unknown function: public\.LOWERCASE_HINT_ERROR_EXPLICIT_SCHEMA_FN\(\), but lowercase_hint_error_explicit_schema_fn\(\) exists: function undefined
+SELECT public."LOWERCASE_HINT_ERROR_EXPLICIT_SCHEMA_FN"();
+
+subtest end

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -447,7 +447,7 @@ func (sr *schemaResolver) ResolveFunction(
 		extraMsg := ""
 		var lowerName tree.UnresolvedName
 		if fn.ExplicitSchema {
-			lowerName = tree.MakeUnresolvedName(strings.ToLower(name.Parts[0]), strings.ToLower(name.Parts[1]))
+			lowerName = tree.MakeUnresolvedName(strings.ToLower(name.Parts[1]), strings.ToLower(name.Parts[0]))
 		} else {
 			lowerName = tree.MakeUnresolvedName(strings.ToLower(name.Parts[0]))
 		}


### PR DESCRIPTION
Backport 1/1 commits from #107281.

/cc @cockroachdb/release

---

Fixes #107278

Previously the function lower-case alternative hint did not work if a schema was explicitly specified.

This PR adds support by fixing the order of arguments provided to `tree.MakeUnresolvedName()` and adds missing test cases.

Release note: None

Release justification: Error hint bug fix and additional tests.
