### PR TITLE
colbuilder: fix recently exposed type schema corruption

### DIFF
--- a/pkg/sql/colexec/colbuilder/BUILD.bazel
+++ b/pkg/sql/colexec/colbuilder/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "colbuilder",
-    srcs = ["execplan.go"],
+    srcs = [
+        "execplan.go",
+        "execplan_util.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colexec/colbuilder",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/sql/colexec/colbuilder/execplan_util.go
+++ b/pkg/sql/colexec/colbuilder/execplan_util.go
@@ -1,0 +1,34 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+// addProjection adds a simple projection on top of op according to projection
+// and returns the updated operator and type schema.
+//
+// Note that this method is the only place that's allowed to create a simple
+// project op in colbuilder package (enforced by the linter) in order to force
+// the caller to think about the type schema to prevent type schema corruption
+// issues like #47889 and #107615.
+func addProjection(
+	op colexecop.Operator, typs []*types.T, projection []uint32,
+) (colexecop.Operator, []*types.T) {
+	newTypes := make([]*types.T, len(projection))
+	for i, j := range projection {
+		newTypes[i] = typs[j]
+	}
+	return colexecbase.NewSimpleProjectOp(op, len(typs), projection), newTypes
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -136,3 +136,45 @@ INSERT INTO t64676 VALUES
 
 statement ok
 SELECT i + d FROM t64676
+
+# Regression test for type schema corruption when planning filter expressions
+# (#107615).
+statement ok
+CREATE TABLE t107615 AS
+	SELECT
+		g::INT2 AS _int2,
+		g::INT4 AS _int4,
+		g::INT8 AS _int8,
+		g::FLOAT8 AS _float8,
+		'2001-01-01'::DATE + g AS _date,
+		'2001-01-01'::TIMESTAMP + g * '1 day'::INTERVAL AS _timestamp,
+		'2001-01-01'::TIMESTAMPTZ + g * '1 day'::INTERVAL AS _timestamptz,
+		g * '1 day'::INTERVAL AS _interval,
+		g % 2 = 1 AS _bool,
+		g::DECIMAL AS _decimal,
+		g::STRING AS _string,
+		g::STRING::BYTES AS _bytes,
+		substring('00000000-0000-0000-0000-' || g::STRING || '00000000000', 1, 36)::UUID AS _uuid
+	FROM
+		generate_series(1, 5) AS g;
+SET testing_optimizer_random_seed = 4478711114964600496;
+SELECT
+	1.2345678901234564e+23:::FLOAT8,
+	_string,
+	_int2,
+	tableoid,
+	_int2,
+	'1942-08-15 21:13:20+00':::TIMESTAMPTZ,
+	'\xc3a0':::BYTES,
+	true,
+	_timestamp,
+	_date,
+	e'\x01':::STRING,
+    _uuid,
+	'{"test": "json"}':::JSONB,
+	_int4,
+	_interval
+FROM
+	t107615
+WHERE
+	(_bool OR (NOT _bool));

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2025,6 +2025,41 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	t.Run("TestColbuilderSimpleProject", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			// We prohibit usage of colexecbase.NewSimpleProjectOp outside of
+			// addProjection helper in colbuilder package.
+			`colexecbase\.NewSimpleProjectOp`,
+			"--",
+			"sql/colexec/colbuilder*",
+			":!sql/colexec/colbuilder/execplan_util.go",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf("\n%s <- forbidden; use addProjection to prevent type schema corruption", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	t.Run("TestGCAssert", func(t *testing.T) {
 		skip.UnderShort(t)
 


### PR DESCRIPTION
This commit fixes recently exposed (or introduced, depending on how you look at this) type schema corruption that can occur when planning filter expressions. In particular, the bug was exactly as the comment deleted in 85fd4fb4a1ede027450551545644de129a7e51c4 described:
```
// As an example, consider the following scenario in the context of
// planFilterExpr method:
// 1. r.ColumnTypes={types.Bool} with len=1 and cap=4
// 2. planSelectionOperators adds another types.Int column, so
//    filterColumnTypes={types.Bool, types.Int} with len=2 and cap=4
//    Crucially, it uses exact same underlying array as r.ColumnTypes
//    uses.
// 3. we project out second column, so r.ColumnTypes={types.Bool}
// 4. later, we add another types.Float column, so
//    r.ColumnTypes={types.Bool, types.Float}, but there is enough
//    capacity in the array, so we simply overwrite the second slot
//    with the new type which corrupts filterColumnTypes to become
//    {types.Bool, types.Float}, and we can get into a runtime type
//    mismatch situation.
```
More concretely, in `planFilterExpr` we are using the passed-in type schema to append new types for the intermediate projection operators, and then we create a "simple project op" that removes those intermediate operators. If we later try to add more output columns, we will overwrite types captured by the intermediate projected away operators. The bug was that the simple project op did not create a new type schema like it's supposed to do.

This is now fixed, and we now enforce that the simple project op in `colbuilder` package can only be created by the helper method that explicitly returns the updated type schema, hoping that this will encourage the callers to think about the type schema management to prevent such issues in the future.

Fixes: #107615.

Release note: None