### PR TITLE
backupccl,server: fix `TestBackupRestoreTenant`

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6943,7 +6943,6 @@ func TestBackupRestoreInsideMultiPodTenant(t *testing.T) {
 func TestBackupRestoreTenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 107669)
 
 	params := base.TestClusterArgs{ServerArgs: base.TestServerArgs{
 		Knobs: base.TestingKnobs{
@@ -7353,7 +7352,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 		restoreDB.Exec(t, `ALTER TENANT [20] STOP SERVICE`)
 		restoreDB.Exec(t, `DROP TENANT [20] IMMEDIATE`)
 
-		restoreDB.Exec(t, `RESTORE TENANT 11 FROM 'nodelocal://1/clusterwide' WITH virtual_cluster_name = 'tenant-20'`)
+		restoreDB.Exec(t, `RESTORE TENANT 11 FROM 'nodelocal://1/clusterwide' WITH virtual_cluster = '20', virtual_cluster_name = 'tenant-20'`)
 
 		tenantID = roachpb.MustMakeTenantID(20)
 		if err := restoreTC.Server(0).(*server.TestServer).WaitForTenantReadiness(ctx, tenantID); err != nil {


### PR DESCRIPTION
In #107669 we noticed this test getting stuck
in `WaitForTenantReadiness` post restore causing
the test to timeout. There were a couple of underlying issues:

The test uses `EnableTenantIDReuse` which means that the restore in https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/backupccl/backup_test.go#L7355 would create a tenant at the first available tenant ID. This is tenant 2 in the case of this test, which means that our assertion for `WaitForTenantReadiness` on tenant ID 20 was incorrect.

This begs the question why was this test ever passing. In `WaitForTenantReadiness` we nudge the watcher to re-run an initial scan and handle a complete update. As part of handling a complete update the in-RAM caches are hydrated with the most up-to-date information about the tenants. Our access of the cache in `WaitForTenantReadiness` however did not wait for the new initial scan to complete, and this could result in the method returning a stale tenant entry from the cache before the initial scan had completed. So, even though tenant 20 had been dropped before the restore https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/backupccl/backup_test.go#L7353 the watcher's cache would still report the tenant as ready.

This change ensures that `WaitForTenantReadiness` only returns once the complete update from the initial scan has been handled.

Fixes: #107685
Fixes: #107669

Release note: None