### PR TITLE
concurrency: allow shared locking requests into the lock table 

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -713,6 +713,13 @@ func scanSpans(
 			sa = spanset.SpanReadWrite
 		case lock.Exclusive:
 			sa = spanset.SpanReadWrite
+		case lock.Shared:
+			// Unlike non-locking reads, shared-locking reads are isolated at all
+			// timestamps (not just the request's timestamp); so we acquire a read
+			// latch at max timestamp. See
+			// https://github.com/cockroachdb/cockroach/issues/102264.
+			sa = spanset.SpanReadOnly
+			ts = hlc.MaxTimestamp
 		default:
 			d.Fatalf(t, "unsupported lock strength: %s", str)
 		}

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -1,0 +1,103 @@
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10 epoch=0 seq=0
+----
+
+new-txn txn=txn2 ts=10 epoch=0 seq=0
+----
+
+new-request r=req1 txn=txn1 ts=10 spans=shared@a
+----
+
+acquire r=req1 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+
+# ------------------------------------------------------------------------------
+# Ensure conflict resolution semantics for shared locks are sane -- that is,
+# if a shared lock is held on a key, {shared, non} locking requests are allowed
+# to proceed; {intent, exclusive} locking requests are not.
+# ------------------------------------------------------------------------------
+
+new-request r=req2 txn=txn2 ts=10 spans=none@a
+----
+
+scan r=req2
+----
+start-waiting: false
+
+new-request r=req3 txn=txn2 ts=10 spans=shared@a
+----
+
+# req3 should not actively wait, as it's locking strength is shared, but it
+# should be able to acquire a joint claim.
+scan r=req3
+----
+start-waiting: false
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+   queued writers:
+    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
+
+# TODO(arul): This is currently a limitation of the lock table, as it doesn't
+# allow multiple locks on a single key from different transactions.
+acquire r=req3 k=a durability=u strength=shared
+----
+existing lock cannot be acquired by different transaction
+
+new-request r=req4 txn=txn2 ts=10 spans=exclusive@a
+----
+
+scan r=req4
+----
+start-waiting: true
+
+new-request r=req5 txn=txn2 ts=10 spans=intent@a
+----
+
+scan r=req5
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+   queued writers:
+    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 3
+
+# ------------------------------------------------------------------------------
+# Ensure requests with locking strength shared actively wait if there are active
+# waiters with conflicting lock strengths (even though the lock itself is
+# compatible with the shared lock request).
+# ------------------------------------------------------------------------------
+
+new-request r=req6 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req6
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+   queued writers:
+    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 5, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 3


### PR DESCRIPTION
This patch extends the list of permissible locking strengths to include
SHARED and tests conflict resolution for shared locks with other lock
strengths.

Note that (currently) the lock table doesn't support multiple locks from
different transactions on a single key; as such, 2 transactions cannot
simultaneously hold shared locks on a single key. This restriction will
be lifted in the future.

Release note: None