### PR TITLE
sql: allow UDFs and builtins with SQL bodies in prepared stmt arguments

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2201,6 +2201,13 @@ func TestTenantLogic_udf_plpgsql(
 	runLogicTest(t, "udf_plpgsql")
 }
 
+func TestTenantLogic_udf_prepare(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_prepare")
+}
+
 func TestTenantLogic_udf_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -35,7 +35,6 @@ func (p *planner) fillInPlaceholders(
 	}
 
 	qArgs := make(tree.QueryArguments, len(params))
-	var semaCtx tree.SemaContext
 	for i, e := range params {
 		idx := tree.PlaceholderIdx(i)
 
@@ -54,7 +53,7 @@ func (p *planner) fillInPlaceholders(
 			}
 		}
 		typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
-			ctx, e, typ, "EXECUTE parameter" /* context */, &semaCtx, volatility.Volatile, true, /*allowAssignmentCast*/
+			ctx, e, typ, "EXECUTE parameter" /* context */, p.SemaCtx(), volatility.Volatile, true, /*allowAssignmentCast*/
 		)
 		if err != nil {
 			return nil, pgerror.WithCandidateCode(err, pgcode.WrongObjectType)

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -888,3 +888,17 @@ select nameconcatoid(repeat('a', 62), 2), length(nameconcatoid(repeat('a', 62), 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_2  63
 
 subtest end
+
+# Built-ins defined with a SQL Body can be used as prepared statement arguments.
+statement ok
+PREPARE p_sql_body AS SELECT '[' || $1::TEXT || ']'
+
+query T
+EXECUTE p_sql_body(nameconcatoid('name', 12345))
+----
+[name_12345]
+
+query T
+EXECUTE p_sql_body('(' || nameconcatoid('name', 12345) || ')')
+----
+[(name_12345)]

--- a/pkg/sql/logictest/testdata/logic_test/udf_prepare
+++ b/pkg/sql/logictest/testdata/logic_test/udf_prepare
@@ -1,0 +1,8 @@
+statement ok
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$
+
+statement ok
+PREPARE p AS SELECT $1::INT
+
+statement error pgcode 0A000 cannot evaluate function in this context
+EXECUTE p(f())

--- a/pkg/sql/logictest/testdata/logic_test/udf_prepare
+++ b/pkg/sql/logictest/testdata/logic_test/udf_prepare
@@ -1,8 +1,61 @@
 statement ok
-CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$
+CREATE FUNCTION one() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$
 
 statement ok
-PREPARE p AS SELECT $1::INT
+PREPARE p1 AS SELECT $1::INT
 
-statement error pgcode 0A000 cannot evaluate function in this context
-EXECUTE p(f())
+query I
+EXECUTE p1(one())
+----
+1
+
+query I
+EXECUTE p1(10 + one() + 10)
+----
+21
+
+statement ok
+CREATE TABLE ab (
+  a INT,
+  b INT
+);
+INSERT INTO ab VALUES (1, 10), (2, 20)
+
+statement ok
+PREPARE p2 AS SELECT * FROM ab WHERE a >= $1
+
+query II rowsort
+EXECUTE p2(one())
+----
+1  10
+2  20
+
+query II
+EXECUTE p2(one() + 1)
+----
+2  20
+
+statement error pgcode 42601 variable sub-expressions are not allowed in EXECUTE parameter
+EXECUTE p2(one() + a)
+
+statement ok
+CREATE TABLE parent (id INT PRIMARY KEY);
+CREATE TABLE child (id INT PRIMARY KEY, p_id INT NOT NULL REFERENCES parent(id) ON DELETE CASCADE);
+INSERT INTO parent VALUES (1), (3);
+INSERT INTO child VALUES (10, 1), (30, 3);
+
+statement ok
+PREPARE del AS DELETE FROM parent WHERE id = $1
+
+statement ok
+EXECUTE del(one())
+
+query I
+SELECT * FROM parent
+----
+3
+
+query II
+SELECT * FROM child
+----
+30  3

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2165,6 +2165,13 @@ func TestLogic_udf_plpgsql(
 	runLogicTest(t, "udf_plpgsql")
 }
 
+func TestLogic_udf_prepare(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_prepare")
+}
+
 func TestLogic_udf_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2172,6 +2172,13 @@ func TestLogic_udf_plpgsql(
 	runLogicTest(t, "udf_plpgsql")
 }
 
+func TestLogic_udf_prepare(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_prepare")
+}
+
 func TestLogic_udf_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2186,6 +2186,13 @@ func TestLogic_udf_plpgsql(
 	runLogicTest(t, "udf_plpgsql")
 }
 
+func TestLogic_udf_prepare(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_prepare")
+}
+
 func TestLogic_udf_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2165,6 +2165,13 @@ func TestLogic_udf_plpgsql(
 	runLogicTest(t, "udf_plpgsql")
 }
 
+func TestLogic_udf_prepare(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_prepare")
+}
+
 func TestLogic_udf_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -2102,6 +2102,13 @@ func TestLogic_udf_plpgsql(
 	runLogicTest(t, "udf_plpgsql")
 }
 
+func TestLogic_udf_prepare(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_prepare")
+}
+
 func TestLogic_udf_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2193,6 +2193,13 @@ func TestLogic_udf_plpgsql(
 	runLogicTest(t, "udf_plpgsql")
 }
 
+func TestLogic_udf_prepare(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_prepare")
+}
+
 func TestLogic_udf_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2389,6 +2389,13 @@ func TestLogic_udf_plpgsql(
 	runLogicTest(t, "udf_plpgsql")
 }
 
+func TestLogic_udf_prepare(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_prepare")
+}
+
 func TestLogic_udf_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -865,7 +865,7 @@ func (h *harness) runPrepared(tb testing.TB, phase Phase) {
 		if phase == AssignPlaceholdersNoNorm {
 			h.optimizer.DisableOptimizations()
 		}
-		err := h.optimizer.Factory().AssignPlaceholders(h.prepMemo)
+		err := h.optimizer.Factory().AssignPlaceholders(h.prepMemo, nil /* buildPlaceholderAsScalar */)
 		if err != nil {
 			tb.Fatalf("%v", err)
 		}

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/opt/exec/explain",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",
+        "//pkg/sql/opt/optbuilder",
         "//pkg/sql/opt/ordering",
         "//pkg/sql/opt/props",
         "//pkg/sql/opt/props/physical",

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -288,11 +288,7 @@ func (cb *cascadeBuilder) planCascade(
 			if !ok {
 				return nil, errors.AssertionFailedf("placeholder value for %s not provided", placeholder.Idx)
 			}
-			err := bld.Build(texpr)
-			if err != nil {
-				return nil, err
-			}
-			return factory.Memo().RootExpr().(opt.ScalarExpr), nil
+			return bld.Build(texpr)
 		}
 		if err := factory.AssignPlaceholders(preparedMemo, buildPlaceholderAsScalar); err != nil {
 			return nil, errors.Wrap(err, "while assigning placeholders in cascade expression")

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf_prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf_prepare
@@ -1,0 +1,27 @@
+# LogicTest: local
+
+statement ok
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$
+
+statement ok
+PREPARE p AS SELECT $1::INT
+
+query T
+EXPLAIN ANALYZE EXECUTE p(f())
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• values
+  nodes: <hidden>
+  regions: <hidden>
+  actual row count: 1
+  size: 1 column, 1 row

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -623,6 +623,13 @@ func TestExecBuild_udf(
 	runExecBuildLogicTest(t, "udf")
 }
 
+func TestExecBuild_udf_prepare(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "udf_prepare")
+}
+
 func TestExecBuild_union(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -120,10 +120,10 @@ func TestIndexConstraints(t *testing.T) {
 					computedCols = make(map[opt.ColumnID]opt.ScalarExpr)
 					for col, expr := range sv.ComputedCols() {
 						b := optbuilder.NewScalar(context.Background(), &semaCtx, &evalCtx, &f)
-						if err := b.Build(expr); err != nil {
+						computedColExpr, err := b.Build(expr)
+						if err != nil {
 							d.Fatalf(t, "error building computed column expression: %v", err)
 						}
-						computedColExpr := f.Memo().RootExpr().(opt.ScalarExpr)
 						computedCols[col] = computedColExpr
 						var sharedProps props.Shared
 						memo.BuildSharedProps(computedColExpr, &sharedProps, &evalCtx)
@@ -314,10 +314,10 @@ func buildFilters(
 		return memo.FiltersExpr{}, err
 	}
 	b := optbuilder.NewScalar(context.Background(), semaCtx, evalCtx, f)
-	if err := b.Build(expr); err != nil {
+	root, err := b.Build(expr)
+	if err != nil {
 		return memo.FiltersExpr{}, err
 	}
-	root := f.Memo().RootExpr().(opt.ScalarExpr)
 	if _, ok := root.(*memo.TrueExpr); ok {
 		return memo.TrueFilter, nil
 	}

--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -103,10 +103,10 @@ func TestLookupConstraints(t *testing.T) {
 							return 0, opt.ColSet{}, err
 						}
 						b := optbuilder.NewScalar(context.Background(), &semaCtx, &evalCtx, &f)
-						if err := b.Build(expr); err != nil {
+						compExpr, err := b.Build(expr)
+						if err != nil {
 							return 0, opt.ColSet{}, err
 						}
-						compExpr := f.Memo().RootExpr().(opt.ScalarExpr)
 						var sharedProps props.Shared
 						memo.BuildSharedProps(compExpr, &sharedProps, &evalCtx)
 						md.TableMeta(tableID).AddComputedCol(colID, compExpr, sharedProps.OuterCols)
@@ -312,11 +312,10 @@ func makeFiltersExpr(
 	}
 
 	b := optbuilder.NewScalar(context.Background(), semaCtx, evalCtx, f)
-	if err := b.Build(expr); err != nil {
+	root, err := b.Build(expr)
+	if err != nil {
 		return nil, err
 	}
-
-	root := f.Memo().RootExpr().(opt.ScalarExpr)
 
 	return memo.FiltersExpr{f.ConstructFiltersItem(root)}, nil
 }

--- a/pkg/sql/opt/memo/expr_test.go
+++ b/pkg/sql/opt/memo/expr_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
@@ -93,11 +92,11 @@ func TestExprIsNeverNull(t *testing.T) {
 				}
 
 				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory())
-				err = b.Build(expr)
+				scalar, err := b.Build(expr)
 				if err != nil {
 					return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
 				}
-				result := memo.ExprIsNeverNull(o.Memo().RootExpr().(opt.ScalarExpr), sv.NotNullCols())
+				result := memo.ExprIsNeverNull(scalar, sv.NotNullCols())
 				return fmt.Sprintf("%t\n", result)
 
 			default:

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -313,12 +313,6 @@ func (m *Memo) SetRoot(e RelExpr, phys *physical.Required) {
 	}
 }
 
-// SetScalarRoot stores the root memo expression when it is a scalar expression.
-// Used only for testing.
-func (m *Memo) SetScalarRoot(scalar opt.ScalarExpr) {
-	m.rootExpr = scalar
-}
-
 // HasPlaceholders returns true if the memo contains at least one placeholder
 // operator.
 func (m *Memo) HasPlaceholders() bool {

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -97,10 +97,11 @@ func TestCompositeSensitive(t *testing.T) {
 		}
 
 		b := optbuilder.NewScalar(context.Background(), &semaCtx, &evalCtx, &f)
-		if err := b.Build(expr); err != nil {
+		scalar, err := b.Build(expr)
+		if err != nil {
 			d.Fatalf(t, "error building: %v", err)
 		}
-		return fmt.Sprintf("%v", memo.CanBeCompositeSensitive(md, f.Memo().RootExpr()))
+		return fmt.Sprintf("%v", memo.CanBeCompositeSensitive(md, scalar))
 	})
 }
 

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -112,14 +112,14 @@ func TestBuilder(t *testing.T) {
 				// of the build process.
 				o.DisableOptimizations()
 				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory())
-				err = b.Build(expr)
+				scalar, err := b.Build(expr)
 				if err != nil {
 					return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
 				}
 				f := memo.MakeExprFmtCtx(
 					ctx, tester.Flags.ExprFormat, false /* redactableValues */, o.Memo(), catalog,
 				)
-				f.FormatExpr(o.Memo().RootExpr())
+				f.FormatExpr(scalar)
 				return f.Buffer.String()
 
 			default:

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -1177,7 +1177,7 @@ func NewScalar(
 
 // Build a memo structure from a TypedExpr: the root group represents a scalar
 // expression equivalent to expr.
-func (sb *ScalarBuilder) Build(expr tree.Expr) (err error) {
+func (sb *ScalarBuilder) Build(expr tree.Expr) (_ opt.ScalarExpr, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			// This code allows us to propagate errors without adding lots of checks
@@ -1194,8 +1194,7 @@ func (sb *ScalarBuilder) Build(expr tree.Expr) (err error) {
 
 	typedExpr := sb.scope.resolveType(expr, types.Any)
 	scalar := sb.buildScalar(typedExpr, &sb.scope, nil, nil, nil)
-	sb.factory.Memo().SetScalarRoot(scalar)
-	return nil
+	return scalar, nil
 }
 
 // reType is similar to tree.ReType, except that it panics with an internal

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -370,11 +370,10 @@ func makeFiltersExpr(
 	}
 
 	b := optbuilder.NewScalar(context.Background(), semaCtx, evalCtx, f)
-	if err := b.Build(expr); err != nil {
+	root, err := b.Build(expr)
+	if err != nil {
 		return nil, err
 	}
-
-	root := f.Memo().RootExpr().(opt.ScalarExpr)
 
 	return memo.FiltersExpr{f.ConstructFiltersItem(root)}, nil
 }

--- a/pkg/sql/opt/testutils/build.go
+++ b/pkg/sql/opt/testutils/build.go
@@ -57,11 +57,12 @@ func BuildScalar(
 	}
 
 	b := optbuilder.NewScalar(context.Background(), semaCtx, evalCtx, f)
-	if err := b.Build(expr); err != nil {
+	root, err := b.Build(expr)
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	return f.Memo().RootExpr().(opt.ScalarExpr)
+	return root
 }
 
 // BuildFilters builds the given input string as a FiltersExpr and returns it.

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1261,7 +1261,7 @@ func (ot *OptTester) AssignPlaceholders(
 	o.NotifyOnMatchedRule(maybeDisableRule)
 
 	o.Factory().FoldingControl().AllowStableFolds()
-	if err := o.Factory().AssignPlaceholders(prepMemo); err != nil {
+	if err := o.Factory().AssignPlaceholders(prepMemo, nil /* buildPlaceholderAsScalar */); err != nil {
 		return nil, err
 	}
 	return o.Optimize()

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -509,11 +509,7 @@ func (opc *optPlanningCtx) reuseMemo(
 		if !ok {
 			return nil, errors.AssertionFailedf("placeholder value for %s not provided", placeholder.Idx)
 		}
-		err := bld.Build(texpr)
-		if err != nil {
-			return nil, err
-		}
-		return f.Memo().RootExpr().(opt.ScalarExpr), nil
+		return bld.Build(texpr)
 	}
 	if err := f.AssignPlaceholders(cachedMemo, buildPlaceholderAsScalar); err != nil {
 		return nil, err

--- a/pkg/sql/sem/eval/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test.go
@@ -100,12 +100,13 @@ func optBuildScalar(evalCtx *eval.Context, e tree.Expr) (tree.TypedExpr, error) 
 	o.Init(ctx, evalCtx, nil /* catalog */)
 	semaCtx := tree.MakeSemaContext()
 	b := optbuilder.NewScalar(ctx, &semaCtx, evalCtx, o.Factory())
-	if err := b.Build(e); err != nil {
+	scalar, err := b.Build(e)
+	if err != nil {
 		return nil, err
 	}
 
 	bld := execbuilder.New(
-		ctx, nil /* factory */, &o, o.Memo(), nil /* catalog */, o.Memo().RootExpr(),
+		ctx, nil /* factory */, &o, o.Memo(), nil /* catalog */, scalar,
 		evalCtx, false, /* allowAutoCommit */
 		false, /* isANSIDML */
 	)

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -476,6 +476,10 @@ func (e *evaluator) EvalFuncExpr(ctx context.Context, expr *tree.FuncExpr) (tree
 		return tree.DNull, err
 	}
 
+	if fn.Body != "" {
+		return nil, pgerror.Newf(pgcode.FeatureNotSupported, "cannot evaluate function in this context")
+	}
+
 	res, err := fn.Fn.(FnOverload)(ctx, e.ctx(), args)
 	if err != nil {
 		return nil, expr.MaybeWrapError(err)


### PR DESCRIPTION
#### sql: prevent panic when using UDF as EXECUTE argument

Informs #99008

Release note (bug fix): A bug has been fixed that caused nodes to crash
when attempting to `EXECUTE` a prepared statement with an argument that
referenced a user-defined function. This bug was present since
user-defined functions were introduces in version 22.2.

#### sql: allow UDFs and builtins with SQL bodies in prepared stmt arguments

User-defined functions and builtin functions defined with SQL bodies can
now be used as arguments when executing prepared statements. This was
not previously allowed because placeholders could only be assigned from
constant values that resulted from evaluating the typed expressions
representing the placeholder arguments. This did not work for functions
defined with SQL bodies because they cannot simply be evaluated like
other AST trees and they must be built by the optimizer and turned into
`tree.RoutineExpr`s.

This commit lifts the restriction by falling back to building
placeholders as `opt.ScalarExpr`s if evaluation of the typed expression
fails.

Fixes #99008

Release note (sql change): User-defined functions can now be used as
placeholder arguments when executing prepared statements with `EXECUTE`.

#### opt: simplify ScalarBuilder.Build

Release note: None