### PR TITLE
kvserver: disable replicate queue and lease transfers in closedts tests

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -1206,8 +1206,14 @@ func setupClusterForClosedTSTesting(
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '%s';
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '%s';
 SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = true;
+SET CLUSTER SETTING kv.allocator.load_based_rebalancing = 'off';
 `, targetDuration, targetDuration/4),
 		";")...)
+
+	// Disable replicate queues to avoid errant lease transfers.
+	//
+	// See: https://github.com/cockroachdb/cockroach/issues/101824.
+	tc.ToggleReplicateQueues(false)
 
 	return tc, tc.ServerConn(0), desc
 }


### PR DESCRIPTION
For a more holistic suggestion on how to fix this for the likely many other
tests susceptible to similar issues, see:
https://github.com/cockroachdb/cockroach/issues/107528

> 1171 runs so far, 0 failures, over 15m55s

Fixes https://github.com/cockroachdb/cockroach/issues/101824.

Release note: None
Epic: none
