### PR TITLE
plpgsql: add support for execution of routines with exception blocks

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1930,6 +1930,7 @@ GO_TARGETS = [
     "//pkg/sql/plpgsql/parser/lexbase:lexbase",
     "//pkg/sql/plpgsql/parser:parser_test",
     "//pkg/sql/plpgsql/parser:plpgparser",
+    "//pkg/sql/plpgsql:plpgsql",
     "//pkg/sql/privilege:privilege",
     "//pkg/sql/privilege:privilege_test",
     "//pkg/sql/protoreflect/test:test",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -455,6 +455,7 @@ go_library(
         "//pkg/sql/pgwire/pgwirecancel",
         "//pkg/sql/physicalplan",
         "//pkg/sql/physicalplan/replicaoracle",
+        "//pkg/sql/plpgsql",
         "//pkg/sql/privilege",
         "//pkg/sql/protoreflect",
         "//pkg/sql/querycache",

--- a/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
+++ b/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
@@ -1004,3 +1004,379 @@ SELECT f(-1, -1), f(-1, 0), f(-1, 1), f(-1, 10), f(0, -1), f(0, 0), f(0, 1), f(0
   f(1, -1), f(1, 0), f(1, 1), f(1, 10), f(10, -1), f(10, 0), f(10, 1), f(10, 10);
 ----
 15  14  13  12  11  10  9  8  7  6  5  4  3  2  1  0
+
+# Testing EXCEPTION blocks.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 100;
+    WHEN invalid_regular_expression THEN
+      RETURN 200;
+    WHEN SQLSTATE '2200C' THEN
+      RETURN 300;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+100
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN invalid_regular_expression THEN
+      RETURN 200;
+    WHEN division_by_zero THEN
+      RETURN 100;
+    WHEN SQLSTATE '2200C' THEN
+      RETURN 300;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+100
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN SQLSTATE '22012' THEN
+      RETURN 100;
+    WHEN invalid_regular_expression THEN
+      RETURN 200;
+    WHEN SQLSTATE '2200C' THEN
+      RETURN 300;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+100
+
+statement ok
+DROP FUNCTION f(INT);
+CREATE OR REPLACE FUNCTION f(i INT) RETURNS INT AS $$
+  BEGIN
+    IF i > 0 THEN
+      RETURN 1 // 0;
+    ELSE
+      RETURN sqrt(i::FLOAT)::INT;
+    END IF;
+  EXCEPTION
+    WHEN SQLSTATE '22012' OR invalid_argument_for_power_function THEN
+      RETURN 100;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query III
+SELECT f(-1), f(0), f(1);
+----
+100  0  100
+
+statement ok
+CREATE OR REPLACE FUNCTION f(i INT) RETURNS INT AS $$
+  BEGIN
+    IF i > 0 THEN
+      RETURN 1 // 0;
+    ELSE
+      RETURN sqrt(i::FLOAT)::INT;
+    END IF;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 100;
+    WHEN SQLSTATE '2201F' THEN
+      RETURN -1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query III
+SELECT f(-1), f(0), f(1);
+----
+-1  0  100
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RAISE division_by_zero;
+    RETURN 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 100;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+100
+
+statement ok
+CREATE OR REPLACE FUNCTION f(i INT) RETURNS INT AS $$
+  BEGIN
+    IF i = 0 THEN
+      RAISE division_by_zero;
+    END IF;
+    IF i = 1 THEN
+      RAISE invalid_text_representation;
+    END IF;
+    IF i = 2 THEN
+      RAISE SQLSTATE '22P03';
+    END IF;
+    RAISE SQLSTATE '22007';
+    RETURN 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 101;
+    WHEN SQLSTATE '22P02' THEN
+      RETURN 102;
+    WHEN invalid_binary_representation THEN
+      RETURN 103;
+    WHEN SQLSTATE '22007' THEN
+      RETURN 104;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# Raise with error name, catch with error name.
+query I
+SELECT f(0);
+----
+101
+
+# Raise with error name, catch with code.
+query I
+SELECT f(1);
+----
+102
+
+# Raise with code, catch with error name.
+query I
+SELECT f(2);
+----
+103
+
+# Raise with code, catch with code.
+query I
+SELECT f(3);
+----
+104
+
+# Uncaught exception.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RAISE SQLSTATE '12345';
+    RETURN 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 101;
+    WHEN SQLSTATE '22P02' THEN
+      RETURN 102;
+    WHEN invalid_binary_representation THEN
+      RETURN 103;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 12345 pq: 12345
+SELECT f();
+
+# No exception raised.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RETURN 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 101;
+    WHEN SQLSTATE '22P02' THEN
+      RETURN 102;
+    WHEN invalid_binary_representation THEN
+      RETURN 103;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+0
+
+# Have to drop the function here because otherwise it's seen as a
+# "parameter name change" error.
+statement ok
+DROP FUNCTION f(INT);
+
+# The exception block does not catch errors thrown during variable declaration.
+statement ok
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    i INT := 100 // n;
+  BEGIN
+    RETURN i;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 101;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 22012 pq: division by zero
+SELECT f(0);
+
+query II
+SELECT f(-1), f(1)
+----
+-100  100
+
+# When an error is thrown, any variable assignments that happened before the
+# error should be visible to the exception handler. Any variable assignments
+# during or after the error should not be visible.
+statement ok
+CREATE OR REPLACE FUNCTION f(i INT, j INT, k INT) RETURNS INT AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    x := 1 // i;
+    x := 2 // j;
+    x := 3 // k;
+    RETURN x;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query IIII
+SELECT f(0, 0, 0), f(1, 0, 0), f(1, 1, 0), f(1, 1, 1);
+----
+0  1  2  3
+
+# Have to drop the function here because otherwise it's seen as a
+# "parameter name change" error.
+statement ok
+DROP FUNCTION f(INT);
+
+statement ok
+CREATE OR REPLACE FUNCTION f(i INT) RETURNS INT AS $$
+  DECLARE
+    x INT;
+  BEGIN
+    IF i = 0 THEN
+      x := 100;
+      RAISE division_by_zero;
+    ELSE
+      x := 200;
+      RAISE division_by_zero;
+    END IF;
+    RETURN 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query II
+SELECT f(0), f(1);
+----
+100  200
+
+# Have to drop the function here because otherwise it's seen as a
+# "parameter name change" error.
+statement ok
+DROP FUNCTION f(INT, INT);
+
+statement ok
+CREATE OR REPLACE FUNCTION f(n INT, a INT) RETURNS INT AS $$
+  DECLARE
+    x INT;
+    i INT := 0;
+  BEGIN
+    LOOP IF i >= n THEN EXIT; END IF;
+      x := 1 // (i - a);
+      i := i + 1;
+    END LOOP;
+    RETURN -1;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query IIIIIII
+SELECT f(5, -1), f(5, 0), f(5, 1), f(5, 2), f(5, 3), f(5, 4), f(5, 5);
+----
+-1  0  1  2  3  4  -1
+
+# Duplicate catch branches are allowed; postgres just takes the first.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 100;
+    WHEN division_by_zero THEN
+      RETURN 200;
+    WHEN SQLSTATE '22012' THEN
+      RETURN 300;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+100
+
+statement error pgcode 42704 pq: unrecognized exception condition "this_error_does_not_exist"
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RETURN 0;
+  EXCEPTION
+    WHEN this_error_does_not_exist THEN
+      RETURN 100;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# SQLSTATE error code must be 5 digits and/or letters.
+statement error pgcode 42601 pq: invalid SQLSTATE code '123'
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RETURN 0;
+  EXCEPTION
+    WHEN SQLSTATE '123' THEN
+      RETURN 100;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42601 pq: invalid SQLSTATE code '123aB'
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RETURN 0;
+  EXCEPTION
+    WHEN SQLSTATE '123aB' THEN
+      RETURN 100;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# It is possible for the exception handler itself to result in an error; when
+# that happens, it does not attempt to catch its own error.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RAISE division_by_zero USING message = 'Oh no, division by zero!';
+      RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 22012 pq: Oh no, division by zero!
+SELECT f();

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -921,6 +922,11 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	udf := scalar.(*memo.UDFCallExpr)
 	if udf.Def == nil {
 		return nil, errors.AssertionFailedf("expected non-nil UDF definition")
+	}
+	if udf.Def.ExceptionBlock != nil {
+		return nil, unimplemented.New("exception block",
+			"exception blocks for PLpgSQL functions are not yet supported",
+		)
 	}
 
 	// Build the argument expressions.

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/sql/opt/invertedexpr",  # keep
         "//pkg/sql/opt/props",
         "//pkg/sql/opt/props/physical",
+        "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/rowenc/valueside",
         "//pkg/sql/sem/cast",

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -963,6 +963,18 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 		} else {
 			tp.Child("recursive-call")
 		}
+		// Only print the exception handler for the top-level call.
+		if udf.Def.ExceptionBlock != nil && strings.HasPrefix(udf.Def.Name, "exception_block") {
+			n = tp.Child("exception-handler")
+			for i := range udf.Def.ExceptionBlock.Codes {
+				code := udf.Def.ExceptionBlock.Codes[i]
+				body := udf.Def.ExceptionBlock.Actions[i].Body
+				branch := n.Childf("SQLSTATE '%s'", code)
+				for j := range body {
+					f.formatExpr(body[j], branch)
+				}
+			}
+		}
 	}
 
 	f.Buffer.Reset()

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -413,6 +413,7 @@ func (c *CustomFuncs) InlineConstVar(f memo.FiltersExpr) memo.FiltersExpr {
 //  4. Its arguments are only Variable or Const expressions.
 //  5. It is not a record-returning function.
 //  6. It does not recursively call itself.
+//  7. It does not have an exception-handling block.
 //
 // UDFs with mutations (INSERT, UPDATE, UPSERT, DELETE) cannot be inlined, but
 // we do not need an explicit check for this because immutable UDFs cannot
@@ -446,7 +447,8 @@ func (c *CustomFuncs) IsInlinableUDF(args memo.ScalarListExpr, udfp *memo.UDFCal
 		panic(errors.AssertionFailedf("expected non-nil UDF definition"))
 	}
 	if udfp.Def.IsRecursive || udfp.Def.Volatility == volatility.Volatile ||
-		len(udfp.Def.Body) != 1 || udfp.Def.SetReturning || udfp.Def.MultiColDataSource {
+		len(udfp.Def.Body) != 1 || udfp.Def.SetReturning || udfp.Def.MultiColDataSource ||
+		udfp.Def.ExceptionBlock != nil {
 		return false
 	}
 	if !args.IsConstantsAndPlaceholdersAndVariables() {

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -139,6 +139,11 @@ type plpgsqlBuilder struct {
 	// statements that follow the loop.
 	exitContinuations []continuation
 
+	// exceptionBlock is the exception handler built to handle the (optional)
+	// EXCEPTION block of the PLpgSQL routine. See the buildExceptions comments
+	// for more detail.
+	exceptionBlock *memo.ExceptionBlock
+
 	identCounter int
 }
 
@@ -197,22 +202,32 @@ func (b *plpgsqlBuilder) build(block *plpgsqltree.PLpgSQLStmtBlock, s *scope) *s
 			b.constants[dec.Var] = struct{}{}
 		}
 	}
-	if s = b.buildPLpgSQLStatements(block.Body, s); s != nil {
-		return s
+	b.buildExceptions(block)
+	if b.exceptionBlock != nil {
+		// Wrap the body in a routine to ensure that any errors thrown from the body
+		// are caught. Note that errors thrown during variable elimination are
+		// intentionally not caught.
+		catchCon := b.makeContinuation("exception_block")
+		b.finishContinuation(block.Body, &catchCon, false /* recursive */)
+		s = b.callContinuation(&catchCon, s)
+	} else {
+		// No exception block, so no need to wrap the body statements.
+		s = b.buildPLpgSQLStatements(block.Body, s)
 	}
-	// At least one path in the control flow does not terminate with a RETURN
-	// statement.
-	//
-	// Postgres throws this error at runtime, so it's possible to define a
-	// function that runs correctly for some inputs, but returns this error for
-	// others. We are compiling rather than interpreting, so it seems better to
-	// eagerly return the error if there is an execution path with no RETURN.
-	// TODO(drewk): consider using RAISE (when it is implemented) to throw the
-	// error at runtime instead.
-	panic(pgerror.New(
-		pgcode.RoutineExceptionFunctionExecutedNoReturnStatement,
-		"control reached end of function without RETURN",
-	))
+	if s == nil {
+		// At least one path in the control flow does not terminate with a RETURN
+		// statement.
+		//
+		// Postgres throws this error at runtime, so it's possible to define a
+		// function that runs correctly for some inputs, but returns this error for
+		// others. We are compiling rather than interpreting, so it seems better to
+		// eagerly return the error if there is an execution path with no RETURN.
+		panic(pgerror.New(
+			pgcode.RoutineExceptionFunctionExecutedNoReturnStatement,
+			"control reached end of function without RETURN",
+		))
+	}
+	return s
 }
 
 // buildPLpgSQLStatements performs the majority of the work building a PL/pgSQL
@@ -235,6 +250,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			returnScalar := b.buildPLpgSQLExpr(t.Expr, b.returnType, s)
 			returnColName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_return"))
 			returnScope := s.push()
+			b.ensureScopeHasExpr(returnScope)
 			b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, returnScalar)
 			b.ob.constructProjectForScope(s, returnScope)
 			return returnScope
@@ -242,6 +258,16 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			// Assignment (:=) is handled by projecting a new column with the same
 			// name as the variable being assigned.
 			s = b.addPLpgSQLAssign(s, t.Var, t.Value)
+			if b.exceptionBlock != nil {
+				// If exception handling is required, we have to start a new
+				// continuation after each variable assignment. This ensures that in the
+				// event of an error, the arguments of the currently executing routine
+				// will be the correct values for the variables, and can be passed to
+				// the exception handler routines.
+				catchCon := b.makeContinuation("assign_exception_block")
+				b.finishContinuation(stmts[i+1:], &catchCon, false /* recursive */)
+				return b.callContinuation(&catchCon, s)
+			}
 		case *plpgsqltree.PLpgSQLStmtIf:
 			// IF statement control flow is handled by calling a "continuation"
 			// function in each branch that executes all the statements that logically
@@ -298,6 +324,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			// Return a single column that projects the result of the CASE statement.
 			returnColName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_if"))
 			returnScope := s.push()
+			b.ensureScopeHasExpr(returnScope)
 			b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, scalar)
 			b.ob.constructProjectForScope(s, returnScope)
 			return returnScope
