### PR TITLE
release-22.2: cloud: allow parallel running of cloud unit tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh
@@ -25,8 +25,8 @@ export AWS_CONFIG_FILE="$PWD/.aws/config"
 log_into_aws
 
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- --config=ci \
-    test //pkg/cloud/gcp:gcp_test //pkg/cloud/amazon:amazon_test //pkg/ccl/cloudccl/gcp:gcp_test //pkg/ccl/cloudccl/amazon:amazon_test \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- \
+    test --config=ci //pkg/cloud/gcp:gcp_test //pkg/cloud/amazon:amazon_test //pkg/ccl/cloudccl/gcp:gcp_test //pkg/ccl/cloudccl/amazon:amazon_test \
     --test_env=GO_TEST_WRAP_TESTV=1 \
     --test_env=GO_TEST_WRAP=1 \
     --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE \

--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -66,14 +66,18 @@ func TestAzure(t *testing.T) {
 		return
 	}
 	testSettings := cluster.MakeTestingClusterSettings()
-	cloudtestutils.CheckExportStore(t, cfg.filePath("backup-test"),
+	testID := cloudtestutils.NewTestID()
+	testPath := fmt.Sprintf("backup-test-%d", testID)
+	testListPath := fmt.Sprintf("listing-test-%d", testID)
+
+	cloudtestutils.CheckExportStore(t, cfg.filePath(testPath),
 		false, username.RootUserName(),
 		nil, /* ie */
 		nil, /* ief */
 		nil, /* kvDB */
 		testSettings,
 	)
-	cloudtestutils.CheckListFiles(t, cfg.filePath("listing-test"), username.RootUserName(),
+	cloudtestutils.CheckListFiles(t, cfg.filePath(testListPath), username.RootUserName(),
 		nil, /* ie */
 		nil, /* ief */
 		nil, /* kvDB */
@@ -90,9 +94,11 @@ func TestAntagonisticAzureRead(t *testing.T) {
 		return
 	}
 	testSettings := cluster.MakeTestingClusterSettings()
+	testID := cloudtestutils.NewTestID()
+	antagonistPath := fmt.Sprintf("antagonistic-read-%d", testID)
 
 	conf, err := cloud.ExternalStorageConfFromURI(
-		cfg.filePath("antagonistic-read"), username.RootUserName())
+		cfg.filePath(antagonistPath), username.RootUserName())
 	require.NoError(t, err)
 
 	cloudtestutils.CheckAntagonisticRead(t, conf, testSettings)

--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -605,3 +605,8 @@ func IsImplicitAuthConfigured() bool {
 	credentials := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 	return credentials != ""
 }
+
+func NewTestID() uint64 {
+	rng, _ := randutil.NewTestRand()
+	return rng.Uint64()
+}


### PR DESCRIPTION
Backport 1/1 commits from #107205.

/cc @cockroachdb/release

---

Append a random uint64 in the paths of cloud unit tests to prevent parallel executions from interfering with each other. This is necessary since these tests now run for all release branches and can run in parallel.

Fixes: #107137
Fixes: #107139

Release note: None
Release justification: test-only change
