### PR TITLE
roachtest: include link to testeng grafana in issue posts

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
         "test_test.go",
     ],
     args = ["-test.timeout=55s"],
+    data = glob(["testdata/**"]),
     embed = [":roachtest_lib"],
     deps = [
         "//pkg/cmd/internal/issues",
@@ -90,6 +91,7 @@ go_test(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/testutils",
+        "//pkg/testutils/echotest",
         "//pkg/util/quotapool",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -47,6 +47,26 @@ func roachtestPrefix(p string) string {
 	return "ROACHTEST_" + p
 }
 
+// generateHelpCommand creates a HelpCommand for createPostRequest
+func generateHelpCommand(
+	clusterName string, start time.Time, end time.Time,
+) func(renderer *issues.Renderer) {
+	return func(renderer *issues.Renderer) {
+		issues.HelpCommandAsLink(
+			"roachtest README",
+			"https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md",
+		)(renderer)
+		issues.HelpCommandAsLink(
+			"How To Investigate (internal)",
+			"https://cockroachlabs.atlassian.net/l/c/SSSBr8c7",
+		)(renderer)
+		issues.HelpCommandAsLink(
+			"Grafana",
+			fmt.Sprintf("https://go.crdb.dev/p/roachfana/%s/%d/%d", clusterName, start.UnixMilli(), end.UnixMilli()),
+		)(renderer)
+	}
+}
+
 // postIssueCondition encapsulates a condition that causes issue
 // posting to be skipped. The `reason` field contains a textual
 // description as to why issue posting was skipped.
@@ -197,16 +217,7 @@ func (g *githubIssues) createPostRequest(
 		Artifacts:       artifacts,
 		ExtraLabels:     labels,
 		ExtraParams:     clusterParams,
-		HelpCommand: func(renderer *issues.Renderer) {
-			issues.HelpCommandAsLink(
-				"roachtest README",
-				"https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md",
-			)(renderer)
-			issues.HelpCommandAsLink(
-				"How To Investigate (internal)",
-				"https://cockroachlabs.atlassian.net/l/c/SSSBr8c7",
-			)(renderer)
-		},
+		HelpCommand:     generateHelpCommand(clusterName, start, end),
 	}, nil
 }
 

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -14,8 +14,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/internal/issues"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -25,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/team"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -101,6 +104,16 @@ func TestShouldPost(t *testing.T) {
 		require.Equal(t, c.expectedPost, doPost)
 		require.Equal(t, c.expectedReason, skipReason)
 	}
+}
+
+func TestGenerateHelpCommand(t *testing.T) {
+	start := time.Date(2023, time.July, 21, 16, 34, 3, 817, time.UTC)
+	end := time.Date(2023, time.July, 21, 16, 42, 13, 137, time.UTC)
+
+	r := &issues.Renderer{}
+	generateHelpCommand("foo-cluster", start, end)(r)
+
+	echotest.Require(t, r.String(), filepath.Join("testdata", "help_command.txt"))
 }
 
 func TestCreatePostRequest(t *testing.T) {

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -200,10 +200,12 @@ func TestCreatePostRequest(t *testing.T) {
 			}
 
 			if c.loadTeamsFailed {
-				// Assert that if TEAMS.yaml cannot be loaded then function panics.
-				assert.Panics(t, func() { github.createPostRequest(ti, c.failure, "message") })
+				// Assert that if TEAMS.yaml cannot be loaded then function errors.
+				_, err := github.createPostRequest("github_test", ti.start, ti.end, testSpec, c.failure, "message")
+				assert.Error(t, err, "Expected an error in createPostRequest when loading teams fails, but got nil")
 			} else {
-				req := github.createPostRequest(ti, c.failure, "message")
+				req, err := github.createPostRequest("github_test", ti.start, ti.end, testSpec, c.failure, "message")
+				assert.NoError(t, err, "Expected no error in createPostRequest")
 
 				if c.expectedParams != nil {
 					require.Equal(t, c.expectedParams, req.ExtraParams)

--- a/pkg/cmd/roachtest/testdata/help_command.txt
+++ b/pkg/cmd/roachtest/testdata/help_command.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/p/roachfana/foo-cluster/1689957243000/1689957733000)
+
+----
+----


### PR DESCRIPTION
This adds a link, populated with relevant cluster name and test timeframe, to the testeng grafana instance for failed roachtests.

Fixes: #105894
Release note: None