### PR TITLE
prototype: sql: custom column storage type

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -521,6 +521,13 @@ func TestTenantLogic_cursor(
 	runLogicTest(t, "cursor")
 }
 
+func TestTenantLogic_custom_col_storage_type(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "custom_col_storage_type")
+}
+
 func TestTenantLogic_custom_escape_character(
 	t *testing.T,
 ) {

--- a/pkg/sql/catalog/schemaexpr/computed_column.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column.go
@@ -71,13 +71,14 @@ func ValidateComputedColumnExpression(
 				c.GetName(),
 			)
 		}
-		if c.IsComputed() {
-			return pgerror.Newf(
-				pgcode.InvalidTableDefinition,
-				"%s expression cannot reference computed columns",
-				context,
-			)
-		}
+		// TODO: Allow this if they are mutually referenced.
+		// if c.IsComputed() {
+		// 	return pgerror.Newf(
+		// 		pgcode.InvalidTableDefinition,
+		// 		"%s expression cannot reference computed columns",
+		// 		context,
+		// 	)
+		// }
 		depColIDs.Add(c.GetID())
 
 		return nil

--- a/pkg/sql/logictest/testdata/logic_test/custom_col_storage_type
+++ b/pkg/sql/logictest/testdata/logic_test/custom_col_storage_type
@@ -1,0 +1,65 @@
+# Create a table with a STRING virtual column, a, that is computed from a hidden
+# INT stored computed column, a_internal.
+#
+# The expression for a describes how the stored INT, a_internal, is converted to
+# the user-facing STRING. The expression for a_internal describes how the
+# user-facing STRING value is converted to the stored INT.
+#
+# NOTE: I don't love this syntax, but it made it easy to get something working.
+# An option I'd like to explore would be to specify a single column and both an
+# input and output expression for it. One rough idea would be something like:
+#
+#   a STRING AS INT IN (substring(external.a, 3)::INT) OUT ('a_' || internal.a)
+#
+# In this example, a has the form 'a_<integer>', but only the integer portion is
+# stored, and it is stored as an integer and not as a string.
+statement ok
+CREATE TABLE t_test (
+  k INT PRIMARY KEY,
+  a_internal INT NOT VISIBLE AS (substring(a, 3)::INT) STORED,
+  a STRING AS ('a_' || a_internal) VIRTUAL
+)
+
+# Insert a row into the table. Notice that the integer 123456789 is written, but
+# the string is not.
+query T kvtrace
+INSERT INTO t_test VALUES (1, 'a_123456789')
+----
+CPut /Table/106/1/1/0 -> /TUPLE/2:2:Int/123456789
+
+# When we perform a read, the integer value is conveted back into a STRING.
+query IT
+SELECT k, a FROM t_test
+----
+1  a_123456789
+
+# The query plan shows how the expression for a, ('a_' || a_internal), is
+# projected in order to produce to user-facing STRING value, 'a_123456789'.
+query T
+EXPLAIN (OPT, VERBOSE)
+SELECT k, a FROM t_test
+----
+project
+ ├── columns: k:1 a:3
+ ├── immutable
+ ├── stats: [rows=1000]
+ ├── cost: 1128.84
+ ├── key: (1)
+ ├── fd: (1)-->(3)
+ ├── distribution: test
+ ├── prune: (1,3)
+ ├── scan t_test
+ │    ├── columns: k:1 a_internal:2
+ │    ├── computed column expressions
+ │    │    ├── a_internal:2
+ │    │    │    └── substring(a:3, 3)::INT8
+ │    │    └── a:3
+ │    │         └── 'a_' || a_internal:2
+ │    ├── stats: [rows=1000]
+ │    ├── cost: 1108.82
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── distribution: test
+ │    └── prune: (1,2)
+ └── projections
+      └── 'a_' || a_internal:2 [as=a:3, outer=(2), immutable]

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -499,6 +499,13 @@ func TestLogic_cursor(
 	runLogicTest(t, "cursor")
 }
 
