### PR TITLE
release-22.2: colbuilder: clean up type schema handling

### DIFF
--- a/pkg/sql/colexec/colbuilder/BUILD.bazel
+++ b/pkg/sql/colexec/colbuilder/BUILD.bazel
@@ -3,7 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "colbuilder",
-    srcs = ["execplan.go"],
+    srcs = [
+        "execplan.go",
+        "execplan_util.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colexec/colbuilder",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/sql/colexec/colbuilder/execplan_test.go
+++ b/pkg/sql/colexec/colbuilder/execplan_test.go
@@ -200,3 +200,36 @@ func BenchmarkRenderPlanning(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkNestedAndPlanning benchmarks how long it takes to run a query with
+// many expressions logically AND'ed in a single output column.
+func BenchmarkNestedAndPlanning(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(b, base.TestServerArgs{SQLMemoryPoolSize: 10 << 30})
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	// Disable fallback to the row-by-row processing wrapping.
+	sqlDB.Exec(b, "SET CLUSTER SETTING sql.distsql.vectorize_render_wrapping.min_render_count = 9999999")
+	sqlDB.Exec(b, "CREATE TABLE bench (i INT)")
+	for _, numRenders := range []int{1 << 4, 1 << 8, 1 << 12} {
+		var sb strings.Builder
+		sb.WriteString("SELECT ")
+		for i := 0; i < numRenders; i++ {
+			if i > 0 {
+				sb.WriteString(" AND ")
+			}
+			sb.WriteString(fmt.Sprintf("i < %d", i+1))
+		}
+		sb.WriteString(" FROM bench")
+		query := sb.String()
+		b.Run(fmt.Sprintf("renders=%d", numRenders), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				sqlDB.Exec(b, query)
+			}
+		})
+	}
+}

--- a/pkg/sql/colexec/colbuilder/execplan_util.go
+++ b/pkg/sql/colexec/colbuilder/execplan_util.go
@@ -1,0 +1,34 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+// addProjection adds a simple projection on top of op according to projection
+// and returns the updated operator and type schema.
+//
+// Note that this method is the only place that's allowed to create a simple
+// project op in colbuilder package (enforced by the linter) in order to force
+// the caller to think about the type schema to prevent type schema corruption
+// issues like #47889 and #107615.
+func addProjection(
+	op colexecop.Operator, typs []*types.T, projection []uint32,
+) (colexecop.Operator, []*types.T) {
+	newTypes := make([]*types.T, len(projection))
+	for i, j := range projection {
+		newTypes[i] = typs[j]
+	}
+	return colexecbase.NewSimpleProjectOp(op, len(typs), projection), newTypes
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -136,3 +136,45 @@ INSERT INTO t64676 VALUES
 
 statement ok
 SELECT i + d FROM t64676
+
+# Regression test for type schema corruption when planning filter expressions
+# (#107615).
+statement ok
+CREATE TABLE t107615 AS
+	SELECT
+		g::INT2 AS _int2,
+		g::INT4 AS _int4,
+		g::INT8 AS _int8,
+		g::FLOAT8 AS _float8,
+		'2001-01-01'::DATE + g AS _date,
+		'2001-01-01'::TIMESTAMP + g * '1 day'::INTERVAL AS _timestamp,
+		'2001-01-01'::TIMESTAMPTZ + g * '1 day'::INTERVAL AS _timestamptz,
+		g * '1 day'::INTERVAL AS _interval,
+		g % 2 = 1 AS _bool,
+		g::DECIMAL AS _decimal,
+		g::STRING AS _string,
+		g::STRING::BYTES AS _bytes,
+		substring('00000000-0000-0000-0000-' || g::STRING || '00000000000', 1, 36)::UUID AS _uuid
+	FROM
+		generate_series(1, 5) AS g;
+SET testing_optimizer_random_seed = 4478711114964600496;
+SELECT
+	1.2345678901234564e+23:::FLOAT8,
+	_string,
+	_int2,
+	tableoid,
+	_int2,
+	'1942-08-15 21:13:20+00':::TIMESTAMPTZ,
+	'\xc3a0':::BYTES,
+	true,
+	_timestamp,
+	_date,
+	e'\x01':::STRING,
+    _uuid,
+	'{"test": "json"}':::JSONB,
+	_int4,
+	_interval
+FROM
+	t107615
+WHERE
+	(_bool OR (NOT _bool));


### PR DESCRIPTION
Backport 2/2 commits from #107324.

/cc @cockroachdb/release

---

This commit refactors how we're keeping track of the current type schema of the operators in `NewColOperator`. Previously, we would create a new type slice for each operator due to "type schema corruption" bugs we observed (#47889). We fixed that bug by being extremely conservative, and this commit applies a different more reasonable fix.

In particular, it is safe to append to the current type slice we have in scope, and we only need to be careful when we're trying to create a "projection" (i.e. when we need to change the order of types or modify one type in-place). Thus, this commit switches to making a copy only in those scenarios which should happen at most once per processor spec (previously, it could happen thousands of times for elaborate render expressions).

Furthermore, this commit reuses the same type slice from `InputSyncSpec` since creation of the operators occurs _after_ the spec has been communicated across the wire (or locally), so we're free to use it as we please.

```
name                               old time/op    new time/op    delta
NestedAndPlanning/renders=16-24       627µs ± 1%     624µs ± 2%     ~     (p=0.143 n=10+10)
NestedAndPlanning/renders=256-24     3.54ms ± 0%    3.04ms ± 1%  -14.14%  (p=0.000 n=9+10)
NestedAndPlanning/renders=4096-24     211ms ± 4%      68ms ± 1%  -67.61%  (p=0.000 n=10+10)

name                               old alloc/op   new alloc/op   delta
NestedAndPlanning/renders=16-24      74.0kB ±20%    68.9kB ±10%     ~     (p=0.053 n=10+9)
NestedAndPlanning/renders=256-24     1.71MB ± 0%    0.60MB ± 0%  -65.07%  (p=0.000 n=8+8)
NestedAndPlanning/renders=4096-24     303MB ± 0%      13MB ± 1%  -95.58%  (p=0.000 n=8+8)

name                               old allocs/op  new allocs/op  delta
NestedAndPlanning/renders=16-24         754 ±18%       733 ±18%     ~     (p=0.105 n=9+9)
NestedAndPlanning/renders=256-24      6.44k ± 0%     5.93k ± 0%   -7.88%  (p=0.000 n=8+8)
NestedAndPlanning/renders=4096-24      146k ± 6%      136k ± 0%   -7.02%  (p=0.000 n=8+8)
```

Fixes: #104996.

Release note (bug fix): Previously, CockroachDB when planning expressions containing many sub-expressions (e.g. deeply-nested AND / OR structures) would use memory quadratical in the number of sub-expressions, and in the worst cases (thousands of sub-expressions) this could lead to OOMs. The bug has been present since at least 22.1 and has now been fixed.

Release justification: bug fix.