@@ -387,6 +414,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			)
 			raiseColName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_raise"))
 			raiseScope := con.s.push()
+			b.ensureScopeHasExpr(raiseScope)
 			b.ob.synthesizeColumn(raiseScope, raiseColName, types.Int, nil /* expr */, raiseCall)
 			b.ob.constructProjectForScope(con.s, raiseScope)
 			con.def.Body = []memo.RelExpr{raiseScope.expr}
@@ -421,6 +449,7 @@ func (b *plpgsqlBuilder) addPLpgSQLAssign(
 		panic(pgerror.Newf(pgcode.Syntax, "\"%s\" is not a known variable", ident))
 	}
 	assignScope := inScope.push()
+	b.ensureScopeHasExpr(assignScope)
 	for i := range inScope.cols {
 		col := &inScope.cols[i]
 		if col.name.ReferenceName() == ident {
@@ -472,8 +501,16 @@ func (b *plpgsqlBuilder) getRaiseArgs(
 		message = b.makeRaiseFormatMessage(s, raise.Message, raise.Params)
 	}
 	if raise.Code != "" {
+		if !pgcode.IsValidPGCode(raise.Code) {
+			panic(pgerror.Newf(pgcode.Syntax, "invalid SQLSTATE code '%s'", raise.Code))
+		}
 		code = makeConstStr(raise.Code)
 	} else if raise.CodeName != "" {
+		if _, ok := pgcode.PLpgSQLConditionNameToCode[raise.CodeName]; !ok {
+			panic(pgerror.Newf(
+				pgcode.UndefinedObject, "unrecognized exception condition \"%s\"", raise.CodeName,
+			))
+		}
 		code = makeConstStr(raise.CodeName)
 	}
 	// Retrieve the RAISE options, if any.
@@ -569,6 +606,117 @@ func (b *plpgsqlBuilder) makeRaiseFormatMessage(
 	return result
 }
 
+// buildExceptions builds the ExceptionBlock for a PLpgSQL routine as a list of
+// matchable error codes and routine definitions that handle each matched error.
+// There are two sets of statements that need to be wrapped in a continuation
+// with an exception handler:
+//  1. The entire set of body statements, not including variable initialization.
+//  2. Execution of all statements following a variable assignment.
+//
+// The first condition handles the case when an error occurs before any variable
+// assignments happen. PLpgSQL exception blocks do not catch errors that occur
+// during variable declaration.
+//
+// The second condition is necessary because the exception block must see the
+// most recent values for all variables from the point when the error occurred.
+// It works because if an error occurs before the assignment continuation is
+// called, it must have happened logically during or before the assignment
+// statement completed. Therefore, the assignment did not succeed and the
+// previous values for the variables should be used. If the error occurs after
+// the assignment continuation is called, the continuation will have access to
+// the updated value from the assignment, and can supply it to the exception
+// handler. Consider the following example:
+//
+//		 CREATE TABLE t (x INT PRIMARY KEY);
+//
+//		 CREATE FUNCTION f() RETURNS INT AS $$
+//			  DECLARE
+//			    i INT = 0;
+//			  BEGIN
+//			    INSERT INTO t VALUES (i); --Insert 1
+//			    i := 1;
+//			    INSERT INTO t VALUES (i); --Insert 2
+//	        i := 2;
+//			    RETURN -1;
+//			  EXCEPTION WHEN unique_violation THEN
+//			    RETURN i;
+//		    END
+//		 $$ LANGUAGE PLpgSQL;
+//
+// We'll build the following continuations to handle the assignment statements:
+//
+//		 Continuation 1 (called by initial scope):
+//		   --Initial: i = 0
+//			 INSERT INTO t VALUES (i); --Insert 1
+//		   i := 1;
+//		 Continuation 2 (called by continuation 1):
+//		   --Initial: i = 1
+//			 INSERT INTO t VALUES (i); --Insert 2
+//	     i := 2;
+//		 Continuation 3 (called by continuation 2):
+//		   --Initial: i = 2
+//			 RETURN -1;
+//
+// Consider what happens if Insert 1 fails with a uniqueness violation. The body
+// of Continuation 1 will result in the error, and Continuation 1 will match
+// that error against the exception handler. It will then invoke the handler
+// *with its own arguments* - in this case, i=0. The handler will then return
+// 0 as the result of the routine.
+//
+// If Insert 1 succeeds and Insert 2 fails, Continuation 1 will successfully
+// evaluate and call into Continuation 2 with the updated value of i=1. When
+// Continuation 2 calls the exception handler, once again it will use its own
+// argument i=1.
+//
+// If Insert 2 succeeds as well, it will project the new value i=2 and pass it
+// to Continuation 3. However, Continuation 3 does not use the variable i and
+// cannot throw an exception, and so the "i := 2" assignment will never become
+// visible.
+//
+// Currently, all continuations set the exception handler if there is one. This
+// is necessary because tail-call optimization depends on parent routines doing
+// no further work after a tail-call returns.
+// TODO(drewk): We could make a special case for exception handling, since the
+// exception handler is the same across all PLpgSQL routines. This would allow
+// us to only set the exception handler for the two cases above.
+func (b *plpgsqlBuilder) buildExceptions(block *plpgsqltree.PLpgSQLStmtBlock) {
+	if len(block.Exceptions) == 0 {
+		return
+	}
+	codes := make([]pgcode.Code, 0, len(block.Exceptions))
+	handlers := make([]*memo.UDFDefinition, 0, len(block.Exceptions))
+	for _, e := range block.Exceptions {
+		handlerCon := b.makeContinuation("exception_handler")
+		b.finishContinuation(e.Action, &handlerCon, false /* recursive */)
+		handlerCon.def.Volatility = volatility.Volatile
+		for _, cond := range e.Conditions {
+			if cond.SqlErrState != "" {
+				if !pgcode.IsValidPGCode(cond.SqlErrState) {
+					panic(pgerror.Newf(pgcode.Syntax, "invalid SQLSTATE code '%s'", cond.SqlErrState))
+				}
+				codes = append(codes, pgcode.MakeCode(cond.SqlErrState))
+				handlers = append(handlers, handlerCon.def)
+				continue
+			}
+			// The match condition was supplied by name instead of code.
+			branchCodes, ok := pgcode.PLpgSQLConditionNameToCode[cond.SqlErrName]
+			if !ok {
+				panic(pgerror.Newf(
+					pgcode.UndefinedObject, "unrecognized exception condition \"%s\"", cond.SqlErrName,
+				))
+			}
+			for i := range branchCodes {
+				codes = append(codes, pgcode.MakeCode(branchCodes[i]))
+				handlers = append(handlers, handlerCon.def)
+			}
+		}
+	}
+	b.exceptionBlock = &memo.ExceptionBlock{
+		Codes:   codes,
+		Actions: handlers,
+	}
+}
+
 // makeContinuation allocates a new continuation function with an uninitialized
 // definition.
 func (b *plpgsqlBuilder) makeContinuation(name string) continuation {
@@ -595,6 +743,7 @@ func (b *plpgsqlBuilder) makeContinuation(name string) continuation {
 			Name:              b.makeIdentifier(name),
 			Typ:               b.returnType,
 			CalledOnNullInput: true,
+			ExceptionBlock:    b.exceptionBlock,
 		},
 		s: s,
 	}
@@ -666,6 +815,7 @@ func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
 
 	returnColName := scopeColName("").WithMetadataName(con.def.Name)
 	returnScope := s.push()
+	b.ensureScopeHasExpr(returnScope)
 	b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, call)
 	b.ob.constructProjectForScope(s, returnScope)
 	return returnScope

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -3232,3 +3232,873 @@ project
                      │                                            └── projections
                      │                                                 └── variable: i:3 [as=stmt_return_2:5]
                      └── const: 1
+
+# Testing EXCEPTION blocks.
+exec-ddl
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 100;
+    WHEN invalid_regular_expression THEN
+      RETURN 200;
+    WHEN SQLSTATE '2200C' THEN
+      RETURN 300;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f();
+----
+project
+ ├── columns: f:6
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:6]
+           └── body
+                └── limit
+                     ├── columns: exception_block_7:5
+                     ├── project
+                     │    ├── columns: exception_block_7:5
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── udf: exception_block_7 [as=exception_block_7:5]
+                     │              ├── body
+                     │              │    └── project
+                     │              │         ├── columns: stmt_return_8:4!null
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── floor-div [as=stmt_return_8:4]
+                     │              │                   ├── const: 1
+                     │              │                   └── const: 0
+                     │              └── exception-handler
+                     │                   ├── SQLSTATE '22012'
+                     │                   │    └── project
+                     │                   │         ├── columns: stmt_return_2:1!null
+                     │                   │         ├── values
+                     │                   │         │    └── tuple
+                     │                   │         └── projections
+                     │                   │              └── const: 100 [as=stmt_return_2:1]
+                     │                   ├── SQLSTATE '2201B'
+                     │                   │    └── project
+                     │                   │         ├── columns: stmt_return_4:2!null
+                     │                   │         ├── values
+                     │                   │         │    └── tuple
+                     │                   │         └── projections
+                     │                   │              └── const: 200 [as=stmt_return_4:2]
+                     │                   └── SQLSTATE '2200C'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_6:3!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 300 [as=stmt_return_6:3]
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(i INT) RETURNS INT AS $$
+  BEGIN
+    IF i > 0 THEN
+      RETURN 1 // 0;
+    ELSE
+      RETURN sqrt(i::FLOAT)::INT;
+    END IF;
+  EXCEPTION
+    WHEN SQLSTATE '22012' OR indicator_overflow THEN
+      RETURN 100;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(0);
+----
+project
+ ├── columns: f:10
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:10]
+           ├── args
+           │    └── const: 0
+           ├── params: i:1
+           └── body
+                └── limit
+                     ├── columns: exception_block_3:9
+                     ├── project
+                     │    ├── columns: exception_block_3:9
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── udf: exception_block_3 [as=exception_block_3:9]
+                     │              ├── args
+                     │              │    └── variable: i:1
+                     │              ├── params: i:4
+                     │              ├── body
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_7:8
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_7:8]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── gt
+                     │              │                   │    │    ├── variable: i:4
+                     │              │                   │    │    └── const: 0
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_return_5:6!null
+                     │              │                   │              ├── values
+                     │              │                   │              │    └── tuple
+                     │              │                   │              └── projections
+                     │              │                   │                   └── floor-div [as=stmt_return_5:6]
+                     │              │                   │                        ├── const: 1
+                     │              │                   │                        └── const: 0
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_return_6:7
+                     │              │                             ├── values
+                     │              │                             │    └── tuple
+                     │              │                             └── projections
+                     │              │                                  └── cast: INT8 [as=stmt_return_6:7]
+                     │              │                                       └── function: sqrt
+                     │              │                                            └── cast: FLOAT8
+                     │              │                                                 └── variable: i:4
+                     │              └── exception-handler
+                     │                   ├── SQLSTATE '22012'
+                     │                   │    └── project
+                     │                   │         ├── columns: stmt_return_2:3!null
+                     │                   │         ├── values
+                     │                   │         │    └── tuple
+                     │                   │         └── projections
+                     │                   │              └── const: 100 [as=stmt_return_2:3]
+                     │                   └── SQLSTATE '22022'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:3!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 100 [as=stmt_return_2:3]
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(i INT) RETURNS INT AS $$
+  BEGIN
+    IF i > 0 THEN
+      RETURN 1 // 0;
+    ELSE
+      RETURN sqrt(i::FLOAT)::INT;
+    END IF;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 100;
+    WHEN SQLSTATE '22022' THEN
+      RETURN -1;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(0);
+----
+project
+ ├── columns: f:12
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:12]
+           ├── args
+           │    └── const: 0
+           ├── params: i:1
+           └── body
+                └── limit
+                     ├── columns: exception_block_5:11
+                     ├── project
+                     │    ├── columns: exception_block_5:11
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── udf: exception_block_5 [as=exception_block_5:11]
+                     │              ├── args
+                     │              │    └── variable: i:1
+                     │              ├── params: i:6
+                     │              ├── body
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_9:10
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_9:10]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── gt
+                     │              │                   │    │    ├── variable: i:6
+                     │              │                   │    │    └── const: 0
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_return_7:8!null
+                     │              │                   │              ├── values
+                     │              │                   │              │    └── tuple
+                     │              │                   │              └── projections
+                     │              │                   │                   └── floor-div [as=stmt_return_7:8]
+                     │              │                   │                        ├── const: 1
+                     │              │                   │                        └── const: 0
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_return_8:9
+                     │              │                             ├── values
+                     │              │                             │    └── tuple
+                     │              │                             └── projections
+                     │              │                                  └── cast: INT8 [as=stmt_return_8:9]
+                     │              │                                       └── function: sqrt
+                     │              │                                            └── cast: FLOAT8
+                     │              │                                                 └── variable: i:6
+                     │              └── exception-handler
+                     │                   ├── SQLSTATE '22012'
+                     │                   │    └── project
+                     │                   │         ├── columns: stmt_return_2:3!null
+                     │                   │         ├── values
+                     │                   │         │    └── tuple
+                     │                   │         └── projections
+                     │                   │              └── const: 100 [as=stmt_return_2:3]
+                     │                   └── SQLSTATE '22022'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_4:5!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: -1 [as=stmt_return_4:5]
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RAISE division_by_zero;
+    RETURN 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 101;
+    WHEN SQLSTATE '22P02' THEN
+      RETURN 102;
+    WHEN invalid_binary_representation THEN
+      RETURN 103;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f();
+----
+project
+ ├── columns: f:8
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:8]
+           └── body
+                └── limit
+                     ├── columns: exception_block_7:7
+                     ├── project
+                     │    ├── columns: exception_block_7:7
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── udf: exception_block_7 [as=exception_block_7:7]
+                     │              ├── body
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_8":6
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── udf: _stmt_raise_8 [as="_stmt_raise_8":6]
+                     │              │                   └── body
+                     │              │                        ├── project
+                     │              │                        │    ├── columns: stmt_raise_9:4
+                     │              │                        │    ├── values
+                     │              │                        │    │    └── tuple
+                     │              │                        │    └── projections
+                     │              │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_9:4]
+                     │              │                        │              ├── const: 'ERROR'
+                     │              │                        │              ├── const: 'division_by_zero'
+                     │              │                        │              ├── const: ''
+                     │              │                        │              ├── const: ''
+                     │              │                        │              └── const: 'division_by_zero'
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_return_10:5!null
+                     │              │                             ├── values
+                     │              │                             │    └── tuple
+                     │              │                             └── projections
+                     │              │                                  └── const: 0 [as=stmt_return_10:5]
+                     │              └── exception-handler
+                     │                   ├── SQLSTATE '22012'
+                     │                   │    └── project
+                     │                   │         ├── columns: stmt_return_2:1!null
+                     │                   │         ├── values
+                     │                   │         │    └── tuple
+                     │                   │         └── projections
+                     │                   │              └── const: 101 [as=stmt_return_2:1]
+                     │                   ├── SQLSTATE '22P02'
+                     │                   │    └── project
+                     │                   │         ├── columns: stmt_return_4:2!null
+                     │                   │         ├── values
+                     │                   │         │    └── tuple
+                     │                   │         └── projections
+                     │                   │              └── const: 102 [as=stmt_return_4:2]
+                     │                   └── SQLSTATE '22P03'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_6:3!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 103 [as=stmt_return_6:3]
+                     └── const: 1
+
+# The exception block does not catch errors thrown during variable declaration.
+exec-ddl
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    i INT := 100 // n;
+  BEGIN
+    RETURN i;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN 101;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(0);
+----
+project
+ ├── columns: f:10
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:10]
+           ├── args
+           │    └── const: 0
+           ├── params: n:1
+           └── body
+                └── limit
+                     ├── columns: exception_block_3:9
+                     ├── project
+                     │    ├── columns: exception_block_3:9
+                     │    ├── project
+                     │    │    ├── columns: i:2
+                     │    │    ├── values
+                     │    │    │    └── tuple
+                     │    │    └── projections
+                     │    │         └── floor-div [as=i:2]
+                     │    │              ├── const: 100
+                     │    │              └── variable: n:1
+                     │    └── projections
+                     │         └── udf: exception_block_3 [as=exception_block_3:9]
+                     │              ├── args
+                     │              │    ├── variable: i:2
+                     │              │    └── variable: n:1
+                     │              ├── params: i:6 n:7
+                     │              ├── body
+                     │              │    └── project
+                     │              │         ├── columns: stmt_return_4:8
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── variable: i:6 [as=stmt_return_4:8]
+                     │              └── exception-handler
+                     │                   └── SQLSTATE '22012'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:5!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 101 [as=stmt_return_2:5]
+                     └── const: 1
+
+# Each variable assignment is wrapped in an exception handler.
+exec-ddl
+CREATE OR REPLACE FUNCTION f(i INT, j INT, k INT) RETURNS INT AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    x := 1 // i;
+    x := 2 // j;
+    x := 3 // k;
+    RETURN x;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN x;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(0, 0, 0);
+----
+project
+ ├── columns: f:34
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:34]
+           ├── args
+           │    ├── const: 0
+           │    ├── const: 0
+           │    └── const: 0
+           ├── params: i:1 j:2 k:3
+           └── body
+                └── limit
+                     ├── columns: exception_block_3:33
+                     ├── project
+                     │    ├── columns: exception_block_3:33
+                     │    ├── project
+                     │    │    ├── columns: x:4!null
+                     │    │    ├── values
+                     │    │    │    └── tuple
+                     │    │    └── projections
+                     │    │         └── const: 0 [as=x:4]
+                     │    └── projections
+                     │         └── udf: exception_block_3 [as=exception_block_3:33]
+                     │              ├── args
+                     │              │    ├── variable: x:4
+                     │              │    ├── variable: i:1
+                     │              │    ├── variable: j:2
+                     │              │    └── variable: k:3
+                     │              ├── params: x:10 i:11 j:12 k:13
+                     │              ├── body
+                     │              │    └── project
+                     │              │         ├── columns: assign_exception_block_4:32
+                     │              │         ├── project
+                     │              │         │    ├── columns: x:14
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── floor-div [as=x:14]
+                     │              │         │              ├── const: 1
+                     │              │         │              └── variable: i:11
+                     │              │         └── projections
+                     │              │              └── udf: assign_exception_block_4 [as=assign_exception_block_4:32]
+                     │              │                   ├── args
+                     │              │                   │    ├── variable: x:14
+                     │              │                   │    ├── variable: i:11
+                     │              │                   │    ├── variable: j:12
+                     │              │                   │    └── variable: k:13
+                     │              │                   ├── params: x:15 i:16 j:17 k:18
+                     │              │                   └── body
+                     │              │                        └── project
+                     │              │                             ├── columns: assign_exception_block_5:31
+                     │              │                             ├── project
+                     │              │                             │    ├── columns: x:19
+                     │              │                             │    ├── values
+                     │              │                             │    │    └── tuple
+                     │              │                             │    └── projections
+                     │              │                             │         └── floor-div [as=x:19]
+                     │              │                             │              ├── const: 2
+                     │              │                             │              └── variable: j:17
+                     │              │                             └── projections
+                     │              │                                  └── udf: assign_exception_block_5 [as=assign_exception_block_5:31]
+                     │              │                                       ├── args
+                     │              │                                       │    ├── variable: x:19
+                     │              │                                       │    ├── variable: i:16
+                     │              │                                       │    ├── variable: j:17
+                     │              │                                       │    └── variable: k:18
+                     │              │                                       ├── params: x:20 i:21 j:22 k:23
+                     │              │                                       └── body
+                     │              │                                            └── project
+                     │              │                                                 ├── columns: assign_exception_block_6:30
+                     │              │                                                 ├── project
+                     │              │                                                 │    ├── columns: x:24
+                     │              │                                                 │    ├── values
+                     │              │                                                 │    │    └── tuple
+                     │              │                                                 │    └── projections
+                     │              │                                                 │         └── floor-div [as=x:24]
+                     │              │                                                 │              ├── const: 3
+                     │              │                                                 │              └── variable: k:23
+                     │              │                                                 └── projections
+                     │              │                                                      └── udf: assign_exception_block_6 [as=assign_exception_block_6:30]
+                     │              │                                                           ├── args
+                     │              │                                                           │    ├── variable: x:24
+                     │              │                                                           │    ├── variable: i:21
+                     │              │                                                           │    ├── variable: j:22
+                     │              │                                                           │    └── variable: k:23
+                     │              │                                                           ├── params: x:25 i:26 j:27 k:28
+                     │              │                                                           └── body
+                     │              │                                                                └── project
+                     │              │                                                                     ├── columns: stmt_return_7:29
+                     │              │                                                                     ├── values
+                     │              │                                                                     │    └── tuple
+                     │              │                                                                     └── projections
+                     │              │                                                                          └── variable: x:25 [as=stmt_return_7:29]
+                     │              └── exception-handler
+                     │                   └── SQLSTATE '22012'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:9
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: x:5 [as=stmt_return_2:9]
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(i INT) RETURNS INT AS $$
+  DECLARE
+    x INT;
+  BEGIN
+    IF i = 0 THEN
+      x := 100;
+      RAISE division_by_zero;
+    ELSE
+      x := 200;
+      RAISE division_by_zero;
+    END IF;
+    RETURN 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN x;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(0);
+----
+project
+ ├── columns: f:31
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:31]
+           ├── args
+           │    └── const: 0
+           ├── params: i:1
+           └── body
+                └── limit
+                     ├── columns: exception_block_3:30
+                     ├── project
+                     │    ├── columns: exception_block_3:30
+                     │    ├── project
+                     │    │    ├── columns: x:2
+                     │    │    ├── values
+                     │    │    │    └── tuple
+                     │    │    └── projections
+                     │    │         └── cast: INT8 [as=x:2]
+                     │    │              └── null
+                     │    └── projections
+                     │         └── udf: exception_block_3 [as=exception_block_3:30]
+                     │              ├── args
+                     │              │    ├── variable: x:2
+                     │              │    └── variable: i:1
+                     │              ├── params: x:6 i:7
+                     │              ├── body
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_12:29
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_12:29]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── eq
+                     │              │                   │    │    ├── variable: i:7
+                     │              │                   │    │    └── const: 0
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: assign_exception_block_6:19
+                     │              │                   │              ├── project
+                     │              │                   │              │    ├── columns: x:11!null
+                     │              │                   │              │    ├── values
+                     │              │                   │              │    │    └── tuple
+                     │              │                   │              │    └── projections
+                     │              │                   │              │         └── const: 100 [as=x:11]
+                     │              │                   │              └── projections
+                     │              │                   │                   └── udf: assign_exception_block_6 [as=assign_exception_block_6:19]
+                     │              │                   │                        ├── args
+                     │              │                   │                        │    ├── variable: x:11
+                     │              │                   │                        │    └── variable: i:7
+                     │              │                   │                        ├── params: x:12 i:13
+                     │              │                   │                        └── body
+                     │              │                   │                             └── project
+                     │              │                   │                                  ├── columns: "_stmt_raise_7":18
+                     │              │                   │                                  ├── values
+                     │              │                   │                                  │    └── tuple
+                     │              │                   │                                  └── projections
+                     │              │                   │                                       └── udf: _stmt_raise_7 [as="_stmt_raise_7":18]
+                     │              │                   │                                            ├── args
+                     │              │                   │                                            │    ├── variable: x:12
+                     │              │                   │                                            │    └── variable: i:13
+                     │              │                   │                                            ├── params: x:14 i:15
+                     │              │                   │                                            └── body
+                     │              │                   │                                                 ├── project
+                     │              │                   │                                                 │    ├── columns: stmt_raise_8:16
+                     │              │                   │                                                 │    ├── values
+                     │              │                   │                                                 │    │    └── tuple
+                     │              │                   │                                                 │    └── projections
+                     │              │                   │                                                 │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:16]
+                     │              │                   │                                                 │              ├── const: 'ERROR'
+                     │              │                   │                                                 │              ├── const: 'division_by_zero'
+                     │              │                   │                                                 │              ├── const: ''
+                     │              │                   │                                                 │              ├── const: ''
+                     │              │                   │                                                 │              └── const: 'division_by_zero'
+                     │              │                   │                                                 └── project
+                     │              │                   │                                                      ├── columns: stmt_if_4:17
+                     │              │                   │                                                      ├── values
+                     │              │                   │                                                      │    └── tuple
+                     │              │                   │                                                      └── projections
+                     │              │                   │                                                           └── udf: stmt_if_4 [as=stmt_if_4:17]
+                     │              │                   │                                                                ├── args
+                     │              │                   │                                                                │    ├── variable: x:14
+                     │              │                   │                                                                │    └── variable: i:15
+                     │              │                   │                                                                ├── params: x:8 i:9
+                     │              │                   │                                                                └── body
+                     │              │                   │                                                                     └── project
+                     │              │                   │                                                                          ├── columns: stmt_return_5:10!null
+                     │              │                   │                                                                          ├── values
+                     │              │                   │                                                                          │    └── tuple
+                     │              │                   │                                                                          └── projections
+                     │              │                   │                                                                               └── const: 0 [as=stmt_return_5:10]
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: assign_exception_block_9:28
+                     │              │                             ├── project
+                     │              │                             │    ├── columns: x:20!null
+                     │              │                             │    ├── values
+                     │              │                             │    │    └── tuple
+                     │              │                             │    └── projections
+                     │              │                             │         └── const: 200 [as=x:20]
+                     │              │                             └── projections
+                     │              │                                  └── udf: assign_exception_block_9 [as=assign_exception_block_9:28]
+                     │              │                                       ├── args
+                     │              │                                       │    ├── variable: x:20
+                     │              │                                       │    └── variable: i:7
+                     │              │                                       ├── params: x:21 i:22
+                     │              │                                       └── body
+                     │              │                                            └── project
+                     │              │                                                 ├── columns: "_stmt_raise_10":27
+                     │              │                                                 ├── values
+                     │              │                                                 │    └── tuple
+                     │              │                                                 └── projections
+                     │              │                                                      └── udf: _stmt_raise_10 [as="_stmt_raise_10":27]
+                     │              │                                                           ├── args
+                     │              │                                                           │    ├── variable: x:21
+                     │              │                                                           │    └── variable: i:22
+                     │              │                                                           ├── params: x:23 i:24
+                     │              │                                                           └── body
+                     │              │                                                                ├── project
+                     │              │                                                                │    ├── columns: stmt_raise_11:25
+                     │              │                                                                │    ├── values
+                     │              │                                                                │    │    └── tuple
+                     │              │                                                                │    └── projections
+                     │              │                                                                │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_11:25]
+                     │              │                                                                │              ├── const: 'ERROR'
+                     │              │                                                                │              ├── const: 'division_by_zero'
+                     │              │                                                                │              ├── const: ''
+                     │              │                                                                │              ├── const: ''
+                     │              │                                                                │              └── const: 'division_by_zero'
+                     │              │                                                                └── project
+                     │              │                                                                     ├── columns: stmt_if_4:26
+                     │              │                                                                     ├── values
+                     │              │                                                                     │    └── tuple
+                     │              │                                                                     └── projections
+                     │              │                                                                          └── udf: stmt_if_4 [as=stmt_if_4:26]
+                     │              │                                                                               ├── args
+                     │              │                                                                               │    ├── variable: x:23
+                     │              │                                                                               │    └── variable: i:24
+                     │              │                                                                               ├── params: x:8 i:9
+                     │              │                                                                               └── body
+                     │              │                                                                                    └── project
+                     │              │                                                                                         ├── columns: stmt_return_5:10!null
+                     │              │                                                                                         ├── values
+                     │              │                                                                                         │    └── tuple
+                     │              │                                                                                         └── projections
+                     │              │                                                                                              └── const: 0 [as=stmt_return_5:10]
+                     │              └── exception-handler
+                     │                   └── SQLSTATE '22012'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:5
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: x:3 [as=stmt_return_2:5]
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(n INT, a INT) RETURNS INT AS $$
+  DECLARE
+    x INT;
+    i INT := 0;
+  BEGIN
+    LOOP IF i >= n THEN EXIT; END IF;
+      x := 1 // (i - a);
+      i := i + 1;
+    END LOOP;
+    RETURN -1;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(0, 0);
+----
+project
+ ├── columns: f:45
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:45]
+           ├── args
+           │    ├── const: 0
+           │    └── const: 0
+           ├── params: n:1 a:2
+           └── body
+                └── limit
+                     ├── columns: exception_block_3:44
+                     ├── project
+                     │    ├── columns: exception_block_3:44
+                     │    ├── project
+                     │    │    ├── columns: i:4!null x:3
+                     │    │    ├── project
+                     │    │    │    ├── columns: x:3
+                     │    │    │    ├── values
+                     │    │    │    │    └── tuple
+                     │    │    │    └── projections
+                     │    │    │         └── cast: INT8 [as=x:3]
+                     │    │    │              └── null
+                     │    │    └── projections
+                     │    │         └── const: 0 [as=i:4]
+                     │    └── projections
+                     │         └── udf: exception_block_3 [as=exception_block_3:44]
+                     │              ├── args
+                     │              │    ├── variable: x:3
+                     │              │    ├── variable: i:4
+                     │              │    ├── variable: n:1
+                     │              │    └── variable: a:2
+                     │              ├── params: x:10 i:11 n:12 a:13
+                     │              ├── body
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_6:43
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── udf: stmt_loop_6 [as=stmt_loop_6:43]
+                     │              │                   ├── args
+                     │              │                   │    ├── variable: x:10
+                     │              │                   │    ├── variable: i:11
+                     │              │                   │    ├── variable: n:12
+                     │              │                   │    └── variable: a:13
+                     │              │                   ├── params: x:19 i:20 n:21 a:22
+                     │              │                   └── body
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_if_10:42
+                     │              │                             ├── values
+                     │              │                             │    └── tuple
+                     │              │                             └── projections
+                     │              │                                  └── case [as=stmt_if_10:42]
+                     │              │                                       ├── true
+                     │              │                                       ├── when
+                     │              │                                       │    ├── ge
+                     │              │                                       │    │    ├── variable: i:20
+                     │              │                                       │    │    └── variable: n:21
+                     │              │                                       │    └── subquery
+                     │              │                                       │         └── project
+                     │              │                                       │              ├── columns: loop_exit_4:40
+                     │              │                                       │              ├── values
+                     │              │                                       │              │    └── tuple
+                     │              │                                       │              └── projections
+                     │              │                                       │                   └── udf: loop_exit_4 [as=loop_exit_4:40]
+                     │              │                                       │                        ├── args
+                     │              │                                       │                        │    ├── variable: x:19
+                     │              │                                       │                        │    ├── variable: i:20
+                     │              │                                       │                        │    ├── variable: n:21
+                     │              │                                       │                        │    └── variable: a:22
+                     │              │                                       │                        ├── params: x:14 i:15 n:16 a:17
+                     │              │                                       │                        └── body
+                     │              │                                       │                             └── project
+                     │              │                                       │                                  ├── columns: stmt_return_5:18!null
+                     │              │                                       │                                  ├── values
+                     │              │                                       │                                  │    └── tuple
+                     │              │                                       │                                  └── projections
+                     │              │                                       │                                       └── const: -1 [as=stmt_return_5:18]
+                     │              │                                       └── subquery
+                     │              │                                            └── project
+                     │              │                                                 ├── columns: stmt_if_7:41
+                     │              │                                                 ├── values
+                     │              │                                                 │    └── tuple
+                     │              │                                                 └── projections
+                     │              │                                                      └── udf: stmt_if_7 [as=stmt_if_7:41]
+                     │              │                                                           ├── args
+                     │              │                                                           │    ├── variable: x:19
+                     │              │                                                           │    ├── variable: i:20
+                     │              │                                                           │    ├── variable: n:21
+                     │              │                                                           │    └── variable: a:22
+                     │              │                                                           ├── params: x:23 i:24 n:25 a:26
+                     │              │                                                           └── body
+                     │              │                                                                └── project
+                     │              │                                                                     ├── columns: assign_exception_block_8:39
+                     │              │                                                                     ├── project
+                     │              │                                                                     │    ├── columns: x:27
+                     │              │                                                                     │    ├── values
+                     │              │                                                                     │    │    └── tuple
+                     │              │                                                                     │    └── projections
+                     │              │                                                                     │         └── floor-div [as=x:27]
+                     │              │                                                                     │              ├── const: 1
+                     │              │                                                                     │              └── minus
+                     │              │                                                                     │                   ├── variable: i:24
+                     │              │                                                                     │                   └── variable: a:26
+                     │              │                                                                     └── projections
+                     │              │                                                                          └── udf: assign_exception_block_8 [as=assign_exception_block_8:39]
+                     │              │                                                                               ├── args
+                     │              │                                                                               │    ├── variable: x:27
+                     │              │                                                                               │    ├── variable: i:24
+                     │              │                                                                               │    ├── variable: n:25
+                     │              │                                                                               │    └── variable: a:26
+                     │              │                                                                               ├── params: x:28 i:29 n:30 a:31
+                     │              │                                                                               └── body
+                     │              │                                                                                    └── project
+                     │              │                                                                                         ├── columns: assign_exception_block_9:38
+                     │              │                                                                                         ├── project
+                     │              │                                                                                         │    ├── columns: i:32
+                     │              │                                                                                         │    ├── values
+                     │              │                                                                                         │    │    └── tuple
+                     │              │                                                                                         │    └── projections
+                     │              │                                                                                         │         └── plus [as=i:32]
+                     │              │                                                                                         │              ├── variable: i:29
+                     │              │                                                                                         │              └── const: 1
+                     │              │                                                                                         └── projections
+                     │              │                                                                                              └── udf: assign_exception_block_9 [as=assign_exception_block_9:38]
+                     │              │                                                                                                   ├── args
+                     │              │                                                                                                   │    ├── variable: x:28
+                     │              │                                                                                                   │    ├── variable: i:32
+                     │              │                                                                                                   │    ├── variable: n:30
+                     │              │                                                                                                   │    └── variable: a:31
+                     │              │                                                                                                   ├── params: x:33 i:34 n:35 a:36
+                     │              │                                                                                                   └── body
+                     │              │                                                                                                        └── project
+                     │              │                                                                                                             ├── columns: stmt_loop_6:37
+                     │              │                                                                                                             ├── values
+                     │              │                                                                                                             │    └── tuple
+                     │              │                                                                                                             └── projections
+                     │              │                                                                                                                  └── udf: stmt_loop_6 [as=stmt_loop_6:37]
+                     │              │                                                                                                                       ├── args
+                     │              │                                                                                                                       │    ├── variable: x:33
+                     │              │                                                                                                                       │    ├── variable: i:34
+                     │              │                                                                                                                       │    ├── variable: n:35
+                     │              │                                                                                                                       │    └── variable: a:36
+                     │              │                                                                                                                       └── recursive-call
+                     │              └── exception-handler
+                     │                   └── SQLSTATE '22012'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:9
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: i:6 [as=stmt_return_2:9]
+                     └── const: 1

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -10,6 +10,8 @@
 
 package pgcode
 