+func TestLogic_custom_col_storage_type(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "custom_col_storage_type")
+}
+
 func TestLogic_custom_escape_character(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -499,6 +499,13 @@ func TestLogic_cursor(
 	runLogicTest(t, "cursor")
 }
 
+func TestLogic_custom_col_storage_type(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "custom_col_storage_type")
+}
+
 func TestLogic_custom_escape_character(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -499,6 +499,13 @@ func TestLogic_cursor(
 	runLogicTest(t, "cursor")
 }
 
+func TestLogic_custom_col_storage_type(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "custom_col_storage_type")
+}
+
 func TestLogic_custom_escape_character(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -492,6 +492,13 @@ func TestLogic_cursor(
 	runLogicTest(t, "cursor")
 }
 
+func TestLogic_custom_col_storage_type(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "custom_col_storage_type")
+}
+
 func TestLogic_custom_escape_character(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -492,6 +492,13 @@ func TestLogic_cursor(
 	runLogicTest(t, "cursor")
 }
 
+func TestLogic_custom_col_storage_type(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "custom_col_storage_type")
+}
+
 func TestLogic_custom_escape_character(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -499,6 +499,13 @@ func TestLogic_cursor(
 	runLogicTest(t, "cursor")
 }
 
+func TestLogic_custom_col_storage_type(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "custom_col_storage_type")
+}
+
 func TestLogic_custom_escape_character(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -520,6 +520,13 @@ func TestLogic_cursor(
 	runLogicTest(t, "cursor")
 }
 
+func TestLogic_custom_col_storage_type(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "custom_col_storage_type")
+}
+
 func TestLogic_custom_escape_character(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -551,8 +551,20 @@ func (mb *mutationBuilder) addTargetTableColsForInsert(maxCols int) {
 			continue
 		}
 
-		mb.addTargetCol(i)
-		numCols++
+		// TODO: Find the corresponding stored computed column.
+		if mb.alias == tree.MakeUnqualifiedTableName("t_test") && col.IsVirtualComputed() {
+			for j, m := 0, mb.tab.ColumnCount(); j < m; j++ {
+				col := mb.tab.Column(i)
+				if col.IsComputed() && !col.IsVirtualComputed() {
+					mb.addTargetCol(j)
+					numCols++
+					break
+				}
+			}
+		} else {
+			mb.addTargetCol(i)
+			numCols++
+		}
 	}
 
 	// Ensure that the number of input columns does not exceed the number of

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -12,11 +12,9 @@ package optbuilder
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -508,9 +506,10 @@ func (mb *mutationBuilder) addTargetCol(ord int) {
 	}
 
 	// Computed columns cannot be targeted with input values.
-	if tabCol.IsComputed() {
-		panic(schemaexpr.CannotWriteToComputedColError(string(tabCol.ColName())))
-	}
+	// TODO: Address this.
+	// if tabCol.IsComputed() {
+	// 	panic(schemaexpr.CannotWriteToComputedColError(string(tabCol.ColName())))
+	// }
 
 	// Ensure that the name list does not contain duplicates.
 	colID := mb.tabID.ColumnID(ord)
@@ -1102,16 +1101,17 @@ func (mb *mutationBuilder) buildReturning(returning *tree.ReturningExprs) {
 // checkNumCols raises an error if the expected number of columns does not match
 // the actual number of columns.
 func (mb *mutationBuilder) checkNumCols(expected, actual int) {
-	if actual != expected {
-		more, less := "expressions", "target columns"
-		if actual < expected {
-			more, less = less, more
-		}
-
-		panic(pgerror.Newf(pgcode.Syntax,
-			"%s has more %s than %s, %d expressions for %d targets",
-			strings.ToUpper(mb.opName), more, less, actual, expected))
-	}
+	// TODO: Fix this.
+	// if actual != expected {
+	// 	more, less := "expressions", "target columns"
+	// 	if actual < expected {
+	// 		more, less = less, more
+	// 	}
+	//
+	// 	panic(pgerror.Newf(pgcode.Syntax,
+	// 		"%s has more %s than %s, %d expressions for %d targets",
+	// 		strings.ToUpper(mb.opName), more, less, actual, expected))
+	// }
 }
 
 // parseComputedExpr parses the computed expression for the given table column,


### PR DESCRIPTION
This is a VERY rough prototype showing what a solution for a custom
storage type might look like. The goal is to allow users to store values
that are automatically transformed from a space-inefficient
application-facing values to storage-efficient data types on-disk.

For example, an application may be coded to insert and fetch string
values like `'a_123456789'`, where the `a_` always prefixes an integer.
The goal is to store just the integer representation of the suffix, and
avoid the space-inefficient storage of the string - all without
application changes.

Postgres provides this ability via user-defined types and custom
input/output functions defined in C.

> A user-defined type must always have input and output functions. These
> functions determine how the type appears in strings (for input by the
> user and output to the user) and how the type is organized in memory.
> The input function takes a null-terminated character string as its
> argument and returns the internal (in memory) representation of the
> type. The output function takes the internal representation of the
> type as argument and returns a null-terminated character string.

https://www.postgresql.org/docs/current/xtypes.html

This prototype explores how this same use-case could be addressed using
existing features of SQL and familiar syntax. See the newly added tests
for an example. Note that I didn't spend much time thinking about syntax
- my main goal was getting something working quickly.

Epic: None

Release note: None
