### PR TITLE
release-22.2: sql: use txn.NewBatch instead of &kv.Batch{}

### DIFF
--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -264,7 +264,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 
 			// Don't write the descriptor, just write the namespace entry.
 			// This will mean that resolution still is based on the old name.
-			b := &kv.Batch{}
+			b := txn.NewBatch()
 			b.CPut(catalogkeys.MakeDatabaseNameKey(lm.Codec(), mut.Name), mut.GetID(), nil)
 			err = txn.Run(ctx, b)
 			require.NoError(t, err)

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	clustersettings "github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -156,7 +155,7 @@ func doCreateSequence(
 
 	// Initialize the sequence value.
 	seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(id))
-	b := &kv.Batch{}
+	b := p.Txn().NewBatch()
 
 	startVal := desc.SequenceOpts.Start
 	for _, option := range opts {

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -250,7 +249,7 @@ func (p *planner) createDescriptorWithID(
 		log.Fatalf(ctx, "%v", errors.AssertionFailedf("id key must be zero for descriptors skipping namespace"))
 	}
 
-	b := &kv.Batch{}
+	b := p.Txn().NewBatch()
 	descID := descriptor.GetID()
 
 	if !descriptor.SkipNamespace() {

--- a/pkg/sql/gcjob/descriptor_utils.go
+++ b/pkg/sql/gcjob/descriptor_utils.go
@@ -32,7 +32,7 @@ func deleteDatabaseZoneConfig(
 		return nil
 	}
 	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		b := &kv.Batch{}
+		b := txn.NewBatch()
 
 		// Delete the zone config entry for the dropped database associated with the
 		// job, if it exists.

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -716,7 +716,7 @@ func (p *planner) ForceDeleteTableData(ctx context.Context, descID int64) error 
 	requestHeader := roachpb.RequestHeader{
 		Key: tableSpan.Key, EndKey: tableSpan.EndKey,
 	}
-	b := &kv.Batch{}
+	b := p.Txn().NewBatch()
 	if p.execCfg.Settings.Version.IsActive(ctx, clusterversion.UseDelRangeInGCJob) &&
 		storage.CanUseMVCCRangeTombstones(ctx, p.execCfg.Settings) {
 		b.AddRawRequest(&roachpb.DeleteRangeRequest{

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -131,7 +131,7 @@ func (p *planner) CreateSchemaNamespaceEntry(
 		log.VEventf(ctx, 2, "CPut %s -> %d", schemaNameKey, schemaID)
 	}
 
-	b := &kv.Batch{}
+	b := p.Txn().NewBatch()
 	b.CPut(schemaNameKey, schemaID, nil)
 
 	return p.txn.Run(ctx, b)


### PR DESCRIPTION
Backport 1/1 commits from #107236.

/cc @cockroachdb/release

---

This will make these requests properly passes along the admission control headers.

informs https://github.com/cockroachdb/cockroach/issues/79212
Epic: None
Release justification: low risk fix
Release note: None
