### PR TITLE
changefeedccl: make TestChangefeedRandomExpressions failures fatal

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -964,7 +964,7 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 			err = assertPayloadsBaseErr(context.Background(), seedFeed, assertedPayloads, false, false)
 			closeFeedIgnoreError(t, seedFeed)
 			if err != nil {
-				t.Error(err)
+				t.Fatal(err)
 			}
 		}
 		if n > 100 {


### PR DESCRIPTION
When this test fails due to a changefeed not being able to handle a predicate (which is exactly what should make this test fail), the test does not terminate. This makes it so the error message get burried in log lines such as in (#107382). In some cases like (#102016), the error is not visible because the test output is truncated and the full output has expired in teamcity. This change makes such failures fatal so the error is the last thing output to the test logs.

Epic: None
Release note: None
