### PR TITLE
ui: improve hot ranges requesting per page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -126,6 +126,15 @@ export const hotRangesReducerObj = new PaginatedCachedDataReducer(
   api.getHotRanges,
   "hotRanges",
   hotRangesRequestToID,
+  // Set page size to be multiple of 128 ranges as it is predefined number of collected hot ranges per store
+  // `numTopReplicasToTrack` in pkg/kv/kvserver/replica_rankings.go
+  // With one store per node (as default case) would cause to get all hot ranges from node in one pass if we set
+  // page_limit to 128.
+  // Current value is 128 * 3 to visit 3 nodes with one request. It should be relatively fast and covers case for
+  // cluster with minimal recommended number of nodes.
+  128 * 3,
+  undefined,
+  moment.duration(5, "m"),
 );
 
 export const refreshDatabaseDetails = databaseDetailsReducerObj.refresh;

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
@@ -55,16 +55,6 @@ const HotRangesPage = () => {
     }
   }, [dispatch, isValid]);
 
-  useEffect(() => {
-    dispatch(
-      refreshHotRanges(
-        new HotRangesRequest({
-          page_size: 1000,
-        }),
-      ),
-    );
-  }, [dispatch]);
-
   const [filteredHotRanges, setFilteredHotRanges] =
     useState<HotRange[]>(hotRanges);
 


### PR DESCRIPTION
This patch updates `page_size` value for Hot Ranges request to match with number of collected hot ranges per store on node. It allows reduce the number of visits to the same node by ensuring that we get all hot ranges from the store in one pass.
This optimization might not help for clusters where might be very few ranges per node.
Also request timeout increased to 5 min to mitigate risk that sequential visiting nodes might be slow.

Release note (ui change): optimize hot ranges requests to minimize the risk to timeout response.