### PR TITLE
sql: handle mixed-case for pg_get_serial_sequence

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -245,7 +245,18 @@ create table serial_2 ("capITALS" SERIAL)
 query T
 SELECT pg_get_serial_sequence('serial_2', 'capITALS')
 ----
-public.serial_2_capITALS_seq
+public."serial_2_capITALS_seq"
+
+statement ok
+create schema "schema-hyphen"
+
+statement ok
+create table "schema-hyphen"."Serial_3" ("capITALS" SERIAL)
+
+query T
+SELECT pg_get_serial_sequence('"schema-hyphen"."Serial_3"', 'capITALS')
+----
+"schema-hyphen"."Serial_3_capITALS_seq"
 
 statement ok
 INSERT INTO serial (a, b) VALUES (0, 2), (DEFAULT, DEFAULT), (DEFAULT, 3)

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -832,7 +832,7 @@ var pgBuiltins = map[string]builtinDefinition{
 					return tree.DNull, nil
 				}
 				res.ExplicitCatalog = false
-				return tree.NewDString(fmt.Sprintf(`%s.%s`, res.Schema(), res.Object())), nil
+				return tree.NewDString(fmt.Sprintf(`%s.%s`, res.SchemaName.String(), res.ObjectName.String())), nil
 			},
 			Info:       "Returns the name of the sequence used by the given column_name in the table table_name.",
 			Volatility: volatility.Stable,


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/107234
Release note (bug fix): The pg_get_serial_sequence builtin function can now handle mixed-case names correctly.