### PR TITLE
roachtest: use port outside ephemeral range for `acceptance/gossip/restart-node-one`

### DIFF
--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -433,9 +433,9 @@ SELECT count(replicas)
 	err := c.RunE(ctx, c.Node(1),
 		` ./cockroach start --insecure --background --store={store-dir} `+
 			`--log-dir={log-dir} --cache=10% --max-sql-memory=10% `+
-			`--listen-addr=:$[{pgport:1}+10000] --http-port=$[{pgport:1}+1] `+
+			`--listen-addr=:$[{pgport:1}+1000] --http-port=$[{pgport:1}+1] `+
 			`--join={pghost:1}:{pgport:1} `+
-			`--advertise-addr={pghost:1}:$[{pgport:1}+10000] `+
+			`--advertise-addr={pghost:1}:$[{pgport:1}+1000] `+
 			`> {log-dir}/cockroach.stdout 2> {log-dir}/cockroach.stderr`)
 	if err != nil {
 		t.Fatal(err)
@@ -473,7 +473,7 @@ SELECT count(replicas)
 		if err != nil {
 			t.Fatal(err)
 		}
-		url.Host = fmt.Sprintf("%s:%d", host, v+10000)
+		url.Host = fmt.Sprintf("%s:%d", host, v+1000)
 		db, err := gosql.Open("postgres", url.String())
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Fixes #106834.
Similar to #68281.

`acceptance/gossip/restart-node-one` starts a cockroach server listening on port 36257. This port number falls within Linux' default ephemeral port range of 32768-60999 (see `/proc/sys/net/ipv4/ip_local_port_range`) which TCP clients pick source ports from when establishing outbound connections. This can cause the server to attempt to bind to a port already being used for a client connection, preventing server startup and failing the test (as seen in cockroachdb#106834).

This patch changes the port number to the arbitrarily chosen 27257 outside of the ephemeral port range, thus avoiding these collisions.

Release note: None