### PR TITLE
rangefeed: add scheduler based rangefeed processor

### DIFF
--- a/pkg/cli/debug_merge_logs_test.go
+++ b/pkg/cli/debug_merge_logs_test.go
@@ -247,9 +247,9 @@ func TestDebugMergeLogs(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Run the test for each possible log format.
-	format := []interface{}{"crdb-v2", "crdb-v1"}
-	testutils.RunValues(t, "format", format, func(t *testing.T, format interface{}) {
-		cases := getCases(format.(string))
+	format := []string{"crdb-v2", "crdb-v1"}
+	testutils.RunValues(t, "format", format, func(t *testing.T, format string) {
+		cases := getCases(format)
 		for _, c := range cases {
 			t.Run(c.name, c.run)
 		}

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -73,7 +73,7 @@ const (
 var (
 	cdcBenchScanTypes = []cdcBenchScanType{
 		cdcBenchInitialScan, cdcBenchCatchupScan, cdcBenchColdCatchupScan}
-	cdcBenchServers   = []cdcBenchServer{cdcBenchProcessorServer} // TODO(erikgrinaker): scheduler
+	cdcBenchServers   = []cdcBenchServer{cdcBenchProcessorServer, cdcBenchSchedulerServer}
 	cdcBenchProtocols = []cdcBenchProtocol{cdcBenchRangefeedProtocol, cdcBenchMuxProtocol}
 )
 
@@ -375,6 +375,16 @@ func runCDCBenchWorkload(
 	case cdcBenchNoProtocol:
 	default:
 		t.Fatalf("unknown protocol %q", protocol)
+	}
+
+	switch server {
+	case cdcBenchProcessorServer:
+		settings.ClusterSettings["kv.rangefeed.scheduler.enabled"] = "false"
+	case cdcBenchSchedulerServer:
+		settings.ClusterSettings["kv.rangefeed.scheduler.enabled"] = "true"
+	case cdcBenchNoServer:
+	default:
+		t.Fatalf("unknown server type %q", server)
 	}
 
 	c.Put(ctx, t.Cockroach(), "./cockroach")

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -28,6 +28,7 @@ type Option interface {
 type config struct {
 	scanConfig
 	retryOptions       retry.Options
+	useMuxRangefeed    bool
 	onInitialScanDone  OnInitialScanDone
 	withInitialScan    bool
 	onInitialScanError OnInitialScanError
@@ -224,6 +225,7 @@ func WithOnFrontierAdvance(f OnFrontierAdvance) Option {
 
 func initConfig(c *config, options []Option) {
 	*c = config{} // the default config is its zero value
+	c.useMuxRangefeed = useMuxRangeFeed
 	for _, o := range options {
 		o.set(c)
 	}
@@ -301,5 +303,11 @@ func WithPProfLabel(key, value string) Option {
 func WithSystemTablePriority() Option {
 	return optionFunc(func(c *config) {
 		c.overSystemTable = true
+	})
+}
+
+func WithMuxRangefeed(enabled bool) Option {
+	return optionFunc(func(c *config) {
+		c.useMuxRangefeed = enabled
 	})
 }

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -295,7 +295,7 @@ func (f *RangeFeed) run(ctx context.Context, frontier *span.Frontier) {
 	if f.scanConfig.overSystemTable {
 		rangefeedOpts = append(rangefeedOpts, kvcoord.WithSystemTablePriority())
 	}
-	if useMuxRangeFeed {
+	if f.useMuxRangefeed {
 		rangefeedOpts = append(rangefeedOpts, kvcoord.WithMuxRangeFeed())
 	}
 	if f.withDiff {

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -12,6 +12,7 @@ package rangefeed_test
 
 import (
 	"context"
+	"fmt"
 	"runtime/pprof"
 	"sync"
 	"testing"
@@ -55,94 +56,122 @@ var (
 
 type kvs = storageutils.KVs
 
+type feedProcessorType struct {
+	useMuxRangefeed bool
+	useScheduler    bool
+}
+
+func (t feedProcessorType) String() string {
+	return fmt.Sprintf("mux=%t_scheduler=%t", t.useMuxRangefeed, t.useScheduler)
+}
+
+var procTypes = []feedProcessorType{
+	{
+		useMuxRangefeed: false,
+		useScheduler:    false,
+	},
+	{
+		useMuxRangefeed: true,
+		useScheduler:    false,
+	},
+	{
+		useMuxRangefeed: true,
+		useScheduler:    true,
+	},
+}
+
 // TestRangeFeedIntegration is a basic integration test demonstrating all of
 // the pieces working together.
 func TestRangeFeedIntegration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(ctx)
-	ts := srv.ApplicationLayer()
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx := context.Background()
+		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+		defer srv.Stopper().Stop(ctx)
+		ts := srv.ApplicationLayer()
 
-	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-	_, _, err := srv.SplitRange(scratchKey)
-	require.NoError(t, err)
-	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-	mkKey := func(k string) roachpb.Key {
-		return encoding.EncodeStringAscending(scratchKey, k)
-	}
-	// Split the range a bunch of times.
-	const splits = 10
-	for i := 0; i < splits; i++ {
-		_, _, err := srv.SplitRange(mkKey(string([]byte{'a' + byte(i)})))
+		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+		_, _, err := srv.SplitRange(scratchKey)
 		require.NoError(t, err)
-	}
+		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+		mkKey := func(k string) roachpb.Key {
+			return encoding.EncodeStringAscending(scratchKey, k)
+		}
+		// Split the range a bunch of times.
+		const splits = 10
+		for i := 0; i < splits; i++ {
+			_, _, err := srv.SplitRange(mkKey(string([]byte{'a' + byte(i)})))
+			require.NoError(t, err)
+		}
 
-	require.NoError(t, db.Put(ctx, mkKey("a"), 1))
-	require.NoError(t, db.Put(ctx, mkKey("b"), 2))
-	afterB := db.Clock().Now()
-	require.NoError(t, db.Put(ctx, mkKey("c"), 3))
+		require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+		require.NoError(t, db.Put(ctx, mkKey("b"), 2))
+		afterB := db.Clock().Now()
+		require.NoError(t, db.Put(ctx, mkKey("c"), 3))
 
-	sp := roachpb.Span{
-		Key:    scratchKey,
-		EndKey: scratchKey.PrefixEnd(),
-	}
+		sp := roachpb.Span{
+			Key:    scratchKey,
+			EndKey: scratchKey.PrefixEnd(),
+		}
 
-	// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-	}
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
+		}
 
-	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-	require.NoError(t, err)
-	rows := make(chan *kvpb.RangeFeedValue)
-	initialScanDone := make(chan struct{})
-	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, afterB,
-		func(ctx context.Context, value *kvpb.RangeFeedValue) {
-			select {
-			case rows <- value:
-			case <-ctx.Done():
-			}
-		},
-		rangefeed.WithDiff(true),
-		rangefeed.WithInitialScan(func(ctx context.Context) {
-			close(initialScanDone)
-		}),
-	)
-	require.NoError(t, err)
-	defer r.Close()
-	{
-		v1 := <-rows
-		require.Equal(t, mkKey("a"), v1.Key)
-		// Ensure the initial scan contract is fulfilled when WithDiff is specified.
-		require.Equal(t, v1.Value.RawBytes, v1.PrevValue.RawBytes)
-		require.Equal(t, v1.Value.Timestamp, afterB)
-		require.True(t, v1.PrevValue.Timestamp.IsEmpty())
-	}
-	{
-		v2 := <-rows
-		require.Equal(t, mkKey("b"), v2.Key)
-	}
-	<-initialScanDone
-	{
-		v3 := <-rows
-		require.Equal(t, mkKey("c"), v3.Key)
-	}
-
-	// Write a new value for "a" and make sure it is seen.
-	require.NoError(t, db.Put(ctx, mkKey("a"), 4))
-	{
-		v4 := <-rows
-		require.Equal(t, mkKey("a"), v4.Key)
-		prev, err := v4.PrevValue.GetInt()
+		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
 		require.NoError(t, err)
-		require.Equal(t, int64(1), prev)
-		updated, err := v4.Value.GetInt()
+		rows := make(chan *kvpb.RangeFeedValue)
+		initialScanDone := make(chan struct{})
+		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, afterB,
+			func(ctx context.Context, value *kvpb.RangeFeedValue) {
+				select {
+				case rows <- value:
+				case <-ctx.Done():
+				}
+			},
+			rangefeed.WithDiff(true),
+			rangefeed.WithInitialScan(func(ctx context.Context) {
+				close(initialScanDone)
+			}),
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
 		require.NoError(t, err)
-		require.Equal(t, int64(4), updated)
-	}
+		defer r.Close()
+		{
+			v1 := <-rows
+			require.Equal(t, mkKey("a"), v1.Key)
+			// Ensure the initial scan contract is fulfilled when WithDiff is specified.
+			require.Equal(t, v1.Value.RawBytes, v1.PrevValue.RawBytes)
+			require.Equal(t, v1.Value.Timestamp, afterB)
+			require.True(t, v1.PrevValue.Timestamp.IsEmpty())
+		}
+		{
+			v2 := <-rows
+			require.Equal(t, mkKey("b"), v2.Key)
+		}
+		<-initialScanDone
+		{
+			v3 := <-rows
+			require.Equal(t, mkKey("c"), v3.Key)
+		}
+
+		// Write a new value for "a" and make sure it is seen.
+		require.NoError(t, db.Put(ctx, mkKey("a"), 4))
+		{
+			v4 := <-rows
+			require.Equal(t, mkKey("a"), v4.Key)
+			prev, err := v4.PrevValue.GetInt()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), prev)
+			updated, err := v4.Value.GetInt()
+			require.NoError(t, err)
+			require.Equal(t, int64(4), updated)
+		}
+	})
 }
 
 // TestWithOnFrontierAdvance sets up a rangefeed on a span that has more than
@@ -152,122 +181,124 @@ func TestWithOnFrontierAdvance(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-		ReplicationMode: base.ReplicationManual,
-	})
-	defer tc.Stopper().Stop(ctx)
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx := context.Background()
+		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+		})
+		defer tc.Stopper().Stop(ctx)
 
-	srv := tc.Server(0)
-	ts := srv.ApplicationLayer()
-	db := ts.DB()
-
-	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-	_, _, err := srv.SplitRange(scratchKey)
-	require.NoError(t, err)
-	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-
-	mkKey := func(k string) roachpb.Key {
-		return encoding.EncodeStringAscending(scratchKey, k)
-	}
-
-	sp := roachpb.Span{
-		Key:    scratchKey,
-		EndKey: scratchKey.PrefixEnd(),
-	}
-
-	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		// Lower the closed timestamp target duration to speed up the test.
-		closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
-	}
-
-	// Split the range into two so we know the frontier has more than one span to
-	// track for certain. We later write to both these ranges.
-	_, _, err = srv.SplitRange(mkKey("b"))
-	require.NoError(t, err)
-
-	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-	require.NoError(t, err)
-
-	// mu protects secondWriteTS.
-	var mu syncutil.Mutex
-	secondWriteFinished := false
-	frontierAdvancedAfterSecondWrite := false
-
-	// Track the checkpoint TS for spans belonging to both the ranges we split
-	// above. This can then be used to compute the minimum timestamp for both
-	// these spans. We use the key we write to for the ranges below as keys for
-	// this map.
-	spanCheckpointTimestamps := make(map[string]hlc.Timestamp)
-	forwardCheckpointForKey := func(key string, checkpoint *kvpb.RangeFeedCheckpoint) {
-		ts := hlc.MinTimestamp
-		if prevTS, found := spanCheckpointTimestamps[key]; found {
-			ts = prevTS
+		srv := tc.Server(0)
+		ts := srv.ApplicationLayer()
+		db := ts.DB()
+		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+		_, _, err := srv.SplitRange(scratchKey)
+		require.NoError(t, err)
+		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+		mkKey := func(k string) roachpb.Key {
+			return encoding.EncodeStringAscending(scratchKey, k)
 		}
-		ts.Forward(checkpoint.ResolvedTS)
-		spanCheckpointTimestamps[key] = ts
-	}
-	rows := make(chan *kvpb.RangeFeedValue)
-	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
-		func(ctx context.Context, value *kvpb.RangeFeedValue) {
-			select {
-			case rows <- value:
-			case <-ctx.Done():
+
+		sp := roachpb.Span{
+			Key:    scratchKey,
+			EndKey: scratchKey.PrefixEnd(),
+		}
+
+		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
+			// Lower the closed timestamp target duration to speed up the test.
+			closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
+		}
+
+		// Split the range into two so we know the frontier has more than one span to
+		// track for certain. We later write to both these ranges.
+		_, _, err = srv.SplitRange(mkKey("b"))
+		require.NoError(t, err)
+
+		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+		require.NoError(t, err)
+
+		// mu protects secondWriteTS.
+		var mu syncutil.Mutex
+		secondWriteFinished := false
+		frontierAdvancedAfterSecondWrite := false
+
+		// Track the checkpoint TS for spans belonging to both the ranges we split
+		// above. This can then be used to compute the minimum timestamp for both
+		// these spans. We use the key we write to for the ranges below as keys for
+		// this map.
+		spanCheckpointTimestamps := make(map[string]hlc.Timestamp)
+		forwardCheckpointForKey := func(key string, checkpoint *kvpb.RangeFeedCheckpoint) {
+			ts := hlc.MinTimestamp
+			if prevTS, found := spanCheckpointTimestamps[key]; found {
+				ts = prevTS
 			}
-		},
-		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-			if checkpoint.Span.ContainsKey(mkKey("a")) {
-				forwardCheckpointForKey("a", checkpoint)
-			}
-			if checkpoint.Span.ContainsKey(mkKey("c")) {
-				forwardCheckpointForKey("c", checkpoint)
-			}
-		}),
-		rangefeed.WithOnFrontierAdvance(func(ctx context.Context, frontierTS hlc.Timestamp) {
-			minTS := hlc.MaxTimestamp
-			for _, ts := range spanCheckpointTimestamps {
-				minTS.Backward(ts)
-			}
-			assert.Truef(
-				t,
-				frontierTS.Equal(minTS),
-				"expected frontier timestamp to be equal to minimum timestamp across spans %s, found %s",
-				minTS,
-				frontierTS,
-			)
+			ts.Forward(checkpoint.ResolvedTS)
+			spanCheckpointTimestamps[key] = ts
+		}
+		rows := make(chan *kvpb.RangeFeedValue)
+		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
+			func(ctx context.Context, value *kvpb.RangeFeedValue) {
+				select {
+				case rows <- value:
+				case <-ctx.Done():
+				}
+			},
+			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+				if checkpoint.Span.ContainsKey(mkKey("a")) {
+					forwardCheckpointForKey("a", checkpoint)
+				}
+				if checkpoint.Span.ContainsKey(mkKey("c")) {
+					forwardCheckpointForKey("c", checkpoint)
+				}
+			}),
+			rangefeed.WithOnFrontierAdvance(func(ctx context.Context, frontierTS hlc.Timestamp) {
+				minTS := hlc.MaxTimestamp
+				for _, ts := range spanCheckpointTimestamps {
+					minTS.Backward(ts)
+				}
+				assert.Truef(
+					t,
+					frontierTS.Equal(minTS),
+					"expected frontier timestamp to be equal to minimum timestamp across spans %s, found %s",
+					minTS,
+					frontierTS,
+				)
+				mu.Lock()
+				defer mu.Unlock()
+				if secondWriteFinished {
+					frontierAdvancedAfterSecondWrite = true
+				}
+			}),
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
+		require.NoError(t, err)
+		defer r.Close()
+
+		// Write to a key on both the ranges.
+		require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+
+		v := <-rows
+		require.Equal(t, mkKey("a"), v.Key)
+
+		require.NoError(t, db.Put(ctx, mkKey("c"), 1))
+		mu.Lock()
+		secondWriteFinished = true
+		mu.Unlock()
+
+		v = <-rows
+		require.Equal(t, mkKey("c"), v.Key)
+
+		testutils.SucceedsSoon(t, func() error {
 			mu.Lock()
 			defer mu.Unlock()
-			if secondWriteFinished {
-				frontierAdvancedAfterSecondWrite = true
+			if frontierAdvancedAfterSecondWrite {
+				return nil
 			}
-		}),
-	)
-	require.NoError(t, err)
-	defer r.Close()
-
-	// Write to a key on both the ranges.
-	require.NoError(t, db.Put(ctx, mkKey("a"), 1))
-
-	v := <-rows
-	require.Equal(t, mkKey("a"), v.Key)
-
-	require.NoError(t, db.Put(ctx, mkKey("c"), 1))
-	mu.Lock()
-	secondWriteFinished = true
-	mu.Unlock()
-
-	v = <-rows
-	require.Equal(t, mkKey("c"), v.Key)
-
-	testutils.SucceedsSoon(t, func() error {
-		mu.Lock()
-		defer mu.Unlock()
-		if frontierAdvancedAfterSecondWrite {
-			return nil
-		}
-		return errors.New("expected frontier to advance after second write")
+			return errors.New("expected frontier to advance after second write")
+		})
 	})
 }
 
@@ -277,94 +308,98 @@ func TestWithOnCheckpoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(ctx)
-	ts := srv.ApplicationLayer()
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx := context.Background()
+		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+		defer srv.Stopper().Stop(ctx)
+		ts := srv.ApplicationLayer()
 
-	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-	_, _, err := srv.SplitRange(scratchKey)
-	require.NoError(t, err)
-	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-	mkKey := func(k string) roachpb.Key {
-		return encoding.EncodeStringAscending(scratchKey, k)
-	}
+		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+		_, _, err := srv.SplitRange(scratchKey)
+		require.NoError(t, err)
+		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+		mkKey := func(k string) roachpb.Key {
+			return encoding.EncodeStringAscending(scratchKey, k)
+		}
 
-	sp := roachpb.Span{
-		Key:    scratchKey,
-		EndKey: scratchKey.PrefixEnd(),
-	}
-	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		// Lower the closed timestamp target duration to speed up the test.
-		closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
-	}
+		sp := roachpb.Span{
+			Key:    scratchKey,
+			EndKey: scratchKey.PrefixEnd(),
+		}
+		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
+			// Lower the closed timestamp target duration to speed up the test.
+			closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
+		}
 
-	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-	require.NoError(t, err)
+		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+		require.NoError(t, err)
 
-	var mu syncutil.RWMutex
-	var afterWriteTS hlc.Timestamp
-	checkpoints := make(chan *kvpb.RangeFeedCheckpoint)
+		var mu syncutil.RWMutex
+		var afterWriteTS hlc.Timestamp
+		checkpoints := make(chan *kvpb.RangeFeedCheckpoint)
 
-	// We need to start a goroutine that reads of the checkpoints channel, so to
-	// not block the rangefeed itself.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// We should expect a checkpoint event covering the key we just wrote, at a
-		// timestamp greater than when we wrote it.
-		testutils.SucceedsSoon(t, func() error {
-			for {
-				select {
-				case c := <-checkpoints:
-					mu.RLock()
-					writeTSUnset := afterWriteTS.IsEmpty()
-					mu.RUnlock()
-					if writeTSUnset {
-						return errors.New("write to key hasn't gone through yet")
+		// We need to start a goroutine that reads of the checkpoints channel, so to
+		// not block the rangefeed itself.
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// We should expect a checkpoint event covering the key we just wrote, at a
+			// timestamp greater than when we wrote it.
+			testutils.SucceedsSoon(t, func() error {
+				for {
+					select {
+					case c := <-checkpoints:
+						mu.RLock()
+						writeTSUnset := afterWriteTS.IsEmpty()
+						mu.RUnlock()
+						if writeTSUnset {
+							return errors.New("write to key hasn't gone through yet")
+						}
+
+						if afterWriteTS.LessEq(c.ResolvedTS) && c.Span.ContainsKey(mkKey("a")) {
+							return nil
+						}
+					default:
+						return errors.New("no valid checkpoints found")
 					}
-
-					if afterWriteTS.LessEq(c.ResolvedTS) && c.Span.ContainsKey(mkKey("a")) {
-						return nil
-					}
-				default:
-					return errors.New("no valid checkpoints found")
 				}
-			}
-		})
-	}()
+			})
+		}()
 
-	rows := make(chan *kvpb.RangeFeedValue)
-	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
-		func(ctx context.Context, value *kvpb.RangeFeedValue) {
-			select {
-			case rows <- value:
-			case <-ctx.Done():
-			}
-		},
-		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-			select {
-			case checkpoints <- checkpoint:
-			case <-ctx.Done():
-			}
-		}),
-	)
-	require.NoError(t, err)
-	defer r.Close()
+		rows := make(chan *kvpb.RangeFeedValue)
+		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
+			func(ctx context.Context, value *kvpb.RangeFeedValue) {
+				select {
+				case rows <- value:
+				case <-ctx.Done():
+				}
+			},
+			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+				select {
+				case checkpoints <- checkpoint:
+				case <-ctx.Done():
+				}
+			}),
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
+		require.NoError(t, err)
+		defer r.Close()
 
-	require.NoError(t, db.Put(ctx, mkKey("a"), 1))
-	mu.Lock()
-	afterWriteTS = db.Clock().Now()
-	mu.Unlock()
-	{
-		v := <-rows
-		require.Equal(t, mkKey("a"), v.Key)
-	}
+		require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+		mu.Lock()
+		afterWriteTS = db.Clock().Now()
+		mu.Unlock()
+		{
+			v := <-rows
+			require.Equal(t, mkKey("a"), v.Key)
+		}
 
-	wg.Wait()
+		wg.Wait()
+	})
 }
 
 // TestRangefeedValueTimestamps tests that the rangefeed values (and previous
@@ -374,110 +409,114 @@ func TestRangefeedValueTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(ctx)
-	ts := srv.ApplicationLayer()
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx := context.Background()
+		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+		defer srv.Stopper().Stop(ctx)
+		ts := srv.ApplicationLayer()
 
-	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-	_, _, err := srv.SplitRange(scratchKey)
-	require.NoError(t, err)
-	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-	mkKey := func(k string) roachpb.Key {
-		return encoding.EncodeStringAscending(scratchKey, k)
-	}
-
-	sp := roachpb.Span{
-		Key:    scratchKey,
-		EndKey: scratchKey.PrefixEnd(),
-	}
-	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		// Lower the closed timestamp target duration to speed up the test.
-		closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
-	}
-
-	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-	require.NoError(t, err)
-
-	rows := make(chan *kvpb.RangeFeedValue)
-	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
-		func(ctx context.Context, value *kvpb.RangeFeedValue) {
-			select {
-			case rows <- value:
-			case <-ctx.Done():
-			}
-		},
-		rangefeed.WithDiff(true),
-	)
-	require.NoError(t, err)
-	defer r.Close()
-
-	mustGetInt := func(value roachpb.Value) int {
-		val, err := value.GetInt()
+		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+		_, _, err := srv.SplitRange(scratchKey)
 		require.NoError(t, err)
-		return int(val)
-	}
+		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+		mkKey := func(k string) roachpb.Key {
+			return encoding.EncodeStringAscending(scratchKey, k)
+		}
 
-	{
-		beforeWriteTS := db.Clock().Now()
-		require.NoError(t, db.Put(ctx, mkKey("a"), 1))
-		afterWriteTS := db.Clock().Now()
+		sp := roachpb.Span{
+			Key:    scratchKey,
+			EndKey: scratchKey.PrefixEnd(),
+		}
+		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
+			// Lower the closed timestamp target duration to speed up the test.
+			closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
+		}
 
-		v := <-rows
-		require.Equal(t, mustGetInt(v.Value), 1)
-		require.True(t, beforeWriteTS.Less(v.Value.Timestamp))
-		require.True(t, v.Value.Timestamp.Less(afterWriteTS))
-
-		require.False(t, v.PrevValue.IsPresent())
-	}
-
-	{
-		beforeOverwriteTS := db.Clock().Now()
-		require.NoError(t, db.Put(ctx, mkKey("a"), 2))
-		afterOverwriteTS := db.Clock().Now()
-
-		v := <-rows
-		require.Equal(t, mustGetInt(v.Value), 2)
-		require.True(t, beforeOverwriteTS.Less(v.Value.Timestamp))
-		require.True(t, v.Value.Timestamp.Less(afterOverwriteTS))
-
-		require.True(t, v.PrevValue.IsPresent())
-		require.Equal(t, mustGetInt(v.PrevValue), 1)
-		require.True(t, v.PrevValue.Timestamp.IsEmpty())
-	}
-
-	{
-		beforeDelTS := db.Clock().Now()
-		_, err = db.Del(ctx, mkKey("a"))
+		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
 		require.NoError(t, err)
-		afterDelTS := db.Clock().Now()
 
-		v := <-rows
-		require.False(t, v.Value.IsPresent())
-		require.True(t, beforeDelTS.Less(v.Value.Timestamp))
-		require.True(t, v.Value.Timestamp.Less(afterDelTS))
-
-		require.True(t, v.PrevValue.IsPresent())
-		require.Equal(t, mustGetInt(v.PrevValue), 2)
-		require.True(t, v.PrevValue.Timestamp.IsEmpty())
-	}
-
-	{
-		beforeDelTS := db.Clock().Now()
-		_, err = db.Del(ctx, mkKey("a"))
+		rows := make(chan *kvpb.RangeFeedValue)
+		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
+			func(ctx context.Context, value *kvpb.RangeFeedValue) {
+				select {
+				case rows <- value:
+				case <-ctx.Done():
+				}
+			},
+			rangefeed.WithDiff(true),
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
 		require.NoError(t, err)
-		afterDelTS := db.Clock().Now()
+		defer r.Close()
 
-		v := <-rows
-		require.False(t, v.Value.IsPresent())
-		require.True(t, beforeDelTS.Less(v.Value.Timestamp))
-		require.True(t, v.Value.Timestamp.Less(afterDelTS))
+		mustGetInt := func(value roachpb.Value) int {
+			val, err := value.GetInt()
+			require.NoError(t, err)
+			return int(val)
+		}
 
-		require.False(t, v.PrevValue.IsPresent())
-		require.True(t, v.PrevValue.Timestamp.IsEmpty())
-	}
+		{
+			beforeWriteTS := db.Clock().Now()
+			require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+			afterWriteTS := db.Clock().Now()
+
+			v := <-rows
+			require.Equal(t, mustGetInt(v.Value), 1)
+			require.True(t, beforeWriteTS.Less(v.Value.Timestamp))
+			require.True(t, v.Value.Timestamp.Less(afterWriteTS))
+
+			require.False(t, v.PrevValue.IsPresent())
+		}
+
+		{
+			beforeOverwriteTS := db.Clock().Now()
+			require.NoError(t, db.Put(ctx, mkKey("a"), 2))
+			afterOverwriteTS := db.Clock().Now()
+
+			v := <-rows
+			require.Equal(t, mustGetInt(v.Value), 2)
+			require.True(t, beforeOverwriteTS.Less(v.Value.Timestamp))
+			require.True(t, v.Value.Timestamp.Less(afterOverwriteTS))
+
+			require.True(t, v.PrevValue.IsPresent())
+			require.Equal(t, mustGetInt(v.PrevValue), 1)
+			require.True(t, v.PrevValue.Timestamp.IsEmpty())
+		}
+
+		{
+			beforeDelTS := db.Clock().Now()
+			_, err = db.Del(ctx, mkKey("a"))
+			require.NoError(t, err)
+			afterDelTS := db.Clock().Now()
+
+			v := <-rows
+			require.False(t, v.Value.IsPresent())
+			require.True(t, beforeDelTS.Less(v.Value.Timestamp))
+			require.True(t, v.Value.Timestamp.Less(afterDelTS))
+
+			require.True(t, v.PrevValue.IsPresent())
+			require.Equal(t, mustGetInt(v.PrevValue), 2)
+			require.True(t, v.PrevValue.Timestamp.IsEmpty())
+		}
+
+		{
+			beforeDelTS := db.Clock().Now()
+			_, err = db.Del(ctx, mkKey("a"))
+			require.NoError(t, err)
+			afterDelTS := db.Clock().Now()
+
+			v := <-rows
+			require.False(t, v.Value.IsPresent())
+			require.True(t, beforeDelTS.Less(v.Value.Timestamp))
+			require.True(t, v.Value.Timestamp.Less(afterDelTS))
+
+			require.False(t, v.PrevValue.IsPresent())
+			require.True(t, v.PrevValue.Timestamp.IsEmpty())
+		}
+	})
 }
 
 // TestWithOnSSTable tests that the rangefeed emits SST ingestions correctly.
