### PR TITLE
release-23.1: server: ensure SQL statement diagnostic requests work with secondary tenants

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -362,9 +362,11 @@ func generateRandomName() string {
 func TestAdminAPIStatementDiagnosticsBundle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
-	ts := s.(*TestServer)
+
+	ts := s.TenantOrServer()
 
 	query := "EXPLAIN ANALYZE (DEBUG) SELECT 'secret'"
 	_, err := db.Exec(query)

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -402,10 +402,7 @@ func newTenantServer(
 	}
 
 	// Tell the status/admin servers how to access SQL structures.
-	//
-	// TODO(knz): If/when we want to support statement diagnostic requests
-	// in secondary tenants, this is where we would call setStmtDiagnosticsRequester(),
-	// like in NewServer().
+	sStatus.setStmtDiagnosticsRequester(sqlServer.execCfg.StmtDiagnosticsRecorder)
 	serverIterator.sqlServer = sqlServer
 	sStatus.baseStatusServer.sqlServer = sqlServer
 	sAdmin.sqlServer = sqlServer

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -835,6 +835,11 @@ func (t *TestTenant) SettingsWatcher() interface{} {
 	return t.SQLServer.settingsWatcher
 }
 
+// InternalExecutor is part of TestTenantInterface.
+func (t *TestTenant) InternalExecutor() interface{} {
+	return t.SQLServer.internalExecutor
+}
+
 // StartSharedProcessTenant is part of TestServerInterface.
 func (ts *TestServer) StartSharedProcessTenant(
 	ctx context.Context, args base.TestSharedProcessTenantArgs,
@@ -1376,7 +1381,7 @@ func (ts *TestServer) LeaseManager() interface{} {
 	return ts.sqlServer.leaseMgr
 }
 
-// InternalExecutor is part of TestServerInterface.
+// InternalExecutor is part of TestTenantInterface.
 func (ts *TestServer) InternalExecutor() interface{} {
 	return ts.sqlServer.internalExecutor
 }

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -130,10 +130,6 @@ type TestServerInterface interface {
 	// LeaseManager() returns the *sql.LeaseManager as an interface{}.
 	LeaseManager() interface{}
 
-	// InternalExecutor returns a *sql.InternalExecutor as an interface{} (which
-	// also implements insql.InternalExecutor if the test cannot depend on sql).
-	InternalExecutor() interface{}
-
 	// InternalExecutorInternalExecutorFactory returns a
 	// insql.InternalDB as an interface{}.
 	InternalDB() interface{}

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -99,6 +99,10 @@ type TestTenantInterface interface {
 	// The real return type is sql.ExecutorConfig.
 	ExecutorConfig() interface{}
 
+	// InternalExecutor returns a *sql.InternalExecutor as an interface{} (which
+	// also implements isql.InternalExecutor if the test cannot depend on sql).
+	InternalExecutor() interface{}
+
 	// RangeFeedFactory returns the range feed factory used by the tenant.
 	// The real return type is *rangefeed.Factory.
 	RangeFeedFactory() interface{}


### PR DESCRIPTION
Backport 1/1 commits from #106931.

/cc @cockroachdb/release

---

Epic: CRDB-26687
Informs: CRDB-18499
Informs #76378.

---
Release justification: bug fix
