### PR TITLE
opt: remove Metadata.AllUserDefinedFunctions

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -483,7 +483,7 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	if err := c.PrintCreateEnum(&buf, b.flags.RedactValues); err != nil {
 		b.printError(fmt.Sprintf("-- error getting schema for enums: %v", err), &buf)
 	}
-	if len(mem.Metadata().AllUserDefinedFunctions()) != 0 {
+	if mem.Metadata().HasUserDefinedFunctions() {
 		// Get all relevant user-defined functions.
 		blankLine()
 		if err := c.PrintRelevantCreateUdf(&buf, strings.ToLower(b.stmt), b.flags.RedactValues, &b.errorStrings); err != nil {

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -540,9 +540,9 @@ func (md *Metadata) AllUserDefinedTypes() []*types.T {
 	return md.userDefinedTypesSlice
 }
 
-// AllUserDefinedFunctions returns all user defined functions used in this query.
-func (md *Metadata) AllUserDefinedFunctions() map[cat.StableID]*tree.Overload {
-	return md.udfDeps
+// HasUserDefinedFunctions returns true if the query references a UDF.
+func (md *Metadata) HasUserDefinedFunctions() bool {
+	return len(md.udfDeps) > 0
 }
 
 // AddUserDefinedFunction adds a user-defined function to the metadata for this


### PR DESCRIPTION
The metadata method `AllUserDefinedFunctions` has been replaced with a
new function `HasUserDefinedFunctions` which provides a simpler API
without exposing the underlying UDF dependency map. The map is still
available outside of the opt package via the `TestingUDFDeps` method
which is designed for testing use only.

Epic: None

Release note: None