@@ -485,87 +524,94 @@ func TestWithOnSSTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109473),
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx := context.Background()
+		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
+			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109473),
+		})
+		defer srv.Stopper().Stop(ctx)
+		tsrv := srv.ApplicationLayer()
+
+		_, _, err := srv.SplitRange(roachpb.Key("a"))
+		require.NoError(t, err)
+
+		for _, l := range []serverutils.ApplicationLayerInterface{tsrv, srv.SystemLayer()} {
+			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
+		}
+		f, err := rangefeed.NewFactory(tsrv.AppStopper(), db, tsrv.ClusterSettings(), nil)
+		require.NoError(t, err)
+
+		// We start the rangefeed over a narrower span than the AddSSTable (c-e vs
+		// a-f), to ensure the entire SST is emitted even if the registration is
+		// narrower.
+		var once sync.Once
+		checkpointC := make(chan struct{})
+		sstC := make(chan kvcoord.RangeFeedMessage)
+		spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}
+		r, err := f.RangeFeed(ctx, "test", spans, db.Clock().Now(),
+			func(ctx context.Context, value *kvpb.RangeFeedValue) {},
+			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+				once.Do(func() {
+					close(checkpointC)
+				})
+			}),
+			rangefeed.WithOnSSTable(func(
+				ctx context.Context, sst *kvpb.RangeFeedSSTable, registeredSpan roachpb.Span,
+			) {
+				select {
+				case sstC <- kvcoord.RangeFeedMessage{
+					RangeFeedEvent: &kvpb.RangeFeedEvent{
+						SST: sst,
+					},
+					RegisteredSpan: registeredSpan,
+				}:
+				case <-ctx.Done():
+				}
+			}),
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
+		require.NoError(t, err)
+		defer r.Close()
+
+		// Wait for initial checkpoint.
+		select {
+		case <-checkpointC:
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for checkpoint")
+		}
+
+		// Ingest an SST.
+		now := db.Clock().Now()
+		now.Logical = 0
+		ts := int(now.WallTime)
+		sstKVs := kvs{
+			pointKV("a", ts, "1"),
+			pointKV("b", ts, "2"),
+			pointKV("c", ts, "3"),
+			rangeKV("d", "e", ts, ""),
+		}
+		sst, sstStart, sstEnd := storageutils.MakeSST(t, tsrv.ClusterSettings(), sstKVs)
+		_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
+			false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{},
+			nil, /* stats */
+			false /* ingestAsWrites */, now)
+		require.Nil(t, pErr)
+
+		// Wait for the SST event and check its contents.
+		var sstMessage kvcoord.RangeFeedMessage
+		select {
+		case sstMessage = <-sstC:
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for SST event")
+		}
+
+		require.Equal(t, roachpb.Span{Key: sstStart, EndKey: sstEnd}, sstMessage.SST.Span)
+		require.Equal(t, now, sstMessage.SST.WriteTS)
+		require.Equal(t, sstKVs, storageutils.ScanSST(t, sstMessage.SST.Data))
+		require.Equal(t, spans[0], sstMessage.RegisteredSpan)
 	})
-	defer srv.Stopper().Stop(ctx)
-	tsrv := srv.ApplicationLayer()
-
-	_, _, err := srv.SplitRange(roachpb.Key("a"))
-	require.NoError(t, err)
-
-	for _, l := range []serverutils.ApplicationLayerInterface{tsrv, srv.SystemLayer()} {
-		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-	}
-	f, err := rangefeed.NewFactory(tsrv.AppStopper(), db, tsrv.ClusterSettings(), nil)
-	require.NoError(t, err)
-
-	// We start the rangefeed over a narrower span than the AddSSTable (c-e vs
-	// a-f), to ensure the entire SST is emitted even if the registration is
-	// narrower.
-	var once sync.Once
-	checkpointC := make(chan struct{})
-	sstC := make(chan kvcoord.RangeFeedMessage)
-	spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}
-	r, err := f.RangeFeed(ctx, "test", spans, db.Clock().Now(),
-		func(ctx context.Context, value *kvpb.RangeFeedValue) {},
-		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-			once.Do(func() {
-				close(checkpointC)
-			})
-		}),
-		rangefeed.WithOnSSTable(func(ctx context.Context, sst *kvpb.RangeFeedSSTable, registeredSpan roachpb.Span) {
-			select {
-			case sstC <- kvcoord.RangeFeedMessage{
-				RangeFeedEvent: &kvpb.RangeFeedEvent{
-					SST: sst,
-				},
-				RegisteredSpan: registeredSpan,
-			}:
-			case <-ctx.Done():
-			}
-		}),
-	)
-	require.NoError(t, err)
-	defer r.Close()
-
-	// Wait for initial checkpoint.
-	select {
-	case <-checkpointC:
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for checkpoint")
-	}
-
-	// Ingest an SST.
-	now := db.Clock().Now()
-	now.Logical = 0
-	ts := int(now.WallTime)
-	sstKVs := kvs{
-		pointKV("a", ts, "1"),
-		pointKV("b", ts, "2"),
-		pointKV("c", ts, "3"),
-		rangeKV("d", "e", ts, ""),
-	}
-	sst, sstStart, sstEnd := storageutils.MakeSST(t, tsrv.ClusterSettings(), sstKVs)
-	_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
-		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
-		false /* ingestAsWrites */, now)
-	require.Nil(t, pErr)
-
-	// Wait for the SST event and check its contents.
-	var sstMessage kvcoord.RangeFeedMessage
-	select {
-	case sstMessage = <-sstC:
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for SST event")
-	}
-
-	require.Equal(t, roachpb.Span{Key: sstStart, EndKey: sstEnd}, sstMessage.SST.Span)
-	require.Equal(t, now, sstMessage.SST.WriteTS)
-	require.Equal(t, sstKVs, storageutils.ScanSST(t, sstMessage.SST.Data))
-	require.Equal(t, spans[0], sstMessage.RegisteredSpan)
 }
 
 // TestWithOnSSTableCatchesUpIfNotSet tests that the rangefeed runs a catchup
@@ -576,101 +622,105 @@ func TestWithOnSSTableCatchesUpIfNotSet(t *testing.T) {
 
 	storage.DisableMetamorphicSimpleValueEncoding(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109473),
-			Knobs: base.TestingKnobs{
-				Store: &kvserver.StoreTestingKnobs{
-					SmallEngineBlocks: smallEngineBlocks,
+		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109473), Knobs: base.TestingKnobs{
+					Store: &kvserver.StoreTestingKnobs{
+						SmallEngineBlocks: smallEngineBlocks,
+					},
 				},
 			},
-		},
-	})
-	defer tc.Stopper().Stop(ctx)
-	tsrv := tc.Server(0)
-	srv := tsrv.ApplicationLayer()
-	db := srv.DB()
+		})
+		defer tc.Stopper().Stop(ctx)
+		tsrv := tc.Server(0)
+		srv := tsrv.ApplicationLayer()
+		db := srv.DB()
 
-	_, _, err := tc.SplitRange(roachpb.Key("a"))
-	require.NoError(t, err)
-	require.NoError(t, tc.WaitForFullReplication())
+		_, _, err := tc.SplitRange(roachpb.Key("a"))
+		require.NoError(t, err)
+		require.NoError(t, tc.WaitForFullReplication())
 
-	// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-	for _, l := range []serverutils.ApplicationLayerInterface{srv, tsrv.SystemLayer()} {
-		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-	}
-
-	f, err := rangefeed.NewFactory(srv.AppStopper(), db, srv.ClusterSettings(), nil)
-	require.NoError(t, err)
-
-	// We start the rangefeed over a narrower span than the AddSSTable (c-e vs
-	// a-f), to ensure only the restricted span is emitted by the catchup scan.
-	var once sync.Once
-	checkpointC := make(chan struct{})
-	rowC := make(chan *kvpb.RangeFeedValue)
-	spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}
-	r, err := f.RangeFeed(ctx, "test", spans, db.Clock().Now(),
-		func(ctx context.Context, value *kvpb.RangeFeedValue) {
-			select {
-			case rowC <- value:
-			case <-ctx.Done():
-			}
-		},
-		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-			once.Do(func() {
-				close(checkpointC)
-			})
-		}),
-	)
-	require.NoError(t, err)
-	defer r.Close()
-
-	// Wait for initial checkpoint.
-	select {
-	case <-checkpointC:
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for checkpoint")
-	}
-
-	// Ingest an SST.
-	now := db.Clock().Now()
-	now.Logical = 0
-	ts := int(now.WallTime)
-	sstKVs := kvs{
-		pointKV("a", ts, "1"),
-		pointKV("b", ts, "2"),
-		pointKV("c", ts, "3"),
-		pointKV("d", ts, "4"),
-		pointKV("e", ts, "5"),
-	}
-	expectKVs := kvs{pointKV("c", ts, "3"), pointKV("d", ts, "4")}
-	sst, sstStart, sstEnd := storageutils.MakeSST(t, srv.ClusterSettings(), sstKVs)
-	_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
-		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
-		false /* ingestAsWrites */, now)
-	require.Nil(t, pErr)
-
-	// Assert that we receive the KV pairs within the rangefeed span.
-	timer := time.NewTimer(3 * time.Second)
-	var seenKVs kvs
-	for len(seenKVs) < len(expectKVs) {
-		select {
-		case row := <-rowC:
-			seenKVs = append(seenKVs, storage.MVCCKeyValue{
-				Key: storage.MVCCKey{
-					Key:       row.Key,
-					Timestamp: row.Value.Timestamp,
-				},
-				Value: row.Value.RawBytes,
-			})
-		case <-timer.C:
-			require.Fail(t, "timed out waiting for catchup scan", "saw entries: %v", seenKVs)
+		for _, l := range []serverutils.ApplicationLayerInterface{tsrv, tsrv.SystemLayer()} {
+			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
 		}
-	}
-	require.Equal(t, expectKVs, seenKVs)
+
+		f, err := rangefeed.NewFactory(srv.AppStopper(), db, srv.ClusterSettings(), nil)
+		require.NoError(t, err)
+
+		// We start the rangefeed over a narrower span than the AddSSTable (c-e vs
+		// a-f), to ensure only the restricted span is emitted by the catchup scan.
+		var once sync.Once
+		checkpointC := make(chan struct{})
+		rowC := make(chan *kvpb.RangeFeedValue)
+		spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}
+		r, err := f.RangeFeed(ctx, "test", spans, db.Clock().Now(),
+			func(ctx context.Context, value *kvpb.RangeFeedValue) {
+				select {
+				case rowC <- value:
+				case <-ctx.Done():
+				}
+			},
+			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+				once.Do(func() {
+					close(checkpointC)
+				})
+			}),
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
+		require.NoError(t, err)
+		defer r.Close()
+
+		// Wait for initial checkpoint.
+		select {
+		case <-checkpointC:
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for checkpoint")
+		}
+
+		// Ingest an SST.
+		now := db.Clock().Now()
+		now.Logical = 0
+		ts := int(now.WallTime)
+		sstKVs := kvs{
+			pointKV("a", ts, "1"),
+			pointKV("b", ts, "2"),
+			pointKV("c", ts, "3"),
+			pointKV("d", ts, "4"),
+			pointKV("e", ts, "5"),
+		}
+		expectKVs := kvs{pointKV("c", ts, "3"), pointKV("d", ts, "4")}
+		sst, sstStart, sstEnd := storageutils.MakeSST(t, srv.ClusterSettings(), sstKVs)
+		_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
+			false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{},
+			nil, /* stats */
+			false /* ingestAsWrites */, now)
+		require.Nil(t, pErr)
+
+		// Assert that we receive the KV pairs within the rangefeed span.
+		timer := time.NewTimer(3 * time.Second)
+		var seenKVs kvs
+		for len(seenKVs) < len(expectKVs) {
+			select {
+			case row := <-rowC:
+				seenKVs = append(seenKVs, storage.MVCCKeyValue{
+					Key: storage.MVCCKey{
+						Key:       row.Key,
+						Timestamp: row.Value.Timestamp,
+					},
+					Value: row.Value.RawBytes,
+				})
+			case <-timer.C:
+				require.Fail(t, "timed out waiting for catchup scan", "saw entries: %v", seenKVs)
+			}
+		}
+		require.Equal(t, expectKVs, seenKVs)
+	})
 }
 
 // TestWithOnDeleteRange tests that the rangefeed emits MVCC range tombstones.
@@ -681,174 +731,181 @@ func TestWithOnDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			Knobs: base.TestingKnobs{
-				Store: &kvserver.StoreTestingKnobs{
-					SmallEngineBlocks: smallEngineBlocks,
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx := context.Background()
+		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Store: &kvserver.StoreTestingKnobs{
+						SmallEngineBlocks: smallEngineBlocks,
+					},
 				},
 			},
-		},
+		})
+		defer tc.Stopper().Stop(ctx)
+		tsrv := tc.Server(0)
+		srv := tsrv.ApplicationLayer()
+		db := srv.DB()
+
+		_, _, err := tc.SplitRange(roachpb.Key("a"))
+		require.NoError(t, err)
+		require.NoError(t, tc.WaitForFullReplication())
+
+		for _, l := range []serverutils.ApplicationLayerInterface{tsrv, tsrv.SystemLayer()} {
+			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
+		}
+
+		f, err := rangefeed.NewFactory(srv.AppStopper(), db, srv.ClusterSettings(), nil)
+		require.NoError(t, err)
+
+		mkKey := func(s string) string {
+			return string(append(srv.Codec().TenantPrefix(), roachpb.Key(s)...))
+		}
+		// We lay down a few MVCC range tombstones and points. The first range
+		// tombstone should not be visible, because initial scans do not emit
+		// tombstones, nor should the points covered by it. The second range tombstone
+		// should be visible, because catchup scans do emit tombstones. The range
+		// tombstone should be ordered after the initial point, but before the foo
+		// catchup point, and the previous values should respect the range tombstones.
+		require.NoError(t, db.Put(ctx, mkKey("covered"), "covered"))
+		require.NoError(t, db.Put(ctx, mkKey("foo"), "covered"))
+		require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
+		require.NoError(t, db.Put(ctx, mkKey("foo"), "initial"))
+		rangeFeedTS := db.Clock().Now()
+		require.NoError(t, db.Put(ctx, mkKey("covered"), "catchup"))
+		require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
+		require.NoError(t, db.Put(ctx, mkKey("foo"), "catchup"))
+
+		// We start the rangefeed over a narrower span than the DeleteRanges (c-g),
+		// to ensure the DeleteRange event is truncated to the registration span.
+		var checkpointOnce sync.Once
+		checkpointC := make(chan struct{})
+		deleteRangeC := make(chan *kvpb.RangeFeedDeleteRange)
+		rowC := make(chan *kvpb.RangeFeedValue)
+
+		spans := []roachpb.Span{{
+			Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
+			EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
+		}}
+		r, err := f.RangeFeed(ctx, "test", spans, rangeFeedTS,
+			func(ctx context.Context, e *kvpb.RangeFeedValue) {
+				select {
+				case rowC <- e:
+				case <-ctx.Done():
+				}
+			},
+			rangefeed.WithDiff(true),
+			rangefeed.WithInitialScan(nil),
+			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+				checkpointOnce.Do(func() {
+					close(checkpointC)
+				})
+			}),
+			rangefeed.WithOnDeleteRange(func(ctx context.Context, e *kvpb.RangeFeedDeleteRange) {
+				select {
+				case deleteRangeC <- e:
+				case <-ctx.Done():
+				}
+			}),
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
+		require.NoError(t, err)
+		defer r.Close()
+
+		// Wait for initial scan. We should see the foo=initial point, but not the
+		// range tombstone nor the covered points.
+		select {
+		case e := <-rowC:
+			require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
+			value, err := e.Value.GetBytes()
+			require.NoError(t, err)
+			require.Equal(t, "initial", string(value))
+			prevValue, err := e.PrevValue.GetBytes()
+			require.NoError(t, err)
+			require.Equal(t, "initial", string(prevValue)) // initial scans supply current as prev
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for initial scan event")
+		}
+
+		// Wait for catchup scan. We should see the second range tombstone, truncated
+		// to the rangefeed bounds (c-g), and it should be ordered before the points
+		// covered=catchup and foo=catchup. both points should have a tombstone as the
+		// previous value.
+		select {
+		case e := <-deleteRangeC:
+			require.Equal(t, roachpb.Span{
+				Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
+				EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
+			}, e.Span)
+			require.NotEmpty(t, e.Timestamp)
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for DeleteRange event")
+		}
+
+		select {
+		case e := <-rowC:
+			require.Equal(t, roachpb.Key(mkKey("covered")), e.Key)
+			value, err := e.Value.GetBytes()
+			require.NoError(t, err)
+			require.Equal(t, "catchup", string(value))
+			prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
+			require.NoError(t, err)
+			require.True(t, prevValue.IsTombstone())
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for foo=catchup event")
+		}
+
+		select {
+		case e := <-rowC:
+			require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
+			value, err := e.Value.GetBytes()
+			require.NoError(t, err)
+			require.Equal(t, "catchup", string(value))
+			prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
+			require.NoError(t, err)
+			require.True(t, prevValue.IsTombstone())
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for foo=catchup event")
+		}
+
+		// Wait for checkpoint after catchup scan.
+		select {
+		case <-checkpointC:
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for checkpoint")
+		}
+
+		// Send another DeleteRange, and wait for the rangefeed event. This should
+		// be truncated to the rangefeed bounds (c-g).
+		require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
+		select {
+		case e := <-deleteRangeC:
+			require.Equal(t, roachpb.Span{
+				Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
+				EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
+			}, e.Span)
+			require.NotEmpty(t, e.Timestamp)
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for DeleteRange event")
+		}
+
+		// A final point write should be emitted with a tombstone as the previous value.
+		require.NoError(t, db.Put(ctx, mkKey("foo"), "final"))
+		select {
+		case e := <-rowC:
+			require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
+			value, err := e.Value.GetBytes()
+			require.NoError(t, err)
+			require.Equal(t, "final", string(value))
+			prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
+			require.NoError(t, err)
+			require.True(t, prevValue.IsTombstone())
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for foo=final event")
+		}
 	})
-	defer tc.Stopper().Stop(ctx)
-	tsrv := tc.Server(0)
-	srv := tsrv.ApplicationLayer()
-	db := srv.DB()
-
-	_, _, err := tc.SplitRange(roachpb.Key("a"))
-	require.NoError(t, err)
-	require.NoError(t, tc.WaitForFullReplication())
-
-	_, err = tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true")
-	require.NoError(t, err)
-	f, err := rangefeed.NewFactory(srv.AppStopper(), db, srv.ClusterSettings(), nil)
-	require.NoError(t, err)
-
-	mkKey := func(s string) string {
-		return string(append(srv.Codec().TenantPrefix(), roachpb.Key(s)...))
-	}
-	// We lay down a few MVCC range tombstones and points. The first range
-	// tombstone should not be visible, because initial scans do not emit
-	// tombstones, nor should the points covered by it. The second range tombstone
-	// should be visible, because catchup scans do emit tombstones. The range
-	// tombstone should be ordered after the initial point, but before the foo
-	// catchup point, and the previous values should respect the range tombstones.
-	require.NoError(t, db.Put(ctx, mkKey("covered"), "covered"))
-	require.NoError(t, db.Put(ctx, mkKey("foo"), "covered"))
-	require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
-	require.NoError(t, db.Put(ctx, mkKey("foo"), "initial"))
-	rangeFeedTS := db.Clock().Now()
-	require.NoError(t, db.Put(ctx, mkKey("covered"), "catchup"))
-	require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
-	require.NoError(t, db.Put(ctx, mkKey("foo"), "catchup"))
-
-	// We start the rangefeed over a narrower span than the DeleteRanges (c-g),
-	// to ensure the DeleteRange event is truncated to the registration span.
-	var checkpointOnce sync.Once
-	checkpointC := make(chan struct{})
-	deleteRangeC := make(chan *kvpb.RangeFeedDeleteRange)
-	rowC := make(chan *kvpb.RangeFeedValue)
-
-	spans := []roachpb.Span{{
-		Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
-		EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
-	}}
-	r, err := f.RangeFeed(ctx, "test", spans, rangeFeedTS,
-		func(ctx context.Context, e *kvpb.RangeFeedValue) {
-			select {
-			case rowC <- e:
-			case <-ctx.Done():
-			}
-		},
-		rangefeed.WithDiff(true),
-		rangefeed.WithInitialScan(nil),
-		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-			checkpointOnce.Do(func() {
-				close(checkpointC)
-			})
-		}),
-		rangefeed.WithOnDeleteRange(func(ctx context.Context, e *kvpb.RangeFeedDeleteRange) {
-			select {
-			case deleteRangeC <- e:
-			case <-ctx.Done():
-			}
-		}),
-	)
-	require.NoError(t, err)
-	defer r.Close()
-
-	// Wait for initial scan. We should see the foo=initial point, but not the
-	// range tombstone nor the covered points.
-	select {
-	case e := <-rowC:
-		require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
-		value, err := e.Value.GetBytes()
-		require.NoError(t, err)
-		require.Equal(t, "initial", string(value))
-		prevValue, err := e.PrevValue.GetBytes()
-		require.NoError(t, err)
-		require.Equal(t, "initial", string(prevValue)) // initial scans supply current as prev
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for initial scan event")
-	}
-
-	// Wait for catchup scan. We should see the second range tombstone, truncated
-	// to the rangefeed bounds (c-g), and it should be ordered before the points
-	// covered=catchup and foo=catchup. both points should have a tombstone as the
-	// previous value.
-	select {
-	case e := <-deleteRangeC:
-		require.Equal(t, roachpb.Span{
-			Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
-			EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
-		}, e.Span)
-		require.NotEmpty(t, e.Timestamp)
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for DeleteRange event")
-	}
-
-	select {
-	case e := <-rowC:
-		require.Equal(t, roachpb.Key(mkKey("covered")), e.Key)
-		value, err := e.Value.GetBytes()
-		require.NoError(t, err)
-		require.Equal(t, "catchup", string(value))
-		prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
-		require.NoError(t, err)
-		require.True(t, prevValue.IsTombstone())
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for foo=catchup event")
-	}
-
-	select {
-	case e := <-rowC:
-		require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
-		value, err := e.Value.GetBytes()
-		require.NoError(t, err)
-		require.Equal(t, "catchup", string(value))
-		prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
-		require.NoError(t, err)
-		require.True(t, prevValue.IsTombstone())
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for foo=catchup event")
-	}
-
-	// Wait for checkpoint after catchup scan.
-	select {
-	case <-checkpointC:
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for checkpoint")
-	}
-
-	// Send another DeleteRange, and wait for the rangefeed event. This should
-	// be truncated to the rangefeed bounds (c-g).
-	require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
-	select {
-	case e := <-deleteRangeC:
-		require.Equal(t, roachpb.Span{
-			Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
-			EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
-		}, e.Span)
-		require.NotEmpty(t, e.Timestamp)
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for DeleteRange event")
-	}
-
-	// A final point write should be emitted with a tombstone as the previous value.
-	require.NoError(t, db.Put(ctx, mkKey("foo"), "final"))
-	select {
-	case e := <-rowC:
-		require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
-		value, err := e.Value.GetBytes()
-		require.NoError(t, err)
-		require.Equal(t, "final", string(value))
-		prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
-		require.NoError(t, err)
-		require.True(t, prevValue.IsTombstone())
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for foo=final event")
-	}
 }
 
 // TestUnrecoverableErrors verifies that unrecoverable internal errors are surfaced
@@ -857,89 +914,93 @@ func TestUnrecoverableErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109472),
-
-		Knobs: base.TestingKnobs{
-			SpanConfig: &spanconfig.TestingKnobs{
-				ConfigureScratchRange: true,
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx := context.Background()
+		srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109472),
+			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					ConfigureScratchRange: true,
+				},
 			},
-		},
-	})
-	defer srv.Stopper().Stop(ctx)
-	ts := srv.ApplicationLayer()
+		})
 
-	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-	_, _, err := srv.SplitRange(scratchKey)
-	require.NoError(t, err)
-	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+		defer srv.Stopper().Stop(ctx)
+		ts := srv.ApplicationLayer()
 
-	sp := roachpb.Span{
-		Key:    scratchKey,
-		EndKey: scratchKey.PrefixEnd(),
-	}
-	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		// Lower the closed timestamp target duration to speed up the test.
-		closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
-	}
+		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+		_, _, err := srv.SplitRange(scratchKey)
+		require.NoError(t, err)
+		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
 
-	store, err := srv.GetStores().(*kvserver.Stores).GetStore(srv.GetFirstStoreID())
-	require.NoError(t, err)
+		sp := roachpb.Span{
+			Key:    scratchKey,
+			EndKey: scratchKey.PrefixEnd(),
+		}
+		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
+			// Lower the closed timestamp target duration to speed up the test.
+			closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
+		}
 
-	{
-		// Lower the protectedts Cache refresh interval, so that the
-		// `preGCThresholdTS` defined below is less than the protectedts
-		// `readAt - GCTTL` window, resulting in a BatchTimestampBelowGCError.
-		_, err := sqlDB.Exec("SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms'")
+		store, err := srv.GetStores().(*kvserver.Stores).GetStore(srv.GetFirstStoreID())
 		require.NoError(t, err)
 
-		ptsReader := store.GetStoreConfig().ProtectedTimestampReader
-		require.NoError(t,
-			spanconfigptsreader.TestingRefreshPTSState(ctx, t, ptsReader, srv.SystemLayer().Clock().Now()))
-	}
+		{
+			// Lower the protectedts Cache refresh interval, so that the
+			// `preGCThresholdTS` defined below is less than the protectedts
+			// `readAt - GCTTL` window, resulting in a BatchTimestampBelowGCError.
+			_, err = sqlDB.Exec("SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms'")
+			require.NoError(t, err)
 
-	f, err := rangefeed.NewFactory(ts.AppStopper(), kvDB, ts.ClusterSettings(), nil)
-	require.NoError(t, err)
-
-	preGCThresholdTS := hlc.Timestamp{WallTime: 1}
-	mu := struct {
-		syncutil.Mutex
-		internalErr error
-	}{}
-
-	testutils.SucceedsSoon(t, func() error {
-		repl := store.LookupReplica(roachpb.RKey(scratchKey))
-		if repl.SpanConfig().GCPolicy.IgnoreStrictEnforcement {
-			return errors.New("waiting for span config to apply")
+			ptsReader := store.GetStoreConfig().ProtectedTimestampReader
+			require.NoError(t,
+				spanconfigptsreader.TestingRefreshPTSState(ctx, t, ptsReader, srv.SystemLayer().Clock().Now()))
 		}
-		require.NoError(t, repl.ReadProtectedTimestampsForTesting(ctx))
-		return nil
-	})
 
-	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, preGCThresholdTS,
-		func(context.Context, *kvpb.RangeFeedValue) {},
-		rangefeed.WithDiff(true),
-		rangefeed.WithOnInternalError(func(ctx context.Context, err error) {
+		f, err := rangefeed.NewFactory(ts.AppStopper(), kvDB, ts.ClusterSettings(), nil)
+		require.NoError(t, err)
+
+		preGCThresholdTS := hlc.Timestamp{WallTime: 1}
+		mu := struct {
+			syncutil.Mutex
+			internalErr error
+		}{}
+
+		testutils.SucceedsSoon(t, func() error {
+			repl := store.LookupReplica(roachpb.RKey(scratchKey))
+			if repl.SpanConfig().GCPolicy.IgnoreStrictEnforcement {
+				return errors.New("waiting for span config to apply")
+			}
+			require.NoError(t, repl.ReadProtectedTimestampsForTesting(ctx))
+			return nil
+		})
+
+		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, preGCThresholdTS,
+			func(context.Context, *kvpb.RangeFeedValue) {},
+			rangefeed.WithDiff(true),
+			rangefeed.WithOnInternalError(func(ctx context.Context, err error) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				mu.internalErr = err
+			}),
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
+		require.NoError(t, err)
+		defer r.Close()
+
+		testutils.SucceedsSoon(t, func() error {
 			mu.Lock()
 			defer mu.Unlock()
 
-			mu.internalErr = err
-		}),
-	)
-	require.NoError(t, err)
-	defer r.Close()
-
-	testutils.SucceedsSoon(t, func() error {
-		mu.Lock()
-		defer mu.Unlock()
-
-		if !errors.HasType(mu.internalErr, &kvpb.BatchTimestampBeforeGCError{}) {
-			return errors.New("expected internal error")
-		}
-		return nil
+			if !errors.HasType(mu.internalErr, &kvpb.BatchTimestampBeforeGCError{}) {
+				return errors.New("expected internal error")
+			}
+			return nil
+		})
 	})
 }
 
