### PR TITLE
roachtest: add read committed variants of ycsb

### DIFF
--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -29,6 +29,7 @@ const envYCSBFlags = "ROACHTEST_YCSB_FLAGS"
 func registerYCSB(r registry.Registry) {
 	workloads := []string{"A", "B", "C", "D", "E", "F"}
 	cpusConfigs := []int{8, 32}
+	cpusWithReadCommitted := 32
 	cpusWithGlobalMVCCRangeTombstone := 32
 
 	// concurrencyConfigs contains near-optimal concurrency levels for each
@@ -45,7 +46,7 @@ func registerYCSB(r registry.Registry) {
 	}
 
 	runYCSB := func(
-		ctx context.Context, t test.Test, c cluster.Cluster, wl string, cpus int, rangeTombstone bool,
+		ctx context.Context, t test.Test, c cluster.Cluster, wl string, cpus int, readCommitted, rangeTombstone bool,
 	) {
 		// For now, we only want to run the zfs tests on GCE, since only GCE supports
 		// starting roachprod instances on zfs.
@@ -75,9 +76,11 @@ func registerYCSB(r registry.Registry) {
 		m := c.NewMonitor(ctx, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			var args string
-			args += fmt.Sprintf(" --select-for-update=%t", t.IsBuildVersion("v19.2.0"))
 			args += " --ramp=" + ifLocal(c, "0s", "2m")
 			args += " --duration=" + ifLocal(c, "10s", "30m")
+			if readCommitted {
+				args += " --isolation-level=read_committed"
+			}
 			if envFlags := os.Getenv(envYCSBFlags); envFlags != "" {
 				args += " " + envFlags
 			}
@@ -107,7 +110,7 @@ func registerYCSB(r registry.Registry) {
 				Benchmark: true,
 				Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus)),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runYCSB(ctx, t, c, wl, cpus, false /* rangeTombstone */)
+					runYCSB(ctx, t, c, wl, cpus, false /* readCommitted */, false /* rangeTombstone */)
 				},
 				Tags: registry.Tags(`aws`),
 			})
@@ -119,8 +122,21 @@ func registerYCSB(r registry.Registry) {
 					Benchmark: true,
 					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.SetFileSystem(spec.Zfs)),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-						runYCSB(ctx, t, c, wl, cpus, false /* rangeTombstone */)
+						runYCSB(ctx, t, c, wl, cpus, false /* readCommitted */, false /* rangeTombstone */)
 					},
+				})
+			}
+
+			if cpus == cpusWithReadCommitted {
+				r.Add(registry.TestSpec{
+					Name:      fmt.Sprintf("%s/isolation-level=read-committed", name),
+					Owner:     registry.OwnerTestEng,
+					Benchmark: true,
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus)),
+					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+						runYCSB(ctx, t, c, wl, cpus, true /* readCommitted */, false /* rangeTombstone */)
+					},
+					Tags: registry.Tags(`aws`),
 				})
 			}
 
@@ -131,7 +147,7 @@ func registerYCSB(r registry.Registry) {
 					Benchmark: true,
 					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus)),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-						runYCSB(ctx, t, c, wl, cpus, true /* rangeTombstone */)
+						runYCSB(ctx, t, c, wl, cpus, false /* readCommitted */, true /* rangeTombstone */)
 					},
 					Tags: registry.Tags(`aws`),
 				})


### PR DESCRIPTION
Closes #107112.

This PR adds the following six roachtest variants:
```
ycsb/A/nodes=3/cpu=32/isolation-level=read-committed
ycsb/B/nodes=3/cpu=32/isolation-level=read-committed
ycsb/C/nodes=3/cpu=32/isolation-level=read-committed
ycsb/D/nodes=3/cpu=32/isolation-level=read-committed
ycsb/E/nodes=3/cpu=32/isolation-level=read-committed
ycsb/F/nodes=3/cpu=32/isolation-level=read-committed
```

It does so after adding an `--isolation-level` flag to ycsb, which controls the isolation level to run the workload transactions under. If unset, the workload will run with the default isolation level of the database.

Release note: None