+import "regexp"
+
 // Code is a wrapper around a string to ensure that pgcodes are used in
 // different pgerror functions by avoiding accidental string input.
 type Code struct {
@@ -402,3 +404,15 @@ var (
 	// used without the session variable being enabled.
 	ExperimentalFeature = MakeCode("XCEXF")
 )
+
+var pgCodeRegexp = regexp.MustCompile(`[A-Z0-9]{5}`)
+
+// IsValidPGCode returns true if the given code is a valid error code. Note that
+// this does not check if the code is one of the pre-defined error codes like
+// "Syntax" or "InvalidName" - instead, it checks that the format of the code is
+// valid. This is because it is possible for users to throw and catch arbitrary
+// error codes in PLpgSQL routines.
+func IsValidPGCode(code string) bool {
+	// The code must consist of 5 digits and/or upper-case ASCII letters.
+	return pgCodeRegexp.MatchString(code)
+}

--- a/pkg/sql/plpgsql/BUILD.bazel
+++ b/pkg/sql/plpgsql/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "plpgsql",
+    srcs = ["plpgsql_error.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/plpgsql",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gogo_protobuf//proto",
+    ],
+)

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -149,6 +149,23 @@ func (u *plpgsqlSymUnion) plpgsqlOptionExprs() []plpgsqltree.PLpgSQLStmtRaiseOpt
     return u.val.([]plpgsqltree.PLpgSQLStmtRaiseOption)
 }
 
