### PR TITLE
release-23.1: sql: remove stale skip in TestTelemetry

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -656,7 +656,7 @@ func (ts *TestServer) Start(ctx context.Context) error {
 // calling the TestServerInterface.StartTenant method or by calling the wrapper
 // serverutils.StartTenant method.
 type TestTenant struct {
-	*SQLServer
+	sql    *SQLServer
 	Cfg    *BaseConfig
 	SQLCfg *SQLConfig
 	*httpTestServer
@@ -668,6 +668,16 @@ type TestTenant struct {
 }
 
 var _ serverutils.TestTenantInterface = &TestTenant{}
+
+// SQLInstanceID is part of TestTenantInterface.
+func (t *TestTenant) SQLInstanceID() base.SQLInstanceID {
+	return t.sql.SQLInstanceID()
+}
+
+// AnnotateCtx is part of TestTenantInterface.
+func (t *TestTenant) AnnotateCtx(ctx context.Context) context.Context {
+	return t.sql.AnnotateCtx(ctx)
+}
 
 // SQLAddr is part of TestTenantInterface interface.
 func (t *TestTenant) SQLAddr() string {
@@ -686,12 +696,17 @@ func (t *TestTenant) RPCAddr() string {
 
 // DB is part of the TestTenantInterface.
 func (t *TestTenant) DB() *kv.DB {
-	return t.execCfg.DB
+	return t.sql.execCfg.DB
 }
 
 // PGServer is part of TestTenantInterface.
 func (t *TestTenant) PGServer() interface{} {
-	return t.pgServer
+	return t.sql.pgServer
+}
+
+// SQLServer is part of TestTenantInterface.
+func (t *TestTenant) SQLServer() interface{} {
+	return t.sql.pgServer.SQLServer
 }
 
 // PGPreServer exposes the pgwire.PreServeConnHandler instance used by
@@ -705,47 +720,47 @@ func (ts *TestTenant) PGPreServer() *pgwire.PreServeConnHandler {
 
 // DiagnosticsReporter is part of TestTenantInterface.
 func (t *TestTenant) DiagnosticsReporter() interface{} {
-	return t.diagnosticsReporter
+	return t.sql.diagnosticsReporter
 }
 
 // StatusServer is part of TestTenantInterface.
 func (t *TestTenant) StatusServer() interface{} {
-	return t.execCfg.SQLStatusServer
+	return t.sql.execCfg.SQLStatusServer
 }
 
 // TenantStatusServer is part of TestTenantInterface.
 func (t *TestTenant) TenantStatusServer() interface{} {
-	return t.execCfg.TenantStatusServer
+	return t.sql.execCfg.TenantStatusServer
 }
 
 // DistSQLServer is part of TestTenantInterface.
 func (t *TestTenant) DistSQLServer() interface{} {
-	return t.SQLServer.distSQLServer
+	return t.sql.distSQLServer
 }
 
 // DistSenderI is part of the TestTenantInterface.
 func (t *TestTenant) DistSenderI() interface{} {
-	return t.SQLServer.execCfg.DistSender
+	return t.sql.execCfg.DistSender
 }
 
 // RPCContext is part of TestTenantInterface.
 func (t *TestTenant) RPCContext() *rpc.Context {
-	return t.execCfg.RPCContext
+	return t.sql.execCfg.RPCContext
 }
 
 // JobRegistry is part of TestTenantInterface.
 func (t *TestTenant) JobRegistry() interface{} {
-	return t.SQLServer.jobRegistry
+	return t.sql.jobRegistry
 }
 
 // ExecutorConfig is part of TestTenantInterface.
 func (t *TestTenant) ExecutorConfig() interface{} {
-	return *t.SQLServer.execCfg
+	return *t.sql.execCfg
 }
 
 // RangeFeedFactory is part of TestTenantInterface.
 func (t *TestTenant) RangeFeedFactory() interface{} {
-	return t.SQLServer.execCfg.RangeFeedFactory
+	return t.sql.execCfg.RangeFeedFactory
 }
 
 // ClusterSettings is part of TestTenantInterface.
@@ -755,12 +770,12 @@ func (t *TestTenant) ClusterSettings() *cluster.Settings {
 
 // Stopper is part of TestTenantInterface.
 func (t *TestTenant) Stopper() *stop.Stopper {
-	return t.stopper
+	return t.sql.stopper
 }
 
 // Clock is part of TestTenantInterface.
 func (t *TestTenant) Clock() *hlc.Clock {
-	return t.SQLServer.execCfg.Clock
+	return t.sql.execCfg.Clock
 }
 
 // AmbientCtx implements serverutils.TestTenantInterface. This
@@ -777,32 +792,32 @@ func (t *TestTenant) TestingKnobs() *base.TestingKnobs {
 
 // SpanConfigKVAccessor is part TestTenantInterface.
 func (t *TestTenant) SpanConfigKVAccessor() interface{} {
-	return t.SQLServer.tenantConnect
+	return t.sql.tenantConnect
 }
 
 // SpanConfigReporter is part TestTenantInterface.
 func (t *TestTenant) SpanConfigReporter() interface{} {
-	return t.SQLServer.tenantConnect
+	return t.sql.tenantConnect
 }
 
 // SpanConfigReconciler is part TestTenantInterface.
 func (t *TestTenant) SpanConfigReconciler() interface{} {
-	return t.SQLServer.spanconfigMgr.Reconciler
+	return t.sql.spanconfigMgr.Reconciler
 }
 
 // SpanConfigSQLTranslatorFactory is part TestTenantInterface.
 func (t *TestTenant) SpanConfigSQLTranslatorFactory() interface{} {
-	return t.SQLServer.spanconfigSQLTranslatorFactory
+	return t.sql.spanconfigSQLTranslatorFactory
 }
 
 // SpanConfigSQLWatcher is part TestTenantInterface.
 func (t *TestTenant) SpanConfigSQLWatcher() interface{} {
-	return t.SQLServer.spanconfigSQLWatcher
+	return t.sql.spanconfigSQLWatcher
 }
 
 // SystemConfigProvider is part TestTenantInterface.
 func (t *TestTenant) SystemConfigProvider() config.SystemConfigProvider {
-	return t.SQLServer.systemConfigWatcher
+	return t.sql.systemConfigWatcher
 }
 
 // DrainClients exports the drainClients() method for use by tests.
@@ -812,32 +827,32 @@ func (t *TestTenant) DrainClients(ctx context.Context) error {
 
 // MustGetSQLCounter implements TestTenantInterface.
 func (t *TestTenant) MustGetSQLCounter(name string) int64 {
-	return mustGetSQLCounterForRegistry(t.metricsRegistry, name)
+	return mustGetSQLCounterForRegistry(t.sql.metricsRegistry, name)
 }
 
 // RangeDescIteratorFactory implements the TestTenantInterface.
 func (t *TestTenant) RangeDescIteratorFactory() interface{} {
-	return t.SQLServer.execCfg.RangeDescIteratorFactory
+	return t.sql.execCfg.RangeDescIteratorFactory
 }
 
 // Codec is part of the TestTenantInterface.
 func (t *TestTenant) Codec() keys.SQLCodec {
-	return t.execCfg.Codec
+	return t.sql.execCfg.Codec
 }
 
 // Tracer is part of the TestTenantInterface.
 func (t *TestTenant) Tracer() *tracing.Tracer {
-	return t.SQLServer.ambientCtx.Tracer
+	return t.sql.ambientCtx.Tracer
 }
 
 // SettingsWatcher is part of the TestTenantInterface.
 func (t *TestTenant) SettingsWatcher() interface{} {
-	return t.SQLServer.settingsWatcher
+	return t.sql.settingsWatcher
 }
 
 // InternalExecutor is part of TestTenantInterface.
 func (t *TestTenant) InternalExecutor() interface{} {
-	return t.SQLServer.internalExecutor
+	return t.sql.internalExecutor
 }
 
 // StartSharedProcessTenant is part of TestServerInterface.
@@ -924,7 +939,7 @@ func (ts *TestServer) StartSharedProcessTenant(
 	hts.t.authentication = sqlServerWrapper.authentication
 	hts.t.sqlServer = sqlServer
 	testTenant := &TestTenant{
-		SQLServer:      sqlServer,
+		sql:            sqlServer,
 		Cfg:            sqlServer.cfg,
 		SQLCfg:         sqlServerWrapper.sqlCfg,
 		pgPreServer:    sqlServerWrapper.pgPreServer,
@@ -942,7 +957,7 @@ func (ts *TestServer) StartSharedProcessTenant(
 
 // MigrationServer is part of the TestTenantInterface.
 func (t *TestTenant) MigrationServer() interface{} {
-	return t.migrationServer
+	return t.sql.migrationServer
 }
 
 // StartTenant is part of TestServerInterface.
@@ -1188,7 +1203,7 @@ func (ts *TestServer) StartTenant(
 	hts.t.sqlServer = sw.sqlServer
 
 	return &TestTenant{
-		SQLServer:      sw.sqlServer,
+		sql:            sw.sqlServer,
 		Cfg:            &baseCfg,
 		SQLCfg:         &sqlCfg,
 		pgPreServer:    sw.pgPreServer,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -77,9 +77,9 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 		if n.Unique {
 			panic(pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes can't be unique"))
 		}
-		b.IncrementSchemaChangeIndexCounter("inverted_index")
-		if len(n.Columns) > 0 {
-			b.IncrementSchemaChangeIndexCounter("multi_column_inverted_index")
+		b.IncrementSchemaChangeIndexCounter("inverted")
+		if len(n.Columns) > 1 {
+			b.IncrementSchemaChangeIndexCounter("multi_column_inverted")
 		}
 	}
 	var idxSpec indexSpec

--- a/pkg/sql/sqltestutils/BUILD.bazel
+++ b/pkg/sql/sqltestutils/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/catconstants",
+        "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/tests",
         "//pkg/testutils",
         "//pkg/testutils/diagutils",

--- a/pkg/sql/sqltestutils/telemetry.go
+++ b/pkg/sql/sqltestutils/telemetry.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/diagutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -90,27 +91,16 @@ func TelemetryTest(t *testing.T, serverArgs []base.TestServerArgs, testTenant bo
 		test.Start(t, serverArgs)
 		defer test.Close()
 
-		if testTenant || test.cluster.StartedDefaultTestTenant() {
-			// TODO(andyk): Re-enable these tests once tenant clusters fully
-			// support the features they're using.
-			switch path {
-			case "testdata/telemetry/execution",
-				// Index & multiregion are disabled because it requires
-				// multi-region syntax to be enabled for secondary tenants.
-				"testdata/telemetry/multiregion",
-				"testdata/telemetry/index",
-				"testdata/telemetry/planning",
-				"testdata/telemetry/sql-stats":
-				skip.WithIssue(t, 47893, "tenant clusters do not support SQL features used by this test")
-			}
+		if path == "testdata/telemetry/sql-stats" {
+			skip.WithIssue(t, 107593)
 		}
 
 		// Run test against physical CRDB cluster.
 		t.Run("server", func(t *testing.T) {
 			datadriven.RunTest(t, path, func(t *testing.T, td *datadriven.TestData) string {
-				sqlServer := test.server.SQLServer().(*sql.Server)
 				reporter := test.server.DiagnosticsReporter().(*diagnostics.Reporter)
-				return test.RunTest(td, test.serverDB, reporter.ReportDiagnostics, sqlServer)
+				statsController := test.server.SQLServer().(*sql.Server).GetSQLStatsController()
+				return test.RunTest(td, test.serverDB, reporter.ReportDiagnostics, statsController)
 			})
 		})
 
@@ -118,9 +108,9 @@ func TelemetryTest(t *testing.T, serverArgs []base.TestServerArgs, testTenant bo
 			// Run test against logical tenant cluster.
 			t.Run("tenant", func(t *testing.T) {
 				datadriven.RunTest(t, path, func(t *testing.T, td *datadriven.TestData) string {
-					sqlServer := test.server.SQLServer().(*sql.Server)
 					reporter := test.tenant.DiagnosticsReporter().(*diagnostics.Reporter)
-					return test.RunTest(td, test.tenantDB, reporter.ReportDiagnostics, sqlServer)
+					statsController := test.tenant.SQLServer().(*sql.Server).GetSQLStatsController()
+					return test.RunTest(td, test.tenantDB, reporter.ReportDiagnostics, statsController)
 				})
 			})
 		}
@@ -157,6 +147,7 @@ func (tt *telemetryTest) Start(t *testing.T, serverArgs []base.TestServerArgs) {
 	diagSrvURL := tt.diagSrv.URL()
 	mapServerArgs := make(map[int]base.TestServerArgs, len(serverArgs))
 	for i, v := range serverArgs {
+		v.DisableDefaultTestTenant = true
 		v.Knobs.Server = &server.TestingKnobs{
 			DiagnosticsTestingKnobs: diagnostics.TestingKnobs{
 				OverrideReportingURL: &diagSrvURL,
@@ -191,7 +182,7 @@ func (tt *telemetryTest) RunTest(
 	td *datadriven.TestData,
 	db *gosql.DB,
 	reportDiags func(ctx context.Context),
-	sqlServer *sql.Server,
+	statsController *persistedsqlstats.Controller,
 ) (out string) {
 	defer func() {
 		if out == "" {
@@ -270,7 +261,7 @@ func (tt *telemetryTest) RunTest(
 
 	case "sql-stats":
 		// Report diagnostics once to reset the stats.
-		sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
+		statsController.ResetLocalSQLStats(ctx)
 		reportDiags(ctx)
 
 		_, err := db.Exec(td.Input)
@@ -278,7 +269,7 @@ func (tt *telemetryTest) RunTest(
 		if err != nil {
 			fmt.Fprintf(&buf, "error: %v\n", err)
 		}
-		sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
+		statsController.ResetLocalSQLStats(ctx)
 		reportDiags(ctx)
 		last := tt.diagSrv.LastRequestData()
 		buf.WriteString(formatSQLStats(last.SqlStats))

--- a/pkg/sql/testdata/telemetry/index
+++ b/pkg/sql/testdata/telemetry/index
@@ -66,7 +66,7 @@ feature-usage
 CREATE TABLE err (i INT, j JSON, INVERTED INDEX (i, j) WHERE i);
 CREATE TABLE err (i INT, geom GEOMETRY, INVERTED INDEX (i, geom) WHERE i);
 ----
-error: pq: expected index predicate expression to have type bool, but 'i' has type int
+error: pq: expected INDEX PREDICATE expression to have type bool, but 'i' has type int
 
 feature-usage
 CREATE TABLE e (i INT, INDEX ((i + 10)))
@@ -132,7 +132,7 @@ feature-usage
 CREATE INVERTED INDEX err ON d (i, j) WHERE i;
 CREATE INVERTED INDEX err ON g4 (i, geom) WHERE i
 ----
-error: pq: expected index predicate expression to have type bool, but 'i' has type int
+error: pq: expected INDEX PREDICATE expression to have type bool, but 'i' has type int
 
 feature-usage
 CREATE INDEX i4 ON d ((i + 10))
@@ -142,20 +142,14 @@ sql.schema.expression_index
 feature-usage
 CREATE TABLE trigrams (t TEXT, u TEXT, INVERTED INDEX(t gin_trgm_ops))
 ----
-sql.schema.trigram_inverted_index
 sql.schema.inverted_index
+sql.schema.trigram_inverted_index
 
-exec
+feature-usage
 CREATE INDEX ON trigrams USING GIN(u gin_trgm_ops)
 ----
-sql.schema.trigram_inverted_index
 sql.schema.inverted_index
-
-exec
-CREATE INVERTED INDEX ON trigrams USING GIN(u gin_trgm_ops)
-----
 sql.schema.trigram_inverted_index
-sql.schema.inverted_index
 
 #### ALTER TABLE tests.
 

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -148,9 +148,6 @@ type TestServerInterface interface {
 	// MigrationServer returns the internal *migrationServer as in interface{}
 	MigrationServer() interface{}
 
-	// SQLServer returns the *sql.Server as an interface{}.
-	SQLServer() interface{}
-
 	// SQLLivenessProvider returns the sqlliveness.Provider as an interface{}.
 	SQLLivenessProvider() interface{}
 

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -67,6 +67,9 @@ type TestTenantInterface interface {
 	// PGServer returns the tenant's *pgwire.Server as an interface{}.
 	PGServer() interface{}
 
+	// SQLServer returns the *sql.Server as an interface{}.
+	SQLServer() interface{}
+
 	// DiagnosticsReporter returns the tenant's *diagnostics.Reporter as an
 	// interface{}. The DiagnosticsReporter periodically phones home to report
 	// diagnostics and usage.


### PR DESCRIPTION
Backport #10755.

This commit unskips multiple telemetry tests that were skipped for no good reason (they were referencing an unrelated issue). This uncovered some bugs in the new schema changer telemetry reporting where we duplicated `_index` twice in the feature counter for inverted indexes. Also, `index` telemetry test contained an invalid statement which is now removed.

The only file that is still skipped is `sql-stats` where the output doesn't match the expectations, and I'm not sure whether the test is stale or something is broken, so a separate issue was filed.

Epic: None

Release note: None

Release justification: bug fix.