### PR TITLE
sql/schemachanger: DROP INDEX could drop unrelated foreign keys

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -464,3 +464,40 @@ t1_96731    t1_96731_pkey    PRIMARY KEY      PRIMARY KEY (i ASC)  true
 
 statement ok
 DROP TABLE t1_96731, t2_96731;
+
+
+# In #107576 we had a bug where we were not correctly resolving foreign key
+# references by filtering down to the target table for DROP INDEX. As a side effect
+# we could end up cleaning foreign key references in other unrelated tables. In
+# the example below fk_drop_other has foreign key back references which are not
+# relevant.
+subtest drop_index_fk_check
+
+statement ok
+CREATE TABLE fk_drop_target
+ ( k int primary key,
+   j int);
+CREATE TABLE fk_drop_ref_src(
+  k int,
+  j int primary key);
+CREATE UNIQUE INDEX target_j
+     ON fk_drop_target(j);
+ CREATE TABLE fk_ref_dst(
+  k int primary key,
+  j int,
+  m int,
+   CONSTRAINT "j_fk" FOREIGN KEY (j) REFERENCES
+       fk_drop_target(k),
+   CONSTRAINT m_fk   FOREIGN KEY (m) REFERENCES
+        fk_drop_ref_src(j)
+ );
+
+statement ok
+DROP INDEX fk_drop_target@target_j CASCADE;
+
+query T rowsort
+SELECT constraint_name from [SHOW CONSTRAINTS FROM fk_ref_dst];
+----
+fk_ref_dst_pkey
+j_fk
+m_fk

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
@@ -269,8 +269,8 @@ func maybeDropDependentFKConstraints(
 
 	// dropDependentFKConstraint is a helper function that drops a dependent
 	// FK constraint with ID `fkConstraintID`.
-	dropDependentFKConstraint := func(fkConstraintID catid.ConstraintID) {
-		b.BackReferences(tableID).Filter(hasConstraintIDAttrFilter(fkConstraintID)).
+	dropDependentFKConstraint := func(fkTableID catid.DescID, fkConstraintID catid.ConstraintID) {
+		b.BackReferences(tableID).Filter(hasTableID(fkTableID)).Filter(hasConstraintIDAttrFilter(fkConstraintID)).
 			ForEach(func(
 				current scpb.Status, target scpb.TargetStatus, e scpb.Element,
 			) {
@@ -278,7 +278,10 @@ func maybeDropDependentFKConstraints(
 			})
 	}
 
-	b.BackReferences(tableID).ForEach(func(
+	// Iterate over all FKs inbound to this table and decide whether any other
+	// unique constraints will satisfy them if we were to drop the current unique
+	// constraint.
+	b.BackReferences(tableID).Filter(containsDescIDFilter(tableID)).ForEach(func(
 		current scpb.Status, target scpb.TargetStatus, e scpb.Element,
 	) {
 		switch t := e.(type) {
@@ -287,13 +290,13 @@ func maybeDropDependentFKConstraints(
 				return
 			}
 			ensureCascadeBehavior(t.TableID)
-			dropDependentFKConstraint(t.ConstraintID)
+			dropDependentFKConstraint(t.TableID, t.ConstraintID)
 		case *scpb.ForeignKeyConstraintUnvalidated:
 			if !shouldDropFK(t.ReferencedColumnIDs) {
 				return
 			}
 			ensureCascadeBehavior(t.TableID)
-			dropDependentFKConstraint(t.ConstraintID)
+			dropDependentFKConstraint(t.TableID, t.ConstraintID)
 		}
 	})
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -454,6 +454,22 @@ func notReachedTargetYetFilter(status scpb.Status, target scpb.TargetStatus, _ s
 	return status != target.Status()
 }
 
+func containsDescIDFilter(
+	descID catid.DescID,
+) func(_ scpb.Status, _ scpb.TargetStatus, _ scpb.Element) bool {
+	return func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) (included bool) {
+		return screl.ContainsDescID(e, descID)
+	}
+}
+
+func hasTableID(
+	tableID catid.DescID,
+) func(_ scpb.Status, _ scpb.TargetStatus, _ scpb.Element) bool {
+	return func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) (included bool) {
+		return screl.GetDescID(e) == tableID
+	}
+}
+
 func hasIndexIDAttrFilter(
 	indexID catid.IndexID,
 ) func(_ scpb.Status, _ scpb.TargetStatus, _ scpb.Element) bool {


### PR DESCRIPTION
Previously, when DROP INDEX was resolving and iterating over foreign keys, it did not validate that these foreign keys were related to the index we were dropping. As a result, if any table referred back to the target table with the index, we would analyze its foreign keys. If cascade wasn't specified this could incorrectly end up blocking the DROP INDEX on unrelated foreign key references assuming they need our index. Or worse with cascade we could remove foreign key constraints in other tables. To address this, this patch filters the back references to only look at ones related to the target table, which causes the correct set to be analuzed / dropped.

Fixes: #107576

Release note (bug fix): Dropping an index could end up failing or cleaning foreign keys (when CASCADE is specified) on other tables referencing the target table with this index.