### PR TITLE
release-22.2: compose: Deflake testComposeCompare

### DIFF
--- a/pkg/compose/BUILD.bazel
+++ b/pkg/compose/BUILD.bazel
@@ -10,8 +10,12 @@ go_library(
 
 go_test(
     name = "compose_test",
+    size = "enormous",
     srcs = ["compose_test.go"],
-    args = ["-test.timeout=295s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = [
         "//c-deps:libgeos",
         "//pkg/compose:compare/docker-compose.yml",

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 var (
+	// flagEach controls how long we are going to run each compose test. Ensure bazel BUILD file
+	// of compose tests has a longer timeout.
 	flagEach      = flag.Duration("each", 10*time.Minute, "individual test timeout")
 	flagTests     = flag.String("tests", ".", "tests within docker compose to run")
 	flagArtifacts = flag.String("artifacts", "", "artifact directory")

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -226,6 +226,9 @@ func getColRef(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, *colRef,
 	if s.disableDecimals && col.typ.Family() == types.DecimalFamily {
 		return nil, nil, false
 	}
+	if s.disableOIDs && col.typ.Family() == types.OidFamily {
+		return nil, nil, false
+	}
 	return col.typedExpr(), col, true
 }
 

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -47,6 +47,10 @@ func (s *Smither) pickAnyType(typ *types.T) *types.T {
 		if s.disableDecimals {
 			typ = s.randType()
 		}
+	case types.OidFamily:
+		if s.disableOIDs {
+			typ = s.randType()
+		}
 	}
 	return typ
 }
@@ -58,11 +62,14 @@ func (s *Smither) randScalarType() *types.T {
 	if s.types != nil {
 		scalarTypes = s.types.scalarTypes
 	}
-	typ := randgen.RandTypeFromSlice(s.rnd, scalarTypes)
-	if s.disableDecimals {
-		for typ.Family() == types.DecimalFamily {
-			typ = randgen.RandTypeFromSlice(s.rnd, scalarTypes)
+	var typ *types.T
+	for {
+		typ = randgen.RandTypeFromSlice(s.rnd, scalarTypes)
+		if (s.disableDecimals && typ.Family() == types.DecimalFamily) ||
+			(s.disableOIDs && typ.Family() == types.OidFamily) {
+			continue
 		}
+		break
 	}
 	return typ
 }
@@ -91,11 +98,14 @@ func (s *Smither) randType() *types.T {
 	if s.types != nil {
 		seedTypes = s.types.seedTypes
 	}
-	typ := randgen.RandTypeFromSlice(s.rnd, seedTypes)
-	if s.disableDecimals {
-		for typ.Family() == types.DecimalFamily {
-			typ = randgen.RandTypeFromSlice(s.rnd, seedTypes)
+	var typ *types.T
+	for {
+		typ = randgen.RandTypeFromSlice(s.rnd, seedTypes)
+		if s.disableDecimals && typ.Family() == types.DecimalFamily ||
+			(s.disableOIDs && typ.Family() == types.OidFamily) {
+			continue
 		}
+		break
 	}
 	return typ
 }


### PR DESCRIPTION
Backport 1/1 commits from #107224.

/cc @cockroachdb/release

---

We identified the fixed the following issues concerning test testComposeCompare:
1. Disallow several functions because they're not supported in Postgist
2. Disable random generation of `OID` type because it's natural to have the same OIDs assigned to different objects between CRDB and Postgist.
3. Disable using index hints because Postgist does not support this feature.
4. Disable locales because Postgist requires them to be double-quoted
and it's not feasible to change locale name formatting to be double-quoted.
5. Fixed a test bug where we'd mistakenly allow generation of stmts like `CREATE TABLE t (... inverted index (...))` in our test against Postgist.
6. Make this test a "enormous" test which has an 1-hour timeout because it executes two subtests sequentially for 10m each.

Inform #89361
Epic: None
Release justification: Deflake test.
Release note: None
