### PR TITLE
release-22.2: ui,build: push cluster-ui assets into external folder during watch mode

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=56
+DEV_VERSION=57
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -82,6 +82,23 @@ bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 12345
 
 exec
+dev ui watch --cluster-ui-dst /path/to/foo --cluster-ui-dst /path/to/bar
+----
+bazel fetch //pkg/ui/workspaces/db-console:db-console-ccl
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+bazel info bazel-bin --color=no
+bazel info workspace --color=no
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
+cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+bazel info workspace --color=no
+bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch --env.copy-to=/path/to/foo --env.copy-to=/path/to/bar
+bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000
+
+exec
 dev ui lint
 ----
 bazel test //pkg/ui:lint --test_output errors

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -52,6 +52,14 @@ func mustGetFlagString(cmd *cobra.Command, name string) string {
 	return val
 }
 
+func mustGetFlagStringArray(cmd *cobra.Command, name string) []string {
+	val, err := cmd.Flags().GetStringArray(name)
+	if err != nil {
+		log.Fatalf("unexpected error: %v", err)
+	}
+	return val
+}
+
 func mustGetFlagBool(cmd *cobra.Command, name string) bool {
 	val, err := cmd.Flags().GetBool(name)
 	if err != nil {

--- a/pkg/ui/workspaces/cluster-ui/BUILD.bazel
+++ b/pkg/ui/workspaces/cluster-ui/BUILD.bazel
@@ -109,6 +109,8 @@ DEPENDENCIES = [
     "@npm_cluster_ui//reselect",
     "@npm_cluster_ui//sass",
     "@npm_cluster_ui//sass-loader",
+    "@npm_cluster_ui//schema-utils",
+    "@npm_cluster_ui//semver",
     "@npm_cluster_ui//sinon",
     "@npm_cluster_ui//source-map-loader",
     "@npm_cluster_ui//style-loader",
@@ -184,6 +186,7 @@ webpack(
     ],
     data = glob([
         "src/**",
+        "build/webpack/**",
     ]) + [
         ".babelrc",
         "tsconfig.json",

--- a/pkg/ui/workspaces/cluster-ui/build/webpack/copyEmittedFilesPlugin.js
+++ b/pkg/ui/workspaces/cluster-ui/build/webpack/copyEmittedFilesPlugin.js
@@ -1,0 +1,199 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+const fs = require("fs");
+const fsp = require("fs/promises");
+const os = require("os");
+const path = require("path");
+const semver = require("semver");
+const { validate } = require("schema-utils");
+
+const PLUGIN_NAME = `CopyEmittedFilesPlugin`;
+
+const SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    destinations: {
+      description: "Destination directories to copy emitted files to.",
+      type: "array",
+      items: {
+        type: "string",
+      },
+      // Disallow duplicates.
+      uniqueItems: true,
+    },
+  },
+};
+
+/**
+ * A webpack plugin that copies emitted files to additional directories.
+ * Its main purpose is to allow a watch-mode compilation to continuously "push"
+ * output files into external directories. This avoids the "multiple/mismatched
+ * copies of dependency $foo" behavior that often comes with symlink-based
+ * "pull" solutions like 'pnpm link'.
+ */
+class CopyEmittedFilesPlugin {
+  constructor(options) {
+    validate(SCHEMA, options, {
+      name: PLUGIN_NAME,
+      baseDataPath: "options",
+    });
+    this.options = options;
+  }
+
+  /**
+   * The implementation of the plugin. Runs one time once webpack starts up,
+   * setting up event listeners for various webpack events.
+   * @see https://webpack.js.org/contribute/writing-a-plugin/#creating-a-plugin
+   */
+  apply(compiler) {
+    // If no destinations have been configured or if this isn't a watch-mode
+    // build, this plugin should do nothing.
+    // It's therefore safe to keep an instance of this plugin in the 'Plugins'
+    // array, as it'll have no impact on unconfigured builds.
+    if (this.options.destinations.length === 0 || !compiler.options.watch) {
+      return;
+    }
+
+    const logger = compiler.getInfrastructureLogger(PLUGIN_NAME);
+
+    // Extract the major and minor versions of this cluster-ui build.
+    const pkgVersion = getPkgVersion(compiler.context);
+
+    // Sanitize provided paths to ensure they point to a reasonable version of
+    // cluster-ui.
+    const destinations = this.options.destinations.map((dstOpt) => {
+      const dst = detildeify(dstOpt);
+
+      // The user provided paths to a specific cluster-ui version.
+      if (dst.includes("@cockroachlabs/cluster-ui-")) {
+        // Remove a possibly-trailing '/' literal.
+        const dstClean = dst[dst.length - 1] === "/"
+          ? dst.slice(0, dst.length - 1)
+          : dst;
+
+        return dstClean;
+      }
+
+      // If the user provided a path to a project, look for a top-level
+      // node_modules/ within that directory
+      const dirents = fs.readdirSync(dst, { encoding: "utf-8", withFileTypes: true });
+      for (const dirent of dirents) {
+        if (dirent.name === "node_modules" && dirent.isDirectory()) {
+          return path.join(
+            dst,
+            `./node_modules/@cockroachlabs/cluster-ui-${pkgVersion.major}-${pkgVersion.minor}`,
+          );
+        }
+      }
+
+      const hasPnpmLock = dirents.some((dirent) => dirent.name === "pnpm-lock.yaml");
+      if (hasPnpmLock) {
+        logger.error(`Directory ${dst} doesn't have a node_modules directory, but does have a pnpm-lock.yaml.`);
+        logger.error(`Do you need to run 'pnpm install' there?`);
+        throw "missing node_modules";
+      }
+
+      logger.error(`Directory ${dst} doesn't have a node_modules directory, and does not appear to be`);
+      logger.error(`a JS package.`);
+      throw "unknown destination";
+    });
+
+    logger.info("Emitted files will be copied to:");
+    for (const dst of destinations) {
+      logger.info("  " + tildeify(dst));
+    }
+
+    const relOutputPath = path.relative(compiler.context, compiler.options.output.path);
+    // Clear destination areas and recreate output directory structure in each
+    // to ensure destinations all match the local output tree.
+    // @see https://v4.webpack.js.org/api/compiler-hooks/#afterenvironment
+    compiler.hooks.afterEnvironment.tap(PLUGIN_NAME, () => {
+      logger.warn("Deleting destinations in preparation for copied files:");
+      for (const dst of destinations) {
+        const prettyDst = tildeify(dst);
+        const stat = fs.statSync(dst);
+
+        if (stat.isDirectory()) {
+          logger.warn(`  rm -r ${prettyDst}`);
+        } else {
+          logger.warn(`  rm ${prettyDst}`);
+        }
+        fs.rmSync(dst, { recursive: stat.isDirectory() });
+
+        logger.debug(`mkdir -p ${path.join(dst, relOutputPath)}`);
+        fs.mkdirSync(path.join(dst, relOutputPath), { recursive: true });
+
+        logger.debug(`cp package.json ${path.join(dst, "package.json")}`);
+        fs.copyFileSync(
+          path.join(compiler.context, "package.json"),
+          path.join(dst, "package.json"),
+        );
+      }
+    });
+
+    // Copy files to each destination as they're emitted.
+    // @see https://v4.webpack.js.org/api/compiler-hooks/#assetemitted
+    compiler.hooks.assetEmitted.tapPromise(PLUGIN_NAME, (file) => {
+      return Promise.all(
+        destinations.map((dstBase) => {
+          const prettyDst = tildeify(dstBase);
+          const src = path.join(relOutputPath, file);
+          const dst = path.join(dstBase, relOutputPath, file);
+          logger.info(`cp ${src} ${path.join(prettyDst, relOutputPath)}`);
+          return fsp.copyFile(src, dst);
+        }),
+      );
+    });
+  }
+}
+
+/**
+ * Extracts the major and minor version number from the package at pkgRoot.
+ * @param pkgRoot {string} - the absolute path to the directory that holds the
+ *                           package's package.json
+ * @returns {object} - an object containing the major (`.major`) and minor
+ *                     (`.minor`) versions of the package
+ */
+function getPkgVersion(pkgRoot) {
+  const pkgJsonStr = fs.readFileSync(
+    path.join(pkgRoot, "package.json"),
+    "utf-8",
+  );
+  const pkgJson = JSON.parse(pkgJsonStr);
+  const version = semver.parse(pkgJson.version);
+  return {
+    major: version.major,
+    minor: version.minor,
+  };
+}
+
+/**
+ * Replaces the user's home directory with '~' in the provided path. The
+ * opposite of `detildeify`.
+ * @param {string} path - the path to replace a home directory in
+ * @returns {string} `path` but with the user's home directory swapped for '~'
+ */
+function tildeify(path) {
+  return path.replace(os.homedir(), "~");
+}
+
+/**
+ * Replaces '~' with the user's home directory in the provided path. The
+ * opposite of `tildeify`.
+ * @param {string} path - the path to replace a '~' in
+ * @returns {string} `path` but with '~' swapped for the user's home directory.
+ */
+function detildeify(path) {
+  return path.replace("~", os.homedir());
+}
+
+module.exports.CopyEmittedFilesPlugin = CopyEmittedFilesPlugin;

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -138,6 +138,8 @@
     "reselect": "^4.0.0",
     "sass": "^1.34.0",
     "sass-loader": "^10.2.0",
+    "schema-utils": "3.0.0",
+    "semver": "6.3.0",
     "sinon": "^9.0.2",
     "source-map-loader": "^0.2.4",
     "style-loader": "^1.1.3",

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -14,6 +14,8 @@ const WebpackBar = require("webpackbar");
 const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 const { ESBuildMinifyPlugin } = require("esbuild-loader");
 
+const { CopyEmittedFilesPlugin } = require("./build/webpack/copyEmittedFilesPlugin");
+
 // tslint:disable:object-literal-sort-keys
 module.exports = (env, argv) => {
   env = env || {};
@@ -168,6 +170,19 @@ module.exports = (env, argv) => {
         /node_modules\/antd\/lib\/style\/index\.less/,
         path.resolve(__dirname, "src/core/antd-patch.less"),
       ),
+      // When requested with --env.copy-to=foo, copy all emitted files to
+      // arbitrary destination(s). Note that multiple destinations are supported
+      // but providing --env.copy-to multiple times at the command-line.
+      // This plugin does nothing in one-shot (i.e. non-watch) builds, or when
+      // no destinations are provided.
+      new CopyEmittedFilesPlugin({
+        destinations: (function() {
+          const copyTo = env["copy-to"] || [];
+          return typeof copyTo === "string"
+            ? [copyTo]
+            : copyTo;
+        })(),
+      }),
     ],
 
     // When importing a module whose path matches one of the following, just

--- a/pkg/ui/workspaces/cluster-ui/yarn.lock
+++ b/pkg/ui/workspaces/cluster-ui/yarn.lock
@@ -12656,6 +12656,15 @@ schema-utils@2.7.0:
     ajv "^6.12.2"
     ajv-keywords "^3.4.1"
 
+schema-utils@3.0.0, schema-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.0.0.tgz#67502f6aa2b66a2d4032b4279a2944978a0913ef"
+  integrity sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
+  dependencies:
+    "@types/json-schema" "^7.0.6"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
+
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -12672,15 +12681,6 @@ schema-utils@^2.6.5, schema-utils@^2.7.0:
   dependencies:
     "@types/json-schema" "^7.0.5"
     ajv "^6.12.4"
-    ajv-keywords "^3.5.2"
-
-schema-utils@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.0.0.tgz#67502f6aa2b66a2d4032b4279a2944978a0913ef"
-  integrity sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
-  dependencies:
-    "@types/json-schema" "^7.0.6"
-    ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
 seamless-immutable@^7.1.3:
@@ -12703,6 +12703,11 @@ semver@5.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
+semver@6.3.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
 semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
@@ -12714,11 +12719,6 @@ semver@7.x, semver@^7.3.2, semver@^7.3.4:
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
-
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.3.5:
   version "7.3.7"


### PR DESCRIPTION
Backport 1/1 commits from #107493.

/cc @cockroachdb/release

---

Previously, watch mode builds of cluster-ui (e.g. 'dev ui watch' or 'pnpm build:watch') would emit files only to
pkg/ui/workspaces/cluster-ui/dist. Using that output in a watch task of a private repo required setting up symlinks via a 'make' task[1]. Unfortunately, that symlink made it far too easy for the node module resolution algorithm in that private repo to follow the symlink back to cockroach.git, which gave that project access to the modules in pkg/ui/node_modules/ and pkg/ui/workspaces/cluster-ui/node_modules. This resulted in webpack finding multiple copies of react-router (which expects to be a singleton), typescript finding multiple incompatible versions of react, etc.

Unfortunately, webpack doesn't support multiple output directories natively. Add a custom webpack plugin that copies emitted files to an arbitrary number of output directories.

[1] pnpm link doesn't work due to some package-name aliasing we've got
    going on there.

Release note: None
Epic: none