+
+func (u *plpgsqlSymUnion) plpgsqlException() *plpgsqltree.PLpgSQLException {
+    return u.val.(*plpgsqltree.PLpgSQLException)
+}
+
+func (u *plpgsqlSymUnion) plpgsqlExceptions() []plpgsqltree.PLpgSQLException {
+    return u.val.([]plpgsqltree.PLpgSQLException)
+}
+
+func (u *plpgsqlSymUnion) plpgsqlCondition() *plpgsqltree.PLpgSQLCondition {
+    return u.val.(*plpgsqltree.PLpgSQLCondition)
+}
+
+func (u *plpgsqlSymUnion) plpgsqlConditions() []plpgsqltree.PLpgSQLCondition {
+    return u.val.([]plpgsqltree.PLpgSQLCondition)
+}
+
 %}
 /*
  * Basic non-keyword token types.  These are hard-wired into the core lexer.
@@ -329,9 +346,10 @@ func (u *plpgsqlSymUnion) plpgsqlOptionExprs() []plpgsqltree.PLpgSQLStmtRaiseOpt
 %type <*plpgsqltree.PLpgSQLDecl> decl_stmt decl_statement
 %type <[]plpgsqltree.PLpgSQLDecl> decl_sect opt_decl_stmts decl_stmts
 
-%type <*plpgsqltree.PLpgSQLExceptionBlock> exception_sect
+%type <[]plpgsqltree.PLpgSQLException> exception_sect proc_exceptions
 %type <*plpgsqltree.PLpgSQLException>	proc_exception
-%type <*plpgsqltree.PLpgSQLCondition>	proc_conditions proc_condition
+%type <[]plpgsqltree.PLpgSQLCondition> proc_conditions
+%type <*plpgsqltree.PLpgSQLCondition> proc_condition
 
 %type <*plpgsqltree.PLpgSQLStmtCaseWhenArm>	case_when
 %type <[]*plpgsqltree.PLpgSQLStmtCaseWhenArm>	case_when_list
@@ -372,6 +390,7 @@ pl_block: opt_block_label decl_sect BEGIN proc_sect exception_sect END opt_label
       Label: $1,
       Decls: $2.plpgsqlDecls(),
       Body: $4.plpgsqlStatements(),
+      Exceptions: $5.plpgsqlExceptions(),
     }
   }
 ;
@@ -1285,44 +1304,56 @@ cursor_variable: IDENT
   }
 ;
 
-exception_sect:
-  { }
-| EXCEPTION
+exception_sect: /* EMPTY */
   {
-    return unimplemented(plpgsqllex, "exception")
+    $$.val = []plpgsqltree.PLpgSQLException(nil)
   }
