### PR TITLE
release-22.2: optbuilder: fix panic on upsert with concurrent ALTER ADD of virtual computed column

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -1293,3 +1293,258 @@ project
                 │         └── null [type=unknown]
                 └── cast: STRING [type=string]
                      └── null [type=unknown]
+
+# The following 8 tests check whether a virtual computed column as the key to
+# a unique index projects the computed column expression correctly while it's
+# being mutated (e.g. ADD/DROP COLUMN).
+exec-ddl
+CREATE TABLE t1 (
+  a INT PRIMARY KEY,
+  b INT,
+  "b_plus_one:delete-only" INT AS (b + 1) VIRTUAL,
+  UNIQUE INDEX "b_plus_one_idx:delete-only" (b_plus_one)
+)
+----
+
+opt
+UPSERT INTO t1 VALUES (1, 2) RETURNING a, b
+----
+upsert t1
+ ├── columns: a:1!null b:2!null
+ ├── arbiter indexes: t1_pkey
+ ├── canary column: a:8
+ ├── fetch columns: a:8 b:9 b_plus_one:10
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    └── column2:7 => b:2
+ ├── update-mapping:
+ │    └── column2:7 => b:2
+ ├── return-mapping:
+ │    ├── upsert_a:13 => a:1
+ │    └── column2:7 => b:2
+ └── project
+      ├── columns: upsert_a:13 column1:6!null column2:7!null a:8 b:9 b_plus_one:10
+      ├── left-join (cross)
+      │    ├── columns: column1:6!null column2:7!null a:8 b:9 b_plus_one:10
+      │    ├── values
+      │    │    ├── columns: column1:6!null column2:7!null
+      │    │    └── (1, 2)
+      │    ├── project
+      │    │    ├── columns: b_plus_one:10 a:8!null b:9
+      │    │    ├── scan t1
+      │    │    │    ├── columns: a:8!null b:9
+      │    │    │    ├── constraint: /8: [/1 - /1]
+      │    │    │    └── flags: disabled not visible index feature
+      │    │    └── projections
+      │    │         └── b:9 + 1 [as=b_plus_one:10]
+      │    └── filters (true)
+      └── projections
+           └── CASE WHEN a:8 IS NULL THEN column1:6 ELSE a:8 END [as=upsert_a:13]
+
+opt
+UPDATE t1 SET b = b-1 WHERE a = 1 AND b = 2 RETURNING a, b
+----
+update t1
+ ├── columns: a:1!null b:2!null
+ ├── fetch columns: a:6 b:7 b_plus_one:8
+ ├── update-mapping:
+ │    └── b_new:11 => b:2
+ └── project
+      ├── columns: b_new:11!null b_plus_one:8!null a:6!null b:7!null
+      ├── select
+      │    ├── columns: a:6!null b:7!null
+      │    ├── scan t1
+      │    │    ├── columns: a:6!null b:7
+      │    │    └── constraint: /6: [/1 - /1]
+      │    └── filters
+      │         └── b:7 = 2
+      └── projections
+           ├── b:7 - 1 [as=b_new:11]
+           └── b:7 + 1 [as=b_plus_one:8]
+
+opt
+DELETE FROM t1 WHERE a = 2 AND b = 2 RETURNING a, b
+----
+delete t1
+ ├── columns: a:1!null b:2!null
+ ├── fetch columns: a:6 b:7 b_plus_one:8
+ └── project
+      ├── columns: b_plus_one:8!null a:6!null b:7!null
+      ├── select
+      │    ├── columns: a:6!null b:7!null
+      │    ├── scan t1
+      │    │    ├── columns: a:6!null b:7
+      │    │    └── constraint: /6: [/2 - /2]
+      │    └── filters
+      │         └── b:7 = 2
+      └── projections
+           └── b:7 + 1 [as=b_plus_one:8]
+
+opt
+INSERT INTO t1 VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET b=t1.b+100 RETURNING a, b
+----
+upsert t1
+ ├── columns: a:1!null b:2
+ ├── arbiter indexes: t1_pkey
+ ├── canary column: a:8
+ ├── fetch columns: a:8 b:9 b_plus_one:10
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    └── column2:7 => b:2
+ ├── update-mapping:
+ │    └── upsert_b:15 => b:2
+ ├── return-mapping:
+ │    ├── upsert_a:14 => a:1
+ │    └── upsert_b:15 => b:2
+ └── project
+      ├── columns: upsert_a:14 upsert_b:15 column1:6!null column2:7!null a:8 b:9 b_plus_one:10
+      ├── left-join (cross)
+      │    ├── columns: column1:6!null column2:7!null a:8 b:9 b_plus_one:10
+      │    ├── values
+      │    │    ├── columns: column1:6!null column2:7!null
+      │    │    └── (1, 2)
+      │    ├── project
+      │    │    ├── columns: b_plus_one:10 a:8!null b:9
+      │    │    ├── scan t1
+      │    │    │    ├── columns: a:8!null b:9
+      │    │    │    ├── constraint: /8: [/1 - /1]
+      │    │    │    └── flags: disabled not visible index feature
+      │    │    └── projections
+      │    │         └── b:9 + 1 [as=b_plus_one:10]
+      │    └── filters (true)
+      └── projections
+           ├── CASE WHEN a:8 IS NULL THEN column1:6 ELSE a:8 END [as=upsert_a:14]
+           └── CASE WHEN a:8 IS NULL THEN column2:7 ELSE b:9 + 100 END [as=upsert_b:15]
+
+exec-ddl
+CREATE TABLE t11 (
+  a INT PRIMARY KEY,
+  b INT,
+  "b_plus_one:write-only" INT AS (b + 1) VIRTUAL,
+  UNIQUE INDEX "b_plus_one_idx:write-only" (b_plus_one)
+)
+----
+
+opt
+UPSERT INTO t11 VALUES (1, 2) RETURNING a, b
+----
+upsert t11
+ ├── columns: a:1!null b:2!null
+ ├── arbiter indexes: t11_pkey
+ ├── canary column: a:9
+ ├── fetch columns: a:9 b:10 b_plus_one:11
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    ├── column2:7 => b:2
+ │    └── b_plus_one_comp:8 => b_plus_one:3
+ ├── update-mapping:
+ │    ├── column2:7 => b:2
+ │    └── b_plus_one_comp:8 => b_plus_one:3
+ ├── return-mapping:
+ │    ├── upsert_a:14 => a:1
+ │    └── column2:7 => b:2
+ └── project
+      ├── columns: upsert_a:14 column1:6!null column2:7!null b_plus_one_comp:8!null a:9 b:10 b_plus_one:11
+      ├── left-join (cross)
+      │    ├── columns: column1:6!null column2:7!null b_plus_one_comp:8!null a:9 b:10 b_plus_one:11
+      │    ├── values
+      │    │    ├── columns: column1:6!null column2:7!null b_plus_one_comp:8!null
+      │    │    └── (1, 2, 3)
+      │    ├── project
+      │    │    ├── columns: b_plus_one:11 a:9!null b:10
+      │    │    ├── scan t11
+      │    │    │    ├── columns: a:9!null b:10
+      │    │    │    ├── constraint: /9: [/1 - /1]
+      │    │    │    └── flags: disabled not visible index feature
+      │    │    └── projections
+      │    │         └── b:10 + 1 [as=b_plus_one:11]
+      │    └── filters (true)
+      └── projections
+           └── CASE WHEN a:9 IS NULL THEN column1:6 ELSE a:9 END [as=upsert_a:14]
+
+opt
+UPDATE t11 SET b = b-1 WHERE a = 1 AND b = 2 RETURNING a, b
+----
+update t11
+ ├── columns: a:1!null b:2!null
+ ├── fetch columns: a:6 b:7 b_plus_one:8
+ ├── update-mapping:
+ │    ├── b_new:11 => b:2
+ │    └── b_plus_one_comp:12 => b_plus_one:3
+ └── project
+      ├── columns: b_plus_one_comp:12!null a:6!null b:7!null b_plus_one:8!null b_new:11!null
+      ├── project
+      │    ├── columns: b_new:11!null b_plus_one:8!null a:6!null b:7!null
+      │    ├── select
+      │    │    ├── columns: a:6!null b:7!null
+      │    │    ├── scan t11
+      │    │    │    ├── columns: a:6!null b:7
+      │    │    │    └── constraint: /6: [/1 - /1]
+      │    │    └── filters
+      │    │         └── b:7 = 2
+      │    └── projections
+      │         ├── b:7 - 1 [as=b_new:11]
+      │         └── b:7 + 1 [as=b_plus_one:8]
+      └── projections
+           └── b_new:11 + 1 [as=b_plus_one_comp:12]
+
+opt
+DELETE FROM t11 WHERE a = 2 AND b = 2 RETURNING a, b
+----
+delete t11
+ ├── columns: a:1!null b:2!null
+ ├── fetch columns: a:6 b:7 b_plus_one:8
+ └── project
+      ├── columns: b_plus_one:8!null a:6!null b:7!null
+      ├── select
+      │    ├── columns: a:6!null b:7!null
+      │    ├── scan t11
+      │    │    ├── columns: a:6!null b:7
+      │    │    └── constraint: /6: [/2 - /2]
+      │    └── filters
+      │         └── b:7 = 2
+      └── projections
+           └── b:7 + 1 [as=b_plus_one:8]
+
+opt
+INSERT INTO t11 VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET b=t11.b+100 RETURNING a, b
+----
+upsert t11
+ ├── columns: a:1!null b:2
+ ├── arbiter indexes: t11_pkey
+ ├── canary column: a:9
+ ├── fetch columns: a:9 b:10 b_plus_one:11
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    ├── column2:7 => b:2
+ │    └── b_plus_one_comp:8 => b_plus_one:3
+ ├── update-mapping:
+ │    ├── upsert_b:17 => b:2
+ │    └── upsert_b_plus_one:18 => b_plus_one:3
+ ├── return-mapping:
+ │    ├── upsert_a:16 => a:1
+ │    └── upsert_b:17 => b:2
+ └── project
+      ├── columns: upsert_a:16 upsert_b:17 upsert_b_plus_one:18 column1:6!null column2:7!null b_plus_one_comp:8!null a:9 b:10 b_plus_one:11
+      ├── project
+      │    ├── columns: b_new:14 column1:6!null column2:7!null b_plus_one_comp:8!null a:9 b:10 b_plus_one:11
+      │    ├── left-join (cross)
+      │    │    ├── columns: column1:6!null column2:7!null b_plus_one_comp:8!null a:9 b:10 b_plus_one:11
+      │    │    ├── values
+      │    │    │    ├── columns: column1:6!null column2:7!null b_plus_one_comp:8!null
+      │    │    │    └── (1, 2, 3)
+      │    │    ├── project
+      │    │    │    ├── columns: b_plus_one:11 a:9!null b:10
+      │    │    │    ├── scan t11
+      │    │    │    │    ├── columns: a:9!null b:10
+      │    │    │    │    ├── constraint: /9: [/1 - /1]
+      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── projections
+      │    │    │         └── b:10 + 1 [as=b_plus_one:11]
+      │    │    └── filters (true)
+      │    └── projections
+      │         └── b:10 + 100 [as=b_new:14]
+      └── projections
+           ├── CASE WHEN a:9 IS NULL THEN column1:6 ELSE a:9 END [as=upsert_a:16]
+           ├── CASE WHEN a:9 IS NULL THEN column2:7 ELSE b_new:14 END [as=upsert_b:17]
+           └── CASE WHEN a:9 IS NULL THEN b_plus_one_comp:8 ELSE b_new:14 + 1 END [as=upsert_b_plus_one:18]

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -13,8 +13,10 @@ package sql_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -27,6 +29,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -214,6 +218,156 @@ SELECT * FROM d.t@b_idx   = %s
 					sqlDB.QueryStr(t, `SELECT * FROM d.t@b_idx`),
 				)
 			}