@@ -949,79 +1010,83 @@ func TestMVCCHistoryMutationError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(ctx)
-	ts := srv.ApplicationLayer()
+		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+		defer srv.Stopper().Stop(ctx)
+		ts := srv.ApplicationLayer()
 
-	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-	_, _, err := srv.SplitRange(scratchKey)
-	require.NoError(t, err)
-	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-	sp := roachpb.Span{
-		Key:    scratchKey,
-		EndKey: scratchKey.PrefixEnd(),
-	}
-	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		// Lower the closed timestamp target duration to speed up the test.
-		closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
-	}
-
-	// Set up a rangefeed.
-	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-	require.NoError(t, err)
-
-	var once sync.Once
-	checkpointC := make(chan struct{})
-	errC := make(chan error)
-	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, ts.Clock().Now(),
-		func(context.Context, *kvpb.RangeFeedValue) {},
-		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-			once.Do(func() {
-				close(checkpointC)
-			})
-		}),
-		rangefeed.WithOnInternalError(func(ctx context.Context, err error) {
-			select {
-			case errC <- err:
-			case <-ctx.Done():
-			}
-		}),
-	)
-	require.NoError(t, err)
-	defer r.Close()
-
-	// Wait for initial checkpoint.
-	select {
-	case <-checkpointC:
-	case err := <-errC:
+		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+		_, _, err := srv.SplitRange(scratchKey)
 		require.NoError(t, err)
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for checkpoint")
-	}
+		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+		sp := roachpb.Span{
+			Key:    scratchKey,
+			EndKey: scratchKey.PrefixEnd(),
+		}
+		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
+			// Lower the closed timestamp target duration to speed up the test.
+			closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
+		}
 
-	// Send a ClearRange request that mutates MVCC history.
-	_, pErr := kv.SendWrapped(ctx, db.NonTransactionalSender(), &kvpb.ClearRangeRequest{
-		RequestHeader: kvpb.RequestHeader{
-			Key:    sp.Key,
-			EndKey: sp.EndKey,
-		},
+		// Set up a rangefeed.
+		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+		require.NoError(t, err)
+
+		var once sync.Once
+		checkpointC := make(chan struct{})
+		errC := make(chan error)
+		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, ts.Clock().Now(),
+			func(context.Context, *kvpb.RangeFeedValue) {},
+			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+				once.Do(func() {
+					close(checkpointC)
+				})
+			}),
+			rangefeed.WithOnInternalError(func(ctx context.Context, err error) {
+				select {
+				case errC <- err:
+				case <-ctx.Done():
+				}
+			}),
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
+		require.NoError(t, err)
+		defer r.Close()
+
+		// Wait for initial checkpoint.
+		select {
+		case <-checkpointC:
+		case err := <-errC:
+			require.NoError(t, err)
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for checkpoint")
+		}
+
+		// Send a ClearRange request that mutates MVCC history.
+		_, pErr := kv.SendWrapped(ctx, db.NonTransactionalSender(), &kvpb.ClearRangeRequest{
+			RequestHeader: kvpb.RequestHeader{
+				Key:    sp.Key,
+				EndKey: sp.EndKey,
+			},
+		})
+		require.Nil(t, pErr)
+
+		// Wait for the MVCCHistoryMutationError.
+		select {
+		case err := <-errC:
+			var mvccErr *kvpb.MVCCHistoryMutationError
+			require.ErrorAs(t, err, &mvccErr)
+			require.Equal(t, &kvpb.MVCCHistoryMutationError{Span: sp}, err)
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "timed out waiting for error")
+		}
 	})
-	require.Nil(t, pErr)
-
-	// Wait for the MVCCHistoryMutationError.
-	select {
-	case err := <-errC:
-		var mvccErr *kvpb.MVCCHistoryMutationError
-		require.ErrorAs(t, err, &mvccErr)
-		require.Equal(t, &kvpb.MVCCHistoryMutationError{Span: sp}, err)
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "timed out waiting for error")
-	}
 }
 
 // TestRangefeedWithLabelsOption verifies go routines started by rangefeed are
@@ -1030,108 +1095,112 @@ func TestRangefeedWithLabelsOption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(ctx)
-	ts := srv.ApplicationLayer()
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx := context.Background()
+		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+		defer srv.Stopper().Stop(ctx)
+		ts := srv.ApplicationLayer()
 
-	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-	_, _, err := srv.SplitRange(scratchKey)
-	require.NoError(t, err)
-	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-	mkKey := func(k string) roachpb.Key {
-		return encoding.EncodeStringAscending(scratchKey, k)
-	}
-	// Split the range a bunch of times.
-	const splits = 10
-	for i := 0; i < splits; i++ {
-		_, _, err := srv.SplitRange(mkKey(string([]byte{'a' + byte(i)})))
+		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+		_, _, err := srv.SplitRange(scratchKey)
 		require.NoError(t, err)
-	}
-
-	require.NoError(t, db.Put(ctx, mkKey("a"), 1))
-	require.NoError(t, db.Put(ctx, mkKey("b"), 2))
-	afterB := db.Clock().Now()
-	require.NoError(t, db.Put(ctx, mkKey("c"), 3))
-
-	sp := roachpb.Span{
-		Key:    scratchKey,
-		EndKey: scratchKey.PrefixEnd(),
-	}
-	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-	}
-
-	const rangefeedName = "test-feed"
-	type label struct {
-		k, v string
-	}
-	defaultLabel := label{k: "rangefeed", v: rangefeedName}
-	label1 := label{k: "caller-label", v: "foo"}
-	label2 := label{k: "another-label", v: "bar"}
-
-	allLabelsCorrect := struct {
-		syncutil.Mutex
-		correct bool
-	}{correct: true}
-
-	verifyLabels := func(ctx context.Context) {
-		allLabelsCorrect.Lock()
-		defer allLabelsCorrect.Unlock()
-		if !allLabelsCorrect.correct {
-			return
+		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+		mkKey := func(k string) roachpb.Key {
+			return encoding.EncodeStringAscending(scratchKey, k)
+		}
+		// Split the range a bunch of times.
+		const splits = 10
+		for i := 0; i < splits; i++ {
+			_, _, err := srv.SplitRange(mkKey(string([]byte{'a' + byte(i)})))
+			require.NoError(t, err)
 		}
 
-		m := make(map[string]string)
-		pprof.ForLabels(ctx, func(k, v string) bool {
-			m[k] = v
-			return true
-		})
+		require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+		require.NoError(t, db.Put(ctx, mkKey("b"), 2))
+		afterB := db.Clock().Now()
+		require.NoError(t, db.Put(ctx, mkKey("c"), 3))
 
-		allLabelsCorrect.correct =
-			m[defaultLabel.k] == defaultLabel.v && m[label1.k] == label1.v && m[label2.k] == label2.v
-	}
+		sp := roachpb.Span{
+			Key:    scratchKey,
+			EndKey: scratchKey.PrefixEnd(),
+		}
+		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
+		}
 
-	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-	require.NoError(t, err)
-	initialScanDone := make(chan struct{})
+		const rangefeedName = "test-feed"
+		type label struct {
+			k, v string
+		}
+		defaultLabel := label{k: "rangefeed", v: rangefeedName}
+		label1 := label{k: "caller-label", v: "foo"}
+		label2 := label{k: "another-label", v: "bar"}
 
-	// We'll emit keyD a bit later, once initial scan completes.
-	keyD := mkKey("d")
-	var keyDSeen sync.Once
-	keyDSeenCh := make(chan struct{})
+		allLabelsCorrect := struct {
+			syncutil.Mutex
+			correct bool
+		}{correct: true}
 
-	r, err := f.RangeFeed(ctx, rangefeedName, []roachpb.Span{sp}, afterB,
-		func(ctx context.Context, value *kvpb.RangeFeedValue) {
-			verifyLabels(ctx)
-			if value.Key.Equal(keyD) {
-				keyDSeen.Do(func() { close(keyDSeenCh) })
+		verifyLabels := func(ctx context.Context) {
+			allLabelsCorrect.Lock()
+			defer allLabelsCorrect.Unlock()
+			if !allLabelsCorrect.correct {
+				return
 			}
-		},
-		rangefeed.WithPProfLabel(label1.k, label1.v),
-		rangefeed.WithPProfLabel(label2.k, label2.v),
-		rangefeed.WithInitialScanParallelismFn(func() int { return 3 }),
-		rangefeed.WithOnScanCompleted(func(ctx context.Context, sp roachpb.Span) error {
-			verifyLabels(ctx)
-			return nil
-		}),
-		rangefeed.WithInitialScan(func(ctx context.Context) {
-			verifyLabels(ctx)
-			close(initialScanDone)
-		}),
-	)
-	require.NoError(t, err)
-	defer r.Close()
 
-	<-initialScanDone
+			m := make(map[string]string)
+			pprof.ForLabels(ctx, func(k, v string) bool {
+				m[k] = v
+				return true
+			})
 
-	// Write a new value for "a" and make sure it is seen.
-	require.NoError(t, db.Put(ctx, keyD, 5))
-	<-keyDSeenCh
-	allLabelsCorrect.Lock()
-	defer allLabelsCorrect.Unlock()
-	require.True(t, allLabelsCorrect.correct)
+			allLabelsCorrect.correct =
+				m[defaultLabel.k] == defaultLabel.v && m[label1.k] == label1.v && m[label2.k] == label2.v
+		}
+
+		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+		require.NoError(t, err)
+		initialScanDone := make(chan struct{})
+
+		// We'll emit keyD a bit later, once initial scan completes.
+		keyD := mkKey("d")
+		var keyDSeen sync.Once
+		keyDSeenCh := make(chan struct{})
+
+		r, err := f.RangeFeed(ctx, rangefeedName, []roachpb.Span{sp}, afterB,
+			func(ctx context.Context, value *kvpb.RangeFeedValue) {
+				verifyLabels(ctx)
+				if value.Key.Equal(keyD) {
+					keyDSeen.Do(func() { close(keyDSeenCh) })
+				}
+			},
+			rangefeed.WithPProfLabel(label1.k, label1.v),
+			rangefeed.WithPProfLabel(label2.k, label2.v),
+			rangefeed.WithInitialScanParallelismFn(func() int { return 3 }),
+			rangefeed.WithOnScanCompleted(func(ctx context.Context, sp roachpb.Span) error {
+				verifyLabels(ctx)
+				return nil
+			}),
+			rangefeed.WithInitialScan(func(ctx context.Context) {
+				verifyLabels(ctx)
+				close(initialScanDone)
+			}),
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
+		require.NoError(t, err)
+		defer r.Close()
+
+		<-initialScanDone
+
+		// Write a new value for "a" and make sure it is seen.
+		require.NoError(t, db.Put(ctx, keyD, 5))
+		<-keyDSeenCh
+		allLabelsCorrect.Lock()
+		defer allLabelsCorrect.Unlock()
+		require.True(t, allLabelsCorrect.correct)
+	})
 }
 
 // TestRangeFeedStartTimeExclusive tests that the start timestamp of the