-  proc_exceptions
+| EXCEPTION proc_exceptions
   {
-    unimplemented(plpgsqllex, "exception")
+    $$.val = $2.plpgsqlExceptions()
   }
 ;
 
 proc_exceptions: proc_exceptions proc_exception
   {
+    e := $2.plpgsqlException()
+    $$.val = append($1.plpgsqlExceptions(), *e)
   }
 | proc_exception
   {
+    e := $1.plpgsqlException()
+    $$.val = []plpgsqltree.PLpgSQLException{*e}
   }
 ;
 
 proc_exception: WHEN proc_conditions THEN proc_sect
   {
+    $$.val = &plpgsqltree.PLpgSQLException{
+      Conditions: $2.plpgsqlConditions(),
+      Action: $4.plpgsqlStatements(),
+    }
   }
 ;
 
 proc_conditions: proc_conditions OR proc_condition
   {
+    c := $3.plpgsqlCondition()
+    $$.val = append($1.plpgsqlConditions(), *c)
   }
 | proc_condition
   {
+    c := $1.plpgsqlCondition()
+    $$.val = []plpgsqltree.PLpgSQLCondition{*c}
   }
 ;
 
 proc_condition: any_identifier
   {
+    $$.val = &plpgsqltree.PLpgSQLCondition{SqlErrName: $1}
   }
 | SQLSTATE SCONST
   {
+    $$.val = &plpgsqltree.PLpgSQLCondition{SqlErrState: $2}
   }
 ;
 

