### PR TITLE
asim: add randomized range generation 

### DIFF
--- a/pkg/kv/kvserver/asim/state/new_state.go
+++ b/pkg/kv/kvserver/asim/state/new_state.go
@@ -12,6 +12,7 @@ package state
 
 import (
 	"fmt"
+	"math/rand"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/config"
@@ -61,6 +62,79 @@ func exactDistribution(counts []int) []float64 {
 	}
 	for i, count := range counts {
 		distribution[i] = float64(count) / float64(total)
+	}
+	return distribution
+}
+
+// weighted struct handles weighted random index selection from an input array,
+// weightedStores.
+//
+// For example, consider input weightedStores = [0.1, 0.2, 0.7].
+// - newWeighted constructs cumulative weighs, creating cumulativeWeighted [0.1,
+// 0.3, 1.0].
+// - rand function then randomly selects a number n within the range of [0.0,
+// 1.0) and finds which bucket ([0.0, 0.1], (0.1, 0.3], (0.3, 1.0]) n falls
+// under. It finds the smallest index within cumulativeWeights that >= n. Thus,
+// indices with greater weights have a higher probability of being selected as
+// they cover larger cumulative weights range. For instance, if it selects 0.5,
+// Rand would return index 2 since 0.7 is the smallest index that is >= 0.5.
+type weighted struct {
+	cumulativeWeights []float64
+}
+
+// newWeighted constructs cumulative weights that are used later to select a
+// single random index from weightedStores based on the associated weights.
+func newWeighted(weightedStores []float64) weighted {
+	cumulativeWeights := make([]float64, len(weightedStores))
+	prefixSumWeight := float64(0)
+	for i, item := range weightedStores {
+		prefixSumWeight += item
+		cumulativeWeights[i] = prefixSumWeight
+	}
+	if cumulativeWeights[len(weightedStores)-1] != float64(1) {
+		panic(fmt.Sprintf("total cumulative weights for all stores should sum up to one but got %.2f\n",
+			cumulativeWeights[len(weightedStores)-1]))
+	}
+	return weighted{cumulativeWeights: cumulativeWeights}
+}
+
+// rand randomly picks an index from weightedStores based on the associated
+// weights.
+func (w weighted) rand(randSource *rand.Rand) int {
+	r := randSource.Float64()
+	index := sort.Search(len(w.cumulativeWeights), func(i int) bool { return w.cumulativeWeights[i] >= r })
+	return index
+}
+
+// weightedRandDistribution generates a weighted random distribution across
+// stores. It achieves this by randomly selecting an index from weightedStores
+// 10 times while considering the weights, and repeating this process ten times.
+// The output is a weighted random distribution reflecting the selections made.
+func weightedRandDistribution(randSource *rand.Rand, weightedStores []float64) []float64 {
+	w := newWeighted(weightedStores)
+	numSamples := 10
+	votes := make([]int, len(weightedStores))
+	for i := 0; i < numSamples; i++ {
+		index := w.rand(randSource)
+		votes[index] += 1
+	}
+	return exactDistribution(votes)
+}
+
+// randDistribution generates a random distribution across stores. It achieves
+// this by creating an array of size n, selecting random numbers from [0, 10)
+// for each index, and returning the exact distribution of this result.
+func randDistribution(randSource *rand.Rand, n int) []float64 {
+	total := float64(0)
+	distribution := make([]float64, n)
+	for i := 0; i < n; i++ {
+		num := float64(randSource.Intn(10))
+		distribution[i] = num
+		total += num
+	}
+
+	for i := 0; i < n; i++ {
+		distribution[i] = distribution[i] / total
 	}
 	return distribution
 }
@@ -250,6 +324,61 @@ func RangesInfoEvenDistribution(
 		int64(MinKey), int64(keyspace), rangeSize)
 }
 
+// RangesInfoWeightedRandDistribution returns a RangesInfo, where ranges are
+// generated with a weighted random distribution across stores.
+func RangesInfoWeightedRandDistribution(
+	randSource *rand.Rand,
+	weightedStores []float64,
+	ranges int,
+	keyspace int,
+	replicationFactor int,
+	rangeSize int64,
+) RangesInfo {
+	if randSource == nil || len(weightedStores) == 0 {
+		panic("randSource cannot be nil and weightedStores must be non-empty in order to generate weighted random range info")
+	}
+	distribution := weightedRandDistribution(randSource, weightedStores)
+	storeList := makeStoreList(len(weightedStores))
+	spanConfig := defaultSpanConfig
+	spanConfig.NumReplicas = int32(replicationFactor)
+	spanConfig.NumVoters = int32(replicationFactor)
+	return RangesInfoWithDistribution(
+		storeList,
+		distribution,
+		distribution,
+		ranges,
+		spanConfig,
+		int64(MinKey),
+		int64(keyspace),
+		rangeSize, /* rangeSize */
+	)
+}
+
+// RangesInfoRandDistribution returns a RangesInfo, where ranges are generated
+// with a random distribution across stores.
+func RangesInfoRandDistribution(
+	randSource *rand.Rand,
+	stores int,
+	ranges int,
+	keyspace int,
+	replicationFactor int,
+	rangeSize int64,
+) RangesInfo {
+	if randSource == nil {
+		panic("randSource cannot be nil in order to generate random range info")
+	}
+	distribution := randDistribution(randSource, stores)
+	storeList := makeStoreList(stores)
+
+	spanConfig := defaultSpanConfig
+	spanConfig.NumReplicas = int32(replicationFactor)
+	spanConfig.NumVoters = int32(replicationFactor)
+
+	return RangesInfoWithDistribution(
+		storeList, distribution, distribution, ranges, spanConfig,
+		int64(MinKey), int64(keyspace), rangeSize)
+}
+
 // NewStateWithDistribution returns a State where the stores given are
 // initialized with the specified % of the replicas. This is done on a best
 // effort basis, given the replication factor. It may be impossible to satisfy
