### PR TITLE
compose: Deflake TestComposeCompare

### DIFF
--- a/pkg/sql/randgen/mutator.go
+++ b/pkg/sql/randgen/mutator.go
@@ -735,127 +735,131 @@ func postgresCreateTableMutator(
 ) (mutated []tree.Statement, changed bool) {
 	for _, stmt := range stmts {
 		mutated = append(mutated, stmt)
-		switch stmt := stmt.(type) {
-		case *tree.CreateTable:
-			// Get all the column types first.
-			colTypes := make(map[string]*types.T)
-			for _, def := range stmt.Defs {
-				switch def := def.(type) {
-				case *tree.ColumnTableDef:
-					colType := tree.MustBeStaticallyKnownType(def.Type)
-					// Disable locales because CRDB random generator generates
-					// locales without double-quotes, and they are unknown to
-					// Postgres (e.g. `i TEXT COLLATE de_DE` won't work with
-					// Postgres).
-					if colType.Family() == types.CollatedStringFamily {
-						colType = types.String
-					}
-					colTypes[string(def.Name)] = colType
-				}
-			}
+		mutatedStmt, ok := stmt.(*tree.CreateTable)
+		if !ok {
+			continue
+		}
 
-			// Exclude `INDEX` and `UNIQUE` table defs and hoist them into separate
-			// `CREATE INDEX` and `CREATE UNIQUE INDEX` statements.
-			var newdefs tree.TableDefs
-			for _, def := range stmt.Defs {
-				switch def := def.(type) {
-				case *tree.IndexTableDef:
-					// Postgres doesn't support indexes in CREATE TABLE, so split them out
-					// to their own statement.
-					var newCols tree.IndexElemList
-					for _, col := range def.Columns {
-						isBox2d := false
-						// NB: col.Column is empty for expression-based indexes.
-						if col.Expr == nil {
-							// Postgres doesn't support box2d as a btree index key.
-							colTypeFamily := colTypes[string(col.Column)].Family()
-							if colTypeFamily == types.Box2DFamily {
-								isBox2d = true
-							}
-						}
-						if isBox2d {
-							changed = true
-						} else {
-							newCols = append(newCols, col)
-						}
-					}
-					if len(newCols) == 0 {
-						// Break without adding this index at all.
-						break
-					}
-					def.Columns = newCols
-					// Hoist this IndexTableDef into a separate CreateIndex.
-					changed = true
-					// TODO(rafi): Postgres supports inverted indexes with a different
-					// syntax than Cockroach. Maybe we could add it later.
-					// The syntax is `CREATE INDEX name ON table USING gin(column)`.
-					if !def.Inverted {
-						mutated = append(mutated, &tree.CreateIndex{
-							Name:     def.Name,
-							Table:    stmt.Table,
-							Inverted: def.Inverted,
-							Columns:  newCols,
-							Storing:  def.Storing,
-							// Postgres doesn't support NotVisible Index, so NotVisible is not populated here.
-						})
-					}
-				case *tree.UniqueConstraintTableDef:
-					var newCols tree.IndexElemList
-					for _, col := range def.Columns {
-						isBox2d := false
-						// NB: col.Column is empty for expression-based indexes.
-						if col.Expr == nil {
-							// Postgres doesn't support box2d as a btree index key.
-							colTypeFamily := colTypes[string(col.Column)].Family()
-							if colTypeFamily == types.Box2DFamily {
-								isBox2d = true
-							}
-						}
-						if isBox2d {
-							changed = true
-						} else {
-							newCols = append(newCols, col)
+		// Get all the column types first.
+		colTypes := make(map[string]*types.T)
+		for _, def := range mutatedStmt.Defs {
+			def, ok := def.(*tree.ColumnTableDef)
+			if !ok {
+				continue
+			}
+			colDefType := tree.MustBeStaticallyKnownType(def.Type)
+			colTypes[string(def.Name)] = colDefType
+		}
+
+		// - Exclude `INDEX` and `UNIQUE` table defs and hoist them into separate
+		// `CREATE INDEX` and `CREATE UNIQUE INDEX` statements because Postgres does
+		// not support them in `CREATE TABLE` stmt.
+		// - Erase `COLLATE locale` from column defs because Postgres only support
+		// double-quoted locale.
+		var newdefs tree.TableDefs
+		for _, def := range mutatedStmt.Defs {
+			switch def := def.(type) {
+			case *tree.IndexTableDef:
+				var newCols tree.IndexElemList
+				for _, col := range def.Columns {
+					isBox2d := false
+					// NB: col.Column is empty for expression-based indexes.
+					if col.Expr == nil {
+						// Postgres doesn't support box2d as a btree index key.
+						colTypeFamily := colTypes[string(col.Column)].Family()
+						if colTypeFamily == types.Box2DFamily {
+							isBox2d = true
 						}
 					}
-					if len(newCols) == 0 {
-						// Break without adding this index at all.
-						break
+					if isBox2d {
+						changed = true
+					} else {
+						newCols = append(newCols, col)
 					}
-					def.Columns = newCols
-					if def.PrimaryKey {
-						for i, col := range def.Columns {
-							// Postgres doesn't support descending PKs.
-							if col.Direction != tree.DefaultDirection {
-								def.Columns[i].Direction = tree.DefaultDirection
-								changed = true
-							}
-						}
-						if def.Name != "" {
-							// Unset Name here because constraint names cannot be shared among
-							// tables, so multiple PK constraints named "primary" is an error.
-							def.Name = ""
-							changed = true
-						}
-						newdefs = append(newdefs, def)
-						break
-					}
+				}
+				if len(newCols) == 0 {
+					// Break without adding this index at all.
+					break
+				}
+				def.Columns = newCols
+				// Hoist this IndexTableDef into a separate CreateIndex.
+				changed = true
+				// TODO(rafi): Postgres supports inverted indexes with a different
+				// syntax than Cockroach. Maybe we could add it later.
+				// The syntax is `CREATE INDEX name ON table USING gin(column)`.
+				if !def.Inverted {
 					mutated = append(mutated, &tree.CreateIndex{
 						Name:     def.Name,
-						Table:    stmt.Table,
-						Unique:   true,
+						Table:    mutatedStmt.Table,
 						Inverted: def.Inverted,
 						Columns:  newCols,
 						Storing:  def.Storing,
 						// Postgres doesn't support NotVisible Index, so NotVisible is not populated here.
 					})
-					changed = true
-				default:
-					newdefs = append(newdefs, def)
 				}
+			case *tree.UniqueConstraintTableDef:
+				var newCols tree.IndexElemList
+				for _, col := range def.Columns {
+					isBox2d := false
+					// NB: col.Column is empty for expression-based indexes.
+					if col.Expr == nil {
+						// Postgres doesn't support box2d as a btree index key.
+						colTypeFamily := colTypes[string(col.Column)].Family()
+						if colTypeFamily == types.Box2DFamily {
+							isBox2d = true
+						}
+					}
+					if isBox2d {
+						changed = true
+					} else {
+						newCols = append(newCols, col)
+					}
+				}
+				if len(newCols) == 0 {
+					// Break without adding this index at all.
+					break
+				}
+				def.Columns = newCols
+				if def.PrimaryKey {
+					for i, col := range def.Columns {
+						// Postgres doesn't support descending PKs.
+						if col.Direction != tree.DefaultDirection {
+							def.Columns[i].Direction = tree.DefaultDirection
+							changed = true
+						}
+					}
+					if def.Name != "" {
+						// Unset Name here because constraint names cannot be shared among
+						// tables, so multiple PK constraints named "primary" is an error.
+						def.Name = ""
+						changed = true
+					}
+					newdefs = append(newdefs, def)
+					break
+				}
+				mutated = append(mutated, &tree.CreateIndex{
+					Name:     def.Name,
+					Table:    mutatedStmt.Table,
+					Unique:   true,
+					Inverted: def.Inverted,
+					Columns:  newCols,
+					Storing:  def.Storing,
+					// Postgres doesn't support NotVisible Index, so NotVisible is not populated here.
+				})
+				changed = true
+			case *tree.ColumnTableDef:
+				if def.Type.(*types.T).Family() == types.CollatedStringFamily {
+					def.Type = types.String
+					changed = true
+				}
+				newdefs = append(newdefs, def)
+			default:
+				newdefs = append(newdefs, def)
 			}
-			stmt.Defs = newdefs
 		}
+		mutatedStmt.Defs = newdefs
 	}
+
 	return mutated, changed
 }
 

--- a/pkg/sql/randgen/mutator_test.go
+++ b/pkg/sql/randgen/mutator_test.go
@@ -17,12 +17,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPostgresMutator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	rng, _ := randutil.NewTestRand()
 	q := `
-		CREATE TABLE t (s STRING FAMILY fam1, b BYTES, FAMILY fam2 (b), PRIMARY KEY (s ASC, b DESC), INDEX (s) STORING (b))
+		CREATE TABLE t (s STRING FAMILY fam1, b BYTES, FAMILY fam2 (b), PRIMARY KEY (s ASC, b DESC), INDEX (s) STORING (b), c TEXT COLLATE en_US NOT NULL)
 		    PARTITION BY LIST (s)
 		        (
 		            PARTITION europe_west VALUES IN ('a', 'b')
@@ -31,27 +33,45 @@ func TestPostgresMutator(t *testing.T) {
 		SET CLUSTER SETTING "sql.stats.automatic_collection.enabled" = false;
 	`
 
-	rng, _ := randutil.NewTestRand()
-	{
-		mutated, changed := randgen.ApplyString(rng, q, randgen.PostgresMutator)
-		if !changed {
-			t.Fatal("expected changed")
-		}
-		mutated = strings.TrimSpace(mutated)
-		expect := `CREATE TABLE t (s TEXT, b BYTEA, PRIMARY KEY (s ASC, b DESC), INDEX (s) INCLUDE (b));`
-		if mutated != expect {
-			t.Fatalf("unexpected: %s", mutated)
-		}
+	type TestCase struct {
+		name string
+		// original statement(s) string and mutators to apply
+		original string
+		mutators []randgen.Mutator
+		// mutated after applying mutators
+		mutated string
+		changed bool
 	}
-	{
-		mutated, changed := randgen.ApplyString(rng, q, randgen.PostgresCreateTableMutator, randgen.PostgresMutator)
-		if !changed {
-			t.Fatal("expected changed")
-		}
-		mutated = strings.TrimSpace(mutated)
-		expect := "CREATE TABLE t (s TEXT, b BYTEA, PRIMARY KEY (s, b));\nCREATE INDEX ON t (s) INCLUDE (b);"
-		if mutated != expect {
-			t.Fatalf("unexpected: %s", mutated)
-		}
+
+	for _, testCase := range []TestCase{
+		{
+			name:     "postgresCreateTableMutator",
+			original: q,
+			mutators: []randgen.Mutator{randgen.PostgresCreateTableMutator},
+			mutated:  "CREATE TABLE t (s STRING FAMILY fam1, b BYTES, FAMILY fam2 (b), PRIMARY KEY (s, b), c STRING NOT NULL) PARTITION BY LIST (s) (PARTITION europe_west VALUES IN ('a', 'b'));\nCREATE INDEX ON t (s) STORING (b);\nALTER TABLE table1 INJECT STATISTICS 'blah';\nSET CLUSTER SETTING \"sql.stats.automatic_collection.enabled\" = false;",
+			changed:  true,
+		},
+		{
+			name:     "postgresMutator",
+			original: q,
+			mutators: []randgen.Mutator{randgen.PostgresMutator},
+			mutated:  `CREATE TABLE t (s TEXT, b BYTEA, PRIMARY KEY (s ASC, b DESC), INDEX (s) INCLUDE (b), c TEXT COLLATE en_US NOT NULL);`,
+			changed:  true,
+		},
+		{
+			name:     "postgresCreateTableMutator + postgresMutator",
+			original: q,
+			mutators: []randgen.Mutator{randgen.PostgresCreateTableMutator, randgen.PostgresMutator},
+			mutated:  "CREATE TABLE t (s TEXT, b BYTEA, PRIMARY KEY (s, b), c TEXT NOT NULL);\nCREATE INDEX ON t (s) INCLUDE (b);",
+			changed:  true,
+		},
+		{},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, changed := randgen.ApplyString(rng, testCase.original, testCase.mutators...)
+			require.Equal(t, testCase.changed, changed, "expected changed=%v; get %v", testCase.changed, changed)
+			actual = strings.TrimSpace(actual)
+			require.Equal(t, testCase.mutated, actual, "expected mutated = %v; get %v", testCase.mutated, actual)
+		})
 	}
 }


### PR DESCRIPTION
This commit fixes a previously overlooked issue to actually disable using locales when creating tables in the TestComposeCompare test.

Inform #82867
Epic: None
Release justification: Test fixes
Release Note: None