@@ -1140,55 +1209,59 @@ func TestRangeFeedStartTimeExclusive(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(ctx)
-	ts := srv.ApplicationLayer()
+	testutils.RunValues(t, "feed_type", procTypes, func(t *testing.T, s feedProcessorType) {
+		ctx := context.Background()
+		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+		defer srv.Stopper().Stop(ctx)
+		ts := srv.ApplicationLayer()
 
-	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-	_, _, err := srv.SplitRange(scratchKey)
-	require.NoError(t, err)
-	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-	mkKey := func(k string) roachpb.Key {
-		return encoding.EncodeStringAscending(scratchKey, k)
-	}
-	span := roachpb.Span{Key: scratchKey, EndKey: scratchKey.PrefixEnd()}
-
-	// Write three versions of "foo". Get the timestamp of the second version.
-	require.NoError(t, db.Put(ctx, mkKey("foo"), 1))
-	require.NoError(t, db.Put(ctx, mkKey("foo"), 2))
-	kv, err := db.Get(ctx, mkKey("foo"))
-	require.NoError(t, err)
-	ts2 := kv.Value.Timestamp
-	require.NoError(t, db.Put(ctx, mkKey("foo"), 3))
-
-	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-	}
-
-	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-	require.NoError(t, err)
-	rows := make(chan *kvpb.RangeFeedValue)
-	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{span}, ts2,
-		func(ctx context.Context, value *kvpb.RangeFeedValue) {
-			select {
-			case rows <- value:
-			case <-ctx.Done():
-			}
-		},
-	)
-	require.NoError(t, err)
-	defer r.Close()
-
-	// The first emitted version should be 3.
-	select {
-	case row := <-rows:
-		require.Equal(t, mkKey("foo"), row.Key)
-		v, err := row.Value.GetInt()
+		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+		_, _, err := srv.SplitRange(scratchKey)
 		require.NoError(t, err)
-		require.EqualValues(t, 3, v)
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for event")
-	}
+		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+		mkKey := func(k string) roachpb.Key {
+			return encoding.EncodeStringAscending(scratchKey, k)
+		}
+		span := roachpb.Span{Key: scratchKey, EndKey: scratchKey.PrefixEnd()}
+
+		// Write three versions of "foo". Get the timestamp of the second version.
+		require.NoError(t, db.Put(ctx, mkKey("foo"), 1))
+		require.NoError(t, db.Put(ctx, mkKey("foo"), 2))
+		kv, err := db.Get(ctx, mkKey("foo"))
+		require.NoError(t, err)
+		ts2 := kv.Value.Timestamp
+		require.NoError(t, db.Put(ctx, mkKey("foo"), 3))
+
+		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+			kvserver.RangeFeedUseScheduler.Override(ctx, &l.ClusterSettings().SV, s.useScheduler)
+		}
+
+		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+		require.NoError(t, err)
+		rows := make(chan *kvpb.RangeFeedValue)
+		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{span}, ts2,
+			func(ctx context.Context, value *kvpb.RangeFeedValue) {
+				select {
+				case rows <- value:
+				case <-ctx.Done():
+				}
+			},
+			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
+		)
+		require.NoError(t, err)
+		defer r.Close()
+
+		// The first emitted version should be 3.
+		select {
+		case row := <-rows:
+			require.Equal(t, mkKey("foo"), row.Key)
+			v, err := row.Value.GetInt()
+			require.NoError(t, err)
+			require.EqualValues(t, 3, v)
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for event")
+		}
+	})
 }

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -62,7 +62,11 @@ type feedProcessorType struct {
 }
 
 func (t feedProcessorType) String() string {
-	return fmt.Sprintf("mux=%t_scheduler=%t", t.useMuxRangefeed, t.useScheduler)
+	if t.useMuxRangefeed {
+		return fmt.Sprintf("mux/scheduler=%t", t.useScheduler)
+	} else {
+		return fmt.Sprintf("single/scheduler=%t", t.useScheduler)
+	}
 }
 
 var procTypes = []feedProcessorType{

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1114,14 +1114,14 @@ func TestEvalAddSSTable(t *testing.T) {
 		},
 	}
 	testutils.RunTrueAndFalse(t, "IngestAsWrites", func(t *testing.T, ingestAsWrites bool) {
-		testutils.RunValues(t, "RewriteConcurrency", []interface{}{0, 8}, func(t *testing.T, c interface{}) {
-			testutils.RunValues(t, "ApproximateDiskBytes", []interface{}{0, 1000000}, func(t *testing.T, approxBytes interface{}) {
-				approxDiskBytes := uint64(approxBytes.(int))
+		testutils.RunValues(t, "RewriteConcurrency", []int64{0, 8}, func(t *testing.T, c int64) {
+			testutils.RunValues(t, "ApproximateDiskBytes", []int{0, 1000000}, func(t *testing.T, approxBytes int) {
+				approxDiskBytes := uint64(approxBytes)
 				for name, tc := range testcases {
 					t.Run(name, func(t *testing.T) {
 						ctx := context.Background()
 						st := cluster.MakeTestingClusterSettings()
-						batcheval.AddSSTableRewriteConcurrency.Override(ctx, &st.SV, int64(c.(int)))
+						batcheval.AddSSTableRewriteConcurrency.Override(ctx, &st.SV, c)
 						batcheval.AddSSTableRequireAtRequestTimestamp.Override(ctx, &st.SV, tc.requireReqTS)
 
 						engine := storage.NewDefaultInMemForTesting()

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -441,9 +441,9 @@ func TestTxnReadWithinUncertaintyInterval(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testutils.RunTrueAndFalse(t, "observedTS", func(t *testing.T, observedTS bool) {
-		readOps := []interface{}{"get", "scan", "revScan"}
-		testutils.RunValues(t, "readOp", readOps, func(t *testing.T, readOp interface{}) {
-			testTxnReadWithinUncertaintyInterval(t, observedTS, readOp.(string))
+		readOps := []string{"get", "scan", "revScan"}
+		testutils.RunValues(t, "readOp", readOps, func(t *testing.T, readOp string) {
+			testTxnReadWithinUncertaintyInterval(t, observedTS, readOp)
 		})
 	})
 }

--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -622,18 +622,18 @@ func TestReliableIntentCleanup(t *testing.T) {
 		}
 
 		// The actual tests are run here, using all combinations of parameters.
-		testutils.RunValues(t, "numKeys", []interface{}{1, 100, 100000}, func(t *testing.T, numKeys interface{}) {
+		testutils.RunValues(t, "numKeys", []int{1, 100, 100000}, func(t *testing.T, numKeys int) {
 			testutils.RunTrueAndFalse(t, "singleRange", func(t *testing.T, singleRange bool) {
 				testutils.RunTrueAndFalse(t, "txn", func(t *testing.T, txn bool) {
 					if !txn {
 						testNonTxn(t, testNonTxnSpec{
-							numKeys:     numKeys.(int),
+							numKeys:     numKeys,
 							singleRange: singleRange,
 						})
 						return
 					}
-					finalize := []interface{}{"commit", "rollback", "cancel", "cancelAsync"}
-					testutils.RunValues(t, "finalize", finalize, func(t *testing.T, finalize interface{}) {
+					finalize := []string{"commit", "rollback", "cancel", "cancelAsync"}
+					testutils.RunValues(t, "finalize", finalize, func(t *testing.T, finalize string) {
 						// TODO(erikgrinaker): cleanup does not always work reliably with
 						// context cancellation, so we skip these for now to deflake the test.
 						if finalize == "cancel" || finalize == "cancelAsync" {
@@ -642,22 +642,22 @@ func TestReliableIntentCleanup(t *testing.T) {
 						if finalize == "cancelAsync" {
 							// cancelAsync can't run together with abort.
 							testTxn(t, testTxnSpec{
-								numKeys:     numKeys.(int),
+								numKeys:     numKeys,
 								singleRange: singleRange,
-								finalize:    finalize.(string),
+								finalize:    finalize,
 							})
 							return
 						}
-						abort := []interface{}{"no", "push", "heartbeat"}
-						testutils.RunValues(t, "abort", abort, func(t *testing.T, abort interface{}) {
-							if abort.(string) == "no" {
+						abort := []string{"no", "push", "heartbeat"}
+						testutils.RunValues(t, "abort", abort, func(t *testing.T, abort string) {
+							if abort == "no" {
 								abort = "" // "no" just makes the test output better
 							}
 							testTxn(t, testTxnSpec{
-								numKeys:     numKeys.(int),
+								numKeys:     numKeys,
 								singleRange: singleRange,
-								finalize:    finalize.(string),
-								abort:       abort.(string),
+								finalize:    finalize,
+								abort:       abort,
 							})
 						})
 					})

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "processor.go",
         "registry.go",
         "resolved_timestamp.go",
+        "scheduled_processor.go",
         "scheduler.go",
         "task.go",
     ],

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -49,6 +49,7 @@ func newErrBufferCapacityExceeded() *kvpb.Error {
 type Config struct {
 	log.AmbientContext
 	Clock   *hlc.Clock
+	Stopper *stop.Stopper
 	RangeID roachpb.RangeID
 	Span    roachpb.RSpan
 
@@ -74,6 +75,10 @@ type Config struct {
 
 	// Optional Processor memory budget.
 	MemBudget *FeedBudget
+
+	// Rangefeed scheduler to use for processor. If set, SchedulerProcessor would
+	// be instantiated.
+	Scheduler *Scheduler
 }
 
 // SetDefaults initializes unset fields in Config to values
@@ -193,6 +198,19 @@ type Processor interface {
 	ForwardClosedTS(ctx context.Context, closedTS hlc.Timestamp) bool
 }
 
+// NewProcessor creates a new rangefeed Processor. The corresponding processing
+// loop should be launched using the Start method.
+func NewProcessor(cfg Config) Processor {
+	cfg.SetDefaults()
+	cfg.AmbientContext.AddLogTag("rangefeed", nil)
+	if cfg.Scheduler != nil {
+		// TODO(oleg): remove logging
+		log.Infof(context.Background(), "creating new style processor for range feed on r%d", cfg.RangeID)
+		return NewScheduledProcessor(cfg)
+	}
+	return NewLegacyProcessor(cfg)
+}
+
 type LegacyProcessor struct {
 	Config
 	reg registry
@@ -271,11 +289,7 @@ type spanErr struct {
 	pErr *kvpb.Error
 }
 
-// NewProcessor creates a new rangefeed Processor. The corresponding goroutine
-// should be launched using the Start method.
-func NewProcessor(cfg Config) Processor {
-	cfg.SetDefaults()
-	cfg.AmbientContext.AddLogTag("rangefeed", nil)
+func NewLegacyProcessor(cfg Config) *LegacyProcessor {
 	p := &LegacyProcessor{
 		Config: cfg,
 		reg:    makeRegistry(cfg.Metrics),
@@ -709,18 +723,24 @@ func (p *LegacyProcessor) setResolvedTSInitialized(ctx context.Context) {
 // caller to establish causality with actions taken by the Processor goroutine.
 // It does so by flushing the event pipeline.
 func (p *LegacyProcessor) syncEventC() {
-	syncC := make(chan struct{})
-	ev := getPooledEvent(event{sync: &syncEvent{c: syncC}})
+	p.syncEventCWithEvent(&syncEvent{c: make(chan struct{})})
+}
+
+// syncEventCWithEvent allows sync event to be sent and waited on its channel.
+// Exposed to allow special test syncEvents that contain span to be sent.
+func (p *LegacyProcessor) syncEventCWithEvent(se *syncEvent) {
+	ev := getPooledEvent(event{sync: se})
 	select {
 	case p.eventC <- ev:
 		select {
-		case <-syncC:
+		case <-se.c:
 		// Synchronized.
 		case <-p.stoppedC:
 			// Already stopped. Do nothing.
 		}
 	case <-p.stoppedC:
-		// Already stopped. Do nothing.
+		// Already stopped. Return event back to the pool.
+		putPooledEvent(ev)
 	}
 }
 

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -149,6 +149,7 @@ type processorTestHelper struct {
 	rts          *resolvedTimestamp
 	syncEventC   func()
 	sendSpanSync func(*roachpb.Span)
+	scheduler    *ClientScheduler
 }
 
 // syncEventAndRegistrations waits for all previously sent events to be
@@ -163,6 +164,28 @@ func (h *processorTestHelper) syncEventAndRegistrations() {
 // own internal buffers.
 func (h *processorTestHelper) syncEventAndRegistrationsSpan(span roachpb.Span) {
 	h.sendSpanSync(&span)
+}
+
+func (h *processorTestHelper) triggerTxnPushUntilPushed(
+	t *testing.T, ackC chan struct{}, timeout time.Duration,
+) {
+	if h.scheduler != nil {
+		deadline := time.After(timeout)
+		for {
+			h.scheduler.Enqueue(PushTxnQueued)
+			select {
+			case <-deadline:
+				t.Fatal("failed to get txn push notification")
+			case ackC <- struct{}{}:
+				return
+			case <-time.After(100 * time.Millisecond):
+				// We keep sending events to avoid the situation where event arrives
+				// but flag indicating that push is still running is not reset.
+			}
+		}
+	} else {
+		ackC <- struct{}{}
+	}
 }
 
 type procType bool
@@ -295,6 +318,7 @@ func newTestProcessor(
 		h.sendSpanSync = func(span *roachpb.Span) {
 			p.syncSendAndWait(&syncEvent{c: make(chan struct{}), testRegCatchupSpan: span})
 		}
+		h.scheduler = &p.scheduler
 	default:
 		panic("unknown processor type")
 	}
@@ -884,186 +908,187 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 	})
 }
 
-// TODO(oleg): write test for scheduler where push would be scheduled externally.
 func TestProcessorTxnPushAttempt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ts10 := hlc.Timestamp{WallTime: 10}
-	ts20 := hlc.Timestamp{WallTime: 20}
-	ts25 := hlc.Timestamp{WallTime: 25}
-	ts30 := hlc.Timestamp{WallTime: 30}
-	ts50 := hlc.Timestamp{WallTime: 50}
-	ts60 := hlc.Timestamp{WallTime: 60}
-	ts70 := hlc.Timestamp{WallTime: 70}
-	ts90 := hlc.Timestamp{WallTime: 90}
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
+		ts10 := hlc.Timestamp{WallTime: 10}
+		ts20 := hlc.Timestamp{WallTime: 20}
+		ts25 := hlc.Timestamp{WallTime: 25}
+		ts30 := hlc.Timestamp{WallTime: 30}
+		ts50 := hlc.Timestamp{WallTime: 50}
+		ts60 := hlc.Timestamp{WallTime: 60}
+		ts70 := hlc.Timestamp{WallTime: 70}
+		ts90 := hlc.Timestamp{WallTime: 90}
 
-	// Create a set of transactions.
-	txn1, txn2, txn3 := uuid.MakeV4(), uuid.MakeV4(), uuid.MakeV4()
-	txn1Meta := enginepb.TxnMeta{ID: txn1, Key: keyA, IsoLevel: isolation.Serializable, WriteTimestamp: ts10, MinTimestamp: ts10}
-	txn2Meta := enginepb.TxnMeta{ID: txn2, Key: keyB, IsoLevel: isolation.Snapshot, WriteTimestamp: ts20, MinTimestamp: ts20}
-	txn3Meta := enginepb.TxnMeta{ID: txn3, Key: keyC, IsoLevel: isolation.ReadCommitted, WriteTimestamp: ts30, MinTimestamp: ts30}
-	txn1Proto := &roachpb.Transaction{TxnMeta: txn1Meta, Status: roachpb.PENDING}
-	txn2Proto := &roachpb.Transaction{TxnMeta: txn2Meta, Status: roachpb.PENDING}
-	txn3Proto := &roachpb.Transaction{TxnMeta: txn3Meta, Status: roachpb.PENDING}
+		// Create a set of transactions.
+		txn1, txn2, txn3 := uuid.MakeV4(), uuid.MakeV4(), uuid.MakeV4()
+		txn1Meta := enginepb.TxnMeta{ID: txn1, Key: keyA, IsoLevel: isolation.Serializable, WriteTimestamp: ts10, MinTimestamp: ts10}
+		txn2Meta := enginepb.TxnMeta{ID: txn2, Key: keyB, IsoLevel: isolation.Snapshot, WriteTimestamp: ts20, MinTimestamp: ts20}
+		txn3Meta := enginepb.TxnMeta{ID: txn3, Key: keyC, IsoLevel: isolation.ReadCommitted, WriteTimestamp: ts30, MinTimestamp: ts30}
+		txn1Proto := &roachpb.Transaction{TxnMeta: txn1Meta, Status: roachpb.PENDING}
+		txn2Proto := &roachpb.Transaction{TxnMeta: txn2Meta, Status: roachpb.PENDING}
+		txn3Proto := &roachpb.Transaction{TxnMeta: txn3Meta, Status: roachpb.PENDING}
 
-	// Modifications for test 2.
-	txn1MetaT2Pre := enginepb.TxnMeta{ID: txn1, Key: keyA, IsoLevel: isolation.Serializable, WriteTimestamp: ts25, MinTimestamp: ts10}
-	txn1MetaT2Post := enginepb.TxnMeta{ID: txn1, Key: keyA, IsoLevel: isolation.Serializable, WriteTimestamp: ts50, MinTimestamp: ts10}
-	txn2MetaT2Post := enginepb.TxnMeta{ID: txn2, Key: keyB, IsoLevel: isolation.Snapshot, WriteTimestamp: ts60, MinTimestamp: ts20}
-	txn3MetaT2Post := enginepb.TxnMeta{ID: txn3, Key: keyC, IsoLevel: isolation.ReadCommitted, WriteTimestamp: ts70, MinTimestamp: ts30}
-	txn1ProtoT2 := &roachpb.Transaction{TxnMeta: txn1MetaT2Post, Status: roachpb.COMMITTED}
-	txn2ProtoT2 := &roachpb.Transaction{TxnMeta: txn2MetaT2Post, Status: roachpb.PENDING}
-	txn3ProtoT2 := &roachpb.Transaction{TxnMeta: txn3MetaT2Post, Status: roachpb.PENDING}
+		// Modifications for test 2.
+		txn1MetaT2Pre := enginepb.TxnMeta{ID: txn1, Key: keyA, IsoLevel: isolation.Serializable, WriteTimestamp: ts25, MinTimestamp: ts10}
+		txn1MetaT2Post := enginepb.TxnMeta{ID: txn1, Key: keyA, IsoLevel: isolation.Serializable, WriteTimestamp: ts50, MinTimestamp: ts10}
+		txn2MetaT2Post := enginepb.TxnMeta{ID: txn2, Key: keyB, IsoLevel: isolation.Snapshot, WriteTimestamp: ts60, MinTimestamp: ts20}
+		txn3MetaT2Post := enginepb.TxnMeta{ID: txn3, Key: keyC, IsoLevel: isolation.ReadCommitted, WriteTimestamp: ts70, MinTimestamp: ts30}
+		txn1ProtoT2 := &roachpb.Transaction{TxnMeta: txn1MetaT2Post, Status: roachpb.COMMITTED}
+		txn2ProtoT2 := &roachpb.Transaction{TxnMeta: txn2MetaT2Post, Status: roachpb.PENDING}
+		txn3ProtoT2 := &roachpb.Transaction{TxnMeta: txn3MetaT2Post, Status: roachpb.PENDING}
 
-	// Modifications for test 3.
-	txn2MetaT3Post := enginepb.TxnMeta{ID: txn2, Key: keyB, IsoLevel: isolation.Snapshot, WriteTimestamp: ts60, MinTimestamp: ts20}
-	txn3MetaT3Post := enginepb.TxnMeta{ID: txn3, Key: keyC, IsoLevel: isolation.ReadCommitted, WriteTimestamp: ts90, MinTimestamp: ts30}
-	txn2ProtoT3 := &roachpb.Transaction{TxnMeta: txn2MetaT3Post, Status: roachpb.ABORTED}
-	txn3ProtoT3 := &roachpb.Transaction{TxnMeta: txn3MetaT3Post, Status: roachpb.PENDING}
+		// Modifications for test 3.
+		txn2MetaT3Post := enginepb.TxnMeta{ID: txn2, Key: keyB, IsoLevel: isolation.Snapshot, WriteTimestamp: ts60, MinTimestamp: ts20}
+		txn3MetaT3Post := enginepb.TxnMeta{ID: txn3, Key: keyC, IsoLevel: isolation.ReadCommitted, WriteTimestamp: ts90, MinTimestamp: ts30}
+		txn2ProtoT3 := &roachpb.Transaction{TxnMeta: txn2MetaT3Post, Status: roachpb.ABORTED}
+		txn3ProtoT3 := &roachpb.Transaction{TxnMeta: txn3MetaT3Post, Status: roachpb.PENDING}
 
-	testNum := 0
-	pausePushAttemptsC := make(chan struct{})
-	resumePushAttemptsC := make(chan struct{})
-	defer close(pausePushAttemptsC)
-	defer close(resumePushAttemptsC)
+		testNum := 0
+		pausePushAttemptsC := make(chan struct{})
+		resumePushAttemptsC := make(chan struct{})
+		defer close(pausePushAttemptsC)
+		defer close(resumePushAttemptsC)
 
-	// Create a TxnPusher that performs assertions during the first 3 uses.
-	var tp testTxnPusher
-	tp.mockPushTxns(func(txns []enginepb.TxnMeta, ts hlc.Timestamp) ([]*roachpb.Transaction, error) {
-		// The txns are not in a sorted order. Enforce one.
-		sort.Slice(txns, func(i, j int) bool {
-			return bytes.Compare(txns[i].Key, txns[j].Key) < 0
+		// Create a TxnPusher that performs assertions during the first 3 uses.
+		var tp testTxnPusher
+		tp.mockPushTxns(func(txns []enginepb.TxnMeta, ts hlc.Timestamp) ([]*roachpb.Transaction, error) {
+			// The txns are not in a sorted order. Enforce one.
+			sort.Slice(txns, func(i, j int) bool {
+				return bytes.Compare(txns[i].Key, txns[j].Key) < 0
+			})
+
+			testNum++
+			switch testNum {
+			case 1:
+				assert.Equal(t, 3, len(txns))
+				assert.Equal(t, txn1Meta, txns[0])
+				assert.Equal(t, txn2Meta, txns[1])
+				assert.Equal(t, txn3Meta, txns[2])
+				if t.Failed() {
+					return nil, errors.New("test failed")
+				}
+
+				// Push does not succeed. Protos not at larger ts.
+				return []*roachpb.Transaction{txn1Proto, txn2Proto, txn3Proto}, nil
+			case 2:
+				assert.Equal(t, 3, len(txns))
+				assert.Equal(t, txn1MetaT2Pre, txns[0])
+				assert.Equal(t, txn2Meta, txns[1])
+				assert.Equal(t, txn3Meta, txns[2])
+				if t.Failed() {
+					return nil, errors.New("test failed")
+				}
+
+				// Push succeeds. Return new protos.
+				return []*roachpb.Transaction{txn1ProtoT2, txn2ProtoT2, txn3ProtoT2}, nil
+			case 3:
+				assert.Equal(t, 2, len(txns))
+				assert.Equal(t, txn2MetaT2Post, txns[0])
+				assert.Equal(t, txn3MetaT2Post, txns[1])
+				if t.Failed() {
+					return nil, errors.New("test failed")
+				}
+
+				// Push succeeds. Return new protos.
+				return []*roachpb.Transaction{txn2ProtoT3, txn3ProtoT3}, nil
+			default:
+				return nil, nil
+			}
+		})
+		tp.mockResolveIntentsFn(func(ctx context.Context, intents []roachpb.LockUpdate) error {
+			// There's nothing to assert here. We expect the intents to correspond to
+			// transactions that had their LockSpans populated when we pushed them. This
+			// test doesn't simulate that.
+
+			if testNum > 3 {
+				return nil
+			}
+
+			<-pausePushAttemptsC
+			<-resumePushAttemptsC
+			return nil
 		})
 
-		testNum++
-		switch testNum {
-		case 1:
-			assert.Equal(t, 3, len(txns))
-			assert.Equal(t, txn1Meta, txns[0])
-			assert.Equal(t, txn2Meta, txns[1])
-			assert.Equal(t, txn3Meta, txns[2])
-			if t.Failed() {
-				return nil, errors.New("test failed")
-			}
+		p, h, stopper := newTestProcessor(t, withPusher(&tp), withProcType(pt))
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
 
-			// Push does not succeed. Protos not at larger ts.
-			return []*roachpb.Transaction{txn1Proto, txn2Proto, txn3Proto}, nil
-		case 2:
-			assert.Equal(t, 3, len(txns))
-			assert.Equal(t, txn1MetaT2Pre, txns[0])
-			assert.Equal(t, txn2Meta, txns[1])
-			assert.Equal(t, txn3Meta, txns[2])
-			if t.Failed() {
-				return nil, errors.New("test failed")
-			}
-
-			// Push succeeds. Return new protos.
-			return []*roachpb.Transaction{txn1ProtoT2, txn2ProtoT2, txn3ProtoT2}, nil
-		case 3:
-			assert.Equal(t, 2, len(txns))
-			assert.Equal(t, txn2MetaT2Post, txns[0])
-			assert.Equal(t, txn3MetaT2Post, txns[1])
-			if t.Failed() {
-				return nil, errors.New("test failed")
-			}
-
-			// Push succeeds. Return new protos.
-			return []*roachpb.Transaction{txn2ProtoT3, txn3ProtoT3}, nil
-		default:
-			return nil, nil
+		// Add a few intents and move the closed timestamp forward.
+		writeIntentOpFromMeta := func(txn enginepb.TxnMeta) enginepb.MVCCLogicalOp {
+			return writeIntentOpWithDetails(txn.ID, txn.Key, txn.IsoLevel, txn.MinTimestamp,
+				txn.WriteTimestamp)
 		}
+		p.ConsumeLogicalOps(ctx,
+			writeIntentOpFromMeta(txn1Meta),
+			writeIntentOpFromMeta(txn2Meta),
+			writeIntentOpFromMeta(txn2Meta),
+			writeIntentOpFromMeta(txn3Meta),
+		)
+		p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 40})
+		h.syncEventC()
+		require.Equal(t, hlc.Timestamp{WallTime: 9}, h.rts.Get())
+
+		// Wait for the first txn push attempt to complete.
+		h.triggerTxnPushUntilPushed(t, pausePushAttemptsC, 30*time.Second)
+
+		// The resolved timestamp hasn't moved.
+		h.syncEventC()
+		require.Equal(t, hlc.Timestamp{WallTime: 9}, h.rts.Get())
+
+		// Write another intent for one of the txns. This moves the resolved
+		// timestamp forward.
+		p.ConsumeLogicalOps(ctx, writeIntentOpFromMeta(txn1MetaT2Pre))
+		h.syncEventC()
+		require.Equal(t, hlc.Timestamp{WallTime: 19}, h.rts.Get())
+
+		// Unblock the second txn push attempt and wait for it to complete.
+		resumePushAttemptsC <- struct{}{}
+		h.triggerTxnPushUntilPushed(t, pausePushAttemptsC, 30*time.Second)
+
+		// The resolved timestamp should have moved forwards to the closed
+		// timestamp.
+		h.syncEventC()
+		require.Equal(t, hlc.Timestamp{WallTime: 40}, h.rts.Get())
+
+		// Forward the closed timestamp.
+		p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 80})
+		h.syncEventC()
+		require.Equal(t, hlc.Timestamp{WallTime: 49}, h.rts.Get())
+
+		// Txn1's first intent is committed. Resolved timestamp doesn't change.
+		p.ConsumeLogicalOps(ctx, commitIntentOp(txn1MetaT2Post.ID, txn1MetaT2Post.WriteTimestamp))
+		h.syncEventC()
+		require.Equal(t, hlc.Timestamp{WallTime: 49}, h.rts.Get())
+
+		// Txn1's second intent is committed. Resolved timestamp moves forward.
+		p.ConsumeLogicalOps(ctx, commitIntentOp(txn1MetaT2Post.ID, txn1MetaT2Post.WriteTimestamp))
+		h.syncEventC()
+		require.Equal(t, hlc.Timestamp{WallTime: 59}, h.rts.Get())
+
+		// Unblock the third txn push attempt and wait for it to complete.
+		resumePushAttemptsC <- struct{}{}
+		h.triggerTxnPushUntilPushed(t, pausePushAttemptsC, 30*time.Second)
+
+		// The resolved timestamp should have moved forwards to the closed
+		// timestamp.
+		h.syncEventC()
+		require.Equal(t, hlc.Timestamp{WallTime: 80}, h.rts.Get())
+
+		// Forward the closed timestamp.
+		p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 100})
+		h.syncEventC()
+		require.Equal(t, hlc.Timestamp{WallTime: 89}, h.rts.Get())
+
+		// Commit txn3's only intent. Resolved timestamp moves forward.
+		p.ConsumeLogicalOps(ctx, commitIntentOp(txn3MetaT3Post.ID, txn3MetaT3Post.WriteTimestamp))
+		h.syncEventC()
+		require.Equal(t, hlc.Timestamp{WallTime: 100}, h.rts.Get())
+
+		// Release push attempt to avoid deadlock.
+		resumePushAttemptsC <- struct{}{}
 	})
-	tp.mockResolveIntentsFn(func(ctx context.Context, intents []roachpb.LockUpdate) error {
-		// There's nothing to assert here. We expect the intents to correspond to
-		// transactions that had their LockSpans populated when we pushed them. This
-		// test doesn't simulate that.
-
-		if testNum > 3 {
-			return nil
-		}
-
-		<-pausePushAttemptsC
-		<-resumePushAttemptsC
-		return nil
-	})
-
-	p, h, stopper := newTestProcessor(t, withPusher(&tp), withProcType(legacyProcessor))
-	ctx := context.Background()
-	defer stopper.Stop(ctx)
-
-	// Add a few intents and move the closed timestamp forward.
-	writeIntentOpFromMeta := func(txn enginepb.TxnMeta) enginepb.MVCCLogicalOp {
-		return writeIntentOpWithDetails(txn.ID, txn.Key, txn.IsoLevel, txn.MinTimestamp,
-			txn.WriteTimestamp)
-	}
-	p.ConsumeLogicalOps(ctx,
-		writeIntentOpFromMeta(txn1Meta),
-		writeIntentOpFromMeta(txn2Meta),
-		writeIntentOpFromMeta(txn2Meta),
-		writeIntentOpFromMeta(txn3Meta),
-	)
-	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 40})
-	h.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 9}, h.rts.Get())
-
-	// Wait for the first txn push attempt to complete.
-	pausePushAttemptsC <- struct{}{}
-
-	// The resolved timestamp hasn't moved.
-	h.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 9}, h.rts.Get())
-
-	// Write another intent for one of the txns. This moves the resolved
-	// timestamp forward.
-	p.ConsumeLogicalOps(ctx, writeIntentOpFromMeta(txn1MetaT2Pre))
-	h.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 19}, h.rts.Get())
-
-	// Unblock the second txn push attempt and wait for it to complete.
-	resumePushAttemptsC <- struct{}{}
-	pausePushAttemptsC <- struct{}{}
-
-	// The resolved timestamp should have moved forwards to the closed
-	// timestamp.
-	h.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 40}, h.rts.Get())
-
-	// Forward the closed timestamp.
-	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 80})
-	h.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 49}, h.rts.Get())
-
-	// Txn1's first intent is committed. Resolved timestamp doesn't change.
-	p.ConsumeLogicalOps(ctx, commitIntentOp(txn1MetaT2Post.ID, txn1MetaT2Post.WriteTimestamp))
-	h.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 49}, h.rts.Get())
-
-	// Txn1's second intent is committed. Resolved timestamp moves forward.
-	p.ConsumeLogicalOps(ctx, commitIntentOp(txn1MetaT2Post.ID, txn1MetaT2Post.WriteTimestamp))
-	h.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 59}, h.rts.Get())
-
-	// Unblock the third txn push attempt and wait for it to complete.
-	resumePushAttemptsC <- struct{}{}
-	pausePushAttemptsC <- struct{}{}
-
-	// The resolved timestamp should have moved forwards to the closed
-	// timestamp.
-	h.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 80}, h.rts.Get())
-
-	// Forward the closed timestamp.
-	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 100})
-	h.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 89}, h.rts.Get())
-
-	// Commit txn3's only intent. Resolved timestamp moves forward.
-	p.ConsumeLogicalOps(ctx, commitIntentOp(txn3MetaT3Post.ID, txn3MetaT3Post.WriteTimestamp))
-	h.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 100}, h.rts.Get())
-
-	// Release push attempt to avoid deadlock.
-	resumePushAttemptsC <- struct{}{}
 }
 
 // TestProcessorConcurrentStop tests that all methods in Processor's API

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -144,31 +144,105 @@ func rangeFeedCheckpoint(span roachpb.Span, ts hlc.Timestamp) *kvpb.RangeFeedEve
 const testProcessorEventCCap = 16
 const testProcessorEventCTimeout = 10 * time.Millisecond
 
-func newTestProcessorWithTxnPusher(
-	t *testing.T, rtsIter storage.SimpleMVCCIterator, txnPusher TxnPusher,
-) (*LegacyProcessor, *stop.Stopper) {
-	t.Helper()
-	stopper := stop.NewStopper()
+type processorTestHelper struct {
+	span         roachpb.RSpan
+	rts          *resolvedTimestamp
+	syncEventC   func()
+	sendSpanSync func(*roachpb.Span)
+}
 
-	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
-	if txnPusher != nil {
-		pushTxnInterval = 10 * time.Millisecond
-		pushTxnAge = 50 * time.Millisecond
+// syncEventAndRegistrations waits for all previously sent events to be
+// processed *and* for all registration output loops to fully process their own
+// internal buffers.
+func (h *processorTestHelper) syncEventAndRegistrations() {
+	h.sendSpanSync(&all)
+}
+
+// syncEventAndRegistrations waits for all previously sent events to be
+// processed *and* for matching registration output loops to fully process their
+// own internal buffers.
+func (h *processorTestHelper) syncEventAndRegistrationsSpan(span roachpb.Span) {
+	h.sendSpanSync(&span)
+}
+
+type procType bool
+
+const (
+	legacyProcessor    procType = false
+	schedulerProcessor          = true
+)
+
+var testTypes = []procType{legacyProcessor, schedulerProcessor}
+
+func (t procType) String() string {
+	if t {
+		return "scheduler"
 	}
-	p := NewProcessor(Config{
-		AmbientContext:   log.MakeTestingAmbientCtxWithNewTracer(),
-		Clock:            hlc.NewClockForTesting(nil),
-		Span:             roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
-		TxnPusher:        txnPusher,
-		PushTxnsInterval: pushTxnInterval,
-		PushTxnsAge:      pushTxnAge,
-		EventChanTimeout: testProcessorEventCTimeout,
-		EventChanCap:     testProcessorEventCCap,
-		Metrics:          NewMetrics(),
-	})
-	require.NoError(t, p.Start(stopper, makeIntentScannerConstructor(rtsIter)))
-	impl := p.(*LegacyProcessor)
-	return impl, stopper
+	return "legacy"
+}
+
+type testConfig struct {
+	Config
+	useScheduler bool
+	isc          IntentScannerConstructor
+}
+
+type option func(*testConfig)
+
+func withPusher(txnPusher TxnPusher) option {
+	return func(config *testConfig) {
+		config.PushTxnsInterval = 10 * time.Millisecond
+		config.PushTxnsAge = 50 * time.Millisecond
+		config.TxnPusher = txnPusher
+	}
+}
+
+func withProcType(t procType) option {
+	return func(config *testConfig) {
+		config.useScheduler = bool(t)
+	}
+}
+
+func withBudget(b *FeedBudget) option {
+	return func(config *testConfig) {
+		config.MemBudget = b
+	}
+}
+
+func withMetrics(m *Metrics) option {
+	return func(config *testConfig) {
+		config.Metrics = m
+	}
+}
+
+func withRtsIter(rtsIter storage.SimpleMVCCIterator) option {
+	return func(config *testConfig) {
+		config.isc = makeIntentScannerConstructor(rtsIter)
+	}
+}
+
+func withChanTimeout(d time.Duration) option {
+	return func(config *testConfig) {
+		config.EventChanTimeout = d
+	}
+}
+
+func withChanCap(cap int) option {
+	return func(config *testConfig) {
+		config.EventChanCap = cap
+	}
+}
+
+func withEventTimeout(timeout time.Duration) option {
+	return func(config *testConfig) {
+		config.EventChanTimeout = timeout
+	}
+}
+
+func withSpan(span roachpb.RSpan) option {
+	return func(config *testConfig) {
+		config.Span = span
+	}
 }
 
 func makeIntentScannerConstructor(rtsIter storage.SimpleMVCCIterator) IntentScannerConstructor {
@@ -179,10 +253,53 @@ func makeIntentScannerConstructor(rtsIter storage.SimpleMVCCIterator) IntentScan
 }
 
 func newTestProcessor(
-	t *testing.T, rtsIter storage.SimpleMVCCIterator,
-) (*LegacyProcessor, *stop.Stopper) {
+	t testing.TB, opts ...option,
+) (Processor, *processorTestHelper, *stop.Stopper) {
 	t.Helper()
-	return newTestProcessorWithTxnPusher(t, rtsIter, nil /* pusher */)
+	stopper := stop.NewStopper()
+
+	cfg := testConfig{
+		Config: Config{
+			RangeID:          2,
+			Stopper:          stopper,
+			AmbientContext:   log.MakeTestingAmbientCtxWithNewTracer(),
+			Clock:            hlc.NewClockForTesting(nil),
+			Span:             roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
+			EventChanTimeout: testProcessorEventCTimeout,
+			EventChanCap:     testProcessorEventCCap,
+			Metrics:          NewMetrics(),
+		},
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.useScheduler {
+		sch := NewScheduler(SchedulerConfig{Workers: 1})
+		_ = sch.Start(context.Background(), stopper)
+		cfg.Scheduler = sch
+	}
+	s := NewProcessor(cfg.Config)
+	h := processorTestHelper{}
+	switch p := s.(type) {
+	case *LegacyProcessor:
+		h.rts = &p.rts
+		h.span = p.Span
+		h.syncEventC = p.syncEventC
+		h.sendSpanSync = func(span *roachpb.Span) {
+			p.syncEventCWithEvent(&syncEvent{c: make(chan struct{}), testRegCatchupSpan: span})
+		}
+	case *ScheduledProcessor:
+		h.rts = &p.rts
+		h.span = p.Span
+		h.syncEventC = p.syncEventC
+		h.sendSpanSync = func(span *roachpb.Span) {
+			p.syncSendAndWait(&syncEvent{c: make(chan struct{}), testRegCatchupSpan: span})
+		}
+	default:
+		panic("unknown processor type")
+	}
+	require.NoError(t, s.Start(stopper, cfg.isc))
+	return s, &h, stopper
 }
 
 func waitErrorFuture(f *future.ErrorFuture) error {
@@ -192,341 +309,372 @@ func waitErrorFuture(f *future.ErrorFuture) error {
 
 func TestProcessorBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	p, stopper := newTestProcessor(t, nil /* rtsIter */)
-	ctx := context.Background()
-	defer stopper.Stop(ctx)
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
+		p, h, stopper := newTestProcessor(t, withProcType(pt))
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
 
-	// Test processor without registrations.
-	require.Equal(t, 0, p.Len())
-	require.NotPanics(t, func() { p.ConsumeLogicalOps(ctx) })
-	require.NotPanics(t, func() { p.ConsumeLogicalOps(ctx, []enginepb.MVCCLogicalOp{}...) })
-	require.NotPanics(t, func() {
-		txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
-		p.ConsumeLogicalOps(ctx,
-			writeValueOp(hlc.Timestamp{WallTime: 1}),
-			writeIntentOp(txn1, hlc.Timestamp{WallTime: 2}),
-			updateIntentOp(txn1, hlc.Timestamp{WallTime: 3}),
-			commitIntentOp(txn1, hlc.Timestamp{WallTime: 4}),
-			writeIntentOp(txn2, hlc.Timestamp{WallTime: 5}),
-			abortIntentOp(txn2))
-		p.syncEventC()
-		require.Equal(t, 0, p.rts.intentQ.Len())
-	})
-	require.NotPanics(t, func() { p.ForwardClosedTS(ctx, hlc.Timestamp{}) })
-	require.NotPanics(t, func() { p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 1}) })
+		// Test processor without registrations.
+		require.Equal(t, 0, p.Len())
+		require.NotPanics(t, func() { p.ConsumeLogicalOps(ctx) })
+		require.NotPanics(t, func() { p.ConsumeLogicalOps(ctx, []enginepb.MVCCLogicalOp{}...) })
+		require.NotPanics(t, func() {
+			txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
+			p.ConsumeLogicalOps(ctx,
+				writeValueOp(hlc.Timestamp{WallTime: 1}),
+				writeIntentOp(txn1, hlc.Timestamp{WallTime: 2}),
+				updateIntentOp(txn1, hlc.Timestamp{WallTime: 3}),
+				commitIntentOp(txn1, hlc.Timestamp{WallTime: 4}),
+				writeIntentOp(txn2, hlc.Timestamp{WallTime: 5}),
+				abortIntentOp(txn2))
+			h.syncEventC()
+			require.Equal(t, 0, h.rts.intentQ.Len())
+		})
+		require.NotPanics(t, func() { p.ForwardClosedTS(ctx, hlc.Timestamp{}) })
+		require.NotPanics(t, func() { p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 1}) })
 
-	// Add a registration.
-	r1Stream := newTestStream()
-	var r1Done future.ErrorFuture
-	r1OK, r1Filter := p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		r1Stream,
-		func() {},
-		&r1Done,
-	)
-	require.True(t, r1OK)
-	p.syncEventAndRegistrations()
-	require.Equal(t, 1, p.Len())
-	require.Equal(t,
-		[]*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+		// Add a registration.
+		r1Stream := newTestStream()
+		var r1Done future.ErrorFuture
+		r1OK, r1Filter := p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-		)},
-		r1Stream.Events(),
-	)
-
-	// Test the processor's operation filter.
-	require.True(t, r1Filter.NeedVal(roachpb.Span{Key: roachpb.Key("a")}))
-	require.True(t, r1Filter.NeedVal(roachpb.Span{Key: roachpb.Key("d"), EndKey: roachpb.Key("r")}))
-	require.False(t, r1Filter.NeedVal(roachpb.Span{Key: roachpb.Key("z")}))
-	require.False(t, r1Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("a")}))
-	require.False(t, r1Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("d"), EndKey: roachpb.Key("r")}))
-	require.False(t, r1Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("z")}))
-
-	// Test checkpoint with one registration.
-	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 5})
-	p.syncEventAndRegistrations()
-	require.Equal(t,
-		[]*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
-			hlc.Timestamp{WallTime: 5},
-		)},
-		r1Stream.Events(),
-	)
-
-	// Test value with one registration.
-	p.ConsumeLogicalOps(ctx,
-		writeValueOpWithKV(roachpb.Key("c"), hlc.Timestamp{WallTime: 6}, []byte("val")))
-	p.syncEventAndRegistrations()
-	require.Equal(t,
-		[]*kvpb.RangeFeedEvent{rangeFeedValue(
-			roachpb.Key("c"),
-			roachpb.Value{
-				RawBytes:  []byte("val"),
-				Timestamp: hlc.Timestamp{WallTime: 6},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			r1Stream,
+			func() {},
+			&r1Done,
+		)
+		require.True(t, r1OK)
+		h.syncEventAndRegistrations()
+		require.Equal(t, 1, p.Len())
+		require.Equal(t,
+			[]*kvpb.RangeFeedEvent{
+				rangeFeedCheckpoint(
+					roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+					hlc.Timestamp{WallTime: 1},
+				),
 			},
-		)},
-		r1Stream.Events(),
-	)
+			r1Stream.Events(),
+		)
 
-	// Test value to non-overlapping key with one registration.
-	p.ConsumeLogicalOps(ctx,
-		writeValueOpWithKV(roachpb.Key("s"), hlc.Timestamp{WallTime: 6}, []byte("val")))
-	p.syncEventAndRegistrations()
-	require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
+		// Test the processor's operation filter.
+		require.True(t, r1Filter.NeedVal(roachpb.Span{Key: roachpb.Key("a")}))
+		require.True(t, r1Filter.NeedVal(roachpb.Span{Key: roachpb.Key("d"), EndKey: roachpb.Key("r")}))
+		require.False(t, r1Filter.NeedVal(roachpb.Span{Key: roachpb.Key("z")}))
+		require.False(t, r1Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("a")}))
+		require.False(t,
+			r1Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("d"), EndKey: roachpb.Key("r")}))
+		require.False(t, r1Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("z")}))
 
-	// Test intent that is aborted with one registration.
-	txn1 := uuid.MakeV4()
-	// Write intent.
-	p.ConsumeLogicalOps(ctx, writeIntentOp(txn1, hlc.Timestamp{WallTime: 6}))
-	p.syncEventAndRegistrations()
-	require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
-	// Abort.
-	p.ConsumeLogicalOps(ctx, abortIntentOp(txn1))
-	p.syncEventC()
-	require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
-	require.Equal(t, 0, p.rts.intentQ.Len())
+		// Test checkpoint with one registration.
+		p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 5})
+		h.syncEventAndRegistrations()
+		require.Equal(t,
+			[]*kvpb.RangeFeedEvent{
+				rangeFeedCheckpoint(
+					roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+					hlc.Timestamp{WallTime: 5},
+				),
+			},
+			r1Stream.Events(),
+		)
 