--- a/pkg/sql/plpgsql/parser/testdata/exception_sect
+++ b/pkg/sql/plpgsql/parser/testdata/exception_sect
@@ -1,13 +1,23 @@
 parse
 DECLARE
 BEGIN
- x := 1;
+  x := 1;
+  RETURN x;
 EXCEPTION
   WHEN division_by_zero THEN
       ASSERT 0 == 0, 'error message';
+      RETURN 0;
 END;
 ----
-expected parse error: at or near "exception": syntax error: unimplemented: this syntax
+DECLARE
+BEGIN
+x := 1;
+RETURN x;
+EXCEPTION
+WHEN division_by_zero THEN
+ASSERT
+RETURN 0;
+END
 
 
 
@@ -15,9 +25,115 @@ parse
 DECLARE
 BEGIN
   x := 10;
+  RETURN x;
 EXCEPTION
   WHEN SQLSTATE '22012' THEN
     x = 22012;
+    RETURN x;
 END;
 ----
-expected parse error: at or near "exception": syntax error: unimplemented: this syntax
+DECLARE
+BEGIN
+x := 10;
+RETURN x;
+EXCEPTION
+WHEN SQLSTATE '22012' THEN
+x := 22012;
+RETURN x;
+END
+
+parse
+DECLARE
+BEGIN
+  x := 10;
+  RETURN x;
+EXCEPTION
+  WHEN SQLSTATE '22012' OR SQLSTATE '22005' THEN
+    x = 100;
+    RETURN x;
+END;
+----
+DECLARE
+BEGIN
+x := 10;
+RETURN x;
+EXCEPTION
+WHEN SQLSTATE '22012' OR SQLSTATE '22005' THEN
+x := 100;
+RETURN x;
+END
+
+parse
+DECLARE
+BEGIN
+  x := 10;
+  RETURN x;
+EXCEPTION
+  WHEN SQLSTATE '22012' OR SQLSTATE '22005' OR feature_not_supported THEN
+    x = 100;
+    RETURN x;
+END;
+----
+DECLARE
+BEGIN
+x := 10;
+RETURN x;
+EXCEPTION
+WHEN SQLSTATE '22012' OR SQLSTATE '22005' OR feature_not_supported THEN
+x := 100;
+RETURN x;
+END
+
+parse
+DECLARE
+BEGIN
+  x := 10;
+  RETURN x;
+EXCEPTION
+  WHEN SQLSTATE '22012' THEN
+    x = 22012;
+    RETURN x;
+  WHEN feature_not_supported THEN
+    x = 12345;
+    RETURN x;
+END;
+----
+DECLARE
+BEGIN
+x := 10;
+RETURN x;
+EXCEPTION
+WHEN SQLSTATE '22012' THEN
+x := 22012;
+RETURN x;
+WHEN feature_not_supported THEN
+x := 12345;
+RETURN x;
+END
+
+parse
+DECLARE
+BEGIN
+  x := 10;
+  RETURN x;
+EXCEPTION
+  WHEN SQLSTATE '22012' THEN
+    x = 22012;
+    RETURN x;
+  WHEN feature_not_supported OR SQLSTATE '22005' THEN
+    x = 12345;
+    RETURN x;
+END;
+----
+DECLARE
+BEGIN
+x := 10;
+RETURN x;
+EXCEPTION
+WHEN SQLSTATE '22012' THEN
+x := 22012;
+RETURN x;
+WHEN feature_not_supported OR SQLSTATE '22005' THEN
+x := 12345;
+RETURN x;
+END

