### PR TITLE
dev: clear all known node_modules/ tree with dev ui clean --all

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=81
+DEV_VERSION=82
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -146,7 +146,10 @@ rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/src/js/node_modules
+rm -rf crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/node_modules
+rm -rf crdb-checkout/pkg/ui/workspaces/e2e-tests/node_modules
+rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/node_modules
 
 exec
 dev ui e2e

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -591,7 +591,10 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 					filepath.Join(workspace, "pkg", "ui", "node_modules"),
 					filepath.Join(uiDirs.dbConsole, "node_modules"),
 					filepath.Join(uiDirs.dbConsole, "src", "js", "node_modules"),
+					filepath.Join(uiDirs.dbConsole, "ccl", "src", "js", "node_modules"),
 					filepath.Join(uiDirs.clusterUI, "node_modules"),
+					filepath.Join(uiDirs.e2eTests, "node_modules"),
+					filepath.Join(uiDirs.eslintPlugin, "node_modules"),
 				)
 			}
 


### PR DESCRIPTION
'dev ui clean --all' previously missed a few node_modules/ directories, which caused that command to be less effective at fixing issues. Remove all known node_modules/ trees.

Release note: None
Epic: none