@@ -318,5 +447,37 @@ func NewStateSkewedDistribution(
 ) State {
 	clusterInfo := ClusterInfoWithStoreCount(stores, 1 /* storesPerNode */)
 	rangesInfo := RangesInfoSkewedDistribution(stores, ranges, keyspace, replicationFactor, 0 /* rangeSize */)
+	return LoadConfig(clusterInfo, rangesInfo, settings)
+}
+
+// NewStateRandDistribution returns a new State where the replica count per
+// store is randomized.
+func NewStateRandDistribution(
+	seed int64,
+	stores int,
+	ranges int,
+	keyspace int,
+	replicationFactor int,
+	settings *config.SimulationSettings,
+) State {
+	randSource := rand.New(rand.NewSource(seed))
+	clusterInfo := ClusterInfoWithStoreCount(stores, 1 /* storesPerNode */)
+	rangesInfo := RangesInfoRandDistribution(randSource, stores, ranges, keyspace, replicationFactor, 0 /* rangeSize */)
+	return LoadConfig(clusterInfo, rangesInfo, settings)
+}
+
+// NewStateWeightedRandDistribution returns a new State where the replica count
+// per store is weighted randomized based on weightedStores.
+func NewStateWeightedRandDistribution(
+	seed int64,
+	weightedStores []float64,
+	ranges int,
+	keyspace int,
+	replicationFactor int,
+	settings *config.SimulationSettings,
+) State {
+	randSource := rand.New(rand.NewSource(seed))
+	clusterInfo := ClusterInfoWithStoreCount(len(weightedStores), 1 /* storesPerNode */)
+	rangesInfo := RangesInfoWeightedRandDistribution(randSource, weightedStores, ranges, keyspace, replicationFactor, 0 /* rangeSize */)
 	return LoadConfig(clusterInfo, rangesInfo, settings)
 }

--- a/pkg/kv/kvserver/asim/tests/default_settings.go
+++ b/pkg/kv/kvserver/asim/tests/default_settings.go
@@ -64,7 +64,7 @@ func defaultLoadGen() gen.BasicLoad {
 const (
 	defaultRanges            = 1
 	defaultPlacementType     = gen.Even
-	defaultReplicationFactor = 1
+	defaultReplicationFactor = 3
 	defaultBytes             = 0
 )
 
@@ -106,5 +106,26 @@ func defaultPlotSettings() plotSettings {
 		stat:   defaultStat,
 		height: defaultHeight,
 		width:  defaultWidth,
+	}
+}
+
+type rangeGenSettings struct {
+	rangeKeyGenType generatorType
+	keySpaceGenType generatorType
+	weightedRand    []float64
+}
+
+const (
+	defaultRangeKeyGenType = uniformGenerator
+	defaultKeySpaceGenType = uniformGenerator
+)
+
+var defaultWeightedRand []float64
+
+func defaultRangeGenSettings() rangeGenSettings {
+	return rangeGenSettings{
+		rangeKeyGenType: defaultRangeKeyGenType,
+		keySpaceGenType: defaultKeySpaceGenType,
+		weightedRand:    defaultWeightedRand,
 	}
 }

--- a/pkg/kv/kvserver/asim/tests/rand_gen.go
+++ b/pkg/kv/kvserver/asim/tests/rand_gen.go
@@ -11,8 +11,10 @@
 package tests
 
 import (
+	"fmt"
 	"math/rand"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/config"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/gen"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 )
@@ -22,4 +24,123 @@ func (f randTestingFramework) randomClusterInfoGen(randSource *rand.Rand) gen.Lo
 	chosenIndex := randSource.Intn(len(state.ClusterOptions))
 	chosenType := state.ClusterOptions[chosenIndex]
 	return loadClusterInfo(chosenType)
