### PR TITLE
ui: increase hot ranges page timeout

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -126,6 +126,9 @@ export const hotRangesReducerObj = new PaginatedCachedDataReducer(
   api.getHotRanges,
   "hotRanges",
   hotRangesRequestToID,
+  1000 /* page limit */,
+  null /* invalidation period */,
+  moment.duration(30, "minutes"),
 );
 
 export const refreshDatabaseDetails = databaseDetailsReducerObj.refresh;

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
@@ -38,7 +38,7 @@ const HotRanges = (props: HotRangesProps) => {
       page_size: pageSize,
       page_token: pageToken,
     });
-    getHotRanges(request).then(response => {
+    getHotRanges(request, moment.duration(30, "minutes")).then(response => {
       if (response.ranges.length == 0) {
         return;
       }


### PR DESCRIPTION
This commit increases the hot ranges request timeout to 30 minutes for both the initial fetch and the refresh.

Informs #https://github.com/cockroachdb/cockroach/issues/104269
Epic: none
Release note (bug fix): The timeout duration when loading the
Hot Ranges page has been increased to 30 minutes.