### PR TITLE
release-23.1: roachtest: include link to testeng grafana in issue posts

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "test_test.go",
     ],
     args = ["-test.timeout=55s"],
+    data = glob(["testdata/**"]),
     embed = [":roachtest_lib"],
     deps = [
         "//pkg/cmd/internal/issues",
@@ -91,6 +92,7 @@ go_test(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/testutils",
+        "//pkg/testutils/echotest",
         "//pkg/util/quotapool",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -202,10 +202,12 @@ func TestCreatePostRequest(t *testing.T) {
 			}
 
 			if c.loadTeamsFailed {
-				// Assert that if TEAMS.yaml cannot be loaded then function panics.
-				assert.Panics(t, func() { github.createPostRequest(ti, c.failure, "message") })
+				// Assert that if TEAMS.yaml cannot be loaded then function errors.
+				_, err := github.createPostRequest("github_test", ti.start, ti.end, testSpec, c.failure, "message")
+				assert.Error(t, err, "Expected an error in createPostRequest when loading teams fails, but got nil")
 			} else {
-				req := github.createPostRequest(ti, c.failure, "message")
+				req, err := github.createPostRequest("github_test", ti.start, ti.end, testSpec, c.failure, "message")
+				assert.NoError(t, err, "Expected no error in createPostRequest")
 
 				if c.expectedParams != nil {
 					require.Equal(t, c.expectedParams, req.ExtraParams)

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -14,8 +14,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/internal/issues"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -25,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/team"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,6 +106,16 @@ func TestShouldPost(t *testing.T) {
 	}
 }
 
+func TestGenerateHelpCommand(t *testing.T) {
+	start := time.Date(2023, time.July, 21, 16, 34, 3, 817, time.UTC)
+	end := time.Date(2023, time.July, 21, 16, 42, 13, 137, time.UTC)
+
+	r := &issues.Renderer{}
+	generateHelpCommand("foo-cluster", start, end)(r)
+
+	echotest.Require(t, r.String(), filepath.Join("testdata", "help_command.txt"))
+}
+
 func TestCreatePostRequest(t *testing.T) {
 	createFailure := func(ref error) failure {
 		return failure{squashedErr: ref}
@@ -173,11 +186,13 @@ func TestCreatePostRequest(t *testing.T) {
 			}
 
 			ti := &testImpl{
-				spec: testSpec,
-				l:    nilLogger(),
+				spec:  testSpec,
+				l:     nilLogger(),
+				start: time.Date(2023, time.July, 21, 16, 34, 3, 817, time.UTC),
+				end:   time.Date(2023, time.July, 21, 16, 42, 13, 137, time.UTC),
 			}
 
-			testClusterImpl := &clusterImpl{spec: clusterSpec, arch: vm.ArchAMD64}
+			testClusterImpl := &clusterImpl{spec: clusterSpec, arch: vm.ArchAMD64, name: "foo"}
 			vo := vm.DefaultCreateOpts()
 			vmOpts := &vo
 
@@ -208,6 +223,11 @@ func TestCreatePostRequest(t *testing.T) {
 			} else {
 				req, err := github.createPostRequest("github_test", ti.start, ti.end, testSpec, c.failure, "message")
 				assert.NoError(t, err, "Expected no error in createPostRequest")
+
+				r := &issues.Renderer{}
+				req.HelpCommand(r)
+				file := fmt.Sprintf("help_command_createpost_%d.txt", idx+1)
+				echotest.Require(t, r.String(), filepath.Join("testdata", file))
 
 				if c.expectedParams != nil {
 					require.Equal(t, c.expectedParams, req.ExtraParams)

--- a/pkg/cmd/roachtest/testdata/help_command.txt
+++ b/pkg/cmd/roachtest/testdata/help_command.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/p/roachfana/foo-cluster/1689957243000/1689957733000)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_1.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_1.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/p/roachfana/foo/1689957243000/1689957733000)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_2.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_2.txt
@@ -1,0 +1,13 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_3.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_3.txt
@@ -1,0 +1,13 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_5.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_5.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/p/roachfana/foo/1689957243000/1689957733000)
+
+----
+----


### PR DESCRIPTION
Backport 2/2 commits from #107391.

/cc @cockroachdb/release

---

This adds a link, populated with relevant cluster name and test timeframe, to the testeng grafana instance for failed roachtests.

Fixes: #105894
Release note: None

---
Release justification: adds helpful testeng grafana link to failed roachtests