--- a/pkg/sql/plpgsql/plpgsql_error.go
+++ b/pkg/sql/plpgsql/plpgsql_error.go
@@ -1,0 +1,66 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package plpgsql contains logic related to parsing and executing PLpgSQL
+// routines.
+package plpgsql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/proto"
+)
+
+// caughtRoutineException is used to wrap an error that is returned by the
+// exception block of a routine so that the exception block does not execute
+// more than once. This is necessary because tail-call optimization does not
+// always succeed (e.g. for distributed execution), and so an error returned by
+// the exception block of a nested routine can encounter the same exception
+// block in the outer routine.
+// TODO(drewk): If we unconditionally apply tail-call optimization for the
+// routines that implement a single PLpgSQL function, we won't have to worry
+// about encountering the same exception handler multiple times.
+// TODO(drewk): If we add support for calling UDFs from other UDFs or nested
+// PLpgSQL blocks before the previous TODO is addressed, we should store an
+// ID for the exception handler that returned the error since handlers could
+// be nested.
+type caughtRoutineException struct {
+	cause error
+}
+
+// NewCaughtRoutineException wraps the given error with a caughtRoutineException
+// indicating that the error has already passed through a PLpgSQL exception
+// handler.
+func NewCaughtRoutineException(err error) error {
+	return &caughtRoutineException{cause: err}
+}
+
+// IsCaughtRoutineException returns true if the given error has already passed
+// through an exception handler.
+func IsCaughtRoutineException(err error) bool {
+	return errors.HasType(err, (*caughtRoutineException)(nil))
+}
+
+var _ errors.Wrapper = &caughtRoutineException{}
+
+func (e *caughtRoutineException) Error() string { return e.cause.Error() }
+func (e *caughtRoutineException) Cause() error  { return e.cause }
+func (e *caughtRoutineException) Unwrap() error { return e.Cause() }
+
+func decodeCaughtRoutineException(
+	_ context.Context, cause error, _ string, _ []string, _ proto.Message,
+) error {
+	return NewCaughtRoutineException(cause)
+}
+
+func init() {
+	errors.RegisterWrapperDecoder(errors.GetTypeKey((*caughtRoutineException)(nil)), decodeCaughtRoutineException)
+}

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -15,6 +15,9 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/plpgsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -131,6 +134,15 @@ func (g *routineGenerator) init(p *planner, expr *tree.RoutineExpr, args tree.Da
 	}
 }
 
