### PR TITLE
rangefeed: introduce processor interface

### DIFF
--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -166,7 +166,7 @@ func runBenchmarkRangefeed(b *testing.B, opts benchmarkRangefeedOpts) {
 	}
 
 	// Wait for catchup scans and flush checkpoint events.
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 
 	// Run the benchmark. We accounted for b.N when constructing events.
 	b.ResetTimer()
@@ -181,7 +181,7 @@ func runBenchmarkRangefeed(b *testing.B, opts benchmarkRangefeedOpts) {
 			b.Fatal("failed to forward closed timestamp")
 		}
 	}
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 
 	// Check that all registrations ended successfully, and emitted the expected
 	// number of events.

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -102,7 +102,98 @@ func (sc *Config) SetDefaults() {
 //  1. it translates logical updates into rangefeed events.
 //  2. it transforms a range-level closed timestamp to a rangefeed-level resolved
 //     timestamp.
-type Processor struct {
+type Processor interface {
+	// Lifecycle of processor.
+
+	// Start processor will start internal tasks and background initializations.
+	// It is ok to start registering streams before background initialization
+	// completes.
+	//
+	// The provided iterator is used to initialize the rangefeed's resolved
+	// timestamp. It must obey the contract of an iterator used for an
+	// initResolvedTSScan. The Processor promises to clean up the iterator by
+	// calling its Close method when it is finished.
+	//
+	// Note that newRtsIter must be called under the same lock as first
+	// registration to ensure that all there would be no missing events.
+	// This is currently achieved by Register function synchronizing with
+	// the work loop before the lock is released.
+	//
+	// If the iterator is nil then no initialization scan will be performed and
+	// the resolved timestamp will immediately be considered initialized.
+	Start(stopper *stop.Stopper, newRtsIter IntentScannerConstructor) error
+	// Stop processor and close all registrations.
+	//
+	// It is meant to be called by replica when it finds that all streams were
+	// stopped before removing references to the processor.
+	//
+	// It is not valid to restart a processor after it has been stopped.
+	Stop()
+	// StopWithErr terminates all registrations with an error and then winds down
+	// any internal processor resources.
+	//
+	// It is not valid to restart a processor after it has been stopped.
+	StopWithErr(pErr *kvpb.Error)
+
+	// Lifecycle of registrations.
+
+	// Register registers the stream over the specified span of keys.
+	//
+	// The registration will not observe any events that were consumed before this
+	// method was called. It is undefined whether the registration will observe
+	// events that are consumed concurrently with this call. The channel will be
+	// provided an error when the registration closes.
+	//
+	// The optionally provided "catch-up" iterator is used to read changes from the
+	// engine which occurred after the provided start timestamp (exclusive).
+	//
+	// If the method returns false, the processor will have been stopped, so calling
+	// Stop is not necessary. If the method returns true, it will also return an
+	// updated operation filter that includes the operations required by the new
+	// registration.
+	//
+	// NB: startTS is exclusive; the first possible event will be at startTS.Next().
+	Register(
+		span roachpb.RSpan,
+		startTS hlc.Timestamp, // exclusive
+		catchUpIterConstructor CatchUpIteratorConstructor,
+		withDiff bool,
+		stream Stream,
+		disconnectFn func(),
+		done *future.ErrorFuture,
+	) (bool, *Filter)
+	// DisconnectSpanWithErr disconnects all rangefeed registrations that overlap
+	// the given span with the given error.
+	DisconnectSpanWithErr(span roachpb.Span, pErr *kvpb.Error)
+	// Filter returns a new operation filter based on the registrations attached to
+	// the processor. Returns nil if the processor has been stopped already.
+	Filter() *Filter
+	// Len returns the number of registrations attached to the processor.
+	Len() int
+
+	// Data flow.
+
+	// ConsumeLogicalOps informs the rangefeed processor of the set of logical
+	// operations. It returns false if consuming the operations hit a timeout, as
+	// specified by the EventChanTimeout configuration. If the method returns false,
+	// the processor will have been stopped, so calling Stop is not necessary.
+	ConsumeLogicalOps(ctx context.Context, ops ...enginepb.MVCCLogicalOp) bool
+	// ConsumeSSTable informs the rangefeed processor of an SSTable that was added
+	// via AddSSTable. It returns false if consuming the SSTable hit a timeout, as
+	// specified by the EventChanTimeout configuration. If the method returns false,
+	// the processor will have been stopped, so calling Stop is not necessary.
+	ConsumeSSTable(
+		ctx context.Context, sst []byte, sstSpan roachpb.Span, writeTS hlc.Timestamp,
+	) bool
+	// ForwardClosedTS indicates that the closed timestamp that serves as the basis
+	// for the rangefeed processor's resolved timestamp has advanced. It returns
+	// false if forwarding the closed timestamp hit a timeout, as specified by the
+	// EventChanTimeout configuration. If the method returns false, the processor
+	// will have been stopped, so calling Stop is not necessary.
+	ForwardClosedTS(ctx context.Context, closedTS hlc.Timestamp) bool
+}
+
+type LegacyProcessor struct {
 	Config
 	reg registry
 	rts resolvedTimestamp
@@ -182,10 +273,10 @@ type spanErr struct {
 
 // NewProcessor creates a new rangefeed Processor. The corresponding goroutine
 // should be launched using the Start method.
-func NewProcessor(cfg Config) *Processor {
+func NewProcessor(cfg Config) Processor {
 	cfg.SetDefaults()
 	cfg.AmbientContext.AddLogTag("rangefeed", nil)
-	p := &Processor{
+	p := &LegacyProcessor{
 		Config: cfg,
 		reg:    makeRegistry(cfg.Metrics),
 		rts:    makeResolvedTimestamp(),
@@ -215,19 +306,17 @@ type IntentScannerConstructor func() IntentScanner
 // ensure that the engine has not been closed.
 type CatchUpIteratorConstructor func(roachpb.Span, hlc.Timestamp) *CatchUpIterator
 
-// Start launches a goroutine to process rangefeed events and send them to
-// registrations.
+// Start implements Processor interface.
 //
-// The provided iterator is used to initialize the rangefeed's resolved
-// timestamp. It must obey the contract of an iterator used for an
-// initResolvedTSScan. The Processor promises to clean up the iterator by
-// calling its Close method when it is finished. If the iterator is nil then
-// no initialization scan will be performed and the resolved timestamp will
-// immediately be considered initialized.
-func (p *Processor) Start(stopper *stop.Stopper, rtsIterFunc IntentScannerConstructor) error {
+// LegacyProcessor launches a goroutine to process rangefeed events and send
+// them to registrations.
+//
+// Note that to fulfill newRtsIter contract, LegacyProcessor will create
+// iterator at the start of its work loop prior to firing async task.
+func (p *LegacyProcessor) Start(stopper *stop.Stopper, newRtsIter IntentScannerConstructor) error {
 	ctx := p.AnnotateCtx(context.Background())
-	if err := stopper.RunAsyncTask(ctx, "rangefeed.Processor", func(ctx context.Context) {
-		p.run(ctx, p.RangeID, rtsIterFunc, stopper)
+	if err := stopper.RunAsyncTask(ctx, "rangefeed.LegacyProcessor", func(ctx context.Context) {
+		p.run(ctx, p.RangeID, newRtsIter, stopper)
 	}); err != nil {
 		p.reg.DisconnectWithErr(all, kvpb.NewError(err))
 		close(p.stoppedC)
@@ -237,7 +326,7 @@ func (p *Processor) Start(stopper *stop.Stopper, rtsIterFunc IntentScannerConstr
 }
 
 // run is called from Start and runs the rangefeed.
-func (p *Processor) run(
+func (p *LegacyProcessor) run(
 	ctx context.Context,
 	_forStacks roachpb.RangeID,
 	rtsIterFunc IntentScannerConstructor,
@@ -257,7 +346,7 @@ func (p *Processor) run(
 	// initialize the unresolvedIntentQueue. Ignore error if quiescing.
 	if rtsIterFunc != nil {
 		rtsIter := rtsIterFunc()
-		initScan := newInitResolvedTSScan(p, rtsIter)
+		initScan := newInitResolvedTSScan(p.Span, p, rtsIter)
 		err := stopper.RunAsyncTask(ctx, "rangefeed: init resolved ts", initScan.Run)
 		if err != nil {
 			initScan.Cancel()
@@ -373,7 +462,7 @@ func (p *Processor) run(
 				// Launch an async transaction push attempt that pushes the
 				// timestamp of all transactions beneath the push offset.
 				// Ignore error if quiescing.
-				pushTxns := newTxnPushAttempt(p, toPush, now, txnPushAttemptC)
+				pushTxns := newTxnPushAttempt(p.Span, p.TxnPusher, p, toPush, now, txnPushAttemptC)
 				err := stopper.RunAsyncTask(ctx, "rangefeed: pushing old txns", pushTxns.Run)
 				if err != nil {
 					pushTxns.Cancel()
@@ -401,32 +490,21 @@ func (p *Processor) run(
 	}
 }
 
-// Stop shuts down the processor and closes all registrations. Safe to call on
-// nil Processor. It is not valid to restart a processor after it has been
-// stopped.
-func (p *Processor) Stop() {
+// Stop implements Processor interface.
+func (p *LegacyProcessor) Stop() {
 	p.StopWithErr(nil)
 }
 
-// StopWithErr shuts down the processor and closes all registrations with the
-// specified error. Safe to call on nil Processor. It is not valid to restart a
-// processor after it has been stopped.
-func (p *Processor) StopWithErr(pErr *kvpb.Error) {
-	if p == nil {
-		return
-	}
+// StopWithErr implements Processor interface.
+func (p *LegacyProcessor) StopWithErr(pErr *kvpb.Error) {
 	// Flush any remaining events before stopping.
 	p.syncEventC()
 	// Send the processor a stop signal.
 	p.sendStop(pErr)
 }
 
-// DisconnectSpanWithErr disconnects all rangefeed registrations that overlap
-// the given span with the given error.
-func (p *Processor) DisconnectSpanWithErr(span roachpb.Span, pErr *kvpb.Error) {
-	if p == nil {
-		return
-	}
+// DisconnectSpanWithErr implements Processor interface.
+func (p *LegacyProcessor) DisconnectSpanWithErr(span roachpb.Span, pErr *kvpb.Error) {
 	select {
 	case p.spanErrC <- spanErr{span: span, pErr: pErr}:
 	case <-p.stoppedC:
@@ -434,7 +512,7 @@ func (p *Processor) DisconnectSpanWithErr(span roachpb.Span, pErr *kvpb.Error) {
 	}
 }
 
-func (p *Processor) sendStop(pErr *kvpb.Error) {
+func (p *LegacyProcessor) sendStop(pErr *kvpb.Error) {
 	select {
 	case p.stopC <- pErr:
 		// stopC has non-zero capacity so this should not block unless
@@ -444,25 +522,8 @@ func (p *Processor) sendStop(pErr *kvpb.Error) {
 	}
 }
 
-// Register registers the stream over the specified span of keys.
-//
-// The registration will not observe any events that were consumed before this
-// method was called. It is undefined whether the registration will observe
-// events that are consumed concurrently with this call. The channel will be
-// provided an error when the registration closes.
-//
-// The optionally provided "catch-up" iterator is used to read changes from the
-// engine which occurred after the provided start timestamp (exclusive).
-//
-// If the method returns false, the processor will have been stopped, so calling
-// Stop is not necessary. If the method returns true, it will also return an
-// updated operation filter that includes the operations required by the new
-// registration.
-//
-// NOT safe to call on nil Processor.
-//
-// NB: startTS is exclusive; the first possible event will be at startTS.Next().
-func (p *Processor) Register(
+// Register  implements Processor interface.
+func (p *LegacyProcessor) Register(
 	span roachpb.RSpan,
 	startTS hlc.Timestamp,
 	catchUpIterConstructor CatchUpIteratorConstructor,
@@ -479,7 +540,8 @@ func (p *Processor) Register(
 	blockWhenFull := p.Config.EventChanTimeout == 0 // for testing
 	r := newRegistration(
 		span.AsRawSpanWithNoLocals(), startTS, catchUpIterConstructor, withDiff,
-		p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn, done)
+		p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn, done,
+	)
 	select {
 	case p.regC <- r:
 		// Wait for response.
@@ -489,12 +551,8 @@ func (p *Processor) Register(
 	}
 }
 
-// Len returns the number of registrations attached to the processor.
-func (p *Processor) Len() int {
-	if p == nil {
-		return 0
-	}
-
+// Len implements Processor interface.
+func (p *LegacyProcessor) Len() int {
 	// Ask the processor goroutine.
 	select {
 	case p.lenReqC <- struct{}{}:
@@ -505,13 +563,8 @@ func (p *Processor) Len() int {
 	}
 }
 
-// Filter returns a new operation filter based on the registrations attached to
-// the processor. Returns nil if the processor has been stopped already.
-func (p *Processor) Filter() *Filter {
-	if p == nil {
-		return nil
-	}
-
+// Filter implements Processor interface.
+func (p *LegacyProcessor) Filter() *Filter {
 	// Ask the processor goroutine.
 	select {
 	case p.filterReqC <- struct{}{}:
@@ -522,45 +575,25 @@ func (p *Processor) Filter() *Filter {
 	}
 }
 
-// ConsumeLogicalOps informs the rangefeed processor of the set of logical
-// operations. It returns false if consuming the operations hit a timeout, as
-// specified by the EventChanTimeout configuration. If the method returns false,
-// the processor will have been stopped, so calling Stop is not necessary. Safe
-// to call on nil Processor.
-func (p *Processor) ConsumeLogicalOps(ctx context.Context, ops ...enginepb.MVCCLogicalOp) bool {
-	if p == nil {
-		return true
-	}
+// ConsumeLogicalOps implements Processor interface.
+func (p *LegacyProcessor) ConsumeLogicalOps(
+	ctx context.Context, ops ...enginepb.MVCCLogicalOp,
+) bool {
 	if len(ops) == 0 {
 		return true
 	}
 	return p.sendEvent(ctx, event{ops: ops}, p.EventChanTimeout)
 }
 
-// ConsumeSSTable informs the rangefeed processor of an SSTable that was added
-// via AddSSTable. It returns false if consuming the SSTable hit a timeout, as
-// specified by the EventChanTimeout configuration. If the method returns false,
-// the processor will have been stopped, so calling Stop is not necessary. Safe
-// to call on nil Processor.
-func (p *Processor) ConsumeSSTable(
+// ConsumeSSTable implements Processor interface.
+func (p *LegacyProcessor) ConsumeSSTable(
 	ctx context.Context, sst []byte, sstSpan roachpb.Span, writeTS hlc.Timestamp,
 ) bool {
-	if p == nil {
-		return true
-	}
 	return p.sendEvent(ctx, event{sst: &sstEvent{sst, sstSpan, writeTS}}, p.EventChanTimeout)
 }
 
-// ForwardClosedTS indicates that the closed timestamp that serves as the basis
-// for the rangefeed processor's resolved timestamp has advanced. It returns
-// false if forwarding the closed timestamp hit a timeout, as specified by the
-// EventChanTimeout configuration. If the method returns false, the processor
-// will have been stopped, so calling Stop is not necessary.  Safe to call on
-// nil Processor.
-func (p *Processor) ForwardClosedTS(ctx context.Context, closedTS hlc.Timestamp) bool {
-	if p == nil {
-		return true
-	}
+// ForwardClosedTS implements Processor interface.
+func (p *LegacyProcessor) ForwardClosedTS(ctx context.Context, closedTS hlc.Timestamp) bool {
 	if closedTS.IsEmpty() {
 		return true
 	}
@@ -570,7 +603,7 @@ func (p *Processor) ForwardClosedTS(ctx context.Context, closedTS hlc.Timestamp)
 // sendEvent informs the Processor of a new event. If a timeout is specified,
 // the method will wait for no longer than that duration before giving up,
 // shutting down the Processor, and returning false. 0 for no timeout.
-func (p *Processor) sendEvent(ctx context.Context, e event, timeout time.Duration) bool {
+func (p *LegacyProcessor) sendEvent(ctx context.Context, e event, timeout time.Duration) bool {
 	// The code is a bit unwieldy because we try to avoid any allocations on fast
 	// path where we have enough budget and outgoing channel is free. If not, we
 	// try to set up timeout for acquiring budget and then reuse this timeout when
@@ -665,14 +698,14 @@ func (p *Processor) sendEvent(ctx context.Context, e event, timeout time.Duratio
 
 // setResolvedTSInitialized informs the Processor that its resolved timestamp has
 // all the information it needs to be considered initialized.
-func (p *Processor) setResolvedTSInitialized(ctx context.Context) {
+func (p *LegacyProcessor) setResolvedTSInitialized(ctx context.Context) {
 	p.sendEvent(ctx, event{initRTS: true}, 0)
 }
 
 // syncEventC synchronizes access to the Processor goroutine, allowing the
 // caller to establish causality with actions taken by the Processor goroutine.
 // It does so by flushing the event pipeline.
-func (p *Processor) syncEventC() {
+func (p *LegacyProcessor) syncEventC() {
 	syncC := make(chan struct{})
 	ev := getPooledEvent(event{sync: &syncEvent{c: syncC}})
 	select {
@@ -688,7 +721,7 @@ func (p *Processor) syncEventC() {
 	}
 }
 
-func (p *Processor) consumeEvent(ctx context.Context, e *event) {
+func (p *LegacyProcessor) consumeEvent(ctx context.Context, e *event) {
 	switch {
 	case e.ops != nil:
 		p.consumeLogicalOps(ctx, e.ops, e.alloc)
@@ -714,7 +747,7 @@ func (p *Processor) consumeEvent(ctx context.Context, e *event) {
 	}
 }
 
-func (p *Processor) consumeLogicalOps(
+func (p *LegacyProcessor) consumeLogicalOps(
 	ctx context.Context, ops []enginepb.MVCCLogicalOp, alloc *SharedBudgetAllocation,
 ) {
 	for _, op := range ops {
@@ -756,7 +789,7 @@ func (p *Processor) consumeLogicalOps(
 	}
 }
 
-func (p *Processor) consumeSSTable(
+func (p *LegacyProcessor) consumeSSTable(
 	ctx context.Context,
 	sst []byte,
 	sstSpan roachpb.Span,
@@ -766,19 +799,19 @@ func (p *Processor) consumeSSTable(
 	p.publishSSTable(ctx, sst, sstSpan, sstWTS, alloc)
 }
 
-func (p *Processor) forwardClosedTS(ctx context.Context, newClosedTS hlc.Timestamp) {
+func (p *LegacyProcessor) forwardClosedTS(ctx context.Context, newClosedTS hlc.Timestamp) {
 	if p.rts.ForwardClosedTS(newClosedTS) {
 		p.publishCheckpoint(ctx)
 	}
 }
 
-func (p *Processor) initResolvedTS(ctx context.Context) {
+func (p *LegacyProcessor) initResolvedTS(ctx context.Context) {
 	if p.rts.Init() {
 		p.publishCheckpoint(ctx)
 	}
 }
 
-func (p *Processor) publishValue(
+func (p *LegacyProcessor) publishValue(
 	ctx context.Context,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
@@ -805,7 +838,7 @@ func (p *Processor) publishValue(
 	p.reg.PublishToOverlapping(ctx, roachpb.Span{Key: key}, &event, alloc)
 }
 
-func (p *Processor) publishDeleteRange(
+func (p *LegacyProcessor) publishDeleteRange(
 	ctx context.Context,
 	startKey, endKey roachpb.Key,
 	timestamp hlc.Timestamp,
@@ -824,7 +857,7 @@ func (p *Processor) publishDeleteRange(
 	p.reg.PublishToOverlapping(ctx, span, &event, alloc)
 }
 
-func (p *Processor) publishSSTable(
+func (p *LegacyProcessor) publishSSTable(
 	ctx context.Context,
 	sst []byte,
 	sstSpan roachpb.Span,
@@ -846,7 +879,7 @@ func (p *Processor) publishSSTable(
 	}, alloc)
 }
 
-func (p *Processor) publishCheckpoint(ctx context.Context) {
+func (p *LegacyProcessor) publishCheckpoint(ctx context.Context) {
 	// TODO(nvanbenschoten): persist resolvedTimestamp. Give Processor a client.DB.
 	// TODO(nvanbenschoten): rate limit these? send them periodically?
 
@@ -854,7 +887,7 @@ func (p *Processor) publishCheckpoint(ctx context.Context) {
 	p.reg.PublishToOverlapping(ctx, all, event, nil)
 }
 
-func (p *Processor) newCheckpointEvent() *kvpb.RangeFeedEvent {
+func (p *LegacyProcessor) newCheckpointEvent() *kvpb.RangeFeedEvent {
 	// Create a RangeFeedCheckpoint over the Processor's entire span. Each
 	// individual registration will trim this down to just the key span that
 	// it is listening on in registration.maybeStripEvent before publishing.

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -146,7 +146,7 @@ const testProcessorEventCTimeout = 10 * time.Millisecond
 
 func newTestProcessorWithTxnPusher(
 	t *testing.T, rtsIter storage.SimpleMVCCIterator, txnPusher TxnPusher,
-) (*Processor, *stop.Stopper) {
+) (*LegacyProcessor, *stop.Stopper) {
 	t.Helper()
 	stopper := stop.NewStopper()
 
@@ -167,7 +167,8 @@ func newTestProcessorWithTxnPusher(
 		Metrics:          NewMetrics(),
 	})
 	require.NoError(t, p.Start(stopper, makeIntentScannerConstructor(rtsIter)))
-	return p, stopper
+	impl := p.(*LegacyProcessor)
+	return impl, stopper
 }
 
 func makeIntentScannerConstructor(rtsIter storage.SimpleMVCCIterator) IntentScannerConstructor {
@@ -179,7 +180,7 @@ func makeIntentScannerConstructor(rtsIter storage.SimpleMVCCIterator) IntentScan
 
 func newTestProcessor(
 	t *testing.T, rtsIter storage.SimpleMVCCIterator,
-) (*Processor, *stop.Stopper) {
+) (*LegacyProcessor, *stop.Stopper) {
 	t.Helper()
 	return newTestProcessorWithTxnPusher(t, rtsIter, nil /* pusher */)
 }
@@ -435,33 +436,6 @@ func TestProcessorBasic(t *testing.T) {
 	require.False(t, r3OK)
 }
 
-func TestNilProcessor(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	ctx := context.Background()
-	var p *Processor
-
-	// All of the following should be no-ops.
-	require.Equal(t, 0, p.Len())
-	require.NotPanics(t, func() { p.Stop() })
-	require.NotPanics(t, func() { p.StopWithErr(nil) })
-	require.NotPanics(t, func() { p.ConsumeLogicalOps(ctx) })
-	require.NotPanics(t, func() { p.ConsumeLogicalOps(ctx, make([]enginepb.MVCCLogicalOp, 5)...) })
-	require.NotPanics(t, func() { p.ForwardClosedTS(ctx, hlc.Timestamp{}) })
-	require.NotPanics(t, func() { p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 1}) })
-
-	// The following should panic because they are not safe
-	// to call on a nil Processor.
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-	require.Panics(t, func() { _ = p.Start(stopper, nil) })
-	require.Panics(t, func() {
-		var done future.ErrorFuture
-		p.Register(roachpb.RSpan{}, hlc.Timestamp{}, nil, false, nil,
-			func() {}, &done,
-		)
-	})
-}
-
 func TestProcessorSlowConsumer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	p, stopper := newTestProcessor(t, nil /* rtsIter */)
@@ -566,6 +540,7 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
+	m := NewMetrics()
 	p := NewProcessor(Config{
 		AmbientContext:   log.MakeTestingAmbientCtxWithNewTracer(),
 		Clock:            hlc.NewClockForTesting(nil),
@@ -573,7 +548,7 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 		PushTxnsInterval: pushTxnInterval,
 		PushTxnsAge:      pushTxnAge,
 		EventChanCap:     testProcessorEventCCap,
-		Metrics:          NewMetrics(),
+		Metrics:          m,
 		MemBudget:        fb,
 		EventChanTimeout: time.Millisecond,
 	})
@@ -593,7 +568,7 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 		func() {},
 		&r1Done,
 	)
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 
 	// Block it.
 	unblock := r1Stream.BlockSend()
@@ -614,16 +589,16 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 	}
 
 	// Unblock stream processing part to consume error.
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 
 	// Unblock the 'send' channel. The events should quickly be consumed.
 	unblock()
 	unblock = nil
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 
 	require.Equal(t, newErrBufferCapacityExceeded().GoError(), waitErrorFuture(&r1Done))
-	require.Equal(t, 0, p.reg.Len(), "registration was not removed")
-	require.Equal(t, int64(1), p.Metrics.RangeFeedBudgetExhausted.Count())
+	require.Equal(t, 0, p.Len(), "registration was not removed")
+	require.Equal(t, int64(1), m.RangeFeedBudgetExhausted.Count())
 }
 
 // TestProcessorMemoryBudgetReleased that memory budget is correctly released.
@@ -662,7 +637,7 @@ func TestProcessorMemoryBudgetReleased(t *testing.T) {
 		func() {},
 		&r1Done,
 	)
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 
 	// Write entries and check they are consumed so that we could write more
 	// data than total budget if inflight messages are within budget.
@@ -673,7 +648,7 @@ func TestProcessorMemoryBudgetReleased(t *testing.T) {
 			hlc.Timestamp{WallTime: int64(i + 2)},
 			[]byte("value")))
 	}
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 
 	// Count consumed values
 	consumedOps := 0
@@ -682,7 +657,7 @@ func TestProcessorMemoryBudgetReleased(t *testing.T) {
 			consumedOps++
 		}
 	}
-	require.Equal(t, 1, p.reg.Len(), "registration was removed")
+	require.Equal(t, 1, p.Len(), "registration was removed")
 	require.Equal(t, 10, consumedOps)
 }
 
@@ -1071,14 +1046,14 @@ func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 // syncEventAndRegistrations waits for all previously sent events to be
 // processed *and* for all registration output loops to fully process their own
 // internal buffers.
-func (p *Processor) syncEventAndRegistrations() {
+func (p *LegacyProcessor) syncEventAndRegistrations() {
 	p.syncEventAndRegistrationSpan(all)
 }
 
 // syncEventAndRegistrations waits for all previously sent events to be
 // processed *and* for all registration output loops for registrations
 // overlapping the given span to fully process their own internal buffers.
-func (p *Processor) syncEventAndRegistrationSpan(span roachpb.Span) {
+func (p *LegacyProcessor) syncEventAndRegistrationSpan(span roachpb.Span) {
 	syncC := make(chan struct{})
 	ev := getPooledEvent(event{sync: &syncEvent{c: syncC, testRegCatchupSpan: &span}})
 	select {
@@ -1152,7 +1127,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 		&done,
 	)
 	rErrC := notifyWhenDone(&done)
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 
 	for i := 0; i < totalEvents; i++ {
 		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
@@ -1243,7 +1218,7 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 		&done,
 	)
 	rErrC := notifyWhenDone(&done)
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 
 	for i := 0; i < totalEvents; i++ {
 		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
@@ -1336,7 +1311,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 		func() {},
 		&r2Done,
 	)
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 
 	for i := 0; i < totalEvents; i++ {
 		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
@@ -1366,7 +1341,8 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 // stop and drain remaining allocations.
 // We use account and not a monitor for those checks because monitor doesn't
 // necessary return all data to the pool until processor is stopped.
-func requireBudgetDrainedSoon(t *testing.T, processor *Processor, stream *consumer) {
+func requireBudgetDrainedSoon(t *testing.T, p Processor, stream *consumer) {
+	processor := p.(*LegacyProcessor)
 	testutils.SucceedsSoon(t, func() error {
 		processor.MemBudget.mu.Lock()
 		used := processor.MemBudget.mu.memBudget.Used()
@@ -1496,7 +1472,7 @@ func TestProcessorBackpressure(t *testing.T) {
 	require.True(t, ok)
 
 	// Wait for the initial checkpoint.
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 	require.Len(t, stream.Events(), 1)
 
 	// Block the registration consumer, and spawn a goroutine to post events to
@@ -1532,7 +1508,7 @@ func TestProcessorBackpressure(t *testing.T) {
 	}
 
 	// Wait for the final checkpoint event.
-	p.syncEventAndRegistrations()
+	syncEventAndRegistrations(p)
 	events := stream.Events()
 	require.Equal(t, &kvpb.RangeFeedEvent{
 		Checkpoint: &kvpb.RangeFeedCheckpoint{
@@ -1540,4 +1516,9 @@ func TestProcessorBackpressure(t *testing.T) {
 			ResolvedTS: hlc.Timestamp{WallTime: numEvents},
 		},
 	}, events[len(events)-1])
+}
+
+func syncEventAndRegistrations(p Processor) {
+	impl := p.(*LegacyProcessor)
+	impl.syncEventAndRegistrations()
 }

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -12,6 +12,7 @@ package rangefeed
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -28,8 +29,15 @@ import (
 type runnable interface {
 	// Run executes the runnable. Cannot be called multiple times.
 	Run(context.Context)
-	// Must be called if runnable is not Run.
+	// Cancel must be called if runnable is not Run.
 	Cancel()
+}
+
+// processorTaskHelper abstracts away processor for tasks.
+type processorTaskHelper interface {
+	StopWithErr(pErr *kvpb.Error)
+	setResolvedTSInitialized(ctx context.Context)
+	sendEvent(ctx context.Context, e event, timeout time.Duration) bool
 }
 
 // initResolvedTSScan scans over all keys using the provided iterator and
@@ -39,12 +47,13 @@ type runnable interface {
 // The Processor can initialize its resolvedTimestamp once the scan completes
 // because it knows it is now tracking all intents in its key range.
 type initResolvedTSScan struct {
-	p  *Processor
-	is IntentScanner
+	span roachpb.RSpan
+	p    processorTaskHelper
+	is   IntentScanner
 }
 
-func newInitResolvedTSScan(p *Processor, c IntentScanner) runnable {
-	return &initResolvedTSScan{p: p, is: c}
+func newInitResolvedTSScan(span roachpb.RSpan, p processorTaskHelper, c IntentScanner) runnable {
+	return &initResolvedTSScan{span: span, p: p, is: c}
 }
 
 func (s *initResolvedTSScan) Run(ctx context.Context) {
@@ -60,8 +69,8 @@ func (s *initResolvedTSScan) Run(ctx context.Context) {
 }
 
 func (s *initResolvedTSScan) iterateAndConsume(ctx context.Context) error {
-	startKey := s.p.Span.Key.AsRawKey()
-	endKey := s.p.Span.EndKey.AsRawKey()
+	startKey := s.span.Key.AsRawKey()
+	endKey := s.span.EndKey.AsRawKey()
 	return s.is.ConsumeIntents(ctx, startKey, endKey, func(op enginepb.MVCCWriteIntentOp) bool {
 		var ops [1]enginepb.MVCCLogicalOp
 		ops[0].SetValue(&op)
@@ -249,20 +258,29 @@ type TxnPusher interface {
 //     - ABORTED:   inform the Processor to stop caring about the transaction.
 //     It will never commit and its intents can be safely ignored.
 type txnPushAttempt struct {
-	p     *Processor
-	txns  []enginepb.TxnMeta
-	ts    hlc.Timestamp
-	doneC chan struct{}
+	span   roachpb.RSpan
+	pusher TxnPusher
+	p      processorTaskHelper
+	txns   []enginepb.TxnMeta
+	ts     hlc.Timestamp
+	doneC  chan struct{}
 }
 
 func newTxnPushAttempt(
-	p *Processor, txns []enginepb.TxnMeta, ts hlc.Timestamp, doneC chan struct{},
+	span roachpb.RSpan,
+	pusher TxnPusher,
+	p processorTaskHelper,
+	txns []enginepb.TxnMeta,
+	ts hlc.Timestamp,
+	doneC chan struct{},
 ) runnable {
 	return &txnPushAttempt{
-		p:     p,
-		txns:  txns,
-		ts:    ts,
-		doneC: doneC,
+		span:   span,
+		pusher: pusher,
+		p:      p,
+		txns:   txns,
+		ts:     ts,
+		doneC:  doneC,
 	}
 }
 
@@ -278,7 +296,7 @@ func (a *txnPushAttempt) pushOldTxns(ctx context.Context) error {
 	// This may cause transaction restarts, but span refreshing should
 	// prevent a restart for any transaction that has not been written
 	// over at a larger timestamp.
-	pushedTxns, err := a.p.TxnPusher.PushTxns(ctx, a.txns, a.ts)
+	pushedTxns, err := a.pusher.PushTxns(ctx, a.txns, a.ts)
 	if err != nil {
 		return err
 	}
@@ -319,7 +337,7 @@ func (a *txnPushAttempt) pushOldTxns(ctx context.Context) error {
 			// intents are resolved before the resolved timestamp can advance past the
 			// transaction's commit timestamp, so the best we can do is help speed up
 			// the resolution.
-			txnIntents := intentsInBound(txn, a.p.Span.AsRawSpanWithNoLocals())
+			txnIntents := intentsInBound(txn, a.span.AsRawSpanWithNoLocals())
 			intentsToCleanup = append(intentsToCleanup, txnIntents...)
 		case roachpb.ABORTED:
 			// The transaction is aborted, so it doesn't need to be tracked
@@ -346,7 +364,7 @@ func (a *txnPushAttempt) pushOldTxns(ctx context.Context) error {
 			// LockSpans populated. If, however, we ran into a transaction that its
 			// coordinator tried to rollback but didn't follow up with garbage
 			// collection, then LockSpans will be populated.
-			txnIntents := intentsInBound(txn, a.p.Span.AsRawSpanWithNoLocals())
+			txnIntents := intentsInBound(txn, a.span.AsRawSpanWithNoLocals())
 			intentsToCleanup = append(intentsToCleanup, txnIntents...)
 		}
 	}
@@ -355,7 +373,7 @@ func (a *txnPushAttempt) pushOldTxns(ctx context.Context) error {
 	a.p.sendEvent(ctx, event{ops: ops}, 0)
 
 	// Resolve intents, if necessary.
-	return a.p.TxnPusher.ResolveIntents(ctx, intentsToCleanup)
+	return a.pusher.ResolveIntents(ctx, intentsToCleanup)
 }
 
 func (a *txnPushAttempt) Cancel() {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -860,7 +860,7 @@ type Replica struct {
 		// Requires Replica.raftMu be held when providing logical ops and
 		//  informing the processor of closed timestamp updates. This properly
 		//  synchronizes updates that are linearized and driven by the Raft log.
-		proc *rangefeed.Processor
+		proc rangefeed.Processor
 		// opFilter is a best-effort filter that informs the raft processing
 		// goroutine of which logical operations the rangefeed processor is
 		// interested in based on the processor's current registrations.

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -263,25 +263,25 @@ func (r *Replica) RangeFeed(
 	return &done
 }
 
-func (r *Replica) getRangefeedProcessorAndFilter() (*rangefeed.Processor, *rangefeed.Filter) {
+func (r *Replica) getRangefeedProcessorAndFilter() (rangefeed.Processor, *rangefeed.Filter) {
 	r.rangefeedMu.RLock()
 	defer r.rangefeedMu.RUnlock()
 	return r.rangefeedMu.proc, r.rangefeedMu.opFilter
 }
 
-func (r *Replica) getRangefeedProcessor() *rangefeed.Processor {
+func (r *Replica) getRangefeedProcessor() rangefeed.Processor {
 	p, _ := r.getRangefeedProcessorAndFilter()
 	return p
 }
 
-func (r *Replica) setRangefeedProcessor(p *rangefeed.Processor) {
+func (r *Replica) setRangefeedProcessor(p rangefeed.Processor) {
 	r.rangefeedMu.Lock()
 	defer r.rangefeedMu.Unlock()
 	r.rangefeedMu.proc = p
 	r.store.addReplicaWithRangefeed(r.RangeID)
 }
 
-func (r *Replica) unsetRangefeedProcessorLocked(p *rangefeed.Processor) {
+func (r *Replica) unsetRangefeedProcessorLocked(p rangefeed.Processor) {
 	if r.rangefeedMu.proc != p {
 		// The processor was already unset.
 		return
@@ -291,7 +291,7 @@ func (r *Replica) unsetRangefeedProcessorLocked(p *rangefeed.Processor) {
 	r.store.removeReplicaWithRangefeed(r.RangeID)
 }
 
-func (r *Replica) unsetRangefeedProcessor(p *rangefeed.Processor) {
+func (r *Replica) unsetRangefeedProcessor(p rangefeed.Processor) {
 	r.rangefeedMu.Lock()
 	defer r.rangefeedMu.Unlock()
 	r.unsetRangefeedProcessorLocked(p)
@@ -344,7 +344,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	withDiff bool,
 	stream rangefeed.Stream,
 	done *future.ErrorFuture,
-) *rangefeed.Processor {
+) rangefeed.Processor {
 	defer logSlowRangefeedRegistration(ctx)()
 
 	// Attempt to register with an existing Rangefeed processor, if one exists.
@@ -370,9 +370,8 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	}
 	r.rangefeedMu.Unlock()
 
-	feedBudget := r.store.GetStoreConfig().RangefeedBudgetFactory.CreateBudget(r.startKey)
-
 	// Create a new rangefeed.
+	feedBudget := r.store.GetStoreConfig().RangefeedBudgetFactory.CreateBudget(r.startKey)
 	desc := r.Desc()
 	tp := rangefeedTxnPusher{ir: r.store.intentResolver, r: r}
 	cfg := rangefeed.Config{
@@ -447,7 +446,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 
 // maybeDisconnectEmptyRangefeed tears down the provided Processor if it is
 // still active and if it no longer has any registrations.
-func (r *Replica) maybeDisconnectEmptyRangefeed(p *rangefeed.Processor) {
+func (r *Replica) maybeDisconnectEmptyRangefeed(p rangefeed.Processor) {
 	r.rangefeedMu.Lock()
 	defer r.rangefeedMu.Unlock()
 	if p == nil || p != r.rangefeedMu.proc {
@@ -464,7 +463,7 @@ func (r *Replica) maybeDisconnectEmptyRangefeed(p *rangefeed.Processor) {
 
 // disconnectRangefeedWithErr broadcasts the provided error to all rangefeed
 // registrations and tears down the provided rangefeed Processor.
-func (r *Replica) disconnectRangefeedWithErr(p *rangefeed.Processor, pErr *kvpb.Error) {
+func (r *Replica) disconnectRangefeedWithErr(p rangefeed.Processor, pErr *kvpb.Error) {
 	p.StopWithErr(pErr)
 	r.unsetRangefeedProcessor(p)
 }


### PR DESCRIPTION
This PR extracts externally visible processor functions into interface.
This will allow us to provide alternative implementations while keepingan option to fall back to old one.

Release note: None

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-26372