### PR TITLE
sql: fix crdb_internal.encode_key in some contexts

### DIFF
--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -222,9 +222,6 @@ func TestCreateAsShow(t *testing.T) {
 		{
 			sql:   "SHOW RANGE FROM TABLE show_ranges_tbl FOR ROW (0)",
 			setup: "CREATE TABLE show_ranges_tbl (id int PRIMARY KEY)",
-			// TODO(sql-foundations): Fix `invalid memory address or nil pointer dereference` error in job.
-			//  See https://github.com/cockroachdb/cockroach/issues/106397.
-			skip: true,
 		},
 		{
 			sql: "SHOW SURVIVAL GOAL FROM DATABASE",

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -467,6 +467,7 @@ func newInternalPlanner(
 	p.schemaResolver.txn = p.txn
 	p.schemaResolver.authAccessor = p
 	p.evalCatalogBuiltins.Init(execCfg.Codec, p.txn, p.Descriptors())
+	p.extendedEvalCtx.CatalogBuiltins = &p.evalCatalogBuiltins
 
 	return p, func() {
 		// Note that we capture ctx here. This is only valid as long as we create


### PR DESCRIPTION
Previously, we forgot to set `CatalogBuiltins` for the internal planner which is used by `crdb_internal.encode_key` (which, in turn, is used to power `SHOW RANGE ... FOR ROW`), so evaluating it would lead to an error. For example, the internal planner is used in the backfill. This is now fixed.

Fixes: #106397.

Release note (bug fix): CockroachDB would previously return an error when using `SHOW RANGE ... FOR ROW ...` in `CREATE TABLE ... AS ...` construct, and this is now fixed.