### PR TITLE
server,testcluster: make more tests work with secondary tenants

### DIFF
--- a/pkg/server/application_api/schema_inspection_test.go
+++ b/pkg/server/application_api/schema_inspection_test.go
@@ -22,9 +22,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
@@ -44,13 +44,13 @@ import (
 func TestAdminAPIDatabases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// Disable the default test tenant for now as this tests fails with
-		// it enabled. Tracked with #81590.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
-	ts := s.(*server.TestServer)
+	ts := s.ApplicationLayer()
 
 	ac := ts.AmbientCtx()
 	ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
@@ -110,7 +110,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 			// Test databases endpoint.
 			var resp serverpb.DatabasesResponse
 			if err := srvtestutils.GetAdminJSONProtoWithAdminOption(
-				s,
+				ts,
 				"databases",
 				&resp,
 				tc.isAdmin,
@@ -135,7 +135,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 			urlEscapeDbName := url.PathEscape(testDbName)
 
 			if err := srvtestutils.GetAdminJSONProtoWithAdminOption(
-				s,
+				ts,
 				"databases/"+urlEscapeDbName,
 				&details,
 				tc.isAdmin,
@@ -191,15 +191,16 @@ func TestAdminAPIDatabases(t *testing.T) {
 func TestAdminAPIDatabaseDoesNotExist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// Disable the default test tenant for now as this tests fails with
-		// it enabled. Tracked with #81590.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
+	ts := s.ApplicationLayer()
 
 	const errPattern = "database.+does not exist"
-	if err := srvtestutils.GetAdminJSONProto(s, "databases/i_do_not_exist", nil); !testutils.IsError(err, errPattern) {
+	if err := srvtestutils.GetAdminJSONProto(ts, "databases/i_do_not_exist", nil); !testutils.IsError(err, errPattern) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}
 }
@@ -207,17 +208,18 @@ func TestAdminAPIDatabaseDoesNotExist(t *testing.T) {
 func TestAdminAPIDatabaseSQLInjection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// Disable the default test tenant for now as this tests fails with
-		// it enabled. Tracked with #81590.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
+	ts := s.ApplicationLayer()
 
 	const fakedb = "system;DROP DATABASE system;"
 	const path = "databases/" + fakedb
 	const errPattern = `target database or schema does not exist`
-	if err := srvtestutils.GetAdminJSONProto(s, path, nil); !testutils.IsError(err, errPattern) {
+	if err := srvtestutils.GetAdminJSONProto(ts, path, nil); !testutils.IsError(err, errPattern) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}
 }
@@ -225,23 +227,24 @@ func TestAdminAPIDatabaseSQLInjection(t *testing.T) {
 func TestAdminAPITableDoesNotExist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// Disable the default test tenant for now as this tests fails with
-		// it enabled. Tracked with #81590.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
+	ts := s.ApplicationLayer()
 
 	const fakename = "i_do_not_exist"
 	const badDBPath = "databases/" + fakename + "/tables/foo"
 	const dbErrPattern = `relation \\"` + fakename + `.foo\\" does not exist`
-	if err := srvtestutils.GetAdminJSONProto(s, badDBPath, nil); !testutils.IsError(err, dbErrPattern) {
+	if err := srvtestutils.GetAdminJSONProto(ts, badDBPath, nil); !testutils.IsError(err, dbErrPattern) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, dbErrPattern)
 	}
 
 	const badTablePath = "databases/system/tables/" + fakename
 	const tableErrPattern = `relation \\"system.` + fakename + `\\" does not exist`
-	if err := srvtestutils.GetAdminJSONProto(s, badTablePath, nil); !testutils.IsError(err, tableErrPattern) {
+	if err := srvtestutils.GetAdminJSONProto(ts, badTablePath, nil); !testutils.IsError(err, tableErrPattern) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, tableErrPattern)
 	}
 }
@@ -249,17 +252,18 @@ func TestAdminAPITableDoesNotExist(t *testing.T) {
 func TestAdminAPITableSQLInjection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// Disable the default test tenant for now as this tests fails with
-		// it enabled. Tracked with #81590.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
+	ts := s.ApplicationLayer()
 
 	const fakeTable = "users;DROP DATABASE system;"
 	const path = "databases/system/tables/" + fakeTable
 	const errPattern = `relation \"system.` + fakeTable + `\" does not exist`
-	if err := srvtestutils.GetAdminJSONProto(s, path, nil); !testutils.IsError(err, regexp.QuoteMeta(errPattern)) {
+	if err := srvtestutils.GetAdminJSONProto(ts, path, nil); !testutils.IsError(err, regexp.QuoteMeta(errPattern)) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}
 }
@@ -267,6 +271,11 @@ func TestAdminAPITableSQLInjection(t *testing.T) {
 func TestAdminAPITableDetails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	const schemaName = "testschema"
 
 	for _, tc := range []struct {
 		name, dbName, tblName, pkName string
@@ -277,17 +286,12 @@ func TestAdminAPITableDetails(t *testing.T) {
 		{name: "upper", dbName: "TEST", tblName: `"TBL"`, pkName: "TBL_pkey"}, // Regression test for issue #14056
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-				// Disable the default test tenant for now as this tests fails
-				// with it enabled. Tracked with #81590.
-				DefaultTestTenant: base.TODOTestTenantDisabled,
-			})
+			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 			defer s.Stopper().Stop(context.Background())
-			ts := s.(*server.TestServer)
+			ts := s.ApplicationLayer()
 
 			escDBName := tree.NameStringP(&tc.dbName)
 			tblName := tc.tblName
-			schemaName := "testschema"
 
 			ac := ts.AmbientCtx()
 			ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
@@ -320,7 +324,7 @@ func TestAdminAPITableDetails(t *testing.T) {
 			// Perform API call.
 			var resp serverpb.TableDetailsResponse
 			url := fmt.Sprintf("databases/%s/tables/%s", tc.dbName, tblName)
-			if err := srvtestutils.GetAdminJSONProto(s, url, &resp); err != nil {
+			if err := srvtestutils.GetAdminJSONProto(ts, url, &resp); err != nil {
 				t.Fatal(err)
 			}
 
@@ -439,11 +443,14 @@ func TestAdminAPIDatabaseDetails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
 	const numServers = 3
 	tc := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(context.Background())
 
-	db := tc.ServerConn(0)
+	db := tc.ApplicationLayer(0).SQLConn(t, "")
 
 	_, err := db.Exec("CREATE DATABASE test")
 	require.NoError(t, err)
@@ -458,14 +465,14 @@ func TestAdminAPIDatabaseDetails(t *testing.T) {
 
 	// Flush all stores here so that we can read the ApproximateDiskBytes field without waiting for a flush.
 	for i := 0; i < numServers; i++ {
-		s := tc.Server(i)
+		s := tc.Server(i).StorageLayer()
 		err = s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
 			return store.TODOEngine().Flush()
 		})
 		require.NoError(t, err)
 	}
 
-	s := tc.Server(0)
+	s := tc.Server(0).ApplicationLayer()
 
 	var resp serverpb.DatabaseDetailsResponse
 	require.NoError(t, serverutils.GetJSONProto(s, "/_admin/v1/databases/test", &resp))
@@ -498,6 +505,9 @@ func TestAdminAPITableStats(t *testing.T) {
 	skip.UnderStress(t, "flaky under stress #107156")
 	skip.UnderRace(t, "flaky under race #107156")
 
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
 	const nodeCount = 3
 	tc := testcluster.StartTestCluster(t, nodeCount, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationAuto,
@@ -508,10 +518,11 @@ func TestAdminAPITableStats(t *testing.T) {
 		},
 	})
 	defer tc.Stopper().Stop(context.Background())
-	server0 := tc.Server(0)
+
+	server0 := tc.Server(0).ApplicationLayer()
 
 	// Create clients (SQL, HTTP) connected to server 0.
-	db := tc.ServerConn(0)
+	db := server0.SQLConn(t, "")
 
 	client, err := server0.GetAdminHTTPClient()
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -478,7 +478,7 @@ AND info NOT LIKE '%sql.stats%'
 ORDER BY "timestamp", info
 ----
 1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
-1  {"EventType": "set_cluster_setting", "SettingName": "kv.range_merge.queue_enabled", "Statement": "SET CLUSTER SETTING \"kv.range_merge.queue_enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
+1  {"ApplicationName": "$ internal-enable-merge-queue", "EventType": "set_cluster_setting", "SettingName": "kv.range_merge.queue_enabled", "Statement": "SET CLUSTER SETTING \"kv.range_merge.queue_enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
 1  {"EventType": "set_cluster_setting", "SettingName": "sql.crdb_internal.table_row_statistics.as_of_time", "Statement": "SET CLUSTER SETTING \"sql.crdb_internal.table_row_statistics.as_of_time\" = e'-1\\u00B5s'", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "-00:00:00.000001"}
 1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
 1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = DEFAULT", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "DEFAULT"}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2263,7 +2263,6 @@ func TestLint(t *testing.T) {
 			":!server/application_api/insights_test.go",
 			":!server/application_api/jobs_test.go",
 			":!server/application_api/query_plan_test.go",
-			":!server/application_api/schema_inspection_test.go",
 			":!server/application_api/security_test.go",
 			":!server/application_api/zcfg_test.go",
 			":!server/grpc_gateway_test.go",

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/server/serverpb",
         "//pkg/spanconfig",
         "//pkg/sql/catalog",
+        "//pkg/sql/isql",
         "//pkg/sql/randgen",
         "//pkg/storage",
         "//pkg/testutils",


### PR DESCRIPTION

Epic: CRDB-18499
Informs #76378.