### PR TITLE
release-23.1: liveness: write LastUpTimestamp only on self-heartbeat

### DIFF
--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -1408,7 +1408,7 @@ func (nl *NodeLiveness) updateLivenessAttempt(
 	nl.mu.RLock()
 	cb := nl.mu.onSelfLive
 	nl.mu.RUnlock()
-	if cb != nil {
+	if nl.gossip.NodeID.Get() == update.newLiveness.NodeID && cb != nil {
 		cb(ctx)
 	}
 	return Record{Liveness: update.newLiveness, raw: v.TagAndDataBytes()}, nil


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/pull/107265#issuecomment-1651186014.

Release justification: fixes a bug.
Epic: none
Release note (bug fix): it was possible for a node status to reflect a "last up" timestamp that lead the actual last liveness heartbeat of the node. This has been fixed.