### PR TITLE
roachtest/mixedversion: monitor nodes in every test

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -650,21 +650,15 @@ of nodes, outputting a line whenever a change is detected:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		messages, err := roachprod.Monitor(context.Background(), config.Logger, args[0], monitorOpts)
+		eventChan, err := roachprod.Monitor(context.Background(), config.Logger, args[0], monitorOpts)
 		if err != nil {
 			return err
 		}
-		for msg := range messages {
-			if msg.Err != nil {
-				msg.Msg += "error: " + msg.Err.Error()
-			}
-			thisError := errors.Newf("%d: %s", msg.Node, msg.Msg)
-			if msg.Err != nil || strings.Contains(msg.Msg, "dead") {
-				err = errors.CombineErrors(err, thisError)
-			}
-			fmt.Println(thisError.Error())
+		for info := range eventChan {
+			fmt.Println(info.String())
 		}
-		return err
+
+		return nil
 	}),
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "mixedversion",
     srcs = [
+        "helper.go",
         "mixedversion.go",
         "planner.go",
         "runner.go",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -1,0 +1,134 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mixedversion
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"math/rand"
+	"path"
+	"strings"
+	"sync/atomic"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+)
+
+func (h *Helper) RandomNode(prng *rand.Rand, nodes option.NodeListOption) int {
+	return nodes[prng.Intn(len(nodes))]
+}
+
+// RandomDB returns a (nodeID, connection) tuple for a randomly picked
+// cockroach node according to the parameters passed.
+func (h *Helper) RandomDB(prng *rand.Rand, nodes option.NodeListOption) (int, *gosql.DB) {
+	node := h.RandomNode(prng, nodes)
+	return node, h.Connect(node)
+}
+
+// QueryRow performs `db.QueryRowContext` on a randomly picked
+// database node. The query and the node picked are logged in the logs
+// of the step that calls this function.
+func (h *Helper) QueryRow(rng *rand.Rand, query string, args ...interface{}) *gosql.Row {
+	node, db := h.RandomDB(rng, h.runner.crdbNodes)
+	h.stepLogger.Printf("running SQL statement:\n%s\nArgs: %v\nNode: %d", query, args, node)
+	return db.QueryRowContext(h.ctx, query, args...)
+}
+
+// Exec performs `db.ExecContext` on a randomly picked database node.
+// The query and the node picked are logged in the logs of the step
+// that calls this function.
+func (h *Helper) Exec(rng *rand.Rand, query string, args ...interface{}) error {
+	node, db := h.RandomDB(rng, h.runner.crdbNodes)
+	h.stepLogger.Printf("running SQL statement:\n%s\nArgs: %v\nNode: %d", query, args, node)
+	_, err := db.ExecContext(h.ctx, query, args...)
+	return err
+}
+
+func (h *Helper) Connect(node int) *gosql.DB {
+	return h.runner.conn(node)
+}
+
+// SetContext should be called by steps that need access to the test
+// context, as that is only visible to them.
+func (h *Helper) SetContext(c *Context) {
+	h.testContext = c
+}
+
+// Context returns the test context associated with a certain step. It
+// is made available for user-functions (see runHookStep).
+func (h *Helper) Context() *Context {
+	return h.testContext
+}
+
+// Background allows test authors to create functions that run in the
+// background in mixed-version hooks.
+func (h *Helper) Background(
+	name string, fn func(context.Context, *logger.Logger) error,
+) context.CancelFunc {
+	return h.runner.background.Start(name, func(ctx context.Context) error {
+		bgLogger, err := h.loggerFor(name)
+		if err != nil {
+			return fmt.Errorf("failed to create logger for background function %q: %w", name, err)
+		}
+
+		err = panicAsError(bgLogger, func() error { return fn(ctx, bgLogger) })
+		if err != nil {
+			if isContextCanceled(ctx) {
+				return err
+			}
+
+			desc := fmt.Sprintf("error in background function %s: %s", name, err)
+			return h.runner.testFailure(desc, bgLogger)
+		}
+
+		return nil
+	})
+}
+
+// BackgroundCommand has the same semantics of `Background()`; the
+// command passed will run and the test will fail if the command is
+// not successful.
+func (h *Helper) BackgroundCommand(cmd string, nodes option.NodeListOption) context.CancelFunc {
+	desc := fmt.Sprintf("run command: %q", cmd)
+	return h.Background(desc, func(ctx context.Context, l *logger.Logger) error {
+		l.Printf("running command `%s` on nodes %v in the background", cmd, nodes)
+		return h.runner.cluster.RunE(ctx, nodes, cmd)
+	})
+}
+
+// ExpectDeath alerts the testing infrastructure that a node is
+// expected to die. Regular restarts as part of the mixedversion
+// testing are already taken into account. This function should only
+// be used by tests that perform their own node restarts or chaos
+// events.
+func (h *Helper) ExpectDeath() {
+	h.ExpectDeaths(1)
+}
+
+// ExpectDeaths is the general version of `ExpectDeath()`.
+func (h *Helper) ExpectDeaths(n int) {
+	h.runner.monitor.ExpectDeaths(n)
+}
+
+// loggerFor creates a logger instance to be used by background
+// functions (created by calling `Background` on the helper
+// instance). It is similar to the logger instances created for
+// mixed-version steps, but with the `background_` prefix.
+func (h *Helper) loggerFor(name string) (*logger.Logger, error) {
+	atomic.AddInt64(&h.bgCount, 1)
+
+	fileName := invalidChars.ReplaceAllString(strings.ToLower(name), "")
+	fileName = fmt.Sprintf("background_%s_%d", fileName, h.bgCount)
+	fileName = path.Join(logPrefix, fileName)
+
+	return prefixedLogger(h.runner.logger, fileName)
+}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -653,6 +653,7 @@ func (s restartWithNewBinaryStep) Description() string {
 func (s restartWithNewBinaryStep) Run(
 	ctx context.Context, l *logger.Logger, c cluster.Cluster, h *Helper,
 ) error {
+	h.ExpectDeath()
 	return clusterupgrade.RestartNodesWithNewBinary(
 		ctx,
 		s.rt,

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -601,116 +600,6 @@ func (br *backgroundRunner) Terminate() {
 
 func (br *backgroundRunner) CompletedEvents() <-chan backgroundEvent {
 	return br.events
-}
-
-func (h *Helper) RandomNode(prng *rand.Rand, nodes option.NodeListOption) int {
-	return nodes[prng.Intn(len(nodes))]
-}
-
-// RandomDB returns a (nodeID, connection) tuple for a randomly picked
-// cockroach node according to the parameters passed.
-func (h *Helper) RandomDB(prng *rand.Rand, nodes option.NodeListOption) (int, *gosql.DB) {
-	node := h.RandomNode(prng, nodes)
-	return node, h.Connect(node)
-}
-
-// QueryRow performs `db.QueryRowContext` on a randomly picked
-// database node. The query and the node picked are logged in the logs
-// of the step that calls this function.
-func (h *Helper) QueryRow(rng *rand.Rand, query string, args ...interface{}) *gosql.Row {
-	node, db := h.RandomDB(rng, h.runner.crdbNodes)
-	h.stepLogger.Printf("running SQL statement:\n%s\nArgs: %v\nNode: %d", query, args, node)
-	return db.QueryRowContext(h.ctx, query, args...)
-}
-
-// Exec performs `db.ExecContext` on a randomly picked database node.
-// The query and the node picked are logged in the logs of the step
-// that calls this function.
-func (h *Helper) Exec(rng *rand.Rand, query string, args ...interface{}) error {
-	node, db := h.RandomDB(rng, h.runner.crdbNodes)
-	h.stepLogger.Printf("running SQL statement:\n%s\nArgs: %v\nNode: %d", query, args, node)
-	_, err := db.ExecContext(h.ctx, query, args...)
-	return err
-}
-
-func (h *Helper) Connect(node int) *gosql.DB {
-	return h.runner.conn(node)
-}
-
-// SetContext should be called by steps that need access to the test
-// context, as that is only visible to them.
-func (h *Helper) SetContext(c *Context) {
-	h.testContext = c
-}
-
-// Context returns the test context associated with a certain step. It
-// is made available for user-functions (see runHookStep).
-func (h *Helper) Context() *Context {
-	return h.testContext
-}
-
-// Background allows test authors to create functions that run in the
-// background in mixed-version hooks.
-func (h *Helper) Background(
-	name string, fn func(context.Context, *logger.Logger) error,
-) context.CancelFunc {
-	return h.runner.background.Start(name, func(ctx context.Context) error {
-		bgLogger, err := h.loggerFor(name)
-		if err != nil {
-			return fmt.Errorf("failed to create logger for background function %q: %w", name, err)
-		}
-
-		err = panicAsError(bgLogger, func() error { return fn(ctx, bgLogger) })
-		if err != nil {
-			if isContextCanceled(ctx) {
-				return err
-			}
-
-			desc := fmt.Sprintf("error in background function %s: %s", name, err)
-			return h.runner.testFailure(desc, bgLogger)
-		}
-
-		return nil
-	})
-}
-
-// BackgroundCommand has the same semantics of `Background()`; the
-// command passed will run and the test will fail if the command is
-// not successful.
-func (h *Helper) BackgroundCommand(cmd string, nodes option.NodeListOption) context.CancelFunc {
-	desc := fmt.Sprintf("run command: %q", cmd)
-	return h.Background(desc, func(ctx context.Context, l *logger.Logger) error {
-		l.Printf("running command `%s` on nodes %v in the background", cmd, nodes)
-		return h.runner.cluster.RunE(ctx, nodes, cmd)
-	})
-}
-
-// ExpectDeath alerts the testing infrastructure that a node is
-// expected to die. Regular restarts as part of the mixedversion
-// testing are already taken into account. This function should only
-// be used by tests that perform their own node restarts or chaos
-// events.
-func (h *Helper) ExpectDeath() {
-	h.ExpectDeaths(1)
-}
-
-// ExpectDeaths is the general version of `ExpectDeath()`.
-func (h *Helper) ExpectDeaths(n int) {
-	h.runner.monitor.ExpectDeaths(n)
-}
-
-// loggerFor creates a logger instance to be used by background
-// functions (created by calling `Background` on the helper
-// instance). It is similar to the logger instances created for
-// mixed-version steps, but with the `background_` prefix.
-func (h *Helper) loggerFor(name string) (*logger.Logger, error) {
-	atomic.AddInt64(&h.bgCount, 1)
-
-	fileName := invalidChars.ReplaceAllString(strings.ToLower(name), "")
-	fileName = fmt.Sprintf("background_%s_%d", fileName, h.bgCount)
-	fileName = path.Join(logPrefix, fileName)
-
-	return prefixedLogger(h.runner.logger, fileName)
 }
 
 func (tf *testFailure) Error() string {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -22,6 +22,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -61,6 +62,7 @@ type (
 		group     ctxgroup.Group
 		ctx       context.Context
 		events    chan backgroundEvent
+		logger    *logger.Logger
 		stopFuncs []StopFunc
 	}
 
@@ -81,6 +83,19 @@ type (
 		clusterVersionsAfter  []roachpb.Version
 	}
 
+	// crdbMonitor is a thin wrapper around the roachtest monitor API
+	// (cluster.NewMonitor) that produces error events through a channel
+	// whenever an unexpected node death happens. It also allows us to
+	// provide an API for test authors to inform the framework that a
+	// node death is expected if the test performs its own restarts or
+	// chaos events.
+	crdbMonitor struct {
+		once      sync.Once
+		crdbNodes option.NodeListOption
+		monitor   cluster.Monitor
+		errCh     chan error
+	}
+
 	testRunner struct {
 		ctx       context.Context
 		cancel    context.CancelFunc
@@ -94,6 +109,7 @@ type (
 		clusterVersions atomic.Value
 
 		background *backgroundRunner
+		monitor    *crdbMonitor
 
 		connCache struct {
 			mu    syncutil.Mutex
@@ -123,24 +139,18 @@ func newTestRunner(
 		logger:     l,
 		cluster:    c,
 		crdbNodes:  crdbNodes,
-		background: newBackgroundRunner(ctx),
+		background: newBackgroundRunner(ctx, l),
+		monitor:    newCRDBMonitor(ctx, c, crdbNodes),
 		seed:       randomSeed,
 	}
 }
 
 // run implements the test running logic, which boils down to running
 // each step in sequence.
-func (tr *testRunner) run() error {
-	defer tr.closeConnections()
-	defer func() {
-		// Stop background functions explicitly so that the corresponding
-		// termination is marked `TriggeredByTest` (not necessary for
-		// correctness, just for clarity).
-		tr.logger.Printf("stopping background functions")
-		tr.background.Terminate()
-	}()
-
+func (tr *testRunner) run() (retErr error) {
 	stepsErr := make(chan error)
+	defer func() { tr.teardown(stepsErr, retErr != nil) }()
+
 	go func() {
 		defer close(stepsErr)
 		for _, step := range tr.plan.steps {
@@ -165,6 +175,9 @@ func (tr *testRunner) run() error {
 			}
 
 			return fmt.Errorf("background step `%s` returned error: %w", event.Name, event.Err)
+
+		case err := <-tr.monitor.Err():
+			return tr.testFailure(err.Error(), tr.logger)
 		}
 	}
 }
@@ -186,6 +199,7 @@ func (tr *testRunner) runStep(ctx context.Context, step testStep) error {
 			if err := tr.refreshClusterVersions(); err != nil {
 				return err
 			}
+			tr.monitor.Init()
 		}
 	}
 
@@ -242,16 +256,10 @@ func (tr *testRunner) runSingleStep(ctx context.Context, ss singleStep, l *logge
 		tr.logStep(prefix, ss, l)
 	}()
 
-	if err := func() (retErr error) {
-		defer func() {
-			if r := recover(); r != nil {
-				l.Printf("panic stack trace:\n%s", string(debug.Stack()))
-				retErr = fmt.Errorf("panic (stack trace above): %v", r)
-			}
-		}()
+	if err := panicAsError(l, func() error {
 		return ss.Run(ctx, l, tr.cluster, tr.newHelper(ctx, l))
-	}(); err != nil {
-		if isContextCanceled(err) {
+	}); err != nil {
+		if isContextCanceled(ctx) {
 			l.Printf("step terminated (context canceled)")
 			// Avoid creating a `stepError` (which involves querying binary
 			// and cluster versions) when the context was canceled as the
@@ -333,6 +341,36 @@ func (tr *testRunner) testFailure(desc string, l *logger.Logger) error {
 	}
 
 	return tf
+}
+
+// teardown groups together all tasks that happen once a test finishes.
+func (tr *testRunner) teardown(stepsChan chan error, testFailed bool) {
+	if testFailed {
+		tr.logger.Printf("mixed-version test FAILED")
+	} else {
+		tr.logger.Printf("mixed-version test PASSED")
+	}
+
+	tr.cancel()
+
+	// Stop background functions explicitly so that the corresponding
+	// termination is marked `TriggeredByTest` (not necessary for
+	// correctness, just for clarity).
+	tr.logger.Printf("stopping background functions")
+	tr.background.Terminate()
+
+	// If the test failed, we wait for any currently running steps to
+	// return before passing control back to the roachtest
+	// framework. This achieves a test.log that does not contain any
+	// test step output once roachtest started to collect failure
+	// artifacts, which would be confusing.
+	if testFailed {
+		tr.logger.Printf("waiting for all steps to finish after context cancelation")
+		waitForChannel(stepsChan, "test steps", tr.logger)
+	}
+
+	tr.logger.Printf("closing database connections")
+	tr.closeConnections()
 }
 
 func (tr *testRunner) logStep(prefix string, step singleStep, l *logger.Logger) {
@@ -462,11 +500,44 @@ func (tr *testRunner) closeConnections() {
 	}
 }
 
-func newBackgroundRunner(ctx context.Context) *backgroundRunner {
+func newCRDBMonitor(
+	ctx context.Context, c cluster.Cluster, crdbNodes option.NodeListOption,
+) *crdbMonitor {
+	return &crdbMonitor{
+		crdbNodes: crdbNodes,
+		monitor:   c.NewMonitor(ctx, crdbNodes),
+		errCh:     make(chan error),
+	}
+}
+
+// Init must be called once the cluster is initialized and the
+// cockroach process is running on the nodes. Init is idempotent.
+func (cm *crdbMonitor) Init() {
+	cm.once.Do(func() {
+		go func() {
+			if err := cm.monitor.WaitE(); err != nil {
+				cm.errCh <- err
+			}
+		}()
+	})
+}
+
+// Err returns a channel that will receive errors whenever an
+// unexpected node death is observed.
+func (cm *crdbMonitor) Err() chan error {
+	return cm.errCh
+}
+
+func (cm *crdbMonitor) ExpectDeaths(n int) {
+	cm.monitor.ExpectDeaths(int32(n))
+}
+
+func newBackgroundRunner(ctx context.Context, l *logger.Logger) *backgroundRunner {
 	g := ctxgroup.WithContext(ctx)
 	return &backgroundRunner{
 		group:  g,
 		ctx:    ctx,
+		logger: l,
 		events: make(chan backgroundEvent),
 	}
 }
@@ -481,11 +552,20 @@ func (br *backgroundRunner) Start(name string, fn func(context.Context) error) c
 	var expectedContextCancelation bool
 	br.group.Go(func() error {
 		err := fn(bgCtx)
-		br.events <- backgroundEvent{
+		event := backgroundEvent{
 			Name:            name,
 			Err:             err,
-			TriggeredByTest: err != nil && isContextCanceled(err) && expectedContextCancelation,
+			TriggeredByTest: err != nil && isContextCanceled(bgCtx) && expectedContextCancelation,
 		}
+
+		select {
+		case br.events <- event:
+			// exit goroutine
+		case <-br.ctx.Done():
+			// Test already finished, exit goroutine.
+			return nil
+		}
+
 		return err
 	})
 
@@ -503,11 +583,20 @@ func (br *backgroundRunner) Start(name string, fn func(context.Context) error) c
 // started during the test. This includes background functions created
 // during test runtime (using `helper.Background()`), as well as
 // background steps declared in the test setup (using
-// `BackgroundFunc`, `Workload`, et al).
+// `BackgroundFunc`, `Workload`, et al). Returns when all background
+// functions have returned.
 func (br *backgroundRunner) Terminate() {
 	for _, stop := range br.stopFuncs {
 		stop()
 	}
+
+	doneCh := make(chan error)
+	go func() {
+		defer close(doneCh)
+		_ = br.group.Wait()
+	}()
+
+	waitForChannel(doneCh, "background functions", br.logger)
 }
 
 func (br *backgroundRunner) CompletedEvents() <-chan backgroundEvent {
@@ -571,9 +660,9 @@ func (h *Helper) Background(
 			return fmt.Errorf("failed to create logger for background function %q: %w", name, err)
 		}
 
-		err = fn(ctx, bgLogger)
+		err = panicAsError(bgLogger, func() error { return fn(ctx, bgLogger) })
 		if err != nil {
-			if isContextCanceled(err) {
+			if isContextCanceled(ctx) {
 				return err
 			}
 
@@ -594,6 +683,20 @@ func (h *Helper) BackgroundCommand(cmd string, nodes option.NodeListOption) cont
 		l.Printf("running command `%s` on nodes %v in the background", cmd, nodes)
 		return h.runner.cluster.RunE(ctx, nodes, cmd)
 	})
+}
+
+// ExpectDeath alerts the testing infrastructure that a node is
+// expected to die. Regular restarts as part of the mixedversion
+// testing are already taken into account. This function should only
+// be used by tests that perform their own node restarts or chaos
+// events.
+func (h *Helper) ExpectDeath() {
+	h.ExpectDeaths(1)
+}
+
+// ExpectDeaths is the general version of `ExpectDeath()`.
+func (h *Helper) ExpectDeaths(n int) {
+	h.runner.monitor.ExpectDeaths(n)
 }
 
 // loggerFor creates a logger instance to be used by background
@@ -654,6 +757,39 @@ func loadAtomicVersions(v atomic.Value) []roachpb.Version {
 	return v.Load().([]roachpb.Version)
 }
 
+// panicAsError ensures that the any panics that might happen while
+// the function passed runs are captured and returned as regular
+// errors. A stack trace is included in the logs when that happens to
+// facilitate debugging.
+func panicAsError(l *logger.Logger, f func() error) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			l.Printf("panic stack trace:\n%s", string(debug.Stack()))
+			retErr = fmt.Errorf("panic (stack trace above): %v", r)
+		}
+	}()
+	return f()
+}
+
+// waitForChannel waits for the given channel `ch` to close; returns
+// when that happens. If the channel does not close within 5 minutes,
+// the function logs a message and returns.
+//
+// The main use-case for this function is waiting for user-provided
+// hooks to return after the context passed to them is canceled. We
+// want to allow some time for them to finish, but we also don't want
+// to block indefinitely if a function inadvertently ignores context
+// cancelation.
+func waitForChannel(ch chan error, desc string, l *logger.Logger) {
+	maxWait := 5 * time.Minute
+	select {
+	case <-ch:
+		// return
+	case <-time.After(maxWait):
+		l.Printf("waited for %s for %s to finish, giving up", maxWait, desc)
+	}
+}
+
 func formatVersions(versions []roachpb.Version) string {
 	var pairs []string
 	for idx, version := range versions {
@@ -663,15 +799,13 @@ func formatVersions(versions []roachpb.Version) string {
 	return fmt.Sprintf("[%s]", strings.Join(pairs, ", "))
 }
 
-// isContextCanceled returns a boolean indicating whether the error
-// given happened because some context was canceled.
-func isContextCanceled(err error) bool {
-	// TODO(renato): unfortunately, we have to resort to string
-	// comparison here. The most common use case for this function is
-	// detecting cluster commands that fail when the test context is
-	// canceled (after test success or failure), and roachtest does not
-	// return an error that wraps the context cancelation (in other
-	// words, `errors.Is` doesn't work). Once we fix this behavior, we
-	// should use structured errors here.
-	return strings.Contains(err.Error(), context.Canceled.Error())
+// isContextCanceled returns a boolean indicating whether the context
+// passed is canceled.
+func isContextCanceled(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
@@ -61,7 +61,7 @@ func testTestRunner() *testRunner {
 		cancel:     cancel,
 		logger:     nilLogger,
 		crdbNodes:  nodes,
-		background: newBackgroundRunner(runnerCtx),
+		background: newBackgroundRunner(runnerCtx, nilLogger),
 		seed:       seed,
 	}
 }

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1906,7 +1906,7 @@ func (mvb *mixedVersionBackup) verifyBackupCollection(
 		// as the tables we backed up. In addition, we need to wipe the
 		// cluster before attempting a restore.
 		restoredTables = collection.tables
-		if err := mvb.resetCluster(ctx, l, version); err != nil {
+		if err := mvb.resetCluster(ctx, l, h, version); err != nil {
 			return err
 		}
 	case *tableBackup:
@@ -1972,9 +1972,10 @@ func (mvb *mixedVersionBackup) verifyBackupCollection(
 // specified version binary. This is done before we attempt restoring a
 // full cluster backup.
 func (mvb *mixedVersionBackup) resetCluster(
-	ctx context.Context, l *logger.Logger, version string,
+	ctx context.Context, l *logger.Logger, h *mixedversion.Helper, version string,
 ) error {
 	l.Printf("resetting cluster using version %q", clusterupgrade.VersionMsg(version))
+	h.ExpectDeaths(len(mvb.roachNodes))
 	if err := mvb.cluster.WipeE(ctx, l, true /* preserveCerts */, mvb.roachNodes); err != nil {
 		return fmt.Errorf("failed to wipe cluster: %w", err)
 	}

--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -112,7 +112,6 @@ func newRemoteSession(l *logger.Logger, command *remoteCommand) *remoteSession {
 		}
 	}
 
-	//const logfile = ""
 	args := []string{
 		command.user + "@" + command.host,
 


### PR DESCRIPTION
This PR includes a few changes related to the roachprod/roachtest monitor itself, and integrates it with the `mixedversion` package. Specifically, the changes are as follows (each bullet point corresponds to a commit):

* emit structured events from the roachprod monitor; this removes the need to perform string parsing on callers.
* change `mixedversion` framework to monitor nodes by default. An unexpected node death immediately fails the test.
* move public functions on the `*mixedversion.Helper` struct to its own file, for ease of browsing.
* update the README with instructions on background tasks; most importantly, mixedversion tests can't use `cluster.NewMonitor` like other roachtests.

Epic: CRDB-19321

Release notes: None