### PR TITLE
kvserver: downgrade "unable to transfer lease" log

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -513,7 +513,7 @@ func (sr *StoreRebalancer) applyLeaseRebalance(
 			candidateReplica.RangeUsageInfo(),
 		)
 	}); err != nil {
-		log.KvDistribution.Errorf(ctx, "unable to transfer lease to s%d: %+v", target.StoreID, err)
+		log.KvDistribution.Infof(ctx, "unable to transfer lease to s%d: %v", target.StoreID, err)
 		return false
 	}
 	return true


### PR DESCRIPTION
It doesn't rise up to "ERROR" level and also doesn't need to log a large stack
trace.

Seen while looking into #106140.

Epic: none
Release note: None
