### PR TITLE
ui: fix app = empty string filter on stmts page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -75,7 +75,7 @@ import { commonStyles } from "../common";
 import { Loading, Timestamp } from "src";
 import LoadingError from "../sqlActivity/errorComponent";
 import { INTERNAL_APP_NAME_PREFIX } from "src/util/constants";
-import { filteredStatementsData } from "../sqlActivity/util";
+import { filterStatementsData } from "../sqlActivity/util";
 
 const cx = classNames.bind(styles);
 const stmtCx = classNames.bind(statementsStyles);
@@ -438,12 +438,7 @@ export class IndexDetailsPage extends React.Component<
           criteria.includes(statement.applicationName),
       );
     }
-    return filteredStatementsData(
-      filters,
-      search,
-      filteredStatements,
-      isTenant,
-    );
+    return filterStatementsData(filters, search, filteredStatements, isTenant);
   };
 
   render(): React.ReactElement {

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.spec.tsx
@@ -10,7 +10,7 @@
 
 import {
   convertRawStmtsToAggregateStatistics,
-  filteredStatementsData,
+  filterStatementsData,
   getAppsFromStmtsResponse,
 } from "src/sqlActivity/util";
 import { mockStmtStats, Stmt } from "src/api/testUtils";
@@ -18,7 +18,7 @@ import { Filters } from "src/queryFilter/filter";
 import Long from "long";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 
-describe("filteredStatementsData", () => {
+describe("filterStatementsData", () => {
   function filterAndCheckStmts(
     stmtsRaw: Stmt[],
     filters: Filters,
@@ -27,7 +27,7 @@ describe("filteredStatementsData", () => {
   ) {
     const statements = convertRawStmtsToAggregateStatistics(stmtsRaw);
 
-    const filteredStmts = filteredStatementsData(
+    const filteredStmts = filterStatementsData(
       filters,
       searchString,
       statements,

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.spec.tsx
@@ -17,6 +17,7 @@ import { mockStmtStats, Stmt } from "src/api/testUtils";
 import { Filters } from "src/queryFilter/filter";
 import Long from "long";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { unset } from "../util";
 
 describe("filterStatementsData", () => {
   function filterAndCheckStmts(
@@ -70,85 +71,139 @@ describe("filterStatementsData", () => {
     filterAndCheckStmts(stmtsRaw, {}, "giraffe", expectedIDs);
   });
 
-  it("should filter out statements not matching filter app", () => {
-    const stmtsRaw = [
-      {
-        id: 1,
-        app: "hello world",
-      },
-      {
-        id: 2,
-        app: "giraffe", // Should match.
-      },
-      {
-        id: 3,
-        app: "giraffes are cool", // Should NOT match. App names must match exactly.
-      },
-      {
-        id: 4,
-        app: "elephants cannot jump",
-      },
-      {
-        id: 5,
-        app: "gira",
-      },
-    ].map(stmt =>
+  it.each([
+    {
+      stmts: [
+        {
+          id: 1,
+          app: "hello world",
+        },
+        {
+          id: 2,
+          app: "giraffe", // Should match.
+        },
+        {
+          id: 3,
+          app: "giraffes are cool", // Should NOT match. App names must match exactly.
+        },
+        {
+          id: 4,
+          app: "elephants cannot jump",
+        },
+        {
+          id: 5,
+          app: "gira",
+        },
+      ],
+      appName: "giraffe",
+      expectedIDs: [2],
+    },
+    {
+      stmts: [
+        {
+          id: 1,
+          app: "",
+        },
+        {
+          id: 2,
+          app: "",
+        },
+        {
+          id: 3,
+          app: "hello",
+        },
+        {
+          id: 4,
+          app: "",
+        },
+        {
+          id: 5,
+          app: "",
+        },
+      ],
+      appName: unset,
+      expectedIDs: [1, 2, 4, 5],
+    },
+    {
+      stmts: [
+        {
+          id: 1,
+          app: "hello world",
+        },
+        {
+          id: 2,
+          app: "giraffes", // Should NOT match.
+        },
+        {
+          id: 3,
+          app: "giraffe", // Should match.
+        },
+        {
+          id: 4,
+          app: "elephant", // Should match.
+        },
+        {
+          id: 5,
+          app: "gira", // Should NOT match. Exact matches only.
+        },
+        {
+          id: 6,
+          app: "giraffe", // Should match.
+        },
+        {
+          id: 7,
+          app: "elephants cannot jump", // Should not match.
+        },
+      ],
+      appName: "giraffe, elephant",
+      expectedIDs: [3, 4, 6],
+    },
+    {
+      stmts: [
+        {
+          id: 1,
+          app: "hello world",
+        },
+        {
+          id: 2,
+          app: "giraffes", // Should NOT match.
+        },
+        {
+          id: 3,
+          app: "giraffe", // Should match.
+        },
+        {
+          id: 4,
+          app: "elephant", // Should match.
+        },
+        {
+          id: 5,
+          app: "gira", // Should NOT match. Exact matches only.
+        },
+        {
+          id: 6,
+          app: "giraffe", // Should match.
+        },
+        {
+          id: 7,
+          app: "elephants cannot jump", // Should not match.
+        },
+      ],
+      appName: "aaaaaaaaaaaaaaaaaaaaaaaa",
+      expectedIDs: [],
+    },
+  ])("should filter out statements not matching filter apps", tc => {
+    const stmtsRaw = tc.stmts.map(stmt =>
       mockStmtStats({
         id: Long.fromInt(stmt.id),
         key: { key_data: { app: stmt.app } },
       }),
     );
 
-    const expectedIDs = [2];
     const filters: Filters = {
-      app: "giraffe",
+      app: tc.appName,
     };
-    filterAndCheckStmts(stmtsRaw, filters, null, expectedIDs);
-  });
-
-  it("should filter out statements not matching multiple filter apps", () => {
-    const filters: Filters = {
-      app: "giraffe, elephant",
-    };
-
-    const stmtsRaw = [
-      {
-        id: 1,
-        app: "hello world",
-      },
-      {
-        id: 2,
-        app: "giraffes", // Should NOT match.
-      },
-      {
-        id: 3,
-        app: "giraffe", // Should match.
-      },
-      {
-        id: 4,
-        app: "elephant", // Should match.
-      },
-      {
-        id: 5,
-        app: "gira", // Should NOT match. Exact matches only.
-      },
-      {
-        id: 6,
-        app: "giraffe", // Should match.
-      },
-      {
-        id: 7,
-        app: "elephants cannot jump", // Should not match.
-      },
-    ].map(stmt =>
-      mockStmtStats({
-        id: Long.fromInt(stmt.id),
-        key: { key_data: { app: stmt.app } },
-      }),
-    );
-
-    const expectedIDs = [3, 4, 6];
-    filterAndCheckStmts(stmtsRaw, filters, null, expectedIDs);
+    filterAndCheckStmts(stmtsRaw, filters, null, tc.expectedIDs);
   });
 
   it("should filter out statements not matching sql type", () => {

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.tsx
@@ -43,7 +43,7 @@ export function filterBySearchQuery(
     );
 }
 
-export function filteredStatementsData(
+export function filterStatementsData(
   filters: Filters,
   search: string,
   statements: AggregateStatistics[],

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.tsx
@@ -92,7 +92,10 @@ export function filterStatementsData(
     })
     .filter(
       statement =>
-        !appNames?.length || appNames.includes(statement.applicationName),
+        !appNames?.length ||
+        appNames.includes(
+          statement.applicationName ? statement.applicationName : unset,
+        ),
     )
     .filter(statement => (filters.fullScan ? statement.fullScan : true))
     .filter(

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -81,7 +81,7 @@ import {
   StatementDiagnosticsResponse,
 } from "../api";
 import {
-  filteredStatementsData,
+  filterStatementsData,
   convertRawStmtsToAggregateStatisticsMemoized,
   getAppsFromStmtsResponseMemoized,
 } from "../sqlActivity/util";
@@ -529,7 +529,7 @@ export class StatementsPage extends React.Component<
       databases,
       hasAdminRole,
     } = this.props;
-    const data = filteredStatementsData(filters, search, statements, isTenant);
+    const data = filterStatementsData(filters, search, statements, isTenant);
 
     const apps = getAppsFromStmtsResponseMemoized(
       this.props.statementsResponse?.data,


### PR DESCRIPTION
The filter on app name = empty string was not working on
the stmts page. This was due to the fact that we use (unset)
as the option in the filter to represent selecting the empty
string app name. However when filtering statements, the empty
string app name on the stmt was not changed accordingly.
this commit fixes this and also adds testing for the unset case.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/107748

Release note (bug fix): Filter on stmts page works for
app name = empty string (represented as 'unset').

https://www.loom.com/share/2fee4f0fb7b04208803e0dac1d9694ab?sid=5cabecf9-1c2a-406b-89a8-b378ed07d329

