### PR TITLE
ui: show txn fingerprint details page with unspecified app

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsUtils.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsUtils.tsx
@@ -41,7 +41,7 @@ export const getTxnFromSqlStatsTxns = (
   txnFingerprintID: string | null,
   apps: string[] | null,
 ): Transaction | null => {
-  if (!txns?.length || !apps?.length || !txnFingerprintID) {
+  if (!txns?.length || !txnFingerprintID) {
     return null;
   }
 
@@ -49,7 +49,7 @@ export const getTxnFromSqlStatsTxns = (
     txn =>
       txn.stats_data.transaction_fingerprint_id.toString() ===
         txnFingerprintID &&
-      (apps.length ? apps.includes(txn.stats_data.app ?? unset) : true),
+      (apps?.length ? apps.includes(txn.stats_data.app ?? unset) : true),
   );
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -82,9 +82,12 @@ interface TransactionLinkTargetProps {
 export const TransactionLinkTarget = (
   props: TransactionLinkTargetProps,
 ): string => {
-  const searchParams = propsToQueryString({
-    [appNamesAttr]: [props.application],
-  });
+  let searchParams = "";
+  if (props.application != null) {
+    searchParams = propsToQueryString({
+      [appNamesAttr]: [props.application],
+    });
+  }
 
   return `/transaction/${props.transactionFingerprintId}?${searchParams}`;
 };


### PR DESCRIPTION
Previously, when the app was not specified in the url search params for the txn details fingerprint page, the page would fail to load. This commit allows the page to load when there is no app specified but a fingerprint id that matches the requested page in the payload. The first matching fingerprint id is loaded.

Additionally, the TransactionDetailsLink will not include the appNames search param unless the provided prop is non-nullish.

Fixes: #107731

Release note (bug fix): Txn fingerprint details page in the console UI should load with the fingerprint details even if no app is specified in the URL.




Demo:
https://www.loom.com/share/810308d3dcd74ca888c42287ebafaecf