### PR TITLE
roachprod-microbench: fix delta string parsing

### DIFF
--- a/pkg/cmd/roachprod-microbench/google/service.go
+++ b/pkg/cmd/roachprod-microbench/google/service.go
@@ -212,7 +212,7 @@ func (srv *Service) createRawSheet(
 			vals = append(vals, numCell(entry.Summaries[run].Center))
 		}
 		delta := comparison.FormattedDelta
-		if delta == "~" {
+		if delta == "~" || delta == "?" {
 			vals = append(vals, strCell(delta))
 		} else {
 			vals = append(vals, percentCell(deltaToNum(delta)))


### PR DESCRIPTION
A microbenchmark run, ran into an unexpected value for the delta string produced by the perf package. This change adds the "?" case so that all other values can be parsed correctly.

Release note: None
Epic: None