-	// Test intent that is committed with one registration.
-	txn2 := uuid.MakeV4()
-	// Write intent.
-	p.ConsumeLogicalOps(ctx, writeIntentOp(txn2, hlc.Timestamp{WallTime: 10}))
-	p.syncEventAndRegistrations()
-	require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
-	// Forward closed timestamp. Should now be stuck on intent.
-	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 15})
-	p.syncEventAndRegistrations()
-	require.Equal(t,
-		[]*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
-			hlc.Timestamp{WallTime: 9},
-		)},
-		r1Stream.Events(),
-	)
-	// Update the intent. Should forward resolved timestamp.
-	p.ConsumeLogicalOps(ctx, updateIntentOp(txn2, hlc.Timestamp{WallTime: 12}))
-	p.syncEventAndRegistrations()
-	require.Equal(t,
-		[]*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
-			hlc.Timestamp{WallTime: 11},
-		)},
-		r1Stream.Events(),
-	)
-	// Commit intent. Should forward resolved timestamp to closed timestamp.
-	p.ConsumeLogicalOps(ctx,
-		commitIntentOpWithKV(txn2, roachpb.Key("e"), hlc.Timestamp{WallTime: 13}, []byte("ival")))
-	p.syncEventAndRegistrations()
-	require.Equal(t,
-		[]*kvpb.RangeFeedEvent{
-			rangeFeedValue(
-				roachpb.Key("e"),
-				roachpb.Value{
-					RawBytes:  []byte("ival"),
-					Timestamp: hlc.Timestamp{WallTime: 13},
-				},
-			),
+		// Test value with one registration.
+		p.ConsumeLogicalOps(ctx,
+			writeValueOpWithKV(roachpb.Key("c"), hlc.Timestamp{WallTime: 6}, []byte("val")))
+		h.syncEventAndRegistrations()
+		require.Equal(t,
+			[]*kvpb.RangeFeedEvent{
+				rangeFeedValue(
+					roachpb.Key("c"),
+					roachpb.Value{
+						RawBytes:  []byte("val"),
+						Timestamp: hlc.Timestamp{WallTime: 6},
+					},
+				),
+			},
+			r1Stream.Events(),
+		)
+
+		// Test value to non-overlapping key with one registration.
+		p.ConsumeLogicalOps(ctx,
+			writeValueOpWithKV(roachpb.Key("s"), hlc.Timestamp{WallTime: 6}, []byte("val")))
+		h.syncEventAndRegistrations()
+		require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
+
+		// Test intent that is aborted with one registration.
+		txn1 := uuid.MakeV4()
+		// Write intent.
+		p.ConsumeLogicalOps(ctx, writeIntentOp(txn1, hlc.Timestamp{WallTime: 6}))
+		h.syncEventAndRegistrations()
+		require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
+		// Abort.
+		p.ConsumeLogicalOps(ctx, abortIntentOp(txn1))
+		h.syncEventC()
+		require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
+		require.Equal(t, 0, h.rts.intentQ.Len())
+
+		// Test intent that is committed with one registration.
+		txn2 := uuid.MakeV4()
+		// Write intent.
+		p.ConsumeLogicalOps(ctx, writeIntentOp(txn2, hlc.Timestamp{WallTime: 10}))
+		h.syncEventAndRegistrations()
+		require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
+		// Forward closed timestamp. Should now be stuck on intent.
+		p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 15})
+		h.syncEventAndRegistrations()
+		require.Equal(t,
+			[]*kvpb.RangeFeedEvent{
+				rangeFeedCheckpoint(
+					roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+					hlc.Timestamp{WallTime: 9},
+				),
+			},
+			r1Stream.Events(),
+		)
+		// Update the intent. Should forward resolved timestamp.
+		p.ConsumeLogicalOps(ctx, updateIntentOp(txn2, hlc.Timestamp{WallTime: 12}))
+		h.syncEventAndRegistrations()
+		require.Equal(t,
+			[]*kvpb.RangeFeedEvent{
+				rangeFeedCheckpoint(
+					roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+					hlc.Timestamp{WallTime: 11},
+				),
+			},
+			r1Stream.Events(),
+		)
+		// Commit intent. Should forward resolved timestamp to closed timestamp.
+		p.ConsumeLogicalOps(ctx,
+			commitIntentOpWithKV(txn2, roachpb.Key("e"), hlc.Timestamp{WallTime: 13}, []byte("ival")))
+		h.syncEventAndRegistrations()
+		require.Equal(t,
+			[]*kvpb.RangeFeedEvent{
+				rangeFeedValue(
+					roachpb.Key("e"),
+					roachpb.Value{
+						RawBytes:  []byte("ival"),
+						Timestamp: hlc.Timestamp{WallTime: 13},
+					},
+				),
+				rangeFeedCheckpoint(
+					roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+					hlc.Timestamp{WallTime: 15},
+				),
+			},
+			r1Stream.Events(),
+		)
+
+		// Add another registration with withDiff = true.
+		r2Stream := newTestStream()
+		var r2Done future.ErrorFuture
+		r2OK, r1And2Filter := p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
+			hlc.Timestamp{WallTime: 1},
+			nil,  /* catchUpIter */
+			true, /* withDiff */
+			r2Stream,
+			func() {},
+			&r2Done,
+		)
+		require.True(t, r2OK)
+		h.syncEventAndRegistrations()
+		require.Equal(t, 2, p.Len())
+		require.Equal(t,
+			[]*kvpb.RangeFeedEvent{
+				rangeFeedCheckpoint(
+					roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("z")},
+					hlc.Timestamp{WallTime: 15},
+				),
+			},
+			r2Stream.Events(),
+		)
+
+		// Test the processor's new operation filter.
+		require.True(t, r1And2Filter.NeedVal(roachpb.Span{Key: roachpb.Key("a")}))
+		require.True(t, r1And2Filter.NeedVal(roachpb.Span{Key: roachpb.Key("y")}))
+		require.True(t,
+			r1And2Filter.NeedVal(roachpb.Span{Key: roachpb.Key("y"), EndKey: roachpb.Key("zzz")}))
+		require.False(t, r1And2Filter.NeedVal(roachpb.Span{Key: roachpb.Key("zzz")}))
+		require.False(t, r1And2Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("a")}))
+		require.True(t, r1And2Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("y")}))
+		require.True(t,
+			r1And2Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("y"), EndKey: roachpb.Key("zzz")}))
+		require.False(t, r1And2Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("zzz")}))
+
+		// Both registrations should see checkpoint.
+		p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 20})
+		h.syncEventAndRegistrations()
+		chEventAM := []*kvpb.RangeFeedEvent{
 			rangeFeedCheckpoint(
 				roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
-				hlc.Timestamp{WallTime: 15},
+				hlc.Timestamp{WallTime: 20},
 			),
-		},
-		r1Stream.Events(),
-	)
+		}
+		require.Equal(t, chEventAM, r1Stream.Events())
+		chEventCZ := []*kvpb.RangeFeedEvent{
+			rangeFeedCheckpoint(
+				roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("z")},
+				hlc.Timestamp{WallTime: 20},
+			),
+		}
+		require.Equal(t, chEventCZ, r2Stream.Events())
 
-	// Add another registration with withDiff = true.
-	r2Stream := newTestStream()
-	var r2Done future.ErrorFuture
-	r2OK, r1And2Filter := p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
-		hlc.Timestamp{WallTime: 1},
-		nil,  /* catchUpIter */
-		true, /* withDiff */
-		r2Stream,
-		func() {},
-		&r2Done,
-	)
-	require.True(t, r2OK)
-	p.syncEventAndRegistrations()
-	require.Equal(t, 2, p.Len())
-	require.Equal(t,
-		[]*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("z")},
-			hlc.Timestamp{WallTime: 15},
-		)},
-		r2Stream.Events(),
-	)
+		// Test value with two registration that overlaps both.
+		p.ConsumeLogicalOps(ctx,
+			writeValueOpWithKV(roachpb.Key("k"), hlc.Timestamp{WallTime: 22}, []byte("val2")))
+		h.syncEventAndRegistrations()
+		valEvent := []*kvpb.RangeFeedEvent{
+			rangeFeedValue(
+				roachpb.Key("k"),
+				roachpb.Value{
+					RawBytes:  []byte("val2"),
+					Timestamp: hlc.Timestamp{WallTime: 22},
+				},
+			),
+		}
+		require.Equal(t, valEvent, r1Stream.Events())
+		require.Equal(t, valEvent, r2Stream.Events())
 
-	// Test the processor's new operation filter.
-	require.True(t, r1And2Filter.NeedVal(roachpb.Span{Key: roachpb.Key("a")}))
-	require.True(t, r1And2Filter.NeedVal(roachpb.Span{Key: roachpb.Key("y")}))
-	require.True(t, r1And2Filter.NeedVal(roachpb.Span{Key: roachpb.Key("y"), EndKey: roachpb.Key("zzz")}))
-	require.False(t, r1And2Filter.NeedVal(roachpb.Span{Key: roachpb.Key("zzz")}))
-	require.False(t, r1And2Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("a")}))
-	require.True(t, r1And2Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("y")}))
-	require.True(t, r1And2Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("y"), EndKey: roachpb.Key("zzz")}))
-	require.False(t, r1And2Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("zzz")}))
+		// Test value that only overlaps the second registration.
+		p.ConsumeLogicalOps(ctx,
+			writeValueOpWithKV(roachpb.Key("v"), hlc.Timestamp{WallTime: 23}, []byte("val3")))
+		h.syncEventAndRegistrations()
+		valEvent2 := []*kvpb.RangeFeedEvent{
+			rangeFeedValue(
+				roachpb.Key("v"),
+				roachpb.Value{
+					RawBytes:  []byte("val3"),
+					Timestamp: hlc.Timestamp{WallTime: 23},
+				},
+			),
+		}
+		require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
+		require.Equal(t, valEvent2, r2Stream.Events())
 
-	// Both registrations should see checkpoint.
-	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 20})
-	p.syncEventAndRegistrations()
-	chEventAM := []*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
-		hlc.Timestamp{WallTime: 20},
-	)}
-	require.Equal(t, chEventAM, r1Stream.Events())
-	chEventCZ := []*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-		roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("z")},
-		hlc.Timestamp{WallTime: 20},
-	)}
-	require.Equal(t, chEventCZ, r2Stream.Events())
+		// Cancel the first registration.
+		r1Stream.Cancel()
+		require.NotNil(t, waitErrorFuture(&r1Done))
 
-	// Test value with two registration that overlaps both.
-	p.ConsumeLogicalOps(ctx,
-		writeValueOpWithKV(roachpb.Key("k"), hlc.Timestamp{WallTime: 22}, []byte("val2")))
-	p.syncEventAndRegistrations()
-	valEvent := []*kvpb.RangeFeedEvent{rangeFeedValue(
-		roachpb.Key("k"),
-		roachpb.Value{
-			RawBytes:  []byte("val2"),
-			Timestamp: hlc.Timestamp{WallTime: 22},
-		},
-	)}
-	require.Equal(t, valEvent, r1Stream.Events())
-	require.Equal(t, valEvent, r2Stream.Events())
+		// Stop the processor with an error.
+		pErr := kvpb.NewErrorf("stop err")
+		p.StopWithErr(pErr)
+		require.NotNil(t, waitErrorFuture(&r2Done))
 
-	// Test value that only overlaps the second registration.
-	p.ConsumeLogicalOps(ctx,
-		writeValueOpWithKV(roachpb.Key("v"), hlc.Timestamp{WallTime: 23}, []byte("val3")))
-	p.syncEventAndRegistrations()
-	valEvent2 := []*kvpb.RangeFeedEvent{rangeFeedValue(
-		roachpb.Key("v"),
-		roachpb.Value{
-			RawBytes:  []byte("val3"),
-			Timestamp: hlc.Timestamp{WallTime: 23},
-		},
-	)}
-	require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
-	require.Equal(t, valEvent2, r2Stream.Events())
-
-	// Cancel the first registration.
-	r1Stream.Cancel()
-	require.NotNil(t, waitErrorFuture(&r1Done))
-
-	// Stop the processor with an error.
-	pErr := kvpb.NewErrorf("stop err")
-	p.StopWithErr(pErr)
-	require.NotNil(t, waitErrorFuture(&r2Done))
-
-	// Adding another registration should fail.
-	r3Stream := newTestStream()
-	var r3Done future.ErrorFuture
-	r3OK, _ := p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		r3Stream,
-		func() {},
-		&r3Done,
-	)
-	require.False(t, r3OK)
+		// Adding another registration should fail.
+		r3Stream := newTestStream()
+		var r3Done future.ErrorFuture
+		r3OK, _ := p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
+			hlc.Timestamp{WallTime: 1},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			r3Stream,
+			func() {},
+			&r3Done,
+		)
+		require.False(t, r3OK)
+	})
 }
 
 func TestProcessorSlowConsumer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	p, stopper := newTestProcessor(t, nil /* rtsIter */)
-	ctx := context.Background()
-	defer stopper.Stop(ctx)
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
+		p, h, stopper := newTestProcessor(t, withProcType(pt))
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
 
-	// Add a registration.
-	r1Stream := newTestStream()
-	var r1Done future.ErrorFuture
-	_, _ = p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		r1Stream,
-		func() {},
-		&r1Done,
-	)
-	r2Stream := newTestStream()
-	var r2Done future.ErrorFuture
-	p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		r2Stream,
-		func() {},
-		&r2Done,
-	)
-	p.syncEventAndRegistrations()
-	require.Equal(t, 2, p.Len())
-	require.Equal(t,
-		[]*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
-			hlc.Timestamp{WallTime: 0},
-		)},
-		r1Stream.Events(),
-	)
-	require.Equal(t,
-		[]*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
-			hlc.Timestamp{WallTime: 0},
-		)},
-		r2Stream.Events(),
-	)
+		// Add a registration.
+		r1Stream := newTestStream()
+		var r1Done future.ErrorFuture
+		_, _ = p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+			hlc.Timestamp{WallTime: 1},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			r1Stream,
+			func() {},
+			&r1Done,
+		)
+		r2Stream := newTestStream()
+		var r2Done future.ErrorFuture
+		p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
+			hlc.Timestamp{WallTime: 1},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			r2Stream,
+			func() {},
+			&r2Done,
+		)
+		h.syncEventAndRegistrations()
+		require.Equal(t, 2, p.Len())
+		require.Equal(t,
+			[]*kvpb.RangeFeedEvent{
+				rangeFeedCheckpoint(
+					roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+					hlc.Timestamp{WallTime: 0},
+				),
+			},
+			r1Stream.Events(),
+		)
+		require.Equal(t,
+			[]*kvpb.RangeFeedEvent{
+				rangeFeedCheckpoint(
+					roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+					hlc.Timestamp{WallTime: 0},
+				),
+			},
+			r2Stream.Events(),
+		)
 
-	// Block its Send method and fill up the registration's input channel.
-	unblock := r1Stream.BlockSend()
-	defer func() {
-		if unblock != nil {
-			unblock()
+		// Block its Send method and fill up the registration's input channel.
+		unblock := r1Stream.BlockSend()
+		defer func() {
+			if unblock != nil {
+				unblock()
+			}
+		}()
+		// Need one more message to fill the channel because the first one will be
+		// sent to the stream and block the registration outputLoop goroutine.
+		toFill := testProcessorEventCCap + 1
+		for i := 0; i < toFill; i++ {
+			ts := hlc.Timestamp{WallTime: int64(i + 2)}
+			p.ConsumeLogicalOps(ctx, writeValueOpWithKV(roachpb.Key("k"), ts, []byte("val")))
+
+			// Wait for just the unblocked registration to catch up. This prevents
+			// the race condition where this registration overflows anyway due to
+			// the rapid event consumption and small buffer size.
+			h.syncEventAndRegistrationsSpan(spXY)
 		}
-	}()
-	// Need one more message to fill the channel because the first one will be
-	// sent to the stream and block the registration outputLoop goroutine.
-	toFill := testProcessorEventCCap + 1
-	for i := 0; i < toFill; i++ {
-		ts := hlc.Timestamp{WallTime: int64(i + 2)}
-		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(roachpb.Key("k"), ts, []byte("val")))
 
-		// Wait for just the unblocked registration to catch up. This prevents
-		// the race condition where this registration overflows anyway due to
-		// the rapid event consumption and small buffer size.
-		p.syncEventAndRegistrationSpan(spXY)
-	}
+		// Consume one more event. Should not block, but should cause r1 to overflow
+		// its registration buffer and drop the event.
+		p.ConsumeLogicalOps(ctx,
+			writeValueOpWithKV(roachpb.Key("k"), hlc.Timestamp{WallTime: 18}, []byte("val")))
 
-	// Consume one more event. Should not block, but should cause r1 to overflow
-	// its registration buffer and drop the event.
-	p.ConsumeLogicalOps(ctx,
-		writeValueOpWithKV(roachpb.Key("k"), hlc.Timestamp{WallTime: 18}, []byte("val")))
+		// Wait for just the unblocked registration to catch up.
+		h.syncEventAndRegistrationsSpan(spXY)
+		require.Equal(t, toFill+1, len(r2Stream.Events()))
+		require.Equal(t, 2, p.Len())
 
-	// Wait for just the unblocked registration to catch up.
-	p.syncEventAndRegistrationSpan(spXY)
-	require.Equal(t, toFill+1, len(r2Stream.Events()))
-	require.Equal(t, 2, p.reg.Len())
-
-	// Unblock the send channel. The events should quickly be consumed.
-	unblock()
-	unblock = nil
-	p.syncEventAndRegistrations()
-	// At least one event should have been dropped due to overflow. We expect
-	// exactly one event to be dropped, but it is possible that multiple events
-	// were dropped due to rapid event consumption before the r1's outputLoop
-	// began consuming from its event buffer.
-	require.LessOrEqual(t, len(r1Stream.Events()), toFill)
-	require.Equal(t, newErrBufferCapacityExceeded().GoError(), waitErrorFuture(&r1Done))
-	testutils.SucceedsSoon(t, func() error {
-		if act, exp := p.Len(), 1; exp != act {
-			return fmt.Errorf("processor had %d regs, wanted %d", act, exp)
-		}
-		return nil
+		// Unblock the send channel. The events should quickly be consumed.
+		unblock()
+		unblock = nil
+		h.syncEventAndRegistrations()
+		// At least one event should have been dropped due to overflow. We expect
+		// exactly one event to be dropped, but it is possible that multiple events
+		// were dropped due to rapid event consumption before the r1's outputLoop
+		// began consuming from its event buffer.
+		require.LessOrEqual(t, len(r1Stream.Events()), toFill)
+		require.Equal(t, newErrBufferCapacityExceeded().GoError(), waitErrorFuture(&r1Done))
+		testutils.SucceedsSoon(t, func() error {
+			if act, exp := p.Len(), 1; exp != act {
+				return fmt.Errorf("processor had %d regs, wanted %d", act, exp)
+			}
+			return nil
+		})
 	})
 }
 
@@ -535,130 +683,105 @@ func TestProcessorSlowConsumer(t *testing.T) {
 // result of budget exhaustion.
 func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
 
-	fb := newTestBudget(40)
+		fb := newTestBudget(40)
+		m := NewMetrics()
+		p, h, stopper := newTestProcessor(t, withBudget(fb), withChanTimeout(time.Millisecond),
+			withMetrics(m), withProcType(pt))
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
 
-	stopper := stop.NewStopper()
-	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
-	m := NewMetrics()
-	p := NewProcessor(Config{
-		AmbientContext:   log.MakeTestingAmbientCtxWithNewTracer(),
-		Clock:            hlc.NewClockForTesting(nil),
-		Span:             roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
-		PushTxnsInterval: pushTxnInterval,
-		PushTxnsAge:      pushTxnAge,
-		EventChanCap:     testProcessorEventCCap,
-		Metrics:          m,
-		MemBudget:        fb,
-		EventChanTimeout: time.Millisecond,
+		// Add a registration.
+		r1Stream := newTestStream()
+		var r1Done future.ErrorFuture
+		_, _ = p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+			hlc.Timestamp{WallTime: 1},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			r1Stream,
+			func() {},
+			&r1Done,
+		)
+		h.syncEventAndRegistrations()
+
+		// Block it.
+		unblock := r1Stream.BlockSend()
+		defer func() {
+			if unblock != nil {
+				unblock()
+			}
+		}()
+
+		// Write entries till budget is exhausted
+		for i := 0; i < 10; i++ {
+			if !p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+				roachpb.Key("k"),
+				hlc.Timestamp{WallTime: int64(i + 2)},
+				[]byte(fmt.Sprintf("this is big value %02d", i)))) {
+				break
+			}
+		}
+		// Ensure that stop event generated by memory budget error is processed.
+		h.syncEventC()
+
+		// Unblock the 'send' channel. The events should quickly be consumed.
+		unblock()
+		unblock = nil
+		h.syncEventAndRegistrations()
+
+		require.Equal(t, newErrBufferCapacityExceeded().GoError(), waitErrorFuture(&r1Done))
+		require.Equal(t, 0, p.Len(), "registration was not removed")
+		require.Equal(t, int64(1), m.RangeFeedBudgetExhausted.Count())
 	})
-	require.NoError(t, p.Start(stopper, nil))
-	ctx := context.Background()
-	defer stopper.Stop(ctx)
-
-	// Add a registration.
-	r1Stream := newTestStream()
-	var r1Done future.ErrorFuture
-	_, _ = p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		r1Stream,
-		func() {},
-		&r1Done,
-	)
-	syncEventAndRegistrations(p)
-
-	// Block it.
-	unblock := r1Stream.BlockSend()
-	defer func() {
-		if unblock != nil {
-			unblock()
-		}
-	}()
-
-	// Write entries till budget is exhausted
-	for i := 0; i < 10; i++ {
-		if !p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
-			roachpb.Key("k"),
-			hlc.Timestamp{WallTime: int64(i + 2)},
-			[]byte(fmt.Sprintf("this is big value %02d", i)))) {
-			break
-		}
-	}
-
-	// Unblock stream processing part to consume error.
-	syncEventAndRegistrations(p)
-
-	// Unblock the 'send' channel. The events should quickly be consumed.
-	unblock()
-	unblock = nil
-	syncEventAndRegistrations(p)
-
-	require.Equal(t, newErrBufferCapacityExceeded().GoError(), waitErrorFuture(&r1Done))
-	require.Equal(t, 0, p.Len(), "registration was not removed")
-	require.Equal(t, int64(1), m.RangeFeedBudgetExhausted.Count())
 }
 
 // TestProcessorMemoryBudgetReleased that memory budget is correctly released.
 func TestProcessorMemoryBudgetReleased(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
+		fb := newTestBudget(40)
+		p, h, stopper := newTestProcessor(t, withBudget(fb), withChanTimeout(15*time.Minute),
+			withProcType(pt))
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
 
-	fb := newTestBudget(40)
+		// Add a registration.
+		r1Stream := newTestStream()
+		var r1Done future.ErrorFuture
+		p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+			hlc.Timestamp{WallTime: 1},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			r1Stream,
+			func() {},
+			&r1Done,
+		)
+		h.syncEventAndRegistrations()
 
-	stopper := stop.NewStopper()
-	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
-	p := NewProcessor(Config{
-		AmbientContext:   log.MakeTestingAmbientCtxWithNewTracer(),
-		Clock:            hlc.NewClockForTesting(nil),
-		Span:             roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
-		PushTxnsInterval: pushTxnInterval,
-		PushTxnsAge:      pushTxnAge,
-		EventChanCap:     testProcessorEventCCap,
-		Metrics:          NewMetrics(),
-		MemBudget:        fb,
-		EventChanTimeout: 15 * time.Minute, // Enable timeout to allow consumer to process
-		// events even if we reach memory budget capacity.
-	})
-	require.NoError(t, p.Start(stopper, nil))
-	ctx := context.Background()
-	defer stopper.Stop(ctx)
-
-	// Add a registration.
-	r1Stream := newTestStream()
-	var r1Done future.ErrorFuture
-	p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		r1Stream,
-		func() {},
-		&r1Done,
-	)
-	syncEventAndRegistrations(p)
-
-	// Write entries and check they are consumed so that we could write more
-	// data than total budget if inflight messages are within budget.
-	const eventCount = 10
-	for i := 0; i < eventCount; i++ {
-		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
-			roachpb.Key("k"),
-			hlc.Timestamp{WallTime: int64(i + 2)},
-			[]byte("value")))
-	}
-	syncEventAndRegistrations(p)
-
-	// Count consumed values
-	consumedOps := 0
-	for _, e := range r1Stream.Events() {
-		if e.Val != nil {
-			consumedOps++
+		// Write entries and check they are consumed so that we could write more
+		// data than total budget if inflight messages are within budget.
+		const eventCount = 10
+		for i := 0; i < eventCount; i++ {
+			p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+				roachpb.Key("k"),
+				hlc.Timestamp{WallTime: int64(i + 2)},
+				[]byte("value")))
 		}
-	}
-	require.Equal(t, 1, p.Len(), "registration was removed")
-	require.Equal(t, 10, consumedOps)
+		h.syncEventAndRegistrations()
+
+		// Count consumed values
+		consumedOps := 0
+		for _, e := range r1Stream.Events() {
+			if e.Val != nil {
+				consumedOps++
+			}
+		}
+		require.Equal(t, 1, p.Len(), "registration was removed")
+		require.Equal(t, 10, consumedOps)
+	})
 }
 
 // TestProcessorInitializeResolvedTimestamp tests that when a Processor is given
@@ -667,94 +790,101 @@ func TestProcessorMemoryBudgetReleased(t *testing.T) {
 func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
-	rtsIter := newTestIterator([]storage.MVCCKeyValue{
-		makeKV("a", "val1", 10),
-		makeIntent("c", txn1, "txnKey1", 15),
-		makeProvisionalKV("c", "txnKey1", 15),
-		makeKV("c", "val3", 11),
-		makeKV("c", "val4", 9),
-		makeIntent("d", txn2, "txnKey2", 21),
-		makeProvisionalKV("d", "txnKey2", 21),
-		makeKV("d", "val5", 20),
-		makeKV("d", "val6", 19),
-		makeKV("m", "val8", 1),
-		makeIntent("n", txn1, "txnKey1", 12),
-		makeProvisionalKV("n", "txnKey1", 12),
-		makeIntent("r", txn1, "txnKey1", 19),
-		makeProvisionalKV("r", "txnKey1", 19),
-		makeKV("r", "val9", 4),
-		makeIntent("w", txn1, "txnKey1", 3),
-		makeProvisionalKV("w", "txnKey1", 3),
-		makeIntent("z", txn2, "txnKey2", 21),
-		makeProvisionalKV("z", "txnKey2", 21),
-		makeKV("z", "val11", 4),
-	}, nil)
-	rtsIter.block = make(chan struct{})
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
+		txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
+		rtsIter := newTestIterator([]storage.MVCCKeyValue{
+			makeKV("a", "val1", 10),
+			makeIntent("c", txn1, "txnKey1", 15),
+			makeProvisionalKV("c", "txnKey1", 15),
+			makeKV("c", "val3", 11),
+			makeKV("c", "val4", 9),
+			makeIntent("d", txn2, "txnKey2", 21),
+			makeProvisionalKV("d", "txnKey2", 21),
+			makeKV("d", "val5", 20),
+			makeKV("d", "val6", 19),
+			makeKV("m", "val8", 1),
+			makeIntent("n", txn1, "txnKey1", 12),
+			makeProvisionalKV("n", "txnKey1", 12),
+			makeIntent("r", txn1, "txnKey1", 19),
+			makeProvisionalKV("r", "txnKey1", 19),
+			makeKV("r", "val9", 4),
+			makeIntent("w", txn1, "txnKey1", 3),
+			makeProvisionalKV("w", "txnKey1", 3),
+			makeIntent("z", txn2, "txnKey2", 21),
+			makeProvisionalKV("z", "txnKey2", 21),
+			makeKV("z", "val11", 4),
+		}, nil)
+		rtsIter.block = make(chan struct{})
 
-	p, stopper := newTestProcessor(t, rtsIter)
-	ctx := context.Background()
-	defer stopper.Stop(ctx)
+		p, h, stopper := newTestProcessor(t, withRtsIter(rtsIter), withProcType(pt))
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
 
-	// The resolved timestamp should not be initialized.
-	require.False(t, p.rts.IsInit())
-	require.Equal(t, hlc.Timestamp{}, p.rts.Get())
+		// The resolved timestamp should not be initialized.
+		require.False(t, h.rts.IsInit())
+		require.Equal(t, hlc.Timestamp{}, h.rts.Get())
 
-	// Add a registration.
-	r1Stream := newTestStream()
-	var r1Done future.ErrorFuture
-	p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		r1Stream,
-		func() {},
-		&r1Done,
-	)
-	p.syncEventAndRegistrations()
-	require.Equal(t, 1, p.Len())
+		// Add a registration.
+		r1Stream := newTestStream()
+		var r1Done future.ErrorFuture
+		p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+			hlc.Timestamp{WallTime: 1},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			r1Stream,
+			func() {},
+			&r1Done,
+		)
+		h.syncEventAndRegistrations()
+		require.Equal(t, 1, p.Len())
 
