### PR TITLE
sql: add request unit to tracing sampled query event

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -3003,6 +3003,7 @@ contains common SQL event/execution details.
 | `MvccRangeKeySkippedPoints` | RangeKeySkippedPoints collects the count of the subset of ContainedPoints point keys that were skipped during iteration due to range-key masking. For details, see pkg/storage/engine.go, pebble.RangeKeyIteratorStats, and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
 | `SchemaChangerMode` | SchemaChangerMode is the mode that was used to execute the schema change, if any. | no |
 | `SQLInstanceIDs` | SQLInstanceIDs is a list of all the SQL instance id used in this statements execution. | no |
+| `RequestUnitEstimate` | Estimated request units the statement cost | no |
 
 
 #### Common fields

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -383,6 +383,7 @@ func (p *planner) maybeLogStatementInternal(
 				KvGrpcCalls:                           queryLevelStats.KVBatchRequestsIssued,
 				NetworkMessages:                       queryLevelStats.NetworkMessages,
 				CpuTimeNanos:                          queryLevelStats.CPUTime.Nanoseconds(),
+				RequestUnitEstimate:                   float64(queryLevelStats.RUEstimate),
 				IndexRecommendations:                  indexRecs,
 				Indexes:                               p.curPlan.instrumentation.indexesUsed,
 				ScanCount:                             int64(p.curPlan.instrumentation.scanCounts[exec.ScanCount]),

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -162,6 +162,7 @@ func TestTelemetryLogging(t *testing.T) {
 				CPUTime:                            113,
 				KVBatchRequestsIssued:              113,
 				KVTime:                             114,
+				RUEstimate:                         115,
 				Regions:                            []string{"eastus1"},
 			},
 			enableTracing: false,
@@ -403,6 +404,7 @@ func TestTelemetryLogging(t *testing.T) {
 				CPUTime:                            9223372036854775807,
 				KVBatchRequestsIssued:              9223372036854775807,
 				KVTime:                             9223372036854775807,
+				RUEstimate:                         9223372036854775807,
 				Regions:                            []string{"9223372036854775807EastUS9223372036854775807/z^&*&#()(!@%&^61%^7'\\\\&*@#$%"},
 				SqlInstanceIds: map[base.SQLInstanceID]struct{}{
 					base.SQLInstanceID(-2147483648): {},
@@ -580,6 +582,7 @@ func TestTelemetryLogging(t *testing.T) {
 					require.Equal(t, tc.queryLevelStats.KVPairsRead, sampledQueryFromLog.KVPairsRead)
 					require.Equal(t, tc.queryLevelStats.KVBatchRequestsIssued, sampledQueryFromLog.KvGrpcCalls)
 					require.Equal(t, tc.queryLevelStats.KVTime.Nanoseconds(), sampledQueryFromLog.KvTimeNanos)
+					require.Equal(t, float64(tc.queryLevelStats.RUEstimate), sampledQueryFromLog.RequestUnitEstimate)
 					require.Equal(t, tc.queryLevelStats.Regions, sampledQueryFromLog.Regions)
 					if len(tc.queryLevelStats.SqlInstanceIds) > 0 {
 						arr := make([]int32, 0, len(tc.queryLevelStats.SqlInstanceIds))

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -4854,6 +4854,15 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, ']')
 	}
 
+	if m.RequestUnitEstimate != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RequestUnitEstimate\":"...)
+		b = strconv.AppendFloat(b, float64(m.RequestUnitEstimate), 'f', -1, 64)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -291,9 +291,12 @@ message SampledQuery {
   // SQLInstanceIDs is a list of all the SQL instance id used in this statements execution.
   repeated int32 sql_instance_ids = 77 [(gogoproto.jsontag) = ',omitempty', (gogoproto.customname) = "SQLInstanceIDs", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
+  // Estimated request units the statement cost
+  double request_unit_estimate = 78 [(gogoproto.jsontag) = ",omitempty"];
+
   reserved 12;
 
-  // Next available ID: 78.
+  // Next available ID: 79.
 }
 
 


### PR DESCRIPTION
Fixes: #95194

Release note (sql change): Add the request unit estimate to the sampled query event.