### PR TITLE
ui: Update pnpm lockfile and version of pnpm

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -30,7 +30,7 @@ jobs:
 
     - uses: pnpm/action-setup@v2
       with:
-        version: 8
+        version: ">=8.6.10"
 
     - name: Setup NodeJS
       uses: actions/setup-node@v3

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: pnpm/action-setup@v2
       with:
-        version: 8
+        version: ">=8.6.10"
 
     - name: Setup NodeJS
       uses: actions/setup-node@v3

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "repository": "github.com/cockroachdb/cockroach",
   "license": "MIT",
+  "engines": {
+    "pnpm": ">=8.6.10"
+  },
   "pnpm": {
     "neverBuiltDependencies": [
       "contextify"

--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -39,7 +39,7 @@ overrides:
   '@cockroachlabs/cluster-ui>antd': 3.26.20
   analytics-node>axios-retry: 3.1.9
 
-packageExtensionsChecksum: 39f4d224bf661de76c208d27f33ed125
+packageExtensionsChecksum: c8401d95bcfa63cade05749ae746f3fe
 
 patchedDependencies:
   topojson@3.0.2:
@@ -11546,6 +11546,7 @@ packages:
     resolution: {integrity: sha512-K5CSPbOVumvT1ceFb+maul2vow0WrTGxF3PXJpyjOuxilSGwgPqbub2M8oHTLz0hJ7lzSKBFSKTx299fpttlmQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+    requiresBuild: true
     dev: true
     optional: true
 


### PR DESCRIPTION
Potentially due to a recent bug in pnpm[^1] where the order of the dependencies
would effect the checksum, there is an error currently[^2] in the Cluster UI
publishing workflow. To resolve this, this commit did the following:

1. With an updated version of pnpm (version 8.6.10), ran `pnpm install`
   which updated the `pnpm-lock.yaml`
1. Added and `engines` entry in `pkg/ui/package.json` to ensure that at
   least pnpm version 8.6.10 is used.
1. Updated the version of pnpm used in cluster ui release actions to
   8.6.10

[^1]: https://github.com/pnpm/pnpm/issues/6824
[^2]: https://go.crdb.dev/p/zhjq-wq6u-hnfk

Release note (build change): fixing a bug in Cluster UI publishing due
to pnpm version.
