### PR TITLE
sql: fix TestRandomSyntaxFunctions related bugs/flakes

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -434,6 +434,11 @@ func (p *planner) RevalidateUniqueConstraintsInCurrentDB(ctx context.Context) er
 		return err
 	}
 	return inDB.ForEachDescriptor(func(desc catalog.Descriptor) error {
+		// If the context is cancelled, then we should bail out, since
+		// the actual revalidate operation might not check anything.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		tableDesc, err := catalog.AsTableDescriptor(desc)
 		if err != nil {
 			return err

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5762,9 +5762,10 @@ SELECT
 				tree.ParamType{Name: "raw_value", Typ: types.Bytes},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (d tree.Datum, err error) {
 				var v roachpb.Value
 				v.RawBytes = []byte(tree.MustBeDBytes(args[0]))
+
 				return tree.NewDString(v.PrettyPrint()), nil
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -346,6 +346,10 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 				switch lower {
 				case "pg_sleep":
 					continue
+				case "crdb_internal.gen_rand_ident":
+					// Generates random identifiers, so a large number are dangerous and
+					// can take a long time.
+					continue
 				case "st_frechetdistance", "st_buffer":
 					// Some spatial function are slow and testing them here
 					// is not worth it.


### PR DESCRIPTION
Previously TestRandomSyntaxFunctions could flake due to the following bugs:
1. crdb_internal.revalidate_unique_constraints_in_all_tables did not handle cancelled contexts properly which could lead to timeouts
2. crdb_internal.pretty_value could fail on random values could panic decoding, so a recover should be used inside this builtin.
3. TestRandomSyntaxFunctions was testing crdb_internal.gen_rand_ident, which can take a long time based on the input parameters (specifically when a large number of identifiers is requested)

Fixes: #107410
Fixes: #107411