+		})
+	}
+}
+
+// TestConcurrentUpsertAddDropVirtualComputedColumn tests DML statements with a
+// RETURNING clause running concurrently with an ALTER TABLE ADD/DROP COLUMN
+// which adds or drops a virtual computed column.
+func TestConcurrentUpsertAddDropVirtualComputedColumn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, `CREATE TABLE d.t (a INT, b INT, PRIMARY KEY(a, b), INDEX b_idx (b))`)
+
+	var mu syncutil.Mutex
+	const numRows = 12
+
+	testCases := []struct {
+		name            string
+		updateStmt      string
+		checkVirtualCol bool
+		returningBDelta int
+		alterStmt       string
+		testQuery       string
+		result          []string
+		colAValue       int
+	}{
+		// Upsert case.
+		{
+			name:            "upsert add",
+			updateStmt:      `UPSERT INTO d.t VALUES ($1, $2) RETURNING a, b`,
+			returningBDelta: 0,
+			alterStmt:       `ALTER TABLE d.t ADD COLUMN b_plus_one INT AS (b+1) VIRTUAL UNIQUE`,
+			testQuery:       `SELECT count(*) FROM d.t@primary WHERE b_plus_one IS NOT NULL`,
+			result:          []string{fmt.Sprint(numRows)},
+			colAValue:       1,
+		},
+		{
+			name:            "upsert drop",
+			updateStmt:      `UPSERT INTO d.t VALUES ($1, $2+100) RETURNING a, b`,
+			returningBDelta: 100,
+			alterStmt:       `ALTER TABLE d.t DROP COLUMN b_plus_one`,
+			testQuery:       `SELECT a, b FROM d.t@primary ORDER BY 1 DESC, 2 LIMIT 1`,
+			result:          []string{"2", "101"},
+			colAValue:       2,
+		},
+		// Update cases.
+		{
+			name:            "update add",
+			updateStmt:      `UPDATE d.t SET b = b-1 WHERE a = $1 AND b = $2 RETURNING a, b`,
+			returningBDelta: -1,
+			alterStmt:       `ALTER TABLE d.t ADD COLUMN b_plus_2 INT AS (b+2) VIRTUAL UNIQUE`,
+			testQuery:       `SELECT count(*) FROM d.t@primary WHERE b_plus_2 IS NOT NULL`,
+			result:          []string{fmt.Sprint(2 * numRows)},
+			colAValue:       1,
+		},
+		{
+			name:            "update drop",
+			updateStmt:      `UPDATE d.t SET b = b-1 WHERE a = $1 AND b = $2-1 RETURNING a, b`,
+			returningBDelta: -2,
+			alterStmt:       `ALTER TABLE d.t DROP COLUMN b_plus_2`,
+			testQuery:       `SELECT a, b FROM d.t@primary ORDER BY 1,2 LIMIT 1`,
+			result:          []string{"1", "-1"},
+			colAValue:       1,
+		},
+		// Delete cases.
+		{
+			name:            "delete add",
+			updateStmt:      `DELETE FROM d.t WHERE a = $1 AND b = $2+100 RETURNING a, b`,
+			returningBDelta: 100,
+			alterStmt:       `ALTER TABLE d.t ADD COLUMN b_plus_one INT AS (b+1) VIRTUAL UNIQUE`,
+			testQuery:       `SELECT count(*) FROM d.t@primary WHERE b_plus_one IS NOT NULL`,
+			result:          []string{fmt.Sprint(numRows)},
+			colAValue:       2,
+		},
+		{
+			name:            "delete drop",
+			updateStmt:      `DELETE FROM d.t WHERE a = $1 AND b = $2-2 RETURNING a, b`,
+			returningBDelta: -2,
+			alterStmt:       `ALTER TABLE d.t DROP COLUMN b_plus_one`,
+			testQuery:       `SELECT count(*) FROM d.t@primary`,
+			result:          []string{"0"},
+			colAValue:       1,
+		},
+		// Insert cases.
+		{
+			name:            "insert add",
+			updateStmt:      `INSERT INTO d.t VALUES ($1, $2) ON CONFLICT (a, b) DO UPDATE SET b=d.t.b+100 RETURNING a, b`,
+			returningBDelta: 0,
+			alterStmt:       `ALTER TABLE d.t ADD COLUMN b_plus_one INT AS (b+1) VIRTUAL UNIQUE`,
+			testQuery:       `SELECT count(*) FROM d.t@primary WHERE b_plus_one IS NOT NULL`,
+			result:          []string{fmt.Sprint(numRows)},
+			colAValue:       2,
+		},
+		{
+			name:            "insert drop",
+			updateStmt:      `INSERT INTO d.t VALUES ($1, $2) ON CONFLICT (a, b) DO UPDATE SET b=d.t.b+100 RETURNING a, b`,
+			returningBDelta: 100,
+			alterStmt:       `ALTER TABLE d.t DROP COLUMN b_plus_one`,
+			testQuery:       `SELECT * FROM d.t@primary ORDER BY 1, 2 LIMIT 1`,
+			result:          []string{"2", "101"},
+			colAValue:       2,
+		},
+	}
+
+	for _, test := range testCases {
+		updateStmt := test.updateStmt
+		alterStmt := test.alterStmt
+		colAValue := test.colAValue
+		returningBDelta := test.returningBDelta
+		testQuery := test.testQuery
+		result := test.result
+		// Serialize the tests because the next test relies on the results of
+		// the previous one.
+		mu.Lock()
+		t.Run(test.name, func(t *testing.T) {
+			defer mu.Unlock()
+			g, ctx := errgroup.WithContext(context.Background())
+			g.Go(func() error {
+				for j := 1; j <= numRows; j++ {
+					rows := sqlDB.QueryStr(t, updateStmt, colAValue, j)
+					expected := []string{fmt.Sprint(colAValue), fmt.Sprint(j + returningBDelta)}
+					require.Equal(t, expected, rows[0])
+				}
+				return nil
+			})
+			g.Go(func() error {
+				// Let the updates start before the ALTER TABLE is issued.
+				time.Sleep(500 * time.Microsecond)
+				if _, err := sqlDB.DB.ExecContext(ctx, alterStmt); err != nil {
+					return err
+				}
+				return nil
+			})
+			if err := g.Wait(); err != nil {
+				t.Errorf(`%+v
+SELECT * FROM d.t@primary = %s
+SELECT * FROM d.t@b_idx   = %s
+`,
+					err,
+					sqlDB.QueryStr(t, `SELECT * FROM d.t@primary`),
+					sqlDB.QueryStr(t, `SELECT * FROM d.t@b_idx`),
+				)
+			}
+			results := sqlDB.QueryStr(t, testQuery)
+			require.Equal(t, result, results[0])
 		})
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #106782.

/cc @cockroachdb/release

---

A panic may happen when an upsert or other DML is run in one SQL
connection while simultaneously an ALTER TABLE ADD COLUMN of a virtual
computed column is run in a different SQL connection.

This is due to `Builder.buildScan` attempting to project the
newly-added virtual column as part of index arbiter processing
for the upsert, causing an access to the tabMeta.ComputedCols map,
which has not been allocated, resulting in a panic due to the nil-pointer
access. Other DML operations like updates, inserts and deletes may also
observe this behavior.

The fix is to collect the oridinals of all virtual computed columns
under mutation inside `buildScan`, from the set of column ordinals being
selected, and pass that to addComputedColsForTable. If the computed
column for which we're building the computed column expression is in
this `includeVirtualMutationColOrds` set, then always build the
expression, even when the column is under mutation.

Fixes https://github.com/cockroachlabs/support/issues/2457
Fixes #107357

Release note (bug fix): This patch fixes an internal error in UPDATE,
UPSERT, INSERT or DELETE statements run concurrently with
ALTER TABLE ADD COLUMN of a virtual computed column on the same table.

Co-authored-by: Marcus Gartner <marcus@cockroachlabs.com>

----

Release justification: Fix for failing DML statements with concurrent ALTER TABLE ADD of a virtual computed column.
