### PR TITLE
diagnosticsccl: fix TestUsageQuantization

### DIFF
--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -288,8 +288,6 @@ func TestUsageQuantization(t *testing.T) {
 
 	url := r.URL()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(106901),
-
 		Settings: st,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -587,8 +587,12 @@ func (ts *TestServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 	// Since we're creating a tenant, it doesn't make sense to pass through the
 	// Server testing knobs, since the bulk of them only apply to the system
 	// tenant. Any remaining knobs which are required by the tenant should be
-	// setup in StartTenant below.
+	// passed through here.
 	params.TestingKnobs.Server = &TestingKnobs{}
+
+	if ts.params.Knobs.Server != nil {
+		params.TestingKnobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs = ts.params.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs
+	}
 
 	// Temporarily disable the error that is returned if a tenant should not be started manually,
 	// so that we can start the default test tenant internally here.


### PR DESCRIPTION
TestUsageQuantization failed with secondary tenants because the test's server.TestingKnobs were not being passed through to test tenant creation.

Resolves #106901
Epic: none
Release note: None