### PR TITLE
ui: make `now` option always enable on time picker

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.tsx
@@ -38,7 +38,6 @@ export const TimeFrameControls = ({
     onArrowClick(direction);
 
   const left = disabledArrows.includes(ArrowDirection.LEFT);
-  const center = disabledArrows.includes(ArrowDirection.CENTER);
   const right = disabledArrows.includes(ArrowDirection.RIGHT);
   const delay = 0.3;
 
@@ -84,8 +83,7 @@ export const TimeFrameControls = ({
       >
         <Button
           onClick={handleChangeArrow(ArrowDirection.CENTER)}
-          disabled={center}
-          className={cx("_action", center ? "disabled" : "active", "btn__now")}
+          className={cx("_action", "active", "btn__now")}
         >
           Now
         </Button>

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
@@ -368,8 +368,8 @@ describe("TimeScaleDropdown functions", function () {
   it("generateDisabledArrows must return array with disabled buttons", () => {
     const arrows = generateDisabledArrows(currentWindow);
     const wrapper = makeTimeScaleDropdown(state);
-    assert.equal(wrapper.find(".controls-content ._action.disabled").length, 2);
-    assert.deepEqual(arrows, [ArrowDirection.CENTER, ArrowDirection.RIGHT]);
+    expect(wrapper.find(".controls-content ._action.disabled").length).toBe(1);
+    expect(arrows).toEqual([ArrowDirection.CENTER, ArrowDirection.RIGHT]);
   });
 
   it("generateDisabledArrows must render 3 active buttons and return empty array", () => {


### PR DESCRIPTION
Previously, it could take some time for the `Now` button to be enabled on the time picker, but now that we show the time for which the data is being displayed for, we should give the option to always refresh to the latest one.
So this commit makes the `Now` button always enabled.

Fixes #106946

Release note (ui change): The `Now` option on the time picker is always enabled.