### PR TITLE
cluster-ui: delete unused vars

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
@@ -93,11 +93,7 @@ const getDatabaseId: DatabaseDetailsQuery<DatabaseIdRow> = {
       resp.idResp.error = txn_result.error;
     }
   },
-  handleMaxSizeError: (
-    dbName: string,
-    response: SqlTxnResult<DatabaseIdRow>,
-    dbDetail: DatabaseDetailsResponse,
-  ) => {
+  handleMaxSizeError: (_dbName, _response, _dbDetail) => {
     return new Promise<boolean>(() => false);
   },
 };
@@ -135,11 +131,7 @@ const getDatabaseGrantsQuery: DatabaseDetailsQuery<DatabaseGrantsRow> = {
       }
     }
   },
-  handleMaxSizeError: (
-    dbName: string,
-    response: SqlTxnResult<DatabaseGrantsRow>,
-    dbDetail: DatabaseDetailsResponse,
-  ) => {
+  handleMaxSizeError: (_dbName, _response, _dbDetail) => {
     return new Promise<boolean>(() => false);
   },
 };
@@ -284,11 +276,7 @@ const getDatabaseZoneConfig: DatabaseDetailsQuery<DatabaseZoneConfigRow> = {
       resp.idResp.error = txn_result.error;
     }
   },
-  handleMaxSizeError: (
-    dbName: string,
-    response: SqlTxnResult<DatabaseZoneConfigRow>,
-    dbDetail: DatabaseDetailsResponse,
-  ) => {
+  handleMaxSizeError: (_dbName, _response, _dbDetail) => {
     return new Promise<boolean>(() => false);
   },
 };
@@ -341,11 +329,7 @@ const getDatabaseSpanStats: DatabaseDetailsQuery<DatabaseSpanStatsRow> = {
       );
     }
   },
-  handleMaxSizeError: (
-    dbName: string,
-    response: SqlTxnResult<DatabaseSpanStatsRow>,
-    dbDetail: DatabaseDetailsResponse,
-  ) => {
+  handleMaxSizeError: (_dbName, _response, _dbDetail) => {
     return new Promise<boolean>(() => false);
   },
 };
@@ -390,11 +374,7 @@ const getDatabaseReplicasAndRegions: DatabaseDetailsQuery<DatabaseReplicasRegion
         resp.stats.replicaData.error = txn_result.error;
       }
     },
-    handleMaxSizeError: (
-      dbName: string,
-      response: SqlTxnResult<DatabaseReplicasRegionsRow>,
-      dbDetail: DatabaseDetailsResponse,
-    ) => {
+    handleMaxSizeError: (_dbName, _response, _dbDetail) => {
       return new Promise<boolean>(() => false);
     },
   };
@@ -444,11 +424,7 @@ const getDatabaseIndexUsageStats: DatabaseDetailsQuery<IndexUsageStatistic> = {
       resp.stats.indexStats.error = txn_result.error;
     }
   },
-  handleMaxSizeError: (
-    dbName: string,
-    response: SqlTxnResult<IndexUsageStatistic>,
-    dbDetail: DatabaseDetailsResponse,
-  ) => {
+  handleMaxSizeError: (_dbName, _response, _dbDetail) => {
     return new Promise<boolean>(() => false);
   },
 };

--- a/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.tsx
@@ -86,7 +86,7 @@ const customStyles = {
     ...provided,
     maxHeight: "310px",
   }),
