### PR TITLE
release-23.1: sql/schemachanger: DROP INDEX could drop unrelated foreign keys

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -565,3 +565,40 @@ t_with_idx_data_loss  relation "t_with_idx_data_loss" (125): primary index "t_wi
 
 statement ok
 DROP TABLE t_with_idx_data_loss;
+
+
+# In #107576 we had a bug where we were not correctly resolving foreign key
+# references by filtering down to the target table for DROP INDEX. As a side effect
+# we could end up cleaning foreign key references in other unrelated tables. In
+# the example below fk_drop_other has foreign key back references which are not
+# relevant.
+subtest drop_index_fk_check
+
+statement ok
+CREATE TABLE fk_drop_target
+ ( k int primary key,
+   j int);
+CREATE TABLE fk_drop_ref_src(
+  k int,
+  j int primary key);
+CREATE UNIQUE INDEX target_j
+     ON fk_drop_target(j);
+ CREATE TABLE fk_ref_dst(
+  k int primary key,
+  j int,
+  m int,
+   CONSTRAINT "j_fk" FOREIGN KEY (j) REFERENCES
+       fk_drop_target(k),
+   CONSTRAINT m_fk   FOREIGN KEY (m) REFERENCES
+        fk_drop_ref_src(j)
+ );
+
+statement ok
+DROP INDEX fk_drop_target@target_j CASCADE;
+
+query T rowsort
+SELECT constraint_name from [SHOW CONSTRAINTS FROM fk_ref_dst];
+----
+fk_ref_dst_pkey
+j_fk
+m_fk

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -417,6 +417,22 @@ func statusPublicFilter(status scpb.Status, _ scpb.TargetStatus, _ scpb.Element)
 	return status == scpb.Status_PUBLIC
 }
 
+func containsDescIDFilter(
+	descID catid.DescID,
+) func(_ scpb.Status, _ scpb.TargetStatus, _ scpb.Element) bool {
+	return func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) (included bool) {
+		return screl.ContainsDescID(e, descID)
+	}
+}
+
+func hasTableID(
+	tableID catid.DescID,
+) func(_ scpb.Status, _ scpb.TargetStatus, _ scpb.Element) bool {
+	return func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) (included bool) {
+		return screl.GetDescID(e) == tableID
+	}
+}
+
 func hasIndexIDAttrFilter(
 	indexID catid.IndexID,
 ) func(_ scpb.Status, _ scpb.TargetStatus, _ scpb.Element) bool {


### PR DESCRIPTION
Backport 1/1 commits from #107633.

/cc @cockroachdb/release

---

Previously, when DROP INDEX was resolving and iterating over foreign keys, it did not validate that these foreign keys were related to the index we were dropping. As a result, if any table referred back to the target table with the index, we would analyze its foreign keys. If cascade wasn't specified this could incorrectly end up blocking the DROP INDEX on unrelated foreign key references assuming they need our index. Or worse with cascade we could remove foreign key constraints in other tables. To address this, this patch filters the back references to only look at ones related to the target table, which causes the correct set to be analyzed / dropped.

Fixes: #107576

Release note (bug fix): Dropping an index could end up failing or cleaning foreign keys (when CASCADE is specified) on other tables referencing the target table with this index.

Release justification: low risk and resolves bug that can cause foreign keys to be incorrectly removed
