### PR TITLE
roachtest: add network_logging test

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -109,6 +109,7 @@ go_library(
         "multitenant_utils.go",
         "mvcc_gc.go",
         "network.go",
+        "network_logging.go",
         "nodejs_postgres.go",
         "npgsql.go",
         "npgsql_blocklist.go",

--- a/pkg/cmd/roachtest/tests/network_logging.go
+++ b/pkg/cmd/roachtest/tests/network_logging.go
@@ -1,0 +1,120 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// 3 node CRDB cluster, plus 1 node for workload
+	numNodesNetworkLogging = 4
+	fluentBitTCPPort       = 5170
+	// YAML template string defining a FluentBit and HTTP log sink, both with buffering enabled.
+	// Container ports for both sinks are left to be interpolated (%d).
+	logConfigTemplate = "{ http-defaults: { format: json-fluent, buffering: { max-staleness: 5s, flush-trigger-size: 1.0MiB, max-buffer-size: 50MiB } }, fluent-defaults: { format: json-fluent, buffering: { max-staleness: 5s, flush-trigger-size: 1.0MiB, max-buffer-size: 50MiB } }, sinks: { fluent-servers: { test-output: { channels: {INFO: all}, net: tcp, address: localhost:%d, filter: INFO, redact: false } }, http-servers: { test-output: { channels: {INFO: all}, address: http://localhost:%d, filter: INFO, method: POST, unsafe-tls: true } } } }"
+)
+
+func registerNetworkLogging(r registry.Registry) {
+	runNetworkLogging := func(
+		ctx context.Context,
+		t test.Test,
+		c cluster.Cluster,
+	) {
+		crdbNodes := c.Range(1, c.Spec().NodeCount-1)
+		workloadNode := c.Node(c.Spec().NodeCount)
+
+		// Install Docker, which we'll use for FluentBit.
+		t.Status("installing docker")
+		if err := c.Install(ctx, t.L(), crdbNodes, "docker"); err != nil {
+			t.Fatalf("failed to install docker: %v", err)
+		}
+
+		t.Status("installing FluentBit containers on CRDB nodes")
+		// Create FluentBit container on the node with a TCP input and dev/null output.
+		err := c.RunE(ctx, crdbNodes, fmt.Sprintf(
+			"sudo docker run -d -p %d:%d --name=fluentbit fluent/fluent-bit -i tcp -o null",
+			fluentBitTCPPort,
+			fluentBitTCPPort))
+		if err != nil {
+			t.Fatalf("failed to install FluentBit containers: %v", err)
+		}
+
+		// Install Cockroach, including on the workload node,
+		// since we'll use ./cockroach workload.
+		t.Status("installing cockroach")
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
+
+		// Start each node with a log config containing fluent-server and http-server sinks.
+		t.Status("starting cockroach on nodes")
+		startOpts := option.DefaultStartOpts()
+		logCfg := fmt.Sprintf(logConfigTemplate, fluentBitTCPPort, fluentBitTCPPort)
+		startOpts.RoachprodOpts.ExtraArgs = []string{
+			"--log", logCfg,
+		}
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(true)), crdbNodes)
+
+		// Construct pgurls for the workload runner. As a roundabout way of detecting deadlocks,
+		// we set a client timeout on the workload pgclient. If the server becomes unavailable
+		// due to a deadlock, the timeout will eventually trigger and cause the test to fail.
+		// We've had network logging bugs in the past that deadlocked without the nodes dying,
+		// so this helps detect such a case.
+		secureUrls, err := roachprod.PgURL(ctx,
+			t.L(),
+			c.MakeNodes(crdbNodes),
+			"certs", /* certsDir */
+			roachprod.PGURLOptions{
+				External: false,
+				Secure:   true})
+		require.NoError(t, err)
+		workloadPGURLs := make([]string, len(secureUrls))
+		for i, url := range secureUrls {
+			// URLs already are wrapped in '', but we need to add a timeout flag.
+			// Trim the trailing ' and re-add with the flag.
+			trimmed := strings.TrimSuffix(url, "'")
+			workloadPGURLs[i] = fmt.Sprintf("%s&statement_timeout=10s'", trimmed)
+		}
+
+		// Init & run a workload on the workload node.
+		t.Status("initializing workload")
+		initWorkloadCmd := fmt.Sprintf("./cockroach workload init kv %s ", secureUrls[0])
+		c.Run(ctx, workloadNode, initWorkloadCmd)
+
+		t.Status("running workload")
+		m := c.NewMonitor(ctx, crdbNodes)
+		m.Go(func(ctx context.Context) error {
+			joinedURLs := strings.Join(workloadPGURLs, " ")
+			runWorkloadCmd := fmt.Sprintf("./cockroach workload run kv --concurrency=32 --duration=1h %s", joinedURLs)
+			return c.RunE(ctx, workloadNode, runWorkloadCmd)
+		})
+		m.Wait()
+	}
+
+	r.Add(registry.TestSpec{
+		Name:    "network_logging",
+		Owner:   registry.OwnerObsInf,
+		Cluster: r.MakeClusterSpec(numNodesNetworkLogging),
+		Leases:  registry.MetamorphicLeases,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runNetworkLogging(ctx, t, c)
+		},
+	})
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -94,6 +94,7 @@ func RegisterTests(r registry.Registry) {
 	registerMultiTenantUpgrade(r)
 	registerMultiTenantSharedProcess(r)
 	registerNetwork(r)
+	registerNetworkLogging(r)
 	registerNodeJSPostgres(r)
 	registerNpgsql(r)
 	registerPebbleWriteThroughput(r)


### PR DESCRIPTION
Currently, network log features such as the `http-server` and `fluent-server` are not exercised as part of our roachtest framework. Because of this, the feature is largely untested in an e2e environment, leaving a large gap in our test coverage.

This patch adds a new roachtest, `network_logging`, that exercises both of these features. By default, these types of log sinks are buffered via the bufferedSink code, so the tests also exercise that code path.

The test provisions a cluster and runs a workload against it. Each CRDB node is accompanied by a Docker container running FluentBit. The FluentBit containers themselves don't do anything other than receive logs, and then send them to dev/null. Again, the goal of the test is to exercise the *output* of the logs from CRDB, not what's done with them externally on the receiving end, hence dev/null.

The workload run is kv, for a duration of 1h. The type of workload is less important than the fact that logs are flowing through the fluent/http sinks.

A statement_timeout option is included in the pgurl provided to the workload, which will be triggered if the nodes become unavailable due to something like a deadlock scenario.

Release note: none

Addresses: https://github.com/cockroachdb/cockroach/issues/105357

Epic: CC-9681