-	// The registration should be provided a checkpoint immediately with an
-	// empty resolved timestamp because it did not perform a catch-up scan.
-	chEvent := []*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
-		hlc.Timestamp{},
-	)}
-	require.Equal(t, chEvent, r1Stream.Events())
+		// The registration should be provided a checkpoint immediately with an
+		// empty resolved timestamp because it did not perform a catch-up scan.
+		chEvent := []*kvpb.RangeFeedEvent{
+			rangeFeedCheckpoint(
+				roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+				hlc.Timestamp{},
+			),
+		}
+		require.Equal(t, chEvent, r1Stream.Events())
 
-	// The resolved timestamp should still not be initialized.
-	require.False(t, p.rts.IsInit())
-	require.Equal(t, hlc.Timestamp{}, p.rts.Get())
+		// The resolved timestamp should still not be initialized.
+		require.False(t, h.rts.IsInit())
+		require.Equal(t, hlc.Timestamp{}, h.rts.Get())
 
-	// Forward the closed timestamp. The resolved timestamp should still
-	// not be initialized.
-	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 20})
-	require.False(t, p.rts.IsInit())
-	require.Equal(t, hlc.Timestamp{}, p.rts.Get())
+		// Forward the closed timestamp. The resolved timestamp should still
+		// not be initialized.
+		p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 20})
+		require.False(t, h.rts.IsInit())
+		require.Equal(t, hlc.Timestamp{}, h.rts.Get())
 
-	// Let the scan proceed.
-	close(rtsIter.block)
-	<-rtsIter.done
-	require.True(t, rtsIter.closed)
+		// Let the scan proceed.
+		close(rtsIter.block)
+		<-rtsIter.done
+		require.True(t, rtsIter.closed)
 
-	// Synchronize the event channel then verify that the resolved timestamp is
-	// initialized and that it's blocked on the oldest unresolved intent's txn
-	// timestamp. Txn1 has intents at many times but the unresolvedIntentQueue
-	// tracks its latest, which is 19, so the resolved timestamp is
-	// 19.FloorPrev() = 18.
-	p.syncEventAndRegistrations()
-	require.True(t, p.rts.IsInit())
-	require.Equal(t, hlc.Timestamp{WallTime: 18}, p.rts.Get())
+		// Synchronize the event channel then verify that the resolved timestamp is
+		// initialized and that it's blocked on the oldest unresolved intent's txn
+		// timestamp. Txn1 has intents at many times but the unresolvedIntentQueue
+		// tracks its latest, which is 19, so the resolved timestamp is
+		// 19.FloorPrev() = 18.
+		h.syncEventAndRegistrations()
+		require.True(t, h.rts.IsInit())
+		require.Equal(t, hlc.Timestamp{WallTime: 18}, h.rts.Get())
 
-	// The registration should have been informed of the new resolved timestamp.
-	chEvent = []*kvpb.RangeFeedEvent{rangeFeedCheckpoint(
-		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
-		hlc.Timestamp{WallTime: 18},
-	)}
-	require.Equal(t, chEvent, r1Stream.Events())
+		// The registration should have been informed of the new resolved timestamp.
+		chEvent = []*kvpb.RangeFeedEvent{
+			rangeFeedCheckpoint(
+				roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+				hlc.Timestamp{WallTime: 18},
+			),
+		}
+		require.Equal(t, chEvent, r1Stream.Events())
+	})
 }
 
+// TODO(oleg): write test for scheduler where push would be scheduled externally.
 func TestProcessorTxnPushAttempt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -857,13 +987,14 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 		return nil
 	})
 
-	p, stopper := newTestProcessorWithTxnPusher(t, nil /* rtsIter */, &tp)
+	p, h, stopper := newTestProcessor(t, withPusher(&tp), withProcType(legacyProcessor))
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 
 	// Add a few intents and move the closed timestamp forward.
 	writeIntentOpFromMeta := func(txn enginepb.TxnMeta) enginepb.MVCCLogicalOp {
-		return writeIntentOpWithDetails(txn.ID, txn.Key, txn.IsoLevel, txn.MinTimestamp, txn.WriteTimestamp)
+		return writeIntentOpWithDetails(txn.ID, txn.Key, txn.IsoLevel, txn.MinTimestamp,
+			txn.WriteTimestamp)
 	}
 	p.ConsumeLogicalOps(ctx,
 		writeIntentOpFromMeta(txn1Meta),
@@ -872,21 +1003,21 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 		writeIntentOpFromMeta(txn3Meta),
 	)
 	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 40})
-	p.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 9}, p.rts.Get())
+	h.syncEventC()
+	require.Equal(t, hlc.Timestamp{WallTime: 9}, h.rts.Get())
 
 	// Wait for the first txn push attempt to complete.
 	pausePushAttemptsC <- struct{}{}
 
 	// The resolved timestamp hasn't moved.
-	p.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 9}, p.rts.Get())
+	h.syncEventC()
+	require.Equal(t, hlc.Timestamp{WallTime: 9}, h.rts.Get())
 
 	// Write another intent for one of the txns. This moves the resolved
 	// timestamp forward.
 	p.ConsumeLogicalOps(ctx, writeIntentOpFromMeta(txn1MetaT2Pre))
-	p.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 19}, p.rts.Get())
+	h.syncEventC()
+	require.Equal(t, hlc.Timestamp{WallTime: 19}, h.rts.Get())
 
 	// Unblock the second txn push attempt and wait for it to complete.
 	resumePushAttemptsC <- struct{}{}
@@ -894,23 +1025,23 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 
 	// The resolved timestamp should have moved forwards to the closed
 	// timestamp.
-	p.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 40}, p.rts.Get())
+	h.syncEventC()
+	require.Equal(t, hlc.Timestamp{WallTime: 40}, h.rts.Get())
 
 	// Forward the closed timestamp.
 	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 80})
-	p.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 49}, p.rts.Get())
+	h.syncEventC()
+	require.Equal(t, hlc.Timestamp{WallTime: 49}, h.rts.Get())
 
 	// Txn1's first intent is committed. Resolved timestamp doesn't change.
 	p.ConsumeLogicalOps(ctx, commitIntentOp(txn1MetaT2Post.ID, txn1MetaT2Post.WriteTimestamp))
-	p.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 49}, p.rts.Get())
+	h.syncEventC()
+	require.Equal(t, hlc.Timestamp{WallTime: 49}, h.rts.Get())
 
 	// Txn1's second intent is committed. Resolved timestamp moves forward.
 	p.ConsumeLogicalOps(ctx, commitIntentOp(txn1MetaT2Post.ID, txn1MetaT2Post.WriteTimestamp))
-	p.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 59}, p.rts.Get())
+	h.syncEventC()
+	require.Equal(t, hlc.Timestamp{WallTime: 59}, h.rts.Get())
 
 	// Unblock the third txn push attempt and wait for it to complete.
 	resumePushAttemptsC <- struct{}{}
@@ -918,18 +1049,18 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 
 	// The resolved timestamp should have moved forwards to the closed
 	// timestamp.
-	p.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 80}, p.rts.Get())
+	h.syncEventC()
+	require.Equal(t, hlc.Timestamp{WallTime: 80}, h.rts.Get())
 
 	// Forward the closed timestamp.
 	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 100})
-	p.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 89}, p.rts.Get())
+	h.syncEventC()
+	require.Equal(t, hlc.Timestamp{WallTime: 89}, h.rts.Get())
 
 	// Commit txn3's only intent. Resolved timestamp moves forward.
 	p.ConsumeLogicalOps(ctx, commitIntentOp(txn3MetaT3Post.ID, txn3MetaT3Post.WriteTimestamp))
-	p.syncEventC()
-	require.Equal(t, hlc.Timestamp{WallTime: 100}, p.rts.Get())
+	h.syncEventC()
+	require.Equal(t, hlc.Timestamp{WallTime: 100}, h.rts.Get())
 
 	// Release push attempt to avoid deadlock.
 	resumePushAttemptsC <- struct{}{}
@@ -940,134 +1071,113 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 // not then it would be possible for them to deadlock.
 func TestProcessorConcurrentStop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ctx := context.Background()
-	const trials = 10
-	for i := 0; i < trials; i++ {
-		p, stopper := newTestProcessor(t, nil /* rtsIter */)
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
 
-		var wg sync.WaitGroup
-		wg.Add(6)
-		go func() {
-			defer wg.Done()
-			runtime.Gosched()
-			s := newTestStream()
-			var done future.ErrorFuture
-			p.Register(p.Span, hlc.Timestamp{}, nil, false, s,
-				func() {}, &done)
-		}()
-		go func() {
-			defer wg.Done()
-			runtime.Gosched()
-			p.Len()
-		}()
-		go func() {
-			defer wg.Done()
-			runtime.Gosched()
-			p.ConsumeLogicalOps(ctx,
-				writeValueOpWithKV(roachpb.Key("s"), hlc.Timestamp{WallTime: 6}, []byte("val")))
-		}()
-		go func() {
-			defer wg.Done()
-			runtime.Gosched()
-			p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 2})
-		}()
-		go func() {
-			defer wg.Done()
-			runtime.Gosched()
-			p.Stop()
-		}()
-		go func() {
-			defer wg.Done()
-			runtime.Gosched()
-			stopper.Stop(context.Background())
-		}()
-		wg.Wait()
-	}
+		ctx := context.Background()
+		const trials = 10
+		for i := 0; i < trials; i++ {
+			p, h, stopper := newTestProcessor(t, withProcType(pt))
+
+			var wg sync.WaitGroup
+			wg.Add(6)
+			go func() {
+				defer wg.Done()
+				runtime.Gosched()
+				s := newTestStream()
+				var done future.ErrorFuture
+				p.Register(h.span, hlc.Timestamp{}, nil, false, s,
+					func() {}, &done)
+			}()
+			go func() {
+				defer wg.Done()
+				runtime.Gosched()
+				p.Len()
+			}()
+			go func() {
+				defer wg.Done()
+				runtime.Gosched()
+				p.ConsumeLogicalOps(ctx,
+					writeValueOpWithKV(roachpb.Key("s"), hlc.Timestamp{WallTime: 6}, []byte("val")))
+			}()
+			go func() {
+				defer wg.Done()
+				runtime.Gosched()
+				p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 2})
+			}()
+			go func() {
+				defer wg.Done()
+				runtime.Gosched()
+				p.Stop()
+			}()
+			go func() {
+				defer wg.Done()
+				runtime.Gosched()
+				stopper.Stop(context.Background())
+			}()
+			wg.Wait()
+		}
+	})
 }
 
 // TestProcessorRegistrationObservesOnlyNewEvents tests that a registration
 // observes only operations that are consumed after it has registered.
 func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	p, stopper := newTestProcessor(t, nil /* rtsIter */)
-	ctx := context.Background()
-	defer stopper.Stop(ctx)
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
 
-	firstC := make(chan int64)
-	regDone := make(chan struct{})
-	regs := make(map[*testStream]int64)
+		p, h, stopper := newTestProcessor(t, withProcType(pt))
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		for i := int64(1); i < 250; i++ {
-			// Add a new registration every 10 ops.
-			if i%10 == 0 {
-				firstC <- i
-				<-regDone
+		firstC := make(chan int64)
+		regDone := make(chan struct{})
+		regs := make(map[*testStream]int64)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := int64(1); i < 250; i++ {
+				// Add a new registration every 10 ops.
+				if i%10 == 0 {
+					firstC <- i
+					<-regDone
+				}
+
+				// Consume the logical op. Encode the index in the timestamp.
+				p.ConsumeLogicalOps(ctx, writeValueOp(hlc.Timestamp{WallTime: i}))
 			}
+			h.syncEventC()
+			close(firstC)
+		}()
+		go func() {
+			defer wg.Done()
+			for firstIdx := range firstC {
+				// For each index, create a new registration. The first
+				// operation is should see is firstIdx.
+				s := newTestStream()
+				regs[s] = firstIdx
+				var done future.ErrorFuture
+				p.Register(h.span, hlc.Timestamp{}, nil, false,
+					s, func() {}, &done)
+				regDone <- struct{}{}
+			}
+		}()
+		wg.Wait()
+		h.syncEventAndRegistrations()
 
-			// Consume the logical op. Encode the index in the timestamp.
-			p.ConsumeLogicalOps(ctx, writeValueOp(hlc.Timestamp{WallTime: i}))
+		// Verify that no registrations were given operations
+		// from before they registered.
+		for s, expFirstIdx := range regs {
+			events := s.Events()
+			require.IsType(t, &kvpb.RangeFeedCheckpoint{}, events[0].GetValue())
+			require.IsType(t, &kvpb.RangeFeedValue{}, events[1].GetValue())
+
+			firstVal := events[1].GetValue().(*kvpb.RangeFeedValue)
+			firstIdx := firstVal.Value.Timestamp.WallTime
+			require.Equal(t, expFirstIdx, firstIdx)
 		}
-		p.syncEventC()
-		close(firstC)
-	}()
-	go func() {
-		defer wg.Done()
-		for firstIdx := range firstC {
-			// For each index, create a new registration. The first
-			// operation is should see is firstIdx.
-			s := newTestStream()
-			regs[s] = firstIdx
-			var done future.ErrorFuture
-			p.Register(p.Span, hlc.Timestamp{}, nil, false,
-				s, func() {}, &done)
-			regDone <- struct{}{}
-		}
-	}()
-	wg.Wait()
-	p.syncEventAndRegistrations()
-
-	// Verify that no registrations were given operations
-	// from before they registered.
-	for s, expFirstIdx := range regs {
-		events := s.Events()
-		require.IsType(t, &kvpb.RangeFeedCheckpoint{}, events[0].GetValue())
-		require.IsType(t, &kvpb.RangeFeedValue{}, events[1].GetValue())
-
-		firstVal := events[1].GetValue().(*kvpb.RangeFeedValue)
-		firstIdx := firstVal.Value.Timestamp.WallTime
-		require.Equal(t, expFirstIdx, firstIdx)
-	}
-}
-
-// syncEventAndRegistrations waits for all previously sent events to be
-// processed *and* for all registration output loops to fully process their own
-// internal buffers.
-func (p *LegacyProcessor) syncEventAndRegistrations() {
-	p.syncEventAndRegistrationSpan(all)
-}
-
-// syncEventAndRegistrations waits for all previously sent events to be
-// processed *and* for all registration output loops for registrations
-// overlapping the given span to fully process their own internal buffers.
-func (p *LegacyProcessor) syncEventAndRegistrationSpan(span roachpb.Span) {
-	syncC := make(chan struct{})
-	ev := getPooledEvent(event{sync: &syncEvent{c: syncC, testRegCatchupSpan: &span}})
-	select {
-	case p.eventC <- ev:
-		select {
-		case <-syncC:
-		// Synchronized.
-		case <-p.stoppedC:
-			// Already stopped. Do nothing.
-		}
-	case <-p.stoppedC:
-		putPooledEvent(ev)
-		// Already stopped. Do nothing.
-	}
+	})
 }
 
 func notifyWhenDone(f *future.ErrorFuture) chan error {
@@ -1080,7 +1190,6 @@ func notifyWhenDone(f *future.ErrorFuture) chan error {
 
 func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
 	const totalEvents = 100
 
 	// Channel capacity is used in two places, processor channel and registration
@@ -1089,88 +1198,78 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 	// as sync events used to flush queues.
 	const channelCapacity = totalEvents/2 + 10
 
-	s := cluster.MakeTestingClusterSettings()
-	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.NewStandaloneBudget(math.MaxInt64))
-	//budgetEnabled := int32(1)
-	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0, &s.SV)
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
+		s := cluster.MakeTestingClusterSettings()
+		m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+		m.Start(context.Background(), nil, mon.NewStandaloneBudget(math.MaxInt64))
 
-	stopper := stop.NewStopper()
-	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
-	p := NewProcessor(Config{
-		AmbientContext:   log.MakeTestingAmbientCtxWithNewTracer(),
-		Clock:            hlc.NewClockForTesting(nil),
-		Span:             roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
-		PushTxnsInterval: pushTxnInterval,
-		PushTxnsAge:      pushTxnAge,
-		EventChanCap:     channelCapacity,
-		EventChanTimeout: 100 * time.Millisecond, // enough time for registration to process events
-		MemBudget:        fb,
-		Metrics:          NewMetrics(),
-	})
-	require.NoError(t, p.Start(stopper, nil))
-	ctx := context.Background()
-	defer stopper.Stop(ctx)
+		b := m.MakeBoundAccount()
+		fb := NewFeedBudget(&b, 0, &s.SV)
 
-	// Add a registration.
-	rStream := newConsumer(50)
-	defer func() { rStream.Resume() }()
-	var done future.ErrorFuture
-	_, _ = p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		rStream,
-		func() {},
-		&done,
-	)
-	rErrC := notifyWhenDone(&done)
-	syncEventAndRegistrations(p)
+		p, h, stopper := newTestProcessor(t, withBudget(fb), withChanCap(channelCapacity),
+			withEventTimeout(100*time.Millisecond), withProcType(pt))
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
 
-	for i := 0; i < totalEvents; i++ {
-		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
-			roachpb.Key("k"),
-			hlc.Timestamp{WallTime: int64(i + 2)},
-			[]byte(fmt.Sprintf("this is value %04d", i))))
-	}
+		// Add a registration.
+		rStream := newConsumer(50)
+		defer func() { rStream.Resume() }()
+		var done future.ErrorFuture
+		_, _ = p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+			hlc.Timestamp{WallTime: 1},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			rStream,
+			func() {},
+			&done,
+		)
+		rErrC := notifyWhenDone(&done)
+		h.syncEventAndRegistrations()
 
-	// Wait for half of the event to be processed by stream then stop processor.
-	select {
-	case <-rStream.blocked:
-	case err := <-rErrC:
-		t.Fatal("stream failed with error before all data was consumed", err)
-	}
-
-	// Since stop is blocking and needs to flush events we need to do that in
-	// parallel.
-	stopped := make(chan interface{})
-	go func() {
-		p.Stop()
-		stopped <- struct{}{}
-	}()
-
-	// Resume event loop in consumer to unblock any internal loops of processor or
-	// registrations.
-	rStream.Resume()
-
-	// Wait for top function to finish processing before verifying that we
-	// consumed all events.
-	<-stopped
-
-	// We need to wait for budget to drain as Stop would only post stop event
-	// after flushing the queue, but couldn't determine when main processor loop
-	// is actually closed.
-	testutils.SucceedsSoon(t, func() error {
-		fmt.Printf("Budget now: %d bytes remained, %d events processed\n",
-			m.AllocBytes(), rStream.Consumed())
-		if m.AllocBytes() != 0 {
-			return errors.Errorf(
-				"Failed to release all budget after stop: %d bytes remained, %d events processed",
-				m.AllocBytes(), rStream.Consumed())
+		for i := 0; i < totalEvents; i++ {
+			p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+				roachpb.Key("k"),
+				hlc.Timestamp{WallTime: int64(i + 2)},
+				[]byte(fmt.Sprintf("this is value %04d", i))))
 		}
-		return nil
+
+		// Wait for half of the event to be processed by stream then stop processor.
+		select {
+		case <-rStream.blocked:
+		case err := <-rErrC:
+			t.Fatal("stream failed with error before all data was consumed", err)
+		}
+
+		// Since stop is blocking and needs to flush events we need to do that in
+		// parallel.
+		stopped := make(chan interface{})
+		go func() {
+			p.Stop()
+			stopped <- struct{}{}
+		}()
+
+		// Resume event loop in consumer to unblock any internal loops of processor or
+		// registrations.
+		rStream.Resume()
+
+		// Wait for top function to finish processing before verifying that we
+		// consumed all events.
+		<-stopped
+
+		// We need to wait for budget to drain as Stop would only post stop event
+		// after flushing the queue, but couldn't determine when main processor loop
+		// is actually closed.
+		testutils.SucceedsSoon(t, func() error {
+			fmt.Printf("Budget now: %d bytes remained, %d events processed\n",
+				m.AllocBytes(), rStream.Consumed())
+			if m.AllocBytes() != 0 {
+				return errors.Errorf(
+					"Failed to release all budget after stop: %d bytes remained, %d events processed",
+					m.AllocBytes(), rStream.Consumed())
+			}
+			return nil
+		})
 	})
 }
 
@@ -1185,61 +1284,51 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 	// objects. Ideally it would be nice to have
 	const channelCapacity = totalEvents + 5
 
-	fb := newTestBudget(math.MaxInt64)
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
+		fb := newTestBudget(math.MaxInt64)
 
-	stopper := stop.NewStopper()
-	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
-	p := NewProcessor(Config{
-		AmbientContext:   log.MakeTestingAmbientCtxWithNewTracer(),
-		Clock:            hlc.NewClockForTesting(nil),
-		Span:             roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
-		PushTxnsInterval: pushTxnInterval,
-		PushTxnsAge:      pushTxnAge,
-		EventChanCap:     channelCapacity,
-		EventChanTimeout: time.Millisecond,
-		MemBudget:        fb,
-		Metrics:          NewMetrics(),
+		p, h, stopper := newTestProcessor(t, withBudget(fb), withChanCap(channelCapacity),
+			withEventTimeout(time.Millisecond), withProcType(pt))
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
+
+		// Add a registration.
+		rStream := newConsumer(90)
+		defer func() { rStream.Resume() }()
+		var done future.ErrorFuture
+		_, _ = p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+			hlc.Timestamp{WallTime: 1},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			rStream,
+			func() {},
+			&done,
+		)
+		rErrC := notifyWhenDone(&done)
+		h.syncEventAndRegistrations()
+
+		for i := 0; i < totalEvents; i++ {
+			p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+				roachpb.Key("k"),
+				hlc.Timestamp{WallTime: int64(i + 2)},
+				[]byte(fmt.Sprintf("this is value %04d", i))))
+		}
+
+		// Wait for half of the event to be processed then raise error.
+		select {
+		case <-rStream.blocked:
+		case err := <-rErrC:
+			t.Fatal("stream failed with error before stream blocked: ", err)
+		}
+
+		// Resume event loop in consumer and fail Stream to remove registration.
+		rStream.ResumeWithFailure(errors.Errorf("Closing down stream"))
+
+		// We need to wait for budget to drain as all pending events are processed
+		// or dropped.
+		requireBudgetDrainedSoon(t, fb, rStream)
 	})
-	require.NoError(t, p.Start(stopper, nil))
-	ctx := context.Background()
-	defer stopper.Stop(ctx)
-
-	// Add a registration.
-	rStream := newConsumer(90)
-	defer func() { rStream.Resume() }()
-	var done future.ErrorFuture
-	_, _ = p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		rStream,
-		func() {},
-		&done,
-	)
-	rErrC := notifyWhenDone(&done)
-	syncEventAndRegistrations(p)
-
-	for i := 0; i < totalEvents; i++ {
-		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
-			roachpb.Key("k"),
-			hlc.Timestamp{WallTime: int64(i + 2)},
-			[]byte(fmt.Sprintf("this is value %04d", i))))
-	}
-
-	// Wait for half of the event to be processed then raise error.
-	select {
-	case <-rStream.blocked:
-	case err := <-rErrC:
-		t.Fatal("stream failed with error before stream blocked: ", err)
-	}
-
-	// Resume event loop in consumer and fail Stream to remove registration.
-	rStream.ResumeWithFailure(errors.Errorf("Closing down stream"))
-
-	// We need to wait for budget to drain as all pending events are processed
-	// or dropped.
-	requireBudgetDrainedSoon(t, p, rStream)
 }
 
 func newTestBudget(limit int64) *FeedBudget {
@@ -1265,74 +1354,65 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 	// as sync events used to flush queues.
 	const channelCapacity = totalEvents/2 + 10
 
-	fb := newTestBudget(math.MaxInt64)
+	testutils.RunValues(t, "proc type", testTypes, func(t *testing.T, pt procType) {
 
-	stopper := stop.NewStopper()
-	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
-	p := NewProcessor(Config{
-		AmbientContext:   log.MakeTestingAmbientCtxWithNewTracer(),
-		Clock:            hlc.NewClockForTesting(nil),
-		Span:             roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
-		PushTxnsInterval: pushTxnInterval,
-		PushTxnsAge:      pushTxnAge,
-		EventChanCap:     channelCapacity,
-		EventChanTimeout: 100 * time.Millisecond, // enough time for registration to process events
-		MemBudget:        fb,
-		Metrics:          NewMetrics(),
+		fb := newTestBudget(math.MaxInt64)
+
+		p, h, stopper := newTestProcessor(t, withBudget(fb), withChanCap(channelCapacity),
+			withEventTimeout(100*time.Millisecond), withProcType(pt))
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
+
+		// Add a registration.
+		r1Stream := newConsumer(50)
+		defer func() { r1Stream.Resume() }()
+		var r1Done future.ErrorFuture
+		_, _ = p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+			hlc.Timestamp{WallTime: 1},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			r1Stream,
+			func() {},
+			&r1Done,
+		)
+		r1ErrC := notifyWhenDone(&r1Done)
+
+		// Non-blocking registration that would consume all events.
+		r2Stream := newConsumer(0)
+		var r2Done future.ErrorFuture
+		p.Register(
+			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+			hlc.Timestamp{WallTime: 1},
+			nil,   /* catchUpIter */
+			false, /* withDiff */
+			r2Stream,
+			func() {},
+			&r2Done,
+		)
+		h.syncEventAndRegistrations()
+
+		for i := 0; i < totalEvents; i++ {
+			p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+				roachpb.Key("k"),
+				hlc.Timestamp{WallTime: int64(i + 2)},
+				[]byte(fmt.Sprintf("this is value %04d", i))))
+		}
+
+		// Wait for half of the event to be processed then stop processor.
+		select {
+		case <-r1Stream.blocked:
+		case err := <-r1ErrC:
+			t.Fatal("stream failed with error before all data was consumed", err)
+		}
+
+		// Resume event loop in consumer and fail Stream to remove registration.
+		r1Stream.ResumeWithFailure(errors.Errorf("Closing down stream"))
+
+		// We need to wait for budget to drain as all pending events are processed
+		// or dropped.
+		requireBudgetDrainedSoon(t, fb, r1Stream)
 	})
-	require.NoError(t, p.Start(stopper, nil))
-	ctx := context.Background()
-	defer stopper.Stop(ctx)
-
-	// Add a registration.
-	r1Stream := newConsumer(50)
-	defer func() { r1Stream.Resume() }()
-	var r1Done future.ErrorFuture
-	_, _ = p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		r1Stream,
-		func() {},
-		&r1Done,
-	)
-	r1ErrC := notifyWhenDone(&r1Done)
-
-	// Non-blocking registration that would consume all events.
-	r2Stream := newConsumer(0)
-	var r2Done future.ErrorFuture
-	p.Register(
-		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
-		hlc.Timestamp{WallTime: 1},
-		nil,   /* catchUpIter */
-		false, /* withDiff */
-		r2Stream,
-		func() {},
-		&r2Done,
-	)
-	syncEventAndRegistrations(p)
-
-	for i := 0; i < totalEvents; i++ {
-		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
-			roachpb.Key("k"),
-			hlc.Timestamp{WallTime: int64(i + 2)},
-			[]byte(fmt.Sprintf("this is value %04d", i))))
-	}
-
-	// Wait for half of the event to be processed then stop processor.
-	select {
-	case <-r1Stream.blocked:
-	case err := <-r1ErrC:
-		t.Fatal("stream failed with error before all data was consumed", err)
-	}
-
-	// Resume event loop in consumer and fail Stream to remove registration.
-	r1Stream.ResumeWithFailure(errors.Errorf("Closing down stream"))
-
-	// We need to wait for budget to drain as all pending events are processed
-	// or dropped.
-	requireBudgetDrainedSoon(t, p, r1Stream)
 }
 
 // requireBudgetDrainedSoon checks that memory budget drains to zero soon.
@@ -1341,12 +1421,11 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 // stop and drain remaining allocations.
 // We use account and not a monitor for those checks because monitor doesn't
 // necessary return all data to the pool until processor is stopped.
