### PR TITLE
issues: escape title when doing regexp match

### DIFF
--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -496,7 +496,7 @@ func HelpCommandAsLink(title, href string) func(r *Renderer) {
 func filterByPrefixTitleMatch(
 	result *github.IssuesSearchResult, expectedTitle string,
 ) []github.Issue {
-	expectedTitleRegex := regexp.MustCompile(`^` + expectedTitle + `(\s+|$)`)
+	expectedTitleRegex := regexp.MustCompile(`^` + regexp.QuoteMeta(expectedTitle) + `(\s+|$)`)
 	var issues []github.Issue
 	for _, issue := range result.Issues {
 		if title := issue.Title; title != nil && expectedTitleRegex.MatchString(*title) {


### PR DESCRIPTION
Without this, a test name that has regex in it could break this search, or even cause roachtest itself to crash.

Epic: none
Release note: None