### PR TITLE
kvserver: avoid moving parts in closedts tests

### DIFF
--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -221,12 +221,11 @@ func TestRangefeedIsRoutedToNonVoter(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	clusterArgs := aggressiveResolvedTimestampClusterArgs
-	// We want to manually add a non-voter to a range in this test, so disable
-	// the replicateQueue to prevent it from disrupting the test.
-	clusterArgs.ReplicationMode = base.ReplicationManual
+	clusterArgs := aggressiveResolvedTimestampManuallyReplicatedClusterArgs
 	// NB: setupClusterForClosedTSTesting sets a low closed timestamp target
 	// duration.
+	// NB: the replicate queue is disabled in this test, so we can manually add a
+	// non-voter to a range without being disrupted.
 	tc, _, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, 0, clusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
 	tc.AddNonVotersOrFatal(t, desc.StartKey.AsRawKey(), tc.Target(1))

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -228,7 +228,10 @@ func TestRangefeedIsRoutedToNonVoter(t *testing.T) {
 	// non-voter to a range without being disrupted.
 	tc, _, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, 0, clusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
-	tc.AddNonVotersOrFatal(t, desc.StartKey.AsRawKey(), tc.Target(1))
+	// This test doesn't want the default voters on s2 and s3. We want only
+	// the voter on s1 and a non-voter on s2.
+	desc = tc.RemoveVotersOrFatal(t, desc.StartKey.AsRawKey(), tc.Target(1), tc.Target(2))
+	desc = tc.AddNonVotersOrFatal(t, desc.StartKey.AsRawKey(), tc.Target(1))
 
 	db := tc.Server(1).DB()
 	ds := tc.Server(1).DistSenderI().(*kvcoord.DistSender)
@@ -268,7 +271,8 @@ func TestRangefeedIsRoutedToNonVoter(t *testing.T) {
 	}
 	rangefeedCancel()
 	require.Regexp(t, "context canceled", <-rangefeedErrChan)
-	require.Regexp(t, "attempting to create a RangeFeed over replica.*2NON_VOTER", getRecAndFinish().String())
+	require.Regexp(t, `attempting to create a RangeFeed over replica .n2,s2.:\dNON_VOTER`,
+		getRecAndFinish().String())
 }
 
 // TestRangefeedWorksOnLivenessRange ensures that a rangefeed works as expected

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -1170,8 +1170,12 @@ func pickRandomTarget(
 	tc serverutils.TestClusterInterface, lh roachpb.ReplicationTarget, desc roachpb.RangeDescriptor,
 ) (t roachpb.ReplicationTarget) {
 	for {
-		if t = tc.Target(rand.Intn(len(desc.InternalReplicas))); t != lh {
+		n := len(desc.InternalReplicas)
+		if t = tc.Target(rand.Intn(n)); t != lh {
 			return t
+		}
+		if n <= 1 {
+			panic(fmt.Sprintf("the only target in %v is the leaseholder %v", desc, lh))
 		}
 	}
 }

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -1215,6 +1215,8 @@ func setupClusterForClosedTSTesting(
 	clusterArgs base.TestClusterArgs,
 	dbName, tableName string,
 ) (tc serverutils.TestClusterInterface, db0 *gosql.DB, kvTableDesc roachpb.RangeDescriptor) {
+	require.Equal(t, base.ReplicationManual, clusterArgs.ReplicationMode)
+
 	const numNodes = 3
 	if sideTransportInterval == 0 {
 		sideTransportInterval = targetDuration / 4

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1117,7 +1117,6 @@ func TestReplicaRangefeedPushesTransactions(t *testing.T) {
 
 	ctx := context.Background()
 	cArgs := aggressiveResolvedTimestampManuallyReplicatedClusterArgs
-	cArgs.ReplicationMode = base.ReplicationAuto // TODO(during PR)
 	tc, db, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, 0, cArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
 	repls := replsForRange(ctx, t, tc, desc)

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1116,7 +1116,9 @@ func TestReplicaRangefeedPushesTransactions(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	tc, db, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, 0, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
+	cArgs := aggressiveResolvedTimestampManuallyReplicatedClusterArgs
+	cArgs.ReplicationMode = base.ReplicationAuto // TODO(during PR)
+	tc, db, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, 0, cArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
 	repls := replsForRange(ctx, t, tc, desc)
 
@@ -1245,8 +1247,7 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false) // override metamorphism
 
-	cargs := aggressiveResolvedTimestampClusterArgs
-	cargs.ReplicationMode = base.ReplicationManual
+	cargs := aggressiveResolvedTimestampManuallyReplicatedClusterArgs
 	manualClock := hlc.NewHybridManualClock()
 	cargs.ServerArgs = base.TestServerArgs{
 		Settings: st,
@@ -1430,8 +1431,7 @@ func TestNewRangefeedForceLeaseRetry(t *testing.T) {
 
 	var timeoutSimulated bool
 
-	cargs := aggressiveResolvedTimestampClusterArgs
-	cargs.ReplicationMode = base.ReplicationManual
+	cargs := aggressiveResolvedTimestampManuallyReplicatedClusterArgs
 	manualClock := hlc.NewHybridManualClock()
 	cargs.ServerArgs = base.TestServerArgs{
 		Knobs: base.TestingKnobs{


### PR DESCRIPTION
Many tests (two just this last week[^1][^2]) are flaky because the replicate queue
can make rebalancing decisions that undermine the state the test is trying to
set up. Often, this happens "accidentally" because ReplicationAuto is our default
ReplicationMode.

This PR improves the situation at least for closed timestamp integration tests
by switching them all over to `ReplicationManual` (and preventing any new ones
from accidentally using `ReplicationAuto` in the future).

This can be seen as a small step towards #107528, which I am increasingly
convinced is an ocean worth boiling.

[^1]: https://github.com/cockroachdb/cockroach/issues/107179
[^2]: https://github.com/cockroachdb/cockroach/issues/101824

Epic: None
Release note: None