### PR TITLE
randgen: skip virtual columns in generate_test_objects

### DIFF
--- a/pkg/sql/catalog/randgen/templates.go
+++ b/pkg/sql/catalog/randgen/templates.go
@@ -138,8 +138,8 @@ outer:
 		}
 
 		for _, origColDef := range origDesc.Columns {
-			// We don't take over hidden/inaccessible columns.
-			if origColDef.Hidden || origColDef.Inaccessible {
+			// We don't take over hidden/inaccessible/virtual columns.
+			if origColDef.Hidden || origColDef.Inaccessible || origColDef.Virtual {
 				continue
 			}
 			colID := t.desc.NextColumnID

--- a/pkg/sql/logictest/testdata/logic_test/gen_test_objects
+++ b/pkg/sql/logictest/testdata/logic_test/gen_test_objects
@@ -169,6 +169,12 @@ SELECT crdb_internal.generate_test_objects('{"seed":1234,"counts":[10],"table_te
 ----
 {"databases": 0, "schemas": 0, "tables": 10}
 
+# Regression test for not ignoring virtual columns.
+query T
+SELECT crdb_internal.generate_test_objects('{"seed":1234,"counts":[1],"table_templates":["system.statement_statistics"]}'::JSONB)->'generated_counts'
+----
+{"databases": 0, "schemas": 0, "tables": 1}
+
 query T
 SELECT table_name FROM [SHOW TABLES]
 ORDER BY table_name
@@ -182,6 +188,7 @@ priVileges
 replication_critical_localities
 role_id_seq
 statement_bundle_chunks
+sta😣tement_statistics
 ten  ant_set                     tings
 
 # Again, the column names are randomized.


### PR DESCRIPTION
If we don't, then `validateTableIndexes` will fail. Found when running `local` logic tests against the test tenant.

Epic: None

Release note: None