### PR TITLE
geomfn: fix ST_ClosestPoint returning the incorrect SRID

### DIFF
--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -818,11 +818,12 @@ func ClosestPoint(a, b geo.Geometry) (geo.Geometry, error) {
 	}
 	closestPoint, err := geo.MakeGeometryFromPointCoords(
 		shortestLineT.(*geom.LineString).Coord(0).X(),
-		shortestLineT.(*geom.LineString).Coord(0).Y())
+		shortestLineT.(*geom.LineString).Coord(0).Y(),
+	)
 	if err != nil {
 		return geo.Geometry{}, err
 	}
-	return closestPoint, nil
+	return closestPoint.CloneWithSRID(a.SRID())
 }
 
 func verifyDensifyFrac(f float64) error {

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -984,9 +984,9 @@ func TestClosestPoint(t *testing.T) {
 			"POINT(1.5 1.5)",
 		},
 		{"Closest point between MULTIPOLYGON and MULTIPOINT",
-			"MULTIPOLYGON(((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1)), ((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1)))",
-			"MULTIPOINT((20 10),(10 10))",
-			"POINT(4 4)",
+			"SRID=4326;MULTIPOLYGON(((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1)), ((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1)))",
+			"SRID=4326;MULTIPOINT((20 10),(10 10))",
+			"SRID=4326;POINT(4 4)",
 		},
 	}
 


### PR DESCRIPTION
Resolves #107419

Release note (bug fix): ST_ClosestPoint previously did not preserve the correct SRID when comparing two different points. This is now resolved.