### PR TITLE
ui: add latency info to explain plan tab

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -48,6 +48,11 @@ const planDetailsColumnLabels = {
   insights: "Insights",
   indexes: "Used Indexes",
   lastExecTime: "Last Execution Time",
+  latencyMax: "Max Latency",
+  latencyMin: "Min Latency",
+  latencyP50: "P50 Latency",
+  latencyP90: "P90 Latency",
+  latencyP99: "P99 Latency",
   planGist: "Plan Gist",
   vectorized: "Vectorized",
 };
@@ -97,6 +102,71 @@ export const planDetailsTableTitles: PlanDetailsTableTitleType = {
         content={"The average execution time for this Explain Plan."}
       >
         {planDetailsColumnLabels.avgExecTime}
+      </Tooltip>
+    );
+  },
+  latencyP50: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={
+          "The 50th latency percentile for sampled statement executions with this Explain Plan."
+        }
+      >
+        {planDetailsColumnLabels.latencyP50}
+      </Tooltip>
+    );
+  },
+  latencyP90: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={
+          "The 90th latency percentile for sampled statement executions with this Explain Plan."
+        }
+      >
+        {planDetailsColumnLabels.latencyP90}
+      </Tooltip>
+    );
+  },
+  latencyP99: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={
+          "The 99th latency percentile for sampled statement executions with this Explain Plan."
+        }
+      >
+        {planDetailsColumnLabels.latencyP99}
+      </Tooltip>
+    );
+  },
+  latencyMin: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={
+          "The lowest latency value for all statement executions with this Explain Plan."
+        }
+      >
+        {planDetailsColumnLabels.latencyMin}
+      </Tooltip>
+    );
+  },
+  latencyMax: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={
+          "The highest latency value for all statement executions with this Explain Plan."
+        }
+      >
+        {planDetailsColumnLabels.latencyMax}
       </Tooltip>
     );
   },
@@ -334,6 +404,41 @@ export function makeExplainPlanColumns(
         RenderCount(item.metadata.full_scan_count, item.metadata.total_count),
       sort: (item: PlanHashStats) =>
         RenderCount(item.metadata.full_scan_count, item.metadata.total_count),
+    },
+    {
+      name: "latencyMin",
+      title: planDetailsTableTitles.latencyMin(),
+      cell: (item: PlanHashStats) =>
+        formatNumberForDisplay(item.stats.latency_info.min, duration),
+      sort: (item: PlanHashStats) => item.stats.latency_info.min,
+    },
+    {
+      name: "latencyMax",
+      title: planDetailsTableTitles.latencyMax(),
+      cell: (item: PlanHashStats) =>
+        formatNumberForDisplay(item.stats.latency_info.max, duration),
+      sort: (item: PlanHashStats) => item.stats.latency_info.max,
+    },
+    {
+      name: "latencyP50",
+      title: planDetailsTableTitles.latencyP50(),
+      cell: (item: PlanHashStats) =>
+        formatNumberForDisplay(item.stats.latency_info.p50, duration),
+      sort: (item: PlanHashStats) => item.stats.latency_info.p50,
+    },
+    {
+      name: "latencyP90",
+      title: planDetailsTableTitles.latencyP90(),
+      cell: (item: PlanHashStats) =>
+        formatNumberForDisplay(item.stats.latency_info.p90, duration),
+      sort: (item: PlanHashStats) => item.stats.latency_info.p90,
+    },
+    {
+      name: "latencyP99",
+      title: planDetailsTableTitles.latencyP99(),
+      cell: (item: PlanHashStats) =>
+        formatNumberForDisplay(item.stats.latency_info.p99, duration),
+      sort: (item: PlanHashStats) => item.stats.latency_info.p99,
     },
     {
       name: "distSQL",


### PR DESCRIPTION
This commit adds columns for latency information
(p50, p90, p99, pMax, pMin) on Explain Plan tab under Statement Details page.

Fixes #105371

<img width="1707" alt="Screenshot 2023-07-27 at 10 59 41 AM" src="https://github.com/cockroachdb/cockroach/assets/1017486/81a2ce3d-655e-47c1-931b-00e34433b3a1">


Release note (ui change): Add columns for p50, p90, p99 percentiles and latency min and max on Explain Plan tab on Statement Details page.