### PR TITLE
release-23.1: sql: function lower-case alternative hint support for explicit schema

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3554,3 +3554,23 @@ CREATE FUNCTION public.func104242_not_null()
 $$
 
 subtest end
+
+subtest lowercase_hint_error_implicit_schema
+
+statement ok
+CREATE FUNCTION lowercase_hint_error_implicit_schema_fn() RETURNS INT AS 'SELECT 1' LANGUAGE SQL
+
+statement error function undefined\nHINT: lower-case alternative lowercase_hint_error_implicit_schema_fn exists
+SELECT "LOWERCASE_HINT_ERROR_IMPLICIT_SCHEMA_FN"();
+
+subtest end
+
+subtest lowercase_hint_error_explicit_schema
+
+statement ok
+CREATE FUNCTION public.lowercase_hint_error_explicit_schema_fn() RETURNS INT AS 'SELECT 1' LANGUAGE SQL
+
+statement error function undefined\nHINT: lower-case alternative public.lowercase_hint_error_explicit_schema_fn exists
+SELECT public."LOWERCASE_HINT_ERROR_EXPLICIT_SCHEMA_FN"();
+
+subtest end

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -489,7 +489,7 @@ func makeFunctionUndefinedError(
 ) error {
 	var lowerName tree.UnresolvedName
 	if fn.ExplicitSchema {
-		lowerName = tree.MakeUnresolvedName(strings.ToLower(name.Parts[0]), strings.ToLower(name.Parts[1]))
+		lowerName = tree.MakeUnresolvedName(strings.ToLower(name.Parts[1]), strings.ToLower(name.Parts[0]))
 	} else {
 		lowerName = tree.MakeUnresolvedName(strings.ToLower(name.Parts[0]))
 	}


### PR DESCRIPTION
Backport 1/1 commits from #107281.

/cc @cockroachdb/release

---

Fixes #107278

Previously the function lower-case alternative hint did not work if a schema was explicitly specified.

This PR adds support by fixing the order of arguments provided to `tree.MakeUnresolvedName()` and adds missing test cases.

Release note: None

Release justification: Error hint bug fix and additional tests.