### PR TITLE
jobs: add button to request execution details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -49,6 +49,8 @@ import {
 import moment from "moment-timezone";
 import { CockroachCloudContext } from "src/contexts";
 import { JobProfilerView } from "./jobProfilerView";
+import long from "long";
+import { UIConfigState } from "src/store";
 
 const { TabPane } = Tabs;
 
@@ -68,6 +70,7 @@ export interface JobDetailsStateProps {
   onDownloadExecutionFileClicked: (
     req: GetJobProfilerExecutionDetailRequest,
   ) => Promise<GetJobProfilerExecutionDetailResponse>;
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 export interface JobDetailsDispatchProps {
@@ -75,6 +78,8 @@ export interface JobDetailsDispatchProps {
   refreshExecutionDetailFiles: (
     req: ListJobProfilerExecutionDetailsRequest,
   ) => void;
+  onRequestExecutionDetails: (jobID: long) => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export interface JobDetailsState {
@@ -113,6 +118,7 @@ export class JobDetails extends React.Component<
   }
 
   componentDidMount(): void {
+    this.props.refreshUserSQLRoles();
     if (!this.props.jobRequest.data) {
       this.refresh();
     }
@@ -144,6 +150,7 @@ export class JobDetails extends React.Component<
         onDownloadExecutionFileClicked={
           this.props.onDownloadExecutionFileClicked
         }
+        onRequestExecutionDetails={this.props.onRequestExecutionDetails}
       />
     );
   };
@@ -308,11 +315,15 @@ export class JobDetails extends React.Component<
                   <TabPane tab={TabKeysEnum.OVERVIEW} key="overview">
                     {this.renderOverviewTabContent(hasNextRun, nextRun, job)}
                   </TabPane>
-                  {!useContext(CockroachCloudContext) && (
-                    <TabPane tab={TabKeysEnum.PROFILER} key="advancedDebugging">
-                      {this.renderProfilerTabContent(job)}
-                    </TabPane>
-                  )}
+                  {!useContext(CockroachCloudContext) &&
+                    this.props.hasAdminRole && (
+                      <TabPane
+                        tab={TabKeysEnum.PROFILER}
+                        key="advancedDebugging"
+                      >
+                        {this.renderProfilerTabContent(job)}
+                      </TabPane>
+                    )}
                 </Tabs>
               </>
             )}

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
@@ -11,7 +11,7 @@
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 
-import { AppState } from "src/store";
+import { AppState, uiConfigActions } from "src/store";
 import {
   JobDetailsStateProps,
   JobDetailsDispatchProps,
@@ -30,6 +30,8 @@ import {
   actions as jobProfilerActions,
 } from "src/store/jobs/jobProfiler.reducer";
 import { Dispatch } from "redux";
+import long from "long";
+import { selectHasAdminRole } from "src/store/uiConfig";
 
 const emptyState = createInitialState<JobResponse>();
 
@@ -45,6 +47,7 @@ const mapStateToProps = (
     jobProfilerLastUpdated: state.adminUI?.executionDetailFiles?.lastUpdated,
     jobProfilerDataIsValid: state.adminUI?.executionDetailFiles?.valid,
     onDownloadExecutionFileClicked: getExecutionDetailFile,
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 
@@ -52,6 +55,10 @@ const mapDispatchToProps = (dispatch: Dispatch): JobDetailsDispatchProps => ({
   refreshJob: (req: JobRequest) => jobActions.refresh(req),
   refreshExecutionDetailFiles: (req: ListJobProfilerExecutionDetailsRequest) =>
     dispatch(jobProfilerActions.refresh(req)),
+  onRequestExecutionDetails: (jobID: long) => {
+    dispatch(jobProfilerActions.collectExecutionDetails({ job_id: jobID }));
+  },
+  refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
 });
 
 export const JobDetailsPageConnected = withRouter(

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
@@ -24,3 +24,8 @@
 .sorted-table {
     width: 100%;
 }
+
+.gutter-row {
+  display: flex;
+  justify-content: right;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
@@ -50,6 +50,7 @@ export type JobProfilerDispatchProps = {
   refreshExecutionDetailFiles: (
     req: ListJobProfilerExecutionDetailsRequest,
   ) => void;
+  onRequestExecutionDetails: (jobID: long) => void;
 };
 
 export type JobProfilerViewProps = JobProfilerStateProps &
@@ -114,7 +115,7 @@ export function makeJobProfilerViewColumns(
                   );
                 onDownloadExecutionFileClicked(req).then(resp => {
                   const type = getContentTypeForFile(executionDetailFile);
-                  const executionFileBytes = new Blob([resp.data], {
+                  const executionFileBytes = new Blob([resp?.data], {
                     type: type,
                   });
                   Promise.resolve().then(() => {
@@ -143,6 +144,7 @@ export const JobProfilerView: React.FC<JobProfilerViewProps> = ({
   isDataValid,
   onDownloadExecutionFileClicked,
   refreshExecutionDetailFiles,
+  onRequestExecutionDetails,
 }: JobProfilerViewProps) => {
   const columns = makeJobProfilerViewColumns(
     jobID,
@@ -197,7 +199,22 @@ export const JobProfilerView: React.FC<JobProfilerViewProps> = ({
       <>
         <p className={summaryCardStylesCx("summary--card__divider--large")} />
         <Row gutter={24}>
-          <Col className="gutter-row" span={24}>
+          <Col className={cx("gutter-row")} span={24}>
+            <Button
+              intent="secondary"
+              onClick={() => {
+                onRequestExecutionDetails(jobID);
+              }}
+            >
+              Request Execution Details
+            </Button>
+          </Col>
+        </Row>
+        <Row gutter={24}>
+          <Col span={24}>
+            <p
+              className={summaryCardStylesCx("summary--card__divider--large")}
+            />
             <SortedTable
               data={executionDetailFilesResponse.data?.files}
               columns={columns}

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.reducer.ts
@@ -9,10 +9,11 @@
 // licenses/APL.txt.
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { DOMAIN_NAME } from "../utils";
+import { DOMAIN_NAME, noopReducer } from "../utils";
 import moment from "moment-timezone";
 import { createInitialState, RequestState } from "src/api/types";
 import {
+  CollectExecutionDetailsRequest,
   ListJobProfilerExecutionDetailsRequest,
   ListJobProfilerExecutionDetailsResponse,
 } from "src/api";
@@ -58,6 +59,15 @@ const JobProfilerExecutionDetailsSlice = createSlice({
     ) => {
       state.inFlight = true;
     },
+    collectExecutionDetails: (
+      _state,
+      _action: PayloadAction<CollectExecutionDetailsRequest>,
+    ) => {},
+    collectExecutionDetailsCompleted: noopReducer,
+    collectExecutionDetailsFailed: (
+      _state,
+      _action: PayloadAction<Error>,
+    ) => {},
   },
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobProfiler.sagas.ts
@@ -13,6 +13,7 @@ import { actions } from "./jobProfiler.reducer";
 import { call, put, all, takeEvery } from "redux-saga/effects";
 import {
   ListJobProfilerExecutionDetailsRequest,
+  collectExecutionDetails,
   listExecutionDetailFiles,
 } from "src/api";
 
@@ -33,9 +34,24 @@ export function* requestJobProfilerSaga(
   }
 }
 
+export function* collectExecutionDetailsSaga(
+  action: ReturnType<typeof actions.collectExecutionDetails>,
+) {
+  try {
+    yield call(collectExecutionDetails, action.payload);
+    yield put(actions.collectExecutionDetailsCompleted());
+    // request execution details to reflect changed state for newly
+    // requested statement.
+    yield put(actions.request());
+  } catch (e) {
+    yield put(actions.collectExecutionDetailsFailed(e));
+  }
+}
+
 export function* jobProfilerSaga() {
   yield all([
     takeEvery(actions.refresh, refreshJobProfilerSaga),
     takeEvery(actions.request, requestJobProfilerSaga),
+    takeEvery(actions.collectExecutionDetails, collectExecutionDetailsSaga),
   ]);
 }

--- a/pkg/ui/workspaces/db-console/src/redux/jobs/jobsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/jobs/jobsActions.ts
@@ -1,0 +1,41 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Action } from "redux";
+import { PayloadAction } from "src/interfaces/action";
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
+
+export const COLLECT_EXECUTION_DETAILS =
+  "cockroachui/jobs/COLLECT_EXECUTION_DETAILS";
+export const COLLECT_EXECUTION_DETAILS_COMPLETE =
+  "cockroachui/jobs/COLLECT_EXECUTION_DETAILS_COMPLETE";
+export const COLLECT_EXECUTION_DETAILS_FAILED =
+  "cockroachui/jobs/COLLECT_EXECUTION_DETAILS_FAILED";
+
+export function collectExecutionDetailsAction(
+  collectExecutionDetailsRequest: clusterUiApi.CollectExecutionDetailsRequest,
+): PayloadAction<clusterUiApi.CollectExecutionDetailsRequest> {
+  return {
+    type: COLLECT_EXECUTION_DETAILS,
+    payload: collectExecutionDetailsRequest,
+  };
+}
+
+export function collectExecutionDetailsCompleteAction(): Action {
+  return {
+    type: COLLECT_EXECUTION_DETAILS_COMPLETE,
+  };
+}
+
+export function collectExecutionDetailsFailedAction(): Action {
+  return {
+    type: COLLECT_EXECUTION_DETAILS_FAILED,
+  };
+}

--- a/pkg/ui/workspaces/db-console/src/redux/jobs/jobsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/jobs/jobsSagas.ts
@@ -1,0 +1,37 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { PayloadAction } from "@reduxjs/toolkit";
+import { refreshListExecutionDetailFiles } from "oss/src/redux/apiReducers";
+import { all, call, put, takeEvery } from "redux-saga/effects";
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
+import {
+  COLLECT_EXECUTION_DETAILS,
+  collectExecutionDetailsCompleteAction,
+  collectExecutionDetailsFailedAction,
+} from "./jobsActions";
+
+export function* collectExecutionDetailsSaga(
+  action: PayloadAction<clusterUiApi.CollectExecutionDetailsRequest>,
+) {
+  try {
+    yield call(clusterUiApi.collectExecutionDetails, action.payload);
+    yield put(collectExecutionDetailsCompleteAction());
+    yield put(refreshListExecutionDetailFiles() as any);
+  } catch (e) {
+    yield put(collectExecutionDetailsFailedAction());
+  }
+}
+
+export function* jobsSaga() {
+  yield all([
+    takeEvery(COLLECT_EXECUTION_DETAILS, collectExecutionDetailsSaga),
+  ]);
+}

--- a/pkg/ui/workspaces/db-console/src/redux/sagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sagas.ts
@@ -19,6 +19,7 @@ import { sessionsSaga } from "./sessions";
 import { sqlStatsSaga } from "./sqlStats";
 import { indexUsageStatsSaga } from "./indexUsageStats";
 import { timeScaleSaga } from "src/redux/timeScale";
+import { jobsSaga } from "./jobs/jobsSagas";
 
 export default function* rootSaga() {
   yield all([
@@ -26,6 +27,7 @@ export default function* rootSaga() {
     fork(localSettingsSaga),
     fork(customAnalyticsSaga),
     fork(statementsSaga),
+    fork(jobsSaga),
     fork(analyticsSaga),
     fork(sessionsSaga),
     fork(sqlStatsSaga),

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
@@ -18,10 +18,14 @@ import {
   createSelectorForKeyedCachedDataField,
   refreshListExecutionDetailFiles,
   refreshJob,
+  refreshUserSQLRoles,
 } from "src/redux/apiReducers";
-import { AdminUIState } from "src/redux/state";
+import { AdminUIState, AppDispatch } from "src/redux/state";
 import { ListJobProfilerExecutionDetailsResponseMessage } from "src/util/api";
 import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
+import { collectExecutionDetailsAction } from "oss/src/redux/jobs/jobsActions";
+import long from "long";
+import { selectHasAdminRole } from "src/redux/user";
 
 const selectJob = createSelectorForKeyedCachedDataField("job", selectID);
 const selectExecutionDetailFiles =
@@ -43,12 +47,19 @@ const mapStateToProps = (
     jobProfilerLastUpdated: state.cachedData.jobProfiler[jobID]?.setAt,
     jobProfilerDataIsValid: state.cachedData.jobProfiler[jobID]?.valid,
     onDownloadExecutionFileClicked: clusterUiApi.getExecutionDetailFile,
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 
 const mapDispatchToProps = {
   refreshJob,
   refreshExecutionDetailFiles: refreshListExecutionDetailFiles,
+  onRequestExecutionDetails: (jobID: long) => {
+    return (dispatch: AppDispatch) => {
+      dispatch(collectExecutionDetailsAction({ job_id: jobID }));
+    };
+  },
+  refreshUserSQLRoles: refreshUserSQLRoles,
 };
 
 export default withRouter(


### PR DESCRIPTION
This is the last of the three PRs to add support
for requesting, viewing and downloading execution
details from the job details page.

This change wires up the logic needed to request
the execution details for a given job. The request
is powered by the crdb_internal.request_job_execution_details
builtin that triggers the collection of execution details.

Fixes: https://github.com/cockroachdb/cockroach/issues/105076
Release note: None