### PR TITLE
sql: remove stale skip in TestTelemetry

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -79,9 +79,9 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 		if n.Unique {
 			panic(pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes can't be unique"))
 		}
-		b.IncrementSchemaChangeIndexCounter("inverted_index")
-		if len(n.Columns) > 0 {
-			b.IncrementSchemaChangeIndexCounter("multi_column_inverted_index")
+		b.IncrementSchemaChangeIndexCounter("inverted")
+		if len(n.Columns) > 1 {
+			b.IncrementSchemaChangeIndexCounter("multi_column_inverted")
 		}
 	}
 	activeVersion := b.EvalCtx().Settings.Version.ActiveVersion(context.TODO())

--- a/pkg/sql/sqltestutils/BUILD.bazel
+++ b/pkg/sql/sqltestutils/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/catconstants",
+        "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/testutils",
         "//pkg/testutils/diagutils",
         "//pkg/testutils/serverutils",

--- a/pkg/sql/telemetry_test.go
+++ b/pkg/sql/telemetry_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -30,6 +31,7 @@ import (
 func TestTelemetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	defer ccl.TestingEnableEnterprise()()
 	skip.UnderRace(t, "takes >1min under race")
 	skip.UnderDeadlock(t, "takes >1min under deadlock")
 

--- a/pkg/sql/testdata/telemetry/index
+++ b/pkg/sql/testdata/telemetry/index
@@ -66,7 +66,7 @@ feature-usage
 CREATE TABLE err (i INT, j JSON, INVERTED INDEX (i, j) WHERE i);
 CREATE TABLE err (i INT, geom GEOMETRY, INVERTED INDEX (i, geom) WHERE i);
 ----
-error: pq: expected index predicate expression to have type bool, but 'i' has type int
+error: pq: expected INDEX PREDICATE expression to have type bool, but 'i' has type int
 
 feature-usage
 CREATE TABLE e (i INT, INDEX ((i + 10)))
@@ -132,7 +132,7 @@ feature-usage
 CREATE INVERTED INDEX err ON d (i, j) WHERE i;
 CREATE INVERTED INDEX err ON g4 (i, geom) WHERE i
 ----
-error: pq: expected index predicate expression to have type bool, but 'i' has type int
+error: pq: expected INDEX PREDICATE expression to have type bool, but 'i' has type int
 
 feature-usage
 CREATE INDEX i4 ON d ((i + 10))
@@ -142,20 +142,14 @@ sql.schema.expression_index
 feature-usage
 CREATE TABLE trigrams (t TEXT, u TEXT, INVERTED INDEX(t gin_trgm_ops))
 ----
-sql.schema.trigram_inverted_index
 sql.schema.inverted_index
+sql.schema.trigram_inverted_index
 
-exec
+feature-usage
 CREATE INDEX ON trigrams USING GIN(u gin_trgm_ops)
 ----
-sql.schema.trigram_inverted_index
 sql.schema.inverted_index
-
-exec
-CREATE INVERTED INDEX ON trigrams USING GIN(u gin_trgm_ops)
-----
 sql.schema.trigram_inverted_index
-sql.schema.inverted_index
 
 #### ALTER TABLE tests.
 

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2242,7 +2242,6 @@ func TestLint(t *testing.T) {
 			":!sql/importer/read_import_mysql_test.go",
 			":!sql/schemachanger/sctest/test_server_factory.go",
 			":!sql/sqlinstance/instancestorage/instancecache_test.go",
-			":!sql/sqltestutils/telemetry.go",
 			":!sql/tests/server_params.go",
 			":!sql/ttl/ttljob/ttljob_test.go",
 			":!testutils/lint/lint_test.go",


### PR DESCRIPTION
This commit unskips multiple telemetry tests that were skipped for no good reason (they were referencing an unrelated issue). This uncovered some bugs in the new schema changer telemetry reporting where we duplicated `_index` twice in the feature counter for inverted indexes. Also, `index` telemetry test contained an invalid statement which is now removed.

The only file that is still skipped is `sql-stats` where the output doesn't match the expectations, and I'm not sure whether the test is stale or something is broken, so a separate issue was filed.

Addresses: #47893.
Epic: None.

Release note: None