### PR TITLE
server/profiler: remove `server.cpu_profile.enabled` setting

### DIFF
--- a/pkg/server/profiler/cpuprofile_test.go
+++ b/pkg/server/profiler/cpuprofile_test.go
@@ -31,7 +31,6 @@ func TestCPUProfiler(t *testing.T) {
 	sv.Init(ctx, s.Version)
 	cpuProfileInterval.Override(ctx, sv, time.Hour)
 	cpuUsageCombined.Override(ctx, sv, 80)
-	cpuProfileEnabled.Override(ctx, sv, true)
 	pastTime := time.Date(2023, 1, 1, 1, 1, 1, 1, time.UTC)
 	cases := []struct {
 		name                 string

--- a/pkg/server/profiler/cpuprofiler.go
+++ b/pkg/server/profiler/cpuprofiler.go
@@ -61,15 +61,6 @@ var cpuProfileDuration = settings.RegisterDurationSetting(
 	10*time.Second, settings.PositiveDuration,
 )
 
-var cpuProfileEnabled = settings.RegisterBoolSetting(
-	settings.TenantWritable,
-	"server.cpu_profile.enabled",
-	"a bool which indicates whether cpu profiles should be taken by the cpu profiler. "+
-		"in order to have the profiler function, server.cpu_profile.cpu_usage_combined_threshold "+
-		"must also be set to a realistic value",
-	false,
-)
-
 const cpuProfFileNamePrefix = "cpuprof"
 
 // CPUProfiler is used to take CPU profiles.
@@ -116,9 +107,6 @@ func (cp *CPUProfiler) MaybeTakeProfile(ctx context.Context, currentCpuUsage int
 			logcrash.ReportPanic(ctx, &cp.st.SV, p, 1)
 		}
 	}()
-	if !cpuProfileEnabled.Get(&cp.st.SV) {
-		return
-	}
 	cp.profiler.maybeTakeProfile(ctx, currentCpuUsage, cp.takeCPUProfile)
 }
 

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -173,6 +173,7 @@ var retiredSettings = map[string]struct{}{
 	"changefeed.replan_flow_threshold":                         {},
 	"jobs.trace.force_dump_mode":                               {},
 	"timeseries.storage.30m_resolution_ttl":                    {},
+	"server.cpu_profile.enabled":                               {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults


### PR DESCRIPTION
Cpu profiling can be enabled by setting the cluster setting `server.cpu_profile.cpu_usage_combined_threshold`. This makes `server.cpu_profile.enabled` redundant and makes it more difficult and confusing to enable cpu profiling. This commit removes the `server.cpu_profile.enabled` setting entirely. Note that both jdefault values for the cluster settings set profiling off.

Closes: #102024

Release note (sql change): The cluster setting
`server.cpu_profile.enabled` has been removed.
`server.cpu_profile.cpu_usage_combined_threshold` can enable and disable cpu profiling.