### PR TITLE
kvcoord: Fix metrics tracking in mux rangefeed

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -214,6 +214,7 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/retry",
         "//pkg/util/shuffle",
+        "//pkg/util/span",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -306,13 +306,18 @@ type DistSenderMetrics struct {
 	InLeaseTransferBackoffs            *metric.Counter
 	RangeLookups                       *metric.Counter
 	SlowRPCs                           *metric.Gauge
-	RangefeedRanges                    *metric.Gauge
-	RangefeedCatchupRanges             *metric.Gauge
-	RangefeedErrorCatchup              *metric.Counter
-	RangefeedRestartRanges             *metric.Counter
-	RangefeedRestartStuck              *metric.Counter
 	MethodCounts                       [kvpb.NumMethods]*metric.Counter
 	ErrCounts                          [kvpb.NumErrors]*metric.Counter
+	DistSenderRangeFeedMetrics
+}
+
+// DistSenderRangeFeedMetrics is a set of rangefeed specific metrics.
+type DistSenderRangeFeedMetrics struct {
+	RangefeedRanges        *metric.Gauge
+	RangefeedCatchupRanges *metric.Gauge
+	RangefeedErrorCatchup  *metric.Counter
+	RangefeedRestartRanges *metric.Counter
+	RangefeedRestartStuck  *metric.Counter
 }
 
 func makeDistSenderMetrics() DistSenderMetrics {
@@ -334,11 +339,7 @@ func makeDistSenderMetrics() DistSenderMetrics {
 		InLeaseTransferBackoffs:            metric.NewCounter(metaDistSenderInLeaseTransferBackoffsCount),
 		RangeLookups:                       metric.NewCounter(metaDistSenderRangeLookups),
 		SlowRPCs:                           metric.NewGauge(metaDistSenderSlowRPCs),
-		RangefeedRanges:                    metric.NewGauge(metaDistSenderRangefeedTotalRanges),
-		RangefeedCatchupRanges:             metric.NewGauge(metaDistSenderRangefeedCatchupRanges),
-		RangefeedErrorCatchup:              metric.NewCounter(metaDistSenderRangefeedErrorCatchupRanges),
-		RangefeedRestartRanges:             metric.NewCounter(metaDistSenderRangefeedRestartRanges),
-		RangefeedRestartStuck:              metric.NewCounter(metaDistSenderRangefeedRestartStuck),
+		DistSenderRangeFeedMetrics:         makeDistSenderRangeFeedMetrics(),
 	}
 	for i := range m.MethodCounts {
 		method := kvpb.Method(i).String()
@@ -355,6 +356,16 @@ func makeDistSenderMetrics() DistSenderMetrics {
 		m.ErrCounts[i] = metric.NewCounter(meta)
 	}
 	return m
+}
+
+func makeDistSenderRangeFeedMetrics() DistSenderRangeFeedMetrics {
+	return DistSenderRangeFeedMetrics{
+		RangefeedRanges:        metric.NewGauge(metaDistSenderRangefeedTotalRanges),
+		RangefeedCatchupRanges: metric.NewGauge(metaDistSenderRangefeedCatchupRanges),
+		RangefeedErrorCatchup:  metric.NewCounter(metaDistSenderRangefeedErrorCatchupRanges),
+		RangefeedRestartRanges: metric.NewCounter(metaDistSenderRangefeedRestartRanges),
+		RangefeedRestartStuck:  metric.NewCounter(metaDistSenderRangefeedRestartStuck),
+	}
 }
 
 // updateCrossLocalityMetricsOnReplicaAddressedBatchRequest updates

--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -44,6 +44,7 @@ type rangefeedMuxer struct {
 	g ctxgroup.Group
 
 	ds         *DistSender
+	metrics    *DistSenderRangeFeedMetrics
 	cfg        rangeFeedConfig
 	registry   *rangeFeedRegistry
 	catchupSem *limit.ConcurrentRequestLimiter
@@ -84,8 +85,12 @@ func muxRangeFeed(
 		registry:   rr,
 		ds:         ds,
 		cfg:        cfg,
+		metrics:    &ds.metrics.DistSenderRangeFeedMetrics,
 		catchupSem: catchupSem,
 		eventCh:    eventCh,
+	}
+	if cfg.knobs.metrics != nil {
+		m.metrics = cfg.knobs.metrics
 	}
 
 	divideAllSpansOnRangeBoundaries(spans, m.startSingleRangeFeed, ds, &m.g)
@@ -158,7 +163,7 @@ type activeMuxRangeFeed struct {
 	roachpb.ReplicaDescriptor
 	startAfter hlc.Timestamp
 
-	// cathchupRes is the catchup scan quota acquired upon the
+	// catchupRes is the catchup scan quota acquired upon the
 	// start of rangefeed.
 	// It is released when this stream receives first non-empty checkpoint
 	// (meaning: catchup scan completes).
@@ -211,7 +216,7 @@ func (m *rangefeedMuxer) startSingleRangeFeed(
 
 	// Register active mux range feed.
 	stream := &activeMuxRangeFeed{
-		activeRangeFeed: newActiveRangeFeed(span, startAfter, m.registry, m.ds.metrics.RangefeedRanges),
+		activeRangeFeed: newActiveRangeFeed(span, startAfter, m.registry, m.metrics.RangefeedRanges),
 		rSpan:           rs,
 		startAfter:      startAfter,
 		token:           token,
@@ -241,7 +246,7 @@ func (s *activeMuxRangeFeed) start(ctx context.Context, m *rangefeedMuxer) error
 
 	{
 		// Before starting single rangefeed, acquire catchup scan quota.
-		catchupRes, err := acquireCatchupScanQuota(ctx, m.ds, m.catchupSem)
+		catchupRes, err := acquireCatchupScanQuota(ctx, &m.ds.st.SV, m.catchupSem, m.metrics)
 		if err != nil {
 			return err
 		}
@@ -387,13 +392,19 @@ func (m *rangefeedMuxer) startNodeMuxRangeFeed(
 			recvErr = nil
 		}
 
+		toRestart := ms.close()
+
 		// make sure that the underlying error is not fatal. If it is, there is no
 		// reason to restart each rangefeed, so just bail out.
 		if _, err := handleRangefeedError(ctx, recvErr); err != nil {
+			// Regardless of an error, release any resources (i.e. metrics) still
+			// being held by active stream.
+			for _, s := range toRestart {
+				s.release()
+			}
 			return err
 		}
 
-		toRestart := ms.close()
 		if log.V(1) {
 			log.Infof(ctx, "mux to node %d restarted %d streams", ms.nodeID, len(toRestart))
 		}
@@ -429,8 +440,14 @@ func (m *rangefeedMuxer) receiveEventsFromNode(
 			continue
 		}
 
-		if m.cfg.knobs.onMuxRangefeedEvent != nil {
-			m.cfg.knobs.onMuxRangefeedEvent(event)
+		if m.cfg.knobs.onRangefeedEvent != nil {
+			skip, err := m.cfg.knobs.onRangefeedEvent(ctx, active.Span, &event.RangeFeedEvent)
+			if err != nil {
+				return err
+			}
+			if skip {
+				continue
+			}
 		}
 
 		switch t := event.GetValue().(type) {
@@ -451,7 +468,7 @@ func (m *rangefeedMuxer) receiveEventsFromNode(
 		case *kvpb.RangeFeedError:
 			log.VErrEventf(ctx, 2, "RangeFeedError: %s", t.Error.GoError())
 			if active.catchupRes != nil {
-				m.ds.metrics.RangefeedErrorCatchup.Inc(1)
+				m.metrics.RangefeedErrorCatchup.Inc(1)
 			}
 			ms.deleteStream(event.StreamID)
 			// Restart rangefeed on another goroutine. Restart might be a bit
@@ -473,7 +490,7 @@ func (m *rangefeedMuxer) receiveEventsFromNode(
 	}
 }
 
-// restarActiveRangeFeeds restarts one or more rangefeeds.
+// restartActiveRangeFeeds restarts one or more rangefeeds.
 func (m *rangefeedMuxer) restartActiveRangeFeeds(
 	ctx context.Context, reason error, toRestart []*activeMuxRangeFeed,
 ) error {
@@ -489,13 +506,7 @@ func (m *rangefeedMuxer) restartActiveRangeFeeds(
 func (m *rangefeedMuxer) restartActiveRangeFeed(
 	ctx context.Context, active *activeMuxRangeFeed, reason error,
 ) error {
-	m.ds.metrics.RangefeedRestartRanges.Inc(1)
-
-	if log.V(1) {
-		log.Infof(ctx, "RangeFeed %s@%s (r%d, replica %s) disconnected with last checkpoint %s ago: %v",
-			active.Span, active.StartAfter, active.RangeID, active.ReplicaDescriptor,
-			timeutil.Since(active.Resolved.GoTime()), reason)
-	}
+	m.metrics.RangefeedRestartRanges.Inc(1)
 	active.setLastError(reason)
 
 	// Release catchup scan reservation if any -- we will acquire another
@@ -516,6 +527,12 @@ func (m *rangefeedMuxer) restartActiveRangeFeed(
 	if err != nil {
 		// If this is an error we cannot recover from, terminate the rangefeed.
 		return err
+	}
+
+	if log.V(1) {
+		log.Infof(ctx, "RangeFeed %s@%s (r%d, replica %s) disconnected with last checkpoint %s ago: %v (errInfo %v)",
+			active.Span, active.StartAfter, active.RangeID, active.ReplicaDescriptor,
+			timeutil.Since(active.Resolved.GoTime()), reason, errInfo)
 	}
 
 	if errInfo.evict {
@@ -587,13 +604,3 @@ func (c *muxStream) close() []*activeMuxRangeFeed {
 
 	return toRestart
 }
-
-// a test only option to modify mux rangefeed event.
-func withOnMuxEvent(fn func(event *kvpb.MuxRangeFeedEvent)) RangeFeedOption {
-	return optionFunc(func(c *rangeFeedConfig) {
-		c.knobs.onMuxRangefeedEvent = fn
-	})
-}
-
-// TestingWithOnMuxEvent allow external tests access to the withOnMuxEvent option.
-var TestingWithOnMuxEvent = withOnMuxEvent

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -94,7 +94,12 @@ type rangeFeedConfig struct {
 	withDiff        bool
 
 	knobs struct {
-		onMuxRangefeedEvent func(event *kvpb.MuxRangeFeedEvent)
+		// onRangefeedEvent invoked on each rangefeed event.
+		// Returns boolean indicating if event should be skipped or an error
+		// indicating if rangefeed should terminate.
+		onRangefeedEvent func(ctx context.Context, s roachpb.Span, event *kvpb.RangeFeedEvent) (skip bool, _ error)
+		// metrics overrides rangefeed metrics to use.
+		metrics *DistSenderRangeFeedMetrics
 	}
 }
 
@@ -190,7 +195,10 @@ func (ds *DistSender) RangeFeedSpans(
 	for _, opt := range opts {
 		opt.set(&cfg)
 	}
-
+	metrics := &ds.metrics.DistSenderRangeFeedMetrics
+	if cfg.knobs.metrics != nil {
+		metrics = cfg.knobs.metrics
+	}
 	ctx = ds.AnnotateCtx(ctx)
 	ctx, sp := tracing.EnsureChildSpan(ctx, ds.AmbientContext.Tracer, "dist sender")
 	defer sp.Finish()
@@ -218,7 +226,7 @@ func (ds *DistSender) RangeFeedSpans(
 				// Spawn a child goroutine to process this feed.
 				g.GoCtx(func(ctx context.Context) error {
 					return ds.partialRangeFeed(ctx, rr, sri.rs, sri.startAfter,
-						sri.token, &catchupSem, rangeCh, eventCh, cfg)
+						sri.token, &catchupSem, rangeCh, eventCh, cfg, metrics)
 				})
 			case <-ctx.Done():
 				return ctx.Err()
@@ -457,12 +465,13 @@ func (ds *DistSender) partialRangeFeed(
 	rangeCh chan<- singleRangeInfo,
 	eventCh chan<- RangeFeedMessage,
 	cfg rangeFeedConfig,
+	metrics *DistSenderRangeFeedMetrics,
 ) error {
 	// Bound the partial rangefeed to the partial span.
 	span := rs.AsRawSpanWithNoLocals()
 
 	// Register partial range feed with registry.
-	active := newActiveRangeFeed(span, startAfter, rr, ds.metrics.RangefeedRanges)
+	active := newActiveRangeFeed(span, startAfter, rr, metrics.RangefeedRanges)
 	defer active.release()
 
 	// Start a retry loop for sending the batch to the range.
@@ -488,7 +497,7 @@ func (ds *DistSender) partialRangeFeed(
 
 		maxTS, err := ds.singleRangeFeed(
 			ctx, span, startAfter, token.Desc(),
-			catchupSem, eventCh, active.onRangeEvent, cfg)
+			catchupSem, eventCh, active.onRangeEvent, cfg, metrics)
 
 		// Forward the timestamp in case we end up sending it again.
 		startAfter.Forward(maxTS)
@@ -503,7 +512,7 @@ func (ds *DistSender) partialRangeFeed(
 		if err != nil {
 			return err
 		}
-		ds.metrics.RangefeedRestartRanges.Inc(1)
+		metrics.RangefeedRestartRanges.Inc(1)
 		if errInfo.evict {
 			token.Evict(ctx)
 			token = rangecache.EvictionToken{}
@@ -586,18 +595,21 @@ func (a catchupAlloc) Release() {
 }
 
 func acquireCatchupScanQuota(
-	ctx context.Context, ds *DistSender, catchupSem *limit.ConcurrentRequestLimiter,
+	ctx context.Context,
+	sv *settings.Values,
+	catchupSem *limit.ConcurrentRequestLimiter,
+	metrics *DistSenderRangeFeedMetrics,
 ) (catchupAlloc, error) {
 	// Indicate catchup scan is starting;  Before potentially blocking on a semaphore, take
 	// opportunity to update semaphore limit.
-	catchupSem.SetLimit(maxConcurrentCatchupScans(&ds.st.SV))
+	catchupSem.SetLimit(maxConcurrentCatchupScans(sv))
 	res, err := catchupSem.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
-	ds.metrics.RangefeedCatchupRanges.Inc(1)
+	metrics.RangefeedCatchupRanges.Inc(1)
 	return func() {
-		ds.metrics.RangefeedCatchupRanges.Dec(1)
+		metrics.RangefeedCatchupRanges.Dec(1)
 		res.Release()
 	}, nil
 }
@@ -688,6 +700,7 @@ func (ds *DistSender) singleRangeFeed(
 	eventCh chan<- RangeFeedMessage,
 	onRangeEvent onRangeEventCb,
 	cfg rangeFeedConfig,
+	metrics *DistSenderRangeFeedMetrics,
 ) (_ hlc.Timestamp, retErr error) {
 	// Ensure context is cancelled on all errors, to prevent gRPC stream leaks.
 	ctx, cancelFeed := context.WithCancel(ctx)
@@ -707,7 +720,7 @@ func (ds *DistSender) singleRangeFeed(
 
 	// Indicate catchup scan is starting;  Before potentially blocking on a semaphore, take
 	// opportunity to update semaphore limit.
-	catchupRes, err := acquireCatchupScanQuota(ctx, ds, catchupSem)
+	catchupRes, err := acquireCatchupScanQuota(ctx, &ds.st.SV, catchupSem, metrics)
 	if err != nil {
 		return hlc.Timestamp{}, err
 	}
@@ -776,9 +789,19 @@ func (ds *DistSender) singleRangeFeed(
 				log.VErrEventf(ctx, 2, "RPC error: %s", err)
 				if stuckWatcher.stuck() {
 					afterCatchUpScan := catchupRes == nil
-					return args.Timestamp, ds.handleStuckEvent(&args, afterCatchUpScan, stuckWatcher.threshold())
+					return args.Timestamp, handleStuckEvent(&args, afterCatchUpScan, stuckWatcher.threshold(), metrics)
 				}
 				return args.Timestamp, err
+			}
+
+			if cfg.knobs.onRangefeedEvent != nil {
+				skip, err := cfg.knobs.onRangefeedEvent(ctx, span, event)
+				if err != nil {
+					return args.Timestamp, err
+				}
+				if skip {
+					continue
+				}
 			}
 
 			msg := RangeFeedMessage{RangeFeedEvent: event, RegisteredSpan: span}
@@ -799,14 +822,14 @@ func (ds *DistSender) singleRangeFeed(
 			case *kvpb.RangeFeedError:
 				log.VErrEventf(ctx, 2, "RangeFeedError: %s", t.Error.GoError())
 				if catchupRes != nil {
-					ds.metrics.RangefeedErrorCatchup.Inc(1)
+					metrics.RangefeedErrorCatchup.Inc(1)
 				}
 				if stuckWatcher.stuck() {
 					// When the stuck watcher fired, and the rangefeed call is local,
 					// the remote might notice the cancellation first and return from
 					// Recv with an error that we need to special-case here.
 					afterCatchUpScan := catchupRes == nil
-					return args.Timestamp, ds.handleStuckEvent(&args, afterCatchUpScan, stuckWatcher.threshold())
+					return args.Timestamp, handleStuckEvent(&args, afterCatchUpScan, stuckWatcher.threshold(), metrics)
 				}
 				return args.Timestamp, t.Error.GoError()
 			}
@@ -828,10 +851,13 @@ func connectionClass(sv *settings.Values) rpc.ConnectionClass {
 	return rpc.DefaultClass
 }
 
-func (ds *DistSender) handleStuckEvent(
-	args *kvpb.RangeFeedRequest, afterCatchupScan bool, threshold time.Duration,
+func handleStuckEvent(
+	args *kvpb.RangeFeedRequest,
+	afterCatchupScan bool,
+	threshold time.Duration,
+	m *DistSenderRangeFeedMetrics,
 ) error {
-	ds.metrics.RangefeedRestartStuck.Inc(1)
+	m.RangefeedRestartStuck.Inc(1)
 	if afterCatchupScan {
 		telemetry.Count("rangefeed.stuck.after-catchup-scan")
 	} else {
@@ -842,3 +868,23 @@ func (ds *DistSender) handleStuckEvent(
 
 // sentinel error returned when cancelling rangefeed when it is stuck.
 var errRestartStuckRange = errors.New("rangefeed restarting due to inactivity")
+
+// TestingWithOnRangefeedEvent returns a test only option to modify rangefeed event.
+func TestingWithOnRangefeedEvent(
+	fn func(ctx context.Context, s roachpb.Span, event *kvpb.RangeFeedEvent) (skip bool, _ error),
+) RangeFeedOption {
+	return optionFunc(func(c *rangeFeedConfig) {
+		c.knobs.onRangefeedEvent = fn
+	})
+}
+
+// TestingWithRangeFeedMetrics returns a test only option to specify metrics to
+// use while executing this rangefeed.
+func TestingWithRangeFeedMetrics(m *DistSenderRangeFeedMetrics) RangeFeedOption {
+	return optionFunc(func(c *rangeFeedConfig) {
+		c.knobs.metrics = m
+	})
+}
+
+// TestingMakeRangeFeedMetrics exposes makeDistSenderRangeFeedMetrics for test use.
+var TestingMakeRangeFeedMetrics = makeDistSenderRangeFeedMetrics

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
@@ -136,8 +136,8 @@ func TestDistSenderRangeFeedRetryOnTransportErrors(t *testing.T) {
 							stream.EXPECT().Send(gomock.Any()).Return(nil)
 							stream.EXPECT().Recv().Do(func() {
 								cancel()
-							}).Return(nil, context.Canceled)
-							client.EXPECT().MuxRangeFeed(gomock.Any()).Return(stream, nil)
+							}).Return(nil, context.Canceled).AnyTimes()
+							client.EXPECT().MuxRangeFeed(gomock.Any()).Return(stream, nil).AnyTimes()
 						} else {
 							stream := kvpbmock.NewMockInternal_RangeFeedClient(ctrl)
 							stream.EXPECT().Recv().Do(cancel).Return(nil, io.EOF)


### PR DESCRIPTION
Fix an observability bug in mux rangefeed which would incorrectly count various rangefeed related metrics (total ranges, catchup ranges, etc).

Fixes #106152
Fixes #106252

Release note: None