### PR TITLE
kvserver,allocator: minor log message improvements

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2635,7 +2635,7 @@ func (a Allocator) shouldTransferLeaseForAccessLocality(
 		}
 	}
 
-	log.KvDistribution.VEventf(ctx, 1,
+	log.KvDistribution.VEventf(ctx, 5,
 		"shouldTransferLease qpsStats: %+v, replicaLocalities: %+v, replicaWeights: %+v",
 		qpsStats, replicaLocalities, replicaWeights)
 	sourceWeight := math.Max(minReplicaWeight, replicaWeights[source.Node.NodeID])
@@ -2752,7 +2752,7 @@ func loadBasedLeaseRebalanceScore(
 
 	log.KvDistribution.VEventf(
 		ctx,
-		2,
+		5,
 		"node: %d, sourceWeight: %.2f, remoteWeight: %.2f, remoteLatency: %v, "+
 			"rebalanceThreshold: %.2f, meanLeases: %.2f, sourceLeaseCount: %d, overfullThreshold: %d, "+
 			"remoteLeaseCount: %d, underfullThreshold: %d, totalScore: %d",

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -662,7 +662,7 @@ func (rq *replicateQueue) process(
 		}
 
 		if requeue {
-			log.KvDistribution.VEventf(ctx, 1, "re-processing")
+			log.KvDistribution.VEventf(ctx, 1, "re-queuing")
 			rq.maybeAdd(ctx, repl, rq.store.Clock().NowAsClockTimestamp())
 		}
 		return true, nil


### PR DESCRIPTION
`shouldTransferLeaseForAccessLocality` logs detailed information
regarding the replica locality, QPS and request weighting. This
information is not summarized. Bump to v=5, from v=1-v=2 to reduce
vmodule enabled log noise.

Rename replicate queue re-processing, to re-queuing. 
The replicate queue will re-queue, rather than immediately re-process
a replica after a successful process.

Epic: none

Release note: None