### PR TITLE
release-22.2: scbuild: fix concurrent schema change verification bug

### DIFF
--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -163,7 +163,7 @@ func newBuilderState(ctx context.Context, d Dependencies, initial scpb.CurrentSt
 		panic(err)
 	}
 	for _, t := range initial.TargetState.Targets {
-		bs.ensureDescriptor(screl.GetDescID(t.Element()))
+		bs.ensureDescriptors(t.Element())
 	}
 	for i, t := range initial.TargetState.Targets {
 		bs.Ensure(initial.Current[i], scpb.AsTargetStatus(t.TargetStatus), t.Element(), t.Metadata)


### PR DESCRIPTION
Backport 1/1 commits from #106933.

/cc @cockroachdb/release

Release justification: important bug fix

---

Previously, we didn't check for concurrent schema changes on targets set
on elements that the builder state didn't know about yet. This patch
fixes this oversight. This regression was recently introduced by #106175.

Fixes: #106487

Release note: None

