### PR TITLE
backupccl: add WITH SKIP SIZE option to SHOW BACKUP

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -3238,6 +3238,7 @@ var_list ::=
 show_backup_options ::=
 	'AS_JSON'
 	| 'CHECK_FILES'
+	| 'SKIP' 'SIZE'
 	| 'DEBUG_IDS'
 	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
 	| 'KMS' '=' string_or_placeholder_opt_list

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -830,10 +831,14 @@ func backupShowerDefault(
 					fileSizes = info.fileSizes[layer]
 				}
 
-				tableSizes, err := getTableSizes(ctx, info.layerToIterFactory[layer], fileSizes)
-				if err != nil {
-					return nil, err
+				var tableSizes map[catid.DescID]descriptorSize
+				if !opts.SkipSize {
+					tableSizes, err = getTableSizes(ctx, info.layerToIterFactory[layer], fileSizes)
+					if err != nil {
+						return nil, err
+					}
 				}
+
 				backupType := tree.NewDString("full")
 				if manifest.IsIncremental() {
 					backupType = tree.NewDString("incremental")

--- a/pkg/ccl/backupccl/testdata/backup-restore/show_backup
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show_backup
@@ -16,6 +16,16 @@ true
 link-backup cluster=s1 src-path=show_backup_validate,valid-22.2 dest-path=valid-22.2
 ----
 
+query-sql
+SELECT sum(size_bytes) FROM [SHOW BACKUP 'valid-22.2' IN 'nodelocal://1/'];
+----
+1120
+
+query-sql
+SELECT sum(size_bytes) FROM [SHOW BACKUP 'valid-22.2' IN 'nodelocal://1/' WITH skip size];
+----
+0
+
 # This backup is completely valid, but has no jobs.
 query-sql regex=No\sproblems\sfound!
 SELECT * FROM [SHOW BACKUP VALIDATE FROM 'valid-22.2' IN 'nodelocal://1/'];

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7635,6 +7635,10 @@ show_backup_options:
  {
  $$.val = &tree.ShowBackupOptions{CheckFiles: true}
  }
+ | SKIP SIZE
+ {
+ $$.val = &tree.ShowBackupOptions{SkipSize: true}
+ }
  | DEBUG_IDS
  {
  $$.val = &tree.ShowBackupOptions{DebugIDs: true}

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -112,12 +112,12 @@ SHOW BACKUP 'bar' WITH check_files, encryption_passphrase = '*****' -- identifie
 SHOW BACKUP 'bar' WITH check_files, encryption_passphrase = 'secret' -- passwords exposed
 
 parse
-SHOW BACKUP FROM LATEST IN 'bar' WITH incremental_location = 'baz'
+SHOW BACKUP FROM LATEST IN 'bar' WITH incremental_location = 'baz', skip size
 ----
-SHOW BACKUP FROM 'latest' IN 'bar' WITH incremental_location = 'baz' -- normalized!
-SHOW BACKUP FROM ('latest') IN ('bar') WITH incremental_location = ('baz') -- fully parenthesized
-SHOW BACKUP FROM '_' IN '_' WITH incremental_location = '_' -- literals removed
-SHOW BACKUP FROM 'latest' IN 'bar' WITH incremental_location = 'baz' -- identifiers removed
+SHOW BACKUP FROM 'latest' IN 'bar' WITH incremental_location = 'baz', skip size -- normalized!
+SHOW BACKUP FROM ('latest') IN ('bar') WITH incremental_location = ('baz'), skip size -- fully parenthesized
+SHOW BACKUP FROM '_' IN '_' WITH incremental_location = '_', skip size -- literals removed
+SHOW BACKUP FROM 'latest' IN 'bar' WITH incremental_location = 'baz', skip size -- identifiers removed
 
 parse
 SHOW BACKUP FROM LATEST IN ('bar','bar1') WITH KMS = ('foo', 'bar'), incremental_location=('hi','hello')

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -152,6 +152,7 @@ type ShowBackupOptions struct {
 	DecryptionKMSURI     StringOrPlaceholderOptList
 	EncryptionPassphrase Expr
 	Privileges           bool
+	SkipSize             bool
 
 	// EncryptionInfoDir is a hidden option used when the user wants to run the deprecated
 	//
@@ -221,6 +222,10 @@ func (o *ShowBackupOptions) Format(ctx *FmtCtx) {
 		ctx.WriteString("kms = ")
 		ctx.FormatNode(&o.DecryptionKMSURI)
 	}
+	if o.SkipSize {
+		maybeAddSep()
+		ctx.WriteString("skip size")
+	}
 	if o.DebugMetadataSST {
 		maybeAddSep()
 		ctx.WriteString("debug_dump_metadata_sst")
@@ -253,6 +258,7 @@ func (o ShowBackupOptions) IsDefault() bool {
 		cmp.Equal(o.DecryptionKMSURI, options.DecryptionKMSURI) &&
 		o.EncryptionPassphrase == options.EncryptionPassphrase &&
 		o.Privileges == options.Privileges &&
+		o.SkipSize == options.SkipSize &&
 		o.DebugMetadataSST == options.DebugMetadataSST &&
 		o.EncryptionInfoDir == options.EncryptionInfoDir &&
 		o.CheckConnectionTransferSize == options.CheckConnectionTransferSize &&
@@ -319,6 +325,10 @@ func (o *ShowBackupOptions) CombineWith(other *ShowBackupOptions) error {
 		return err
 	}
 	o.Privileges, err = combineBools(o.Privileges, other.Privileges, "privileges")
+	if err != nil {
+		return err
+	}
+	o.SkipSize, err = combineBools(o.SkipSize, other.SkipSize, "skip size")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Computing the sizes requires reading more metadata, which can be skipped if the sizes are not required.

Release note: none.
Epic: none.