### PR TITLE
valueside: use redact type name when can't decode

### DIFF
--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -246,7 +246,7 @@ func DecodeUntaggedDatum(
 	case types.VoidFamily:
 		return a.NewDVoid(), buf, nil
 	default:
-		return nil, buf, errors.Errorf("couldn't decode type %s", t)
+		return nil, buf, errors.Errorf("couldn't decode type %s", t.SQLStringForError())
 	}
 }
 


### PR DESCRIPTION
Informs: #106158
Epic: None

Release note: None