+}
+
+// RandomizedBasicRanges implements the RangeGen interface, supporting random
+// range info distribution.
+type RandomizedBasicRanges struct {
+	gen.BaseRanges
+	placementType gen.PlacementType
+	randSource    *rand.Rand
+}
+
+var _ gen.RangeGen = &RandomizedBasicRanges{}
+
+func (r RandomizedBasicRanges) Generate(
+	seed int64, settings *config.SimulationSettings, s state.State,
+) state.State {
+	if r.placementType != gen.Random {
+		panic("RandomizedBasicRanges generate only randomized distributions")
+	}
+	rangesInfo := r.GetRangesInfo(r.placementType, len(s.Stores()), r.randSource, []float64{})
+	r.LoadRangeInfo(s, rangesInfo)
+	return s
+}
+
+// WeightedRandomizedBasicRanges implements the RangeGen interface, supporting
+// weighted random range info distribution.
+type WeightedRandomizedBasicRanges struct {
+	gen.BaseRanges
+	placementType gen.PlacementType
+	randSource    *rand.Rand
+	weightedRand  []float64
+}
+
+var _ gen.RangeGen = &WeightedRandomizedBasicRanges{}
+
+func (wr WeightedRandomizedBasicRanges) Generate(
+	seed int64, settings *config.SimulationSettings, s state.State,
+) state.State {
+	if wr.placementType != gen.WeightedRandom || len(wr.weightedRand) == 0 {
+		panic("RandomizedBasicRanges generate only weighted randomized distributions with non-empty weightedRand")
+	}
+	rangesInfo := wr.GetRangesInfo(wr.placementType, len(s.Stores()), wr.randSource, wr.weightedRand)
+	wr.LoadRangeInfo(s, rangesInfo)
+	return s
+}
+
+// TODO(wenyihu6): Instead of duplicating the key generator logic in simulators,
+// we should directly reuse the code from the repo pkg/workload/(kv|ycsb) to
+// ensure consistent testing.
+
+// generator generates both ranges and keyspace parameters for ranges
+// generations.
+type generator interface {
+	key() int64
+}
+
+type uniformKeyGenerator struct {
+	min, max int64
+	random   *rand.Rand
+}
+
+// newUniformKeyGen returns a generator that generates number∈[min, max] with a
+// uniform distribution.
+func newUniformKeyGen(min, max int64, rand *rand.Rand) generator {
+	if max <= min {
+		panic(fmt.Sprintf("max (%d) must be greater than min (%d)", max, min))
+	}
+	return &uniformKeyGenerator{
+		min:    min,
+		max:    max,
+		random: rand,
+	}
+}
+
+func (g *uniformKeyGenerator) key() int64 {
+	return g.random.Int63n(g.max-g.min) + g.min
+}
+
+type zipfianKeyGenerator struct {
+	min, max int64
+	random   *rand.Rand
+	zipf     *rand.Zipf
+}
+
+// newZipfianKeyGen returns a generator that generates number ∈[min, max] with a
+// zipfian distribution.
+func newZipfianKeyGen(min, max int64, s float64, v float64, random *rand.Rand) generator {
+	if max <= min {
+		panic(fmt.Sprintf("max (%d) must be greater than min (%d)", max, min))
+	}
+	return &zipfianKeyGenerator{
+		min:    min,
+		max:    max,
+		random: random,
+		zipf:   rand.NewZipf(random, s, v, uint64(max-min)),
+	}
+}
+
+func (g *zipfianKeyGenerator) key() int64 {
+	return int64(g.zipf.Uint64()) + g.min
+}
+
+type generatorType int
+
+const (
+	uniformGenerator generatorType = iota
+	zipfGenerator
+)
+
+// newGenerator returns a generator that generates number ∈[min, max] following
+// a distribution based on gType.
+func newGenerator(randSource *rand.Rand, iMin int64, iMax int64, gType generatorType) generator {
+	switch gType {
+	case uniformGenerator:
+		return newUniformKeyGen(iMin, iMax, randSource)
+	case zipfGenerator:
+		return newZipfianKeyGen(iMin, iMax, 1.1, 1, randSource)
+	default:
+		panic(fmt.Sprintf("unexpected generator type %v", gType))
+	}
 }

--- a/pkg/kv/kvserver/asim/workload/workload.go
+++ b/pkg/kv/kvserver/asim/workload/workload.go
@@ -162,6 +162,10 @@ func (rwg *RandomGenerator) Tick(maxTime time.Time) LoadBatch {
 	return ret
 }
 
+// TODO(wenyihu6): Instead of duplicating the key generator logic in simulators,
+// we should directly reuse the code from the repo pkg/workload/(kv|ycsb) to
+// ensure consistent testing.
+
 // KeyGenerator generates read and write keys.
 type KeyGenerator interface {
 	writeKey() int64


### PR DESCRIPTION
This patch enables random range configuration to be generated.

TestRandomized can now take another setting parameter rangeGen (default: uniform
rangeGenType, uniform keySpaceGenType, empty weightedRand).

These generators are part of the framework fields which persist across
iterations. The numbers produced by the generator shape the distribution across
iterations.

- rangeKeyGenType: determines range generator type across iterations (default:
uniformGenerator, min = 1, max = 1000)

- keySpaceGenType: determines key space generator type across iterations
(default: uniformGenerator, min = 1000, max = 200000)

- weightedRand: if non-empty, enables weighted randomization for range
distribution

This provides three modes for range generation:
1. Default: currently set to uniform distribution
2. Random: randomly generates range distribution across stores
3. Weighted Randomization: enables weighted randomization for range distribution
if and only if given weightedRand is non-empty

Part of: https://github.com/cockroachdb/cockroach/issues/106311

Release note: None