### PR TITLE
netutil: fix a buglet

### DIFF
--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -191,6 +191,7 @@ func (s *TCPServer) ServeWith(
 			serveConn(ctx, rw)
 		})
 		if err != nil {
+			err = errors.CombineErrors(err, rw.Close())
 			return err
 		}
 	}


### PR DESCRIPTION
I was noticing an excess number of conn objects remaining open after a test shutdown.

Release note: None
Epic: CRDB-28893