### PR TITLE
acceptance: make `TestDockerCLI_test_exec_log` wait for unambiguous l…

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -144,6 +144,20 @@ proc flush_server_logs {} {
     report "END FLUSH LOGS"
 }
 
+proc flush_and_sync_logs {filename grep_text} {
+    report "BEGIN FLUSH LOGS $filename"
+    system "kill -HUP `cat server_pid` 2>/dev/null"
+    # Wait for flush to occur.
+    system "for i in `seq 1 5`; do
+              grep '$grep_text' $filename && exit 0;
+              echo still waiting
+              sleep 1
+            done
+            echo 'server failed to flush logs?'
+            exit 1"
+    report "END FLUSH LOGS"
+}
+
 proc force_stop_server {argv} {
     report "BEGIN FORCE STOP SERVER"
     system "kill -KILL `cat server_pid`"


### PR DESCRIPTION
…og line

The `TestDockerCLI_test_exec_log` test had a section where it waits for the last executed stmt to appear in the exec_log file before proceeding to the next section. This is done by grep'ing the query string of the last stmt. This works fine most of the time, however, the 2nd last and last stmt executed happen to have the same query string, so it's possible that we are only seeing the 2nd to last stmt in the log. This can cause the test to fail as in the next section, we expect all query logs to be present in the file.

This commit fixes this by issuing a distinct query as the last query so that we can grep for a distinct query string to verify all stmts should have been written.

A new proc is also added to `common.tcl`: flush_and_sync_logs is a proc that takes 2 arguments, `filename` and `grep_text`. It will trigger a signal hang up to trigger a log flush and then attempt to find the `grep_text` in the specified file.


Epic: none
Fixes: #106367