### PR TITLE
TEAMS: use workflow for SQL Queries issue triage

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -30,3 +30,8 @@ jobs:
           project-url: https://github.com/orgs/cockroachdb/projects/35
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: T-jobs
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/cockroachdb/projects/45
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: T-sql-queries

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -32,7 +32,9 @@ cockroachdb/sql-queries:
   aliases:
     cockroachdb/sql-optimizer: other
     cockroachdb/sql-opt-prs: other
-  triage_column_id: 13549252
+  # SQL Queries team uses GH projects v2, which doesn't have a REST API, so
+  # there is no triage column ID.
+  # See .github/workflows/add-issues-to-project.yml.
   label: T-sql-queries
 cockroachdb/cluster-observability:
   triage_column_id: 12618343


### PR DESCRIPTION
The SQL Queries team now uses Github Projects v2. This commit updates
`TEAMS.yaml` and `.github/workflows/add-issues-to-project.yml` so that
issues are assigned to the correct project for triage.

Epic: None

Release note: None
