### PR TITLE
roachprod: Azure FindActiveAccount username fix

### DIFF
--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -432,8 +432,9 @@ func (p *Provider) FindActiveAccount(l *logger.Logger) (string, error) {
 		return "", errors.Wrapf(err, "could not decode JWT claims segment")
 	}
 
-	// This is in an email address format, we just want the username.
-	return data.Username[:strings.Index(data.Username, "@")], nil
+	// If this is in an email address format, we just want the username.
+	username, _, _ := strings.Cut(data.Username, "@")
+	return username, nil
 }
 
 // List implements the vm.Provider interface. This will query all


### PR DESCRIPTION
This change fixes an issue where FindActiveAccount expects an email based username. It can now handle usernames that are not in email form.

Fixes: #107535

Release Note: None
Epic: none