### PR TITLE
workload/ycsb: mark --read-modify-write-in-txn flag as RuntimeOnly

### DIFF
--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -126,8 +126,9 @@ var ycsbMeta = workload.Meta{
 		g := &ycsb{}
 		g.flags.FlagSet = pflag.NewFlagSet(`ycsb`, pflag.ContinueOnError)
 		g.flags.Meta = map[string]workload.FlagMeta{
-			`isolation-level`: {RuntimeOnly: true},
-			`workload`:        {RuntimeOnly: true},
+			`isolation-level`:          {RuntimeOnly: true},
+			`read-modify-write-in-txn`: {RuntimeOnly: true},
+			`workload`:                 {RuntimeOnly: true},
 		}
 		g.flags.StringVar(&g.isoLevel, `isolation-level`, ``, `Isolation level to run workload transactions under [serializable, snapshot, read_committed]. If unset, the workload will run with the default isolation level of the database.`)
 		g.flags.BoolVar(&g.timeString, `time-string`, false, `Prepend field[0-9] data with current time in microsecond precision.`)


### PR DESCRIPTION
The `read-modify-write-in-txn` flag was added to ycsb in cockroachdb#103117.

This commit marks the flag as RuntimeOnly so that it doesn't break IMPORT when a newer version of `workload` (who knows about the flag) is run against an older version of `cockroach` (who does not).

Epic: None
Release note: None