### PR TITLE
sql: improve query plan for find-running-job-of-type query

### DIFF
--- a/pkg/jobs/utils.go
+++ b/pkg/jobs/utils.go
@@ -58,15 +58,21 @@ func RunningJobExists(
 		typeStrs = s.String()
 	}
 
+	orderBy := " ORDER BY created"
+	if ignoreJobID == jobspb.InvalidJobID {
+		// There is no need to order by the created column if there is no job to
+		// ignore.
+		orderBy = ""
+	}
+
 	stmt := `
 SELECT
   id
 FROM
-  system.jobs
+  system.jobs@jobs_status_created_idx
 WHERE
 	job_type IN ` + typeStrs + ` AND
-  status IN ` + NonTerminalStatusTupleString + `
-ORDER BY created
+  status IN ` + NonTerminalStatusTupleString + orderBy + `
 LIMIT 1`
 	it, err := txn.QueryIterator(
 		ctx,


### PR DESCRIPTION
This commit improves the query plan for the `find-running-jobs-of-type`
query by adding a hint to use the `jobs_status_created_idx` and by
removing an `ORDER BY` clause if a job ID to ignore was not given. This
can eliminate an index join from the query plan in some cases, making
the query plan more efficient.

Informs #107405

Release note: None