-  option: (provided: any, state: any) => ({
+  option: (provided: any, _state: any) => ({
     ...provided,
     backgroundColor: "white",
     color: "#475872",

--- a/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
@@ -26,7 +26,6 @@ import { DatabaseTablePageDataDetails, IndexStat } from "../databaseTablePage";
 import { IndexStatsState } from "../store/indexStats";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { RecommendationType as RecType } from "../indexDetailsPage";
-import { TableIndexStatsResponse } from "../api/indexDetailsApi";
 type IndexUsageStatistic =
   cockroach.server.serverpb.TableIndexStatsResponse.IExtendedCollectedIndexUsageStatistics;
 const { RecommendationType } = cockroach.sql.IndexRecommendation;

--- a/pkg/ui/workspaces/cluster-ui/src/databases/util.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/util.spec.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { assert } from "chai";
 import {
   getNodesByRegionString,
   normalizePrivileges,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
@@ -19,7 +19,7 @@ import {
   TransactionDetailsLink,
 } from "../workloadInsights/util";
 import { TimeScale } from "../../timeScaleDropdown";
-import { Timestamp, Timezone } from "../../timestamp";
+import { Timestamp } from "../../timestamp";
 
 interface InsightDetailsTableProps {
   data: ContentionEvent[];

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -76,7 +76,6 @@ export const StatementInsightDetails: React.FC<
   isTenant,
   timeScale,
   hasAdminRole,
-  setTimeScale,
   refreshUserSQLRoles,
 }) => {
   const [explainPlanState, setExplainPlanState] = useState<ExplainPlanState>({

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -33,7 +33,6 @@ import {
   StatementDetailsLink,
   TransactionDetailsLink,
 } from "../workloadInsights/util";
-import { TimeScale } from "../../timeScaleDropdown";
 import { getStmtInsightRecommendations } from "../utils";
 import { ContentionStatementDetailsTable } from "./insightDetailsTables";
 import { WaitTimeInsightsLabels } from "../../detailsPanels/waitTimeInsightsPanel";

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -36,9 +36,8 @@ import { Tooltip } from "@cockroachlabs/ui-components";
 import { Link } from "react-router-dom";
 import classNames from "classnames/bind";
 import styles from "../util/workloadInsights.module.scss";
-import { TimeScale } from "../../../timeScaleDropdown";
 import { Badge } from "src/badge";
-import { Timestamp, Timezone } from "../../../timestamp";
+import { Timestamp } from "../../../timestamp";
 
 const cx = classNames.bind(styles);
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -112,7 +112,6 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
   selectedColumnNames,
   dropDownSelect,
   maxSizeApiReached,
-  isTenant,
 }: StatementInsightsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -166,19 +166,19 @@ export const insightsTableTitles: InsightsTableTitleType = {
       "username",
     );
   },
-  schemaName: (execType: InsightExecEnum) => {
+  schemaName: (_execType: InsightExecEnum) => {
     return makeToolTip(<p>The name of the contended schema.</p>, "schemaName");
   },
-  databaseName: (execType: InsightExecEnum) => {
+  databaseName: (_execType: InsightExecEnum) => {
     return makeToolTip(
       <p>The name of the contended database.</p>,
       "databaseName",
     );
   },
-  tableName: (execType: InsightExecEnum) => {
+  tableName: (_execType: InsightExecEnum) => {
     return makeToolTip(<p>The name of the contended table.</p>, "tableName");
   },
-  indexName: (execType: InsightExecEnum) => {
+  indexName: (_execType: InsightExecEnum) => {
     return makeToolTip(<p>The name of the contended index.</p>, "indexName");
   },
   applicationName: (execType: InsightExecEnum) => {

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.spec.tsx
@@ -13,13 +13,12 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { JobsPage, JobsPageProps } from "./jobsPage";
 import { formatDuration } from "../util/duration";
 import { allJobsFixture, earliestRetainedTime } from "./jobsPage.fixture";
-import { prettyDOM, prettyFormat, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import * as H from "history";
 
 import Job = cockroach.server.serverpb.IJobResponse;
-import { CoordinatedUniversalTime, TimezoneContext } from "src/contexts";
 
 const getMockJobsPageProps = (jobs: Array<Job>): JobsPageProps => {
   const history = H.createHashHistory();

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/schedulesPage.fixture.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/schedulesPage.fixture.tsx
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { createMemoryHistory } from "history";
 import Long from "long";
 import moment from "moment-timezone";

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/schedulesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/schedulesPage.tsx
@@ -14,7 +14,7 @@ import { Helmet } from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 import { Schedules } from "src/api/schedulesApi";
 import { Delayed } from "src/delayed";
-import { Dropdown, DropdownOption } from "src/dropdown";
+import { Dropdown } from "src/dropdown";
 import { Loading } from "src/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
 import { SortSetting } from "src/sortedtable";

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutions.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutions.selectors.ts
@@ -9,12 +9,7 @@
 // licenses/APL.txt.
 
 import { createSelector } from "reselect";
-import {
-  ActiveExecutions,
-  ActiveTransaction,
-  ExecutionStatus,
-  ExecutionType,
-} from "src/activeExecutions/types";
+import { ActiveExecutions } from "src/activeExecutions/types";
 import { AppState } from "src/store";
 import { selectActiveExecutionsCombiner } from "src/selectors/activeExecutionsCommon.selectors";
 import { selectExecutionID } from "src/selectors/common";

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/common.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/common.ts
@@ -15,17 +15,7 @@ import {
   idAttr,
   statementAttr,
   txnFingerprintIdAttr,
-  unset,
-  ExecutionStatistics,
-  queryByName,
-  appAttr,
-  flattenStatementStats,
-  FixFingerprintHexValue,
 } from "src/util";
-import { createSelector } from "@reduxjs/toolkit";
-import { SqlStatsResponse } from "../api";
-import { AggregateStatistics } from "src/statementsTable";
-import { StatementDiagnosticsDictionary } from "src/store/statementDiagnostics";
 
 // The functions in this file are agnostic to the different shape of each
 // state in db-console and cluster-ui. This file contains selector functions

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsPage.fixture.ts
@@ -46,8 +46,8 @@ const sessionDetailsPropsBase: SessionDetailsProps = {
   },
   setTimeScale: () => {},
   refreshSessions: () => {},
-  cancelSession: (req: CancelSessionRequestMessage) => {},
-  cancelQuery: (req: CancelQueryRequestMessage) => {},
+  cancelSession: (_req: CancelSessionRequestMessage) => {},
+  cancelQuery: (_req: CancelQueryRequestMessage) => {},
   refreshNodes: () => {},
   refreshNodesLiveness: () => {},
   uiConfig: {

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
@@ -210,8 +210,8 @@ export const sessionsPagePropsFixture: SessionsPageProps = {
   columns: null,
   internalAppNamePrefix: "$ internal",
   refreshSessions: () => {},
-  cancelSession: (req: CancelSessionRequestMessage) => {},
-  cancelQuery: (req: CancelQueryRequestMessage) => {},
+  cancelSession: (_req: CancelSessionRequestMessage) => {},
+  cancelQuery: (_req: CancelQueryRequestMessage) => {},
   onSortingChange: () => {},
 };
 
@@ -239,7 +239,7 @@ export const sessionsPagePropsEmptyFixture: SessionsPageProps = {
   columns: null,
   internalAppNamePrefix: "$ internal",
   refreshSessions: () => {},
-  cancelSession: (req: CancelSessionRequestMessage) => {},
-  cancelQuery: (req: CancelQueryRequestMessage) => {},
+  cancelSession: (_req: CancelSessionRequestMessage) => {},
+  cancelQuery: (_req: CancelQueryRequestMessage) => {},
   onSortingChange: () => {},
 };

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
@@ -75,7 +75,7 @@ export const selectFilters = createSelector(
 
 export const SessionsPageConnected = withRouter(
   connect(
-    (state: AppState, props: RouteComponentProps) => ({
+    (state: AppState, _props: RouteComponentProps) => ({
       sessions: selectSessions(state),
       internalAppNamePrefix: selectAppName(state),
       sessionsError: state.adminUI?.sessions.lastError,

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -16,12 +16,7 @@ import {
   DurationToNumber,
   TimestampToMoment,
 } from "src/util/convert";
-import {
-  BytesWithPrecision,
-  Count,
-  DATE_FORMAT,
-  DATE_FORMAT_24_TZ,
-} from "src/util/format";
+import { BytesWithPrecision, Count, DATE_FORMAT } from "src/util/format";
 import { Link } from "react-router-dom";
 import React from "react";
 

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -221,7 +221,7 @@ export class SortedTable<T> extends React.Component<
       data: T[],
       sortSetting: SortSetting,
       columns: ColumnDescriptor<T>[],
-      pagination?: ISortedTablePagination,
+      _pagination?: ISortedTablePagination,
     ): T[] => {
       if (!sortSetting) {
         return this.paginatedData();

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
@@ -11,7 +11,7 @@
 import React from "react";
 import classNames from "classnames/bind";
 import styles from "./sqlActivity.module.scss";
-import moment, { Moment } from "moment-timezone";
+import moment from "moment-timezone";
 
 const cx = classNames.bind(styles);
 
@@ -50,7 +50,7 @@ export function mergeErrors(errs: Error | Error[]): Error {
   };
 
   errors.forEach(
-    (x, i, arr) => (
+    (x, i) => (
       (mergedError.name += ` ${i}: ${x.name};`),
       (mergedError.message += ` ${i}: ${x.message};`)
     ),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -23,7 +23,6 @@ import {
   limitText,
   Count,
   intersperse,
-  EncodeUriName,
   EncodeDatabaseTableIndexUri,
   EncodeDatabaseTableUri,
 } from "../../util";

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -10,7 +10,6 @@
 
 import React from "react";
 import { Anchor } from "src/anchor";
-import moment from "moment-timezone";
 
 import { Tooltip } from "@cockroachlabs/ui-components";
 import {
@@ -24,8 +23,6 @@ import {
   writtenToDisk,
 } from "src/util";
 import { Timezone } from "src/timestamp";
-
-export type NodeNames = { [nodeId: string]: string };
 
 // Single place for column names. Used in table columns and in columns selector.
 export const statisticsColumnLabels = {

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.saga.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.saga.spec.ts
@@ -30,11 +30,9 @@ import {
 } from "./databaseDetails.saga";
 import {
   actions,
-  DatabaseDetailsState,
   KeyedDatabaseDetailsState,
   reducer,
 } from "./databaseDetails.reducer";
-import { DatabasesListState, refreshDatabasesListSaga } from "../databasesList";
 
 describe("DatabaseDetails sagas", () => {
   const database = "test_db";

--- a/pkg/ui/workspaces/cluster-ui/src/store/databasesList/databasesList.reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databasesList/databasesList.reducers.ts
@@ -12,8 +12,6 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { DatabasesListResponse } from "src/api";
 import { DOMAIN_NAME, noopReducer } from "../utils";
 
-import { SqlExecutionRequest } from "../../api/sqlApi";
-
 export type DatabasesListState = {
   data: DatabasesListResponse;
   // Captures thrown errors.

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.selectors.ts
@@ -10,7 +10,6 @@
 
 import { createSelector } from "reselect";
 import { localStorageSelector } from "../utils/selectors";
-import { adminUISelector } from "../utils/selectors";
 
 export const selectSortSetting = createSelector(
   localStorageSelector,

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
@@ -50,10 +50,10 @@ const sqlStatsSlice = createSlice({
       state.inFlight = false;
       state.valid = false;
     },
-    refresh: (state, action: PayloadAction<StatementsRequest>) => {
+    refresh: (state, _action: PayloadAction<StatementsRequest>) => {
       state.inFlight = true;
     },
-    request: (state, action: PayloadAction<StatementsRequest>) => {
+    request: (state, _action: PayloadAction<StatementsRequest>) => {
       state.inFlight = true;
     },
     updateTimeScale: (_, _action: PayloadAction<UpdateTimeScalePayload>) => {},

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelect.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelect.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React, { useState, useRef, useContext } from "react";
+import React, { useState, useRef } from "react";
 import { Button, Dropdown } from "antd";
 import "antd/lib/button/style";
 import "antd/lib/dropdown/style";
@@ -19,7 +19,6 @@ import classNames from "classnames/bind";
 
 import styles from "./rangeSelector.module.scss";
 import { TimeWindow } from "./timeScaleTypes";
-import { TimezoneContext } from "../contexts";
 import { Timezone } from "src/timestamp";
 
 const cx = classNames.bind(styles);
@@ -90,7 +89,6 @@ const RangeSelect = ({
   selected,
 }: RangeSelectProps): React.ReactElement => {
   const [isVisible, setIsVisible] = useState<boolean>(false);
-  const timezone = useContext(TimezoneContext);
   /**
    * customDropdownOptionWasJustSelected holds whether the user had just clicked the "Custom time interval" option in
    * the dropdown menu.

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
@@ -26,7 +26,7 @@ import RangeSelect from "./rangeSelect";
 import { timeFormat as customMenuTimeFormat } from "../dateRangeMenu";
 import { assert } from "chai";
 import { TimeWindow, ArrowDirection, TimeScale } from "./timeScaleTypes";
-import { getAllByText, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 /**
@@ -285,8 +285,6 @@ describe("TimeScaleDropdown functions", function () {
 
   describe("formatRangeSelectSelected", () => {
     it("formatRangeSelectSelected must return title Past 10 Minutes", () => {
-      const _ = makeTimeScaleDropdown(state);
-
       const title = formatRangeSelectSelected(
         currentWindow,
         state.currentScale,

--- a/pkg/ui/workspaces/cluster-ui/src/timestamp/timestamp.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timestamp/timestamp.tsx
@@ -13,7 +13,7 @@ import React, { useContext } from "react";
 import { FormatWithTimezone } from "../util";
 import { CoordinatedUniversalTime, TimezoneContext } from "../contexts";
 
-export function Timezone(props: any) {
+export function Timezone() {
   const timezone = useContext(TimezoneContext);
   return (
     <>

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/snapshotPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/snapshotPage.spec.tsx
@@ -23,7 +23,6 @@ import {
 } from "src/api/tracezApi";
 import GetTracingSnapshotResponse = cockroach.server.serverpb.GetTracingSnapshotResponse;
 import Long from "long";
-import { getByTestId } from "@testing-library/dom/types/queries";
 
 const getMockSnapshotPageProps = (): SnapshotPageProps => {
   const history = H.createHashHistory();
@@ -44,18 +43,14 @@ const getMockSnapshotPageProps = (): SnapshotPageProps => {
     rawTrace: undefined,
     rawTraceLoading: false,
     refreshNodes: () => void {},
-    refreshRawTrace: (req: {
-      nodeID: string;
-      snapshotID: number;
-      traceID: Long;
-    }) => void {},
-    refreshSnapshot: (req: { nodeID: string; snapshotID: number }): void => {},
-    refreshSnapshots: (id: string): void => {},
-    setSort: (value: SortSetting): void => {},
+    refreshRawTrace: () => void {},
+    refreshSnapshot: (_req: { nodeID: string; snapshotID: number }): void => {},
+    refreshSnapshots: (_id: string): void => {},
+    setSort: (_value: SortSetting): void => {},
     setTraceRecordingType: (
-      nodeID: string,
-      traceID: Long,
-      recordingMode: RecordingMode,
+      _nodeID: string,
+      _traceID: Long,
+      _recordingMode: RecordingMode,
     ): Promise<SetTraceRecordingTypeResponse> => {
       return Promise.resolve(undefined);
     },
@@ -73,7 +68,7 @@ const getMockSnapshotPageProps = (): SnapshotPageProps => {
     snapshotLoading: false,
     snapshotsLoading: false,
     sort: undefined,
-    takeSnapshot: (nodeID: string): Promise<TakeTracingSnapshotResponse> => {
+    takeSnapshot: (_nodeID: string): Promise<TakeTracingSnapshotResponse> => {
       return Promise.resolve(undefined);
     },
   };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
@@ -12,7 +12,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { getHighlightedText } from "src/highlightedText";
 import { Tooltip } from "@cockroachlabs/ui-components";
-import { limitText, unset } from "src/util";
+import { limitText } from "src/util";
 import classNames from "classnames/bind";
 import statementsStyles from "../../statementsTable/statementsTableContent.module.scss";
 import transactionsCellsStyles from "./transactionsCells.module.scss";

--- a/pkg/ui/workspaces/cluster-ui/src/util/versions.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/versions.ts
@@ -60,11 +60,10 @@ export function parseStringToVersion(
   const matches = inputString.match(regex);
 
   if (matches) {
-    const [, majorVersion, minorVersion, patchVersion, buildNumber] = matches;
+    const [, majorVersion, minorVersion, patchVersion] = matches;
     const parsedMajorVersion = parseInt(majorVersion);
     const parsedMinorVersion = parseInt(minorVersion) || 0;
     const parsedPatchVersion = parseInt(patchVersion) || 0;
-    const parsedBuildNumber = parseInt(buildNumber) || 0;
 
     return [parsedMajorVersion, parsedMinorVersion, parsedPatchVersion];
   } else {


### PR DESCRIPTION
Delete unused vars in cluster-ui. A following commit will turn unused vars to errors via the eslint config.

Epic: None

Release note: None