### PR TITLE
sql: fix CREATE TABLE AS schema change job description

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1192,19 +1192,6 @@ func newTableDescIfAs(
 		return nil, err
 	}
 
-	colResIndex := 0
-	// TableDefs for a CREATE TABLE ... AS AST node comprise of a ColumnTableDef
-	// for each column, and a ConstraintTableDef for any constraints on those
-	// columns.
-	for _, defs := range p.Defs {
-		var d *tree.ColumnTableDef
-		var ok bool
-		if d, ok = defs.(*tree.ColumnTableDef); ok {
-			d.Type = resultColumns[colResIndex].Typ
-			colResIndex++
-		}
-	}
-
 	// If there are no TableDefs defined by the parser, then we construct a
 	// ColumnTableDef for each column using resultColumns.
 	if len(p.Defs) == 0 {
@@ -1221,6 +1208,19 @@ func newTableDescIfAs(
 			}
 			d.Nullable.Nullability = tree.SilentNull
 			p.Defs = append(p.Defs, tableDef)
+		}
+	} else {
+		colResIndex := 0
+		// TableDefs for a CREATE TABLE ... AS AST node comprise of a ColumnTableDef
+		// for each column, and a ConstraintTableDef for any constraints on those
+		// columns.
+		for _, defs := range p.Defs {
+			var d *tree.ColumnTableDef
+			var ok bool
+			if d, ok = defs.(*tree.ColumnTableDef); ok {
+				d.Type = resultColumns[colResIndex].Typ
+				colResIndex++
+			}
 		}
 	}
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1199,9 +1199,10 @@ func newTableDescIfAs(
 			var d *tree.ColumnTableDef
 			var ok bool
 			var tableDef tree.TableDef = &tree.ColumnTableDef{
-				Name:   tree.Name(colRes.Name),
-				Type:   colRes.Typ,
-				Hidden: colRes.Hidden,
+				Name:       tree.Name(colRes.Name),
+				Type:       colRes.Typ,
+				IsCreateAs: true,
+				Hidden:     colRes.Hidden,
 			}
 			if d, ok = tableDef.(*tree.ColumnTableDef); !ok {
 				return nil, errors.Errorf("failed to cast type to ColumnTableDef\n")
@@ -1219,6 +1220,7 @@ func newTableDescIfAs(
 			var ok bool
 			if d, ok = defs.(*tree.ColumnTableDef); ok {
 				d.Type = resultColumns[colResIndex].Typ
+				d.IsCreateAs = true
 				colResIndex++
 			}
 		}

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -472,9 +472,12 @@ const (
 // ColumnTableDef represents a column definition within a CREATE TABLE
 // statement.
 type ColumnTableDef struct {
-	Name              Name
-	Type              ResolvableTypeReference
-	IsSerial          bool
+	Name     Name
+	Type     ResolvableTypeReference
+	IsSerial bool
+	// IsCreateAs is set to true if the Type is resolved after parsing.
+	// CREATE AS statements must not display column types during formatting.
+	IsCreateAs        bool
 	GeneratedIdentity struct {
 		IsGeneratedAsIdentity   bool
 		GeneratedAsIdentityType GeneratedIdentityType
@@ -754,7 +757,7 @@ func (node *ColumnTableDef) Format(ctx *FmtCtx) {
 
 	// ColumnTableDef node type will not be specified if it represents a CREATE
 	// TABLE ... AS query.
-	if node.Type != nil {
+	if !node.IsCreateAs && node.Type != nil {
 		ctx.WriteByte(' ')
 		node.formatColumnType(ctx)
 	}

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -213,7 +213,7 @@ func (ctx *FmtCtx) FormatTypeReference(ref ResolvableTypeReference) {
 		ctx.FormatNode(t)
 
 	default:
-		panic(errors.AssertionFailedf("type reference must implement NodeFormatter"))
+		panic(errors.AssertionFailedf("type reference %T must implement NodeFormatter", ref))
 	}
 }
 


### PR DESCRIPTION
Fixes #107364

This changes the CREATE TABLE AS schema change job description to no longer incorrectly
include column types.
For example
`CREATE TABLE movr.public.t2 (id INT8) AS SELECT * FROM movr.public.t;`
becomes
`CREATE TABLE movr.public.t2 (id) AS SELECT * FROM movr.public.t;`

Release note (bug fix): Fix CREATE TABLE AS schema change job description SQL syntax.