### PR TITLE
kvcoord: disable fatal assertion on transaction commit sanity check

### DIFF
--- a/pkg/kv/kvclient/kvcoord/replayed_commit_test.go
+++ b/pkg/kv/kvclient/kvcoord/replayed_commit_test.go
@@ -49,7 +49,7 @@ func (f *interceptingTransport) SendNext(
 // in which DistSender retries an (unbeknownst to it) successful EndTxn(commit=true)
 // RPC. It documents that this triggers an assertion failure in TxnCoordSender.
 //
-// See: https://github.com/cockroachdb/cockroach/issues/67765
+// See: https://github.com/cockroachdb/cockroach/issues/103817
 func TestCommitSanityCheckAssertionFiresOnUndetectedAmbiguousCommit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -89,8 +89,6 @@ func TestCommitSanityCheckAssertionFiresOnUndetectedAmbiguousCommit(t *testing.T
 				},
 			}, nil
 		},
-		// Turn the assertion into an error returned via the txn.
-		DisableCommitSanityCheck: true,
 	}
 
 	tc := testcluster.StartTestCluster(t, 1, args)

--- a/pkg/kv/kvclient/kvcoord/testing_knobs.go
+++ b/pkg/kv/kvclient/kvcoord/testing_knobs.go
@@ -48,10 +48,6 @@ type ClientTestingKnobs struct {
 	// only applies to requests sent with the LEASEHOLDER routing policy.
 	DontReorderReplicas bool
 
-	// DisableCommitSanityCheck allows "setting" the DisableCommitSanityCheck to
-	// true without actually overriding the variable.
-	DisableCommitSanityCheck bool
-
 	// CommitWaitFilter allows tests to instrument the beginning of a transaction
 	// commit wait sleep.
 	CommitWaitFilter func()


### PR DESCRIPTION
As #103817 is now a known issue for which a root cause has been identified, the sanity check assertion in place here is disabled, with errors occuring due to the known bug properly linking to the issue ticket. While the transaction coordinator still performs sanity checks to ensure that operations cannot continue on an already-committed transaction, it will no longer log the error with severity `FATAL`, resulting in node crash, and will instead simply return the error.

Part of: #103817

Release note: None