### PR TITLE
server: fix a race in tenant creation

### DIFF
--- a/pkg/server/server_controller_orchestration.go
+++ b/pkg/server/server_controller_orchestration.go
@@ -96,6 +96,9 @@ func (c *serverController) startInitialSecondaryTenantServers(
 func (c *serverController) scanTenantsForRunnableServices(
 	ctx context.Context, ie isql.Executor,
 ) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	// The list of tenants that should have a running server.
 	reqTenants, err := c.getExpectedRunningTenants(ctx, ie)
 	if err != nil {
@@ -107,9 +110,6 @@ func (c *serverController) scanTenantsForRunnableServices(
 	for _, name := range reqTenants {
 		nameLookup[name] = struct{}{}
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	// First check if there are any servers that shouldn't be running
 	// right now.


### PR DESCRIPTION
Previously, scanTenantsForRunnableServices() was not holding the mutex when SELECTing for the existing tenant names, which means that the following may happen:
- scanTenantsForRunnableServices() sees that only the system tenant exists
- createServerEntryLocked() then adds another tenant while holding the mutex
- scanTenantsForRunnableServices() takes the lock and stops the tenant that was just created because only the system tenant should be alive (which is wrong)

This patch changes scanTenantsForRunnableServices() to take the mutex before SELECTing for the existing tenants in order to avoid the race.

Epic: none
Fixes: #107434
Fixes: #107343
Fixes: #107154

Release note: None