### PR TITLE
Revert "github-pull-request-make: temporary workaround"

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -209,13 +209,6 @@ func main() {
 
 	if len(pkgs) > 0 {
 		for name, pkg := range pkgs {
-			// TODO(postamar): remove this temporary workaround
-			// This hack was added to get #106743 over the finish line.
-			if strings.HasPrefix(name, "pkg/ccl/schemachangerccl") ||
-				strings.HasPrefix(name, "pkg/sql/schemachanger") {
-				continue
-			}
-
 			// 20 minutes total seems OK, but at least 2 minutes per test.
 			// This should be reduced. See #46941.
 			duration := (20 * time.Minute) / time.Duration(len(pkgs))


### PR DESCRIPTION
This reverts commit 2bd61c09de2c600291d7e30f77692b66a91289d4.

Relates to #106920.