### PR TITLE
cluster-ui: set 'error' on eslint rule no-unused-vars

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/.eslintrc.json
+++ b/pkg/ui/workspaces/cluster-ui/.eslintrc.json
@@ -10,7 +10,7 @@
     "@typescript-eslint/interface-name-prefix": "off",
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-namespace": "off",
-    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "@cockroachlabs/crdb/require-antd-style-import": "error"
   }
 }


### PR DESCRIPTION
Unused vars will now show up as lint errors in cluster-ui package.

Epic: none

Release note: None