### PR TITLE
teamcity-trigger: don't start a job for an empty target

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -126,6 +126,9 @@ func runTC(queueBuild func(string, map[string]string)) {
 	// Queue stress builds. One per configuration per test target.
 	for _, testTarget := range strings.Split(string(targets), "\n") {
 		testTarget = strings.TrimSpace(testTarget)
+		if testTarget == "" {
+			continue
+		}
 		// By default, run each package for up to 100 iterations.
 		maxRuns := 100
 		maxTime := getMaxTime(testTarget)


### PR DESCRIPTION
This makes no sense, so skip these cases.

Closes: #107779
Closes: #107780
Closes: #107781

Epic: none
Release note: None