### PR TITLE
release-23.1: update predecessor map for 22.2.12 and 23.1.6

### DIFF
--- a/pkg/testutils/release/cockroach_releases.yaml
+++ b/pkg/testutils/release/cockroach_releases.yaml
@@ -8,13 +8,13 @@
   - 22.1.19
   predecessor: "21.2"
 "22.2":
-  latest: 22.2.11
+  latest: 22.2.12
   withdrawn:
   - 22.2.4
   - 22.2.8
   predecessor: "22.1"
 "23.1":
-  latest: 23.1.5
+  latest: 23.1.6
   withdrawn:
   - 23.1.0
   predecessor: "22.2"


### PR DESCRIPTION
Release note: None
Epic: None
Release justification: test-only change