### PR TITLE
cluster ui release workflow lock file file

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -6,7 +6,6 @@ on:
       - master
     paths:
       - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
-      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
       - 'pkg/ui/workspaces/cluster-ui/package.json'
 
 jobs:


### PR DESCRIPTION
This is a tiny PR to remove a `path` watched by the Github action that
no longer exists (`yarn.lock` since we switched to `pnpm`).

Epic: none

Release note: None