-func requireBudgetDrainedSoon(t *testing.T, p Processor, stream *consumer) {
-	processor := p.(*LegacyProcessor)
+func requireBudgetDrainedSoon(t *testing.T, b *FeedBudget, stream *consumer) {
 	testutils.SucceedsSoon(t, func() error {
-		processor.MemBudget.mu.Lock()
-		used := processor.MemBudget.mu.memBudget.Used()
-		processor.MemBudget.mu.Unlock()
+		b.mu.Lock()
+		used := b.mu.memBudget.Used()
+		b.mu.Unlock()
 		fmt.Printf("Budget used: %d bytes, %d events processed\n",
 			used, stream.Consumed())
 		if used != 0 {
@@ -1380,7 +1459,6 @@ func newConsumer(blockAfter int) *consumer {
 }
 
 func (c *consumer) Send(e *kvpb.RangeFeedEvent) error {
-	//fmt.Printf("Stream received event %v\n", e)
 	if e.Val != nil {
 		v := int(atomic.AddInt32(&c.sentValues, 1))
 		if v == c.blockAfter {
@@ -1447,22 +1525,12 @@ func TestProcessorBackpressure(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
 
 	span := roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")}
 
-	// Set up processor.
-	p := NewProcessor(Config{
-		AmbientContext:   log.MakeTestingAmbientContext(nil),
-		Clock:            hlc.NewClockForTesting(nil),
-		Metrics:          NewMetrics(),
-		Span:             span,
-		MemBudget:        newTestBudget(math.MaxInt64),
-		EventChanCap:     1,
-		EventChanTimeout: 0,
-	})
-	require.NoError(t, p.Start(stopper, nil))
+	p, h, stopper := newTestProcessor(t, withSpan(span), withBudget(newTestBudget(math.MaxInt64)),
+		withChanCap(1), withEventTimeout(0), withProcType(legacyProcessor))
+	defer stopper.Stop(ctx)
 	defer p.Stop()
 
 	// Add a registration.
@@ -1472,7 +1540,7 @@ func TestProcessorBackpressure(t *testing.T) {
 	require.True(t, ok)
 
 	// Wait for the initial checkpoint.
-	syncEventAndRegistrations(p)
+	h.syncEventAndRegistrations()
 	require.Len(t, stream.Events(), 1)
 
 	// Block the registration consumer, and spawn a goroutine to post events to
@@ -1508,7 +1576,7 @@ func TestProcessorBackpressure(t *testing.T) {
 	}
 
 	// Wait for the final checkpoint event.
-	syncEventAndRegistrations(p)
+	h.syncEventAndRegistrations()
 	events := stream.Events()
 	require.Equal(t, &kvpb.RangeFeedEvent{
 		Checkpoint: &kvpb.RangeFeedCheckpoint{
@@ -1516,9 +1584,4 @@ func TestProcessorBackpressure(t *testing.T) {
 			ResolvedTS: hlc.Timestamp{WallTime: numEvents},
 		},
 	}, events[len(events)-1])
-}
-
-func syncEventAndRegistrations(p Processor) {
-	impl := p.(*LegacyProcessor)
-	impl.syncEventAndRegistrations()
 }

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -290,9 +290,8 @@ func (r *registration) maybeStripEvent(event *kvpb.RangeFeedEvent) *kvpb.RangeFe
 }
 
 // disconnect cancels the output loop context for the registration and passes an
-// error to the output error stream for the registration. This also sets the
-// disconnected flag on the registration, preventing it from being disconnected
-// again.
+// error to the output error stream for the registration.
+// Safe to run multiple times, but subsequent errors would be discarded.
 func (r *registration) disconnect(pErr *kvpb.Error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -54,6 +54,9 @@ type ScheduledProcessor struct {
 	// Processor startup runs background tasks to scan intents. If processor is
 	// stopped early, this task needs to be terminated to avoid resource waste.
 	startupCancel func()
+	// stopper passed by start that is used for firing up async work from scheduler.
+	stopper       *stop.Stopper
+	txnPushActive bool
 }
 
 // NewScheduledProcessor creates a new scheduler based rangefeed Processor.
@@ -88,6 +91,7 @@ func (p *ScheduledProcessor) Start(
 ) error {
 	ctx := p.Config.AmbientContext.AnnotateCtx(context.Background())
 	ctx, p.startupCancel = context.WithCancel(ctx)
+	p.stopper = stopper
 
 	// Note that callback registration must be performed before starting resolved
 	// timestamp init because resolution posts resolvedTS event when it is done.
@@ -123,6 +127,9 @@ func (p *ScheduledProcessor) process(e processorEventType) processorEventType {
 	}
 	if e&EventQueued != 0 {
 		p.processEvents(ctx)
+	}
+	if e&PushTxnQueued != 0 {
+		p.processPushTxn(ctx)
 	}
 	if e&Stopped != 0 {
 		p.processStop()
@@ -162,6 +169,37 @@ func (p *ScheduledProcessor) processEvents(ctx context.Context) {
 			putPooledEvent(e)
 		default:
 			return
+		}
+	}
+}
+
+func (p *ScheduledProcessor) processPushTxn(ctx context.Context) {
+	if !p.txnPushActive && p.rts.IsInit() {
+		now := p.Clock.Now()
+		before := now.Add(-p.PushTxnsAge.Nanoseconds(), 0)
+		oldTxns := p.rts.intentQ.Before(before)
+
+		if len(oldTxns) > 0 {
+			toPush := make([]enginepb.TxnMeta, len(oldTxns))
+			for i, txn := range oldTxns {
+				toPush[i] = txn.asTxnMeta()
+			}
+
+			// Launch an async transaction push attempt that pushes the
+			// timestamp of all transactions beneath the push offset.
+			// Ignore error if quiescing.
+			pushTxns := newTxnPushAttempt(p.Span, p.TxnPusher, p, toPush, now, func() {
+				p.enqueueRequest(func(ctx context.Context) {
+					p.txnPushActive = false
+				})
+			})
+			p.txnPushActive = true
+			// TODO(oleg): we need to cap number of tasks that we can fire up across
+			// all feeds as they could potentially generate O(n) tasks for push.
+			err := p.stopper.RunAsyncTask(ctx, "rangefeed: pushing old txns", pushTxns.Run)
+			if err != nil {
+				pushTxns.Cancel()
+			}
 		}
 	}
 }
@@ -283,7 +321,7 @@ func (p *ScheduledProcessor) Register(
 		// Add the new registration to the registry.
 		p.reg.Register(&r)
 
-		// Publish an updated filter that includes the new registration.
+		// Prep response with filter that includes the new registration.
 		f := p.reg.NewFilter()
 
 		// Immediately publish a checkpoint event to the registry. This will be the first event
@@ -738,4 +776,9 @@ func (p *ScheduledProcessor) newCheckpointEvent() *kvpb.RangeFeedEvent {
 		ResolvedTS: p.rts.Get(),
 	})
 	return &event
+}
+
+// ID implements Processor interface.
+func (p *ScheduledProcessor) ID() int64 {
+	return p.scheduler.ID()
 }

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -1,0 +1,741 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/future"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+)
+
+// request is any action on processor which is not a data path. e.g. request
+// active filter, length, add registration etc.
+// This request type is only serving as execution mechanism (think RunAsyncTask).
+// Processor state is exclusively updated by the running request, the only
+// concurrent activity that could happen is enqueueing events that is handled by
+// data and request queues independently.
+// To execute a request that returns a value, use runRequest that accepts
+// function that returns value.
+type request func(context.Context)
+
+// ScheduledProcessor is an implementation of processor that uses external
+// scheduler to use processing.
+type ScheduledProcessor struct {
+	Config
+	scheduler ClientScheduler
+
+	reg registry
+	rts resolvedTimestamp
+
+	requestQueue chan request
+	eventC       chan *event
+	// If true, processor is not processing data anymore and waiting for registrations
+	// to be complete.
+	stopping bool
+	stoppedC chan struct{}
+
+	// Processor startup runs background tasks to scan intents. If processor is
+	// stopped early, this task needs to be terminated to avoid resource waste.
+	startupCancel func()
+}
+
+// NewScheduledProcessor creates a new scheduler based rangefeed Processor.
+// Processor needs to be explicitly started after creation.
+func NewScheduledProcessor(cfg Config) *ScheduledProcessor {
+	cfg.SetDefaults()
+	cfg.AmbientContext.AddLogTag("rangefeed", nil)
+	p := &ScheduledProcessor{
+		Config:    cfg,
+		scheduler: NewClientScheduler(cfg.Scheduler),
+		reg:       makeRegistry(cfg.Metrics),
+		rts:       makeResolvedTimestamp(),
+
+		requestQueue: make(chan request, 20),
+		eventC:       make(chan *event, cfg.EventChanCap),
+		// Closed when scheduler removed callback.
+		stoppedC: make(chan struct{}),
+	}
+	return p
+}
+
+// Start performs processor one-time initialization e.g registers with
+// scheduler and fires up background tasks to populate processor state.
+// The provided iterator is used to initialize the rangefeed's resolved
+// timestamp. It must obey the contract of an iterator used for an
+// initResolvedTSScan. The Processor promises to clean up the iterator by
+// calling its Close method when it is finished. If the iterator is nil then
+// no initialization scan will be performed and the resolved timestamp will
+// immediately be considered initialized.
+func (p *ScheduledProcessor) Start(
+	stopper *stop.Stopper, rtsIterFunc IntentScannerConstructor,
+) error {
+	ctx := p.Config.AmbientContext.AnnotateCtx(context.Background())
+	ctx, p.startupCancel = context.WithCancel(ctx)
+
+	// Note that callback registration must be performed before starting resolved
+	// timestamp init because resolution posts resolvedTS event when it is done.
+	if err := p.scheduler.Register(p.process); err != nil {
+		p.cleanup()
+		return err
+	}
+
+	// Launch an async task to scan over the resolved timestamp iterator and
+	// initialize the unresolvedIntentQueue.
+	if rtsIterFunc != nil {
+		rtsIter := rtsIterFunc()
+		initScan := newInitResolvedTSScan(p.Span, p, rtsIter)
+		// TODO(oleg): we need to cap number of tasks that we can fire up across
+		// all feeds as they could potentially generate O(n) tasks during start.
+		if err := stopper.RunAsyncTask(ctx, "rangefeed: init resolved ts", initScan.Run); err != nil {
+			initScan.Cancel()
+			p.scheduler.StopProcessor()
+			return err
+		}
+	} else {
+		p.initResolvedTS(ctx)
+	}
+	return nil
+}
+
+// process is a scheduler callback that is processing scheduled events and
+// requests.
+func (p *ScheduledProcessor) process(e processorEventType) processorEventType {
+	ctx := p.Config.AmbientContext.AnnotateCtx(context.Background())
+	if e&RequestQueued != 0 {
+		p.processRequests(ctx)
+	}
+	if e&EventQueued != 0 {
+		p.processEvents(ctx)
+	}
+	if e&Stopped != 0 {
+		p.processStop()
+	}
+	return 0
+}
+
+// process pending requests.
+func (p *ScheduledProcessor) processRequests(ctx context.Context) {
+	// No need to limit number of processed requests as we don't expect more than
+	// a handful requests within the whole lifecycle.
+	for {
+		select {
+		case e := <-p.requestQueue:
+			e(ctx)
+		default:
+			return
+		}
+	}
+}
+
+// Transform and route pending events.
+func (p *ScheduledProcessor) processEvents(ctx context.Context) {
+	// TODO(oleg): maybe limit max count and allow returning some data for
+	// further processing on next iteration.
+	// Only process as much data as was present at the start of the processing
+	// run to avoid starving other processors.
+	for max := len(p.eventC); max > 0; max-- {
+		select {
+		case e := <-p.eventC:
+			if !p.stopping {
+				// If we are stopping, there's no need to forward any remaining
+				// data since registrations already have errors set.
+				p.consumeEvent(ctx, e)
+			}
+			e.alloc.Release(ctx)
+			putPooledEvent(e)
+		default:
+			return
+		}
+	}
+}
+
+func (p *ScheduledProcessor) processStop() {
+	p.cleanup()
+}
+
+func (p *ScheduledProcessor) cleanup() {
+	// Cleanup is called when all registrations were already disconnected prior to
+	// triggering processor stop (or before we accepted first registration if we
+	// failed to start).
+	// However, we want some defence in depth if lifecycle bug will allow shutdown
+	// before registrations are disconnected and drained. To handle that we will
+	// perform disconnect so that registrations have a chance to stop their work
+	// loop and terminate. This would at least trigger a warning that we are using
+	// memory budget already released by processor.
+	pErr := kvpb.NewError(&kvpb.NodeUnavailableError{})
+	p.reg.DisconnectWithErr(all, pErr)
+
+	// Unregister callback from scheduler
+	p.scheduler.Unregister()
+
+	p.startupCancel()
+	close(p.stoppedC)
+	p.MemBudget.Close(context.Background())
+}
+
+// Stop shuts down the processor and closes all registrations. Safe to call on
+// nil Processor. It is not valid to restart a processor after it has been
+// stopped.
+func (p *ScheduledProcessor) Stop() {
+	p.StopWithErr(nil)
+}
+
+// StopWithErr shuts down the processor and closes all registrations with the
+// specified error. Safe to call on nil Processor. It is not valid to restart a
+// processor after it has been stopped.
+func (p *ScheduledProcessor) StopWithErr(pErr *kvpb.Error) {
+	// Flush any remaining events before stopping.
+	p.syncEventC()
+	// Send the processor a stop signal.
+	p.sendStop(pErr)
+}
+
+// DisconnectSpanWithErr disconnects all rangefeed registrations that overlap
+// the given span with the given error.
+func (p *ScheduledProcessor) DisconnectSpanWithErr(span roachpb.Span, pErr *kvpb.Error) {
+	if p == nil {
+		return
+	}
+	p.enqueueRequest(func(ctx context.Context) {
+		p.reg.DisconnectWithErr(span, pErr)
+	})
+}
+
+func (p *ScheduledProcessor) sendStop(pErr *kvpb.Error) {
+	p.enqueueRequest(func(ctx context.Context) {
+		p.reg.DisconnectWithErr(all, pErr)
+		// First set stopping flag to ensure that once all registrations are removed
+		// processor should stop.
+		p.stopping = true
+		p.scheduler.StopProcessor()
+	})
+}
+
+// Register registers the stream over the specified span of keys.
+//
+// The registration will not observe any events that were consumed before this
+// method was called. It is undefined whether the registration will observe
+// events that are consumed concurrently with this call. The channel will be
+// provided an error when the registration closes.
+//
+// The optionally provided "catch-up" iterator is used to read changes from the
+// engine which occurred after the provided start timestamp (exclusive).
+//
+// If the method returns false, the processor will have been stopped, so calling
+// Stop is not necessary. If the method returns true, it will also return an
+// updated operation filter that includes the operations required by the new
+// registration.
+//
+// NB: startTS is exclusive; the first possible event will be at startTS.Next().
+func (p *ScheduledProcessor) Register(
+	span roachpb.RSpan,
+	startTS hlc.Timestamp,
+	catchUpIterConstructor CatchUpIteratorConstructor,
+	withDiff bool,
+	stream Stream,
+	disconnectFn func(),
+	done *future.ErrorFuture,
+) (bool, *Filter) {
+	// Synchronize the event channel so that this registration doesn't see any
+	// events that were consumed before this registration was called. Instead,
+	// it should see these events during its catch up scan.
+	p.syncEventC()
+
+	blockWhenFull := p.Config.EventChanTimeout == 0 // for testing
+	r := newRegistration(
+		span.AsRawSpanWithNoLocals(), startTS, catchUpIterConstructor, withDiff,
+		p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn, done,
+	)
+
+	filter := runRequest(p, func(ctx context.Context, p *ScheduledProcessor) *Filter {
+		if p.stopping {
+			return nil
+		}
+		if !p.Span.AsRawSpanWithNoLocals().Contains(r.span) {
+			log.Fatalf(ctx, "registration %s not in Processor's key range %v", r, p.Span)
+		}
+
+		// Construct the catchUpIter before notifying the registration that it
+		// has been registered. Note that if the catchUpScan is never run, then
+		// the iterator constructed here will be closed in disconnect.
+		if err := r.maybeConstructCatchUpIter(); err != nil {
+			r.disconnect(kvpb.NewError(err))
+			return nil
+		}
+
+		// Add the new registration to the registry.
+		p.reg.Register(&r)
+
+		// Publish an updated filter that includes the new registration.
+		f := p.reg.NewFilter()
+
+		// Immediately publish a checkpoint event to the registry. This will be the first event
+		// published to this registration after its initial catch-up scan completes. The resolved
+		// timestamp might be empty but the checkpoint event is still useful to indicate that the
+		// catch-up scan has completed. This allows clients to rely on stronger ordering semantics
+		// once they observe the first checkpoint event.
+		r.publish(ctx, p.newCheckpointEvent(), nil)
+
+		// Run an output loop for the registry.
+		runOutputLoop := func(ctx context.Context) {
+			r.runOutputLoop(ctx, p.RangeID)
+			if p.unregisterClient(&r) {
+				// unreg callback is set by replica to tear down processors that have
+				// zero registrations left and to update event filters.
+				if r.unreg != nil {
+					r.unreg()
+				}
+			}
+		}
+		if err := p.Stopper.RunAsyncTask(ctx, "rangefeed: output loop", runOutputLoop); err != nil {
+			// If we can't schedule internally, processor is already stopped which
+			// could only happen on shutdown. Disconnect stream and just remove
+			// registration.
+			r.disconnect(kvpb.NewError(err))
+			p.reg.Unregister(ctx, &r)
+		}
+		return f
+	})
+	if filter != nil {
+		return true, filter
+	}
+	return false, nil
+}
+
+func (p *ScheduledProcessor) unregisterClient(r *registration) bool {
+	return runRequest(p, func(ctx context.Context, p *ScheduledProcessor) bool {
+		p.reg.Unregister(ctx, r)
+		return true
+	})
+}
+
+// ConsumeLogicalOps informs the rangefeed processor of the set of logical
+// operations. It returns false if consuming the operations hit a timeout, as
+// specified by the EventChanTimeout configuration. If the method returns false,
+// the processor will have been stopped, so calling Stop is not necessary. Safe
+// to call on nil Processor.
+func (p *ScheduledProcessor) ConsumeLogicalOps(
+	ctx context.Context, ops ...enginepb.MVCCLogicalOp,
+) bool {
+	if p == nil {
+		return true
+	}
+	if len(ops) == 0 {
+		return true
+	}
+	return p.sendEvent(ctx, event{ops: ops}, p.EventChanTimeout)
+}
+
+// ConsumeSSTable informs the rangefeed processor of an SSTable that was added
+// via AddSSTable. It returns false if consuming the SSTable hit a timeout, as
+// specified by the EventChanTimeout configuration. If the method returns false,
+// the processor will have been stopped, so calling Stop is not necessary. Safe
+// to call on nil Processor.
+func (p *ScheduledProcessor) ConsumeSSTable(
+	ctx context.Context, sst []byte, sstSpan roachpb.Span, writeTS hlc.Timestamp,
+) bool {
+	if p == nil {
+		return true
+	}
+	return p.sendEvent(ctx, event{sst: &sstEvent{sst, sstSpan, writeTS}}, p.EventChanTimeout)
+}
+
+// ForwardClosedTS indicates that the closed timestamp that serves as the basis
+// for the rangefeed processor's resolved timestamp has advanced. It returns
+// false if forwarding the closed timestamp hit a timeout, as specified by the
+// EventChanTimeout configuration. If the method returns false, the processor
+// will have been stopped, so calling Stop is not necessary.  Safe to call on
+// nil Processor.
+func (p *ScheduledProcessor) ForwardClosedTS(ctx context.Context, closedTS hlc.Timestamp) bool {
+	if p == nil {
+		return true
+	}
+	if closedTS.IsEmpty() {
+		return true
+	}
+	return p.sendEvent(ctx, event{ct: ctEvent{closedTS}}, p.EventChanTimeout)
+}
+
+// sendEvent informs the Processor of a new event. If a timeout is specified,
+// the method will wait for no longer than that duration before giving up,
+// shutting down the Processor, and returning false. 0 for no timeout.
+func (p *ScheduledProcessor) sendEvent(ctx context.Context, e event, timeout time.Duration) bool {
+	if p.enqueueEventInternal(ctx, e, timeout) {
+		// We can ignore the event because we don't guarantee that we will drain
+		// all the events after processor was stopped. Memory budget will also be
+		// closed, releasing info about pending events that would be discarded with
+		// processor.
+		p.scheduler.Enqueue(EventQueued)
+		return true
+	}
+	return false
+}
+
+func (p *ScheduledProcessor) enqueueEventInternal(
+	ctx context.Context, e event, timeout time.Duration,
+) bool {
+	// The code is a bit unwieldy because we try to avoid any allocations on fast
+	// path where we have enough budget and outgoing channel is free. If not, we
+	// try to set up timeout for acquiring budget and then reuse this timeout when
+	// inserting value into channel.
+	var alloc *SharedBudgetAllocation
+	if p.MemBudget != nil {
+		size := calculateDateEventSize(e)
+		if size > 0 {
+			var err error
+			// First we will try non-blocking fast path to allocate memory budget.
+			alloc, err = p.MemBudget.TryGet(ctx, size)
+			// If budget is already closed, then just let it through because processor
+			// is terminating.
+			if err != nil && !errors.Is(err, budgetClosedError) {
+				// Since we don't have enough budget, we should try to wait for
+				// allocation returns before failing.
+				if timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, timeout) // nolint:context
+					defer cancel()
+					// We reset timeout here so that subsequent channel write op doesn't
+					// try to wait beyond what is already set up.
+					timeout = 0
+				}
+				p.Metrics.RangeFeedBudgetBlocked.Inc(1)
+				alloc, err = p.MemBudget.WaitAndGet(ctx, size)
+			}
+			if err != nil && !errors.Is(err, budgetClosedError) {
+				p.Metrics.RangeFeedBudgetExhausted.Inc(1)
+				p.sendStop(newErrBufferCapacityExceeded())
+				return false
+			}
+			// Always release allocation pointer after sending as it is nil safe.
+			// In normal case its value is moved into event, in case of allocation
+			// errors it is nil, in case of send errors it is non-nil and this call
+			// ensures that unused allocation is released.
+			defer func() {
+				alloc.Release(ctx)
+			}()
+		}
+	}
+	ev := getPooledEvent(e)
+	ev.alloc = alloc
+	if timeout == 0 {
+		// Timeout is zero if no timeout was requested or timeout is already set on
+		// the context by budget allocation. Just try to write using context as a
+		// timeout.
+		select {
+		case p.eventC <- ev:
+			// Reset allocation after successful posting to prevent deferred cleanup
+			// from freeing it (see comment on defer for explanation).
+			alloc = nil
+		case <-p.stoppedC:
+			// Already stopped. Do nothing.
+		case <-ctx.Done():
+			p.sendStop(newErrBufferCapacityExceeded())
+			return false
+		}
+	} else {
+		// First try fast path operation without blocking and without creating any
+		// contexts in case channel has capacity.
+		select {
+		case p.eventC <- ev:
+			// Reset allocation after successful posting to prevent deferred cleanup
+			// from freeing it (see comment on defer for explanation).
+			alloc = nil
+		case <-p.stoppedC:
+			// Already stopped. Do nothing.
+		default:
+			// Fast path failed since we don't have capacity in channel. Wait for
+			// slots to clear up using context timeout.
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout) // nolint:context
+			defer cancel()
+			select {
+			case p.eventC <- ev:
+				// Reset allocation after successful posting to prevent deferred cleanup
+				// from freeing it  (see comment on defer for explanation).
+				alloc = nil
+			case <-p.stoppedC:
+				// Already stopped. Do nothing.
+			case <-ctx.Done():
+				// Sending on the eventC channel would have blocked.
+				// Instead, tear down the processor and return immediately.
+				p.sendStop(newErrBufferCapacityExceeded())
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// setResolvedTSInitialized informs the Processor that its resolved timestamp has
+// all the information it needs to be considered initialized.
+func (p *ScheduledProcessor) setResolvedTSInitialized(ctx context.Context) {
+	p.sendEvent(ctx, event{initRTS: true}, 0)
+}
+
+// syncEventC synchronizes access to the Processor goroutine, allowing the
+// caller to establish causality with actions taken by the Processor goroutine.
+// It does so by flushing the event pipeline.
+func (p *ScheduledProcessor) syncEventC() {
+	p.syncSendAndWait(&syncEvent{c: make(chan struct{})})
+}
+
+// syncSendAndWait allows sync event to be sent and waited on its channel.
+// Exposed to allow special test syneEvents that contain span to be sent.
+func (p *ScheduledProcessor) syncSendAndWait(se *syncEvent) {
+	ev := getPooledEvent(event{sync: se})
+	select {
+	case p.eventC <- ev:
+		// This shouldn't happen as there should be no sync events after disconnect,
+		// but if there's a bug don't wait it can hang waiting for sync chan.
+		p.scheduler.Enqueue(EventQueued)
+		select {
+		case <-se.c:
+		// Synchronized.
+		case <-p.stoppedC:
+			// Already stopped. Do nothing.
+		}
+	case <-p.stoppedC:
+		// Already stopped. Do nothing.
+		putPooledEvent(ev)
+	}
+}
+
+// Len returns the number of registrations attached to the processor.
+func (p *ScheduledProcessor) Len() int {
+	return runRequest(p, func(_ context.Context, p *ScheduledProcessor) int {
+		return p.reg.Len()
+	})
+}
+
+// Filter returns a new operation filter based on the registrations attached to
+// the processor. Returns nil if the processor has been stopped already.
+func (p *ScheduledProcessor) Filter() *Filter {
+	return runRequest(p, func(_ context.Context, p *ScheduledProcessor) *Filter {
+		return newFilterFromRegistry(&p.reg)
+	})
+}
+
+// runRequest will enqueue request to processor and wait for it to be complete.
+// Function f will be executed on processor callback by scheduler worker. It
+// is guaranteed that only single request is modifying processor at any given
+// time. It is advisable to use provided processor reference for operations
+// rather than using one within closure itself.
+// If request can't be queued or processor stoppedC is closed then default
+// value is returned.
+func runRequest[T interface{}](
+	p *ScheduledProcessor, f func(ctx context.Context, p *ScheduledProcessor) T,
+) (r T) {
+	result := make(chan T, 1)
+	p.enqueueRequest(func(ctx context.Context) {
+		result <- f(ctx, p)
+	})
+	select {
+	case r = <-result:
+		return r
+	case <-p.stoppedC:
+		return r
+	}
+}
+
+func (p *ScheduledProcessor) enqueueRequest(req request) {
+	select {
+	case p.requestQueue <- req:
+		p.scheduler.Enqueue(RequestQueued)
+	case <-p.stoppedC:
+	}
+}
+
+func (p *ScheduledProcessor) consumeEvent(ctx context.Context, e *event) {
+	switch {
+	case e.ops != nil:
+		p.consumeLogicalOps(ctx, e.ops, e.alloc)
+	case !e.ct.IsEmpty():
+		p.forwardClosedTS(ctx, e.ct.Timestamp)
+	case bool(e.initRTS):
+		p.initResolvedTS(ctx)
+	case e.sst != nil:
+		p.consumeSSTable(ctx, e.sst.data, e.sst.span, e.sst.ts, e.alloc)
+	case e.sync != nil:
+		if e.sync.testRegCatchupSpan != nil {
+			if err := p.reg.waitForCaughtUp(*e.sync.testRegCatchupSpan); err != nil {
+				log.Errorf(
+					ctx,
+					"error waiting for registries to catch up during test, results might be impacted: %s",
+					err,
+				)
+			}
+		}
+		close(e.sync.c)
+	default:
+		panic(fmt.Sprintf("missing event variant: %+v", e))
+	}
+}
+
+func (p *ScheduledProcessor) consumeLogicalOps(
+	ctx context.Context, ops []enginepb.MVCCLogicalOp, alloc *SharedBudgetAllocation,
+) {
+	for _, op := range ops {
+		// Publish RangeFeedValue updates, if necessary.
+		switch t := op.GetValue().(type) {
+		case *enginepb.MVCCWriteValueOp:
+			// Publish the new value directly.
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, alloc)
+
+		case *enginepb.MVCCDeleteRangeOp:
+			// Publish the range deletion directly.
+			p.publishDeleteRange(ctx, t.StartKey, t.EndKey, t.Timestamp, alloc)
+
+		case *enginepb.MVCCWriteIntentOp:
+			// No updates to publish.
+
+		case *enginepb.MVCCUpdateIntentOp:
+			// No updates to publish.
+
+		case *enginepb.MVCCCommitIntentOp:
+			// Publish the newly committed value.
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, alloc)
+
+		case *enginepb.MVCCAbortIntentOp:
+			// No updates to publish.
+
+		case *enginepb.MVCCAbortTxnOp:
+			// No updates to publish.
+
+		default:
+			panic(errors.AssertionFailedf("unknown logical op %T", t))
+		}
+
+		// Determine whether the operation caused the resolved timestamp to
+		// move forward. If so, publish a RangeFeedCheckpoint notification.
+		if p.rts.ConsumeLogicalOp(op) {
+			p.publishCheckpoint(ctx)
+		}
+	}
+}
+
+func (p *ScheduledProcessor) consumeSSTable(
+	ctx context.Context,
+	sst []byte,
+	sstSpan roachpb.Span,
+	sstWTS hlc.Timestamp,
+	alloc *SharedBudgetAllocation,
+) {
+	p.publishSSTable(ctx, sst, sstSpan, sstWTS, alloc)
+}
+
+func (p *ScheduledProcessor) forwardClosedTS(ctx context.Context, newClosedTS hlc.Timestamp) {
+	if p.rts.ForwardClosedTS(newClosedTS) {
+		p.publishCheckpoint(ctx)
+	}
+}
+
+func (p *ScheduledProcessor) initResolvedTS(ctx context.Context) {
+	if p.rts.Init() {
+		p.publishCheckpoint(ctx)
+	}
+}
+
+func (p *ScheduledProcessor) publishValue(
+	ctx context.Context,
+	key roachpb.Key,
+	timestamp hlc.Timestamp,
+	value, prevValue []byte,
+	alloc *SharedBudgetAllocation,
+) {
+	if !p.Span.ContainsKey(roachpb.RKey(key)) {
+		log.Fatalf(ctx, "key %v not in Processor's key range %v", key, p.Span)
+	}
+
+	var prevVal roachpb.Value
+	if prevValue != nil {
+		prevVal.RawBytes = prevValue
+	}
+	var event kvpb.RangeFeedEvent
+	event.MustSetValue(&kvpb.RangeFeedValue{
+		Key: key,
+		Value: roachpb.Value{
+			RawBytes:  value,
+			Timestamp: timestamp,
+		},
+		PrevValue: prevVal,
+	})
+	p.reg.PublishToOverlapping(ctx, roachpb.Span{Key: key}, &event, alloc)
+}
+
+func (p *ScheduledProcessor) publishDeleteRange(
+	ctx context.Context,
+	startKey, endKey roachpb.Key,
+	timestamp hlc.Timestamp,
+	alloc *SharedBudgetAllocation,
+) {
+	span := roachpb.Span{Key: startKey, EndKey: endKey}
+	if !p.Span.ContainsKeyRange(roachpb.RKey(startKey), roachpb.RKey(endKey)) {
+		log.Fatalf(ctx, "span %s not in Processor's key range %v", span, p.Span)
+	}
+
+	var event kvpb.RangeFeedEvent
+	event.MustSetValue(&kvpb.RangeFeedDeleteRange{
+		Span:      span,
+		Timestamp: timestamp,
+	})
+	p.reg.PublishToOverlapping(ctx, span, &event, alloc)
+}
+
+func (p *ScheduledProcessor) publishSSTable(
+	ctx context.Context,
+	sst []byte,
+	sstSpan roachpb.Span,
+	sstWTS hlc.Timestamp,
+	alloc *SharedBudgetAllocation,
+) {
+	if sstSpan.Equal(roachpb.Span{}) {
+		panic(errors.AssertionFailedf("received SSTable without span"))
+	}
+	if sstWTS.IsEmpty() {
+		panic(errors.AssertionFailedf("received SSTable without write timestamp"))
+	}
+	p.reg.PublishToOverlapping(ctx, sstSpan, &kvpb.RangeFeedEvent{
+		SST: &kvpb.RangeFeedSSTable{
+			Data:    sst,
+			Span:    sstSpan,
+			WriteTS: sstWTS,
+		},
+	}, alloc)
+}
+
+func (p *ScheduledProcessor) publishCheckpoint(ctx context.Context) {
+	// TODO(nvanbenschoten): persist resolvedTimestamp. Give Processor a client.DB.
+	// TODO(nvanbenschoten): rate limit these? send them periodically?
+
+	event := p.newCheckpointEvent()
+	p.reg.PublishToOverlapping(ctx, all, event, nil)
+}
+
+func (p *ScheduledProcessor) newCheckpointEvent() *kvpb.RangeFeedEvent {
+	// Create a RangeFeedCheckpoint over the Processor's entire span. Each
+	// individual registration will trim this down to just the key span that
+	// it is listening on in registration.maybeStripEvent before publishing.
+	var event kvpb.RangeFeedEvent
+	event.MustSetValue(&kvpb.RangeFeedCheckpoint{
+		Span:       p.Span.AsRawSpanWithNoLocals(),
+		ResolvedTS: p.rts.Get(),
+	})
+	return &event
+}

--- a/pkg/kv/kvserver/rangefeed/scheduler.go
+++ b/pkg/kv/kvserver/rangefeed/scheduler.go
@@ -57,6 +57,9 @@ const (
 	// RequestQueued is scheduled when request closure is put into rangefeed
 	// request queue.
 	RequestQueued
+	// PushTxnQueued is scheduled externally on ranges to push transaction with intents
+	// that block resolved timestamp advancing.
+	PushTxnQueued
 	// numProcessorEventTypes is total number of event types.
 	numProcessorEventTypes int = iota
 )
@@ -66,6 +69,7 @@ var eventNames = map[processorEventType]string{
 	Stopped:       "Stopped",
 	EventQueued:   "Data",
 	RequestQueued: "Request",
+	PushTxnQueued: "PushTxn",
 }
 
 func (e processorEventType) String() string {

--- a/pkg/kv/kvserver/rangefeed/scheduler.go
+++ b/pkg/kv/kvserver/rangefeed/scheduler.go
@@ -41,23 +41,31 @@ import (
 type processorEventType int
 
 const (
-	// queued is an internal event type that indicate that there's already a
+	// Queued is an internal event type that indicate that there's already a
 	// pending work for processor and it is already scheduled for execution.
 	// When more events types come in, they should just be added to existing
 	// pending value.
-	queued processorEventType = 1 << iota
-	// stopped is an event that indicates that there would be no more events
+	Queued processorEventType = 1 << iota
+	// Stopped is an event that indicates that there would be no more events
 	// scheduled for the processor. once it is enqueued, all subsequent events
 	// are rejected. processor should perform any cleanup when receiving this
 	// event that it needs to perform within callback context.
-	stopped
+	Stopped
+	// EventQueued is scheduled when event is put into rangefeed queue for
+	// processing.
+	EventQueued
+	// RequestQueued is scheduled when request closure is put into rangefeed
+	// request queue.
+	RequestQueued
 	// numProcessorEventTypes is total number of event types.
 	numProcessorEventTypes int = iota
 )
 
 var eventNames = map[processorEventType]string{
-	queued:  "Queued",
-	stopped: "Stopped",
+	Queued:        "Queued",
+	Stopped:       "Stopped",
+	EventQueued:   "Data",
+	RequestQueued: "Request",
 }
 
 func (e processorEventType) String() string {
@@ -203,14 +211,14 @@ func (s *Scheduler) Enqueue(id int64, evt processorEventType) {
 
 func (s *Scheduler) enqueueInternalLocked(id int64, evt processorEventType) bool {
 	pending := s.mu.status[id]
-	if pending&stopped != 0 {
+	if pending&Stopped != 0 {
 		return false
 	}
 	if pending == 0 {
 		// Enqueue if processor was idle.
 		s.mu.queue.pushBack(id)
 	}
-	update := pending | evt | queued
+	update := pending | evt | Queued
 	if update != pending {
 		// Only update if event actually changed.
 		s.mu.status[id] = update
@@ -258,11 +266,11 @@ func (s *Scheduler) EnqueueAll(ids []int64, evt processorEventType) {
 	}
 }
 
-// StopProcessor instructs processor to stop gracefully by sending it stopped event.
+// StopProcessor instructs processor to stop gracefully by sending it Stopped event.
 // Once stop is called all subsequent Schedule calls for this id will return
 // error.
 func (s *Scheduler) StopProcessor(id int64) {
-	s.Enqueue(id, stopped)
+	s.Enqueue(id, Stopped)
 }
 
 // processEvents is a main worker method of a scheduler pool. each one should
@@ -285,11 +293,11 @@ func (s *Scheduler) processEvents(ctx context.Context) {
 
 		cb := s.mu.procs[id]
 		e := s.mu.status[id]
-		// Keep queued status and preserve stopped to block any more events.
-		s.mu.status[id] = queued | (e & stopped)
+		// Keep Queued status and preserve Stopped to block any more events.
+		s.mu.status[id] = Queued | (e & Stopped)
 		s.mu.Unlock()
 
-		procEventType := queued ^ e
+		procEventType := Queued ^ e
 		remaining := cb(procEventType)
 
 		if remaining != 0 && buildutil.CrdbTestBuild {
@@ -300,15 +308,15 @@ func (s *Scheduler) processEvents(ctx context.Context) {
 			}
 		}
 
-		if e&stopped != 0 {
+		if e&Stopped != 0 {
 			if remaining != 0 {
 				log.VWarningf(ctx, 5,
 					"rangefeed processor %d didn't process all events on close", id)
 			}
-			// We'll keep stopped state to avoid calling stopped processor again
+			// We'll keep Stopped state to avoid calling stopped processor again
 			// on scheduler shutdown.
 			s.mu.Lock()
-			s.mu.status[id] = stopped
+			s.mu.status[id] = Stopped
 			s.mu.Unlock()
 			continue
 		}
@@ -320,7 +328,7 @@ func (s *Scheduler) processEvents(ctx context.Context) {
 			continue
 		}
 		newStatus := pendingStatus | remaining
-		if newStatus == queued {
+		if newStatus == Queued {
 			// If no events arrived, get rid of id.
 			delete(s.mu.status, id)
 		} else {
@@ -339,8 +347,8 @@ func (s *Scheduler) processEvents(ctx context.Context) {
 // Unregister a processor. This function is removing processor callback and
 // status from scheduler. If processor is currently processing event it will
 // finish processing.
-// Processor won't receive stopped event if it wasn't explicitly sent.
-// To make sure processor performs cleanup, it is easier to send it stopped
+// Processor won't receive Stopped event if it wasn't explicitly sent.
+// To make sure processor performs cleanup, it is easier to send it Stopped
 // event first and let it remove itself from registration during event handling.
 // Any attempts to enqueue events for processor after this call will return an
 // error.
@@ -370,11 +378,11 @@ func (s *Scheduler) Stop() {
 	for id, p := range s.mu.procs {
 		pending := s.mu.status[id]
 		// Ignore processors that already processed their stopped event.
-		if pending == stopped {
+		if pending == Stopped {
 			continue
 		}
 		// Add stopped event on top of what was pending and remove queued.
-		pending = (^queued & pending) | stopped
+		pending = (^Queued & pending) | Stopped
 		s.mu.Unlock()
 		p(pending)
 		s.mu.Lock()
@@ -416,15 +424,14 @@ func (cs *ClientScheduler) Register(cb Callback) error {
 	return err
 }
 
-// Schedule schedules callback for event. Error is returned if client callback
-// wasn't registered prior to this call.
-func (cs *ClientScheduler) Schedule(event processorEventType) {
+// Enqueue schedules callback execution for event.
+func (cs *ClientScheduler) Enqueue(event processorEventType) {
 	cs.s.Enqueue(cs.id, event)
 }
 
-// Stop instructs processor to stop gracefully by sending it stopped event.
+// StopProcessor instructs processor to stop gracefully by sending it Stopped event.
 // Once stop is called all subsequent Schedule calls will return error.
-func (cs *ClientScheduler) Stop() {
+func (cs *ClientScheduler) StopProcessor() {
 	cs.s.StopProcessor(cs.id)
 }
 

--- a/pkg/kv/kvserver/rangefeed/scheduler_test.go
+++ b/pkg/kv/kvserver/rangefeed/scheduler_test.go
@@ -91,7 +91,7 @@ func (c *schedulerConsumer) process(ev processorEventType) processorEventType {
 		return r
 	default:
 	}
-	if ev&stopped != 0 {
+	if ev&Stopped != 0 {
 		c.sched.Unregister(c.id)
 	}
 	return 0
@@ -192,9 +192,9 @@ func (c *schedulerConsumer) requireStopped(t *testing.T, timeout time.Duration) 
 			return false
 		}
 		lastEvent = c.flat[len(c.flat)-1]
-		return lastEvent&stopped != 0
+		return lastEvent&Stopped != 0
 	}) {
-		t.Fatalf("failed to find stopped event at the end of history after %s, lastEvent=%08b", timeout,
+		t.Fatalf("failed to find Stopped event at the end of history after %s, lastEvent=%08b", timeout,
 			lastEvent)
 	}
 }
@@ -318,7 +318,7 @@ func TestClientScheduler(t *testing.T) {
 		cs.Register(func(event processorEventType) (remaining processorEventType) { return 0 }),
 		"reregistration must fail")
 	c.pause()
-	cs.Schedule(te2)
+	cs.Enqueue(te2)
 	c.waitPaused()
 	cs.Unregister()
 	c.resume()
@@ -417,8 +417,8 @@ func TestSchedulerShutdown(t *testing.T) {
 	s.StopProcessor(c2.id)
 	s.Stop()
 	// Ensure that we are not stopped twice.
-	c1.requireHistory(t, time.Second*30, []processorEventType{stopped})
-	c2.requireHistory(t, time.Second*30, []processorEventType{stopped})
+	c1.requireHistory(t, time.Second*30, []processorEventType{Stopped})
+	c2.requireHistory(t, time.Second*30, []processorEventType{Stopped})
 }
 
 func TestQueueReadWrite1By1(t *testing.T) {

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -263,7 +263,7 @@ type txnPushAttempt struct {
 	p      processorTaskHelper
 	txns   []enginepb.TxnMeta
 	ts     hlc.Timestamp
-	doneC  chan struct{}
+	done   func()
 }
 
 func newTxnPushAttempt(
@@ -272,7 +272,7 @@ func newTxnPushAttempt(
 	p processorTaskHelper,
 	txns []enginepb.TxnMeta,
 	ts hlc.Timestamp,
-	doneC chan struct{},
+	done func(),
 ) runnable {
 	return &txnPushAttempt{
 		span:   span,
@@ -280,7 +280,7 @@ func newTxnPushAttempt(
 		p:      p,
 		txns:   txns,
 		ts:     ts,
-		doneC:  doneC,
+		done:   done,
 	}
 }
 
@@ -377,7 +377,7 @@ func (a *txnPushAttempt) pushOldTxns(ctx context.Context) error {
 }
 
 func (a *txnPushAttempt) Cancel() {
-	close(a.doneC)
+	a.done()
 }
 
 // intentsInBound returns LockUpdates for the provided transaction's LockSpans

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -502,7 +502,9 @@ func TestTxnPushAttempt(t *testing.T) {
 	txns := []enginepb.TxnMeta{txn1Meta, txn2Meta, txn3Meta, txn4Meta}
 	doneC := make(chan struct{})
 	pushAttempt := newTxnPushAttempt(p.Span, p.TxnPusher, &p, txns, hlc.Timestamp{WallTime: 15},
-		doneC)
+		func() {
+			close(doneC)
+		})
 	pushAttempt.Run(context.Background())
 	<-doneC // check if closed
 

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -300,7 +300,7 @@ func (r *Replica) setRangefeedProcessor(p rangefeed.Processor) {
 	r.rangefeedMu.Lock()
 	defer r.rangefeedMu.Unlock()
 	r.rangefeedMu.proc = p
-	r.store.addReplicaWithRangefeed(r.RangeID)
+	r.store.addReplicaWithRangefeed(r.RangeID, p.ID())
 }
 
 func (r *Replica) unsetRangefeedProcessorLocked(p rangefeed.Processor) {

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -76,6 +76,18 @@ var RangeFeedSmearInterval = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
+// RangeFeedUseScheduler controls type of rangefeed processor is used to process
+// raft updates and sends updates to clients.
+// TODO(oleg): add metamorphic variable for processor type selection.
+var RangeFeedUseScheduler = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.rangefeed.scheduler.enabled",
+	"use shared fixed pool of workers for all range feeds instead of a "+
+		"worker per range (worker pool size is determined by "+
+		"COCKROACH_RANGEFEED_SCHEDULER_WORKERS env variable)",
+	false,
+)
+
 func init() {
 	// Inject into kvserverbase to allow usage from kvcoord.
 	kvserverbase.RangeFeedRefreshInterval = RangeFeedRefreshInterval
@@ -362,6 +374,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	// of concurrent processor shutdowns (see maybeDisconnectEmptyRangefeed).
 	r.rangefeedMu.Lock()
 	p := r.rangefeedMu.proc
+
 	if p != nil {
 		reg, filter := p.Register(span, startTS, catchUpIter, withDiff, stream, func() { r.maybeDisconnectEmptyRangefeed(p) }, done)
 		if reg {
@@ -382,11 +395,18 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 
 	// Create a new rangefeed.
 	feedBudget := r.store.GetStoreConfig().RangefeedBudgetFactory.CreateBudget(r.startKey)
+
+	var sched *rangefeed.Scheduler
+	if RangeFeedUseScheduler.Get(&r.ClusterSettings().SV) {
+		sched = r.store.getRangefeedScheduler()
+	}
+
 	desc := r.Desc()
 	tp := rangefeedTxnPusher{ir: r.store.intentResolver, r: r}
 	cfg := rangefeed.Config{
 		AmbientContext:   r.AmbientContext,
 		Clock:            r.Clock(),
+		Stopper:          r.store.stopper,
 		RangeID:          r.RangeID,
 		Span:             desc.RSpan(),
 		TxnPusher:        &tp,
@@ -396,6 +416,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 		EventChanTimeout: defaultEventChanTimeout,
 		Metrics:          r.store.metrics.RangeFeedMetrics,
 		MemBudget:        feedBudget,
+		Scheduler:        sched,
 	}
 	p = rangefeed.NewProcessor(cfg)
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1017,7 +1017,10 @@ type Store struct {
 	// The subset of replicas with active rangefeeds.
 	rangefeedReplicas struct {
 		syncutil.Mutex
-		m map[roachpb.RangeID]struct{}
+		// m contains mapping from rangeID that could be used to retrieve replicas
+		// with associated rangefeed processor scheduler IDs that allow enqueueing
+		// periodic events directly.
+		m map[roachpb.RangeID]int64
 	}
 	rangefeedScheduler *rangefeed.Scheduler
 
@@ -1464,7 +1467,7 @@ func NewStore(
 	s.unquiescedReplicas.Unlock()
 
 	s.rangefeedReplicas.Lock()
-	s.rangefeedReplicas.m = map[roachpb.RangeID]struct{}{}
+	s.rangefeedReplicas.m = map[roachpb.RangeID]int64{}
 	s.rangefeedReplicas.Unlock()
 
 	s.tsCache = tscache.New(cfg.Clock)
@@ -2205,6 +2208,8 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// Connect rangefeeds to closed timestamp updates.
 	s.startRangefeedUpdater(ctx)
 
+	s.startRangefeedTxnPushNotifier(ctx)
+
 	if s.replicateQueue != nil {
 		s.storeRebalancer = NewStoreRebalancer(
 			s.cfg.AmbientCtx, s.cfg.Settings, s.replicateQueue, s.replRankings, s.rebalanceObjManager)
@@ -2382,9 +2387,49 @@ func (s *Store) startRangefeedUpdater(ctx context.Context) {
 	})
 }
 
-func (s *Store) addReplicaWithRangefeed(rangeID roachpb.RangeID) {
+// startRangefeedTxnPushNotifier starts a worker that would periodically
+// enqueue txn push event for rangefeed processors to let them push lagging
+// transactions.
+// Note that this is only affecting scheduler based rangefeeds.
+func (s *Store) startRangefeedTxnPushNotifier(ctx context.Context) {
+	_ /* err */ = s.stopper.RunAsyncTaskEx(ctx, stop.TaskOpts{
+		TaskName: "transaction-rangefeed-push-notifier",
+		SpanOpt:  stop.SterileRootSpan,
+	}, func(ctx context.Context) {
+		ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+
+		var schedulerIDs []int64
+		updateSchedulerIDs := func() []int64 {
+			schedulerIDs = schedulerIDs[:0]
+			s.rangefeedReplicas.Lock()
+			for _, id := range s.rangefeedReplicas.m {
+				if id != 0 {
+					// Only process ranges that use scheduler.
+					schedulerIDs = append(schedulerIDs, id)
+				}
+			}
+			s.rangefeedReplicas.Unlock()
+			return schedulerIDs
+		}
+
+		ticker := time.NewTicker(rangefeed.DefaultPushTxnsInterval)
+		for {
+			select {
+			case <-ticker.C:
+				activeIDs := updateSchedulerIDs()
+				s.rangefeedScheduler.EnqueueAll(activeIDs, rangefeed.PushTxnQueued)
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			}
+		}
+	})
+}
+
+func (s *Store) addReplicaWithRangefeed(rangeID roachpb.RangeID, schedulerID int64) {
 	s.rangefeedReplicas.Lock()
-	s.rangefeedReplicas.m[rangeID] = struct{}{}
+	s.rangefeedReplicas.m[rangeID] = schedulerID
 	s.rangefeedReplicas.Unlock()
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -179,6 +179,12 @@ var logStoreTelemetryTicks = envutil.EnvOrDefaultInt(
 	6*60,
 )
 
+// defaultRangefeedSchedulerConcurency specifies how many workers rangefeed
+// scheduler will use to perform rangefeed work. This number will be divided
+// between stores of the node.
+var defaultRangefeedSchedulerConcurency = envutil.EnvOrDefaultInt(
+	"COCKROACH_RANGEFEED_SCHEDULER_WORKERS", min(4*runtime.GOMAXPROCS(0), 64))
+
 // bulkIOWriteLimit is defined here because it is used by BulkIOWriteLimiter.
 var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
 	settings.SystemOnly,
@@ -1013,6 +1019,7 @@ type Store struct {
 		syncutil.Mutex
 		m map[roachpb.RangeID]struct{}
 	}
+	rangefeedScheduler *rangefeed.Scheduler
 
 	// raftRecvQueues is a map of per-Replica incoming request queues. These
 	// queues might more naturally belong in Replica, but are kept separate to
@@ -1222,6 +1229,10 @@ type StoreConfig struct {
 
 	// RangeLogWriter is used to write entries to the system.rangelog table.
 	RangeLogWriter RangeLogWriter
+
+	// RangeFeedSchedulerConcurrency specifies number of rangefeed scheduler
+	// workers for the store.
+	RangeFeedSchedulerConcurrency int
 }
 
 // logRangeAndNodeEventsEnabled is used to enable or disable logging range events
@@ -1255,7 +1266,8 @@ func (sc *StoreConfig) Valid() bool {
 		sc.RaftTickInterval != 0 && sc.RaftHeartbeatIntervalTicks > 0 &&
 		sc.RaftElectionTimeoutTicks > 0 && sc.RaftReproposalTimeoutTicks > 0 &&
 		sc.RaftSchedulerConcurrency > 0 && sc.RaftSchedulerConcurrencyPriority > 0 &&
-		sc.RaftSchedulerShardSize > 0 && sc.ScanInterval >= 0 && sc.AmbientCtx.Tracer != nil
+		sc.RaftSchedulerShardSize > 0 && sc.ScanInterval >= 0 && sc.AmbientCtx.Tracer != nil &&
+		sc.RangeFeedSchedulerConcurrency > 0
 }
 
 // SetDefaults initializes unset fields in StoreConfig to values
@@ -1294,6 +1306,15 @@ func (sc *StoreConfig) SetDefaults(numStores int) {
 	}
 	if raftDisableQuiescence {
 		sc.TestingKnobs.DisableQuiescence = true
+	}
+	if sc.RangeFeedSchedulerConcurrency == 0 {
+		sc.RangeFeedSchedulerConcurrency = defaultRangefeedSchedulerConcurency
+		if numStores > 1 && sc.RangeFeedSchedulerConcurrency > 1 {
+			// We want at least two workers per store to avoid any blocking.
+			sc.RangeFeedSchedulerConcurrency = min(
+				(sc.RangeFeedSchedulerConcurrency-1)/numStores+1, // ceil division
+				2)
+		}
 	}
 }
 
@@ -1952,6 +1973,14 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	if err := s.TODOEngine().SetStoreID(ctx, int32(s.StoreID())); err != nil {
 		return err
 	}
+
+	rfs := rangefeed.NewScheduler(rangefeed.SchedulerConfig{
+		Workers: s.cfg.RangeFeedSchedulerConcurrency,
+	})
+	if err = rfs.Start(ctx, s.stopper); err != nil {
+		return err
+	}
+	s.rangefeedScheduler = rfs
 
 	// Add the store ID to the scanner's AmbientContext before starting it, since
 	// the AmbientContext provided during construction did not include it.
@@ -3711,6 +3740,10 @@ func (s *Store) unregisterLeaseholderByID(ctx context.Context, rangeID roachpb.R
 // tracking.
 func (s *Store) getRootMemoryMonitorForKV() *mon.BytesMonitor {
 	return s.cfg.KVMemoryMonitor
+}
+
+func (s *Store) getRangefeedScheduler() *rangefeed.Scheduler {
+	return s.rangefeedScheduler
 }
 
 // Implementation of the storeForTruncator interface.

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -1271,11 +1271,11 @@ func TestExecutionInsights(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
 	// We'll check both the cluster-wide table and the node-local one.
-	virtualTables := []interface{}{
+	virtualTables := []string{
 		"cluster_execution_insights",
 		"node_execution_insights",
 	}
-	testutils.RunValues(t, "table", virtualTables, func(t *testing.T, table interface{}) {
+	testutils.RunValues(t, "table", virtualTables, func(t *testing.T, table string) {
 		testCases := []struct {
 			option  string
 			granted bool

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1898,11 +1898,10 @@ func TestEngineIteratorVisibility(t *testing.T) {
 			canWrite:         false,
 		},
 	}
-	keyKinds := []interface{}{MVCCKeyAndIntentsIterKind, MVCCKeyIterKind}
+	keyKinds := []MVCCIterKind{MVCCKeyAndIntentsIterKind, MVCCKeyIterKind}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			testutils.RunValues(t, "IterKind", keyKinds, func(t *testing.T, iterKindI interface{}) {
-				iterKind := iterKindI.(MVCCIterKind)
+			testutils.RunValues(t, "IterKind", keyKinds, func(t *testing.T, iterKind MVCCIterKind) {
 				eng := NewDefaultInMemForTesting()
 				defer eng.Close()
 

--- a/pkg/testutils/subtest.go
+++ b/pkg/testutils/subtest.go
@@ -18,16 +18,13 @@ import (
 // RunTrueAndFalse calls the provided function in a subtest, first with the
 // boolean argument set to false and next with the boolean argument set to true.
 func RunTrueAndFalse(t *testing.T, name string, fn func(t *testing.T, b bool)) {
-	for _, b := range []bool{false, true} {
-		t.Run(fmt.Sprintf("%s=%t", name, b), func(t *testing.T) {
-			fn(t, b)
-		})
-	}
+	t.Helper()
+	RunValues(t, name, []bool{false, true}, fn)
 }
 
 // RunValues calls the provided function in a subtest for each of the
 // provided values.
-func RunValues(t *testing.T, name string, values []interface{}, fn func(*testing.T, interface{})) {
+func RunValues[T any](t *testing.T, name string, values []T, fn func(*testing.T, T)) {
 	t.Helper()
 	for _, v := range values {
 		t.Run(fmt.Sprintf("%s=%v", name, v), func(t *testing.T) {


### PR DESCRIPTION
Previously each rangefeed processor run a dedicated goroutine to process range events. With high replica density that produced 10K's of goroutines waking up periodically and overloading go scheduler.
This commit adds a version of processor that uses a scheduler with a fixed pool of workers to process all ranges on the node.

This commit adds a version of processor that uses a scheduler with a fixed pool of workers to process all ranges on the node. Scheduler based processor is off by default and can be enabled by using `kv.rangefeed.use_scheduler_processor` system cluster setting.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-26372

Release note: None
