### PR TITLE
release-23.1: cloud: allow parallel running of cloud unit tests

### DIFF
--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -77,9 +77,11 @@ func TestPutS3(t *testing.T) {
 
 	ctx := context.Background()
 	user := username.RootUserName()
+	testID := cloudtestutils.NewTestID()
+
 	t.Run("auth-empty-no-cred", func(t *testing.T) {
-		_, err := cloud.ExternalStorageFromURI(ctx, fmt.Sprintf("s3://%s/%s", bucket,
-			"backup-test-default"), base.ExternalIODirConfig{}, testSettings,
+		_, err := cloud.ExternalStorageFromURI(ctx, fmt.Sprintf("s3://%s/%s-%d", bucket,
+			"backup-test-default", testID), base.ExternalIODirConfig{}, testSettings,
 			blobs.TestEmptyBlobClientFactory, user,
 			nil, /* ie */
 			nil, /* ief */
@@ -107,15 +109,15 @@ func TestPutS3(t *testing.T) {
 		}
 
 		cloudtestutils.CheckExportStore(t, fmt.Sprintf(
-			"s3://%s/%s?%s=%s",
-			bucket, "backup-test-default",
+			"s3://%s/%s-%d?%s=%s",
+			bucket, "backup-test-default", testID,
 			cloud.AuthParam, cloud.AuthParamImplicit,
 		), false, user,
 			nil, /* db */
 			testSettings)
 	})
 	t.Run("auth-specified", func(t *testing.T) {
-		uri := S3URI(bucket, "backup-test",
+		uri := S3URI(bucket, fmt.Sprintf("backup-test-%d", testID),
 			&cloudpb.ExternalStorage_S3{AccessKey: creds.AccessKeyID, Secret: creds.SecretAccessKey, Region: "us-east-1"},
 		)
 		cloudtestutils.CheckExportStore(
@@ -140,8 +142,8 @@ func TestPutS3(t *testing.T) {
 		}
 
 		cloudtestutils.CheckExportStore(t, fmt.Sprintf(
-			"s3://%s/%s?%s=%s&%s=%s",
-			bucket, "backup-test-sse-256",
+			"s3://%s/%s-%d?%s=%s&%s=%s",
+			bucket, "backup-test-sse-256", testID,
 			cloud.AuthParam, cloud.AuthParamImplicit, AWSServerSideEncryptionMode,
 			"AES256",
 		),
@@ -156,8 +158,8 @@ func TestPutS3(t *testing.T) {
 			skip.IgnoreLint(t, "AWS_KMS_KEY_ARN env var must be set")
 		}
 		cloudtestutils.CheckExportStore(t, fmt.Sprintf(
-			"s3://%s/%s?%s=%s&%s=%s&%s=%s",
-			bucket, "backup-test-sse-kms",
+			"s3://%s/%s-%d?%s=%s&%s=%s&%s=%s",
+			bucket, "backup-test-sse-kms", testID,
 			cloud.AuthParam, cloud.AuthParamImplicit, AWSServerSideEncryptionMode,
 			"aws:kms", AWSServerSideEncryptionKMSID, v,
 		),
@@ -216,6 +218,8 @@ func TestPutS3AssumeRole(t *testing.T) {
 	}
 
 	testSettings := cluster.MakeTestingClusterSettings()
+	testID := cloudtestutils.NewTestID()
+	testPath := fmt.Sprintf("backup-test-%d", testID)
 
 	user := username.RootUserName()
 
@@ -230,7 +234,7 @@ func TestPutS3AssumeRole(t *testing.T) {
 			skip.IgnoreLintf(t, "we only run this test if a default role exists, "+
 				"refer to https://docs.aws.com/cli/latest/userguide/cli-configure-role.html: %s", err)
 		}
-		uri := S3URI(bucket, "backup-test",
+		uri := S3URI(bucket, testPath,
 			&cloudpb.ExternalStorage_S3{Auth: cloud.AuthParamImplicit, RoleARN: roleArn, Region: "us-east-1"},
 		)
 		cloudtestutils.CheckExportStore(
@@ -242,7 +246,7 @@ func TestPutS3AssumeRole(t *testing.T) {
 	})
 
 	t.Run("auth-specified", func(t *testing.T) {
-		uri := S3URI(bucket, "backup-test",
+		uri := S3URI(bucket, testPath,
 			&cloudpb.ExternalStorage_S3{Auth: cloud.AuthParamSpecified, RoleARN: roleArn, AccessKey: creds.AccessKeyID, Secret: creds.SecretAccessKey, Region: "us-east-1"},
 		)
 		cloudtestutils.CheckExportStore(
@@ -272,7 +276,7 @@ func TestPutS3AssumeRole(t *testing.T) {
 			t.Run(tc.auth, func(t *testing.T) {
 				// First verify that none of the individual roles in the chain can be used to access the storage.
 				for _, p := range providerChain {
-					roleURI := S3URI(bucket, "backup-test",
+					roleURI := S3URI(bucket, testPath,
 						&cloudpb.ExternalStorage_S3{
 							Auth:               tc.auth,
 							AssumeRoleProvider: p,
@@ -294,7 +298,7 @@ func TestPutS3AssumeRole(t *testing.T) {
 					delegatesWithoutID = append(delegatesWithoutID, cloudpb.ExternalStorage_AssumeRoleProvider{Role: p.Role})
 				}
 
-				uri := S3URI(bucket, "backup-test",
+				uri := S3URI(bucket, testPath,
 					&cloudpb.ExternalStorage_S3{
 						Auth:                  tc.auth,
 						AssumeRoleProvider:    roleWithoutID,
@@ -309,7 +313,7 @@ func TestPutS3AssumeRole(t *testing.T) {
 				)
 
 				// Finally, check that the chain of roles can be used to access the storage.
-				uri = S3URI(bucket, "backup-test",
+				uri = S3URI(bucket, testPath,
 					&cloudpb.ExternalStorage_S3{
 						Auth:                  tc.auth,
 						AssumeRoleProvider:    providerChain[len(providerChain)-1],
@@ -350,11 +354,12 @@ func TestPutS3Endpoint(t *testing.T) {
 		skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
 	}
 	user := username.RootUserName()
+	testID := cloudtestutils.NewTestID()
 
 	u := url.URL{
 		Scheme:   "s3",
 		Host:     bucket,
-		Path:     "backup-test",
+		Path:     fmt.Sprintf("backup-test-%d", testID),
 		RawQuery: q.Encode(),
 	}
 

--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -591,3 +591,8 @@ func IsImplicitAuthConfigured() bool {
 	credentials := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 	return credentials != ""
 }
+
+func NewTestID() uint64 {
+	rng, _ := randutil.NewTestRand()
+	return rng.Uint64()
+}

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -44,6 +44,7 @@ func TestPutGoogleCloud(t *testing.T) {
 
 	user := username.RootUserName()
 	testSettings := cluster.MakeTestingClusterSettings()
+	testID := cloudtestutils.NewTestID()
 
 	testutils.RunTrueAndFalse(t, "auth-specified-with-auth-param", func(t *testing.T, specified bool) {
 		credentials := os.Getenv("GOOGLE_CREDENTIALS_JSON")
@@ -51,9 +52,10 @@ func TestPutGoogleCloud(t *testing.T) {
 			skip.IgnoreLint(t, "GOOGLE_CREDENTIALS_JSON env var must be set")
 		}
 		encoded := base64.StdEncoding.EncodeToString([]byte(credentials))
-		uri := fmt.Sprintf("gs://%s/%s?%s=%s",
+		uri := fmt.Sprintf("gs://%s/%s-%d?%s=%s",
 			bucket,
 			"backup-test-specified",
+			testID,
 			CredentialsParam,
 			url.QueryEscape(encoded),
 		)
@@ -68,9 +70,10 @@ func TestPutGoogleCloud(t *testing.T) {
 			nil, /* db */
 			testSettings,
 		)
-		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
+		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
 			bucket,
 			"backup-test-specified",
+			testID,
 			"listing-test",
 			cloud.AuthParam,
 			cloud.AuthParamSpecified,
@@ -88,15 +91,16 @@ func TestPutGoogleCloud(t *testing.T) {
 
 		cloudtestutils.CheckExportStore(
 			t,
-			fmt.Sprintf("gs://%s/%s?%s=%s", bucket, "backup-test-implicit",
+			fmt.Sprintf("gs://%s/%s-%d?%s=%s", bucket, "backup-test-implicit", testID,
 				cloud.AuthParam, cloud.AuthParamImplicit),
 			false,
 			user,
 			nil, /* db */
 			testSettings)
-		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s/%s?%s=%s",
+		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s",
 			bucket,
 			"backup-test-implicit",
+			testID,
 			"listing-test",
 			cloud.AuthParam,
 			cloud.AuthParamImplicit,
@@ -120,9 +124,10 @@ func TestPutGoogleCloud(t *testing.T) {
 		token, err := ts.Token()
 		require.NoError(t, err, "getting token")
 
-		uri := fmt.Sprintf("gs://%s/%s?%s=%s",
+		uri := fmt.Sprintf("gs://%s/%s-%d?%s=%s",
 			bucket,
 			"backup-test-specified",
+			testID,
 			BearerTokenParam,
 			token.AccessToken,
 		)
@@ -134,9 +139,10 @@ func TestPutGoogleCloud(t *testing.T) {
 			user,
 			nil, /* db */
 			testSettings)
-		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
+		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
 			bucket,
 			"backup-test-specified",
+			testID,
 			"listing-test",
 			cloud.AuthParam,
 			cloud.AuthParamSpecified,
@@ -162,6 +168,8 @@ func TestGCSAssumeRole(t *testing.T) {
 		skip.IgnoreLint(t, "ASSUME_SERVICE_ACCOUNT env var must be set")
 	}
 
+	testID := cloudtestutils.NewTestID()
+
 	t.Run("specified", func(t *testing.T) {
 		credentials := os.Getenv("GOOGLE_CREDENTIALS_JSON")
 		if credentials == "" {
@@ -171,7 +179,7 @@ func TestGCSAssumeRole(t *testing.T) {
 
 		// Verify that specified permissions with the credentials do not give us
 		// access to the bucket.
-		cloudtestutils.CheckNoPermission(t, fmt.Sprintf("gs://%s/%s?%s=%s", limitedBucket, "backup-test-assume-role",
+		cloudtestutils.CheckNoPermission(t, fmt.Sprintf("gs://%s/%s-%d?%s=%s", limitedBucket, "backup-test-assume-role", testID,
 			CredentialsParam, url.QueryEscape(encoded)), user,
 			nil, /* db */
 			testSettings,
@@ -179,9 +187,10 @@ func TestGCSAssumeRole(t *testing.T) {
 
 		cloudtestutils.CheckExportStore(
 			t,
-			fmt.Sprintf("gs://%s/%s?%s=%s&%s=%s&%s=%s",
+			fmt.Sprintf("gs://%s/%s-%d?%s=%s&%s=%s&%s=%s",
 				limitedBucket,
 				"backup-test-assume-role",
+				testID,
 				cloud.AuthParam,
 				cloud.AuthParamSpecified,
 				AssumeRoleParam,
@@ -191,9 +200,10 @@ func TestGCSAssumeRole(t *testing.T) {
 			nil, /* db */
 			testSettings,
 		)
-		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s&%s=%s",
+		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s&%s=%s",
 			limitedBucket,
 			"backup-test-assume-role",
+			testID,
 			"listing-test",
 			cloud.AuthParam,
 			cloud.AuthParamSpecified,
@@ -214,20 +224,21 @@ func TestGCSAssumeRole(t *testing.T) {
 
 		// Verify that implicit permissions with the credentials do not give us
 		// access to the bucket.
-		cloudtestutils.CheckNoPermission(t, fmt.Sprintf("gs://%s/%s?%s=%s", limitedBucket, "backup-test-assume-role",
+		cloudtestutils.CheckNoPermission(t, fmt.Sprintf("gs://%s/%s-%d?%s=%s", limitedBucket, "backup-test-assume-role", testID,
 			cloud.AuthParam, cloud.AuthParamImplicit), user,
 			nil, /* db */
 			testSettings,
 		)
 
-		cloudtestutils.CheckExportStore(t, fmt.Sprintf("gs://%s/%s?%s=%s&%s=%s", limitedBucket, "backup-test-assume-role",
+		cloudtestutils.CheckExportStore(t, fmt.Sprintf("gs://%s/%s-%d?%s=%s&%s=%s", limitedBucket, "backup-test-assume-role", testID,
 			cloud.AuthParam, cloud.AuthParamImplicit, AssumeRoleParam, assumedAccount), false, user,
 			nil, /* db */
 			testSettings,
 		)
-		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
+		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
 			limitedBucket,
 			"backup-test-assume-role",
+			testID,
 			"listing-test",
 			cloud.AuthParam,
 			cloud.AuthParamImplicit,
@@ -269,9 +280,10 @@ func TestGCSAssumeRole(t *testing.T) {
 				// to access the storage.
 				for _, role := range roleChain {
 					q.Set(AssumeRoleParam, role)
-					roleURI := fmt.Sprintf("gs://%s/%s/%s?%s",
+					roleURI := fmt.Sprintf("gs://%s/%s-%d/%s?%s",
 						limitedBucket,
 						"backup-test-assume-role",
+						testID,
 						"listing-test",
 						q.Encode(),
 					)
@@ -283,9 +295,10 @@ func TestGCSAssumeRole(t *testing.T) {
 
 				// Finally, check that the chain of roles can be used to access the storage.
 				q.Set(AssumeRoleParam, roleChainStr)
-				uri := fmt.Sprintf("gs://%s/%s/%s?%s",
+				uri := fmt.Sprintf("gs://%s/%s-%d/%s?%s",
 					limitedBucket,
 					"backup-test-assume-role",
+					testID,
 					"listing-test",
 					q.Encode(),
 				)


### PR DESCRIPTION
Backport 1/1 commits from #107205.

/cc @cockroachdb/release

---

Append a random uint64 in the paths of cloud unit tests to prevent parallel executions from interfering with each other. This is necessary since these tests now run for all release branches and can run in parallel.

Fixes: #107137
Fixes: #107139

Release note: None
Release justification: test-only change
