### PR TITLE
ui: extend search logic on insights page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.spec.ts
@@ -214,6 +214,26 @@ describe("test workload insights utils", () => {
         "no results",
       );
       expect(filtered.length).toEqual(0);
+
+      filtered = filterTransactionInsights(
+        [
+          ...txnsWithQueries,
+          mockTxnInsightEvent({ sessionID: "my-uniq-session-id-11223344" }),
+          mockTxnInsightEvent({
+            stmtExecutionIDs: ["statement-exec-id-11223344"],
+          }),
+          mockTxnInsightEvent({
+            transactionExecutionID: "txn-exec-id-11223344",
+          }),
+          mockTxnInsightEvent({
+            transactionFingerprintID: "txn-fingerprint-id-11223344",
+          }),
+        ],
+        { app: "" },
+        INTERNAL_APP_PREFIX,
+        "11223344",
+      );
+      expect(filtered.length).toEqual(4);
     });
 
     it("should filter txns given a mix of requirements", () => {
@@ -344,6 +364,29 @@ describe("test workload insights utils", () => {
         "no results",
       );
       expect(filtered.length).toEqual(0);
+
+      filtered = filterStatementInsights(
+        [
+          ...stmtsWithQueries,
+          mockStmtInsightEvent({
+            transactionFingerprintID: "txn-fingerprint-id-11223344",
+          }),
+          mockStmtInsightEvent({
+            transactionExecutionID: "txn-exec-id-11223344",
+          }),
+          mockStmtInsightEvent({ sessionID: "session-id-11223344" }),
+          mockStmtInsightEvent({
+            statementFingerprintID: "stmt-fingerprint-id-11223344",
+          }),
+          mockStmtInsightEvent({
+            statementExecutionID: "stmt-exec-id-11223344",
+          }),
+        ],
+        { app: "" },
+        INTERNAL_APP_PREFIX,
+        "11223344",
+      );
+      expect(filtered.length).toEqual(5);
     });
 
     it("should filter txns given a mix of requirements", () => {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -72,7 +72,13 @@ export const filterTransactionInsights = (
 
     filteredTransactions = filteredTransactions.filter(
       txn =>
-        txn.transactionExecutionID.toLowerCase()?.includes(search) ||
+        [
+          txn.transactionExecutionID,
+          txn.transactionFingerprintID,
+          txn.sessionID,
+        ]
+          .concat(txn.stmtExecutionIDs)
+          .some(id => id.toLowerCase()?.includes(search)) ||
         txn.query.toLowerCase().includes(search),
     );
   }
@@ -220,12 +226,20 @@ export const filterStatementInsights = (
       ),
     );
   }
+
   if (search) {
     search = search.toLowerCase();
     filteredStatements = filteredStatements.filter(
       stmt =>
         !search ||
-        stmt.statementExecutionID.toLowerCase()?.includes(search) ||
+        // Search results in all ID columns of StmtInsightEvent.
+        [
+          stmt.sessionID,
+          stmt.transactionExecutionID,
+          stmt.transactionFingerprintID,
+          stmt.statementExecutionID,
+          stmt.statementFingerprintID,
+        ].some(s => s.toLowerCase()?.includes(search)) ||
         stmt.query?.toLowerCase().includes(search),
     );
   }


### PR DESCRIPTION
This change extends the number of fields where
search is applied (instead of single transaction/
statement execution ID field).
It makes possible to search for any available ID
in Txn or statement insight.

Release note (ui change): search is performed on all ID fields of transaction and statement insights.

Resolves: #107253

Demo:

https://github.com/cockroachdb/cockroach/assets/3106437/7fb56720-3ab2-4be4-9500-457707f6f01d

