### PR TITLE
testutils/floatcmp: check 15 significant digits

### DIFF
--- a/pkg/testutils/floatcmp/floatcmp.go
+++ b/pkg/testutils/floatcmp/floatcmp.go
@@ -141,17 +141,14 @@ func FloatsMatch(expectedString, actualString string) (bool, error) {
 	if expPower != actPower {
 		return false, nil
 	}
-	// TODO(yuzefovich): investigate why we can't always guarantee deterministic
-	// 15 significant digits and switch back from 14 to 15 digits comparison
-	// here. See #56446 for more details.
-	for i := 0; i < 14; i++ {
+	for i := 0; i < 15; i++ {
 		expDigit := int(expected)
 		actDigit := int(actual)
 		if expDigit != actDigit {
 			return false, nil
 		}
-		expected -= (expected - float64(expDigit)) * 10
-		actual -= (actual - float64(actDigit)) * 10
+		expected = (expected - float64(expDigit)) * 10
+		actual = (actual - float64(actDigit)) * 10
 	}
 	return true, nil
 }


### PR DESCRIPTION
A few years ago we decreased the precision of our float comparison from 15 significant digits to 14 to silence some test flakes. Let's try increasing it to 15 again.

Also fix a bug in the comparison due to a `-=` instead of `=`. (Not sure how *significant* this was.)

Fixes: #56446

Release note: None