+// reset closes and re-initializes a routineGenerator for reuse.
+// TODO(drewk): we should hold on to memory for the row container.
+func (g *routineGenerator) reset(
+	ctx context.Context, p *planner, expr *tree.RoutineExpr, args tree.Datums,
+) {
+	g.Close(ctx)
+	g.init(p, expr, args)
+}
+
 // ResolvedType is part of the ValueGenerator interface.
 func (g *routineGenerator) ResolvedType() *types.T {
 	return g.expr.ResolvedType()
@@ -147,9 +159,7 @@ func (g *routineGenerator) Start(ctx context.Context, txn *kv.Txn) (err error) {
 		// A nested routine in tail-call position deferred its execution until now.
 		// Since it's in tail-call position, evaluating it will give the result of
 		// this routine as well.
-		p, expr, args := g.p, g.deferredRoutine.expr, g.deferredRoutine.args
-		g.Close(ctx)
-		g.init(p, expr, args)
+		g.reset(ctx, g.p, g.deferredRoutine.expr, g.deferredRoutine.args)
 	}
 }
 
@@ -220,15 +230,47 @@ func (g *routineGenerator) startInternal(ctx context.Context, txn *kv.Txn) (err 
 		if err != nil {
 			return err
 		}
-
 		return nil
 	})
 	if err != nil {
-		return err
+		return g.handleException(ctx, err)
 	}
 
 	g.rci = newRowContainerIterator(ctx, g.rch)
 	return nil
+}
+
+// handleException attempts to match the code of the given error to an exception
+// handler for the routine. If the error finds a match, the corresponding branch
+// for the exception handler is executed as a routine.
+// TODO(drewk): When there is an exception block, we need to nest the body of
+// the routine in a sub-transaction, probably using savepoints. If an error
+// occurs in the body of a block with an exception handler, changes to the
+// database that happened within the block should be rolled back, but not those
+// that occurred outside the block.
+func (g *routineGenerator) handleException(ctx context.Context, err error) error {
+	if plpgsql.IsCaughtRoutineException(err) {
+		// This error has already been through handleException in a nested call.
+		return err
+	}
+	caughtCode := pgerror.GetPGCode(err)
+	if caughtCode == pgcode.Uncategorized {
+		return err
+	}
+	if handler := g.expr.ExceptionHandler; handler != nil {
+		for i, code := range handler.Codes {
+			if code == caughtCode {
+				g.reset(ctx, g.p, handler.Actions[i], g.args)
+				err = g.startInternal(ctx, g.p.Txn())
+				break
+			}
+		}
+		if err != nil {
+			return plpgsql.NewCaughtRoutineException(err)
+		}
+	}
+	// No exception handler matched.
+	return err
 }
 
 // Next is part of the ValueGenerator interface.

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -27,7 +27,6 @@ import (
 	"math/bits"
 	"math/rand"
 	"net"
-	"regexp"
 	"regexp/syntax"
 	"strconv"
 	"strings"
@@ -8122,8 +8121,7 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				}
 				if codeString := argStrings[4]; codeString != "" {
 					var code string
-					if regexp.MustCompile(`[A-Z0-9]{5}`).MatchString(codeString) {
-						// The supplied argument is a valid PG code.
+					if pgcode.IsValidPGCode(codeString) {
 						code = codeString
 					} else {
 						// The supplied string may be a condition name.

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -59,7 +59,7 @@ type PLpgSQLStmtBlock struct {
 	Label      string
 	Decls      []PLpgSQLDecl
 	Body       []PLpgSQLStatement
-	Exceptions *PLpgSQLExceptionBlock
+	Exceptions []PLpgSQLException
 }
 
 // TODO(drewk): format Label and Exceptions fields.
@@ -75,6 +75,12 @@ func (s *PLpgSQLStmtBlock) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("BEGIN\n")
 	for _, childStmt := range s.Body {
 		childStmt.Format(ctx)
+	}
+	if s.Exceptions != nil {
+		ctx.WriteString("EXCEPTION\n")
+		for _, e := range s.Exceptions {
+			e.Format(ctx)
+		}
 	}
 	ctx.WriteString("END\n")
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1336,7 +1336,7 @@ func TestLint(t *testing.T) {
 		}
 	})
 
-	t.Run("TestProtoMessage", func(t *testing.T) {
+	t.Run("", func(t *testing.T) {
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(
 			pkgDir,
@@ -1359,6 +1359,7 @@ func TestLint(t *testing.T) {
 			":!sql/pgwire/pgerror/severity.go",
 			":!sql/pgwire/pgerror/with_candidate_code.go",
 			":!sql/pgwire/pgwirebase/too_big_error.go",
+			":!sql/plpgsql/plpgsql_error.go",
 			":!sql/protoreflect/redact.go",
 			":!sql/colexecerror/error.go",
 			":!util/timeutil/timeout_error.go",


### PR DESCRIPTION
#### plpgsql: add parser and optbuilder support for exception blocks

This patch adds support in the parser and optbuilder for the
EXCEPTION block of a PLpgSQL routine. A future commit will add
execution support. See the `buildExceptions` comments in `plpgsql.go`
for further detail.

#### plpgsql: add support for execution of routines with exception blocks

This patch adds support for executing a PLpgSQL routine with an
exception block. This allows PLpgSQL routines to catch arbitrary errors
encountered during execution of the main block, and then return either
a datum result or another error. For example:
```
CREATE FUNCTION f(n INT) RETURNS INT AS $$
  BEGIN
    RETURN 1 / n;
  EXCEPTION
    WHEN division_by_zero THEN
      RETURN 100;
  END
$$ LANGUAGE PLpgSQL;

--Returns 1
SELECT f(1);

--Returns 100
SELECT f(0);
```

Fixes #105253

Release note (sql change): Added support for execution of PLpgSQL
functions with exception blocks. This allows a PLpgSQL function to
catch and handle arbitrary errors it encounters during its execution.