### PR TITLE
allocator: remove log.VEventf for alive stores in isStoreReady…

### DIFF
--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -1312,8 +1312,6 @@ func (sp *StorePool) isStoreReadyForRoutineReplicaTransferInternal(
 	}
 	switch status {
 	case storeStatusThrottled, storeStatusAvailable:
-		log.VEventf(ctx, 3,
-			"s%d is a live target, candidate for rebalancing", targetStoreID)
 		return true
 	case storeStatusDead, storeStatusUnknown, storeStatusDecommissioning, storeStatusSuspect, storeStatusDraining:
 		log.VEventf(ctx, 3,


### PR DESCRIPTION
When investigating an allocator simulator test, we observed a significant amount
of time spent by `log.VEventf`, consuming 64% of time (according to pprof CPU
analysis). This was mainly caused by `rankedCandidateListForRebalancing`
repeatedly calling `IsStoreReadyForRoutineReplicaTransfer` on all stores that
pass the `StoreFilterThrottled` filter. As a temporary mitigation, we deleted
`log.VEventf` in `isStoreReadyForRoutineReplicaTransferInternal` for less
interesting cases where stores are alive.  However, our longer term strategy is
to buffer such outputs in the allocator at a higher level to reduce
`log.VEventf` calls.

Informs: https://github.com/cockroachdb/cockroach/issues/107421

Release note: None

----

| Before| After |
| -| - |
| <img width="300" alt="Screenshot 2023-07-21 at 6 08 01 PM" src="https://github.com/cockroachdb/cockroach/assets/56973754/e544282c-9405-49b1-9469-c8e54330794b"> |<img width="300" alt="Screenshot 2023-07-22 at 11 08 33 PM" src="https://github.com/cockroachdb/cockroach/assets/56973754/02c7ee25-d3e4-4b01-9a91-131c05046895">