### PR TITLE
server: increase timeout for application_api tests

### DIFF
--- a/pkg/server/application_api/BUILD.bazel
+++ b/pkg/server/application_api/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
 
 go_test(
     name = "application_api_test",
+    size = "large",
     srcs = [
         "activity_test.go",
         "config_test.go",
@@ -30,7 +31,7 @@ go_test(
         "util_test.go",
         "zcfg_test.go",
     ],
-    args = ["-test.timeout=295s"],
+    args = ["-test.timeout=895s"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
This patch increase the timeout for the tests in the `application_api` package from `5m` to `15m`. Several of these tests have been flaking lately with timeouts.

Fixes #107225
Fixes #107263
Fixes #107308

Release note: None