### PR TITLE
release-23.1: dev,ui: make external symlink detection more resilient

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=79
+DEV_VERSION=82
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/io/os/os.go
+++ b/pkg/cmd/dev/io/os/os.go
@@ -185,6 +185,35 @@ func (o *OS) Setenv(key, value string) error {
 	return err
 }
 
+// IsSymlink wraps around os.Lstat to determine if filename is a symbolic link
+// or not.
+func (o *OS) IsSymlink(filename string) (bool, error) {
+	command := fmt.Sprintf("stat %s", filename)
+	if !o.knobs.silent {
+		o.logger.Print(command)
+	}
+
+	isLinkStr, err := o.Next(command, func() (string, error) {
+		// Use os.Lstat here, since it does not attempt to resolve symlinks.
+		stat, err := os.Lstat(filename)
+		if err != nil {
+			return "", err
+		}
+
+		isLink := stat.Mode()&fs.ModeSymlink != 0
+
+		// o.Next only accepts string return values, so serialize a boolean
+		// and deserialize it outside of o.Next.
+		return strconv.FormatBool(isLink), nil
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	return strconv.ParseBool(isLinkStr)
+}
+
 // Readlink wraps around os.Readlink, which returns the destination of the named
 // symbolic link. If there is an error, it will be of type *PathError.
 func (o *OS) Readlink(filename string) (string, error) {

--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -146,7 +146,10 @@ rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/src/js/node_modules
+rm -rf crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/node_modules
+rm -rf crdb-checkout/pkg/ui/workspaces/e2e-tests/node_modules
+rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/node_modules
 
 exec
 dev ui e2e

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -591,7 +591,10 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 					filepath.Join(workspace, "pkg", "ui", "node_modules"),
 					filepath.Join(uiDirs.dbConsole, "node_modules"),
 					filepath.Join(uiDirs.dbConsole, "src", "js", "node_modules"),
+					filepath.Join(uiDirs.dbConsole, "ccl", "src", "js", "node_modules"),
 					filepath.Join(uiDirs.clusterUI, "node_modules"),
+					filepath.Join(uiDirs.e2eTests, "node_modules"),
+					filepath.Join(uiDirs.eslintPlugin, "node_modules"),
 				)
 			}
 

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -162,8 +162,24 @@ func (d *dev) assertNoLinkedNpmDeps(targets []buildTarget) error {
 				continue
 			}
 
-			// Resolve the possible symlink.
 			depPath := filepath.Join(crlModulesPath, depName)
+
+			// Determine if depName is a symlink. It should be when dependencies
+			// are installed via pnpm, but there are cases involving stale
+			// node_modules/ trees that can result in it being a regular
+			// directory.
+			isSymlink, err := d.os.IsSymlink(depPath)
+			if err != nil {
+				return fmt.Errorf("could not determine if %s is a symlink: %w", depPath, err)
+			}
+
+			// Regular directories cannot (by definition) link outside the Bazel
+			// workspace, so are safe to ignore.
+			if !isSymlink {
+				continue
+			}
+
+			// Resolve the symlink.
 			resolved, err := d.os.Readlink(depPath)
 			if err != nil {
 				return fmt.Errorf("could not evaluate symlink %s: %w", depPath, err)


### PR DESCRIPTION
Backport 2/2 commits from #107543.

/cc @cockroachdb/release

---

Previously, a pre-build assertion (that no JS dependencies are provided by symlinks outside the Bazel workspace) would return errors when it encountered a non-symlink file. While pnpm only produces symlinks for packages it installs, a stale node_modules/ tree could result in unintended errors. Test if a file is a symlink before attempting to call os.Readlink on it.

Release note: None
Epic: none


Release justification: build-only change