### PR TITLE
[dnm] testcluster: skip tests using test cluster by default

### DIFF
--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/testutils",
         "//pkg/testutils/listenerutil",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/util/allstacks",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/listenerutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -243,6 +244,9 @@ func NewTestCluster(t testing.TB, nodes int, clusterArgs base.TestClusterArgs) *
 	if nodes < 1 {
 		t.Fatal("invalid cluster size: ", nodes)
 	}
+	if SkipTestClusterTests {
+		skip.IgnoreLint(t, "SkipTestClusterTests is set")
+	}
 
 	if err := checkServerArgsForCluster(
 		clusterArgs.ServerArgs, clusterArgs.ReplicationMode, disallowJoinAddr,
@@ -350,6 +354,10 @@ func NewTestCluster(t testing.TB, nodes int, clusterArgs base.TestClusterArgs) *
 	return tc
 }
 
+// SkipTestClusterTests results in all tests trying to start a TestCluster being
+// skipped.
+var SkipTestClusterTests = true
+
 // Start is the companion method to NewTestCluster, and is responsible for
 // actually starting up the cluster. Start waits for each server to be fully up
 // and running.
@@ -358,6 +366,9 @@ func NewTestCluster(t testing.TB, nodes int, clusterArgs base.TestClusterArgs) *
 // in a separate thread and with ParallelStart enabled (otherwise it'll block
 // on waiting for init for the first server).
 func (tc *TestCluster) Start(t testing.TB) {
+	if SkipTestClusterTests {
+		t.Fatalf("SkipTestClusterTests is set")
+	}
 	nodes := len(tc.Servers)
 	var errCh chan error
 	if tc.clusterArgs.ParallelStart {


### PR DESCRIPTION
```mermaid
pie title Coverage Gain
    "Free Coverage" : 34
    "Unit" : 30
    "Testcluster" : 17
    "No coverage": 19
```

https://cockroachlabs.slack.com/archives/CFPPAJMKR/p1690530404493519

Methodology for kvserver pkg:

```
go test -tags crdb_test -covermode=count -coverprofile=cover-$(git rev-parse HEAD).out ./pkg/kv/kvserver/ -v 2>&1 | tee log.txt
```

- run TestReplicaGossipFirstRange (not a testcluster test but sets up Store+Replica), which results in the "unavoidable coverage": X percent
  `ok      github.com/cockroachdb/cockroach/pkg/kv/kvserver        0.361s  coverage: 17.4% of statements`

- run only TestErrorHandlingForNonKVCommand (a TestServer test that doesn't do much other than start single node), I would call that coverage unavoidable as well; the test isn't trying to assert anything in particular
  `ok      github.com/cockroachdb/cockroach/pkg/kv/kvserver        1.716s  coverage: 34.4% of statements`
  
- run kvserver tests, but skipping all testcluster tests: Y percent
  `ok      github.com/cockroachdb/cockroach/pkg/kv/kvserver        211.125s        coverage: 64.2% of statements`

- run all kvserver tests: Z percent
  `coverage: 80.0% of statements` (some tests failed)	

So of the 66 percent of coverage that we have to "work for", we get only 47 percent, and a third of that is through TestCluster.

Looking at the coverage line-by-line may inform this statement further.