### PR TITLE
sql: clean up some uses of Unlock

### DIFF
--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -366,13 +366,13 @@ func (fr *FlowRegistry) cancelPendingStreams(
 // ConnectInboundStream calls for the flow will fail to find it and time out.
 func (fr *FlowRegistry) UnregisterFlow(id execinfrapb.FlowID) {
 	fr.Lock()
+	defer fr.Unlock()
 	entry := fr.flows[id]
 	if entry.streamTimer != nil {
 		entry.streamTimer.Stop()
 		entry.streamTimer = nil
 	}
 	fr.releaseEntryLocked(id)
-	fr.Unlock()
 }
 
 // waitForFlow waits until the flow with the given id gets registered - up to

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -202,33 +202,41 @@ const (
 func (s *Storage) isAlive(
 	ctx context.Context, sid sqlliveness.SessionID, syncOrAsync readType,
 ) (alive bool, _ error) {
-	s.mu.Lock()
-	if !s.mu.started {
-		s.mu.Unlock()
-		return false, sqlliveness.NotStartedError
-	}
-	if _, ok := s.mu.deadSessions.Get(sid); ok {
-		s.mu.Unlock()
-		s.metrics.IsAliveCacheHits.Inc(1)
-		return false, nil
-	}
-	if expiration, ok := s.mu.liveSessions.Get(sid); ok {
-		expiration := expiration.(hlc.Timestamp)
-		// The record exists and is valid.
-		if s.clock.Now().Less(expiration) {
-			s.mu.Unlock()
-			s.metrics.IsAliveCacheHits.Inc(1)
-			return true, nil
+
+	// If wait is false, alive is set and future is unset.
+	// If wait is true, alive is unset and future is set.
+	alive, wait, future, err := func() (bool, bool, singleflight.Future, error) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		if !s.mu.started {
+			return false, false, singleflight.Future{}, sqlliveness.NotStartedError
 		}
+		if _, ok := s.mu.deadSessions.Get(sid); ok {
+			s.metrics.IsAliveCacheHits.Inc(1)
+			return false, false, singleflight.Future{}, nil
+		}
+		if expiration, ok := s.mu.liveSessions.Get(sid); ok {
+			expiration := expiration.(hlc.Timestamp)
+			// The record exists and is valid.
+			if s.clock.Now().Less(expiration) {
+				s.metrics.IsAliveCacheHits.Inc(1)
+				return true, false, singleflight.Future{}, nil
+			}
+		}
+
+		// We think that the session is expired; check, and maybe delete it.
+		future := s.deleteOrFetchSessionSingleFlightLocked(ctx, sid)
+
+		// At this point, we know that the singleflight goroutine has been launched.
+		// Releasing the lock when we return ensures that callers will either join
+		// the singleflight or see the result.
+		return false, true, future, nil
+	}()
+	if err != nil || !wait {
+		return alive, err
 	}
 
-	// We think that the session is expired; check, and maybe delete it.
-	future := s.deleteOrFetchSessionSingleFlightLocked(ctx, sid)
-
-	// At this point, we know that the singleflight goroutine has been launched.
-	// Releasing the lock here ensures that callers will either join the single-
-	// flight or see the result.
-	s.mu.Unlock()
 	s.metrics.IsAliveCacheMisses.Inc(1)
 
 	// If we do not want to wait for the result, assume that the session is

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -664,9 +664,11 @@ func (s *Container) SaveToLog(ctx context.Context, appName string) {
 	}
 	var buf bytes.Buffer
 	for key, stats := range s.mu.stmts {
-		stats.mu.Lock()
-		json, err := json.Marshal(stats.mu.data)
-		stats.mu.Unlock()
+		json, err := func() ([]byte, error) {
+			stats.mu.Lock()
+			defer stats.mu.Unlock()
+			return json.Marshal(stats.mu.data)
+		}()
 		if err != nil {
 			log.Errorf(ctx, "error while marshaling stats for %q // %q: %v", appName, key.String(), err)
 			continue


### PR DESCRIPTION
This is a minor cleanup change to use `defer.Unlock` when there are multiple exit paths that need to unlock.

Epic: none
Release note: None